### PR TITLE
Onboarding: show Telegram in channel selection and auto-install bundled channel

### DIFF
--- a/src/channels/wasm/bundled.rs
+++ b/src/channels/wasm/bundled.rs
@@ -1,0 +1,104 @@
+//! Bundled WASM channels that can be installed locally.
+
+use std::path::Path;
+
+use tokio::fs;
+
+#[derive(Clone, Copy)]
+struct BundledChannel {
+    name: &'static str,
+    wasm: &'static [u8],
+    capabilities: &'static [u8],
+}
+
+/// Names of bundled channels shipped with IronClaw.
+pub fn bundled_channel_names() -> &'static [&'static str] {
+    &["telegram"]
+}
+
+/// Install a bundled channel into a channels directory.
+pub async fn install_bundled_channel(
+    name: &str,
+    target_dir: &Path,
+    force: bool,
+) -> Result<(), String> {
+    let channel = bundled_channel(name)
+        .ok_or_else(|| format!("Unknown bundled channel '{}'", name.to_lowercase()))?;
+
+    fs::create_dir_all(target_dir)
+        .await
+        .map_err(|e| format!("Failed to create channels directory: {}", e))?;
+
+    let wasm_path = target_dir.join(format!("{}.wasm", channel.name));
+    let caps_path = target_dir.join(format!("{}.capabilities.json", channel.name));
+
+    let has_existing = wasm_path.exists() || caps_path.exists();
+    if has_existing && !force {
+        return Err(format!(
+            "Channel '{}' already exists at {}",
+            channel.name,
+            target_dir.display()
+        ));
+    }
+
+    fs::write(&wasm_path, channel.wasm)
+        .await
+        .map_err(|e| format!("Failed to write {}: {}", wasm_path.display(), e))?;
+    fs::write(&caps_path, channel.capabilities)
+        .await
+        .map_err(|e| format!("Failed to write {}: {}", caps_path.display(), e))?;
+
+    Ok(())
+}
+
+fn bundled_channel(name: &str) -> Option<BundledChannel> {
+    if name.eq_ignore_ascii_case("telegram") {
+        Some(BundledChannel {
+            name: "telegram",
+            wasm: include_bytes!("../../../channels-src/telegram/telegram.wasm"),
+            capabilities: include_bytes!(
+                "../../../channels-src/telegram/telegram.capabilities.json"
+            ),
+        })
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tempfile::tempdir;
+    use tokio::fs;
+
+    use super::*;
+
+    #[test]
+    fn test_bundled_channel_names_contains_telegram() {
+        assert!(bundled_channel_names().contains(&"telegram"));
+    }
+
+    #[tokio::test]
+    async fn test_install_bundled_channel_writes_files() {
+        let dir = tempdir().unwrap();
+
+        install_bundled_channel("telegram", dir.path(), false)
+            .await
+            .unwrap();
+
+        assert!(dir.path().join("telegram.wasm").exists());
+        assert!(dir.path().join("telegram.capabilities.json").exists());
+    }
+
+    #[tokio::test]
+    async fn test_install_bundled_channel_refuses_overwrite_without_force() {
+        let dir = tempdir().unwrap();
+        let wasm_path = dir.path().join("telegram.wasm");
+        fs::write(&wasm_path, b"custom").await.unwrap();
+
+        let result = install_bundled_channel("telegram", dir.path(), false).await;
+        assert!(result.is_err());
+
+        let existing = fs::read(&wasm_path).await.unwrap();
+        assert_eq!(existing, b"custom");
+    }
+}

--- a/src/channels/wasm/mod.rs
+++ b/src/channels/wasm/mod.rs
@@ -78,6 +78,7 @@
 //! }
 //! ```
 
+mod bundled;
 mod capabilities;
 mod error;
 mod host;
@@ -88,6 +89,7 @@ mod schema;
 mod wrapper;
 
 // Core types
+pub use bundled::{bundled_channel_names, install_bundled_channel};
 pub use capabilities::{ChannelCapabilities, EmitRateLimitConfig, HttpEndpointConfig, PollConfig};
 pub use error::WasmChannelError;
 pub use host::{ChannelEmitRateLimiter, ChannelHostState, EmittedMessage};

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -205,6 +205,8 @@ pub enum CredentialLocation {
     },
     /// Inject as a query parameter
     QueryParam { name: String },
+    /// Inject by replacing a placeholder in URL or body templates
+    UrlPath { placeholder: String },
 }
 
 impl Default for CredentialLocation {

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -200,6 +200,10 @@ fn inject_credential(
                 .query_params
                 .insert(name.clone(), secret.expose().to_string());
         }
+        CredentialLocation::UrlPath { .. } => {
+            // URL placeholder replacement is handled by channel/tool wrappers
+            // that substitute {PLACEHOLDER} values in templated strings.
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add bundled channel installer in  (currently Telegram)
- show bundled channels directly in onboarding channel selection UI
- auto-install selected bundled channels during onboarding before setup
- ensure channel-only onboarding initializes DB migrations before saving channel secrets
- add support for  credential location in capabilities parsing so Telegram capabilities load correctly

## Why
This aligns UX with onboarding-first configuration: users choose channels in one place, without a separate install prompt/command.

## Testing
- 
running 7 tests
test setup::wizard::tests::test_mask_password_in_url ... ok
test setup::wizard::tests::test_capitalize_first ... ok
test setup::wizard::tests::test_wasm_channel_option_names_includes_bundled_when_missing ... ok
test setup::wizard::tests::test_wasm_channel_option_names_dedupes_bundled ... ok
test setup::wizard::tests::test_wizard_with_config ... ok
test setup::wizard::tests::test_wizard_creation ... ok
test setup::wizard::tests::test_install_missing_bundled_channels_installs_telegram ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 499 filtered out; finished in 0.02s
- 
running 1 test
test tools::wasm::capabilities_schema::tests::test_parse_url_path_credential ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 505 filtered out; finished in 0.00s
- 
running 3 tests
test channels::wasm::bundled::tests::test_bundled_channel_names_contains_telegram ... ok
test channels::wasm::bundled::tests::test_install_bundled_channel_refuses_overwrite_without_force ... ok
test channels::wasm::bundled::tests::test_install_bundled_channel_writes_files ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 503 filtered out; finished in 0.00s

## Notes
I intentionally excluded separate CLI channel-command changes from this PR scope.