### PR TITLE
fix: prevent Telegram 409 Conflict on webhook re-registration

### DIFF
--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -897,81 +897,61 @@ fn register_webhook(tunnel_url: &str, webhook_secret: Option<&str>) -> Result<()
         None,
     );
 
-    match result {
-        Ok(response) => {
-            // On 409 Conflict, delete the existing webhook and retry once
-            if response.status == 409 {
-                channel_host::log(
-                    channel_host::LogLevel::Warn,
-                    "409 Conflict -- deleting existing webhook and retrying",
-                );
-                let _ = delete_webhook();
+    let mut response = match result {
+        Ok(response) => response,
+        Err(e) => return Err(format!("HTTP request failed: {}", e)),
+    };
 
-                let retry = channel_host::http_request(
-                    "POST",
-                    "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/setWebhook",
-                    &headers.to_string(),
-                    Some(&body_bytes),
-                    None,
-                );
-                match retry {
-                    Ok(retry_resp) => {
-                        if retry_resp.status != 200 {
-                            let body_str = String::from_utf8_lossy(&retry_resp.body);
-                            return Err(format!(
-                                "HTTP {} (after 409 retry): {}",
-                                retry_resp.status, body_str
-                            ));
-                        }
-                        let api_response: TelegramApiResponse<serde_json::Value> =
-                            serde_json::from_slice(&retry_resp.body)
-                                .map_err(|e| format!("Failed to parse response: {}", e))?;
-                        if !api_response.ok {
-                            return Err(format!(
-                                "Telegram API error (after 409 retry): {}",
-                                api_response
-                                    .description
-                                    .unwrap_or_else(|| "unknown".to_string())
-                            ));
-                        }
-                        channel_host::log(
-                            channel_host::LogLevel::Info,
-                            &format!("Webhook registered successfully (after retry): {}", webhook_url),
-                        );
-                        return Ok(());
-                    }
-                    Err(e) => return Err(format!("HTTP request failed (after 409 retry): {}", e)),
-                }
-            }
+    let mut retried = false;
+    if response.status == 409 {
+        channel_host::log(
+            channel_host::LogLevel::Warn,
+            "409 Conflict -- deleting existing webhook and retrying",
+        );
+        let _ = delete_webhook();
+        retried = true;
 
-            if response.status != 200 {
-                let body_str = String::from_utf8_lossy(&response.body);
-                return Err(format!("HTTP {}: {}", response.status, body_str));
-            }
-
-            // Parse Telegram API response
-            let api_response: TelegramApiResponse<serde_json::Value> =
-                serde_json::from_slice(&response.body)
-                    .map_err(|e| format!("Failed to parse response: {}", e))?;
-
-            if !api_response.ok {
-                return Err(format!(
-                    "Telegram API error: {}",
-                    api_response
-                        .description
-                        .unwrap_or_else(|| "unknown".to_string())
-                ));
-            }
-
-            channel_host::log(
-                channel_host::LogLevel::Info,
-                &format!("Webhook registered successfully: {}", webhook_url),
-            );
-
-            Ok(())
-        }
-        Err(e) => Err(format!("HTTP request failed: {}", e)),
+        response = match channel_host::http_request(
+            "POST",
+            "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/setWebhook",
+            &headers.to_string(),
+            Some(&body_bytes),
+            None,
+        ) {
+            Ok(resp) => resp,
+            Err(e) => return Err(format!("HTTP request failed (after 409 retry): {}", e)),
+        };
     }
+
+    if response.status != 200 {
+        let body_str = String::from_utf8_lossy(&response.body);
+        let context = if retried { " (after 409 retry)" } else { "" };
+        return Err(format!("HTTP {}{}: {}", response.status, context, body_str));
+    }
+
+    // Parse Telegram API response
+    let api_response: TelegramApiResponse<serde_json::Value> =
+        serde_json::from_slice(&response.body)
+            .map_err(|e| format!("Failed to parse response: {}", e))?;
+
+    if !api_response.ok {
+        let context = if retried { " (after 409 retry)" } else { "" };
+        return Err(format!(
+            "Telegram API error{}: {}",
+            context,
+            api_response
+                .description
+                .unwrap_or_else(|| "unknown".to_string())
+        ));
+    }
+
+    let context = if retried { " (after retry)" } else { "" };
+    channel_host::log(
+        channel_host::LogLevel::Info,
+        &format!("Webhook registered successfully{}: {}", context, webhook_url),
+    );
+
+    Ok(())
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

- Delete existing webhook before calling `setWebhook` in `on_start()` webhook mode, matching the defensive cleanup polling mode already does
- Add 409 retry in `register_webhook()` as a safety net -- on 409, calls `delete_webhook()` then retries once

Closes #440

## Relationship to other open PRs

**PR #381** (`fix/telegram-webhook-secret-header`) fixes a different webhook failure: Telegram sends the secret in `X-Telegram-Bot-Api-Secret-Token` but the capabilities file was missing the webhook config, so the router defaulted to `X-Webhook-Secret` and rejected all updates with 401. That PR fixes **message delivery after webhook registration**. This PR fixes **webhook registration itself** (409 Conflict when re-registering). Both are needed for reliable webhook mode, and they touch different files (#381 touches `telegram.capabilities.json`, this PR touches `lib.rs`) so there are no merge conflicts.

PRs #289 (audio pipeline), #395 (broadcast fix), and #409 (file attachments) also touch the Telegram channel but in message parsing/sending code, far from the `on_start()` / `register_webhook()` changes here. No conflict risk.

## Test plan

- [ ] Activate Telegram channel in webhook mode -- should register without 409
- [ ] Re-activate Telegram channel (simulating restart) -- should clear old webhook and re-register cleanly
- [ ] Telegram WASM compiles (`cargo component build` in channels-src/telegram/ with wasm32-wasip1 target)
- [ ] `cargo clippy --all --all-features` -- zero warnings

Generated with [Claude Code](https://claude.com/claude-code)