### PR TITLE
Fix(docs): replace incorrect settings.toml path with accurate storage description

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,8 +139,9 @@ ironclaw onboard
 ```
 
 The wizard handles database connection, NEAR AI authentication (via browser OAuth),
-and secrets encryption (using your system keychain). All settings are saved to
-`~/.ironclaw/settings.toml`.
+and secrets encryption (using your system keychain). Settings are persisted in the
+connected database; bootstrap variables (e.g. `DATABASE_URL`, `LLM_BACKEND`) are
+written to `~/.ironclaw/.env` so they are available before the database connects.
 
 ## Security
 


### PR DESCRIPTION
  - README stated settings are saved to ~/.ironclaw/settings.toml — this file is never created by ironclaw
  - Settings are actually persisted in the connected database (postgres or libsql); bootstrap vars like DATABASE_URL and LLM_BACKEND go to
  ~/.ironclaw/.env
  - Fixes confusion reported in #187 where users couldn't find their config after onboarding