### PR TITLE
feat: add OpenRouter usage examples

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,13 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BASE_URL=http://localhost:1234/v1
 # LLM_API_KEY=sk-...                        # optional for local servers
 
+# === OpenRouter (via OpenAI-compatible) ===
+# LLM_MODEL=anthropic/claude-sonnet-4
+# LLM_BACKEND=openai_compatible
+# LLM_BASE_URL=https://openrouter.ai/api/v1
+# LLM_API_KEY=sk-or-...
+
+
 # Channel Configuration
 # CLI is always enabled
 


### PR DESCRIPTION
Add OpenRouter as a named preset/example when the user selects "OpenAI-compatible endpoint", pre-filling the base URL and suggesting a default model