### PR TITLE
feat: add OpenRouter preset to setup wizard

### DIFF
--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1259,9 +1259,11 @@ mod tests {
         let from_db = Settings::from_db_map(&db_map);
 
         // Step 1 of the new wizard run: user enters a NEW database_url
-        let mut step1_settings = Settings::default();
-        step1_settings.database_backend = Some("postgres".to_string());
-        step1_settings.database_url = Some("postgres://new-host/ironclaw".to_string());
+        let step1_settings = Settings {
+            database_backend: Some("postgres".to_string()),
+            database_url: Some("postgres://new-host/ironclaw".to_string()),
+            ..Settings::default()
+        };
 
         // Wizard flow: load DB → merge_from(step1_overrides)
         let mut current = step1_settings.clone();

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -172,14 +172,18 @@ env-var mode or skipped secrets.
 | Anthropic | API key | `anthropic_api_key` | `ANTHROPIC_API_KEY` |
 | OpenAI | API key | `openai_api_key` | `OPENAI_API_KEY` |
 | Ollama | None | - | - |
-| OpenRouter | API key | `llm_compatible_api_key` | `LLM_API_KEY` |
-| OpenAI-compatible | Optional API key | `llm_compatible_api_key` | `LLM_API_KEY` |
+| OpenRouter¹ | API key | `llm_compatible_api_key` | `LLM_API_KEY` |
+| OpenAI-compatible¹ | Optional API key | `llm_compatible_api_key` | `LLM_API_KEY` |
+
+¹ OpenRouter and OpenAI-compatible share the same secret name and env var because
+OpenRouter is stored as `llm_backend = "openai_compatible"` under the hood.
+Switching between them overwrites the same credential slot.
 
 **OpenRouter** (`setup_openrouter`):
 - Pre-configured OpenAI-compatible preset with base URL `https://openrouter.ai/api/v1`
-- Prompts for API key directly (inlined, not via `setup_api_key_provider()`) so the success message says "OpenRouter"
+- Delegates to `setup_api_key_provider()` with a display name override ("OpenRouter")
 - Sets `llm_backend = "openai_compatible"` and `openai_compatible_base_url` automatically
-- Clears `selected_model` so Step 4 can fetch models from OpenRouter's API
+- Clears `selected_model` so Step 4 prompts for a model name (manual text input, no API-based model fetching)
 
 **API-key providers** (`setup_api_key_provider`):
 1. Check env var → if set, ask to reuse, persist to secrets store


### PR DESCRIPTION
## Summary
- Add OpenRouter as a top-level provider option in the onboarding wizard (Step 3)
- Selecting it pre-fills the base URL (`https://openrouter.ai/api/v1`) and prompts for an API key
- Under the hood uses the existing `openai_compatible` backend — no new backend needed

## Changes
- `src/setup/wizard.rs`: Add OpenRouter as choice 4 in provider menu, add `setup_openrouter()` method
- `src/setup/README.md`: Document OpenRouter provider in Step 3 spec

## Test plan
- [x] `cargo test --lib` — all 1271 tests pass
- [x] `cargo check` / `cargo check --no-default-features --features libsql` / `cargo check --all-features`
- [x] `cargo fmt --check` / `cargo clippy --all --all-features`
- [ ] Manual: run `cargo run -- onboard` and verify OpenRouter appears as option 5 with correct base URL

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)