### PR TITLE
feat: add Avian as a named LLM provider

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -220,6 +220,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | NVIDIA API | ✅ | ❌ | P3 | New provider |
 | OpenRouter | ✅ | ✅ | - | Via OpenAI-compatible provider (RigAdapter) |
 | Tinfoil | ❌ | ✅ | - | Private inference provider (IronClaw-only) |
+| Avian | ❌ | ✅ | - | DeepSeek, Kimi, GLM models (IronClaw-only) |
 | OpenAI-compatible | ❌ | ✅ | - | Generic OpenAI-compatible endpoint (RigAdapter) |
 | Ollama (local) | ✅ | ✅ | - | via `rig::providers::ollama` (full support) |
 | Perplexity | ✅ | ❌ | P3 | Freshness parameter for web_search |
@@ -521,6 +522,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 - ✅ Memory CLI commands (search, read, write, tree, status)
 - ✅ Shell env scrubbing + command injection detection
 - ✅ Tinfoil private inference provider
+- ✅ Avian inference provider
 - ✅ OpenAI-compatible / OpenRouter provider support
 
 ### P1 - High Priority
@@ -579,7 +581,8 @@ IronClaw intentionally differs from OpenClaw in these ways:
 5. **No mobile/desktop apps**: Focus on server-side and CLI initially
 6. **WASM channels**: Novel extension mechanism not in OpenClaw
 7. **Tinfoil private inference**: IronClaw-only provider for private/encrypted inference
-8. **GitHub WASM tool**: Native GitHub integration as WASM tool
-9. **Prompt-based skills**: Different approach than OpenClaw capability bundles (trust gating, attenuation)
+8. **Avian inference**: IronClaw-only provider for DeepSeek, Kimi, GLM, and MiniMax models
+9. **GitHub WASM tool**: Native GitHub integration as WASM tool
+10. **Prompt-based skills**: Different approach than OpenClaw capability bundles (trust gating, attenuation)
 
 These are intentional architectural choices, not gaps to be filled.

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -12,6 +12,7 @@ configurations.
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | Claude models |
 | OpenAI | `openai` | `OPENAI_API_KEY` | GPT models |
 | Ollama | `ollama` | No | Local inference |
+| Avian | `avian` | `AVIAN_API_KEY` | DeepSeek, Kimi, GLM |
 | OpenRouter | `openai_compatible` | `LLM_API_KEY` | 300+ models |
 | Together AI | `openai_compatible` | `LLM_API_KEY` | Fast inference |
 | Fireworks AI | `openai_compatible` | `LLM_API_KEY` | Fast inference |
