### PR TITLE
Fix tool schema OpenAI compatibility

### DIFF
--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -571,8 +571,8 @@ mod tests {
         // compatibility. OpenAI rejects union types containing "array" unless
         // "items" is also specified, and body accepts any JSON value.
         assert!(
-            body.get("description").is_some(),
-            "body schema must have a description"
+            body.get("type").is_none(),
+            "body schema should not have a 'type' to be freeform for OpenAI compatibility"
         );
     }
 

--- a/src/tools/builtin/json.rs
+++ b/src/tools/builtin/json.rs
@@ -191,16 +191,19 @@ mod tests {
     }
 
     #[test]
-    fn test_json_tool_schema_data_has_type() {
+    fn test_json_tool_schema_data_is_freeform() {
         let schema = JsonTool.parameters_schema();
         let data = schema
             .get("properties")
             .and_then(|p| p.get("data"))
             .expect("data schema missing");
 
+        // Data is intentionally freeform (no "type" constraint) for OpenAI
+        // compatibility. OpenAI rejects union types containing "array" unless
+        // "items" is also specified.
         assert!(
-            data.get("type").is_some(),
-            "data schema must include a type for OpenAI-compatible tool validation"
+            data.get("type").is_none(),
+            "data schema should not have a 'type' to be freeform for OpenAI compatibility"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Remove union type arrays from `http` and `json` tool parameter schemas
- OpenAI rejects `"type": ["object", "array", ...]` when `"array"` is present but no `"items"` subschema is defined
- Replace with freeform (untyped) schemas -- OpenAI treats parameters without a `type` constraint as accepting any JSON value
- Fixes: `Invalid schema for function 'http': In context=('properties', 'body', 'type', '1'), array schema missing items.`

## Test plan

- [x] `cargo clippy --all --all-features` -- zero new warnings
- [x] `cargo test --lib -- http::tests` -- 32 passed
- [x] Manual: Chat no longer fails with "Invalid schema for function 'http'" error
- [x] Manual: LLM responds successfully through the web gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)