### PR TITLE
feat: add compose-api worker image with libSQL backend

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,63 +1,90 @@
-# Multi-stage Dockerfile for the IronClaw worker container.
-#
-# This image runs the ironclaw binary in worker mode inside Docker containers.
-# The orchestrator creates instances of this image for sandboxed job execution.
-#
-# Build:
-#   docker build -f Dockerfile.worker -t ironclaw-worker .
-#
-# The image includes common development tools so workers can build software,
-# run tests, and execute shell commands.
+# IronClaw worker image for compose-api deployment.
+# Build: docker build -f ironclaw/Dockerfile.worker -t ironclaw-nearai-worker:local ironclaw/
 
-FROM rust:1.92-bookworm AS builder
+# ── Stage 1: Build IronClaw with libSQL ──────────────────────────────
+FROM rust:1.92-slim-bookworm AS builder
 
-WORKDIR /build
-COPY . .
-
-# Build only the ironclaw binary (release mode)
-RUN cargo build --release --bin ironclaw
-
-# ---
-
-FROM debian:bookworm-slim
-
-# Install common development tools
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    git \
-    build-essential \
-    pkg-config \
-    libssl-dev \
-    nodejs \
-    npm \
-    python3 \
-    python3-pip \
-    python3-venv \
+    pkg-config libssl-dev cmake gcc g++ make \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Rust toolchain for the sandbox user
-ENV RUSTUP_HOME=/usr/local/rustup \
-    CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.92.0 \
-    && chmod -R a+r /usr/local/rustup /usr/local/cargo
+WORKDIR /app
 
-# Install Claude Code CLI (for claude-bridge mode)
-RUN npm install -g @anthropic-ai/claude-code@latest
+# Copy manifests and build script for dependency caching
+COPY Cargo.toml Cargo.lock* build.rs ./
 
-# Copy the binary
-COPY --from=builder /build/target/release/ironclaw /usr/local/bin/ironclaw
+# Dummy main.rs and examples to cache dependencies
+RUN mkdir -p src examples && \
+    echo "fn main() {}" > src/main.rs && \
+    echo "fn main() {}" > examples/test_heartbeat.rs
+RUN cargo build --release --no-default-features --features libsql --bin ironclaw 2>/dev/null || true
+RUN rm -rf src examples
 
-# Create non-root user (UID 1000 matches the orchestrator's container config)
-RUN useradd -m -u 1000 -s /bin/bash sandbox \
-    && mkdir -p /workspace \
-    && chown sandbox:sandbox /workspace \
-    && mkdir -p /home/sandbox/.claude \
-    && chown sandbox:sandbox /home/sandbox/.claude
+# Bust cache for fresh code
+ARG CACHEBUST=0
+RUN echo "cachebust=$CACHEBUST"
 
-USER sandbox
-WORKDIR /workspace
+# Copy actual source and WIT files (needed by wasmtime::component::bindgen!)
+COPY src ./src
+COPY wit ./wit
 
