### PR TITLE
feat: import OpenClaw data (memory, history, settings, credentials)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-util",
+ "json5",
  "libsql",
  "lru",
  "mime_guess",
@@ -2853,6 +2854,17 @@ checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96b0db21af676c1ce64250b5f40f3ce2cf27e4e47cb91ed91eb6fe9350b430c1"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "serde",
 ]
 
 [[package]]
@@ -3668,6 +3680,49 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
 
 [[package]]
 name = "pgvector"
@@ -6067,6 +6122,12 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,9 @@ aho-corasick = "1"
 # YAML parsing for SKILL.md frontmatter
 serde_yml = "0.0.12"
 
+# JSON5 parsing for OpenClaw config import
+json5 = "0.4"
+
 # Filesystem paths
 dirs = "6"
 fs4 = "0.6"

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,0 +1,120 @@
+//! CLI import subcommand.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use clap::Subcommand;
+
+use crate::db::Database;
+use crate::import::{
+    ImportError, OpenClawConfig, OpenClawImporter, OpenClawInstallation, TerminalProgress,
+};
+use crate::secrets::SecretsStore;
+use crate::workspace::Workspace;
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ImportCommand {
+    /// Import data from an OpenClaw installation
+    Openclaw {
+        /// Path to the OpenClaw state directory (default: ~/.openclaw)
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Show what would be imported without writing anything
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+/// Run an import command with pre-existing database and workspace handles.
+pub async fn run_import_command_with_db(
+    cmd: ImportCommand,
+    db: Arc<dyn Database>,
+    workspace: Option<Workspace>,
+    secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+) -> anyhow::Result<()> {
+    match cmd {
+        ImportCommand::Openclaw { path, dry_run } => {
+            run_openclaw_import(path, dry_run, db, workspace, secrets_store).await
+        }
+    }
+}
+
+async fn run_openclaw_import(
+    path: Option<PathBuf>,
+    dry_run: bool,
+    db: Arc<dyn Database>,
+    workspace: Option<Workspace>,
+    secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+) -> anyhow::Result<()> {
+    // Discover installation
+    let installation = OpenClawInstallation::discover(path.as_deref()).map_err(|e| match e {
+        ImportError::NotFound => {
+            anyhow::anyhow!("No OpenClaw installation found. Use --path to specify the location.")
+        }
+        other => anyhow::anyhow!("{}", other),
+    })?;
+
+    println!(
+        "Found OpenClaw installation at {}",
+        installation.state_dir.display()
+    );
+    println!(
+        "  Config: {}",
+        if installation.config_file.is_file() {
+            installation.config_file.display().to_string()
+        } else {
+            "(not found)".to_string()
+        }
+    );
+    println!("  Identity files: {}", installation.identity_files.len());
+    println!("  Memory files: {}", installation.memory_files.len());
+    println!(
+        "  Session dirs: {} (with {} .jsonl files)",
+        installation.session_dirs.len(),
+        installation
+            .session_dirs
+            .iter()
+            .map(|s| s.jsonl_files.len())
+            .sum::<usize>()
+    );
+    println!(
+        "  OAuth file: {}",
+        if installation.oauth_file.is_some() {
+            "found"
+        } else {
+            "not found"
+        }
+    );
+    println!();
+
+    if dry_run {
+        println!("Dry run mode: no data will be written.");
+        println!();
+    }
+
+    // Parse config
+    let config = OpenClawConfig::parse(
+        &installation.config_file,
+        installation.oauth_file.as_deref(),
+    )
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    // Run import
+    let importer = OpenClawImporter::new(installation, config, dry_run);
+    let mut progress = TerminalProgress::new();
+
+    let report = importer
+        .run(
+            &db,
+            workspace.as_ref(),
+            secrets_store.as_ref(),
+            &mut progress,
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    report.print_summary();
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@
 mod completion;
 mod config;
 mod doctor;
+mod import;
 mod mcp;
 pub mod memory;
 pub mod oauth_defaults;
@@ -26,6 +27,7 @@ mod tool;
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
+pub use import::{ImportCommand, run_import_command_with_db};
 pub use mcp::{McpCommand, run_mcp_command};
 pub use memory::MemoryCommand;
 #[cfg(feature = "postgres")]
@@ -113,6 +115,10 @@ pub enum Command {
     /// Manage OS service (launchd / systemd)
     #[command(subcommand)]
     Service(ServiceCommand),
+
+    /// Import data from another personal AI assistant
+    #[command(subcommand)]
+    Import(ImportCommand),
 
     /// Probe external dependencies and validate configuration
     Doctor,

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -46,6 +46,13 @@ impl PgBackend {
         Ok(Self { store, repo })
     }
 
+    /// Create a new PostgreSQL backend from an existing connection pool.
+    pub fn from_pool(pool: Pool) -> Self {
+        let store = Store::from_pool(pool.clone());
+        let repo = Repository::new(pool);
+        Self { store, repo }
+    }
+
     /// Get a clone of the connection pool.
     ///
     /// Useful for sharing with components that still need raw pool access.

--- a/src/import/config_parser.rs
+++ b/src/import/config_parser.rs
@@ -1,0 +1,312 @@
+//! OpenClaw configuration parsing.
+//!
+//! Parses OpenClaw's JSON5 config file and OAuth credentials, mapping
+//! known keys to IronClaw settings and extracting API credentials.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::import::ImportError;
+
+/// A credential extracted from the OpenClaw config or OAuth file.
+#[derive(Debug, Clone)]
+pub struct CredentialEntry {
+    /// Secret name (e.g., `openai_api_key`).
+    pub name: String,
+    /// Plaintext value.
+    pub value: String,
+    /// Optional provider hint (e.g., `openai`, `anthropic`).
+    pub provider: Option<String>,
+}
+
+/// Parsed OpenClaw configuration.
+#[derive(Debug)]
+pub struct OpenClawConfig {
+    /// The raw parsed JSON value.
+    pub raw: serde_json::Value,
+    /// Settings mapped to IronClaw dotted keys.
+    pub mapped_settings: HashMap<String, serde_json::Value>,
+    /// Extracted credentials (API keys, OAuth tokens).
+    pub credentials: Vec<CredentialEntry>,
+}
+
+impl OpenClawConfig {
+    /// Parse the OpenClaw config file and optional OAuth credentials.
+    pub fn parse(config_path: &Path, oauth_path: Option<&Path>) -> Result<Self, ImportError> {
+        let mut mapped_settings = HashMap::new();
+        let mut credentials = Vec::new();
+
+        // Parse config (JSON5 allows comments and trailing commas)
+        let raw = if config_path.is_file() {
+            let content = std::fs::read_to_string(config_path)?;
+            let val: serde_json::Value = json5::from_str(&content).map_err(|e| {
+                ImportError::ConfigParse(format!("{}: {}", config_path.display(), e))
+            })?;
+            Self::map_settings(&val, &mut mapped_settings);
+            Self::extract_credentials(&val, &mut credentials);
+            val
+        } else {
+            serde_json::Value::Object(serde_json::Map::new())
+        };
+
+        // Parse OAuth tokens
+        if let Some(oauth_path) = oauth_path
+            && oauth_path.is_file()
+            && let Err(e) = Self::parse_oauth(oauth_path, &mut credentials)
+        {
+            tracing::warn!("Failed to parse OAuth file: {}", e);
+        }
+
+        Ok(Self {
+            raw,
+            mapped_settings,
+            credentials,
+        })
+    }
+
+    /// Map known OpenClaw config keys to IronClaw settings.
+    fn map_settings(val: &serde_json::Value, settings: &mut HashMap<String, serde_json::Value>) {
+        // agents.defaults.provider -> llm_backend
+        if let Some(provider) = val
+            .pointer("/agents/defaults/provider")
+            .and_then(|v| v.as_str())
+        {
+            let backend = match provider.to_lowercase().as_str() {
+                "openai" | "gpt" => "openai",
+                "anthropic" | "claude" => "anthropic",
+                "ollama" => "ollama",
+                "nearai" | "near" => "nearai",
+                _ => provider,
+            };
+            settings.insert(
+                "llm_backend".to_string(),
+                serde_json::Value::String(backend.to_string()),
+            );
+        }
+
+        // agents.defaults.model -> selected_model
+        if let Some(model) = val
+            .pointer("/agents/defaults/model")
+            .and_then(|v| v.as_str())
+        {
+            settings.insert(
+                "selected_model".to_string(),
+                serde_json::Value::String(model.to_string()),
+            );
+        }
+
+        // agents.defaults.memorySearch.provider -> embeddings.provider
+        if let Some(emb_provider) = val
+            .pointer("/agents/defaults/memorySearch/provider")
+            .and_then(|v| v.as_str())
+        {
+            settings.insert(
+                "embeddings.provider".to_string(),
+                serde_json::Value::String(emb_provider.to_string()),
+            );
+        }
+
+        // agents.defaults.memorySearch.model -> embeddings.model
+        if let Some(emb_model) = val
+            .pointer("/agents/defaults/memorySearch/model")
+            .and_then(|v| v.as_str())
+        {
+            settings.insert(
+                "embeddings.model".to_string(),
+                serde_json::Value::String(emb_model.to_string()),
+            );
+        }
+    }
+
+    /// Extract API keys from auth.profiles where mode == "api_key".
+    fn extract_credentials(val: &serde_json::Value, credentials: &mut Vec<CredentialEntry>) {
+        let Some(profiles) = val.pointer("/auth/profiles").and_then(|v| v.as_object()) else {
+            return;
+        };
+
+        for (profile_id, profile) in profiles {
+            let mode = profile.get("mode").and_then(|v| v.as_str()).unwrap_or("");
+            let provider = profile
+                .get("provider")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            if mode == "api_key" {
+                // Look for the key in common field names
+                let key_value = profile
+                    .get("apiKey")
+                    .or_else(|| profile.get("api_key"))
+                    .or_else(|| profile.get("key"))
+                    .and_then(|v| v.as_str());
+
+                if let Some(key) = key_value {
+                    let name = if let Some(ref p) = provider {
+                        format!("{}_api_key", p.to_lowercase())
+                    } else {
+                        format!("{}_api_key", profile_id.to_lowercase())
+                    };
+
+                    credentials.push(CredentialEntry {
+                        name,
+                        value: key.to_string(),
+                        provider,
+                    });
+                }
+            }
+        }
+    }
+
+    /// Parse OAuth tokens from the credentials/oauth.json file.
+    fn parse_oauth(
+        oauth_path: &Path,
+        credentials: &mut Vec<CredentialEntry>,
+    ) -> Result<(), ImportError> {
+        let content = std::fs::read_to_string(oauth_path)?;
+        let val: serde_json::Value = serde_json::from_str(&content)
+            .map_err(|e| ImportError::ConfigParse(format!("oauth.json: {}", e)))?;
+
+        // OAuth file is typically { "provider_name": { "access_token": "...", ... } }
+        let Some(obj) = val.as_object() else {
+            return Ok(());
+        };
+
+        for (provider, tokens) in obj {
+            if let Some(token) = tokens
+                .get("access_token")
+                .or_else(|| tokens.get("token"))
+                .and_then(|v| v.as_str())
+            {
+                credentials.push(CredentialEntry {
+                    name: format!("{}_oauth_token", provider.to_lowercase()),
+                    value: token.to_string(),
+                    provider: Some(provider.clone()),
+                });
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_json5_config_with_comments() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("openclaw.json");
+
+        // JSON5 with comments and trailing commas
+        std::fs::write(
+            &config_path,
+            r#"{
+                // Main config
+                "auth": {
+                    "profiles": {
+                        "main": {
+                            "provider": "openai",
+                            "mode": "api_key",
+                            "apiKey": "sk-test-12345",
+                        },
+                    },
+                },
+                "agents": {
+                    "defaults": {
+                        "provider": "openai",
+                        "model": "gpt-4o",
+                        "memorySearch": {
+                            "provider": "openai",
+                            "model": "text-embedding-3-small",
+                        },
+                    },
+                },
+            }"#,
+        )
+        .unwrap();
+
+        let config = OpenClawConfig::parse(&config_path, None).unwrap();
+
+        // Check mapped settings
+        assert_eq!(
+            config.mapped_settings.get("llm_backend"),
+            Some(&serde_json::Value::String("openai".to_string()))
+        );
+        assert_eq!(
+            config.mapped_settings.get("selected_model"),
+            Some(&serde_json::Value::String("gpt-4o".to_string()))
+        );
+        assert_eq!(
+            config.mapped_settings.get("embeddings.provider"),
+            Some(&serde_json::Value::String("openai".to_string()))
+        );
+        assert_eq!(
+            config.mapped_settings.get("embeddings.model"),
+            Some(&serde_json::Value::String(
+                "text-embedding-3-small".to_string()
+            ))
+        );
+
+        // Check credentials
+        assert_eq!(config.credentials.len(), 1);
+        assert_eq!(config.credentials[0].name, "openai_api_key");
+        assert_eq!(config.credentials[0].value, "sk-test-12345");
+    }
+
+    #[test]
+    fn parse_oauth_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("openclaw.json");
+        let oauth_path = tmp.path().join("oauth.json");
+
+        std::fs::write(&config_path, "{}").unwrap();
+        std::fs::write(
+            &oauth_path,
+            r#"{
+                "github": {"access_token": "ghp_test123"},
+                "google": {"access_token": "ya29.test456"}
+            }"#,
+        )
+        .unwrap();
+
+        let config = OpenClawConfig::parse(&config_path, Some(&oauth_path)).unwrap();
+
+        assert_eq!(config.credentials.len(), 2);
+        let names: Vec<&str> = config.credentials.iter().map(|c| c.name.as_str()).collect();
+        assert!(names.contains(&"github_oauth_token"));
+        assert!(names.contains(&"google_oauth_token"));
+    }
+
+    #[test]
+    fn parse_missing_config_returns_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("nonexistent.json");
+
+        let config = OpenClawConfig::parse(&config_path, None).unwrap();
+        assert!(config.mapped_settings.is_empty());
+        assert!(config.credentials.is_empty());
+    }
+
+    #[test]
+    fn parse_various_content_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let config_path = tmp.path().join("openclaw.json");
+
+        // Empty object
+        std::fs::write(&config_path, "{}").unwrap();
+        let config = OpenClawConfig::parse(&config_path, None).unwrap();
+        assert!(config.mapped_settings.is_empty());
+
+        // Anthropic provider mapping
+        std::fs::write(
+            &config_path,
+            r#"{"agents": {"defaults": {"provider": "claude"}}}"#,
+        )
+        .unwrap();
+        let config = OpenClawConfig::parse(&config_path, None).unwrap();
+        assert_eq!(
+            config.mapped_settings.get("llm_backend"),
+            Some(&serde_json::Value::String("anthropic".to_string()))
+        );
+    }
+}

--- a/src/import/discovery.rs
+++ b/src/import/discovery.rs
@@ -1,0 +1,295 @@
+//! OpenClaw installation discovery.
+//!
+//! Scans well-known directories for OpenClaw (and legacy) installations,
+//! enumerating config files, workspace memory, session transcripts, and
+//! credential files.
+
+use std::path::{Path, PathBuf};
+
+use crate::import::ImportError;
+
+/// Names tried when looking for the state directory (in order).
+const STATE_DIR_NAMES: &[&str] = &[".openclaw", ".clawdbot", ".moldbot", ".moltbot"];
+
+/// Config file names tried inside the state directory (in order).
+const CONFIG_FILE_NAMES: &[&str] = &[
+    "openclaw.json",
+    "clawdbot.json",
+    "moldbot.json",
+    "moltbot.json",
+];
+
+/// Identity files we look for in the workspace root.
+const IDENTITY_FILE_NAMES: &[&str] = &[
+    "AGENTS.md",
+    "SOUL.md",
+    "IDENTITY.md",
+    "USER.md",
+    "HEARTBEAT.md",
+    "MEMORY.md",
+    "TOOLS.md",
+    "BOOTSTRAP.md",
+];
+
+/// Metadata about an agent's session directory.
+#[derive(Debug, Clone)]
+pub struct SessionDirInfo {
+    pub agent_id: String,
+    pub dir: PathBuf,
+    pub jsonl_files: Vec<PathBuf>,
+}
+
+/// A detected OpenClaw installation with all discoverable data paths.
+#[derive(Debug)]
+pub struct OpenClawInstallation {
+    /// Root state directory (e.g., `~/.openclaw`).
+    pub state_dir: PathBuf,
+    /// Config file path (e.g., `~/.openclaw/openclaw.json`).
+    pub config_file: PathBuf,
+    /// Workspace directory (e.g., `~/.openclaw/workspace/`).
+    pub workspace_dir: PathBuf,
+    /// Per-agent session directories with `.jsonl` files.
+    pub session_dirs: Vec<SessionDirInfo>,
+    /// Identity files found in the workspace root: `(filename, abs_path)`.
+    pub identity_files: Vec<(String, PathBuf)>,
+    /// Memory markdown files from `workspace/memory/`.
+    pub memory_files: Vec<PathBuf>,
+    /// OAuth credentials file, if present.
+    pub oauth_file: Option<PathBuf>,
+}
+
+impl OpenClawInstallation {
+    /// Discover an OpenClaw installation at a specific path or the default
+    /// location (`~/.openclaw` with legacy fallbacks).
+    pub fn discover(path: Option<&Path>) -> Result<Self, ImportError> {
+        let state_dir = if let Some(p) = path {
+            if !p.is_dir() {
+                return Err(ImportError::NotFound);
+            }
+            p.to_path_buf()
+        } else {
+            Self::find_default_state_dir()?
+        };
+
+        // Find config file
+        let config_file = CONFIG_FILE_NAMES
+            .iter()
+            .map(|name| state_dir.join(name))
+            .find(|p| p.is_file())
+            .unwrap_or_else(|| state_dir.join("openclaw.json"));
+
+        // Find workspace directory (respects OPENCLAW_PROFILE env var)
+        let workspace_dir = if let Ok(profile) = std::env::var("OPENCLAW_PROFILE") {
+            state_dir.join(format!("workspace-{}", profile))
+        } else {
+            state_dir.join("workspace")
+        };
+
+        // Discover identity files
+        let identity_files = if workspace_dir.is_dir() {
+            IDENTITY_FILE_NAMES
+                .iter()
+                .filter_map(|name| {
+                    let path = workspace_dir.join(name);
+                    if path.is_file() {
+                        Some((name.to_string(), path))
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // Discover memory files
+        let memory_dir = workspace_dir.join("memory");
+        let memory_files = if memory_dir.is_dir() {
+            Self::scan_md_files(&memory_dir)
+        } else {
+            Vec::new()
+        };
+
+        // Discover session directories
+        let agents_dir = state_dir.join("agents");
+        let session_dirs = if agents_dir.is_dir() {
+            Self::scan_session_dirs(&agents_dir)
+        } else {
+            Vec::new()
+        };
+
+        // Check for OAuth file
+        let oauth_path = state_dir.join("credentials").join("oauth.json");
+        let oauth_file = if oauth_path.is_file() {
+            Some(oauth_path)
+        } else {
+            None
+        };
+
+        Ok(Self {
+            state_dir,
+            config_file,
+            workspace_dir,
+            session_dirs,
+            identity_files,
+            memory_files,
+            oauth_file,
+        })
+    }
+
+    /// Check if an OpenClaw installation exists at the default location.
+    pub fn exists_at_default() -> bool {
+        Self::find_default_state_dir().is_ok()
+    }
+
+    /// Find the default state directory by trying well-known names under `$HOME`.
+    fn find_default_state_dir() -> Result<PathBuf, ImportError> {
+        let home = dirs::home_dir().ok_or(ImportError::NotFound)?;
+
+        for name in STATE_DIR_NAMES {
+            let candidate = home.join(name);
+            if candidate.is_dir() {
+                return Ok(candidate);
+            }
+        }
+
+        Err(ImportError::NotFound)
+    }
+
+    /// Scan a directory for `*.md` files.
+    fn scan_md_files(dir: &Path) -> Vec<PathBuf> {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return Vec::new();
+        };
+
+        entries
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.is_file()
+                    && p.extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("md"))
+            })
+            .collect()
+    }
+
+    /// Scan the `agents/` directory for per-agent session directories.
+    fn scan_session_dirs(agents_dir: &Path) -> Vec<SessionDirInfo> {
+        let Ok(entries) = std::fs::read_dir(agents_dir) else {
+            return Vec::new();
+        };
+
+        entries
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .filter_map(|agent_entry| {
+                let agent_id = agent_entry.file_name().to_string_lossy().to_string();
+                let sessions_dir = agent_entry.path().join("sessions");
+                if !sessions_dir.is_dir() {
+                    return None;
+                }
+
+                let jsonl_files: Vec<PathBuf> = std::fs::read_dir(&sessions_dir)
+                    .ok()?
+                    .filter_map(|e| e.ok())
+                    .map(|e| e.path())
+                    .filter(|p| {
+                        p.is_file()
+                            && p.extension()
+                                .is_some_and(|ext| ext.eq_ignore_ascii_case("jsonl"))
+                    })
+                    .collect();
+
+                if jsonl_files.is_empty() {
+                    return None;
+                }
+
+                Some(SessionDirInfo {
+                    agent_id,
+                    dir: sessions_dir,
+                    jsonl_files,
+                })
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn discover_tempdir_with_mock_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create workspace with identity files
+        let ws = root.join("workspace");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("AGENTS.md"), "# agents").unwrap();
+        std::fs::write(ws.join("SOUL.md"), "# soul").unwrap();
+
+        // Create memory dir with docs
+        let mem = ws.join("memory");
+        std::fs::create_dir_all(&mem).unwrap();
+        std::fs::write(mem.join("notes.md"), "# notes").unwrap();
+        std::fs::write(mem.join("tasks.md"), "# tasks").unwrap();
+
+        // Create agent sessions
+        let sessions = root.join("agents").join("agent1").join("sessions");
+        std::fs::create_dir_all(&sessions).unwrap();
+        std::fs::write(sessions.join("sess1.jsonl"), "{}").unwrap();
+        std::fs::write(sessions.join("sessions.json"), "{}").unwrap();
+
+        // Create config
+        std::fs::write(root.join("openclaw.json"), "{}").unwrap();
+
+        // Create oauth
+        let creds = root.join("credentials");
+        std::fs::create_dir_all(&creds).unwrap();
+        std::fs::write(creds.join("oauth.json"), "{}").unwrap();
+
+        let install = OpenClawInstallation::discover(Some(root)).unwrap();
+
+        assert_eq!(install.state_dir, root);
+        assert_eq!(install.config_file, root.join("openclaw.json"));
+        assert_eq!(install.workspace_dir, ws);
+        assert_eq!(install.identity_files.len(), 2);
+        assert_eq!(install.memory_files.len(), 2);
+        assert_eq!(install.session_dirs.len(), 1);
+        assert_eq!(install.session_dirs[0].agent_id, "agent1");
+        assert_eq!(install.session_dirs[0].jsonl_files.len(), 1);
+        assert!(install.oauth_file.is_some());
+    }
+
+    #[test]
+    fn discover_legacy_names() {
+        let tmp = tempfile::tempdir().unwrap();
+        let root = tmp.path();
+
+        // Use legacy name
+        std::fs::write(root.join("clawdbot.json"), "{}").unwrap();
+        std::fs::create_dir_all(root.join("workspace")).unwrap();
+
+        let install = OpenClawInstallation::discover(Some(root)).unwrap();
+        assert_eq!(install.config_file, root.join("clawdbot.json"));
+    }
+
+    #[test]
+    fn discover_not_found_returns_error() {
+        let tmp = tempfile::tempdir().unwrap();
+        let nonexistent = tmp.path().join("does_not_exist");
+        let result = OpenClawInstallation::discover(Some(&nonexistent));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn discover_empty_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let install = OpenClawInstallation::discover(Some(tmp.path())).unwrap();
+        assert!(install.identity_files.is_empty());
+        assert!(install.memory_files.is_empty());
+        assert!(install.session_dirs.is_empty());
+        assert!(install.oauth_file.is_none());
+    }
+}

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -1,0 +1,126 @@
+//! Import data from other personal AI assistants.
+//!
+//! Currently supports importing from OpenClaw installations, including:
+//! - Memory documents (identity files, workspace memory)
+//! - Conversation history (JSONL session transcripts)
+//! - Settings (config key mapping)
+//! - Credentials (API keys, OAuth tokens)
+
+mod config_parser;
+mod discovery;
+mod openclaw;
+mod progress;
+
+pub use config_parser::{CredentialEntry, OpenClawConfig};
+pub use discovery::OpenClawInstallation;
+pub use openclaw::OpenClawImporter;
+pub use progress::{ImportProgress, SilentProgress, TerminalProgress};
+
+/// Errors that can occur during data import.
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    #[error("No installation found at the expected path")]
+    NotFound,
+
+    #[error("Failed to parse configuration: {0}")]
+    ConfigParse(String),
+
+    #[error("Failed to parse session file: {0}")]
+    SessionParse(String),
+
+    #[error("Database write failed: {0}")]
+    DatabaseWrite(String),
+
+    #[error("Secrets error: {0}")]
+    Secrets(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// Summary of an import operation.
+#[derive(Debug, Default)]
+pub struct ImportReport {
+    /// Number of settings imported.
+    pub settings_count: usize,
+    /// Number of memory documents imported.
+    pub memory_documents: usize,
+    /// Number of identity files imported.
+    pub identity_files: usize,
+    /// Number of conversations imported.
+    pub conversations: usize,
+    /// Number of messages imported.
+    pub messages: usize,
+    /// Number of credentials imported.
+    pub credentials: usize,
+    /// Number of items skipped because they already exist.
+    pub skipped_already_exists: usize,
+    /// Per-item errors that did not abort the import.
+    pub errors: Vec<String>,
+    /// Whether this was a dry run (no writes).
+    pub dry_run: bool,
+}
+
+impl ImportReport {
+    /// Print a human-readable summary to stdout.
+    pub fn print_summary(&self) {
+        println!();
+        if self.dry_run {
+            println!("=== Import Dry Run Summary ===");
+            println!("(No data was written)");
+        } else {
+            println!("=== Import Summary ===");
+        }
+        println!();
+
+        let verb = if self.dry_run {
+            "would import"
+        } else {
+            "imported"
+        };
+
+        if self.settings_count > 0 {
+            println!("  Settings:       {} {}", self.settings_count, verb);
+        }
+        if self.identity_files > 0 {
+            println!("  Identity files: {} {}", self.identity_files, verb);
+        }
+        if self.memory_documents > 0 {
+            println!("  Memory docs:    {} {}", self.memory_documents, verb);
+        }
+        if self.conversations > 0 {
+            println!(
+                "  Conversations:  {} {} ({} messages)",
+                self.conversations, verb, self.messages
+            );
+        }
+        if self.credentials > 0 {
+            println!("  Credentials:    {} {}", self.credentials, verb);
+        }
+        if self.skipped_already_exists > 0 {
+            println!(
+                "  Skipped:        {} (already exist)",
+                self.skipped_already_exists
+            );
+        }
+
+        let total = self.settings_count
+            + self.identity_files
+            + self.memory_documents
+            + self.conversations
+            + self.credentials;
+        if total == 0 && self.skipped_already_exists == 0 {
+            println!("  Nothing to import.");
+        }
+
+        if !self.errors.is_empty() {
+            println!();
+            println!("  Errors ({}):", self.errors.len());
+            for (i, err) in self.errors.iter().enumerate() {
+                println!("    {}. {}", i + 1, err);
+            }
+        }
+
+        println!();
+    }
+}

--- a/src/import/openclaw.rs
+++ b/src/import/openclaw.rs
@@ -1,0 +1,619 @@
+//! Core OpenClaw importer.
+//!
+//! Orchestrates the 5-phase import pipeline: settings, identity files,
+//! memory documents, conversations, and credentials.
+
+use std::io::BufRead;
+use std::sync::Arc;
+
+use uuid::Uuid;
+
+use crate::db::{ConversationStore, SettingsStore};
+use crate::import::config_parser::OpenClawConfig;
+use crate::import::discovery::OpenClawInstallation;
+use crate::import::progress::ImportProgress;
+use crate::import::{ImportError, ImportReport};
+use crate::secrets::{CreateSecretParams, SecretsStore};
+use crate::workspace::Workspace;
+
+/// Well-known identity files that map directly between OpenClaw and IronClaw.
+const DIRECT_IDENTITY_FILES: &[&str] = &[
+    "AGENTS.md",
+    "SOUL.md",
+    "IDENTITY.md",
+    "USER.md",
+    "HEARTBEAT.md",
+    "MEMORY.md",
+];
+
+/// Orchestrates importing data from an OpenClaw installation into IronClaw.
+pub struct OpenClawImporter {
+    installation: OpenClawInstallation,
+    config: OpenClawConfig,
+    dry_run: bool,
+}
+
+impl OpenClawImporter {
+    /// Create a new importer for a discovered installation.
+    pub fn new(installation: OpenClawInstallation, config: OpenClawConfig, dry_run: bool) -> Self {
+        Self {
+            installation,
+            config,
+            dry_run,
+        }
+    }
+
+    /// Run the full import pipeline.
+    pub async fn run(
+        &self,
+        db: &Arc<dyn crate::db::Database>,
+        workspace: Option<&Workspace>,
+        secrets_store: Option<&Arc<dyn SecretsStore + Send + Sync>>,
+        progress: &mut dyn ImportProgress,
+    ) -> Result<ImportReport, ImportError> {
+        let mut report = ImportReport {
+            dry_run: self.dry_run,
+            ..Default::default()
+        };
+
+        self.phase_settings(db.as_ref(), progress, &mut report)
+            .await;
+        self.phase_identity_files(workspace, progress, &mut report)
+            .await;
+        self.phase_memory_documents(workspace, progress, &mut report)
+            .await;
+        self.phase_conversations(db.as_ref(), progress, &mut report)
+            .await;
+        self.phase_credentials(secrets_store, progress, &mut report)
+            .await;
+
+        Ok(report)
+    }
+
+    /// Phase 1: Import settings.
+    async fn phase_settings(
+        &self,
+        db: &dyn SettingsStore,
+        progress: &mut dyn ImportProgress,
+        report: &mut ImportReport,
+    ) {
+        let settings = &self.config.mapped_settings;
+        progress.start_phase("settings", settings.len());
+
+        for (key, value) in settings {
+            match db.get_setting("default", key).await {
+                Ok(Some(_)) => {
+                    progress.item_skipped(key, "already exists");
+                    report.skipped_already_exists += 1;
+                    continue;
+                }
+                Ok(None) => {}
+                Err(e) => {
+                    let msg = format!("Failed to check setting '{}': {}", key, e);
+                    progress.item_error(key, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            }
+
+            if self.dry_run {
+                progress.item_imported(key);
+                report.settings_count += 1;
+                continue;
+            }
+
+            match db.set_setting("default", key, value).await {
+                Ok(()) => {
+                    progress.item_imported(key);
+                    report.settings_count += 1;
+                }
+                Err(e) => {
+                    let msg = format!("Failed to write setting '{}': {}", key, e);
+                    progress.item_error(key, &msg);
+                    report.errors.push(msg);
+                }
+            }
+        }
+
+        progress.end_phase();
+    }
+
+    /// Phase 2: Import identity files.
+    async fn phase_identity_files(
+        &self,
+        workspace: Option<&Workspace>,
+        progress: &mut dyn ImportProgress,
+        report: &mut ImportReport,
+    ) {
+        progress.start_phase("identity files", self.installation.identity_files.len());
+
+        let Some(ws) = workspace else {
+            progress.end_phase();
+            return;
+        };
+
+        for (filename, path) in &self.installation.identity_files {
+            // Only import files that have direct IronClaw equivalents
+            let ironclaw_path = if DIRECT_IDENTITY_FILES.contains(&filename.as_str()) {
+                filename.to_string()
+            } else {
+                // TOOLS.md, BOOTSTRAP.md etc -> import as custom paths
+                format!("imported/{}", filename)
+            };
+
+            // Check if already exists with content
+            match ws.exists(&ironclaw_path).await {
+                Ok(true) => {
+                    // Check if the existing file has non-empty content
+                    if let Ok(doc) = ws.read(&ironclaw_path).await
+                        && !doc.content.is_empty()
+                    {
+                        progress.item_skipped(filename, "already exists with content");
+                        report.skipped_already_exists += 1;
+                        continue;
+                    }
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    let msg = format!("Failed to check '{}': {}", ironclaw_path, e);
+                    progress.item_error(filename, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            }
+
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    let msg = format!("Failed to read '{}': {}", path.display(), e);
+                    progress.item_error(filename, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            };
+
+            if content.trim().is_empty() {
+                progress.item_skipped(filename, "empty file");
+                continue;
+            }
+
+            if self.dry_run {
+                progress.item_imported(filename);
+                report.identity_files += 1;
+                continue;
+            }
+
+            match ws.write(&ironclaw_path, &content).await {
+                Ok(_) => {
+                    progress.item_imported(filename);
+                    report.identity_files += 1;
+                }
+                Err(e) => {
+                    let msg = format!("Failed to write '{}': {}", ironclaw_path, e);
+                    progress.item_error(filename, &msg);
+                    report.errors.push(msg);
+                }
+            }
+        }
+
+        progress.end_phase();
+    }
+
+    /// Phase 3: Import memory documents from filesystem.
+    async fn phase_memory_documents(
+        &self,
+        workspace: Option<&Workspace>,
+        progress: &mut dyn ImportProgress,
+        report: &mut ImportReport,
+    ) {
+        progress.start_phase("memory documents", self.installation.memory_files.len());
+
+        let Some(ws) = workspace else {
+            progress.end_phase();
+            return;
+        };
+
+        for path in &self.installation.memory_files {
+            let filename = match path.file_name() {
+                Some(f) => f.to_string_lossy().to_string(),
+                None => continue,
+            };
+
+            let ironclaw_path = format!("memory/{}", filename);
+
+            match ws.exists(&ironclaw_path).await {
+                Ok(true) => {
+                    progress.item_skipped(&filename, "already exists");
+                    report.skipped_already_exists += 1;
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    let msg = format!("Failed to check '{}': {}", ironclaw_path, e);
+                    progress.item_error(&filename, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            }
+
+            let content = match std::fs::read_to_string(path) {
+                Ok(c) => c,
+                Err(e) => {
+                    let msg = format!("Failed to read '{}': {}", path.display(), e);
+                    progress.item_error(&filename, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            };
+
+            if content.trim().is_empty() {
+                progress.item_skipped(&filename, "empty file");
+                continue;
+            }
+
+            if self.dry_run {
+                progress.item_imported(&filename);
+                report.memory_documents += 1;
+                continue;
+            }
+
+            match ws.write(&ironclaw_path, &content).await {
+                Ok(_) => {
+                    progress.item_imported(&filename);
+                    report.memory_documents += 1;
+                }
+                Err(e) => {
+                    let msg = format!("Failed to write '{}': {}", ironclaw_path, e);
+                    progress.item_error(&filename, &msg);
+                    report.errors.push(msg);
+                }
+            }
+        }
+
+        progress.end_phase();
+    }
+
+    /// Phase 4: Import conversations from JSONL session files.
+    async fn phase_conversations(
+        &self,
+        db: &(dyn ConversationStore + Sync),
+        progress: &mut dyn ImportProgress,
+        report: &mut ImportReport,
+    ) {
+        let total_files: usize = self
+            .installation
+            .session_dirs
+            .iter()
+            .map(|s| s.jsonl_files.len())
+            .sum();
+        progress.start_phase("conversations", total_files);
+
+        for session_dir in &self.installation.session_dirs {
+            for jsonl_path in &session_dir.jsonl_files {
+                let session_key = jsonl_path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().to_string())
+                    .unwrap_or_default();
+
+                // Skip sessions.json (metadata, not a transcript)
+                if session_key == "sessions" {
+                    continue;
+                }
+
+                let label = format!("{}:{}", session_dir.agent_id, session_key);
+
+                // Use a deterministic conversation ID from the session key for idempotency.
+                let conv_id = deterministic_uuid(&label);
+
+                // Check idempotency: if this conversation already has messages, skip.
+                match db.list_conversation_messages(conv_id).await {
+                    Ok(msgs) if !msgs.is_empty() => {
+                        progress.item_skipped(&label, "already imported");
+                        report.skipped_already_exists += 1;
+                        continue;
+                    }
+                    _ => {}
+                }
+
+                // Parse JSONL file
+                let messages = match Self::parse_jsonl(jsonl_path) {
+                    Ok(msgs) => msgs,
+                    Err(e) => {
+                        let msg = format!("Failed to parse '{}': {}", jsonl_path.display(), e);
+                        progress.item_error(&label, &msg);
+                        report.errors.push(msg);
+                        continue;
+                    }
+                };
+
+                if messages.is_empty() {
+                    progress.item_skipped(&label, "no messages");
+                    continue;
+                }
+
+                if self.dry_run {
+                    progress.item_imported(&format!("{} ({} messages)", label, messages.len()));
+                    report.conversations += 1;
+                    report.messages += messages.len();
+                    continue;
+                }
+
+                // Create conversation with deterministic ID using ensure_conversation
+                let thread_id = format!("openclaw:{}:{}", session_dir.agent_id, session_key);
+                if let Err(e) = db
+                    .ensure_conversation(conv_id, "openclaw_import", "default", Some(&thread_id))
+                    .await
+                {
+                    let msg = format!("Failed to create conversation for '{}': {}", label, e);
+                    progress.item_error(&label, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+
+                // Import messages
+                let mut msg_count = 0;
+                for (role, content) in &messages {
+                    match db.add_conversation_message(conv_id, role, content).await {
+                        Ok(_) => msg_count += 1,
+                        Err(e) => {
+                            let msg = format!("Failed to add message to '{}': {}", label, e);
+                            report.errors.push(msg);
+                        }
+                    }
+                }
+
+                progress.item_imported(&format!("{} ({} messages)", label, msg_count));
+                report.conversations += 1;
+                report.messages += msg_count;
+            }
+        }
+
+        progress.end_phase();
+    }
+
+    /// Phase 5: Import credentials.
+    async fn phase_credentials(
+        &self,
+        secrets_store: Option<&Arc<dyn SecretsStore + Send + Sync>>,
+        progress: &mut dyn ImportProgress,
+        report: &mut ImportReport,
+    ) {
+        let creds = &self.config.credentials;
+        progress.start_phase("credentials", creds.len());
+
+        let Some(store) = secrets_store else {
+            if !creds.is_empty() {
+                progress.item_skipped("all", "no secrets store available");
+            }
+            progress.end_phase();
+            return;
+        };
+
+        for cred in creds {
+            match store.exists("default", &cred.name).await {
+                Ok(true) => {
+                    progress.item_skipped(&cred.name, "already exists");
+                    report.skipped_already_exists += 1;
+                    continue;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    let msg = format!("Failed to check credential '{}': {}", cred.name, e);
+                    progress.item_error(&cred.name, &msg);
+                    report.errors.push(msg);
+                    continue;
+                }
+            }
+
+            if self.dry_run {
+                progress.item_imported(&cred.name);
+                report.credentials += 1;
+                continue;
+            }
+
+            let mut params = CreateSecretParams::new(&cred.name, &cred.value);
+            if let Some(ref provider) = cred.provider {
+                params = params.with_provider(provider);
+            }
+
+            match store.create("default", params).await {
+                Ok(_) => {
+                    progress.item_imported(&cred.name);
+                    report.credentials += 1;
+                }
+                Err(e) => {
+                    let msg = format!("Failed to store credential '{}': {}", cred.name, e);
+                    progress.item_error(&cred.name, &msg);
+                    report.errors.push(msg);
+                }
+            }
+        }
+
+        progress.end_phase();
+    }
+
+    /// Parse a JSONL session file into `(role, content)` pairs.
+    fn parse_jsonl(path: &std::path::Path) -> Result<Vec<(String, String)>, ImportError> {
+        let file = std::fs::File::open(path)?;
+        let reader = std::io::BufReader::new(file);
+        let mut messages = Vec::new();
+
+        for (line_num, line) in reader.lines().enumerate() {
+            let line = line?;
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let val: serde_json::Value = match serde_json::from_str(line) {
+                Ok(v) => v,
+                Err(_) => continue, // Skip unparseable lines
+            };
+
+            // Filter for message records
+            if val.get("type").and_then(|v| v.as_str()) != Some("message") {
+                continue;
+            }
+
+            let Some(msg) = val.get("message") else {
+                continue;
+            };
+
+            let role = msg
+                .get("role")
+                .and_then(|v| v.as_str())
+                .unwrap_or("user")
+                .to_string();
+
+            let content = extract_content(msg);
+            if content.is_empty() {
+                continue;
+            }
+
+            messages.push((role, content));
+
+            // Safety limit: don't import absurdly large sessions
+            if messages.len() > 10_000 {
+                tracing::warn!(
+                    "Session file {} truncated at 10,000 messages (line {})",
+                    path.display(),
+                    line_num + 1
+                );
+                break;
+            }
+        }
+
+        Ok(messages)
+    }
+}
+
+/// Extract text content from a message, handling both string and array formats.
+///
+/// OpenClaw messages use either:
+/// - `"content": "Hello"` (plain string)
+/// - `"content": [{"type": "text", "text": "Hello"}]` (structured array)
+fn extract_content(msg: &serde_json::Value) -> String {
+    let Some(content) = msg.get("content") else {
+        return String::new();
+    };
+
+    match content {
+        serde_json::Value::String(s) => s.clone(),
+        serde_json::Value::Array(arr) => {
+            let mut parts = Vec::new();
+            for item in arr {
+                if item.get("type").and_then(|v| v.as_str()) == Some("text")
+                    && let Some(text) = item.get("text").and_then(|v| v.as_str())
+                {
+                    parts.push(text.to_string());
+                }
+            }
+            parts.join("\n")
+        }
+        _ => String::new(),
+    }
+}
+
+/// Generate a deterministic UUID from a string key using blake3.
+fn deterministic_uuid(key: &str) -> Uuid {
+    let hash = blake3::hash(key.as_bytes());
+    let bytes = hash.as_bytes();
+    // Take the first 16 bytes and construct a UUID v4-like value.
+    let mut uuid_bytes = [0u8; 16];
+    uuid_bytes.copy_from_slice(&bytes[..16]);
+    // Set version (4) and variant (RFC 4122) bits for valid UUID format
+    uuid_bytes[6] = (uuid_bytes[6] & 0x0f) | 0x40; // version 4
+    uuid_bytes[8] = (uuid_bytes[8] & 0x3f) | 0x80; // variant RFC 4122
+    Uuid::from_bytes(uuid_bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_content_string() {
+        let msg = serde_json::json!({"content": "Hello world"});
+        assert_eq!(extract_content(&msg), "Hello world");
+    }
+
+    #[test]
+    fn test_extract_content_array() {
+        let msg = serde_json::json!({
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "text", "text": "World"}
+            ]
+        });
+        assert_eq!(extract_content(&msg), "Hello\nWorld");
+    }
+
+    #[test]
+    fn test_extract_content_empty() {
+        let msg = serde_json::json!({"role": "user"});
+        assert_eq!(extract_content(&msg), "");
+    }
+
+    #[test]
+    fn test_extract_content_mixed_array() {
+        let msg = serde_json::json!({
+            "content": [
+                {"type": "text", "text": "Hello"},
+                {"type": "image", "url": "https://example.com/img.png"},
+                {"type": "text", "text": "World"}
+            ]
+        });
+        assert_eq!(extract_content(&msg), "Hello\nWorld");
+    }
+
+    #[test]
+    fn test_deterministic_uuid_is_stable() {
+        let a = deterministic_uuid("test_key");
+        let b = deterministic_uuid("test_key");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_deterministic_uuid_differs_for_different_keys() {
+        let a = deterministic_uuid("key_a");
+        let b = deterministic_uuid("key_b");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn test_parse_jsonl_various_formats() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("test.jsonl");
+
+        std::fs::write(
+            &path,
+            r#"{"type": "message", "message": {"role": "user", "content": "Hello"}}
+{"type": "message", "message": {"role": "assistant", "content": [{"type": "text", "text": "Hi there"}]}}
+{"type": "tool_call", "data": {}}
+{"type": "message", "message": {"role": "user", "content": ""}}
+invalid json line
+{"type": "message", "message": {"role": "user", "content": "Goodbye"}}
+"#,
+        )
+        .unwrap();
+
+        let messages = OpenClawImporter::parse_jsonl(&path).unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[0], ("user".to_string(), "Hello".to_string()));
+        assert_eq!(
+            messages[1],
+            ("assistant".to_string(), "Hi there".to_string())
+        );
+        assert_eq!(messages[2], ("user".to_string(), "Goodbye".to_string()));
+    }
+
+    #[test]
+    fn test_parse_jsonl_empty_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("empty.jsonl");
+        std::fs::write(&path, "").unwrap();
+
+        let messages = OpenClawImporter::parse_jsonl(&path).unwrap();
+        assert!(messages.is_empty());
+    }
+}

--- a/src/import/progress.rs
+++ b/src/import/progress.rs
@@ -1,0 +1,111 @@
+//! Progress reporting for import operations.
+
+/// Trait for reporting import progress to the user.
+pub trait ImportProgress: Send {
+    /// Start a named import phase (e.g., "Settings", "Memory documents").
+    fn start_phase(&mut self, name: &str, total: usize);
+    /// Report that an item was successfully imported.
+    fn item_imported(&mut self, name: &str);
+    /// Report that an item was skipped.
+    fn item_skipped(&mut self, name: &str, reason: &str);
+    /// Report that an item failed.
+    fn item_error(&mut self, name: &str, error: &str);
+    /// End the current phase.
+    fn end_phase(&mut self);
+}
+
+/// Progress reporter that prints to stdout.
+pub struct TerminalProgress {
+    phase_name: String,
+    phase_total: usize,
+    phase_done: usize,
+}
+
+impl Default for TerminalProgress {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TerminalProgress {
+    pub fn new() -> Self {
+        Self {
+            phase_name: String::new(),
+            phase_total: 0,
+            phase_done: 0,
+        }
+    }
+}
+
+impl ImportProgress for TerminalProgress {
+    fn start_phase(&mut self, name: &str, total: usize) {
+        self.phase_name = name.to_string();
+        self.phase_total = total;
+        self.phase_done = 0;
+        if total > 0 {
+            println!("  Importing {} ({} items)...", name, total);
+        } else {
+            println!("  Importing {}...", name);
+        }
+    }
+
+    fn item_imported(&mut self, name: &str) {
+        self.phase_done += 1;
+        println!("    + {}", name);
+    }
+
+    fn item_skipped(&mut self, name: &str, reason: &str) {
+        self.phase_done += 1;
+        println!("    - {} (skipped: {})", name, reason);
+    }
+
+    fn item_error(&mut self, name: &str, error: &str) {
+        self.phase_done += 1;
+        eprintln!("    ! {} (error: {})", name, error);
+    }
+
+    fn end_phase(&mut self) {
+        if self.phase_total > 0 {
+            println!(
+                "  Done: {}/{} {}",
+                self.phase_done, self.phase_total, self.phase_name
+            );
+        }
+    }
+}
+
+/// Silent progress reporter (no-op). Used for tests.
+pub struct SilentProgress;
+
+impl ImportProgress for SilentProgress {
+    fn start_phase(&mut self, _name: &str, _total: usize) {}
+    fn item_imported(&mut self, _name: &str) {}
+    fn item_skipped(&mut self, _name: &str, _reason: &str) {}
+    fn item_error(&mut self, _name: &str, _error: &str) {}
+    fn end_phase(&mut self) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_progress_does_not_panic() {
+        let mut p = TerminalProgress::new();
+        p.start_phase("test", 3);
+        p.item_imported("a");
+        p.item_skipped("b", "exists");
+        p.item_error("c", "broken");
+        p.end_phase();
+    }
+
+    #[test]
+    fn silent_progress_does_not_panic() {
+        let mut p = SilentProgress;
+        p.start_phase("test", 0);
+        p.item_imported("x");
+        p.item_skipped("y", "skip");
+        p.item_error("z", "err");
+        p.end_phase();
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,7 @@ pub mod evaluation;
 pub mod extensions;
 pub mod history;
 pub mod hooks;
+pub mod import;
 pub mod llm;
 pub mod observability;
 pub mod orchestrator;


### PR DESCRIPTION
## Summary

Implements `ironclaw import openclaw` CLI command and onboarding wizard integration for migrating data from OpenClaw installations into IronClaw. Addresses #58.

### What it does

Five-phase import pipeline:
1. **Settings** — maps OpenClaw JSON5 config keys → IronClaw settings (llm_backend, model, embeddings provider/model)
2. **Identity files** — AGENTS.md, SOUL.md, USER.md, IDENTITY.md, HEARTBEAT.md, MEMORY.md
3. **Memory documents** — `workspace/memory/*.md` → IronClaw workspace
4. **Conversations** — JSONL session transcripts → IronClaw conversation history (idempotent via deterministic UUIDs)
5. **Credentials** — API keys from `auth.profiles` + OAuth tokens from `credentials/oauth.json` → encrypted secrets store

### Key features
- Auto-discovers `~/.openclaw` and legacy dirs (`~/.clawdbot`, `~/.moldbot`, `~/.moltbot`)
- Parses JSON5 config (OpenClaw's format)
- `--dry-run` mode to preview without writing
- Fully idempotent — safe to run multiple times (skips existing data)
- Wizard integration — prompts during onboarding if OpenClaw installation detected
- 18 unit tests across discovery, config parsing, and JSONL parsing

### Usage
```bash
ironclaw import openclaw                          # auto-detect ~/.openclaw
ironclaw import openclaw --path /custom/path      # explicit path
ironclaw import openclaw --dry-run                # preview only
```

### Files changed (13 files, +1855 lines)
- `src/import/` — new module: `mod.rs`, `discovery.rs`, `config_parser.rs`, `openclaw.rs`, `progress.rs`
- `src/cli/import.rs` — CLI subcommand handler
- `src/cli/mod.rs`, `src/lib.rs`, `src/main.rs` — wiring
- `src/db/postgres.rs` — added `PgBackend::from_pool()` for wizard reuse
- `src/setup/wizard.rs` — OpenClaw detection step in onboarding
- `Cargo.toml` — added `json5 = "0.4"`

## Questions for code owners

1. **General direction** — Does this approach look right? Any architectural concerns with the import module structure or the 5-phase pipeline? Would you prefer a different abstraction (e.g., a generic `Importer` trait for future sources)?

2. **Tools/skills import** — This PR covers memory, history, settings, and credentials. Should we also import OpenClaw's installed tools and skills (WASM extensions, MCP server configs, SKILL.md files)? OpenClaw has similar concepts — would be straightforward to add as Phase 6/7 if desired.

3. **Wizard placement** — The OpenClaw detection runs after the database setup step in the onboarding wizard. Is this the right spot, or should it be a separate post-wizard flow?

Looking for a general direction before polishing further.

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib -- import` — 18/18 passing
- [x] `cargo check --no-default-features --features libsql` — compiles
- [x] `cargo check --no-default-features --features postgres` — compiles
- [ ] Manual test with real OpenClaw installation
- [ ] Integration test with in-memory DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)