### PR TITLE
Harden web auth: limit query-token auth to SSE endpoints

### DIFF
--- a/src/channels/web/auth.rs
+++ b/src/channels/web/auth.rs
@@ -2,7 +2,7 @@
 
 use axum::{
     extract::{Request, State},
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, Method, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -12,6 +12,33 @@ use subtle::ConstantTimeEq;
 #[derive(Clone)]
 pub struct AuthState {
     pub token: String,
+}
+
+/// Whether query-string token auth is allowed for this request.
+///
+/// Restricting query auth to SSE read endpoints minimizes token-in-URL exposure
+/// on state-changing routes.
+fn allows_query_token_auth(request: &Request) -> bool {
+    if request.method() != Method::GET {
+        return false;
+    }
+
+    matches!(
+        request.uri().path(),
+        "/api/chat/events" | "/api/logs/events"
+    )
+}
+
+/// Extract the `token` query parameter value, URL-decoded.
+fn query_token(request: &Request) -> Option<String> {
+    let query = request.uri().query()?;
+    url::form_urlencoded::parse(query.as_bytes()).find_map(|(k, v)| {
+        if k == "token" {
+            Some(v.into_owned())
+        } else {
+            None
+        }
+    })
 }
 
 /// Auth middleware that validates bearer token from header or query param.
@@ -33,15 +60,12 @@ pub async fn auth_middleware(
         return next.run(request).await;
     }
 
-    // Fall back to query parameter for SSE EventSource (constant-time comparison)
-    if let Some(query) = request.uri().query() {
-        for pair in query.split('&') {
-            if let Some(token) = pair.strip_prefix("token=")
-                && bool::from(token.as_bytes().ct_eq(auth.token.as_bytes()))
-            {
-                return next.run(request).await;
-            }
-        }
+    // Fall back to query parameter for SSE EventSource (constant-time comparison).
+    if allows_query_token_auth(&request)
+        && let Some(token) = query_token(&request)
+        && bool::from(token.as_bytes().ct_eq(auth.token.as_bytes()))
+    {
+        return next.run(request).await;
     }
 
     (StatusCode::UNAUTHORIZED, "Invalid or missing auth token").into_response()
@@ -50,6 +74,25 @@ pub async fn auth_middleware(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::{
+        Router, middleware,
+        routing::{get, post},
+    };
+    use tower::ServiceExt;
+
+    fn test_router(token: &str) -> Router {
+        Router::new()
+            .route("/api/chat/events", get(|| async { "ok" }))
+            .route("/api/logs/events", get(|| async { "ok" }))
+            .route("/api/chat/history", get(|| async { "ok" }))
+            .route("/api/chat/send", post(|| async { "ok" }))
+            .route_layer(middleware::from_fn_with_state(
+                AuthState {
+                    token: token.to_string(),
+                },
+                auth_middleware,
+            ))
+    }
 
     #[test]
     fn test_auth_state_clone() {
@@ -58,5 +101,68 @@ mod tests {
         };
         let cloned = state.clone();
         assert_eq!(cloned.token, "test-token");
+    }
+
+    #[tokio::test]
+    async fn query_token_allowed_for_chat_events_get() {
+        let app = test_router("test-token");
+        let req = axum::http::Request::builder()
+            .uri("/api/chat/events?token=test-token")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn query_token_allowed_for_logs_events_get() {
+        let app = test_router("test-token");
+        let req = axum::http::Request::builder()
+            .uri("/api/logs/events?token=test-token")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn query_token_rejected_for_non_sse_endpoint() {
+        let app = test_router("test-token");
+        let req = axum::http::Request::builder()
+            .uri("/api/chat/history?token=test-token")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn query_token_rejected_for_post_endpoint() {
+        let app = test_router("test-token");
+        let req = axum::http::Request::builder()
+            .method(Method::POST)
+            .uri("/api/chat/send?token=test-token")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn header_bearer_still_works_for_post() {
+        let app = test_router("test-token");
+        let req = axum::http::Request::builder()
+            .method(Method::POST)
+            .uri("/api/chat/send")
+            .header("authorization", "Bearer test-token")
+            .body(axum::body::Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
## Summary
- restrict query-string token auth to SSE GET routes only
- allow query token auth only for:
  - `/api/chat/events`
  - `/api/logs/events`
- keep `Authorization: Bearer` auth behavior unchanged for all protected routes
- parse query token via URL decoding (`url::form_urlencoded`) instead of raw string splitting
- add middleware tests for allowed and blocked auth paths/methods

## Security impact
Previously, `?token=` was accepted across all protected endpoints. If a token leaked from URL handling, it could be replayed against state-changing routes. This patch narrows URL token usage to EventSource-compatible SSE endpoints only.

## Validation
- Ran `cargo test channels::web::auth::tests -- --nocapture`
- Result: 6 passed, 0 failed

## Follow-up
- Consider adding a test that validates URL-decoded query tokens containing reserved characters (`%2B`, `%2F`, `%20`).
