### PR TITLE
refactor: remove ExtensionSource::Bundled, download-only WASM channel install

### DIFF
--- a/src/extensions/discovery.rs
+++ b/src/extensions/discovery.rs
@@ -246,7 +246,6 @@ fn extract_url(source: &ExtensionSource) -> String {
         ExtensionSource::Discovered { url } => url.clone(),
         ExtensionSource::WasmDownload { wasm_url, .. } => wasm_url.clone(),
         ExtensionSource::WasmBuildable { repo_url, .. } => repo_url.clone(),
-        ExtensionSource::Bundled { name } => name.clone(),
     }
 }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -521,9 +521,6 @@ impl ExtensionManager {
                         entry.name, entry.name
                     )))
                 }
-                ExtensionSource::Bundled { name } => {
-                    self.install_bundled_channel_from_artifacts(name).await
-                }
                 _ => Err(ExtensionError::InstallFailed(
                     "WASM channel entry has no download URL".to_string(),
                 )),
@@ -827,39 +824,6 @@ impl ExtensionManager {
         }
 
         Ok(())
-    }
-
-    async fn install_bundled_channel_from_artifacts(
-        &self,
-        name: &str,
-    ) -> Result<InstallResult, ExtensionError> {
-        // Check if already installed
-        let channel_wasm = self.wasm_channels_dir.join(format!("{}.wasm", name));
-        if channel_wasm.exists() {
-            return Err(ExtensionError::AlreadyInstalled(name.to_string()));
-        }
-
-        crate::channels::wasm::install_bundled_channel(name, &self.wasm_channels_dir, false)
-            .await
-            .map_err(ExtensionError::InstallFailed)?;
-
-        tracing::info!(
-            "Installed bundled channel '{}' to {}",
-            name,
-            self.wasm_channels_dir.display()
-        );
-
-        Ok(InstallResult {
-            name: name.to_string(),
-            kind: ExtensionKind::WasmChannel,
-            message: format!(
-                "Channel '{}' installed to {}. Restart IronClaw for the channel to activate. \
-                 Run tool_auth('{}') to configure authentication before restarting.",
-                name,
-                self.wasm_channels_dir.display(),
-                name,
-            ),
-        })
     }
 
     async fn auth_mcp(

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -85,11 +85,6 @@ pub enum ExtensionSource {
     },
     /// Discovered online (not yet validated for a specific source type).
     Discovered { url: String },
-    /// Bundled with the application (pre-built WASM, copied from build artifacts).
-    Bundled {
-        /// Channel or tool name used to locate build artifacts.
-        name: String,
-    },
 }
 
 /// Hint about what authentication method is needed.

--- a/src/extensions/registry.rs
+++ b/src/extensions/registry.rs
@@ -380,72 +380,9 @@ fn builtin_entries() -> Vec<RegistryEntry> {
             },
             auth_hint: AuthHint::Dcr,
         },
