### PR TITLE
fix: reload chat history on SSE reconnect

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -9,6 +9,7 @@ let assistantThreadId = null;
 let hasMore = false;
 let oldestTimestamp = null;
 let loadingOlder = false;
+let sseHasConnectedBefore = false;
 let jobEvents = new Map(); // job_id -> Array of events
 let jobListRefreshTimer = null;
 const JOB_EVENTS_CAP = 500;
@@ -107,6 +108,10 @@ function connectSSE() {
   eventSource.onopen = () => {
     document.getElementById('sse-dot').classList.remove('disconnected');
     document.getElementById('sse-status').textContent = 'Connected';
+    if (sseHasConnectedBefore && currentThreadId) {
+      loadHistory();
+    }
+    sseHasConnectedBefore = true;
   };
 
   eventSource.onerror = () => {


### PR DESCRIPTION
## Summary
- Add `sseHasConnectedBefore` flag to track initial vs reconnection
- On SSE reconnect (not initial connect), reload chat history from DB if a thread is selected
- Debounces naturally: first `onopen` skips reload, subsequent ones trigger it

## Problem
When SSE auto-reconnects after a server restart, the chat UI doesn't re-sync from the database. Messages sent between the crash and reconnect appear lost until the user manually refreshes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)