### PR TITLE
chore: add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all --benches --tests --examples --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    env:
+      RUSTFLAGS: "-D warnings"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      # Run unit tests only; integration tests (tests/) require PostgreSQL + pgvector
+      - run: cargo test --lib

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,19 @@
+name: Security Audit
+
+on:
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
+  pull_request:
+    paths:
+      - "Cargo.toml"
+      - "Cargo.lock"
+
+jobs:
+  audit:
+    name: Cargo Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `ci.yml` workflow that runs `cargo fmt --check`, `cargo clippy`, and `cargo test --lib` on pushes to `main` and all PRs
- Add `security-audit.yml` workflow that runs `cargo-audit` weekly and on `Cargo.toml`/`Cargo.lock` changes in PRs
- Uses `dtolnay/rust-toolchain` and `Swatinem/rust-cache` for reliable, fast builds
- Runs unit tests only (`--lib`); integration tests in `tests/` require PostgreSQL + pgvector and should get their own CI job with service containers

## Motivation

The project currently has no automated quality gates — `fmt`, `clippy`, and `test` are only enforced manually via `.claude/commands/ship.md`. This PR adds the same checks as automated CI so regressions are caught before merge.

## Test plan

- [ ] Verify `ci.yml` triggers on a PR to `main`
- [ ] Verify `security-audit.yml` triggers when `Cargo.toml` or `Cargo.lock` are modified in a PR
- [ ] Confirm all three CI jobs (fmt, clippy, test) pass on current `main`