-# The orchestrator passes the full command via Docker cmd.
-ENTRYPOINT ["ironclaw"]
+# Cargo.toml references examples/ which aren't in the Docker context; stub them out
+RUN mkdir -p examples && echo "fn main() {}" > examples/test_heartbeat.rs
+
+# Build the real binary
+RUN touch src/main.rs && \
+    cargo build --release --no-default-features --features libsql --bin ironclaw
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      openssh-server \
+      ca-certificates \
+      libssl3 \
+      curl \
+      git \
+      build-essential \
+      python3 \
+      jq \
+      procps \
+      vim \
+      less \
+      nano \
+      sudo \
+      login \
+      && apt-get clean \
+      && rm -rf /var/lib/apt/lists/*
+
+# Copy IronClaw binary
+COPY --from=builder /app/target/release/ironclaw /usr/local/bin/ironclaw
+
+# Create non-root user (UID 1001, matching OpenClaw worker pattern)
+RUN useradd -m -u 1001 -s /bin/bash agent && \
+    echo "agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/agent
+
+# Install Rust toolchain for agent user (available via SSH)
+USER agent
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+USER root
+
+# Configure SSH, directories, and agent environment
+RUN mkdir -p /home/agent/.ssh /home/agent/ssh /home/agent/.ironclaw /home/agent/workspace && \
+    ssh-keygen -t ed25519 -f /home/agent/ssh/ssh_host_ed25519_key -N "" && \
+    chmod 700 /home/agent/.ssh && \
+    printf '%s\n' '[ -n "$BASH_VERSION" ] && [ -f "$HOME/.bashrc" ] && . "$HOME/.bashrc"' > /home/agent/.profile && \
+    echo 'source "$HOME/.cargo/env"' >> /home/agent/.bashrc && \
+    chown -R agent:agent /home/agent
+
+# Copy entrypoint and workspace bootstrap files
+COPY worker/entrypoint.sh /app/entrypoint.sh
+COPY worker/workspace/ /app/workspace/
+RUN chmod +x /app/entrypoint.sh
+
+WORKDIR /home/agent
+
+# Expose gateway and SSH ports
+EXPOSE 18789 2222
+
+ENTRYPOINT ["/app/entrypoint.sh"]

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Security: Never log, echo, or print the values of these variables:
+# - NEARAI_API_KEY / NEARAI_SESSION_TOKEN
+# - OPENCLAW_GATEWAY_TOKEN
+# - SSH_PUBKEY
+#
+# WARNING: Do not enable debug mode (set -x) as it will expose all variable values.
+
+# Ensure volume mount points are writable by agent
+mkdir -p /home/agent/.ironclaw /home/agent/workspace
+chown -R agent:agent /home/agent/.ironclaw /home/agent/workspace
+
+# ============================================
+# SSH Server Configuration
+# ============================================
+if [ -n "${SSH_PUBKEY:-}" ]; then
+    echo "Configuring SSH authorized_keys..."
+    mkdir -p /home/agent/.ssh
+    echo "${SSH_PUBKEY}" > /home/agent/.ssh/authorized_keys
+    chmod 755 /home/agent
+    chmod 700 /home/agent/.ssh
+    chmod 600 /home/agent/.ssh/authorized_keys
+    chown -R agent:agent /home/agent/.ssh
+
+    mkdir -p /run/sshd
+    chmod 0755 /run/sshd
+
+    passwd -d agent 2>/dev/null || usermod -U agent 2>/dev/null || true
+
+    echo "Starting SSH daemon on port 2222..."
+    SSHD_OUTPUT=$(/usr/sbin/sshd -f /dev/null \
+        -o Port=2222 \
+        -o ListenAddress=0.0.0.0 \
+        -o HostKey=/home/agent/ssh/ssh_host_ed25519_key \
+        -o AuthorizedKeysFile=/home/agent/.ssh/authorized_keys \
+        -o PasswordAuthentication=no \
+        -o PermitRootLogin=no \
+        -o PidFile=/home/agent/ssh/sshd.pid \
+        -o StrictModes=yes 2>&1) && SSHD_RC=0 || SSHD_RC=$?
+    if [ "$SSHD_RC" -eq 0 ]; then
+        echo "SSH daemon started on port 2222"
+    else
+        echo "Warning: Failed to start SSH daemon (exit code: $SSHD_RC)" >&2
+        echo "SSHD output: $SSHD_OUTPUT" >&2
+    fi
+else
+    echo "Warning: SSH_PUBKEY not set - SSH access will not be available" >&2
+fi
+chown -R agent:agent /home/agent/.ssh 2>/dev/null || true
+
+# ============================================
+# IronClaw Configuration (env var mapping)
+# ============================================
+
+# Database: libSQL embedded (no external DB dependency)
+export DATABASE_BACKEND=libsql
+export LIBSQL_PATH=/home/agent/.ironclaw/ironclaw.db
+
+# Gateway: bind to all interfaces on port 18789 (matches compose port mapping)
+export GATEWAY_ENABLED=true
+export GATEWAY_HOST=0.0.0.0
+export GATEWAY_PORT=18789
+export GATEWAY_AUTH_TOKEN="${OPENCLAW_GATEWAY_TOKEN:-changeme}"
+
+# Disable interactive REPL (no TTY in container; would cause immediate shutdown)
+export CLI_ENABLED=false
+
+# NEAR AI: map compose-api env vars to IronClaw config
+NEARAI_API_URL="${NEARAI_API_URL:-https://cloud-api.near.ai/v1}"
+# Strip trailing /v1 — IronClaw's NEARAI_BASE_URL is the root (it adds /v1 internally)
+export NEARAI_BASE_URL="${NEARAI_API_URL%/v1}"
+
+# Map NEARAI_API_KEY to session token (IronClaw picks up NEARAI_SESSION_TOKEN
+# on startup and saves it to ~/.ironclaw/session.json)
+if [ -n "${NEARAI_API_KEY:-}" ]; then
+    export NEARAI_SESSION_TOKEN="${NEARAI_API_KEY}"
+else
+    echo "Warning: NEARAI_API_KEY not set. IronClaw may not function correctly." >&2
+fi
+
+export RUST_LOG="${RUST_LOG:-ironclaw=info}"
+
+# ============================================
+# Workspace Bootstrap
+# ============================================
+if [ -d /app/workspace ]; then
+    for f in /app/workspace/*.md; do
+        [ -f "$f" ] || continue
+        fname=$(basename "$f")
+        if [ ! -f "/home/agent/workspace/$fname" ]; then
+            cp "$f" "/home/agent/workspace/$fname"
+            chown agent:agent "/home/agent/workspace/$fname"
+            echo "Bootstrap file $fname installed to workspace"
+        fi
+    done
+fi
+
+# ============================================
+# Final Ownership Fix
+# ============================================
+chown -R agent:agent /home/agent/.ironclaw /home/agent/workspace
+
+# ============================================
+# Start IronClaw with auto-restart
+# ============================================
+RESTART_DELAY="${IRONCLAW_RESTART_DELAY:-5}"
+
+while true; do
+    echo "Starting IronClaw..."
+    chown -R agent:agent /home/agent/.ironclaw /home/agent/workspace 2>/dev/null || true
+    runuser -p -u agent -- ironclaw run --no-onboard || true
+    echo "IronClaw exited. Restarting in ${RESTART_DELAY}s..."
+    sleep "$RESTART_DELAY"
+done

--- a/worker/workspace/AGENTS.md
+++ b/worker/workspace/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md - Workspace Guide
+
+This is your workspace. Everything you need to persist lives here.
+
+## Memory
+
+You wake up fresh each session. Files are your only continuity.
+
+- **`MEMORY.md`** -- Your long-term memory. Curated decisions, lessons, and context worth keeping across sessions.
+
+### Rules
+
+- If you want to remember something, **write it to a file**. Mental notes don't survive restarts.
+- After meaningful sessions, create or update `MEMORY.md` with key facts, decisions, and context worth keeping.
+- When you learn a lesson -- update AGENTS.md or the relevant file.
+- Remove outdated info from MEMORY.md when it's no longer relevant.
+
+## Safety
+
+- Don't exfiltrate private data. Ever.
+- Don't run destructive commands without asking. `trash` > `rm`.
+- Be careful with anything that leaves the machine (network requests to unknown hosts, posting to APIs).
+- When in doubt, ask.
+
+## Task Execution
+
+You receive tasks through the gateway. For each task:
+
+1. **Understand** -- Read the full request before acting. Ask clarifying questions if the intent is ambiguous.
+2. **Plan** -- For complex tasks, break into steps. State your plan before executing.
+3. **Execute** -- Use the right tools. Chain calls when needed. Don't stop after one step if more are required.
+4. **Verify** -- Check your work. Run the code, test the output, confirm the result matches the request.
+5. **Report** -- Always respond to the user when done. Lead with the result. Never finish a task silently.
+
+## Make It Yours
+
+This file is a starting point. As you learn what works, update it.

--- a/worker/workspace/IDENTITY.md
+++ b/worker/workspace/IDENTITY.md
@@ -1,0 +1,9 @@
+# IDENTITY.md
+
+- **Name:** Assistant
+- **Creature:** AI assistant
+- **Vibe:** Precise, resourceful, direct
+
+---
+
+_Update this file as your identity evolves._

--- a/worker/workspace/SOUL.md
+++ b/worker/workspace/SOUL.md
@@ -1,0 +1,27 @@
+# SOUL.md
+
+You are a world-class AI assistant. You help users with any task -- coding, research, analysis, writing, problem-solving, and more. Be precise, thorough, and proactive.
+
+## Core Truths
+
+**Have opinions.** You're allowed to disagree, prefer things, find stuff amusing or boring. An assistant with no personality is just a search engine with extra steps.
+
+**Earn trust through competence.** Be careful with external actions (anything that leaves the machine). Be bold with internal ones (reading, organizing, learning, building).
+
+**Be resourceful before asking.** Try to figure it out. Read the file. Check the context. Search for it. _Then_ ask if you're stuck. Come back with answers, not questions.
+
+**Finish the job.** If a task requires multiple steps, do all of them. Don't stop early and wait for the user to say "continue."
+
+## Communication Style
+
+- Lead with the answer. Provide the result first, then explain your reasoning if it adds value.
+- Adapt tone to the user -- technical for developers, clear and simple for everyone else.
+- When uncertain about intent, ask rather than guess wrong.
+
+## Continuity
+
+Each session, you wake up fresh. The files in this workspace _are_ your memory. Read them. Update them. They're how you persist.
+
+---
+
+_This file is yours to evolve. As you learn who you are, update it._

--- a/worker/workspace/USER.md
+++ b/worker/workspace/USER.md
@@ -1,0 +1,16 @@
+# USER.md - About Your Human
+
+_Learn about the person you're helping. Update this as you go._
+
+- **Name:**
+- **What to call them:**
+- **Timezone:**
+- **Notes:**
+
+## Context
+
+_(What do they care about? What projects are they working on? What annoys them? Build this over time.)_
+
+---
+
+The more you know, the better you can help. But remember -- you're learning about a person, not building a dossier. Respect the difference.


### PR DESCRIPTION
## Summary
- Rewrites `Dockerfile.worker` as a multi-stage build that compiles IronClaw with `--features libsql` for embedded SQLite, eliminating external DB dependency
- Adds `worker/entrypoint.sh` that maps compose-api env vars (`NEARAI_API_KEY`, `OPENCLAW_GATEWAY_TOKEN`, etc.) to IronClaw config, sets up SSH on port 2222, and auto-restarts the process
- Adds default workspace bootstrap files (`AGENTS.md`, `SOUL.md`, `IDENTITY.md`, `USER.md`) matching the OpenClaw worker pattern

## Test plan
- [x] `docker build -f Dockerfile.worker -t ironclaw-nearai-worker:local .` succeeds
- [x] Container starts, gateway responds on port 18789 with IronClaw web UI
- [x] Healthcheck passes (`curl -fsS http://localhost:18789/`)
- [x] `CLI_ENABLED=false` prevents REPL EOF crash in headless mode
- [x] End-to-end: compose-api creates IronClaw instance via `service_type=ironclaw`, SSE stream shows full lifecycle through to "ready"