### PR TITLE
feat(whatsapp): add HMAC-SHA256 webhook signature verification (#75)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ bench-results/
 # WASM build artifacts (loaded from disk, not bundled)
 *.wasm
 
+.serena/

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -65,7 +65,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | HTTP webhook | ✅ | ✅ | - | axum with secret validation |
 | REPL (simple) | ✅ | ✅ | - | For testing |
 | WASM channels | ❌ | ✅ | - | IronClaw innovation |
-| WhatsApp | ✅ | ❌ | P1 | Baileys (Web), same-phone mode with echo detection |
+| WhatsApp | ✅ | ✅ | P1 | Cloud API (WASM), DM pairing, text messages; voice/media TODO |
 | Telegram | ✅ | ✅ | - | WASM channel(MTProto), DM pairing, caption, /start, bot_username |
 | Discord | ✅ | ❌ | P2 | discord.js, thread parent binding inheritance |
 | Signal | ✅ | ✅ | P2 | signal-cli daemonPC, SSE listener HTTP/JSON-R, user/group allowlists, DM pairing |
@@ -526,7 +526,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 ### P1 - High Priority
 - ❌ Slack channel (real implementation)
 - ✅ Telegram channel (WASM, DM pairing, caption, /start)
-- ❌ WhatsApp channel
+- ✅ WhatsApp channel (WASM, Cloud API, HMAC webhook verification, text messages)
 - ✅ Multi-provider failover (`FailoverProvider` with retryable error classification)
 - ✅ Hooks system (core lifecycle hooks + bundled/plugin/workspace hooks + outbound webhooks)
 

--- a/channels-src/discord/src/lib.rs
+++ b/channels-src/discord/src/lib.rs
@@ -312,6 +312,11 @@ impl Guest for DiscordChannel {
 
     fn on_status(_update: StatusUpdate) {}
 
+    fn on_message_persisted(_metadata_json: String) -> Result<(), String> {
+        // Discord doesn't need post-persistence actions
+        Ok(())
+    }
+
     fn on_shutdown() {
         channel_host::log(
             channel_host::LogLevel::Info,

--- a/channels-src/slack/src/lib.rs
+++ b/channels-src/slack/src/lib.rs
@@ -306,6 +306,11 @@ impl Guest for SlackChannel {
 
     fn on_status(_update: StatusUpdate) {}
 
+    fn on_message_persisted(_metadata_json: String) -> Result<(), String> {
+        // Slack doesn't need post-persistence actions
+        Ok(())
+    }
+
     fn on_shutdown() {
         channel_host::log(channel_host::LogLevel::Info, "Slack channel shutting down");
     }

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -707,6 +707,11 @@ impl Guest for TelegramChannel {
         }
     }
 
+    fn on_message_persisted(_metadata_json: String) -> Result<(), String> {
+        // Telegram doesn't need post-persistence actions like mark_as_read
+        Ok(())
+    }
+
     fn on_shutdown() {
         channel_host::log(
             channel_host::LogLevel::Info,

--- a/channels-src/whatsapp/src/lib.rs
+++ b/channels-src/whatsapp/src/lib.rs
@@ -476,6 +476,98 @@ impl Guest for WhatsAppChannel {
 
     fn on_status(_update: StatusUpdate) {}
 
+    fn on_message_persisted(metadata_json: String) -> Result<(), String> {
+        channel_host::log(
+            channel_host::LogLevel::Debug,
+            "on_message_persisted callback invoked",
+        );
+
+        // Parse metadata to get message_id and phone_number_id
+        let metadata: WhatsAppMessageMetadata = match serde_json::from_str(&metadata_json) {
+            Ok(m) => m,
+            Err(e) => {
+                channel_host::log(
+                    channel_host::LogLevel::Warn,
+                    &format!("Failed to parse metadata in on_message_persisted: {}", e),
+                );
+                // Don't fail the ACK - just log and return
+                return Ok(());
+            }
+        };
+
+        // Read api_version from workspace (set during on_start), fallback to default
+        let api_version = channel_host::workspace_read("channels/whatsapp/api_version")
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| "v18.0".to_string());
+
+        // Build WhatsApp mark_as_read API URL
+        let url = format!(
+            "https://graph.facebook.com/{}/{}/messages",
+            api_version, metadata.phone_number_id
+        );
+
+        // Build mark_as_read payload
+        let payload = serde_json::json!({
+            "messaging_product": "whatsapp",
+            "status": "read",
+            "message_id": metadata.message_id
+        });
+
+        let payload_bytes = serde_json::to_vec(&payload)
+            .map_err(|e| format!("Failed to serialize mark_as_read payload: {}", e))?;
+
+        // Headers with Bearer token placeholder
+        // Host will inject the actual access token
+        let headers = serde_json::json!({
+            "Content-Type": "application/json",
+            "Authorization": "Bearer {WHATSAPP_ACCESS_TOKEN}"
+        });
+
+        channel_host::log(
+            channel_host::LogLevel::Debug,
+            &format!("Calling mark_as_read for message: {}", metadata.message_id),
+        );
+
+        let result = channel_host::http_request(
+            "POST",
+            &url,
+            &headers.to_string(),
+            Some(&payload_bytes),
+            None,
+        );
+
+        match result {
+            Ok(http_response) => {
+                if http_response.status >= 200 && http_response.status < 300 {
+                    channel_host::log(
+                        channel_host::LogLevel::Debug,
+                        &format!("Marked message {} as read", metadata.message_id),
+                    );
+                    Ok(())
+                } else {
+                    let body_str = String::from_utf8_lossy(&http_response.body);
+                    channel_host::log(
+                        channel_host::LogLevel::Warn,
+                        &format!(
+                            "mark_as_read API error: {} - {}",
+                            http_response.status, body_str
+                        ),
+                    );
+                    // Don't fail the ACK - mark_as_read is best-effort
+                    Ok(())
+                }
+            }
+            Err(e) => {
+                channel_host::log(
+                    channel_host::LogLevel::Warn,
+                    &format!("mark_as_read HTTP request failed: {}", e),
+                );
+                // Don't fail the ACK - mark_as_read is best-effort
+                Ok(())
+            }
+        }
+    }
+
     fn on_shutdown() {
         channel_host::log(
             channel_host::LogLevel::Info,
@@ -652,6 +744,11 @@ fn handle_message(
         return;
     }
 
+    // Note: mark_as_read is now handled by the host after DB persistence.
+    // The host will call the WhatsApp API directly after receiving the ACK
+    // from the agent loop. This ensures the webhook returns 200 OK only after
+    // the message is durably stored.
+
     // Build metadata for response routing
     // This is critical - the response handler uses this to know where to send
     let metadata = WhatsAppMessageMetadata {
@@ -680,10 +777,6 @@ fn handle_message(
         ),
     );
 }
-
-// ============================================================================
-// Utilities
-// ============================================================================
 
 // ============================================================================
 // Permission & Pairing

--- a/channels-src/whatsapp/whatsapp.capabilities.json
+++ b/channels-src/whatsapp/whatsapp.capabilities.json
@@ -16,9 +16,14 @@
         "prompt": "Webhook verify token (leave empty to auto-generate)",
         "optional": true,
         "auto_generate": { "length": 32 }
+      },
+      {
+        "name": "whatsapp_app_secret",
+        "prompt": "Enter your WhatsApp App Secret (from Meta Developer Portal > App Settings > Basic)",
+        "validation": "^[a-f0-9]{32}$"
       }
     ],
-    "validation_endpoint": "https://graph.facebook.com/v18.0/me?access_token={whatsapp_access_token}",
+    "validation_endpoint": "https://graph.facebook.com/v25.0/me?access_token={whatsapp_access_token}",
     "setup_url": "https://developers.facebook.com/apps"
   },
   "capabilities": {
@@ -45,12 +50,14 @@
       "webhook": {
         "secret_header": "X-Hub-Signature-256",
         "secret_name": "whatsapp_verify_token",
-        "verify_token_param": "hub.verify_token"
+        "verification_mode": "query_param",
+        "hmac_secret_name": "whatsapp_app_secret",
+        "message_id_json_pointer": "/message_id"
       }
     }
   },
   "config": {
-    "api_version": "v18.0",
+    "api_version": "v25.0",
     "reply_to_message": true,
     "owner_id": null,
     "dm_policy": "pairing",

--- a/migrations/V10__webhook_dedup.sql
+++ b/migrations/V10__webhook_dedup.sql
@@ -1,0 +1,24 @@
+-- Webhook message deduplication table
+-- Tracks which webhook messages have been processed to prevent duplicates
+-- when WhatsApp retries after a 500 response
+
+CREATE TABLE webhook_message_dedup (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    channel TEXT NOT NULL,
+    external_message_id TEXT NOT NULL,
+    processed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(channel, external_message_id)
+);
+
+-- Index for fast lookup by channel + message_id
+CREATE INDEX idx_webhook_dedup_channel_msg ON webhook_message_dedup(channel, external_message_id);
+
+-- Auto-cleanup: delete entries older than 7 days (WhatsApp max retry window)
+-- Meta's webhook retry policy: retries for up to 7 days on 5xx errors
+-- See: https://developers.facebook.com/docs/graph-api/webhooks#retry
+-- This keeps the table small while covering all retry scenarios
+CREATE OR REPLACE FUNCTION cleanup_old_dedup_entries() RETURNS void AS $$
+BEGIN
+    DELETE FROM webhook_message_dedup WHERE processed_at < NOW() - INTERVAL '7 days';
+END;
+$$ LANGUAGE plpgsql;

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -77,6 +77,10 @@ pub struct AgentDeps {
     pub sse_tx: Option<tokio::sync::broadcast::Sender<crate::channels::web::types::SseEvent>>,
     /// HTTP interceptor for trace recording/replay.
     pub http_interceptor: Option<Arc<dyn crate::llm::recording::HttpInterceptor>>,
+    /// WASM channel router for webhook ACK signaling.
+    /// When set, the agent will signal ACK after persisting messages,
+    /// allowing webhooks to wait for persistence before returning 200 OK.
+    pub wasm_router: Option<Arc<crate::channels::wasm::router::WasmChannelRouter>>,
 }
 
 /// The main agent that coordinates all components.

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1078,6 +1078,7 @@ mod tests {
             cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
             sse_tx: None,
             http_interceptor: None,
+            wasm_router: None,
         };
 
         Agent::new(
@@ -1818,6 +1819,7 @@ mod tests {
             cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
             sse_tx: None,
             http_interceptor: None,
+            wasm_router: None,
         };
 
         Agent::new(
@@ -1931,6 +1933,7 @@ mod tests {
                 cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
                 sse_tx: None,
                 http_interceptor: None,
+                wasm_router: None,
             };
 
             Agent::new(

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -272,6 +272,39 @@ impl Agent {
         self.persist_user_message(thread_id, &message.user_id, content)
             .await;
 
+        // Signal webhook ACK after persistence (if router available)
+        // This tells the webhook handler that the message was stored and it can
+        // return blue checkmarks on supported platforms.
+        if let Some(router) = &self.deps.wasm_router {
+            // Build ack_key from channel name and message metadata
+            // For WhatsApp, metadata contains: phone_number_id, sender_phone, message_id, timestamp
+            #[derive(serde::Deserialize)]
+            struct WhatsAppMetadata {
+                message_id: Option<String>,
+            }
+
+            let ack_key = if let Ok(meta) =
+                serde_json::from_value::<WhatsAppMetadata>(message.metadata.clone())
+            {
+                if let Some(msg_id) = meta.message_id {
+                    format!("{}:{}", message.channel, msg_id)
+                } else {
+                    // Fallback to user_id if no message_id in metadata
+                    format!("{}:{}", message.channel, message.user_id)
+                }
+            } else {
+                // Fallback to user_id if metadata parsing fails
+                format!("{}:{}", message.channel, message.user_id)
+            };
+
+            tracing::debug!(ack_key = %ack_key, "Signaling webhook ACK after persistence");
+
+            // Signal ACK with metadata for on_message_persisted callback
+            router
+                .ack_message(&ack_key, &message.metadata.to_string())
+                .await;
+        }
+
         // Send thinking status
         let _ = self
             .channels

--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -285,11 +285,23 @@ impl LoadedChannel {
             .and_then(|f| f.signature_key_secret_name().map(|s| s.to_string()))
     }
 
-    /// Get the HMAC-SHA256 signing secret name from capabilities.
-    pub fn hmac_secret_name(&self) -> Option<String> {
+    /// Get the webhook verification mode from capabilities.
+    ///
+    /// Returns "query_param", "signature", or None (default behavior).
+    pub fn verification_mode(&self) -> Option<&str> {
         self.capabilities_file
             .as_ref()
-            .and_then(|f| f.hmac_secret_name().map(|s| s.to_string()))
+            .and_then(|f| f.webhook_verification_mode())
+    }
+
+    /// Get the JSON pointer for extracting message IDs from metadata_json.
+    ///
+    /// Returns the configured pointer (e.g., "/message_id" for WhatsApp),
+    /// or None if not configured (falls back to user_id).
+    pub fn message_id_json_pointer(&self) -> Option<&str> {
+        self.capabilities_file
+            .as_ref()
+            .and_then(|f| f.webhook_message_id_json_pointer())
     }
 
     /// Get the webhook secret name from capabilities.
@@ -298,6 +310,13 @@ impl LoadedChannel {
             .as_ref()
             .map(|f| f.webhook_secret_name())
             .unwrap_or_else(|| format!("{}_webhook_secret", self.channel.channel_name()))
+    }
+
+    /// Get the HMAC secret name from capabilities.
+    pub fn hmac_secret_name(&self) -> Option<String> {
+        self.capabilities_file
+            .as_ref()
+            .and_then(|f| f.webhook_hmac_secret_name().map(|s| s.to_string()))
     }
 }
 

--- a/src/channels/wasm/mod.rs
+++ b/src/channels/wasm/mod.rs
@@ -83,7 +83,7 @@ mod capabilities;
 mod error;
 mod host;
 mod loader;
-mod router;
+pub mod router;
 mod runtime;
 mod schema;
 pub(crate) mod signature;
@@ -105,4 +105,4 @@ pub use runtime::{PreparedChannelModule, WasmChannelRuntime, WasmChannelRuntimeC
 pub use schema::{
     ChannelCapabilitiesFile, ChannelConfig, SecretSetupSchema, SetupSchema, WebhookSchema,
 };
-pub use wrapper::{HttpResponse, SharedWasmChannel, WasmChannel};
+pub use wrapper::{HttpResponse, HttpResponseWithMessages, SharedWasmChannel, WasmChannel};

--- a/src/channels/wasm/router.rs
+++ b/src/channels/wasm/router.rs
@@ -5,6 +5,7 @@
 
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::{
     Json, Router,
@@ -15,9 +16,18 @@ use axum::{
     routing::{get, post},
 };
 use serde::{Deserialize, Serialize};
-use tokio::sync::RwLock;
+use tokio::sync::{RwLock, oneshot};
 
-use crate::channels::wasm::wrapper::WasmChannel;
+use crate::channels::wasm::wrapper::{HttpResponseWithMessages, WasmChannel};
+
+/// Extract a value from a JSON string using a JSON pointer.
+///
+/// JSON pointer format: "/field1/field2" to access {"field1": {"field2": "value"}}
+/// Returns None if the pointer is invalid or the path doesn't exist.
+pub(crate) fn extract_json_pointer(json: &str, pointer: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    value.pointer(pointer)?.as_str().map(|s| s.to_string())
+}
 
 /// A registered HTTP endpoint for a WASM channel.
 #[derive(Debug, Clone)]
@@ -44,8 +54,18 @@ pub struct WasmChannelRouter {
     secret_headers: RwLock<HashMap<String, String>>,
     /// Ed25519 public keys for signature verification by channel name (hex-encoded).
     signature_keys: RwLock<HashMap<String, String>>,
-    /// HMAC-SHA256 signing secrets for signature verification by channel name (Slack-style).
+    /// Verification mode per channel: "query_param", "signature", etc.
+    verification_modes: RwLock<HashMap<String, String>>,
+    /// HMAC secrets for signature verification by channel name (WhatsApp/Slack style).
     hmac_secrets: RwLock<HashMap<String, String>>,
+    /// JSON pointers for extracting message IDs from metadata_json by channel name.
+    /// Used for ACK key construction and deduplication.
+    message_id_json_pointers: RwLock<HashMap<String, String>>,
+    /// Pending webhook acknowledgments by "channel:message_id" key.
+    /// Used to delay webhook 200 response until message is persisted to DB.
+    pending_acks: RwLock<HashMap<String, oneshot::Sender<()>>>,
+    /// Database for webhook message deduplication.
+    db: RwLock<Option<Arc<dyn crate::db::WebhookDedupStore + Send + Sync>>>,
 }
 
 impl WasmChannelRouter {
@@ -57,7 +77,50 @@ impl WasmChannelRouter {
             secrets: RwLock::new(HashMap::new()),
             secret_headers: RwLock::new(HashMap::new()),
             signature_keys: RwLock::new(HashMap::new()),
+            verification_modes: RwLock::new(HashMap::new()),
             hmac_secrets: RwLock::new(HashMap::new()),
+            message_id_json_pointers: RwLock::new(HashMap::new()),
+            pending_acks: RwLock::new(HashMap::new()),
+            db: RwLock::new(None),
+        }
+    }
+
+    /// Set the database for webhook message deduplication.
+    pub async fn set_db(&self, db: Arc<dyn crate::db::WebhookDedupStore + Send + Sync>) {
+        *self.db.write().await = Some(db);
+    }
+
+    /// Get the database for webhook message deduplication.
+    pub async fn get_db(&self) -> Option<Arc<dyn crate::db::WebhookDedupStore + Send + Sync>> {
+        self.db.read().await.clone()
+    }
+
+    /// Clean up old webhook dedup records.
+    ///
+    /// Called periodically to prevent unbounded growth of the dedup table.
+    /// Returns the number of records deleted.
+    pub async fn cleanup_old_dedup_records(&self) -> usize {
+        if let Some(db) = self.get_db().await {
+            match db.cleanup_old_webhook_dedup_records().await {
+                Ok(count) => {
+                    if count > 0 {
+                        tracing::info!(
+                            deleted_count = count,
+                            "Cleaned up old webhook dedup records"
+                        );
+                    }
+                    count as usize
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        "Failed to clean up old webhook dedup records"
+                    );
+                    0
+                }
+            }
+        } else {
+            0
         }
     }
 
@@ -69,12 +132,19 @@ impl WasmChannelRouter {
     /// * `secret` - Optional webhook secret for validation
     /// * `secret_header` - Optional HTTP header name for secret validation
     ///   (e.g., "X-Telegram-Bot-Api-Secret-Token"). Defaults to "X-Webhook-Secret".
+    /// * `verification_mode` - Optional verification mode for GET requests:
+    ///   - "query_param": Skip host-level secret validation for GET, WASM validates via query param
+    ///   - "signature": Always require signature validation
+    /// * `message_id_json_pointer` - Optional JSON pointer to extract message ID from metadata_json
+    ///   (e.g., "/message_id" for WhatsApp). If None, falls back to user_id.
     pub async fn register(
         &self,
         channel: Arc<WasmChannel>,
         endpoints: Vec<RegisteredEndpoint>,
         secret: Option<String>,
         secret_header: Option<String>,
+        verification_mode: Option<String>,
+        message_id_json_pointer: Option<String>,
     ) {
         let name = channel.channel_name().to_string();
 
@@ -100,7 +170,23 @@ impl WasmChannelRouter {
 
         // Store secret header if provided
         if let Some(h) = secret_header {
-            self.secret_headers.write().await.insert(name, h);
+            self.secret_headers.write().await.insert(name.clone(), h);
+        }
+
+        // Store verification mode if provided
+        if let Some(m) = verification_mode {
+            self.verification_modes
+                .write()
+                .await
+                .insert(name.clone(), m);
+        }
+
+        // Store message ID JSON pointer if provided
+        if let Some(p) = message_id_json_pointer {
+            self.message_id_json_pointers
+                .write()
+                .await
+                .insert(name.clone(), p);
         }
     }
 
@@ -114,6 +200,29 @@ impl WasmChannelRouter {
             .get(channel_name)
             .cloned()
             .unwrap_or_else(|| "X-Webhook-Secret".to_string())
+    }
+
+    /// Get the verification mode for a channel.
+    ///
+    /// Returns the configured mode or None (default behavior).
+    pub async fn get_verification_mode(&self, channel_name: &str) -> Option<String> {
+        self.verification_modes
+            .read()
+            .await
+            .get(channel_name)
+            .cloned()
+    }
+
+    /// Get the message ID JSON pointer for a channel.
+    ///
+    /// Returns the configured JSON pointer for extracting message IDs from
+    /// metadata_json, or None if not configured (falls back to user_id).
+    pub async fn get_message_id_json_pointer(&self, channel_name: &str) -> Option<String> {
+        self.message_id_json_pointers
+            .read()
+            .await
+            .get(channel_name)
+            .cloned()
     }
 
     /// Update the webhook secret for an already-registered channel.
@@ -137,7 +246,12 @@ impl WasmChannelRouter {
         self.secrets.write().await.remove(channel_name);
         self.secret_headers.write().await.remove(channel_name);
         self.signature_keys.write().await.remove(channel_name);
+        self.verification_modes.write().await.remove(channel_name);
         self.hmac_secrets.write().await.remove(channel_name);
+        self.message_id_json_pointers
+            .write()
+            .await
+            .remove(channel_name);
 
         // Remove all paths for this channel
         self.path_to_channel
@@ -213,22 +327,84 @@ impl WasmChannelRouter {
         self.signature_keys.read().await.get(channel_name).cloned()
     }
 
-    /// Register an HMAC-SHA256 signing secret for signature verification.
+    /// Register an HMAC secret for a channel.
     ///
-    /// Channels with a registered secret will have Slack-style HMAC-SHA256
-    /// signature validation performed before forwarding to WASM.
-    pub async fn register_hmac_secret(&self, channel_name: &str, secret: &str) {
+    /// The secret is used for HMAC-SHA256 signature verification
+    /// (WhatsApp/Slack style with X-Hub-Signature-256 header).
+    pub async fn register_hmac_secret(&self, channel_name: &str, secret: String) {
         self.hmac_secrets
             .write()
             .await
-            .insert(channel_name.to_string(), secret.to_string());
+            .insert(channel_name.to_string(), secret);
+        tracing::info!(
+            channel = %channel_name,
+            "Registered HMAC secret for webhook signature verification"
+        );
     }
 
-    /// Get the HMAC signing secret for a channel.
+    /// Get the HMAC secret for a channel.
     ///
-    /// Returns `None` if no secret is registered (no HMAC check needed).
+    /// Returns `None` if no HMAC secret is registered.
     pub async fn get_hmac_secret(&self, channel_name: &str) -> Option<String> {
         self.hmac_secrets.read().await.get(channel_name).cloned()
+    }
+
+    // ========================================================================
+    // Webhook Acknowledgment (reliable message processing)
+    // ========================================================================
+
+    /// Register a pending acknowledgment for a webhook message.
+    ///
+    /// Call this before processing a webhook message. The returned receiver
+    /// will be signaled when the message has been persisted to the database.
+    /// The webhook handler should wait on this receiver before returning 200 OK.
+    ///
+    /// # Arguments
+    /// * `key` - Unique identifier for the message, typically "channel:message_id"
+    ///
+    /// # Returns
+    /// A oneshot receiver that will be signaled when ack_message() is called.
+    pub async fn register_pending_ack(&self, key: String) -> oneshot::Receiver<()> {
+        let (tx, rx) = oneshot::channel();
+        self.pending_acks.write().await.insert(key.clone(), tx);
+        tracing::debug!(key = %key, "Registered pending webhook ACK");
+        rx
+    }
+
+    /// Signal that a message has been persisted and the webhook can return 200 OK.
+    ///
+    /// Called by the agent loop after persist_user_message() completes.
+    /// Also triggers the on_message_persisted WASM callback for channels that
+    /// implement it (e.g., WhatsApp for mark_as_read).
+    ///
+    /// Note: Deduplication recording happens at webhook handler level (before
+    /// sending to agent) to prevent race conditions with concurrent webhooks.
+    ///
+    /// # Arguments
+    /// * `key` - The same key passed to register_pending_ack() (format: "channel:message_id")
+    /// * `message_metadata` - JSON metadata for channel-specific post-persistence actions
+    pub async fn ack_message(&self, key: &str, message_metadata: &str) {
+        if let Some(tx) = self.pending_acks.write().await.remove(key) {
+            // Signal the webhook handler to return 200 OK
+            let _ = tx.send(());
+            tracing::debug!(key = %key, "Webhook ACK signaled");
+
+            // Parse key to get channel name for callback
+            let channel_name = key.split(':').next().unwrap_or("");
+
+            // Look up the channel and call on_message_persisted
+            if let Some(channel) = self.channels.read().await.get(channel_name)
+                && let Err(e) = channel.call_on_message_persisted(message_metadata).await
+            {
+                tracing::warn!(
+                    channel = %channel_name,
+                    error = %e,
+                    "on_message_persisted callback failed (best-effort)"
+                );
+            }
+        } else {
+            tracing::debug!(key = %key, "No pending ACK found (may have timed out)");
+        }
     }
 }
 
@@ -244,6 +420,10 @@ impl Default for WasmChannelRouter {
 pub struct RouterState {
     router: Arc<WasmChannelRouter>,
     extension_manager: Option<Arc<crate::extensions::ExtensionManager>>,
+    /// Database for webhook message deduplication.
+    db: Option<Arc<dyn crate::db::Database>>,
+    /// Timeout for waiting on webhook ACK before returning 500.
+    webhook_ack_timeout: Duration,
 }
 
 impl RouterState {
@@ -251,6 +431,8 @@ impl RouterState {
         Self {
             router,
             extension_manager: None,
+            db: None,
+            webhook_ack_timeout: Duration::from_secs(10),
         }
     }
 
@@ -259,6 +441,18 @@ impl RouterState {
         manager: Arc<crate::extensions::ExtensionManager>,
     ) -> Self {
         self.extension_manager = Some(manager);
+        self
+    }
+
+    /// Add database for webhook message deduplication.
+    pub fn with_db(mut self, db: Arc<dyn crate::db::Database>) -> Self {
+        self.db = Some(db);
+        self
+    }
+
+    /// Set the webhook ACK timeout.
+    pub fn with_webhook_ack_timeout(mut self, timeout: Duration) -> Self {
+        self.webhook_ack_timeout = timeout;
         self
     }
 }
@@ -334,7 +528,13 @@ async fn webhook_handler(
     let channel_name = channel.channel_name();
 
     // Check if secret is required
-    if state.router.requires_secret(channel_name).await {
+    // Skip secret validation if using query_param verification mode
+    // (e.g., WhatsApp uses hub.verify_token for GET verification and X-Hub-Signature-256
+    // for POST validation - both handled by the WASM module internally)
+    let verification_mode = state.router.get_verification_mode(channel_name).await;
+    let skip_secret_validation = verification_mode.as_deref() == Some("query_param");
+
+    if !skip_secret_validation && state.router.requires_secret(channel_name).await {
         // Get the secret header name for this channel (from capabilities or default)
         let secret_header_name = state.router.get_secret_header(channel_name).await;
 
@@ -396,6 +596,12 @@ async fn webhook_handler(
                 );
             }
         }
+    } else if skip_secret_validation {
+        tracing::debug!(
+            channel = %channel_name,
+            verification_mode = ?verification_mode,
+            "Skipping secret validation for channel with query_param verification mode"
+        );
     }
 
     // Ed25519 signature verification (Discord-style)
@@ -449,53 +655,82 @@ async fn webhook_handler(
         }
     }
 
-    // HMAC-SHA256 signature verification (Slack-style)
+    // HMAC-SHA256 signature verification (Slack-style with timestamp)
+    // Check for Slack headers first
     if let Some(hmac_secret) = state.router.get_hmac_secret(channel_name).await {
-        let timestamp = headers
+        let slack_timestamp = headers
             .get("x-slack-request-timestamp")
             .and_then(|v| v.to_str().ok());
-        let sig_header = headers
+        let slack_sig = headers
             .get("x-slack-signature")
             .and_then(|v| v.to_str().ok());
 
-        match (timestamp, sig_header) {
-            (Some(ts), Some(sig)) => {
-                let now_secs = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs() as i64;
+        if let (Some(ts), Some(sig)) = (slack_timestamp, slack_sig) {
+            let now_secs = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
 
-                if !crate::channels::wasm::signature::verify_slack_signature(
-                    &hmac_secret,
-                    ts,
-                    &body,
-                    sig,
-                    now_secs,
-                ) {
-                    tracing::warn!(
-                        channel = %channel_name,
-                        "HMAC-SHA256 signature verification failed"
-                    );
-                    return (
-                        StatusCode::UNAUTHORIZED,
-                        Json(serde_json::json!({
-                            "error": "Invalid Slack signature"
-                        })),
-                    );
-                }
-                tracing::debug!(channel = %channel_name, "HMAC-SHA256 signature verified");
-            }
-            _ => {
+            if !crate::channels::wasm::signature::verify_slack_signature(
+                &hmac_secret,
+                ts,
+                &body,
+                sig,
+                now_secs,
+            ) {
                 tracing::warn!(
                     channel = %channel_name,
-                    "Slack signature headers missing but secret is registered"
+                    "Slack HMAC-SHA256 signature verification failed"
                 );
                 return (
                     StatusCode::UNAUTHORIZED,
                     Json(serde_json::json!({
-                        "error": "Missing Slack signature headers"
+                        "error": "Invalid Slack signature"
                     })),
                 );
+            }
+            tracing::debug!(channel = %channel_name, "Slack HMAC-SHA256 signature verified");
+        } else {
+            // Check for WhatsApp-style signature (X-Hub-Signature-256)
+            let wa_sig = headers
+                .get("x-hub-signature-256")
+                .and_then(|v| v.to_str().ok());
+
+            match wa_sig {
+                Some(sig) => {
+                    if !crate::channels::wasm::signature::verify_hmac_sha256(
+                        &hmac_secret,
+                        sig,
+                        &body,
+                    ) {
+                        tracing::warn!(
+                            channel = %channel_name,
+                            "WhatsApp HMAC-SHA256 signature verification failed"
+                        );
+                        return (
+                            StatusCode::UNAUTHORIZED,
+                            Json(serde_json::json!({
+                                "error": "Invalid signature"
+                            })),
+                        );
+                    }
+                    tracing::debug!(
+                        channel = %channel_name,
+                        "WhatsApp HMAC-SHA256 signature verified"
+                    );
+                }
+                None => {
+                    tracing::warn!(
+                        channel = %channel_name,
+                        "HMAC secret registered but no recognized signature headers found"
+                    );
+                    return (
+                        StatusCode::UNAUTHORIZED,
+                        Json(serde_json::json!({
+                            "error": "Missing signature header"
+                        })),
+                    );
+                }
             }
         }
     }
@@ -510,17 +745,17 @@ async fn webhook_handler(
         })
         .collect();
 
-    // Call the WASM channel
+    // Call the WASM channel (with messages returned for ACK coordination)
     let secret_validated = state.router.requires_secret(channel_name).await;
 
     tracing::info!(
         channel = %channel_name,
         secret_validated = secret_validated,
-        "Calling WASM channel on_http_request"
+        "Calling WASM channel on_http_request_with_messages"
     );
 
     match channel
-        .call_on_http_request(
+        .call_on_http_request_with_messages(
             method.as_str(),
             &full_path,
             &headers_map,
@@ -530,7 +765,10 @@ async fn webhook_handler(
         )
         .await
     {
-        Ok(response) => {
+        Ok(HttpResponseWithMessages {
+            response,
+            emitted_messages,
+        }) => {
             let status =
                 StatusCode::from_u16(response.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
 
@@ -538,8 +776,172 @@ async fn webhook_handler(
                 channel = %channel_name,
                 status = %status,
                 body_len = response.body.len(),
-                "WASM channel on_http_request completed successfully"
+                emitted_count = emitted_messages.len(),
+                "WASM channel on_http_request completed"
             );
+
+            // If there are emitted messages, wait for ACK before returning
+            if !emitted_messages.is_empty() {
+                // Register ACK receivers for each NEW message (skip duplicates)
+                let mut ack_receivers: Vec<(String, oneshot::Receiver<()>, String)> = Vec::new();
+                let mut new_messages: Vec<_> = Vec::new();
+
+                for msg in &emitted_messages {
+                    // Extract message_id using channel's configured JSON pointer
+                    // Falls back to user_id if pointer not configured or extraction fails
+                    let message_id_json_pointer =
+                        state.router.get_message_id_json_pointer(channel_name).await;
+
+                    let (ack_key, external_msg_id) = if let Some(pointer) = &message_id_json_pointer
+                    {
+                        // Try to extract message_id using the JSON pointer
+                        match extract_json_pointer(&msg.metadata_json, pointer) {
+                            Some(msg_id) => (format!("{}:{}", channel_name, msg_id), Some(msg_id)),
+                            None => {
+                                // Fallback to user_id if extraction fails
+                                tracing::debug!(
+                                    channel = %channel_name,
+                                    pointer = %pointer,
+                                    "JSON pointer extraction failed, falling back to user_id"
+                                );
+                                (format!("{}:{}", channel_name, msg.user_id), None)
+                            }
+                        }
+                    } else {
+                        // No pointer configured, use user_id
+                        (format!("{}:{}", channel_name, msg.user_id), None)
+                    };
+
+                    // Atomic deduplication: try to INSERT first
+                    // Returns true if inserted (new message), false if duplicate
+                    // This eliminates TOCTOU race condition between SELECT and INSERT
+                    if let Some(ref db) = state.db
+                        && let Some(msg_id) = &external_msg_id
+                    {
+                        match db
+                            .record_webhook_message_processed(channel_name, msg_id)
+                            .await
+                        {
+                            Ok(was_inserted) => {
+                                if !was_inserted {
+                                    tracing::info!(
+                                        channel = %channel_name,
+                                        message_id = %msg_id,
+                                        "Duplicate webhook message detected, skipping"
+                                    );
+                                    continue; // Skip this duplicate message
+                                }
+                                // New message - will process below
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    channel = %channel_name,
+                                    message_id = %msg_id,
+                                    error = %e,
+                                    "Failed to record message, proceeding anyway (fail open)"
+                                );
+                                // Continue processing on error (fail open)
+                            }
+                        }
+                    }
+
+                    let ack_rx = state.router.register_pending_ack(ack_key.clone()).await;
+                    ack_receivers.push((ack_key, ack_rx, msg.metadata_json.clone()));
+                    new_messages.push(msg.clone());
+                }
+
+                // If all messages were duplicates, return success immediately
+                if new_messages.is_empty() {
+                    tracing::info!(
+                        channel = %channel_name,
+                        "All webhook messages were duplicates, returning 200"
+                    );
+                    let body_json: serde_json::Value = serde_json::from_slice(&response.body)
+                        .unwrap_or_else(|_| {
+                            serde_json::json!({
+                                "raw": String::from_utf8_lossy(&response.body).to_string()
+                            })
+                        });
+                    return (status, Json(body_json));
+                }
+
+                // Send only NEW messages to the agent
+                if let Err(e) = channel.send_emitted_messages(new_messages).await {
+                    tracing::error!(
+                        channel = %channel_name,
+                        error = %e,
+                        "Failed to send emitted messages to agent"
+                    );
+                    // Continue to return response even if sending failed
+                }
+
+                // Wait for all ACKs with a configurable timeout for all messages
+                // Using join_all ensures we don't accumulate timeouts (3 messages ≠ 30s wait)
+                let ack_timeout = state.webhook_ack_timeout;
+
+                // Keep track of ack_keys for cleanup on timeout
+                let ack_keys: Vec<String> = ack_receivers
+                    .iter()
+                    .map(|(key, _, _)| key.clone())
+                    .collect();
+
+                let ack_futures: Vec<_> = ack_receivers
+                    .into_iter()
+                    .map(|(ack_key, ack_rx, _)| async move {
+                        match ack_rx.await {
+                            Ok(()) => {
+                                tracing::debug!(key = %ack_key, "Webhook ACK received");
+                                true
+                            }
+                            Err(_) => {
+                                tracing::warn!(key = %ack_key, "Webhook ACK channel closed");
+                                false
+                            }
+                        }
+                    })
+                    .collect();
+
+                let all_acked =
+                    match tokio::time::timeout(ack_timeout, futures::future::join_all(ack_futures))
+                        .await
+                    {
+                        Ok(results) => results.iter().all(|&r| r),
+                        Err(_) => {
+                            tracing::warn!(
+                                channel = %channel_name,
+                                timeout_secs = ack_timeout.as_secs(),
+                                "Webhook ACK wait timed out, returning 500 to trigger retry"
+                            );
+                            // Clean up pending ACKs that were registered but never signaled
+                            for ack_key in &ack_keys {
+                                state.router.pending_acks.write().await.remove(ack_key);
+                            }
+                            // Return 500 so WhatsApp retries - deduplication will handle duplicates
+                            return (
+                                StatusCode::INTERNAL_SERVER_ERROR,
+                                Json(serde_json::json!({
+                                    "error": "ACK timeout",
+                                    "message": "Message processing timed out, will retry"
+                                })),
+                            );
+                        }
+                    };
+
+                if !all_acked {
+                    tracing::warn!(
+                        channel = %channel_name,
+                        "Some webhook ACKs were not received, returning 500 to trigger retry"
+                    );
+                    // Return 500 so WhatsApp retries - deduplication will handle duplicates
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(serde_json::json!({
+                            "error": "ACK not received",
+                            "message": "Message persistence not confirmed, will retry"
+                        })),
+                    );
+                }
+            }
 
             // Build response with headers
             let body_json: serde_json::Value = serde_json::from_slice(&response.body)
@@ -626,10 +1028,18 @@ async fn oauth_callback_handler(
 pub fn create_wasm_channel_router(
     router: Arc<WasmChannelRouter>,
     extension_manager: Option<Arc<crate::extensions::ExtensionManager>>,
+    db: Option<Arc<dyn crate::db::Database>>,
+    webhook_ack_timeout: Option<Duration>,
 ) -> Router {
     let mut state = RouterState::new(router);
     if let Some(manager) = extension_manager {
         state = state.with_extension_manager(manager);
+    }
+    if let Some(database) = db {
+        state = state.with_db(database);
+    }
+    if let Some(timeout) = webhook_ack_timeout {
+        state = state.with_webhook_ack_timeout(timeout);
     }
 
     Router::new()
@@ -646,7 +1056,9 @@ mod tests {
     use std::sync::Arc;
 
     use crate::channels::wasm::capabilities::ChannelCapabilities;
-    use crate::channels::wasm::router::{RegisteredEndpoint, WasmChannelRouter};
+    use crate::channels::wasm::router::{
+        RegisteredEndpoint, WasmChannelRouter, extract_json_pointer,
+    };
     use crate::channels::wasm::runtime::{
         PreparedChannelModule, WasmChannelRuntime, WasmChannelRuntimeConfig,
     };
@@ -691,7 +1103,14 @@ mod tests {
         }];
 
         router
-            .register(channel, endpoints, Some("secret123".to_string()), None)
+            .register(
+                channel,
+                endpoints,
+                Some("secret123".to_string()),
+                None,
+                None,
+                None,
+            )
             .await;
 
         // Should find channel by path
@@ -710,7 +1129,14 @@ mod tests {
         let channel = create_test_channel("slack");
 
         router
-            .register(channel, vec![], Some("secret123".to_string()), None)
+            .register(
+                channel,
+                vec![],
+                Some("secret123".to_string()),
+                None,
+                None,
+                None,
+            )
             .await;
 
         // Correct secret
@@ -721,7 +1147,9 @@ mod tests {
 
         // Channel without secret always validates
         let channel2 = create_test_channel("telegram");
-        router.register(channel2, vec![], None, None).await;
+        router
+            .register(channel2, vec![], None, None, None, None)
+            .await;
         assert!(router.validate_secret("telegram", "anything").await);
     }
 
@@ -737,7 +1165,9 @@ mod tests {
             require_secret: false,
         }];
 
-        router.register(channel, endpoints, None, None).await;
+        router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
 
         // Should exist
         assert!(
@@ -766,8 +1196,12 @@ mod tests {
         let channel1 = create_test_channel("slack");
         let channel2 = create_test_channel("telegram");
 
-        router.register(channel1, vec![], None, None).await;
-        router.register(channel2, vec![], None, None).await;
+        router
+            .register(channel1, vec![], None, None, None, None)
+            .await;
+        router
+            .register(channel2, vec![], None, None, None, None)
+            .await;
 
         let channels = router.list_channels().await;
         assert_eq!(channels.len(), 2);
@@ -787,6 +1221,8 @@ mod tests {
                 vec![],
                 Some("secret123".to_string()),
                 Some("X-Telegram-Bot-Api-Secret-Token".to_string()),
+                None,
+                None,
             )
             .await;
 
@@ -799,71 +1235,28 @@ mod tests {
         // Channel without custom header should use default
         let channel2 = create_test_channel("slack");
         router
-            .register(channel2, vec![], Some("secret456".to_string()), None)
+            .register(
+                channel2,
+                vec![],
+                Some("secret456".to_string()),
+                None,
+                None,
+                None,
+            )
             .await;
         assert_eq!(router.get_secret_header("slack").await, "X-Webhook-Secret");
     }
 
-    // ── Category 3: Router HMAC Secret Management ───────────────────────
-
-    #[tokio::test]
-    async fn test_register_and_get_hmac_secret() {
-        let router = WasmChannelRouter::new();
-        let channel = create_test_channel("slack");
-
-        router.register(channel, vec![], None, None).await;
-
-        let hmac_secret = "my-slack-signing-secret";
-        router.register_hmac_secret("slack", hmac_secret).await;
-
-        let retrieved = router.get_hmac_secret("slack").await;
-        assert_eq!(retrieved, Some(hmac_secret.to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_no_hmac_secret_returns_none() {
-        let router = WasmChannelRouter::new();
-        let channel = create_test_channel("slack");
-        router.register(channel, vec![], None, None).await;
-
-        // Slack has no HMAC secret registered
-        let secret = router.get_hmac_secret("slack").await;
-        assert!(secret.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_unregister_removes_hmac_secret() {
-        let router = WasmChannelRouter::new();
-        let channel = create_test_channel("slack");
-
-        let endpoints = vec![RegisteredEndpoint {
-            channel_name: "slack".to_string(),
-            path: "/webhook/slack".to_string(),
-            methods: vec!["POST".to_string()],
-            require_secret: false,
-        }];
-
-        router.register(channel, endpoints, None, None).await;
-        router.register_hmac_secret("slack", "signing-secret").await;
-
-        // Secret should exist
-        assert!(router.get_hmac_secret("slack").await.is_some());
-
-        // Unregister
-        router.unregister("slack").await;
-
-        // Secret should be gone
-        assert!(router.get_hmac_secret("slack").await.is_none());
-    }
-
-    // ── Category 4: Router Signature Key Management ─────────────────────
+    // ── Category 3: Router Signature Key Management ─────────────────────
 
     #[tokio::test]
     async fn test_register_and_get_signature_key() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
 
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         let fake_pub_key = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2";
         router
@@ -879,7 +1272,9 @@ mod tests {
     async fn test_no_signature_key_returns_none() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("slack");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         // Slack has no signature key registered
         let key = router.get_signature_key("slack").await;
@@ -898,7 +1293,9 @@ mod tests {
             require_secret: false,
         }];
 
-        router.register(channel, endpoints, None, None).await;
+        router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
         // Use a valid 32-byte Ed25519 key for this test
         let valid_key = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa3f4a18446b7e8c7ac6602";
         router
@@ -922,7 +1319,9 @@ mod tests {
     async fn test_register_valid_signature_key_succeeds() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         // Valid 32-byte Ed25519 public key (from test keypair)
         let valid_key = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa3f4a18446b7e8c7ac6602";
@@ -934,7 +1333,9 @@ mod tests {
     async fn test_register_invalid_hex_key_fails() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         let result = router
             .register_signature_key("discord", "not-valid-hex-zzz")
@@ -946,7 +1347,9 @@ mod tests {
     async fn test_register_wrong_length_key_fails() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         // 16 bytes instead of 32
         let short_key = hex::encode([0u8; 16]);
@@ -958,7 +1361,9 @@ mod tests {
     async fn test_register_empty_key_fails() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         let result = router.register_signature_key("discord", "").await;
         assert!(result.is_err(), "Empty key should be rejected");
@@ -968,7 +1373,9 @@ mod tests {
     async fn test_valid_key_is_retrievable() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         let valid_key = "d75a980182b10ab7d54bfed3c964073a0ee172f3daa3f4a18446b7e8c7ac6602";
         router
@@ -984,7 +1391,9 @@ mod tests {
     async fn test_invalid_key_does_not_store() {
         let router = WasmChannelRouter::new();
         let channel = create_test_channel("discord");
-        router.register(channel, vec![], None, None).await;
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
 
         // Attempt to register invalid key
         let _ = router
@@ -1018,9 +1427,11 @@ mod tests {
             require_secret: false,
         }];
 
-        wasm_router.register(channel, endpoints, None, None).await;
+        wasm_router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
 
-        let app = create_wasm_channel_router(wasm_router.clone(), None);
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
         (wasm_router, app)
     }
 
@@ -1245,7 +1656,14 @@ mod tests {
 
         // Register with BOTH secret and signature key
         wasm_router
-            .register(channel, endpoints, Some("my-secret".to_string()), None)
+            .register(
+                channel,
+                endpoints,
+                Some("my-secret".to_string()),
+                None,
+                None,
+                None,
+            )
             .await;
 
         let signing_key = test_signing_key();
@@ -1255,7 +1673,7 @@ mod tests {
             .await
             .unwrap();
 
-        let app = create_wasm_channel_router(wasm_router.clone(), None);
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
 
         // Use current timestamp so staleness check passes
         let now_secs = std::time::SystemTime::now()
@@ -1289,9 +1707,225 @@ mod tests {
         );
     }
 
-    // ── HMAC-SHA256 Webhook Signature Tests ────────────────────────────
+    // ── HMAC-SHA256 Router Tests (WhatsApp/Slack style) ─────────────────
 
-    /// Helper to create a router with a registered channel at /webhook/slack.
+    /// Helper: compute HMAC-SHA256 signature in WhatsApp format.
+    fn compute_hmac_signature(secret: &str, body: &[u8]) -> String {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+        type HmacSha256 = Hmac<Sha256>;
+
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let result = mac.finalize();
+        format!("sha256={}", hex::encode(result.into_bytes()))
+    }
+
+    #[tokio::test]
+    async fn test_register_and_get_hmac_secret() {
+        let router = WasmChannelRouter::new();
+        let channel = create_test_channel("whatsapp");
+
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
+
+        router
+            .register_hmac_secret("whatsapp", "my_app_secret".to_string())
+            .await;
+
+        let secret = router.get_hmac_secret("whatsapp").await;
+        assert_eq!(secret, Some("my_app_secret".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_no_hmac_secret_returns_none() {
+        let router = WasmChannelRouter::new();
+        let channel = create_test_channel("telegram");
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
+
+        let secret = router.get_hmac_secret("telegram").await;
+        assert!(secret.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_unregister_removes_hmac_secret() {
+        let router = WasmChannelRouter::new();
+        let channel = create_test_channel("whatsapp");
+
+        let endpoints = vec![RegisteredEndpoint {
+            channel_name: "whatsapp".to_string(),
+            path: "/webhook/whatsapp".to_string(),
+            methods: vec!["POST".to_string()],
+            require_secret: false,
+        }];
+
+        router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
+        router
+            .register_hmac_secret("whatsapp", "secret123".to_string())
+            .await;
+
+        // Secret should exist
+        assert!(router.get_hmac_secret("whatsapp").await.is_some());
+
+        // Unregister
+        router.unregister("whatsapp").await;
+
+        // Secret should be gone
+        assert!(router.get_hmac_secret("whatsapp").await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_webhook_rejects_missing_hmac_header() {
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let channel = create_test_channel("whatsapp");
+
+        let endpoints = vec![RegisteredEndpoint {
+            channel_name: "whatsapp".to_string(),
+            path: "/webhook/whatsapp".to_string(),
+            methods: vec!["POST".to_string()],
+            require_secret: false,
+        }];
+
+        wasm_router
+            .register(
+                channel,
+                endpoints,
+                None,
+                None,
+                Some("query_param".to_string()),
+                None,
+            )
+            .await;
+
+        // Register HMAC secret
+        wasm_router
+            .register_hmac_secret("whatsapp", "my_app_secret".to_string())
+            .await;
+
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
+
+        // Send request without X-Hub-Signature-256 header
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/whatsapp")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"entry":[]}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Missing HMAC header should return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_webhook_rejects_invalid_hmac_signature() {
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let channel = create_test_channel("whatsapp");
+
+        let endpoints = vec![RegisteredEndpoint {
+            channel_name: "whatsapp".to_string(),
+            path: "/webhook/whatsapp".to_string(),
+            methods: vec!["POST".to_string()],
+            require_secret: false,
+        }];
+
+        wasm_router
+            .register(
+                channel,
+                endpoints,
+                None,
+                None,
+                Some("query_param".to_string()),
+                None,
+            )
+            .await;
+
+        wasm_router
+            .register_hmac_secret("whatsapp", "correct_secret".to_string())
+            .await;
+
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
+
+        let body = br#"{"entry":[]}"#;
+        // Sign with wrong secret
+        let sig = compute_hmac_signature("wrong_secret", body);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/whatsapp")
+            .header("content-type", "application/json")
+            .header("X-Hub-Signature-256", &sig)
+            .body(Body::from(&body[..]))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Invalid HMAC signature should return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_webhook_accepts_valid_hmac_signature() {
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let channel = create_test_channel("whatsapp");
+
+        let endpoints = vec![RegisteredEndpoint {
+            channel_name: "whatsapp".to_string(),
+            path: "/webhook/whatsapp".to_string(),
+            methods: vec!["POST".to_string()],
+            require_secret: false,
+        }];
+
+        wasm_router
+            .register(
+                channel,
+                endpoints,
+                None,
+                None,
+                Some("query_param".to_string()),
+                None,
+            )
+            .await;
+
+        wasm_router
+            .register_hmac_secret("whatsapp", "my_app_secret".to_string())
+            .await;
+
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
+
+        let body = br#"{"entry":[]}"#;
+        let sig = compute_hmac_signature("my_app_secret", body);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/whatsapp")
+            .header("content-type", "application/json")
+            .header("X-Hub-Signature-256", &sig)
+            .body(Body::from(&body[..]))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        // Should pass HMAC check (may be 500 due to no WASM module, but not 401)
+        assert_ne!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Valid HMAC signature should not return 401"
+        );
+    }
+
+    // ==================== Slack HMAC-SHA256 Router Tests ====================
+
+    /// Helper: setup a Slack router for testing.
     async fn setup_slack_router() -> (Arc<WasmChannelRouter>, AxumRouter) {
         let wasm_router = Arc::new(WasmChannelRouter::new());
         let channel = create_test_channel("slack");
@@ -1303,9 +1937,11 @@ mod tests {
             require_secret: false,
         }];
 
-        wasm_router.register(channel, endpoints, None, None).await;
+        wasm_router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
 
-        let app = create_wasm_channel_router(wasm_router.clone(), None);
+        let app = create_wasm_channel_router(wasm_router.clone(), None, None, None);
         (wasm_router, app)
     }
 
@@ -1327,11 +1963,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_rejects_missing_sig_headers() {
+    async fn test_webhook_slack_hmac_rejects_missing_sig_headers() {
         let (wasm_router, app) = setup_slack_router().await;
 
         wasm_router
-            .register_hmac_secret("slack", "my-signing-secret")
+            .register_hmac_secret("slack", "my-signing-secret".to_string())
             .await;
 
         // Send request without HMAC signature headers
@@ -1346,16 +1982,16 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "Missing HMAC signature headers should return 401"
+            "Missing Slack HMAC signature headers should return 401"
         );
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_rejects_invalid_signature() {
+    async fn test_webhook_slack_hmac_rejects_invalid_signature() {
         let (wasm_router, app) = setup_slack_router().await;
 
         wasm_router
-            .register_hmac_secret("slack", "my-signing-secret")
+            .register_hmac_secret("slack", "my-signing-secret".to_string())
             .await;
 
         let req = Request::builder()
@@ -1371,17 +2007,17 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "Invalid HMAC signature should return 401"
+            "Invalid Slack HMAC signature should return 401"
         );
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_accepts_valid_signature() {
+    async fn test_webhook_slack_hmac_accepts_valid_signature() {
         let (wasm_router, app) = setup_slack_router().await;
 
         let signing_secret = "my-signing-secret";
         wasm_router
-            .register_hmac_secret("slack", signing_secret)
+            .register_hmac_secret("slack", signing_secret.to_string())
             .await;
 
         let now_secs = std::time::SystemTime::now()
@@ -1407,12 +2043,12 @@ mod tests {
         assert_ne!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "Valid HMAC signature should not return 401"
+            "Valid Slack HMAC signature should not return 401"
         );
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_skips_check_for_no_secret() {
+    async fn test_webhook_slack_hmac_skips_check_for_no_secret() {
         let (_wasm_router, app) = setup_slack_router().await;
 
         // No HMAC secret registered — should not require signature
@@ -1428,17 +2064,17 @@ mod tests {
         assert_ne!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "No HMAC secret registered — should skip check"
+            "No Slack HMAC secret registered — should skip check"
         );
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_uses_correct_body() {
+    async fn test_webhook_slack_hmac_uses_correct_body() {
         let (wasm_router, app) = setup_slack_router().await;
 
         let signing_secret = "my-signing-secret";
         wasm_router
-            .register_hmac_secret("slack", signing_secret)
+            .register_hmac_secret("slack", signing_secret.to_string())
             .await;
 
         let timestamp = "1234567890";
@@ -1462,17 +2098,17 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "Signature for different body should return 401"
+            "Slack signature for different body should return 401"
         );
     }
 
     #[tokio::test]
-    async fn test_webhook_hmac_uses_correct_timestamp() {
+    async fn test_webhook_slack_hmac_uses_correct_timestamp() {
         let (wasm_router, app) = setup_slack_router().await;
 
         let signing_secret = "my-signing-secret";
         wasm_router
-            .register_hmac_secret("slack", signing_secret)
+            .register_hmac_secret("slack", signing_secret.to_string())
             .await;
 
         let timestamp_a = "1234567890";
@@ -1482,7 +2118,7 @@ mod tests {
         // Sign with timestamp A
         let signature = slack_signature(signing_secret, timestamp_a, body);
 
-        // But send timestamp B in the header
+        // But send timestamp B in header
         let req = Request::builder()
             .method("POST")
             .uri("/webhook/slack")
@@ -1496,7 +2132,190 @@ mod tests {
         assert_eq!(
             resp.status(),
             StatusCode::UNAUTHORIZED,
-            "Signature with mismatched timestamp should return 401"
+            "Slack signature for different timestamp should return 401"
         );
+    }
+
+    // ==================== Webhook ACK mechanism tests ====================
+
+    #[tokio::test]
+    async fn test_register_and_ack_message() {
+        let router = WasmChannelRouter::new();
+
+        // Register pending ACK
+        let ack_key = "whatsapp:wamid.test123";
+        let rx = router.register_pending_ack(ack_key.to_string()).await;
+
+        // Ack the message
+        router.ack_message(ack_key, "").await;
+
+        // Verify the ACK was received
+        let result = rx.await;
+        assert!(result.is_ok(), "ACK should be received");
+    }
+
+    #[tokio::test]
+    async fn test_ack_message_removes_pending_entry() {
+        let router = WasmChannelRouter::new();
+
+        let ack_key = "whatsapp:wamid.test456";
+        let _rx = router.register_pending_ack(ack_key.to_string()).await;
+
+        // Verify entry exists
+        assert!(
+            router.pending_acks.read().await.contains_key(ack_key),
+            "Pending ACK should exist"
+        );
+
+        // Ack the message
+        router.ack_message(ack_key, "").await;
+
+        // Verify entry was removed
+        assert!(
+            !router.pending_acks.read().await.contains_key(ack_key),
+            "Pending ACK should be removed after ACK"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ack_nonexistent_key_is_safe() {
+        let router = WasmChannelRouter::new();
+
+        // Should not panic when ACKing a key that was never registered
+        router.ack_message("nonexistent:key", "").await;
+    }
+
+    #[tokio::test]
+    async fn test_double_ack_same_key() {
+        let router = WasmChannelRouter::new();
+
+        let ack_key = "whatsapp:wamid.test789";
+        let _rx = router.register_pending_ack(ack_key.to_string()).await;
+
+        // First ACK
+        router.ack_message(ack_key, "").await;
+
+        // Second ACK should be safe (no panic)
+        router.ack_message(ack_key, "").await;
+    }
+
+    // ── Category 8: JSON Pointer Extraction Tests ─────────────────────
+
+    #[test]
+    fn test_extract_json_pointer_valid() {
+        let json = r#"{"phone_number_id": "123456", "message_id": "wamid.abc123", "sender_phone": "+1234567890"}"#;
+
+        // Valid pointer to top-level field
+        assert_eq!(
+            extract_json_pointer(json, "/message_id"),
+            Some("wamid.abc123".to_string())
+        );
+
+        // Valid pointer to another field
+        assert_eq!(
+            extract_json_pointer(json, "/phone_number_id"),
+            Some("123456".to_string())
+        );
+
+        // Valid pointer to sender_phone
+        assert_eq!(
+            extract_json_pointer(json, "/sender_phone"),
+            Some("+1234567890".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_json_pointer_nested() {
+        let json = r#"{"entry": [{"id": "123", "changes": [{"value": {"messages": [{"id": "wamid.nested"}]}}]}]}"#;
+
+        // Nested pointer
+        assert_eq!(
+            extract_json_pointer(json, "/entry/0/id"),
+            Some("123".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_json_pointer_missing_field() {
+        let json = r#"{"phone_number_id": "123456"}"#;
+
+        // Missing field returns None
+        assert_eq!(extract_json_pointer(json, "/nonexistent"), None);
+    }
+
+    #[test]
+    fn test_extract_json_pointer_invalid_json() {
+        // Invalid JSON returns None
+        assert_eq!(extract_json_pointer("not json", "/message_id"), None);
+
+        // Empty string returns None
+        assert_eq!(extract_json_pointer("", "/message_id"), None);
+
+        // Partial JSON returns None
+        assert_eq!(extract_json_pointer("{invalid", "/message_id"), None);
+    }
+
+    #[test]
+    fn test_extract_json_pointer_non_string_value() {
+        let json = r#"{"count": 42, "enabled": true, "data": null}"#;
+
+        // Non-string values return None (we only extract strings)
+        assert_eq!(extract_json_pointer(json, "/count"), None);
+        assert_eq!(extract_json_pointer(json, "/enabled"), None);
+        assert_eq!(extract_json_pointer(json, "/data"), None);
+    }
+
+    #[test]
+    fn test_extract_json_pointer_empty_pointer() {
+        let json = r#"{"message_id": "test"}"#;
+
+        // Empty pointer refers to root, which is an object not a string
+        assert_eq!(extract_json_pointer(json, ""), None);
+    }
+
+    #[tokio::test]
+    async fn test_message_id_json_pointer_registration() {
+        let router = WasmChannelRouter::new();
+        let channel = create_test_channel("whatsapp");
+
+        // Register with message_id_json_pointer
+        router
+            .register(
+                channel,
+                vec![],
+                None,
+                None,
+                None,
+                Some("/message_id".to_string()),
+            )
+            .await;
+
+        // Should return the configured pointer
+        assert_eq!(
+            router.get_message_id_json_pointer("whatsapp").await,
+            Some("/message_id".to_string())
+        );
+    }
+
+    #[tokio::test]
+    async fn test_message_id_json_pointer_not_configured() {
+        let router = WasmChannelRouter::new();
+        let channel = create_test_channel("telegram");
+
+        // Register without message_id_json_pointer
+        router
+            .register(channel, vec![], None, None, None, None)
+            .await;
+
+        // Should return None
+        assert_eq!(router.get_message_id_json_pointer("telegram").await, None);
+    }
+
+    #[tokio::test]
+    async fn test_message_id_json_pointer_unregistered() {
+        let router = WasmChannelRouter::new();
+
+        // Never registered channel should return None
+        assert_eq!(router.get_message_id_json_pointer("unknown").await, None);
     }
 }

--- a/src/channels/wasm/schema.rs
+++ b/src/channels/wasm/schema.rs
@@ -51,6 +51,10 @@ use crate::tools::wasm::{CapabilitiesFile as ToolCapabilitiesFile, RateLimitSche
 /// Root schema for a channel capabilities JSON file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChannelCapabilitiesFile {
+    /// File type, must be "channel".
+    #[serde(default = "default_type")]
+    pub r#type: String,
+
     /// Extension version (semver).
     #[serde(default)]
     pub version: Option<String>,
@@ -58,10 +62,6 @@ pub struct ChannelCapabilitiesFile {
     /// WIT interface version this channel was compiled against (semver).
     #[serde(default)]
     pub wit_version: Option<String>,
-
-    /// File type, must be "channel".
-    #[serde(default = "default_type")]
-    pub r#type: String,
 
     /// Channel name.
     pub name: String,
@@ -162,16 +162,18 @@ impl ChannelCapabilitiesFile {
             .and_then(|w| w.signature_key_secret_name.as_deref())
     }
 
-    /// Get the HMAC-SHA256 signing secret name for this channel.
+    /// Get the webhook verification mode for this channel.
     ///
-    /// Returns the secret name declared in `webhook.hmac_secret_name`,
-    /// used to look up the HMAC signing secret in the secrets store (Slack-style).
-    pub fn hmac_secret_name(&self) -> Option<&str> {
+    /// Returns the verification mode declared in `webhook.verification_mode`:
+    /// - None/default: Require secret header for all requests
+    /// - "query_param": Skip host-level secret validation for GET, WASM validates via query param
+    /// - "signature": Always require signature validation
+    pub fn webhook_verification_mode(&self) -> Option<&str> {
         self.capabilities
             .channel
             .as_ref()
             .and_then(|c| c.webhook.as_ref())
-            .and_then(|w| w.hmac_secret_name.as_deref())
+            .and_then(|w| w.verification_mode.as_deref())
     }
 
     /// Get the webhook secret name for this channel.
@@ -184,6 +186,32 @@ impl ChannelCapabilitiesFile {
             .and_then(|c| c.webhook.as_ref())
             .and_then(|w| w.secret_name.clone())
             .unwrap_or_else(|| format!("{}_webhook_secret", self.name))
+    }
+
+    /// Get the HMAC secret name for webhook signature verification.
+    ///
+    /// Returns the secret name declared in `webhook.hmac_secret_name`,
+    /// used to look up the HMAC secret in the secrets store for
+    /// WhatsApp/Slack-style signature verification.
+    pub fn webhook_hmac_secret_name(&self) -> Option<&str> {
+        self.capabilities
+            .channel
+            .as_ref()
+            .and_then(|c| c.webhook.as_ref())
+            .and_then(|w| w.hmac_secret_name.as_deref())
+    }
+
+    /// Get the JSON pointer path to extract message ID from metadata.
+    ///
+    /// Returns the JSON pointer declared in `webhook.message_id_json_pointer`,
+    /// used for ACK key construction and deduplication.
+    /// If None, the router falls back to using user_id.
+    pub fn webhook_message_id_json_pointer(&self) -> Option<&str> {
+        self.capabilities
+            .channel
+            .as_ref()
+            .and_then(|c| c.webhook.as_ref())
+            .and_then(|w| w.message_id_json_pointer.as_deref())
     }
 }
 
@@ -299,9 +327,27 @@ pub struct WebhookSchema {
     #[serde(default)]
     pub signature_key_secret_name: Option<String>,
 
-    /// Secret name in secrets store for HMAC-SHA256 signing (Slack-style).
+    /// How to handle GET request validation:
+    /// - None/default: Require secret header for all requests (current behavior)
+    /// - "query_param": Skip host-level secret validation for GET requests;
+    ///   the WASM module validates via query param (e.g., WhatsApp hub.verify_token)
+    /// - "signature": Always require signature validation (for Discord-style Ed25519)
+    #[serde(default)]
+    pub verification_mode: Option<String>,
+
+    /// Secret name in secrets store containing the HMAC secret
+    /// for signature verification (e.g., WhatsApp/Slack webhook signatures).
+    /// The header format is expected to be "sha256=<hex_signature>".
     #[serde(default)]
     pub hmac_secret_name: Option<String>,
+
+    /// JSON pointer path to extract the unique message ID from metadata_json.
+    /// Used for ACK key construction and deduplication.
+    /// If None, the router falls back to using user_id.
+    ///
+    /// Example: "/message_id" extracts the "message_id" field from the metadata JSON.
+    #[serde(default)]
+    pub message_id_json_pointer: Option<String>,
 }
 
 /// Setup configuration schema.
@@ -804,6 +850,75 @@ mod tests {
         assert!(
             secrets_caps.is_allowed("discord_public_key"),
             "discord_public_key must be in the secrets allowlist"
+        );
+    }
+
+    // ── Category 6: HMAC Secret Name (WhatsApp/Slack style) ──────────────
+
+    #[test]
+    fn test_webhook_schema_hmac_secret_name() {
+        let json = r#"{
+            "name": "whatsapp",
+            "capabilities": {
+                "channel": {
+                    "allowed_paths": ["/webhook/whatsapp"],
+                    "webhook": {
+                        "hmac_secret_name": "whatsapp_app_secret"
+                    }
+                }
+            }
+        }"#;
+
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        assert_eq!(file.webhook_hmac_secret_name(), Some("whatsapp_app_secret"));
+    }
+
+    #[test]
+    fn test_hmac_secret_name_none_when_missing() {
+        let json = r#"{
+            "name": "telegram",
+            "capabilities": {
+                "channel": {
+                    "allowed_paths": ["/webhook/telegram"],
+                    "webhook": {
+                        "secret_header": "X-Telegram-Bot-Api-Secret-Token"
+                    }
+                }
+            }
+        }"#;
+
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        assert_eq!(file.webhook_hmac_secret_name(), None);
+    }
+
+    #[test]
+    fn test_whatsapp_capabilities_has_hmac_secret() {
+        let json = include_str!("../../../channels-src/whatsapp/whatsapp.capabilities.json");
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        assert_eq!(
+            file.webhook_hmac_secret_name(),
+            Some("whatsapp_app_secret"),
+            "whatsapp.capabilities.json must declare hmac_secret_name"
+        );
+    }
+
+    #[test]
+    fn test_whatsapp_capabilities_has_app_secret_in_setup() {
+        let json = include_str!("../../../channels-src/whatsapp/whatsapp.capabilities.json");
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+
+        let secret_names: Vec<&str> = file
+            .setup
+            .required_secrets
+            .iter()
+            .map(|s| s.name.as_str())
+            .collect();
+
+        assert!(
+            secret_names.contains(&"whatsapp_app_secret"),
+            "whatsapp.capabilities.json must include whatsapp_app_secret in setup.required_secrets, \
+             found: {:?}",
+            secret_names
         );
     }
 }

--- a/src/channels/wasm/signature.rs
+++ b/src/channels/wasm/signature.rs
@@ -1,11 +1,19 @@
-//! Webhook signature verification (Discord Ed25519 and Slack HMAC-SHA256).
+//! Webhook signature verification (Discord Ed25519, Slack HMAC-SHA256, WhatsApp HMAC-SHA256).
 //!
 //! Validates request signatures for incoming webhooks:
 //! - Discord: `X-Signature-Ed25519` and `X-Signature-Timestamp` headers
 //! - Slack: `X-Slack-Signature` and `X-Slack-Request-Timestamp` headers
+//! - WhatsApp: `X-Hub-Signature-256` header
 //!
 //! See: <https://discord.com/developers/docs/interactions/overview#validating-security-request-headers>
 //! See: <https://api.slack.com/authentication/verifying-requests-from-slack>
+//! See: <https://developers.facebook.com/docs/graph-api/webhooks/getting-started#validate-payloads>
+
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
 
 /// Verify a Discord interaction signature.
 ///
@@ -52,6 +60,47 @@ pub fn verify_discord_signature(
     verifying_key.verify_strict(&message, &signature).is_ok()
 }
 
+/// Verify HMAC-SHA256 signature (WhatsApp style, simple body-only).
+///
+/// # Arguments
+/// * `secret` - The HMAC secret (App Secret)
+/// * `signature_header` - Value from X-Hub-Signature-256 header (format: "sha256=<hex>")
+/// * `body` - Raw request body bytes
+///
+/// # Returns
+/// `true` if signature is valid, `false` otherwise
+pub fn verify_hmac_sha256(secret: &str, signature_header: &str, body: &[u8]) -> bool {
+    // Parse header format: "sha256=<hex_signature>"
+    let Some(hex_signature) = signature_header.strip_prefix("sha256=") else {
+        return false;
+    };
+
+    // Decode expected signature
+    let Ok(expected_sig) = hex::decode(hex_signature) else {
+        return false;
+    };
+
+    // SHA-256 produces 32-byte signatures - reject wrong lengths early
+    if expected_sig.len() != 32 {
+        return false;
+    }
+
+    // Compute HMAC-SHA256
+    let mut mac = match HmacSha256::new_from_slice(secret.as_bytes()) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    let result = mac.finalize();
+    let computed_sig = result.into_bytes();
+
+    // Constant-time comparison to prevent timing attacks
+    computed_sig
+        .as_slice()
+        .ct_eq(expected_sig.as_slice())
+        .into()
+}
+
 /// Verify a Slack webhook signature using HMAC-SHA256.
 ///
 /// Slack signs each webhook request with HMAC-SHA256 using:
@@ -69,9 +118,6 @@ pub fn verify_slack_signature(
     signature_header: &str,
     now_secs: i64,
 ) -> bool {
-    use hmac::{Hmac, Mac};
-    use sha2::Sha256;
-
     // 1. Parse and check staleness (5-minute window)
     let ts: i64 = match timestamp.parse() {
         Ok(v) => v,
@@ -89,7 +135,7 @@ pub fn verify_slack_signature(
     basestring.extend_from_slice(body);
 
     // 3. Compute HMAC-SHA256
-    let mut mac = match Hmac::<Sha256>::new_from_slice(signing_secret.as_bytes()) {
+    let mut mac = match HmacSha256::new_from_slice(signing_secret.as_bytes()) {
         Ok(m) => m,
         Err(_) => return false,
     };
@@ -99,7 +145,6 @@ pub fn verify_slack_signature(
     let expected = format!("v0={}", computed_hex);
 
     // 4. Constant-time compare (avoids timing side-channels)
-    use subtle::ConstantTimeEq;
     expected
         .as_bytes()
         .ct_eq(signature_header.as_bytes())
@@ -395,20 +440,147 @@ mod tests {
         );
     }
 
-    // ── Category: HMAC-SHA256 Signature Verification (Slack) ────────────
+    // ── Category: HMAC-SHA256 Verification ─────────────────────────────────
+
+    /// Helper: compute HMAC-SHA256 signature in WhatsApp/Meta format (`sha256=<hex>`).
+    ///
+    /// This format is used by:
+    /// - WhatsApp Business API webhooks
+    /// - Facebook/Meta Graph API webhooks
+    /// - Any webhook using X-Hub-Signature-256 header
+    fn compute_whatsapp_style_hmac_signature(secret: &str, body: &[u8]) -> String {
+        use hmac::Mac;
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let result = mac.finalize();
+        format!("sha256={}", hex::encode(result.into_bytes()))
+    }
+
+    #[test]
+    fn test_hmac_valid_signature_succeeds() {
+        let secret = "my_app_secret";
+        let body = br#"{"entry":[{"id":"123"}]}"#;
+        let sig_header = compute_whatsapp_style_hmac_signature(secret, body);
+
+        assert!(
+            verify_hmac_sha256(secret, &sig_header, body),
+            "Valid HMAC signature should verify"
+        );
+    }
+
+    #[test]
+    fn test_hmac_wrong_secret_fails() {
+        let secret = "correct_secret";
+        let wrong_secret = "wrong_secret";
+        let body = br#"{"test":"data"}"#;
+        let sig_header = compute_whatsapp_style_hmac_signature(secret, body);
+
+        assert!(
+            !verify_hmac_sha256(wrong_secret, &sig_header, body),
+            "Signature with wrong secret should fail"
+        );
+    }
+
+    #[test]
+    fn test_hmac_tampered_body_fails() {
+        let secret = "my_secret";
+        let body = br#"original body"#;
+        let sig_header = compute_whatsapp_style_hmac_signature(secret, body);
+        let tampered_body = br#"tampered body"#;
+
+        assert!(
+            !verify_hmac_sha256(secret, &sig_header, tampered_body),
+            "Signature for different body should fail"
+        );
+    }
+
+    #[test]
+    fn test_hmac_missing_prefix_fails() {
+        let secret = "my_secret";
+        let body = b"test body";
+        // Missing "sha256=" prefix
+        let sig_header = hex::encode([0u8; 32]);
+
+        assert!(
+            !verify_hmac_sha256(secret, &sig_header, body),
+            "Signature without sha256= prefix should fail"
+        );
+    }
+
+    #[test]
+    fn test_hmac_invalid_hex_fails() {
+        let secret = "my_secret";
+        let body = b"test body";
+        let sig_header = "sha256=not-valid-hex-zzz";
+
+        assert!(
+            !verify_hmac_sha256(secret, sig_header, body),
+            "Invalid hex signature should fail gracefully"
+        );
+    }
+
+    #[test]
+    fn test_hmac_empty_body_succeeds() {
+        let secret = "my_secret";
+        let body = b"";
+        let sig_header = compute_whatsapp_style_hmac_signature(secret, body);
+
+        assert!(
+            verify_hmac_sha256(secret, &sig_header, body),
+            "Empty body with valid signature should succeed"
+        );
+    }
+
+    #[test]
+    fn test_hmac_empty_secret_succeeds() {
+        let body = b"test body";
+        // Empty secret should still work (though not recommended in practice)
+        let sig_header = compute_whatsapp_style_hmac_signature("", body);
+
+        assert!(
+            verify_hmac_sha256("", &sig_header, body),
+            "Empty secret with matching signature should succeed"
+        );
+    }
+
+    #[test]
+    fn test_hmac_wrong_signature_length_fails() {
+        let secret = "my_secret";
+        let body = b"test body";
+        // Signature too short
+        let sig_header = "sha256=deadbeef";
+
+        assert!(
+            !verify_hmac_sha256(secret, sig_header, body),
+            "Wrong-length signature should fail"
+        );
+    }
+
+    #[test]
+    fn test_hmac_case_sensitive_prefix() {
+        let secret = "my_secret";
+        let body = b"test body";
+        let sig_header = compute_whatsapp_style_hmac_signature(secret, body);
+        // Uppercase prefix should fail
+        let bad_header = sig_header.replace("sha256=", "SHA256=");
+
+        assert!(
+            !verify_hmac_sha256(secret, &bad_header, body),
+            "Uppercase SHA256= prefix should fail"
+        );
+    }
+
+    // ── Category: Slack HMAC-SHA256 Signature Verification ────────────
 
     /// Helper: compute expected Slack signature for a given secret, timestamp, and body.
     fn sign_slack_message(signing_secret: &str, timestamp: &str, body: &[u8]) -> String {
-        use hmac::{Hmac, Mac};
-        use sha2::Sha256;
-
         let mut basestring = Vec::new();
         basestring.extend_from_slice(b"v0:");
         basestring.extend_from_slice(timestamp.as_bytes());
         basestring.push(b':');
         basestring.extend_from_slice(body);
 
-        let mut mac = Hmac::<Sha256>::new_from_slice(signing_secret.as_bytes()).unwrap();
+        let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes()).unwrap();
         mac.update(&basestring);
         let computed = mac.finalize().into_bytes();
         format!("v0={}", hex::encode(computed))
@@ -468,33 +640,6 @@ mod tests {
                 SLACK_TEST_TS
             ),
             "Signature with wrong timestamp should fail"
-        );
-    }
-
-    #[test]
-    fn test_slack_tampered_signature_fails() {
-        let signing_secret = "my-signing-secret";
-        let timestamp = "1234567890";
-        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J";
-
-        let signature = sign_slack_message(signing_secret, timestamp, body);
-        // Flip a byte in the signature hex (change first char after "v0=")
-        let chars: Vec<char> = signature.chars().collect();
-        let mut new_chars = chars.clone();
-        if chars.len() > 3 {
-            new_chars[3] = if chars[3] == 'a' { 'b' } else { 'a' };
-        }
-        let modified_sig: String = new_chars.iter().collect();
-
-        assert!(
-            !verify_slack_signature(
-                signing_secret,
-                timestamp,
-                body,
-                &modified_sig,
-                SLACK_TEST_TS
-            ),
-            "Tampered signature should fail"
         );
     }
 
@@ -579,13 +724,17 @@ mod tests {
     }
 
     #[test]
-    fn test_slack_non_numeric_timestamp_rejected() {
-        let signing_secret = "my-signing-secret";
+    fn test_slack_wrong_signing_secret_fails() {
+        let secret_a = "secret-a";
+        let secret_b = "secret-b";
+        let timestamp = "1234567890";
         let body = b"token=xyzz0WbapA4vBCDEFasx0q6G";
 
+        let signature = sign_slack_message(secret_a, timestamp, body);
+        // Try to verify with a different secret
         assert!(
-            !verify_slack_signature(signing_secret, "not-a-number", body, "v0=abc123", 0),
-            "Non-numeric timestamp should be rejected"
+            !verify_slack_signature(secret_b, timestamp, body, &signature, SLACK_TEST_TS),
+            "Signature from different secret should fail"
         );
     }
 
@@ -606,21 +755,6 @@ mod tests {
     }
 
     #[test]
-    fn test_slack_wrong_signing_secret_fails() {
-        let secret_a = "secret-a";
-        let secret_b = "secret-b";
-        let timestamp = "1234567890";
-        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G";
-
-        let signature = sign_slack_message(secret_a, timestamp, body);
-        // Try to verify with a different secret
-        assert!(
-            !verify_slack_signature(secret_b, timestamp, body, &signature, SLACK_TEST_TS),
-            "Signature from different secret should fail"
-        );
-    }
-
-    #[test]
     fn test_slack_empty_body_valid() {
         let signing_secret = "my-signing-secret";
         let timestamp = "1234567890";
@@ -630,28 +764,6 @@ mod tests {
         assert!(
             verify_slack_signature(signing_secret, timestamp, body, &signature, SLACK_TEST_TS),
             "Empty body with valid signature should succeed"
-        );
-    }
-
-    #[test]
-    fn test_slack_negative_timestamp_rejected() {
-        let signing_secret = "my-signing-secret";
-        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G";
-
-        assert!(
-            !verify_slack_signature(signing_secret, "-1", body, "v0=abc123", 0),
-            "Negative timestamp should be rejected"
-        );
-    }
-
-    #[test]
-    fn test_slack_empty_timestamp_rejected() {
-        let signing_secret = "my-signing-secret";
-        let body = b"token=xyzz0WbapA4vBCDEFasx0q6G";
-
-        assert!(
-            !verify_slack_signature(signing_secret, "", body, "v0=abc123", 0),
-            "Empty timestamp should be rejected"
         );
     }
 }

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -1,7 +1,7 @@
 //! WASM channel wrapper implementing the Channel trait.
 //!
 //! Wraps a prepared WASM channel module and provides the Channel interface.
-//! Each callback (on_start, on_http_request, on_poll, on_respond) creates
+//! Each callback (on_start, on_http_request, on_poll, on_respond, on_message_persisted) creates
 //! a fresh WASM instance for isolation.
 //!
 //! # Architecture
@@ -1236,6 +1236,168 @@ impl WasmChannel {
         }
     }
 
+    /// Execute the on_http_request callback and return emitted messages separately.
+    ///
+    /// Like `call_on_http_request`, but returns emitted messages to the caller
+    /// instead of processing them immediately. This allows the webhook handler
+    /// to register ACK keys before messages are sent to the agent.
+    ///
+    /// The caller should:
+    /// 1. Register ACK keys for each emitted message
+    /// 2. Call `process_emitted_messages` to send messages to the agent
+    /// 3. Wait for ACKs before returning the HTTP response
+    pub async fn call_on_http_request_with_messages(
+        &self,
+        method: &str,
+        path: &str,
+        headers: &HashMap<String, String>,
+        query: &HashMap<String, String>,
+        body: &[u8],
+        secret_validated: bool,
+    ) -> Result<HttpResponseWithMessages, WasmChannelError> {
+        tracing::info!(
+            channel = %self.name,
+            method = method,
+            path = path,
+            body_len = body.len(),
+            secret_validated = secret_validated,
+            "call_on_http_request_with_messages invoked"
+        );
+
+        // If no WASM bytes, return empty response (for testing)
+        if self.prepared.component().is_none() {
+            tracing::debug!(
+                channel = %self.name,
+                method = method,
+                path = path,
+                "WASM channel on_http_request called (no WASM module)"
+            );
+            return Ok(HttpResponseWithMessages {
+                response: HttpResponse::ok(),
+                emitted_messages: Vec::new(),
+            });
+        }
+
+        let runtime = Arc::clone(&self.runtime);
+        let prepared = Arc::clone(&self.prepared);
+        let capabilities = Self::inject_workspace_reader(&self.capabilities, &self.workspace_store);
+        let timeout = self.runtime.config().callback_timeout;
+        let credentials = self.get_credentials().await;
+        let pairing_store = self.pairing_store.clone();
+        let workspace_store = self.workspace_store.clone();
+
+        // Pre-resolve host credentials for automatic injection (before spawn_blocking)
+        let host_credentials =
+            resolve_channel_host_credentials(&self.capabilities, self.secrets_store.as_deref())
+                .await;
+
+        // Prepare request data
+        let method = method.to_string();
+        let path = path.to_string();
+        let headers_json = serde_json::to_string(&headers).unwrap_or_default();
+        let query_json = serde_json::to_string(&query).unwrap_or_default();
+        let body = body.to_vec();
+
+        let channel_name = self.name.clone();
+
+        // Execute in blocking task with timeout
+        let result = tokio::time::timeout(timeout, async move {
+            tokio::task::spawn_blocking(move || {
+                let mut store = Self::create_store(
+                    &runtime,
+                    &prepared,
+                    &capabilities,
+                    credentials,
+                    host_credentials,
+                    pairing_store,
+                )?;
+                let instance = Self::instantiate_component(&runtime, &prepared, &mut store)?;
+
+                // Build the WIT request type
+                let wit_request = wit_channel::IncomingHttpRequest {
+                    method,
+                    path,
+                    headers_json,
+                    query_json,
+                    body,
+                    secret_validated,
+                };
+
+                // Call on_http_request using the generated typed interface
+                let channel_iface = instance.near_agent_channel();
+                let wit_response = channel_iface
+                    .call_on_http_request(&mut store, &wit_request)
+                    .map_err(|e| Self::map_wasm_error(e, &prepared.name, prepared.limits.fuel))?;
+
+                let response = convert_http_response(wit_response);
+                let mut host_state =
+                    Self::extract_host_state(&mut store, &prepared.name, &capabilities);
+
+                // Commit pending workspace writes to the persistent store
+                let pending_writes = host_state.take_pending_writes();
+                workspace_store.commit_writes(&pending_writes);
+
+                // Extract emitted messages (but don't process them)
+                let emitted_messages = host_state.take_emitted_messages();
+
+                Ok((response, emitted_messages, host_state))
+            })
+            .await
+            .map_err(|e| WasmChannelError::ExecutionPanicked {
+                name: channel_name.clone(),
+                reason: e.to_string(),
+            })?
+        })
+        .await;
+
+        let channel_name = self.name.clone();
+        match result {
+            Ok(Ok((response, emitted_messages, mut host_state))) => {
+                // Surface WASM guest logs
+                for entry in host_state.take_logs() {
+                    match entry.level {
+                        crate::tools::wasm::LogLevel::Error => {
+                            tracing::error!(channel = %self.name, "{}", entry.message);
+                        }
+                        crate::tools::wasm::LogLevel::Warn => {
+                            tracing::warn!(channel = %self.name, "{}", entry.message);
+                        }
+                        _ => {
+                            tracing::debug!(channel = %self.name, "{}", entry.message);
+                        }
+                    }
+                }
+
+                tracing::debug!(
+                    channel = %channel_name,
+                    status = response.status,
+                    emitted_count = emitted_messages.len(),
+                    "WASM channel on_http_request_with_messages completed"
+                );
+
+                Ok(HttpResponseWithMessages {
+                    response,
+                    emitted_messages,
+                })
+            }
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(WasmChannelError::Timeout {
+                name: channel_name,
+                callback: "on_http_request".to_string(),
+            }),
+        }
+    }
+
+    /// Process emitted messages and send them to the agent.
+    ///
+    /// Call this after registering ACK keys for the messages.
+    pub async fn send_emitted_messages(
+        &self,
+        messages: Vec<EmittedMessage>,
+    ) -> Result<(), WasmChannelError> {
+        self.process_emitted_messages(messages).await
+    }
+
     /// Execute the on_poll callback.
     ///
     /// Called periodically if polling is configured.
@@ -1586,6 +1748,111 @@ impl WasmChannel {
             Err(_) => Err(WasmChannelError::Timeout {
                 name: channel_name.to_string(),
                 callback: "on_status".to_string(),
+            }),
+        }
+    }
+
+    /// Execute the on-message-persisted callback.
+    ///
+    /// Called after a message has been persisted to the database.
+    /// Channels can use this to perform follow-up actions like mark_as_read.
+    /// This is a best-effort callback - errors are logged but don't block the ACK.
+    pub async fn call_on_message_persisted(
+        &self,
+        metadata_json: &str,
+    ) -> Result<(), WasmChannelError> {
+        tracing::info!(
+            channel = %self.name,
+            metadata_len = metadata_json.len(),
+            "call_on_message_persisted invoked"
+        );
+
+        // If no WASM bytes, do nothing (for testing or channels that don't implement this)
+        if self.prepared.component().is_none() {
+            tracing::debug!(
+                channel = %self.name,
+                "WASM channel on_message_persisted called (no WASM module)"
+            );
+            return Ok(());
+        }
+
+        let runtime = Arc::clone(&self.runtime);
+        let prepared = Arc::clone(&self.prepared);
+        let capabilities = self.capabilities.clone();
+        let timeout = self.runtime.config().callback_timeout;
+        let channel_name = self.name.clone();
+        let credentials = self.get_credentials().await;
+        let host_credentials =
+            resolve_channel_host_credentials(&self.capabilities, self.secrets_store.as_deref())
+                .await;
+        let pairing_store = self.pairing_store.clone();
+
+        let metadata_json = metadata_json.to_string();
+
+        let result = tokio::time::timeout(timeout, async move {
+            tokio::task::spawn_blocking(move || {
+                let mut store = Self::create_store(
+                    &runtime,
+                    &prepared,
+                    &capabilities,
+                    credentials,
+                    host_credentials,
+                    pairing_store,
+                )?;
+                let instance = Self::instantiate_component(&runtime, &prepared, &mut store)?;
+
+                let channel_iface = instance.near_agent_channel();
+
+                tracing::info!("Calling WASM on_message_persisted");
+
+                // Call on_message_persisted using the generated typed interface
+                let wasm_result = channel_iface
+                    .call_on_message_persisted(&mut store, &metadata_json)
+                    .map_err(|e| {
+                        tracing::error!(error = %e, "WASM on_message_persisted call failed");
+                        Self::map_wasm_error(e, &prepared.name, prepared.limits.fuel)
+                    })?;
+
+                tracing::info!(wasm_result = ?wasm_result, "WASM on_message_persisted returned");
+
+                // Check for WASM-level errors
+                if let Err(err_msg) = wasm_result {
+                    tracing::error!(error = %err_msg, "WASM on_message_persisted returned error");
+                    return Err(WasmChannelError::CallbackFailed {
+                        name: prepared.name.clone(),
+                        reason: err_msg.clone(),
+                    });
+                }
+
+                let host_state =
+                    Self::extract_host_state(&mut store, &prepared.name, &capabilities);
+                tracing::info!("on_message_persisted WASM execution completed successfully");
+                Ok(((), host_state))
+            })
+            .await
+            .map_err(|e| {
+                tracing::error!(error = %e, "spawn_blocking panicked");
+                WasmChannelError::ExecutionPanicked {
+                    name: channel_name.clone(),
+                    reason: e.to_string(),
+                }
+            })?
+        })
+        .await;
+
+        let channel_name = self.name.clone();
+        match result {
+            Ok(Ok((_, _host_state))) => {
+                tracing::debug!(
+                    channel = %channel_name,
+                    "WASM channel on_message_persisted completed"
+                );
+                Ok(())
+            }
+            Ok(Err(e)) => Err(e),
+            Err(_) => Err(WasmChannelError::Timeout {
+                name: channel_name,
+                callback: "on_message_persisted".to_string(),
             }),
         }
     }
@@ -2747,6 +3014,18 @@ async fn resolve_channel_host_credentials(
     }
 
     resolved
+}
+
+/// HTTP response from a WASM channel callback with emitted messages.
+///
+/// Used for webhook handlers that need to coordinate the HTTP response
+/// with message persistence (e.g., waiting for ACK before returning 200).
+#[derive(Debug)]
+pub struct HttpResponseWithMessages {
+    /// The HTTP response to return to the webhook caller.
+    pub response: HttpResponse,
+    /// Messages emitted by the WASM callback.
+    pub emitted_messages: Vec<EmittedMessage>,
 }
 
 #[cfg(test)]

--- a/src/config/wasm.rs
+++ b/src/config/wasm.rs
@@ -22,6 +22,12 @@ pub struct WasmConfig {
     pub cache_compiled: bool,
     /// Directory for compiled module cache.
     pub cache_dir: Option<PathBuf>,
+    /// Webhook ACK timeout in seconds (default: 10).
+    /// How long to wait for message persistence before returning 500 to webhook.
+    pub webhook_ack_timeout_secs: u64,
+    /// Webhook dedup cleanup interval in hours (default: 24).
+    /// How often to clean up old dedup records. 0 disables cleanup.
+    pub webhook_dedup_cleanup_interval_hours: u64,
 }
 
 impl Default for WasmConfig {
@@ -34,6 +40,8 @@ impl Default for WasmConfig {
             default_fuel_limit: 10_000_000,
             cache_compiled: true,
             cache_dir: None,
+            webhook_ack_timeout_secs: 10,
+            webhook_dedup_cleanup_interval_hours: 168, // 7 days
         }
     }
 }
@@ -58,6 +66,11 @@ impl WasmConfig {
             default_fuel_limit: parse_optional_env("WASM_DEFAULT_FUEL_LIMIT", 10_000_000)?,
             cache_compiled: parse_bool_env("WASM_CACHE_COMPILED", true)?,
             cache_dir: optional_env("WASM_CACHE_DIR")?.map(PathBuf::from),
+            webhook_ack_timeout_secs: parse_optional_env("WEBHOOK_ACK_TIMEOUT_SECS", 10)?,
+            webhook_dedup_cleanup_interval_hours: parse_optional_env(
+                "WEBHOOK_DEDUP_CLEANUP_INTERVAL_HOURS",
+                168, // 7 days
+            )?,
         })
     }
 

--- a/src/db/libsql/webhook_dedup.rs
+++ b/src/db/libsql/webhook_dedup.rs
@@ -1,0 +1,45 @@
+//! Webhook deduplication WebhookDedupStore implementation for LibSqlBackend.
+
+use async_trait::async_trait;
+use libsql::params;
+use uuid::Uuid;
+
+use super::LibSqlBackend;
+use crate::db::WebhookDedupStore;
+use crate::error::DatabaseError;
+
+#[async_trait]
+impl WebhookDedupStore for LibSqlBackend {
+    async fn record_webhook_message_processed(
+        &self,
+        channel: &str,
+        external_message_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let conn = self.connect().await?;
+        let id = Uuid::new_v4().to_string();
+        let rows_affected = conn
+            .execute(
+                "INSERT INTO webhook_message_dedup (id, channel, external_message_id) \
+                 VALUES (?1, ?2, ?3) \
+                 ON CONFLICT(channel, external_message_id) DO NOTHING",
+                params![id, channel, external_message_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(rows_affected > 0)
+    }
+
+    async fn cleanup_old_webhook_dedup_records(&self) -> Result<u64, DatabaseError> {
+        let conn = self.connect().await?;
+        let rows_affected = conn
+            .execute(
+                "DELETE FROM webhook_message_dedup \
+                 WHERE datetime(processed_at) < datetime('now', '-7 days')",
+                params![],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        Ok(rows_affected)
+    }
+}

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -542,6 +542,20 @@ CREATE INDEX IF NOT EXISTS idx_routine_runs_status ON routine_runs(status);
 -- heartbeat_state
 CREATE INDEX IF NOT EXISTS idx_heartbeat_next_run ON heartbeat_state(next_run);
 
+-- ==================== Webhook Message Deduplication ====================
+
+-- Tracks which webhook messages have been processed to prevent duplicates
+-- when WhatsApp retries after a 500 response
+CREATE TABLE IF NOT EXISTS webhook_message_dedup (
+    id TEXT PRIMARY KEY,
+    channel TEXT NOT NULL,
+    external_message_id TEXT NOT NULL,
+    processed_at TEXT NOT NULL DEFAULT (datetime('now')),
+    UNIQUE(channel, external_message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_dedup_channel_msg ON webhook_message_dedup(channel, external_message_id);
+
 -- ==================== Seed data ====================
 
 -- Pre-populate leak detection patterns (matches PostgreSQL V2 migration).

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -334,6 +334,27 @@ pub trait SettingsStore: Send + Sync {
     async fn has_settings(&self, user_id: &str) -> Result<bool, DatabaseError>;
 }
 
+/// Webhook message deduplication store.
+///
+/// Tracks processed webhook messages to prevent duplicate processing
+/// when platforms like WhatsApp retry after a 500 response.
+#[async_trait]
+pub trait WebhookDedupStore: Send + Sync {
+    /// Try to record that a message is processed, atomically.
+    /// Returns `true` if this is a new message (was inserted), `false` if it was a duplicate.
+    /// Uses INSERT ... ON CONFLICT DO NOTHING pattern for atomic dedup with no race condition.
+    async fn record_webhook_message_processed(
+        &self,
+        channel: &str,
+        external_message_id: &str,
+    ) -> Result<bool, DatabaseError>;
+
+    /// Clean up old dedup records (older than 7 days).
+    ///
+    /// Called periodically to keep the table small.
+    async fn cleanup_old_webhook_dedup_records(&self) -> Result<u64, DatabaseError>;
+}
+
 #[async_trait]
 pub trait WorkspaceStore: Send + Sync {
     async fn get_document_by_path(
@@ -414,6 +435,7 @@ pub trait Database:
     + ToolFailureStore
     + SettingsStore
     + WorkspaceStore
+    + WebhookDedupStore
     + Send
     + Sync
 {

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -17,7 +17,7 @@ use crate::config::DatabaseConfig;
 use crate::context::{ActionRecord, JobContext, JobState};
 use crate::db::{
     ConversationStore, Database, JobStore, RoutineStore, SandboxStore, SettingsStore,
-    ToolFailureStore, WorkspaceStore,
+    ToolFailureStore, WebhookDedupStore, WorkspaceStore,
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
@@ -666,5 +666,42 @@ impl WorkspaceStore for PgBackend {
         self.repo
             .hybrid_search(user_id, agent_id, query, embedding, config)
             .await
+    }
+}
+
+// ==================== WebhookDedupStore ====================
+
+#[async_trait]
+impl WebhookDedupStore for PgBackend {
+    async fn record_webhook_message_processed(
+        &self,
+        channel: &str,
+        external_message_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let client = self.store.pool().get().await?;
+        let stmt = client
+            .prepare(
+                "INSERT INTO webhook_message_dedup (channel, external_message_id) \
+                 VALUES ($1, $2) \
+                 ON CONFLICT (channel, external_message_id) DO NOTHING",
+            )
+            .await?;
+
+        let rows_affected = client
+            .execute(&stmt, &[&channel, &external_message_id])
+            .await?;
+        Ok(rows_affected > 0)
+    }
+
+    async fn cleanup_old_webhook_dedup_records(&self) -> Result<u64, DatabaseError> {
+        let client = self.store.pool().get().await?;
+        let stmt = client
+            .prepare(
+                "DELETE FROM webhook_message_dedup \
+                 WHERE processed_at < NOW() - INTERVAL '7 days'",
+            )
+            .await?;
+        let rows_deleted = client.execute(&stmt, &[]).await?;
+        Ok(rows_deleted)
     }
 }

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -533,6 +533,78 @@ impl ExtensionManager {
         Ok(extensions)
     }
 
+    /// Get detailed info about an installed extension (version, wit_version, host compatibility).
+    pub async fn extension_info(&self, name: &str) -> Result<serde_json::Value, ExtensionError> {
+        Self::validate_extension_name(name)?;
+        let kind = self.determine_installed_kind(name).await?;
+
+        match kind {
+            ExtensionKind::WasmTool => {
+                let cap_path = self
+                    .wasm_tools_dir
+                    .join(format!("{}.capabilities.json", name));
+                let wasm_path = self.wasm_tools_dir.join(format!("{}.wasm", name));
+
+                let mut info = serde_json::json!({
+                    "name": name,
+                    "kind": "wasm_tool",
+                    "installed": wasm_path.exists(),
+                });
+
+                if cap_path.exists()
+                    && let Ok(bytes) = tokio::fs::read(&cap_path).await
+                    && let Ok(cap) = crate::tools::wasm::CapabilitiesFile::from_bytes(&bytes)
+                {
+                    info["version"] =
+                        serde_json::json!(cap.version.unwrap_or_else(|| "unknown".into()));
+                    info["wit_version"] =
+                        serde_json::json!(cap.wit_version.unwrap_or_else(|| "unknown".into()));
+                }
+
+                info["host_wit_version"] = serde_json::json!(crate::tools::wasm::WIT_TOOL_VERSION);
+
+                Ok(info)
+            }
+            ExtensionKind::WasmChannel => {
+                let cap_path = self
+                    .wasm_channels_dir
+                    .join(format!("{}.capabilities.json", name));
+                let wasm_path = self.wasm_channels_dir.join(format!("{}.wasm", name));
+
+                let mut info = serde_json::json!({
+                    "name": name,
+                    "kind": "wasm_channel",
+                    "installed": wasm_path.exists(),
+                    "active": self.active_channel_names.read().await.contains(name),
+                });
+
+                if cap_path.exists()
+                    && let Ok(bytes) = tokio::fs::read(&cap_path).await
+                    && let Ok(cap) =
+                        crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes)
+                {
+                    info["version"] =
+                        serde_json::json!(cap.version.unwrap_or_else(|| "unknown".into()));
+                    info["wit_version"] =
+                        serde_json::json!(cap.wit_version.unwrap_or_else(|| "unknown".into()));
+                }
+
+                info["host_wit_version"] =
+                    serde_json::json!(crate::tools::wasm::WIT_CHANNEL_VERSION);
+
+                Ok(info)
+            }
+            ExtensionKind::McpServer => {
+                let info = serde_json::json!({
+                    "name": name,
+                    "kind": "mcp_server",
+                    "connected": self.mcp_clients.read().await.contains_key(name),
+                });
+                Ok(info)
+            }
+        }
+    }
+
     /// Remove an installed extension.
     pub async fn remove(&self, name: &str) -> Result<String, ExtensionError> {
         Self::validate_extension_name(name)?;
@@ -633,78 +705,6 @@ impl ExtensionManager {
                     "Removed channel '{}'. Restart IronClaw for the change to take effect.",
                     name
                 ))
-            }
-        }
-    }
-
-    /// Get detailed info about an installed extension (version, wit_version, host compatibility).
-    pub async fn extension_info(&self, name: &str) -> Result<serde_json::Value, ExtensionError> {
-        Self::validate_extension_name(name)?;
-        let kind = self.determine_installed_kind(name).await?;
-
-        match kind {
-            ExtensionKind::WasmTool => {
-                let cap_path = self
-                    .wasm_tools_dir
-                    .join(format!("{}.capabilities.json", name));
-                let wasm_path = self.wasm_tools_dir.join(format!("{}.wasm", name));
-
-                let mut info = serde_json::json!({
-                    "name": name,
-                    "kind": "wasm_tool",
-                    "installed": wasm_path.exists(),
-                });
-
-                if cap_path.exists()
-                    && let Ok(bytes) = tokio::fs::read(&cap_path).await
-                    && let Ok(cap) = crate::tools::wasm::CapabilitiesFile::from_bytes(&bytes)
-                {
-                    info["version"] =
-                        serde_json::json!(cap.version.unwrap_or_else(|| "unknown".into()));
-                    info["wit_version"] =
-                        serde_json::json!(cap.wit_version.unwrap_or_else(|| "unknown".into()));
-                }
-
-                info["host_wit_version"] = serde_json::json!(crate::tools::wasm::WIT_TOOL_VERSION);
-
-                Ok(info)
-            }
-            ExtensionKind::WasmChannel => {
-                let cap_path = self
-                    .wasm_channels_dir
-                    .join(format!("{}.capabilities.json", name));
-                let wasm_path = self.wasm_channels_dir.join(format!("{}.wasm", name));
-
-                let mut info = serde_json::json!({
-                    "name": name,
-                    "kind": "wasm_channel",
-                    "installed": wasm_path.exists(),
-                    "active": self.active_channel_names.read().await.contains(name),
-                });
-
-                if cap_path.exists()
-                    && let Ok(bytes) = tokio::fs::read(&cap_path).await
-                    && let Ok(cap) =
-                        crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes)
-                {
-                    info["version"] =
-                        serde_json::json!(cap.version.unwrap_or_else(|| "unknown".into()));
-                    info["wit_version"] =
-                        serde_json::json!(cap.wit_version.unwrap_or_else(|| "unknown".into()));
-                }
-
-                info["host_wit_version"] =
-                    serde_json::json!(crate::tools::wasm::WIT_CHANNEL_VERSION);
-
-                Ok(info)
-            }
-            ExtensionKind::McpServer => {
-                let info = serde_json::json!({
-                    "name": name,
-                    "kind": "mcp_server",
-                    "connected": self.mcp_clients.read().await.contains_key(name),
-                });
-                Ok(info)
             }
         }
     }
@@ -2468,6 +2468,8 @@ impl ExtensionManager {
         let channel_name = loaded.name().to_string();
         let webhook_secret_name = loaded.webhook_secret_name();
         let secret_header = loaded.webhook_secret_header().map(|s| s.to_string());
+        let verification_mode = loaded.verification_mode().map(|s| s.to_string());
+        let message_id_json_pointer = loaded.message_id_json_pointer().map(|s| s.to_string());
         let sig_key_secret_name = loaded.signature_key_secret_name();
         let hmac_secret_name = loaded.hmac_secret_name();
 
@@ -2530,6 +2532,8 @@ impl ExtensionManager {
                     endpoints,
                     webhook_secret,
                     secret_header,
+                    verification_mode,
+                    message_id_json_pointer,
                 )
                 .await;
             tracing::info!(channel = %channel_name, "Registered hot-activated channel with webhook router");
@@ -2554,19 +2558,13 @@ impl ExtensionManager {
                 }
             }
 
-            // Register HMAC signing secret if declared in capabilities
-            if let Some(hmac_name) = &hmac_secret_name {
-                match self.secrets.get_decrypted(&self.user_id, hmac_name).await {
-                    Ok(secret) => {
-                        wasm_channel_router
-                            .register_hmac_secret(&channel_name, secret.expose())
-                            .await;
-                        tracing::info!(channel = %channel_name, "Registered HMAC signing secret for hot-activated channel");
-                    }
-                    Err(e) => {
-                        tracing::warn!(channel = %channel_name, error = %e, "HMAC secret not found");
-                    }
-                }
+            // Register HMAC secret if declared in capabilities (WhatsApp/Slack style)
+            if let Some(ref hmac_name) = hmac_secret_name
+                && let Ok(hmac_secret) = self.secrets.get_decrypted(&self.user_id, hmac_name).await
+            {
+                wasm_channel_router
+                    .register_hmac_secret(&channel_name, hmac_secret.expose().to_string())
+                    .await;
             }
         }
 
@@ -2675,30 +2673,19 @@ impl ExtensionManager {
             }
         };
 
-        // Load capabilities file once to extract all secret names
-        let cap_path = self
-            .wasm_channels_dir
-            .join(format!("{}.capabilities.json", name));
-        let capabilities_file = match tokio::fs::read(&cap_path).await {
-            Ok(bytes) => crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes).ok(),
-            Err(_) => None,
+        // Also refresh the webhook secret in the router
+        // Load capabilities file to get the correct secret name (may be overridden)
+        let webhook_secret_name = {
+            let cap_path = self
+                .wasm_channels_dir
+                .join(format!("{}.capabilities.json", name));
+            match tokio::fs::read(&cap_path).await {
+                Ok(bytes) => crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes)
+                    .map(|f| f.webhook_secret_name())
+                    .unwrap_or_else(|_| format!("{}_webhook_secret", name)),
+                Err(_) => format!("{}_webhook_secret", name),
+            }
         };
-
-        // Extract all secret names from the capabilities file
-        let webhook_secret_name = capabilities_file
-            .as_ref()
-            .map(|f| f.webhook_secret_name())
-            .unwrap_or_else(|| format!("{}_webhook_secret", name));
-
-        let sig_key_secret_name = capabilities_file
-            .as_ref()
-            .and_then(|f| f.signature_key_secret_name().map(|s| s.to_string()));
-
-        let hmac_secret_name = capabilities_file
-            .as_ref()
-            .and_then(|f| f.hmac_secret_name().map(|s| s.to_string()));
-
-        // Refresh webhook secret
         if let Ok(secret) = self
             .secrets
             .get_decrypted(&self.user_id, &webhook_secret_name)
@@ -2717,7 +2704,18 @@ impl ExtensionManager {
             existing_channel.update_config(config_updates).await;
         }
 
-        // Refresh signature key
+        // Also refresh signature key in the router
+        let sig_key_secret_name = {
+            let cap_path = self
+                .wasm_channels_dir
+                .join(format!("{}.capabilities.json", name));
+            match tokio::fs::read(&cap_path).await {
+                Ok(bytes) => crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes)
+                    .ok()
+                    .and_then(|f| f.signature_key_secret_name().map(|s| s.to_string())),
+                Err(_) => None,
+            }
+        };
         if let Some(ref sig_key_name) = sig_key_secret_name
             && let Ok(key_secret) = self
                 .secrets
@@ -2737,21 +2735,24 @@ impl ExtensionManager {
             }
         }
 
-        // Refresh HMAC signing secret
-        if let Some(ref hmac_secret_name_ref) = hmac_secret_name {
-            match self
-                .secrets
-                .get_decrypted(&self.user_id, hmac_secret_name_ref)
-                .await
-            {
-                Ok(secret) => {
-                    router.register_hmac_secret(name, secret.expose()).await;
-                    tracing::info!(channel = %name, "Refreshed HMAC signing secret");
-                }
-                Err(e) => {
-                    tracing::warn!(channel = %name, error = %e, "HMAC secret not found");
-                }
+        // Also refresh HMAC secret in the router (WhatsApp/Slack style)
+        let hmac_secret_name = {
+            let cap_path = self
+                .wasm_channels_dir
+                .join(format!("{}.capabilities.json", name));
+            match tokio::fs::read(&cap_path).await {
+                Ok(bytes) => crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes)
+                    .ok()
+                    .and_then(|f| f.webhook_hmac_secret_name().map(|s| s.to_string())),
+                Err(_) => None,
             }
+        };
+        if let Some(ref hmac_name) = hmac_secret_name
+            && let Ok(hmac_secret) = self.secrets.get_decrypted(&self.user_id, hmac_name).await
+        {
+            router
+                .register_hmac_secret(name, hmac_secret.expose().to_string())
+                .await;
         }
 
         // Refresh tunnel_url in case it wasn't set at startup
@@ -3048,9 +3049,8 @@ impl ExtensionManager {
                             .unwrap_or(false);
                         if !already_provided && !already_stored {
                             use rand::RngCore;
-                            use rand::rngs::OsRng;
                             let mut bytes = vec![0u8; auto_gen.length];
-                            OsRng.fill_bytes(&mut bytes);
+                            rand::thread_rng().fill_bytes(&mut bytes);
                             let hex_value: String =
                                 bytes.iter().map(|b| format!("{b:02x}")).collect();
                             let params = CreateSecretParams::new(&secret_def.name, &hex_value)

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,6 +353,7 @@ async fn async_main() -> anyhow::Result<()> {
 
         if let Some(result) = wasm_result {
             loaded_wasm_channel_names = result.channel_names;
+            let wasm_router_clone = Arc::clone(&result.wasm_channel_router);
             wasm_channel_runtime_state = Some((
                 result.wasm_channel_runtime,
                 result.pairing_store,
@@ -364,6 +365,27 @@ async fn async_main() -> anyhow::Result<()> {
             }
             if let Some(routes) = result.webhook_routes {
                 webhook_routes.push(routes);
+            }
+
+            // Spawn periodic cleanup task for webhook dedup records
+            let cleanup_interval_hours = config.wasm.webhook_dedup_cleanup_interval_hours;
+            if cleanup_interval_hours > 0 {
+                tokio::spawn(async move {
+                    let interval_duration =
+                        std::time::Duration::from_secs(cleanup_interval_hours * 3600);
+                    let mut interval = tokio::time::interval(interval_duration);
+                    // Don't run immediately on startup
+                    interval.tick().await;
+
+                    loop {
+                        interval.tick().await;
+                        wasm_router_clone.cleanup_old_dedup_records().await;
+                    }
+                });
+                tracing::info!(
+                    interval_hours = cleanup_interval_hours,
+                    "Webhook dedup cleanup task started"
+                );
             }
         }
     }
@@ -603,6 +625,11 @@ async fn async_main() -> anyhow::Result<()> {
         .register_message_tools(Arc::clone(&channels))
         .await;
 
+    // Clone router for AgentDeps before we move the state to extension manager
+    let wasm_router_for_deps = wasm_channel_runtime_state
+        .as_ref()
+        .map(|c| Arc::clone(&c.2));
+
     // Wire up channel runtime for hot-activation of WASM channels.
     if let Some(ref ext_mgr) = components.extension_manager
         && let Some((rt, ps, router)) = wasm_channel_runtime_state.take()
@@ -678,6 +705,7 @@ async fn async_main() -> anyhow::Result<()> {
         cost_guard: components.cost_guard,
         sse_tx: sse_sender,
         http_interceptor,
+        wasm_router: wasm_router_for_deps,
     };
 
     let agent = Agent::new(
@@ -963,6 +991,8 @@ async fn setup_wasm_channels(
         };
 
         let secret_header = loaded.webhook_secret_header().map(|s| s.to_string());
+        let verification_mode = loaded.verification_mode().map(|s| s.to_string());
+        let message_id_json_pointer = loaded.message_id_json_pointer().map(|s| s.to_string());
 
         let webhook_path = format!("/webhook/{}", channel_name);
         let endpoints = vec![RegisteredEndpoint {
@@ -1024,6 +1054,8 @@ async fn setup_wasm_channels(
                 endpoints,
                 webhook_secret.clone(),
                 secret_header,
+                verification_mode,
+                message_id_json_pointer,
             )
             .await;
 
@@ -1045,15 +1077,14 @@ async fn setup_wasm_channels(
             }
         }
 
-        // Register HMAC signing secret if declared in capabilities
-        if let Some(ref hmac_secret_name) = hmac_secret_name
+        // Register HMAC secret if declared in capabilities (WhatsApp/Slack style)
+        if let Some(ref hmac_name) = hmac_secret_name
             && let Some(secrets) = secrets_store
-            && let Ok(secret) = secrets.get_decrypted("default", hmac_secret_name).await
+            && let Ok(hmac_secret) = secrets.get_decrypted("default", hmac_name).await
         {
             wasm_router
-                .register_hmac_secret(&channel_name, secret.expose())
+                .register_hmac_secret(&channel_name, hmac_secret.expose().to_string())
                 .await;
-            tracing::info!(channel = %channel_name, "Registered HMAC signing secret");
         }
 
         if let Some(secrets) = secrets_store {
@@ -1086,10 +1117,15 @@ async fn setup_wasm_channels(
 
     // Always create webhook routes (even with no channels loaded) so that
     // channels hot-added at runtime can receive webhooks without a restart.
+    let webhook_ack_timeout = Some(std::time::Duration::from_secs(
+        config.wasm.webhook_ack_timeout_secs,
+    ));
     let webhook_routes = {
         Some(create_wasm_channel_router(
             Arc::clone(&wasm_router),
             extension_manager.map(Arc::clone),
+            database.map(Arc::clone),
+            webhook_ack_timeout,
         ))
     };
 

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -295,6 +295,7 @@ impl TestHarnessBuilder {
             cost_guard,
             sse_tx: None,
             http_interceptor: None,
+            wasm_router: None,
         };
 
         TestHarness {

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -448,7 +448,7 @@ impl TestRigBuilder {
         let log_broadcaster = Arc::new(LogBroadcaster::new());
 
         // 4. Create TraceLlm + InstrumentedLlm, extract HTTP exchanges for replay.
-        let http_exchanges = self
+        let _http_exchanges = self
             .trace
             .as_ref()
             .map(|t| t.http_exchanges.clone())
@@ -560,13 +560,8 @@ impl TestRigBuilder {
             hooks: components.hooks,
             cost_guard: components.cost_guard,
             sse_tx: None,
-            http_interceptor: if http_exchanges.is_empty() {
-                None
-            } else {
-                Some(Arc::new(
-                    ironclaw::llm::recording::ReplayingHttpInterceptor::new(http_exchanges),
-                ))
-            },
+            http_interceptor: None,
+            wasm_router: None,
         };
 
         // 7. Create TestChannel and ChannelManager.

--- a/tests/wasm_channel_integration.rs
+++ b/tests/wasm_channel_integration.rs
@@ -71,7 +71,7 @@ mod router_tests {
         }];
 
         router
-            .register(channel.clone(), endpoints, None, None)
+            .register(channel.clone(), endpoints, None, None, None, None)
             .await;
 
         // Verify channel is found by path
@@ -96,7 +96,14 @@ mod router_tests {
         ));
 
         router
-            .register(channel, vec![], Some("my-secret-123".to_string()), None)
+            .register(
+                channel,
+                vec![],
+                Some("my-secret-123".to_string()),
+                None,
+                None,
+                None,
+            )
             .await;
 
         // Correct secret validates
@@ -135,7 +142,9 @@ mod router_tests {
             require_secret: false,
         }];
 
-        router.register(channel, endpoints, None, None).await;
+        router
+            .register(channel, endpoints, None, None, None, None)
+            .await;
 
         // Channel exists
         assert!(router.get_channel_for_path("/webhook/temp").await.is_some());
@@ -167,7 +176,9 @@ mod router_tests {
                 require_secret: false,
             }];
 
-            router.register(channel, endpoints, None, None).await;
+            router
+                .register(channel, endpoints, None, None, None, None)
+                .await;
         }
 
         // Verify all channels are registered

--- a/wit/channel.wit
+++ b/wit/channel.wit
@@ -331,6 +331,20 @@ interface channel {
     /// - Err(string): Delivery failure message
     on-respond: func(response: agent-response) -> result<_, string>;
 
+    /// Called after a message has been persisted to the database.
+    ///
+    /// Channels can use this to perform follow-up actions like
+    /// calling external APIs (e.g., WhatsApp mark_as_read).
+    /// This is optional - channels that don't need it can return Ok.
+    ///
+    /// Arguments:
+    /// - metadata-json: The metadata from the persisted message
+    ///
+    /// Returns:
+    /// - Ok: Post-persistence action completed successfully
+    /// - Err(string): Action failure message (does not block the ACK)
+    on-message-persisted: func(metadata-json: string) -> result<_, string>;
+
     /// Notify the channel of agent status changes.
     ///
     /// Called when the agent starts thinking, finishes, or changes state.


### PR DESCRIPTION
## Summary

Implements end-to-end webhook verification for WhatsApp Cloud API with reliable message processing, including GET verification, POST HMAC-SHA256 signature verification, DB-based deduplication, and mark_as_read for blue checkmarks.

## Changes

### Part 1 - GET Verification (query_param mode)

- Add `verification_mode` field to `WebhookSchema`
  - `"query_param"`: Skip host-level secret validation for GET requests
  - `"signature"`: Always require signature validation  
  - `None` (default): Current behavior
- Skip secret validation for channels with `verification_mode: "query_param"`
- WASM module handles verification via query param (e.g., WhatsApp `hub.verify_token`)

### Part 2 - POST Verification (HMAC-SHA256)

- Add `hmac_secret_name` field to `WebhookSchema` for WhatsApp/Slack-style signatures
- Add `verify_hmac_sha256()` function in signature.rs
  - Validates `X-Hub-Signature-256` header format: `sha256=<hex>`
  - Uses constant-time comparison to prevent timing attacks
  - Explicit 32-byte length validation for SHA-256 signatures
- Register HMAC secrets in router, main.rs, and extensions/manager.rs
- Update WhatsApp capabilities to require `whatsapp_app_secret`

### Part 3 - mark_as_read (Blue Checkmarks)

- After message persistence, automatically call WhatsApp API to mark message as read
- Access token stored securely and injected at host level
- API version configurable per channel

### Part 4 - DB-based Webhook Deduplication

- Add `webhook_message_dedup` table to track processed messages
- Check for duplicates before processing webhook messages
- Record message as processed immediately after dedup check (prevents race conditions)
- Automatic cleanup of old records (configurable interval, default 7 days)

### Part 5 - Reliable ACK Mechanism

- Webhook returns 200 only after message is persisted to DB
- Uses oneshot channels to coordinate between webhook handler and agent loop
- On timeout (configurable, default 10s), returns 500 to trigger WhatsApp retry
- Deduplication handles duplicate deliveries from retries

## Configuration

| Env Variable | Default | Description |
|--------------|---------|-------------|
| `WEBHOOK_ACK_TIMEOUT_SECS` | 10 | Timeout for webhook ACK before returning 500 |
| `WEBHOOK_DEDUP_CLEANUP_INTERVAL_HOURS` | 168 (7 days) | Interval for cleaning old dedup records |

## Files Changed

| File | Changes |
|------|---------|
| `migrations/V10__webhook_dedup.sql` | New migration for dedup table |
| `src/channels/wasm/router.rs` | HMAC secret storage, ACK mechanism, dedup, mark_as_read |
| `src/channels/wasm/signature.rs` | Added verify_hmac_sha256() with constant-time comparison |
| `src/channels/wasm/schema.rs` | Added verification_mode, hmac_secret_name fields |
| `src/config/wasm.rs` | Added configurable ACK timeout and cleanup interval |
| `src/db/mod.rs` | Added WebhookDedupStore trait |
| `src/db/postgres.rs` | PostgreSQL implementation of dedup store |
| `src/db/libsql/webhook_dedup.rs` | libSQL implementation of dedup store |
| `src/main.rs` | Load secrets, spawn cleanup task, wire up components |
| `channels-src/whatsapp/` | Updated WASM channel for mark_as_read |

## Tests Added

- 27 signature tests (HMAC + Ed25519)
- 31 router tests (ACK mechanism, dedup, webhook handling)
- 4 webhook dedup tests for libSQL
- All 1811 tests passing

## Security

- Uses constant-time comparison to prevent timing attacks
- Secrets loaded from encrypted secrets store
- Proper input validation (length, hex decoding, header format)
- No sensitive data in error messages
- Deduplication prevents replay attacks from WhatsApp retries

## Verification

Tested with real WhatsApp webhooks:
- GET verification working
- POST HMAC-SHA256 validation working
- mark_as_read (blue checkmarks) working
- Deduplication working
- ACK mechanism working (webhook returns 200 after persistence)