### PR TITLE
feat: Support direct API key auth and cheap model routing

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -60,6 +60,9 @@ enum AgenticLoopResult {
 pub struct AgentDeps {
     pub store: Option<Arc<Store>>,
     pub llm: Arc<dyn LlmProvider>,
+    /// Cheap/fast LLM for lightweight tasks (heartbeat, routing, evaluation).
+    /// Falls back to the main `llm` if None.
+    pub cheap_llm: Option<Arc<dyn LlmProvider>>,
     pub safety: Arc<SafetyLayer>,
     pub tools: Arc<ToolRegistry>,
     pub workspace: Option<Arc<Workspace>>,
@@ -126,6 +129,11 @@ impl Agent {
 
     fn llm(&self) -> &Arc<dyn LlmProvider> {
         &self.deps.llm
+    }
+
+    /// Get the cheap/fast LLM provider, falling back to the main one.
+    fn cheap_llm(&self) -> &Arc<dyn LlmProvider> {
+        self.deps.cheap_llm.as_ref().unwrap_or(&self.deps.llm)
     }
 
     fn safety(&self) -> &Arc<SafetyLayer> {
@@ -316,7 +324,7 @@ impl Agent {
                     Some(spawn_heartbeat(
                         config,
                         workspace.clone(),
-                        self.llm().clone(),
+                        self.cheap_llm().clone(),
                         Some(notify_tx),
                     ))
                 } else {

--- a/src/config.rs
+++ b/src/config.rs
@@ -202,6 +202,9 @@ impl std::str::FromStr for NearAiApiMode {
 pub struct NearAiConfig {
     /// Model to use (e.g., "claude-3-5-sonnet-20241022", "gpt-4o")
     pub model: String,
+    /// Cheap/fast model for lightweight tasks (heartbeat, routing, evaluation).
+    /// Falls back to the main model if not set.
+    pub cheap_model: Option<String>,
     /// Base URL for the NEAR AI API (default: https://api.near.ai)
     pub base_url: String,
     /// Base URL for auth/refresh endpoints (default: https://private.near.ai)
@@ -241,6 +244,7 @@ impl LlmConfig {
                         "fireworks::accounts/fireworks/models/llama4-maverick-instruct-basic"
                             .to_string()
                     }),
+                cheap_model: optional_env("NEARAI_CHEAP_MODEL")?,
                 base_url: optional_env("NEARAI_BASE_URL")?
                     .unwrap_or_else(|| "https://cloud-api.near.ai".to_string()),
                 auth_base_url: optional_env("NEARAI_AUTH_URL")?

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -455,6 +455,7 @@ impl SetupWizard {
         let config = LlmConfig {
             nearai: crate::config::NearAiConfig {
                 model: "dummy".to_string(),
+                cheap_model: None,
                 base_url,
                 auth_base_url,
                 session_path: crate::llm::session::default_session_path(),


### PR DESCRIPTION
## Summary

- **Direct API key auth**: Skip NEAR AI session/OAuth when using `chat_completions` mode with `NEARAI_API_KEY`, allowing direct connection to any OpenAI-compatible provider (e.g. Anthropic Claude)
- **Cheap model routing**: New `NEARAI_CHEAP_MODEL` env var configures a secondary lightweight model (e.g. Claude Haiku) for cost-sensitive tasks like heartbeat, routing, and evaluation
- **First-run fix**: Skip onboard session file check when an API key is already configured

## Changes

| File | What changed |
|------|-------------|
| `src/main.rs` | Skip session auth in `chat_completions` mode; create cheap LLM provider; pass to `AgentDeps`; skip first-run check when API key set |
| `src/config.rs` | Add `cheap_model: Option<String>` to `NearAiConfig`, load from `NEARAI_CHEAP_MODEL` env |
| `src/llm/mod.rs` | Add `create_cheap_llm_provider()` factory function |
| `src/agent/agent_loop.rs` | Add `cheap_llm` field to `AgentDeps`, `cheap_llm()` accessor with fallback, route heartbeat through cheap model |
| `src/setup/wizard.rs` | Add `cheap_model: None` to fix struct initialization |

## Configuration

```bash
# .env example — direct Anthropic usage with dual models
NEARAI_API_KEY=sk-ant-api03-...
NEARAI_BASE_URL=https://api.anthropic.com
NEARAI_MODEL=claude-sonnet-4-5-20250929
NEARAI_CHEAP_MODEL=claude-haiku-4-5-20251001
NEARAI_API_MODE=chat_completions
```

When `NEARAI_CHEAP_MODEL` is not set, all tasks use the main model (no behavior change).

## Test plan

- [x] Build with `cargo build --release` — compiles cleanly
- [x] Run with Anthropic API key — agent starts, connects, responds
- [x] Both models initialize (`LLM provider initialized` + `Cheap LLM provider initialized` in logs)
- [x] Heartbeat uses cheap model
- [ ] Verify NEAR AI session mode (`Responses`) still works as before (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)