### PR TITLE
style: fix rustfmt and clippy issues in llm module

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -99,13 +99,12 @@ fn create_openai_provider(config: &LlmConfig) -> Result<Arc<dyn LlmProvider>, Ll
     // (Responses API). The Responses API path in rig-core panics when tool results
     // are sent back because ironclaw doesn't thread `call_id` through its ToolCall
     // type. The Chat Completions API works correctly with the existing code.
-    let client: openai::CompletionsClient =
-        openai::Client::new(oai.api_key.expose_secret())
-            .map_err(|e| LlmError::RequestFailed {
-                provider: "openai".to_string(),
-                reason: format!("Failed to create OpenAI client: {}", e),
-            })?
-            .completions_api();
+    let client: openai::CompletionsClient = openai::Client::new(oai.api_key.expose_secret())
+        .map_err(|e| LlmError::RequestFailed {
+            provider: "openai".to_string(),
+            reason: format!("Failed to create OpenAI client: {}", e),
+        })?
+        .completions_api();
 
     let model = client.completion_model(&oai.model);
     tracing::info!("Using OpenAI direct API (model: {})", oai.model);

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -113,10 +113,7 @@ fn normalize_schema_recursive(schema: &mut JsonValue) {
     }
 
     // Force additionalProperties: false (overwrite any existing value)
-    obj.insert(
-        "additionalProperties".to_string(),
-        JsonValue::Bool(false),
-    );
+    obj.insert("additionalProperties".to_string(), JsonValue::Bool(false));
 
     // Ensure "properties" exists
     if !obj.contains_key("properties") {
@@ -157,19 +154,16 @@ fn normalize_schema_recursive(schema: &mut JsonValue) {
                 normalize_schema_recursive(prop_schema);
             }
             // Then make originally-optional properties nullable
-            if !current_required.contains(key) {
-                if let Some(prop_schema) = props.get_mut(key) {
-                    make_nullable(prop_schema);
-                }
+            if !current_required.contains(key)
+                && let Some(prop_schema) = props.get_mut(key)
+            {
+                make_nullable(prop_schema);
             }
         }
     }
 
     // Set required to ALL property keys
-    let required_value: Vec<JsonValue> = all_keys
-        .into_iter()
-        .map(JsonValue::String)
-        .collect();
+    let required_value: Vec<JsonValue> = all_keys.into_iter().map(JsonValue::String).collect();
     obj.insert("required".to_string(), JsonValue::Array(required_value));
 }
 
@@ -188,10 +182,7 @@ fn make_nullable(schema: &mut JsonValue) {
         match type_val {
             // "type": "string" → "type": ["string", "null"]
             JsonValue::String(ref t) if t != "null" => {
-                obj.insert(
-                    "type".to_string(),
-                    serde_json::json!([t, "null"]),
-                );
+                obj.insert("type".to_string(), serde_json::json!([t, "null"]));
             }
             // "type": ["string", "integer"] → add "null" if missing
             JsonValue::Array(ref arr) => {


### PR DESCRIPTION
## Summary

Fix formatting and lint issues that cause the CI Code Style check to fail:

- **src/llm/mod.rs**: Fix method chain indentation for OpenAI client creation
- **src/llm/rig_adapter.rs**: Collapse multi-line single-expression statements (3 occurrences), fix collapsible_if clippy warning using if-let chaining

## Motivation

These issues cause the CI Code Style check to fail on every PR targeting main. This fix unblocks CI for other pending PRs.

## Test plan

- [x] cargo fmt passes
- [x] cargo clippy passes
- [x] No functional changes