-        // -- WASM Channels (bundled) --
-        RegistryEntry {
-            name: "telegram".to_string(),
-            display_name: "Telegram".to_string(),
-            kind: ExtensionKind::WasmChannel,
-            description: "Telegram Bot API channel for receiving and sending messages via Telegram"
-                .to_string(),
-            keywords: vec![
-                "chat".into(),
-                "messaging".into(),
-                "bot".into(),
-                "channel".into(),
-            ],
-            source: ExtensionSource::Bundled {
-                name: "telegram".to_string(),
-            },
-            auth_hint: AuthHint::CapabilitiesAuth,
-        },
-        RegistryEntry {
-            name: "slack".to_string(),
-            display_name: "Slack".to_string(),
-            kind: ExtensionKind::WasmChannel,
-            description: "Slack Events API channel for receiving and sending messages via Slack"
-                .to_string(),
-            keywords: vec![
-                "chat".into(),
-                "messaging".into(),
-                "team".into(),
-                "channel".into(),
-            ],
-            source: ExtensionSource::Bundled {
-                name: "slack".to_string(),
-            },
-            auth_hint: AuthHint::CapabilitiesAuth,
-        },
-        RegistryEntry {
-            name: "discord".to_string(),
-            display_name: "Discord".to_string(),
-            kind: ExtensionKind::WasmChannel,
-            description:
-                "Discord Gateway channel for handling slash commands, buttons, and messages"
-                    .to_string(),
-            keywords: vec![
-                "chat".into(),
-                "messaging".into(),
-                "gaming".into(),
-                "channel".into(),
-            ],
-            source: ExtensionSource::Bundled {
-                name: "discord".to_string(),
-            },
-            auth_hint: AuthHint::CapabilitiesAuth,
-        },
-        RegistryEntry {
-            name: "whatsapp".to_string(),
-            display_name: "WhatsApp".to_string(),
-            kind: ExtensionKind::WasmChannel,
-            description:
-                "WhatsApp Business API channel for receiving and sending WhatsApp messages"
-                    .to_string(),
-            keywords: vec!["chat".into(), "messaging".into(), "channel".into()],
-            source: ExtensionSource::Bundled {
-                name: "whatsapp".to_string(),
-            },
-            auth_hint: AuthHint::CapabilitiesAuth,
-        },
+        // WASM channels (telegram, slack, discord, whatsapp) come from the embedded
+        // registry catalog (registry/channels/*.json) with WasmDownload URLs pointing
+        // to GitHub release artifacts. See new_with_catalog() for merging.
     ]
 }
 
@@ -701,46 +638,6 @@ mod tests {
         assert_eq!(entry.unwrap().display_name, "Slack MCP");
     }
 
-    #[tokio::test]
-    async fn test_search_finds_telegram_channel() {
-        let registry = ExtensionRegistry::new();
-        let results = registry.search("telegram").await;
-
-        assert!(!results.is_empty(), "Should find telegram in registry");
-        assert_eq!(results[0].entry.name, "telegram");
-        assert_eq!(results[0].entry.kind, ExtensionKind::WasmChannel);
-    }
-
-    #[tokio::test]
-    async fn test_search_channel_by_keyword() {
-        let registry = ExtensionRegistry::new();
-        let results = registry.search("bot messaging").await;
-
-        let has_telegram = results.iter().any(|r| r.entry.name == "telegram");
-        assert!(
-            has_telegram,
-            "Telegram should appear in bot messaging search"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_get_bundled_channels() {
-        let registry = ExtensionRegistry::new();
-
-        let telegram = registry.get("telegram").await;
-        assert!(telegram.is_some());
-        assert_eq!(telegram.unwrap().kind, ExtensionKind::WasmChannel);
-
-        let slack = registry.get("slack").await;
-        assert!(slack.is_some());
-        assert_eq!(slack.unwrap().kind, ExtensionKind::WasmChannel);
-
-        let discord = registry.get("discord").await;
-        assert!(discord.is_some());
-        assert_eq!(discord.unwrap().kind, ExtensionKind::WasmChannel);
-
-        let whatsapp = registry.get("whatsapp").await;
-        assert!(whatsapp.is_some());
-        assert_eq!(whatsapp.unwrap().kind, ExtensionKind::WasmChannel);
-    }
+    // Channel tests (telegram, slack, discord, whatsapp) require the embedded catalog
+    // to be loaded via new_with_catalog(). See test_new_with_catalog for catalog coverage.
 }


### PR DESCRIPTION
## Summary
- Remove `ExtensionSource::Bundled` variant and its match arms across discovery, manager, and registry
- Remove `install_bundled_channel_from_artifacts` wrapper from `ExtensionManager` — WASM channel install now goes directly through `install_wasm_channel_from_url` (download from GitHub releases)
- Remove hardcoded telegram/slack/discord/whatsapp entries from `builtin_entries()` — these now come from the embedded registry catalog (`registry/channels/*.json`) via `new_with_catalog()`
- Remove tests that depended on the bundled entries; catalog-based equivalents exist in `test_new_with_catalog`

## Test plan
- [x] `cargo clippy --all --all-features` passes with zero warnings
- [x] `cargo test` passes (registry tests, extension manager tests)
- [ ] Verify `tool_search("telegram")` still finds telegram via catalog entries
- [ ] Verify `tool_install("telegram")` downloads from GitHub releases URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)