### PR TITLE
fix: prevent duplicate WASM channel activation on startup

### DIFF
--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -2742,7 +2742,7 @@ mod tests {
         let ctx = ch.conversation_context(&metadata);
         assert_eq!(ctx.get("sender"), Some(&"+1234567890".to_string()));
         assert_eq!(ctx.get("sender_uuid"), Some(&"uuid-123".to_string()));
-        assert!(ctx.get("group").is_none());
+        assert!(!ctx.contains_key("group"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -602,6 +602,7 @@ async fn main() -> anyhow::Result<()> {
     if let Some(ref ext_mgr) = components.extension_manager
         && let Some((rt, ps, router)) = wasm_channel_runtime_state.take()
     {
+        ext_mgr.set_active_channels(loaded_wasm_channel_names).await;
         ext_mgr
             .set_channel_runtime(
                 Arc::clone(&channels),


### PR DESCRIPTION
## Summary
- Register boot-loaded WASM channel names with the extension manager via `set_active_channels()` after `set_channel_runtime()`
- This enables the existing dedup guard in `activate_wasm_channel()` to correctly route to `refresh_active_channel()` instead of creating a duplicate polling instance
- Fixes 409 Conflict errors from the Telegram API caused by two concurrent `getUpdates` polling loops

## Root Cause
The `set_active_channels()` method and dedup guard already existed but were never wired up — `loaded_wasm_channel_names` was collected at boot but never passed to the extension manager. When the extension manager later hot-activated telegram (e.g. after saving secrets via web UI), it didn't know the channel was already running and created a second instance.

## Test plan
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test` — 1595 tests pass, 0 failures
- [ ] Manual: start ironclaw with telegram configured, verify logs show only one polling instance and no 409 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)