### PR TITLE
fix: add missing build.sh for Discord and WhatsApp channels

### DIFF
--- a/channels-src/discord/build.sh
+++ b/channels-src/discord/build.sh
@@ -13,6 +13,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+if ! command -v wasm-tools &> /dev/null; then
+    echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"
+    exit 1
+fi
+
 echo "Building Discord channel WASM component..."
 
 # Build the WASM module

--- a/channels-src/whatsapp/build.sh
+++ b/channels-src/whatsapp/build.sh
@@ -13,6 +13,11 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
+if ! command -v wasm-tools &> /dev/null; then
+    echo "Error: wasm-tools not found. Install with: cargo install wasm-tools"
+    exit 1
+fi
+
 echo "Building WhatsApp channel WASM component..."
 
 # Build the WASM module


### PR DESCRIPTION
## Summary
- Add `build.sh` to `channels-src/discord/` and `channels-src/whatsapp/`, modeled after `channels-src/telegram/build.sh`
- Without these scripts, the WASM binaries are never compiled and the channels don't appear in the setup wizard

Closes #406

## Test plan
- [ ] Verify `channels-src/discord/build.sh` produces `discord.wasm` (requires `wasm32-wasip2` target)
- [ ] Verify `channels-src/whatsapp/build.sh` produces `whatsapp.wasm`
- [ ] Confirm both channels appear in `ironclaw setup` after building

Generated with [Claude Code](https://claude.com/claude-code)