### PR TITLE
fix: add type annotation for Vec<String> to fix Windows build

### DIFF
--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -566,7 +566,7 @@ async fn setup_tunnel_cloudflare() -> Result<TunnelSettings, ChannelSetupError> 
 /// Detect running cloudflared processes or managed services that could conflict
 /// with IronClaw's tunnel management.
 fn detect_existing_cloudflared() -> Option<String> {
-    let mut conflicts = Vec::new();
+    let mut conflicts: Vec<String> = Vec::new();
 
     // Check for running cloudflared processes (all platforms)
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- Fixes Windows build failure in the v0.13.0 release run
- `let mut conflicts = Vec::new()` at `src/setup/channels.rs:569` can't be inferred on Windows because all `push` calls are inside `#[cfg(unix)]` blocks (which don't compile on Windows)
- Adding `: Vec<String>` type annotation fixes it

## Related

Unblocks the v0.13.0 release — after merging, delete + retag `v0.13.0` to trigger a clean release run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)