### PR TITLE
fix: normalize secret names for case-insensitive credential matching

### DIFF
--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -171,9 +171,12 @@ pub struct CreateSecretParams {
 }
 
 impl CreateSecretParams {
+    /// Create new secret params. The name is normalized to lowercase for
+    /// case-insensitive matching (capabilities.json uses lowercase names
+    /// like `slack_bot_token`, but UIs may store `SLACK_BOT_TOKEN`).
     pub fn new(name: impl Into<String>, value: impl Into<String>) -> Self {
         Self {
-            name: name.into(),
+            name: name.into().to_lowercase(),
             value: SecretString::from(value.into()),
             provider: None,
             expires_at: None,

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -235,14 +235,16 @@ impl CredentialInjector {
         Ok(result)
     }
 
-    /// Check if a secret name is in the allowed list.
+    /// Check if a secret name is in the allowed list (case-insensitive).
     fn is_secret_allowed(&self, name: &str) -> bool {
+        let name_lower = name.to_lowercase();
         for pattern in &self.allowed_secrets {
-            if pattern == name {
+            let pattern_lower = pattern.to_lowercase();
+            if pattern_lower == name_lower {
                 return true;
             }
-            if let Some(prefix) = pattern.strip_suffix('*')
-                && name.starts_with(prefix)
+            if let Some(prefix) = pattern_lower.strip_suffix('*')
+                && name_lower.starts_with(prefix)
             {
                 return true;
             }


### PR DESCRIPTION
## Summary
- Secret names are now normalized to lowercase at creation and lookup time
- Fixes the Slack channel "not_authed" error caused by the web UI storing `SLACK_BOT_TOKEN` while capabilities.json expects `slack_bot_token`
- Applied consistently across all three SecretsStore backends (PostgreSQL, libSQL, InMemory) and the credential injector's allowlist check

Closes #413

## Test plan
- [ ] All 31 existing secrets tests pass
- [ ] Store a secret as `SLACK_BOT_TOKEN`, retrieve it as `slack_bot_token` -- should succeed
- [ ] Credential injection matches `slack_bot_token` in capabilities.json against stored `slack_bot_token` (previously `SLACK_BOT_TOKEN`)
- [ ] `cargo clippy --all --all-features` -- zero warnings

Generated with [Claude Code](https://claude.com/claude-code)