### PR TITLE
feat(extensions): OAuth setup UI for WASM tools + display name labels

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -1,9 +1,9 @@
 {
   "name": "discord",
-  "display_name": "Discord",
+  "display_name": "Discord Channel",
   "kind": "channel",
   "version": "0.1.0",
-  "description": "Discord Gateway/Webhook channel for slash commands, buttons, and messages",
+  "description": "Talk to your agent in Discord",
   "keywords": ["messaging", "chat", "discord", "bot"],
 
   "source": {

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -1,9 +1,9 @@
 {
   "name": "slack",
-  "display_name": "Slack",
+  "display_name": "Slack Channel",
   "kind": "channel",
   "version": "0.1.0",
-  "description": "Slack Events API channel for receiving and responding to Slack messages",
+  "description": "Talk to your agent in Slack",
   "keywords": ["messaging", "chat", "workspace", "slack"],
 
   "source": {

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -1,9 +1,9 @@
 {
   "name": "telegram",
-  "display_name": "Telegram",
+  "display_name": "Telegram Channel",
   "kind": "channel",
   "version": "0.1.0",
-  "description": "Telegram Bot API channel for receiving and responding to messages",
+  "description": "Talk to your agent through a Telegram bot",
   "keywords": ["messaging", "bot", "chat", "telegram"],
 
   "source": {

--- a/registry/channels/whatsapp.json
+++ b/registry/channels/whatsapp.json
@@ -1,9 +1,9 @@
 {
   "name": "whatsapp",
-  "display_name": "WhatsApp",
+  "display_name": "WhatsApp Channel",
   "kind": "channel",
   "version": "0.1.0",
-  "description": "WhatsApp Cloud API channel for receiving and responding to messages",
+  "description": "Talk to your agent through WhatsApp",
   "keywords": ["messaging", "chat", "whatsapp", "meta"],
 
   "source": {

--- a/registry/tools/slack.json
+++ b/registry/tools/slack.json
@@ -1,9 +1,9 @@
 {
   "name": "slack-tool",
-  "display_name": "Slack",
+  "display_name": "Slack Tool",
   "kind": "tool",
   "version": "0.1.0",
-  "description": "Post messages, read channels, and manage conversations via Slack API",
+  "description": "Your agent uses Slack to post and read messages in your workspace",
   "keywords": ["messaging", "chat", "workspace"],
 
   "source": {

--- a/registry/tools/telegram.json
+++ b/registry/tools/telegram.json
@@ -1,9 +1,9 @@
 {
   "name": "telegram-mtproto",
-  "display_name": "Telegram",
+  "display_name": "Telegram Tool",
   "kind": "tool",
   "version": "0.1.0",
-  "description": "Telegram user-mode integration via MTProto for messages and contacts",
+  "description": "Your agent uses your Telegram account to read and send messages",
   "keywords": ["messaging", "chat", "telegram", "mtproto"],
 
   "source": {

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -51,6 +51,7 @@ pub async fn extensions_list_handler(
             };
             ExtensionInfo {
                 name: ext.name,
+                display_name: ext.display_name,
                 kind: ext.kind.to_string(),
                 description: ext.description,
                 url: ext.url,

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -1740,6 +1740,7 @@ async fn extensions_list_handler(
             };
             ExtensionInfo {
                 name: ext.name,
+                display_name: ext.display_name,
                 kind: ext.kind.to_string(),
                 description: ext.description,
                 url: ext.url,

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -324,8 +324,14 @@ function showSlashAutocomplete(matches) {
     const row = document.createElement('div');
     row.className = 'slash-ac-item';
     row.dataset.index = i;
-    row.innerHTML = '<span class="slash-ac-cmd">' + escapeHtml(item.cmd) + '</span>'
-      + '<span class="slash-ac-desc">' + escapeHtml(item.desc) + '</span>';
+    var cmdSpan = document.createElement('span');
+    cmdSpan.className = 'slash-ac-cmd';
+    cmdSpan.textContent = item.cmd;
+    var descSpan = document.createElement('span');
+    descSpan.className = 'slash-ac-desc';
+    descSpan.textContent = item.desc;
+    row.appendChild(cmdSpan);
+    row.appendChild(descSpan);
     row.addEventListener('mousedown', (e) => {
       e.preventDefault(); // prevent blur
       selectSlashItem(item.cmd);
@@ -1643,6 +1649,8 @@ function loadServerLogLevel() {
 
 // --- Extensions ---
 
+var kindLabels = { 'wasm_channel': 'Channel', 'wasm_tool': 'Tool', 'mcp_server': 'MCP' };
+
 function loadExtensions() {
   const extList = document.getElementById('extensions-list');
   const wasmList = document.getElementById('available-wasm-list');
@@ -1718,7 +1726,7 @@ function renderAvailableExtensionCard(entry) {
 
   const kind = document.createElement('span');
   kind.className = 'ext-kind kind-' + entry.kind;
-  kind.textContent = entry.kind;
+  kind.textContent = kindLabels[entry.kind] || entry.kind;
   header.appendChild(kind);
 
   card.appendChild(header);
@@ -1784,7 +1792,7 @@ function renderMcpServerCard(entry, installedExt) {
 
   var kind = document.createElement('span');
   kind.className = 'ext-kind kind-mcp_server';
-  kind.textContent = 'mcp_server';
+  kind.textContent = kindLabels['mcp_server'] || 'mcp_server';
   header.appendChild(kind);
 
   if (installedExt) {
@@ -1868,12 +1876,12 @@ function renderExtensionCard(ext) {
 
   const name = document.createElement('span');
   name.className = 'ext-name';
-  name.textContent = ext.name;
+  name.textContent = ext.display_name || ext.name;
   header.appendChild(name);
 
   const kind = document.createElement('span');
   kind.className = 'ext-kind kind-' + ext.kind;
-  kind.textContent = ext.kind;
+  kind.textContent = kindLabels[ext.kind] || ext.kind;
   header.appendChild(kind);
 
   // Auth dot only for non-WASM-channel extensions (channels use the stepper instead)
@@ -1981,7 +1989,7 @@ function renderExtensionCard(ext) {
     if (ext.needs_setup) {
       const configBtn = document.createElement('button');
       configBtn.className = 'btn-ext configure';
-      configBtn.textContent = ext.authenticated ? 'Reconfigure' : 'Configure';
+      configBtn.textContent = ext.authenticated ? 'Reconfigure' : 'Setup';
       configBtn.addEventListener('click', () => showConfigureModal(ext.name));
       actions.appendChild(configBtn);
     }
@@ -2102,7 +2110,8 @@ function renderConfigureModal(name, secrets) {
     if (secret.provided) {
       const badge = document.createElement('span');
       badge.className = 'field-provided';
-      badge.textContent = 'Set';
+      badge.textContent = '\u2713';
+      badge.title = 'Already configured';
       inputRow.appendChild(badge);
     }
     if (secret.auto_generate && !secret.provided) {

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -367,6 +367,8 @@ pub struct TransitionInfo {
 #[derive(Debug, Serialize)]
 pub struct ExtensionInfo {
     pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     pub kind: String,
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -187,6 +187,9 @@ fn default_true() -> bool {
 pub struct InstalledExtension {
     pub name: String,
     pub kind: ExtensionKind,
+    /// Human-readable display name (e.g. "Telegram Channel" vs "Telegram Tool").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub display_name: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// Server or source URL (e.g. MCP server endpoint).

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -62,6 +62,11 @@ pub struct CapabilitiesFile {
     #[serde(default)]
     pub auth: Option<AuthCapabilitySchema>,
 
+    /// Setup schema: secrets the user must provide before the tool can be used.
+    /// Mirrors the channel `setup.required_secrets` pattern.
+    #[serde(default)]
+    pub setup: Option<ToolSetupSchema>,
+
     /// Nested capabilities wrapper for channel-level JSON compatibility.
     ///
     /// Channel capabilities files nest tool capabilities under a `"capabilities"` key.
@@ -95,6 +100,7 @@ impl CapabilitiesFile {
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);
             self.workspace = self.workspace.or(inner.workspace);
             self.auth = self.auth.or(inner.auth);
+            self.setup = self.setup.or(inner.setup);
         }
         self
     }
@@ -514,6 +520,26 @@ fn default_method() -> String {
 
 fn default_success_status() -> u16 {
     200
+}
+
+/// Setup schema for WASM tools: secrets the user must provide via the UI.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolSetupSchema {
+    /// Secrets the user must provide before the tool can be used.
+    #[serde(default)]
+    pub required_secrets: Vec<ToolSecretSetupSchema>,
+}
+
+/// A single secret required during tool setup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolSecretSetupSchema {
+    /// Secret name in the secrets store (e.g. "google_oauth_client_id").
+    pub name: String,
+    /// User-facing prompt (e.g. "Google OAuth Client ID").
+    pub prompt: String,
+    /// If true, the user may skip this secret.
+    #[serde(default)]
+    pub optional: bool,
 }
 
 #[cfg(test)]
@@ -974,6 +1000,55 @@ mod tests {
         assert_eq!(caps.secrets.unwrap().allowed_names, vec!["my_secret"]);
         assert_eq!(caps.workspace.unwrap().allowed_prefixes, vec!["data/"]);
         assert_eq!(caps.auth.unwrap().secret_name, "my_auth_token");
+    }
+
+    #[test]
+    fn test_parse_tool_setup_schema() {
+        let json = r#"{
+            "setup": {
+                "required_secrets": [
+                    {
+                        "name": "google_oauth_client_id",
+                        "prompt": "Google OAuth Client ID"
+                    },
+                    {
+                        "name": "google_oauth_client_secret",
+                        "prompt": "Google OAuth Client Secret",
+                        "optional": true
+                    }
+                ]
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let setup = caps.setup.unwrap();
+        assert_eq!(setup.required_secrets.len(), 2);
+        assert_eq!(setup.required_secrets[0].name, "google_oauth_client_id");
+        assert_eq!(setup.required_secrets[0].prompt, "Google OAuth Client ID");
+        assert!(!setup.required_secrets[0].optional);
+        assert_eq!(setup.required_secrets[1].name, "google_oauth_client_secret");
+        assert!(setup.required_secrets[1].optional);
+    }
+
+    #[test]
+    fn test_resolve_nested_setup_promoted() {
+        // setup inside capabilities wrapper should be promoted to top level
+        let json = r#"{
+            "capabilities": {
+                "setup": {
+                    "required_secrets": [
+                        { "name": "my_secret", "prompt": "Enter secret" }
+                    ]
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        assert!(
+            caps.setup.is_some(),
+            "setup should be promoted from inner capabilities"
+        );
+        assert_eq!(caps.setup.unwrap().required_secrets[0].name, "my_secret");
     }
 
     #[test]

--- a/tools-src/gmail/gmail-tool.capabilities.json
+++ b/tools-src/gmail/gmail-tool.capabilities.json
@@ -42,5 +42,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/google-calendar/google-calendar-tool.capabilities.json
+++ b/tools-src/google-calendar/google-calendar-tool.capabilities.json
@@ -41,5 +41,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/google-docs/google-docs-tool.capabilities.json
+++ b/tools-src/google-docs/google-docs-tool.capabilities.json
@@ -41,5 +41,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/google-drive/google-drive-tool.capabilities.json
+++ b/tools-src/google-drive/google-drive-tool.capabilities.json
@@ -46,5 +46,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/google-sheets/google-sheets-tool.capabilities.json
+++ b/tools-src/google-sheets/google-sheets-tool.capabilities.json
@@ -41,5 +41,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/google-slides/google-slides-tool.capabilities.json
+++ b/tools-src/google-slides/google-slides-tool.capabilities.json
@@ -41,5 +41,17 @@
       }
     },
     "env_var": "GOOGLE_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "google_oauth_client_id",
+        "prompt": "Google OAuth Client ID (from console.cloud.google.com/apis/credentials)"
+      },
+      {
+        "name": "google_oauth_client_secret",
+        "prompt": "Google OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/okta/okta-tool.capabilities.json
+++ b/tools-src/okta/okta-tool.capabilities.json
@@ -89,5 +89,17 @@
     "setup_url": "https://developer.okta.com/docs/guides/implement-oauth-for-okta/main/",
     "token_hint": "OAuth2 access token (JWT)",
     "env_var": "OKTA_OAUTH_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "okta_oauth_client_id",
+        "prompt": "Okta OAuth Client ID"
+      },
+      {
+        "name": "okta_oauth_client_secret",
+        "prompt": "Okta OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/slack/slack-tool.capabilities.json
+++ b/tools-src/slack/slack-tool.capabilities.json
@@ -46,5 +46,17 @@
     "setup_url": "https://api.slack.com/apps",
     "token_hint": "Starts with 'xoxb-'",
     "env_var": "SLACK_BOT_TOKEN"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "slack_oauth_client_id",
+        "prompt": "Slack OAuth Client ID (from api.slack.com/apps)"
+      },
+      {
+        "name": "slack_oauth_client_secret",
+        "prompt": "Slack OAuth Client Secret"
+      }
+    ]
   }
 }

--- a/tools-src/telegram/telegram-tool.capabilities.json
+++ b/tools-src/telegram/telegram-tool.capabilities.json
@@ -24,5 +24,17 @@
     "display_name": "Telegram",
     "instructions": "1. Go to https://my.telegram.org/apps and create an app\n2. Store your API ID and hash in the workspace:\n   - Write your numeric API ID to telegram/api_id\n   - Write your API hash string to telegram/api_hash\n3. Use the 'login' action with your phone number\n4. Use 'submit_auth_code' with the code you receive\n5. Use 'submit_2fa_password' if you have 2FA enabled\n6. Save the returned session JSON to telegram/session.json",
     "setup_url": "https://my.telegram.org/apps"
+  },
+  "setup": {
+    "required_secrets": [
+      {
+        "name": "telegram_api_id",
+        "prompt": "Telegram API ID (from my.telegram.org/apps)"
+      },
+      {
+        "name": "telegram_api_hash",
+        "prompt": "Telegram API Hash"
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Summary

- **Tool setup via UI**: WASM tools with OAuth (Google Suite, Slack, Okta, Telegram) can now be configured through the Extensions tab Setup modal instead of requiring environment variables
- **Display name labels**: Extension cards show human-readable labels ("Gmail" not "gmail", "Channel"/"Tool"/"MCP" badges)
- **UI polish**: "Setup"/"Reconfigure" button labels, checkmark badge for configured secrets, XSS-safe slash autocomplete

## Changes

### Backend (`src/extensions/manager.rs`)
- `get_setup_schema()` now handles `WasmTool` (reads `setup.required_secrets` from capabilities.json)
- `save_setup_secrets()` now handles `WasmTool` with clear error for missing setup schema
- `check_tool_auth_status()` checks required secrets against secrets store
- `load_tool_capabilities()` helper extracted to reduce 3x filesystem read duplication
- Tools auto-activate after saving setup secrets
- `list()` populates `display_name` from registry for all extension kinds

### Schema (`src/tools/wasm/capabilities_schema.rs`)
- Added `ToolSetupSchema` and `ToolSecretSetupSchema` types
- Added `setup: Option<ToolSetupSchema>` to `CapabilitiesFile`
- `resolve_nested()` merges `setup` from inner capabilities
- Added tests for parsing and nested resolution

### Frontend (`app.js`)
- "Setup" button shown when `needs_setup=true` and not authenticated; "Reconfigure" when already configured
- Checkmark (✓) badge replaces "Set" text for configured secrets
- Fixed `innerHTML` XSS pattern in slash autocomplete → uses `textContent`
- Extension cards display `display_name` and kind labels

### Capabilities files (9 tools)
- Added `setup.required_secrets` to: Gmail, Google Calendar/Docs/Drive/Sheets/Slides, Slack, Okta, Telegram

### Registry
- Updated display names to disambiguate channels vs tools (e.g. "Telegram Channel" vs "Telegram Tool")

## Known limitation

Setup secrets are stored in the secrets store but the OAuth flow currently reads client_id/secret from environment variables or built-in defaults. Google tools work out of the box (built-in Desktop App credentials). For Slack/Okta, wiring the secrets store into the OAuth resolution is a follow-up.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test` — all pass
- [x] Manual: install gmail via registry → Setup button appears → enter secrets → Reconfigure shown
- [x] Manual: shared secrets (google_oauth_client_id) propagate across Google tools
- [x] curl: `/api/extensions`, `/api/extensions/gmail/setup` GET and POST verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)