### PR TITLE
feat(web): classify SSE stream_chunk by type (content/reasoning/tool_call)

### DIFF
--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -309,6 +309,7 @@ impl Channel for GatewayChannel {
             },
             StatusUpdate::StreamChunk(content) => SseEvent::StreamChunk {
                 content,
+                chunk_type: crate::channels::web::types::ChunkType::Content,
                 thread_id: thread_id.clone(),
             },
             StatusUpdate::Status(msg) => SseEvent::Status {

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -193,7 +193,12 @@ function connectSSE() {
     const data = JSON.parse(e.data);
     if (!isCurrentThread(data.thread_id)) return;
     finalizeActivityGroup();
-    appendToLastAssistant(data.content);
+    const chunkType = data.chunk_type || 'content';
+    if (chunkType === 'reasoning') {
+      appendReasoningChunk(data.content);
+    } else {
+      appendToLastAssistant(data.content);
+    }
   });
 
   eventSource.addEventListener('status', (e) => {
@@ -469,6 +474,27 @@ function appendToLastAssistant(chunk) {
   } else {
     addMessage('assistant', chunk);
   }
+}
+
+// Append a reasoning/chain-of-thought chunk inside a collapsible <details> block
+// adjacent to the last assistant message. Creates the block on first call.
+function appendReasoningChunk(chunk) {
+  const container = document.getElementById('chat-messages');
+  let details = container.querySelector('.reasoning-block:last-of-type');
+  if (!details) {
+    details = document.createElement('details');
+    details.className = 'reasoning-block';
+    const summary = document.createElement('summary');
+    summary.textContent = 'Reasoning';
+    details.appendChild(summary);
+    const pre = document.createElement('pre');
+    pre.className = 'reasoning-content';
+    details.appendChild(pre);
+    container.appendChild(details);
+  }
+  const pre = details.querySelector('.reasoning-content');
+  pre.textContent += chunk;
+  container.scrollTop = container.scrollHeight;
 }
 
 // --- Inline Tool Activity Cards ---

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -532,6 +532,30 @@ body {
   font-style: italic;
 }
 
+/* Reasoning / chain-of-thought collapsible block (stream_chunk with chunk_type=reasoning) */
+.reasoning-block {
+  margin: 4px 0 8px;
+  border-left: 2px solid var(--text-secondary);
+  padding-left: 10px;
+  opacity: 0.7;
+}
+
+.reasoning-block summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-style: italic;
+  user-select: none;
+}
+
+.reasoning-block .reasoning-content {
+  margin: 6px 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Tool card */
 
 .activity-tool-card {

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -101,6 +101,20 @@ pub struct ApprovalRequest {
 
 // --- SSE Event Types ---
 
+/// Classifies a streaming text chunk so the UI can render each kind distinctly.
+///
+/// - `Content`  — regular assistant text (rendered inline in the chat bubble).
+/// - `Reasoning` — chain-of-thought / thinking tokens (rendered in a collapsible section).
+/// - `ToolCall`  — inline tool invocation notification emitted before execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ChunkType {
+    #[default]
+    Content,
+    Reasoning,
+    ToolCall,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type")]
 pub enum SseEvent {
@@ -135,6 +149,11 @@ pub enum SseEvent {
     #[serde(rename = "stream_chunk")]
     StreamChunk {
         content: String,
+        /// Classifies the chunk so the UI can render content, reasoning, and
+        /// tool-call notifications differently. Defaults to `Content` for
+        /// backward compatibility with existing producers.
+        #[serde(default)]
+        chunk_type: ChunkType,
         #[serde(skip_serializing_if = "Option::is_none")]
         thread_id: Option<String>,
     },


### PR DESCRIPTION
## Summary

- Add `ChunkType { Content, Reasoning, ToolCall }` enum to `SseEvent::StreamChunk` so the browser UI can distinguish between regular text, chain-of-thought reasoning, and inline tool-call notifications in the SSE stream
- `#[serde(default)]` on `chunk_type` ensures all existing producers are fully backward-compatible (untyped chunks are treated as `Content`)
- Frontend renders `reasoning` chunks inside a collapsible `<details>` block with muted styling; `content` chunks continue rendering inline as before

## Changes

| File | Change |
|------|--------|
| `src/channels/web/types.rs` | Add `ChunkType` enum; add `chunk_type` field to `StreamChunk` variant |
| `src/channels/web/mod.rs` | Set `chunk_type: ChunkType::Content` in `StatusUpdate::StreamChunk` conversion |
| `src/channels/web/static/app.js` | Branch on `chunk_type` in stream_chunk listener; new `appendReasoningChunk()` helper |
| `src/channels/web/static/style.css` | `.reasoning-block` styles (collapsible left-border block) |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test` — all 13 test suites pass, 0 failures
- [x] `cargo check --no-default-features --features libsql` — compiles

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)