### PR TITLE
fix: wire secrets store into all WASM runtime activation paths

### DIFF
--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -19,12 +19,14 @@ use crate::channels::wasm::schema::ChannelCapabilitiesFile;
 use crate::channels::wasm::wrapper::WasmChannel;
 use crate::db::SettingsStore;
 use crate::pairing::PairingStore;
+use crate::secrets::SecretsStore;
 
 /// Loads WASM channels from the filesystem.
 pub struct WasmChannelLoader {
     runtime: Arc<WasmChannelRuntime>,
     pairing_store: Arc<PairingStore>,
     settings_store: Option<Arc<dyn SettingsStore>>,
+    secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
 }
 
 impl WasmChannelLoader {
@@ -38,7 +40,14 @@ impl WasmChannelLoader {
             runtime,
             pairing_store,
             settings_store,
+            secrets_store: None,
         }
+    }
+
+    /// Set the secrets store for host-based credential injection in WASM channels.
+    pub fn with_secrets_store(mut self, store: Arc<dyn SecretsStore + Send + Sync>) -> Self {
+        self.secrets_store = Some(store);
+        self
     }
 
     /// Load a single WASM channel from a file pair.
@@ -127,7 +136,7 @@ impl WasmChannelLoader {
             .await?;
 
         // Create the channel
-        let channel = WasmChannel::new(
+        let mut channel = WasmChannel::new(
             self.runtime.clone(),
             prepared,
             capabilities,
@@ -135,6 +144,9 @@ impl WasmChannelLoader {
             self.pairing_store.clone(),
             self.settings_store.clone(),
         );
+        if let Some(ref secrets) = self.secrets_store {
+            channel = channel.with_secrets_store(Arc::clone(secrets));
+        }
 
         tracing::info!(
             name = name,

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1804,7 +1804,8 @@ impl ExtensionManager {
             None
         };
 
-        let loader = WasmToolLoader::new(Arc::clone(runtime), Arc::clone(&self.tool_registry));
+        let loader = WasmToolLoader::new(Arc::clone(runtime), Arc::clone(&self.tool_registry))
+            .with_secrets_store(Arc::clone(&self.secrets));
         loader
             .load_from_files(name, &wasm_path, cap_path_option)
             .await
@@ -1915,7 +1916,8 @@ impl ExtensionManager {
             Arc::clone(&channel_runtime),
             Arc::clone(&pairing_store),
             settings_store,
-        );
+        )
+        .with_secrets_store(Arc::clone(&self.secrets));
         let loaded = loader
             .load_from_files(name, &wasm_path, cap_path_option)
             .await

--- a/src/main.rs
+++ b/src/main.rs
@@ -911,11 +911,14 @@ async fn setup_wasm_channels(
     let pairing_store = Arc::new(PairingStore::new());
     let settings_store: Option<Arc<dyn ironclaw::db::SettingsStore>> =
         database.map(|db| Arc::clone(db) as Arc<dyn ironclaw::db::SettingsStore>);
-    let loader = WasmChannelLoader::new(
+    let mut loader = WasmChannelLoader::new(
         Arc::clone(&runtime),
         Arc::clone(&pairing_store),
         settings_store,
     );
+    if let Some(secrets) = secrets_store {
+        loader = loader.with_secrets_store(Arc::clone(secrets));
+    }
 
     let results = match loader
         .load_from_dir(&config.channels.wasm_channels_dir)

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -585,7 +585,7 @@ impl ToolRegistry {
             limits: None,
             description: Some(&tool_with_binary.tool.description),
             schema: Some(tool_with_binary.tool.parameters_schema.clone()),
-            secrets_store: None,
+            secrets_store: self.secrets_store.clone(),
             oauth_refresh: None,
         })
         .await


### PR DESCRIPTION
## Summary

- **WASM tools activated at runtime** (via web UI `tool_activate` or Extensions tab) were missing secrets store wiring, causing credential injection to silently fail — tools get 401s from APIs even with configured API keys
- **Four bugs fixed across all WASM activation paths:**
  - `activate_wasm_tool()`: `WasmToolLoader` created without `.with_secrets_store()`
  - `register_wasm_from_storage()`: hardcoded `secrets_store: None` for DB-loaded tools
  - `WasmChannelLoader`: missing `secrets_store` field entirely (added field + builder method)
  - Channel startup + hot-activation: both paths missed wiring secrets through the loader
- The startup path in `app.rs` was already correct; all runtime paths now match it

## Test plan

- [x] `cargo check` — compiles clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test` — 22 relevant tests pass (extensions::manager, channels::wasm::loader, tools::registry)
- [x] `grep` audit confirms no remaining hardcoded `secrets_store: None` in production paths
- [ ] Manual: install web-search via Extensions tab, configure Brave API key, verify search works
- [ ] Manual: install any WASM tool from DB storage, verify credentials inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)