### PR TITLE
fix(web): reset job list UI on restart failure

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -2406,10 +2406,11 @@ function restartJob(jobId) {
   apiFetch('/api/jobs/' + jobId + '/restart', { method: 'POST' })
     .then((res) => {
       showToast('Job restarted as ' + (res.new_job_id || '').substring(0, 8), 'success');
-      loadJobs();
     })
     .catch((err) => {
       showToast('Failed to restart job: ' + err.message, 'error');
+    })
+    .finally(() => {
       loadJobs();
     });
 }


### PR DESCRIPTION
## Summary
- Adds `loadJobs()` call in `restartJob()` catch handler to reset the job row UI state on failure
- Previously the job row stayed highlighted/stale after a failed restart attempt since `loadJobs()` was only called in the success path

## Test plan
- [x] Verify job list refreshes after both successful and failed restart attempts

Closes #485

Generated with [Claude Code](https://claude.com/claude-code)