### PR TITLE
feat: add cooldown management to FailoverProvider

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -174,7 +174,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 |---------|----------|----------|-------|
 | Auto-discovery | ✅ | ❌ | |
 | Failover chains | ✅ | ✅ | `FailoverProvider` with configurable `fallback_model` |
-| Cooldown management | ✅ | ❌ | Skip failed providers |
+| Cooldown management | ✅ | ✅ | Lock-free per-provider cooldown in `FailoverProvider` |
 | Per-session model override | ✅ | ✅ | Model selector in TUI |
 | Model selection UI | ✅ | ✅ | TUI keyboard shortcut |
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -410,6 +410,13 @@ pub struct NearAiConfig {
     /// With the default of 3, the provider makes up to 4 total attempts
     /// (1 initial + 3 retries) before giving up.
     pub max_retries: u32,
+    /// Cooldown duration in seconds for the failover provider (default: 300).
+    /// When a provider accumulates enough consecutive failures it is skipped
+    /// for this many seconds.
+    pub failover_cooldown_secs: u64,
+    /// Number of consecutive retryable failures before a provider enters
+    /// cooldown (default: 3).
+    pub failover_cooldown_threshold: u32,
 }
 
 impl LlmConfig {
@@ -469,6 +476,8 @@ impl LlmConfig {
             api_key: nearai_api_key,
             fallback_model: optional_env("NEARAI_FALLBACK_MODEL")?,
             max_retries: parse_optional_env("NEARAI_MAX_RETRIES", 3)?,
+            failover_cooldown_secs: parse_optional_env("LLM_FAILOVER_COOLDOWN_SECS", 300)?,
+            failover_cooldown_threshold: parse_optional_env("LLM_FAILOVER_THRESHOLD", 3)?,
         };
 
         // Resolve provider-specific configs based on backend

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -17,7 +17,7 @@ mod retry;
 mod rig_adapter;
 pub mod session;
 
-pub use failover::FailoverProvider;
+pub use failover::{CooldownConfig, FailoverProvider};
 pub use nearai::{ModelInfo, NearAiProvider};
 pub use nearai_chat::NearAiChatProvider;
 pub use provider::{
@@ -235,6 +235,8 @@ mod tests {
             api_key: None,
             fallback_model: None,
             max_retries: 3,
+            failover_cooldown_secs: 300,
+            failover_cooldown_threshold: 3,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use ironclaw::{
     context::ContextManager,
     extensions::ExtensionManager,
     llm::{
-        FailoverProvider, LlmProvider, SessionConfig, create_cheap_llm_provider,
+        CooldownConfig, FailoverProvider, LlmProvider, SessionConfig, create_cheap_llm_provider,
         create_llm_provider, create_llm_provider_with_config, create_session_manager,
     },
     orchestrator::{
@@ -532,7 +532,16 @@ async fn main() -> anyhow::Result<()> {
                 fallback = %fallback.model_name(),
                 "LLM failover enabled"
             );
-            Arc::new(FailoverProvider::new(vec![llm, fallback])?)
+            let cooldown_config = CooldownConfig {
+                cooldown_duration: std::time::Duration::from_secs(
+                    config.llm.nearai.failover_cooldown_secs,
+                ),
+                failure_threshold: config.llm.nearai.failover_cooldown_threshold,
+            };
+            Arc::new(FailoverProvider::with_cooldown(
+                vec![llm, fallback],
+                cooldown_config,
+            )?)
         } else {
             llm
         };

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -1022,6 +1022,8 @@ impl SetupWizard {
                 api_key: None,
                 fallback_model: None,
                 max_retries: 3,
+                failover_cooldown_secs: 300,
+                failover_cooldown_threshold: 3,
             },
             openai: None,
             anthropic: None,


### PR DESCRIPTION
## Summary

- Add lock-free per-provider cooldown to `FailoverProvider` so providers that repeatedly fail with retryable errors are temporarily skipped, reducing latency when a provider is known to be down
- Introduces `CooldownConfig` (duration + failure threshold) and `ProviderCooldown` (atomic failure count + cooldown timestamp), consistent with existing `AtomicUsize` pattern for `last_used`
- Safety net: never skips ALL providers — if every provider is in cooldown, the oldest-cooled one (most likely recovered) is always tried

## Changes

| File | Change |
|------|--------|
| `src/llm/failover.rs` | `CooldownConfig`, `ProviderCooldown`, `with_cooldown()` constructor, rewritten `try_providers()`, `MultiCallMockProvider` mock, 7 new tests |
| `src/config.rs` | 2 new fields on `NearAiConfig`: `failover_cooldown_secs`, `failover_cooldown_threshold` |
| `src/llm/mod.rs` | Re-export `CooldownConfig` |
| `src/main.rs` | Build `CooldownConfig` from config, use `with_cooldown()` |
| `src/setup/wizard.rs` | Default values for new config fields |
| `FEATURE_PARITY.md` | "Cooldown management" ❌ → ✅ |

## New env vars

| Variable | Default | Description |
|----------|---------|-------------|
| `LLM_FAILOVER_COOLDOWN_SECS` | 300 | How long a provider stays in cooldown |
| `LLM_FAILOVER_THRESHOLD` | 3 | Consecutive retryable failures before cooldown activates |

## Test plan

- [x] `cooldown_activates_after_threshold` — provider skipped after N failures
- [x] `cooldown_expires_after_duration` — provider retried after cooldown expires (1ms sleep)
- [x] `never_skip_all_providers` — oldest-cooled provider tried when all are down
- [x] `reset_on_success` — failure count resets, provider never enters cooldown
- [x] `threshold_boundary` — threshold-1 failures don't trigger, threshold does
- [x] `non_retryable_does_not_increment_cooldown` — AuthFailed returns immediately, no cooldown
- [x] `three_providers_mixed_cooldown` — first in cooldown, second/third available
- [x] All 10 existing failover tests still pass
- [x] `cargo clippy --all --all-features` — 0 warnings
- [x] `cargo fmt --check` — clean

Part of #80 (implements the "Cooldown management" sub-task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)