### PR TITLE
fix(web): auto-scroll and Enter completion for slash commands

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -359,6 +359,9 @@ function selectSlashItem(cmd) {
 function updateSlashHighlight() {
   const items = document.querySelectorAll('#slash-autocomplete .slash-ac-item');
   items.forEach((el, i) => el.classList.toggle('selected', i === _slashSelected));
+  if (_slashSelected >= 0 && items[_slashSelected]) {
+    items[_slashSelected].scrollIntoView({ block: 'nearest' });
+  }
 }
 
 function filterSlashCommands(value) {
@@ -1196,7 +1199,7 @@ chatInput.addEventListener('keydown', (e) => {
       updateSlashHighlight();
       return;
     }
-    if (e.key === 'Tab' || (e.key === 'Enter' && _slashSelected >= 0)) {
+    if (e.key === 'Tab' || e.key === 'Enter') {
       e.preventDefault();
       const pick = _slashSelected >= 0 ? _slashMatches[_slashSelected] : _slashMatches[0];
       if (pick) selectSlashItem(pick.cmd);


### PR DESCRIPTION
## Summary
- **Auto-scroll**: Arrow-key navigation in the `/` command dropdown now scrolls to keep the highlighted item visible (adds `scrollIntoView({ block: 'nearest' })`)
- **Enter completion**: Pressing Enter while the autocomplete dropdown is visible now completes the first matching command instead of sending the raw partial text (e.g., typing `/sk` + Enter now completes to `/skills` instead of sending `/sk`)

## Test plan
- [x] Open web gateway, type `/` and arrow-key down past the visible area — dropdown should scroll
- [x] Type `/sk` and press Enter — should complete to `/skills `, not send `/sk`
- [x] Arrow-key to a specific item and press Enter — should select that item
- [x] Tab still completes the first match
- [x] Escape closes the dropdown


🤖 Generated with [Claude Code](https://claude.com/claude-code)