### PR TITLE
fix(rig): prevent OpenAI Responses API panic on tool call IDs

### DIFF
--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -580,7 +580,10 @@ mod tests {
         // Extract the generated call_id from the tool result
         let tool_result_call_id = match &history[1] {
             RigMessage::User { content } => match content.first() {
-                UserContent::ToolResult(r) => r.call_id.clone().unwrap_or_default(),
+                UserContent::ToolResult(r) => r
+                    .call_id
+                    .clone()
+                    .expect("tool result call_id must be present"),
                 other => panic!("Expected ToolResult, got: {:?}", other),
             },
             other => panic!("Expected User message, got: {:?}", other),


### PR DESCRIPTION
## Error

```
 thread 'main' (93563) panicked at /home/lwlee2608/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rig-core-0.30.0/src/providers/openai/responses_api/
  mod.rs:415:54:
  The tool call ID should exist!
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
  ```

## Summary
- normalize tool call IDs in the rig adapter so empty/missing IDs never propagate
- populate `call_id` for assistant tool calls and tool results when converting to rig-core messages
- add regression tests for call ID propagation and fallback generation

## Root cause
`rig-core` OpenAI Responses integration expects tool call IDs (`call_id`) to exist. The adapter emitted `call_id: None` and could produce empty IDs via `unwrap_or_default()`, which caused a panic in responses_api (`The tool call ID should exist!`).

## Testing
- `cargo test -q rig_adapter::tests`
