### PR TITLE
refactor: move per-invocation approval checks into Tool trait

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1164,31 +1164,10 @@ impl Agent {
                                 sess.is_tool_auto_approved(&tc.name)
                             };
 
-                            // For shell commands, override auto-approval for
-                            // destructive patterns that should always require
-                            // explicit per-invocation approval.
-                            if is_auto_approved
-                                && tc.name == "shell"
-                                && let Some(cmd) = tc
-                                    .arguments
-                                    .get("command")
-                                    .and_then(|c| c.as_str().map(String::from))
-                                    .or_else(|| {
-                                        tc.arguments
-                                            .as_str()
-                                            .and_then(|s| {
-                                                serde_json::from_str::<serde_json::Value>(s).ok()
-                                            })
-                                            .and_then(|v| {
-                                                v.get("command")
-                                                    .and_then(|c| c.as_str().map(String::from))
-                                            })
-                                    })
-                                && crate::tools::builtin::shell::requires_explicit_approval(&cmd)
-                            {
+                            if is_auto_approved && tool.requires_approval_for(&tc.arguments) {
                                 tracing::info!(
-                                    "Shell command '{}' requires explicit approval despite auto-approve",
-                                    cmd.chars().take(80).collect::<String>()
+                                    "Tool '{}' invocation requires explicit approval despite auto-approve",
+                                    tc.name
                                 );
                                 is_auto_approved = false;
                             }

--- a/src/tools/tool.rs
+++ b/src/tools/tool.rs
@@ -172,6 +172,15 @@ pub trait Tool: Send + Sync {
         false
     }
 
+    /// Whether this invocation requires explicit approval even when the tool
+    /// was previously auto-approved for the session.
+    ///
+    /// Default: `false` (auto-approval can proceed if enabled). Tools can
+    /// override to enforce per-invocation checks for destructive arguments.
+    fn requires_approval_for(&self, _params: &serde_json::Value) -> bool {
+        false
+    }
+
     /// Maximum time this tool is allowed to run before the caller kills it.
     /// Override for long-running tools like sandbox execution.
     /// Default: 60 seconds.


### PR DESCRIPTION
## Summary
- add `Tool::requires_approval_for(&Value)` with a default no-op implementation
- move shell-specific per-invocation approval logic out of `agent_loop` and into `ShellTool`
- replace the hardcoded `tc.name == "shell"` branch in `agent_loop` with a generic tool hook
- keep behavior: auto-approved shell still requires explicit approval for destructive commands
- add shell tests for command extraction and per-invocation approval behavior

## Why
Issue #94 calls out architecture drift: tool-specific approval logic was embedded in the main agent loop. This change keeps policy orchestration in the loop and tool-specific policy in tool implementations.

Closes #94

## Validation
- `cargo +1.92.0 test shell::tests:: -- --nocapture`
- `cargo +1.92.0 test agent::agent_loop -- --nocapture`
- `cargo +1.92.0 test --lib` (contains unrelated sandbox-permission failures in this environment; no failures from changed paths)
