### PR TITLE
fix: replace bare unwrap() with expect() in production code

### DIFF
--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -259,7 +259,7 @@ fn build_wasm_component(source_dir: &Path, release: bool) -> anyhow::Result<Path
         .args(["component", "--version"])
         .output();
 
-    if check.is_err() || !check.unwrap().status.success() {
+    if !check.as_ref().map_or(false, |o| o.status.success()) {
         anyhow::bail!(
             "cargo-component not found. Install with: cargo install cargo-component\n\
              Or use --skip-build with an existing .wasm file."

--- a/src/safety/leak_detector.rs
+++ b/src/safety/leak_detector.rs
@@ -409,105 +409,105 @@ fn default_patterns() -> Vec<LeakPattern> {
         // OpenAI API keys
         LeakPattern {
             name: "openai_api_key".to_string(),
-            regex: Regex::new(r"sk-(?:proj-)?[a-zA-Z0-9]{20,}(?:T3BlbkFJ[a-zA-Z0-9_-]*)?").unwrap(),
+            regex: Regex::new(r"sk-(?:proj-)?[a-zA-Z0-9]{20,}(?:T3BlbkFJ[a-zA-Z0-9_-]*)?").expect("valid openai_api_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // Anthropic API keys
         LeakPattern {
             name: "anthropic_api_key".to_string(),
-            regex: Regex::new(r"sk-ant-api[a-zA-Z0-9_-]{90,}").unwrap(),
+            regex: Regex::new(r"sk-ant-api[a-zA-Z0-9_-]{90,}").expect("valid anthropic_api_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // AWS Access Key ID
         LeakPattern {
             name: "aws_access_key".to_string(),
-            regex: Regex::new(r"AKIA[0-9A-Z]{16}").unwrap(),
+            regex: Regex::new(r"AKIA[0-9A-Z]{16}").expect("valid aws_access_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // GitHub tokens
         LeakPattern {
             name: "github_token".to_string(),
-            regex: Regex::new(r"gh[pousr]_[A-Za-z0-9_]{36,}").unwrap(),
+            regex: Regex::new(r"gh[pousr]_[A-Za-z0-9_]{36,}").expect("valid github_token regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // GitHub fine-grained PAT
         LeakPattern {
             name: "github_fine_grained_pat".to_string(),
-            regex: Regex::new(r"github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}").unwrap(),
+            regex: Regex::new(r"github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}").expect("valid github_fine_grained_pat regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // Stripe keys
         LeakPattern {
             name: "stripe_api_key".to_string(),
-            regex: Regex::new(r"sk_(?:live|test)_[a-zA-Z0-9]{24,}").unwrap(),
+            regex: Regex::new(r"sk_(?:live|test)_[a-zA-Z0-9]{24,}").expect("valid stripe_api_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // NEAR AI session tokens
         LeakPattern {
             name: "nearai_session".to_string(),
-            regex: Regex::new(r"sess_[a-zA-Z0-9]{32,}").unwrap(),
+            regex: Regex::new(r"sess_[a-zA-Z0-9]{32,}").expect("valid nearai_session regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // PEM private keys
         LeakPattern {
             name: "pem_private_key".to_string(),
-            regex: Regex::new(r"-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----").unwrap(),
+            regex: Regex::new(r"-----BEGIN\s+(?:RSA\s+)?PRIVATE\s+KEY-----").expect("valid pem_private_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // SSH private keys
         LeakPattern {
             name: "ssh_private_key".to_string(),
-            regex: Regex::new(r"-----BEGIN\s+(?:OPENSSH|EC|DSA)\s+PRIVATE\s+KEY-----").unwrap(),
+            regex: Regex::new(r"-----BEGIN\s+(?:OPENSSH|EC|DSA)\s+PRIVATE\s+KEY-----").expect("valid ssh_private_key regex"),
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
         // Google API keys
         LeakPattern {
             name: "google_api_key".to_string(),
-            regex: Regex::new(r"AIza[0-9A-Za-z_-]{35}").unwrap(),
+            regex: Regex::new(r"AIza[0-9A-Za-z_-]{35}").expect("valid google_api_key regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Block,
         },
         // Slack tokens
         LeakPattern {
             name: "slack_token".to_string(),
-            regex: Regex::new(r"xox[baprs]-[0-9a-zA-Z-]{10,}").unwrap(),
+            regex: Regex::new(r"xox[baprs]-[0-9a-zA-Z-]{10,}").expect("valid slack_token regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Block,
         },
         // Twilio API keys
         LeakPattern {
             name: "twilio_api_key".to_string(),
-            regex: Regex::new(r"SK[a-fA-F0-9]{32}").unwrap(),
+            regex: Regex::new(r"SK[a-fA-F0-9]{32}").expect("valid twilio_api_key regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Block,
         },
         // SendGrid API keys
         LeakPattern {
             name: "sendgrid_api_key".to_string(),
-            regex: Regex::new(r"SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}").unwrap(),
+            regex: Regex::new(r"SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}").expect("valid sendgrid_api_key regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Block,
         },
         // Bearer tokens (redact instead of block, might be intentional)
         LeakPattern {
             name: "bearer_token".to_string(),
-            regex: Regex::new(r"Bearer\s+[a-zA-Z0-9_-]{20,}").unwrap(),
+            regex: Regex::new(r"Bearer\s+[a-zA-Z0-9_-]{20,}").expect("valid bearer_token regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Redact,
         },
         // Authorization header with key
         LeakPattern {
             name: "auth_header".to_string(),
-            regex: Regex::new(r"(?i)authorization:\s*[a-zA-Z]+\s+[a-zA-Z0-9_-]{20,}").unwrap(),
+            regex: Regex::new(r"(?i)authorization:\s*[a-zA-Z]+\s+[a-zA-Z0-9_-]{20,}").expect("valid auth_header regex"),
             severity: LeakSeverity::High,
             action: LeakAction::Redact,
         },
@@ -516,7 +516,7 @@ fn default_patterns() -> Vec<LeakPattern> {
         // This catches standalone 64-char hex strings (like SHA256 hashes used as secrets).
         LeakPattern {
             name: "high_entropy_hex".to_string(),
-            regex: Regex::new(r"\b[a-fA-F0-9]{64}\b").unwrap(),
+            regex: Regex::new(r"\b[a-fA-F0-9]{64}\b").expect("valid high_entropy_hex regex"),
             severity: LeakSeverity::Medium,
             action: LeakAction::Warn,
         },

--- a/src/safety/sanitizer.rs
+++ b/src/safety/sanitizer.rs
@@ -165,25 +165,25 @@ impl Sanitizer {
         // Regex patterns for more complex detection
         let regex_patterns = vec![
             RegexPattern {
-                regex: Regex::new(r"(?i)base64[:\s]+[A-Za-z0-9+/=]{50,}").unwrap(),
+                regex: Regex::new(r"(?i)base64[:\s]+[A-Za-z0-9+/=]{50,}").expect("valid base64_payload regex"),
                 name: "base64_payload".to_string(),
                 severity: Severity::Medium,
                 description: "Potential encoded payload".to_string(),
             },
             RegexPattern {
-                regex: Regex::new(r"(?i)eval\s*\(").unwrap(),
+                regex: Regex::new(r"(?i)eval\s*\(").expect("valid eval_call regex"),
                 name: "eval_call".to_string(),
                 severity: Severity::High,
                 description: "Potential code evaluation attempt".to_string(),
             },
             RegexPattern {
-                regex: Regex::new(r"(?i)exec\s*\(").unwrap(),
+                regex: Regex::new(r"(?i)exec\s*\(").expect("valid exec_call regex"),
                 name: "exec_call".to_string(),
                 severity: Severity::High,
                 description: "Potential code execution attempt".to_string(),
             },
             RegexPattern {
-                regex: Regex::new(r"\x00").unwrap(),
+                regex: Regex::new(r"\x00").expect("valid null_byte regex"),
                 name: "null_byte".to_string(),
                 severity: Severity::Critical,
                 description: "Null byte injection attempt".to_string(),

--- a/src/sandbox/proxy/http.rs
+++ b/src/sandbox/proxy/http.rs
@@ -273,7 +273,7 @@ async fn handle_connect(
     Response::builder()
         .status(StatusCode::OK)
         .body(empty_body())
-        .unwrap()
+        .expect("valid empty CONNECT response")
 }
 
 /// Forward a request to the target server.
@@ -355,7 +355,7 @@ async fn forward_request(
                         }
                     }
 
-                    Ok(builder.body(full_body(body)).unwrap())
+                    Ok(builder.body(full_body(body)).expect("valid proxied response"))
                 }
                 Err(e) => {
                     tracing::error!("Proxy: failed to read response body: {}", e);
@@ -397,7 +397,7 @@ fn error_response(status: StatusCode, message: String) -> Response<BoxBody<Bytes
         .status(status)
         .header("Content-Type", "text/plain")
         .body(full_body(Bytes::from(message)))
-        .unwrap()
+        .expect("valid error response")
 }
 
 /// Create an empty body.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -573,7 +573,7 @@ impl Settings {
                 .ok_or_else(|| format!("Path not found: {}", path))?;
         }
 
-        let final_key = parts.last().unwrap();
+        let final_key = parts.last().expect("checked non-empty above");
         let obj = current
             .as_object_mut()
             .ok_or_else(|| format!("Parent is not an object: {}", path))?;

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -540,7 +540,7 @@ impl SetupWizard {
             self.test_database_connection(&url).await?;
             // Ensure secrets-related tables exist for channels-only onboarding flows.
             self.run_migrations().await?;
-            self.db_pool.clone().unwrap()
+            self.db_pool.clone().expect("db_pool set in previous step")
         };
 
         // Get crypto (should be set from step 2, or load from keychain/env)
@@ -561,7 +561,7 @@ impl SetupWizard {
             let crypto = SecretsCrypto::new(SecretString::from(key))
                 .map_err(|e| SetupError::Config(e.to_string()))?;
             self.secrets_crypto = Some(Arc::new(crypto));
-            Arc::clone(self.secrets_crypto.as_ref().unwrap())
+            Arc::clone(self.secrets_crypto.as_ref().expect("secrets_crypto set above"))
         };
 
         Ok(SecretsContext::new(pool, crypto, "default"))

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -444,7 +444,7 @@ impl Guest for MyTool {
 
         // Return success
         Response {
-            output: Some(serde_json::to_string(&output).unwrap()),
+            output: Some(serde_json::to_string(&output).expect("serializable output")),
             error: None,
         }
     }

--- a/src/workspace/chunker.rs
+++ b/src/workspace/chunker.rs
@@ -93,7 +93,7 @@ pub fn chunk_document(content: &str, config: ChunkConfig) -> Vec<String> {
 
         // Don't create tiny trailing chunks, merge with previous
         if chunk_words.len() < config.min_chunk_size && !chunks.is_empty() {
-            let last = chunks.pop().unwrap();
+            let last = chunks.pop().expect("checked non-empty above");
             let combined = format!("{} {}", last, chunk_words.join(" "));
             chunks.push(combined);
             break;
@@ -176,7 +176,7 @@ pub fn chunk_by_paragraphs(content: &str, config: ChunkConfig) -> Vec<String> {
     if !current_chunk.is_empty() {
         // If too small, merge with previous chunk if possible
         if current_word_count < config.min_chunk_size && !chunks.is_empty() {
-            let last = chunks.pop().unwrap();
+            let last = chunks.pop().expect("checked non-empty above");
             chunks.push(format!("{}\n\n{}", last, current_chunk.trim()));
         } else {
             chunks.push(current_chunk.trim().to_string());

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -408,7 +408,7 @@ impl Repository {
             self.vector_search(
                 user_id,
                 agent_id,
-                embedding.unwrap(),
+                embedding.expect("checked is_some above"),
                 config.pre_fusion_limit,
             )
             .await?


### PR DESCRIPTION
## Summary

- Replace all 31 bare `.unwrap()` calls in production code with `.expect("reason")` or idiomatic alternatives across 9 files
- After this change, zero `.unwrap()` calls remain in non-test code
- All replacements are in cases where the unwrap is logically safe but lacked documentation:
  - `safety/leak_detector.rs`: 16 hardcoded `Regex::new()` patterns — always valid at compile time
  - `safety/sanitizer.rs`: 4 hardcoded `Regex::new()` patterns — same
  - `sandbox/proxy/http.rs`: 3 `Response::builder()` chains — status/headers/body always valid
  - `setup/wizard.rs`: 2 state unwraps — guarded by control flow (set in prior steps)
  - `workspace/chunker.rs`: 2 `chunks.pop()` calls — both guarded by `!chunks.is_empty()` check
  - `workspace/repository.rs`: 1 `embedding.unwrap()` — guarded by `embedding.is_some()` check
  - `settings.rs`: 1 `parts.last().unwrap()` — guarded by `parts.is_empty()` early return
  - `tools/builder/core.rs`: 1 `serde_json::to_string().unwrap()` — simple struct serialization
  - `cli/tool.rs`: 1 `check.unwrap()` — replaced with `map_or` pattern (eliminates unwrap entirely)

## Motivation

CLAUDE.md states: "Never use `.unwrap()` in production code (tests are fine)". A full audit found 31 bare `.unwrap()` calls in non-test code. While all are logically safe, replacing them with `.expect()` adds documentation for future readers and gives clear panic messages if assumptions are ever violated.

## Test plan

- [x] `cargo test --lib` — all 524 unit tests pass (no test changes in this PR)
- [x] `cargo check` — compiles cleanly
- [x] Verified zero `.unwrap()` in production code after this change
- [ ] Review each replacement to confirm the `expect()` reason is accurate