### PR TITLE
Feature/support custom http headers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,12 +25,18 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BACKEND=openai_compatible
 # LLM_BASE_URL=http://localhost:1234/v1
 # LLM_API_KEY=sk-...                        # optional for local servers
+# Custom HTTP headers for OpenAI-compatible providers
+# Format: comma-separated key:value pairs
+# LLM_EXTRA_HEADERS=HTTP-Referer:https://github.com/nearai/ironclaw,X-Title:ironclaw
 
 # === OpenRouter (via OpenAI-compatible) ===
 # LLM_MODEL=anthropic/claude-sonnet-4
 # LLM_BACKEND=openai_compatible
 # LLM_BASE_URL=https://openrouter.ai/api/v1
 # LLM_API_KEY=sk-or-...
+# Custom HTTP headers for OpenRouter provider
+# Format: comma-separated key:value pairs
+# LLM_EXTRA_HEADERS=HTTP-Referer:https://github.com/nearai/ironclaw,X-Title:ironclaw
 
 
 # Channel Configuration


### PR DESCRIPTION
Some OpenAI-compatible providers (notably OpenRouter) recommend or require custom HTTP headers for attribution:

HTTP-Referer -- identifies the calling application
X-Title -- application name shown in provider dashboards