### PR TITLE
fix(setup): validate PostgreSQL version and pgvector availability before migrations

### DIFF
--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -599,16 +599,16 @@ impl SetupWizard {
             })?;
 
         if pgvector_row.is_none() {
-            return Err(SetupError::Database(
+            return Err(SetupError::Database(format!(
                 "pgvector extension not found on your PostgreSQL server.\n\n\
                  Install it:\n  \
                  macOS:   brew install pgvector\n  \
-                 Ubuntu:  apt install postgresql-16-pgvector\n  \
-                 Docker:  use the pgvector/pgvector:pg16 image\n  \
+                 Ubuntu:  apt install postgresql-{0}-pgvector\n  \
+                 Docker:  use the pgvector/pgvector:pg{0} image\n  \
                  Source:  https://github.com/pgvector/pgvector#installation\n\n\
-                 Then restart PostgreSQL and re-run: ironclaw onboard"
-                    .to_string(),
-            ));
+                 Then restart PostgreSQL and re-run: ironclaw onboard",
+                major_version
+            )));
         }
 
         self.db_pool = Some(pool);


### PR DESCRIPTION
## Summary

- Adds PostgreSQL version check (>= 15) after successful connection in the setup wizard
- Adds pgvector extension availability check before running migrations
- Both provide actionable error messages with platform-specific install guidance

## Problem

The setup wizard accepted any `DATABASE_URL` without validating the server. Two common failure modes:

1. **PostgreSQL 14 or older**: Migrations fail at `CREATE EXTENSION IF NOT EXISTS vector` because pgvector requires PG 15+. The error is opaque.
2. **pgvector not installed**: Even with PG 16, if the pgvector package isn't installed on the server, the extension creation fails with no guidance on how to fix it.

## What changed

`test_database_connection_postgres()` in `src/setup/wizard.rs` now performs two checks after connecting:

1. `SHOW server_version` -- rejects versions below 15 with:
   ```
   PostgreSQL 14.2 detected. IronClaw requires PostgreSQL 15 or later for pgvector support.
   Upgrade: https://www.postgresql.org/download/
   ```

2. `SELECT 1 FROM pg_available_extensions WHERE name = 'vector'` -- if missing:
   ```
   pgvector extension not found on your PostgreSQL server.

   Install it:
     macOS:   brew install pgvector
     Ubuntu:  apt install postgresql-16-pgvector
     Docker:  use the pgvector/pgvector:pg16 image
     Source:  https://github.com/pgvector/pgvector#installation

   Then restart PostgreSQL and re-run: ironclaw onboard
   ```

## Test plan

- [ ] `cargo check` -- compiles (postgres feature)
- [ ] `cargo check --no-default-features --features libsql` -- compiles (code is behind `#[cfg(feature = "postgres")]`)
- [ ] Manual: connect to PG 14 -- wizard rejects with version error
- [ ] Manual: connect to PG 16 without pgvector -- wizard rejects with install guidance
- [ ] Manual: connect to PG 16 with pgvector -- wizard proceeds normally

Closes #415
Closes #416