### PR TITLE
fix: correct download URLs for telegram-mtproto and slack-tool extensions

### DIFF
--- a/registry/tools/slack.json
+++ b/registry/tools/slack.json
@@ -14,7 +14,7 @@
 
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-wasm32-wasip2.tar.gz",
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-tool-wasm32-wasip2.tar.gz",
       "sha256": null
     }
   },

--- a/registry/tools/telegram.json
+++ b/registry/tools/telegram.json
@@ -14,7 +14,7 @@
 
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-wasm32-wasip2.tar.gz",
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-mtproto-wasm32-wasip2.tar.gz",
       "sha256": null
     }
   },


### PR DESCRIPTION
## Summary
- Fixed download URLs in `registry/tools/telegram.json` and `registry/tools/slack.json` that incorrectly pointed to the channel bundles instead of the tool bundles
- `telegram-mtproto` URL: `telegram-wasm32-wasip2.tar.gz` → `telegram-mtproto-wasm32-wasip2.tar.gz`
- `slack-tool` URL: `slack-wasm32-wasip2.tar.gz` → `slack-tool-wasm32-wasip2.tar.gz`

## Test plan
- [ ] Verify CI builds produce correctly-named archives on next release
- [ ] Test `tool_install telegram-mtproto` successfully downloads and extracts the correct bundle
- [ ] Test `tool_install slack-tool` successfully downloads and extracts the correct bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)