@@ -65,6 +66,27 @@ OLLAMA_MODEL=llama3.2
 ```
 
 Pull a model first: `ollama pull llama3.2`
+
+---
+
+## Avian
+
+[Avian](https://avian.io) provides access to DeepSeek, Kimi, GLM, and MiniMax models.
+
+```env
+LLM_BACKEND=avian
+AVIAN_API_KEY=...
+AVIAN_MODEL=deepseek/deepseek-v3.2
+```
+
+Available models:
+
+| Model | ID | Context |
+|---|---|---|
+| DeepSeek V3.2 | `deepseek/deepseek-v3.2` | 164K |
+| Kimi K2.5 | `moonshotai/kimi-k2.5` | 131K |
+| GLM-5 | `z-ai/glm-5` | 131K |
+| MiniMax M2.5 | `minimax/minimax-m2.5` | 1M |
 
 ---
 

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -25,6 +25,8 @@ pub enum LlmBackend {
     OpenAiCompatible,
     /// Tinfoil private inference
     Tinfoil,
+    /// Avian AI inference
+    Avian,
 }
 
 impl std::str::FromStr for LlmBackend {
@@ -38,8 +40,9 @@ impl std::str::FromStr for LlmBackend {
             "ollama" => Ok(Self::Ollama),
             "openai_compatible" | "openai-compatible" | "compatible" => Ok(Self::OpenAiCompatible),
             "tinfoil" => Ok(Self::Tinfoil),
+            "avian" => Ok(Self::Avian),
             _ => Err(format!(
-                "invalid LLM backend '{}', expected one of: nearai, openai, anthropic, ollama, openai_compatible, tinfoil",
+                "invalid LLM backend '{}', expected one of: nearai, openai, anthropic, ollama, openai_compatible, tinfoil, avian",
                 s
             )),
         }
@@ -55,6 +58,7 @@ impl std::fmt::Display for LlmBackend {
             Self::Ollama => write!(f, "ollama"),
             Self::OpenAiCompatible => write!(f, "openai_compatible"),
             Self::Tinfoil => write!(f, "tinfoil"),
+            Self::Avian => write!(f, "avian"),
         }
     }
 }
@@ -102,6 +106,13 @@ pub struct TinfoilConfig {
     pub model: String,
 }
 
+/// Configuration for Avian AI inference.
+#[derive(Debug, Clone)]
+pub struct AvianConfig {
+    pub api_key: SecretString,
+    pub model: String,
+}
+
 /// LLM provider configuration.
 ///
 /// NEAR AI remains the default backend. Users can switch to other providers
@@ -122,6 +133,8 @@ pub struct LlmConfig {
     pub openai_compatible: Option<OpenAiCompatibleConfig>,
     /// Tinfoil config (populated when backend=tinfoil)
     pub tinfoil: Option<TinfoilConfig>,
+    /// Avian config (populated when backend=avian)
+    pub avian: Option<AvianConfig>,
 }
 
 /// NEAR AI configuration.
@@ -325,6 +338,20 @@ impl LlmConfig {
             None
         };
 
+        let avian = if backend == LlmBackend::Avian {
+            let api_key = optional_env("AVIAN_API_KEY")?
+                .map(SecretString::from)
+                .ok_or_else(|| ConfigError::MissingRequired {
+                    key: "AVIAN_API_KEY".to_string(),
+                    hint: "Set AVIAN_API_KEY when LLM_BACKEND=avian".to_string(),
+                })?;
+            let model = optional_env("AVIAN_MODEL")?
+                .unwrap_or_else(|| "deepseek/deepseek-v3.2".to_string());
+            Some(AvianConfig { api_key, model })
+        } else {
+            None
+        };
+
         Ok(Self {
             backend,
             nearai,
@@ -333,6 +360,7 @@ impl LlmConfig {
             ollama,
             openai_compatible,
             tinfoil,
+            avian,
         })
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -37,7 +37,7 @@ pub use self::embeddings::EmbeddingsConfig;
 pub use self::heartbeat::HeartbeatConfig;
 pub use self::hygiene::HygieneConfig;
 pub use self::llm::{
-    AnthropicDirectConfig, LlmBackend, LlmConfig, NearAiConfig, OllamaConfig,
+    AnthropicDirectConfig, AvianConfig, LlmBackend, LlmConfig, NearAiConfig, OllamaConfig,
     OpenAiCompatibleConfig, OpenAiDirectConfig, TinfoilConfig,
 };
 pub use self::routines::RoutineConfig;


### PR DESCRIPTION
## Summary

Adds first-class support for [Avian](https://avian.io) as a named LLM provider, following the same pattern as the Tinfoil provider added in #62.

Avian is an OpenAI-compatible inference service providing access to DeepSeek, Kimi, GLM, and MiniMax models. This PR adds it as a dedicated backend (`LLM_BACKEND=avian`) rather than requiring users to configure it through the generic `openai_compatible` path.

### Changes

- **`src/config/llm.rs`** — `LlmBackend::Avian` enum variant, `AvianConfig` struct, `AVIAN_API_KEY` / `AVIAN_MODEL` env var resolution (default model: `deepseek/deepseek-v3.2`)
- **`src/config/mod.rs`** — Export `AvianConfig`
- **`src/llm/mod.rs`** — `create_avian_provider()` using Chat Completions API via rig-core's OpenAI adapter, routed from `LlmBackend::Avian` match arm
- **`src/setup/wizard.rs`** — Avian in provider selection list, `setup_avian()` API key flow, model picker with all 4 models (DeepSeek V3.2, Kimi K2.5, GLM-5, MiniMax M2.5)
- **`docs/LLM_PROVIDERS.md`** — Avian section with env config and model table
- **`FEATURE_PARITY.md`** — Avian row in provider matrix and design decisions

### Available models

| Model | ID | Context |
|---|---|---|
| DeepSeek V3.2 | `deepseek/deepseek-v3.2` | 164K |
| Kimi K2.5 | `moonshotai/kimi-k2.5` | 131K |
| GLM-5 | `z-ai/glm-5` | 131K |
| MiniMax M2.5 | `minimax/minimax-m2.5` | 1M |

### Usage

```env
LLM_BACKEND=avian
AVIAN_API_KEY=your-key-here
AVIAN_MODEL=deepseek/deepseek-v3.2  # optional, this is the default
```

Or via the setup wizard: `ironclaw onboard` and select "Avian".

cc @ilblackdragon @serrrfirat — would appreciate a review when you get a chance. This follows the same pattern as the Tinfoil provider (#62).