### PR TITLE
docs: Add review discipline guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -579,7 +579,7 @@ Dead code behind the wrong `#[cfg]` gate will only show up when building with a 
 
 ### Mechanical verification before committing
 Run these checks on changed files before committing:
-- `grep -rn '\.unwrap()' <files>` and `grep -rn '\.expect(' <files>` -- no panics in production
+- `grep -rnE '\.unwrap\(|\.expect\(' <files>` -- no panics in production
 - `grep -rn 'super::' <files>` -- use `crate::` imports
 - If you fixed a pattern bug, `grep` for other instances of that pattern across `src/`
 


### PR DESCRIPTION
## Summary
- Codifies lessons learned from Illia's review fixes on the libSQL backend PR (#47) -- patterns we missed that should be caught systematically going forward
- Bans `.expect()` alongside `.unwrap()` in production code, adds mechanical grep checks
- New "Review & Fix Discipline" section: fix all pattern instances not just the flagged one, propagate architectural changes to satellite types, schema translation must include indexes and seed data, feature flag testing in isolation

## Test plan
- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] No code changes, documentation only

Generated with [Claude Code](https://claude.com/claude-code)