### PR TITLE
fix: block send until thread is selected

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -238,6 +238,7 @@ function sendMessage() {
   const sendBtn = document.getElementById('send-btn');
   if (!currentThreadId) {
     console.warn('sendMessage: no thread selected, ignoring');
+    setStatus('Waiting for thread to load...');
     return;
   }
   const content = input.value.trim();
@@ -262,6 +263,8 @@ function sendMessage() {
 }
 
 function enableChatInput() {
+  // Don't re-enable until a thread is selected (prevents orphan messages)
+  if (!currentThreadId) return;
   const input = document.getElementById('chat-input');
   const sendBtn = document.getElementById('send-btn');
   sendBtn.disabled = false;


### PR DESCRIPTION
## Summary
- Disable chat input and send button on page load
- Guard `sendMessage()` to early-return if `currentThreadId` is null
- Guard `enableChatInput()` to prevent SSE events from re-enabling input before a thread is loaded
- Enable input after `loadThreads()` resolves and selects a thread

## Problem
During page load, `currentThreadId` is null until `loadThreads()` resolves. If the user sends a message in that window, it creates an orphan thread. SSE event handlers (response, status:Done, auth_completed, error) also call `enableChatInput()` which could re-enable input prematurely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)