### PR TITLE
feat(web): display logs newest-first in web gateway UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5033,6 +5033,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6207,6 +6213,7 @@ dependencies = [
  "getrandom 0.4.1",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/src/channels/web/log_layer.rs
+++ b/src/channels/web/log_layer.rs
@@ -90,6 +90,9 @@ impl LogBroadcaster {
     }
 
     /// Snapshot of recent entries for replaying to a new subscriber.
+    ///
+    /// Returns entries oldest-first so that the frontend's `prepend()`
+    /// naturally places the newest entry at the top of the DOM.
     pub fn recent_entries(&self) -> Vec<LogEntry> {
         self.recent
             .lock()

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -1105,7 +1105,7 @@ function connectLogSSE() {
       logBuffer.push(entry);
       return;
     }
-    appendLogEntry(entry);
+    prependLogEntry(entry);
   });
 
   logEventSource.onerror = () => {
@@ -1113,7 +1113,7 @@ function connectLogSSE() {
   };
 }
 
-function appendLogEntry(entry) {
+function prependLogEntry(entry) {
   const output = document.getElementById('logs-output');
 
   // Level filter
@@ -1154,16 +1154,16 @@ function appendLogEntry(entry) {
     div.style.display = 'none';
   }
 
-  output.appendChild(div);
+  output.prepend(div);
 
-  // Cap entries
+  // Cap entries (remove oldest at the bottom)
   while (output.children.length > LOG_MAX_ENTRIES) {
-    output.removeChild(output.firstChild);
+    output.removeChild(output.lastChild);
   }
 
-  // Auto-scroll
+  // Auto-scroll to top (newest entries are at the top)
   if (document.getElementById('logs-autoscroll').checked) {
-    output.scrollTop = output.scrollHeight;
+    output.scrollTop = 0;
   }
 }
 
@@ -1173,9 +1173,9 @@ function toggleLogsPause() {
   btn.textContent = logsPaused ? 'Resume' : 'Pause';
 
   if (!logsPaused) {
-    // Flush buffer
+    // Flush buffer: oldest-first + prepend naturally puts newest at top
     for (const entry of logBuffer) {
-      appendLogEntry(entry);
+      prependLogEntry(entry);
     }
     logBuffer = [];
   }


### PR DESCRIPTION
## Summary
- Reverse log display order in the web gateway so newest entries appear at the top, removing the need to scroll for latest activity
- Frontend: rename `appendLogEntry` → `prependLogEntry`, use `prepend()` for DOM insertion, cap oldest entries from the bottom, auto-scroll to top
- Backend: update `recent_entries()` doc comment to clarify the oldest-first return order (which works correctly with the frontend's prepend)

## Test plan
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test log_layer` — all 12 tests pass
- [ ] Manual: open web UI logs tab, verify new entries appear at top
- [ ] Manual: reload page, verify history replays newest-at-top
- [ ] Manual: pause/resume, verify buffered entries flush in correct order
- [ ] Manual: level/target filters still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)