### PR TITLE
support podman

### DIFF
--- a/src/sandbox/detect.rs
+++ b/src/sandbox/detect.rs
@@ -150,6 +150,13 @@ fn docker_binary_exists() -> bool {
             .stderr(std::process::Stdio::null())
             .status()
             .is_ok_and(|s| s.success())
+        ||
+        std::process::Command::new("which")
+            .arg("podman")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|s| s.success())
     }
     #[cfg(windows)]
     {


### PR DESCRIPTION
Allow checking for docker port if either docker or podman is installed. Note, I'm not sure podman fully works, it manages to create jobs but they are not able to communicate to the orchestrator. 
```
Error: Worker failed: Failed to connect to orchestrator at http://172.17.0.1:50051: error sending request for url (http://172.17.0.1:50051/worker/2ec96b1e-356c-48da-89ef-692102395e11/job)
```