### PR TITLE
feat: add review and fix-issue project commands

### DIFF
--- a/.claude/commands/fix-issue.md
+++ b/.claude/commands/fix-issue.md
@@ -1,7 +1,7 @@
 ---
 description: Fetch a GitHub issue, create a branch, research the codebase, plan the fix, implement with tests, and commit
 disable-model-invocation: true
-allowed-tools: Bash(gh *), Bash(git *), Bash(cargo *), Read, Edit, Write, Grep, Glob
+allowed-tools: Bash(gh issue view:*), Bash(gh repo view:*), Bash(git fetch:*), Bash(git checkout:*), Bash(git status:*), Bash(git branch:*), Bash(git add:*), Bash(git commit:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Read, Edit, Write, Grep, Glob
 argument-hint: "<issue-number or github-issue-url>"
 ---
 
@@ -27,7 +27,7 @@ If the issue is closed, warn the user and ask if they still want to proceed.
 Create a fresh branch off the latest main:
 
 1. Fetch latest: `git fetch origin`
-2. Detect default branch: try `origin/main`, fall back to `origin/master`
+2. Detect default branch: `gh repo view --json defaultBranchRef --jq .defaultBranchRef.name`
 3. Create and switch to a new branch: `git checkout -b fix/{number}-{short-slug} origin/{default-branch}`
    - `{short-slug}` is 3-5 words from the issue title, lowercase, hyphenated (e.g. `fix/42-idor-workspace-check`)
 

--- a/.claude/commands/respond-pr.md
+++ b/.claude/commands/respond-pr.md
@@ -1,7 +1,7 @@
 ---
 description: Respond to PR review comments — triage, plan fixes, implement after confirmation, push, and reply to reviewers
 disable-model-invocation: true
-allowed-tools: Bash(gh *), Bash(git *), Bash(cargo *), Read, Edit, Write, Grep, Glob
+allowed-tools: Bash(gh pr list:*), Bash(gh pr comment:*), Bash(gh api:*), Bash(gh repo view:*), Bash(git branch:*), Bash(git status:*), Bash(git add:*), Bash(git commit:*), Bash(git push:*), Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Read, Edit, Write, Grep, Glob
 argument-hint: "[pr-number (optional, auto-detects from branch)]"
 ---
 
@@ -19,16 +19,22 @@ If no PR is found, tell the user and stop.
 
 ## Step 2: Fetch all review comments
 
+Resolve the repo owner and name:
+
+```
+gh repo view --json owner,name --jq '"\(.owner.login)/\(.name)"'
+```
+
 Fetch the full set of review comments (not issue-level comments):
 
 ```
-gh api repos/{owner}/{repo}/pulls/{number}/comments
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/comments
 ```
 
 Also fetch the review summaries:
 
 ```
-gh api repos/{owner}/{repo}/pulls/{number}/reviews
+gh api --paginate repos/{owner}/{repo}/pulls/{number}/reviews
 ```
 
 Deduplicate comments that appear multiple times (bots sometimes post the same finding under different IDs). Group by the actual issue being raised, not by comment ID.

--- a/.claude/commands/review-crate.md
+++ b/.claude/commands/review-crate.md
@@ -1,7 +1,7 @@
 ---
 description: Deep audit of the IronClaw crate for vulnerabilities, bugs, unfinished work, inconsistencies, and oversights
 disable-model-invocation: true
-allowed-tools: Bash(cargo *), Bash(git diff *), Bash(git log *), Bash(git show *), Bash(wc *), Read, Grep, Glob, Task
+allowed-tools: Bash(cargo fmt:*), Bash(cargo clippy:*), Bash(cargo test:*), Bash(cargo audit:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(wc:*), Read, Grep, Glob, Task
 argument-hint: "[path/to/crate]"
 ---
 
@@ -189,7 +189,7 @@ IronClaw key traits: `Database` (~60 methods), `Channel`, `Tool`, `LlmProvider`,
 
 Review `Cargo.toml` and `Cargo.lock`:
 - Are there duplicate versions of the same crate in the lock file? (potential version conflicts)
-- Are there dependencies with known security advisories? Run `cargo audit` if available.
+- Are there dependencies with known security advisories? Run `cargo audit` to check (install with `cargo install cargo-audit` if not present).
 - Are there heavy dependencies used for trivial functionality?
 - Are dependency features minimal?
 


### PR DESCRIPTION
## Summary

- Add 4 Claude Code project commands (`.claude/commands/`) adapted from global skills, tailored to IronClaw's build/test/lint workflow and conventions
- **`/review-pr`** — Paranoid architect PR review across 6 lenses (correctness, edge cases, security, tests, docs, architecture), posts findings as GitHub comments
- **`/review-crate`** — Deep Rust crate audit for vulnerabilities, bugs, unfinished work, inconsistencies, and oversights
- **`/respond-pr`** — Fetch PR review comments, triage, plan fixes, implement after user confirmation, push, and reply to reviewers
- **`/fix-issue`** — End-to-end GitHub issue resolution: fetch issue, create branch, research codebase, plan fix, implement with tests, commit

All commands include IronClaw-specific adaptations: dual-backend persistence checks, quality gate (`cargo fmt` → `clippy` → `test --lib`), and convention enforcement (no `.unwrap()`, `crate::` imports, `thiserror` errors).

## Test plan

- [ ] Verify all 4 files exist in `.claude/commands/` with valid YAML frontmatter
- [ ] Verify `/review-pr`, `/review-crate`, `/respond-pr`, `/fix-issue` appear in Claude Code's skill list
- [ ] Run `/review-pr` against an existing PR to confirm end-to-end flow
- [ ] Run `/fix-issue` against an existing issue to confirm branch creation and planning

🤖 Generated with [Claude Code](https://claude.com/claude-code)