### PR TITLE
fix(workspace): import custom templates before seeding defaults

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -665,18 +665,14 @@ impl AppBuilder {
 
         // Seed workspace and backfill embeddings
         if let Some(ref ws) = workspace {
-            match ws.seed_if_empty().await {
-                Ok(_) => {}
-                Err(e) => {
-                    tracing::warn!("Failed to seed workspace: {}", e);
-                }
-            }
-
-            // Import workspace files from disk if WORKSPACE_IMPORT_DIR is set.
+            // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
             // This lets Docker images / deployment scripts ship customized
             // workspace templates (e.g., AGENTS.md, TOOLS.md) that override
             // the generic seeds. Only imports files that don't already exist
             // in the database — never overwrites user edits.
+            //
+            // Runs before seed_if_empty() so that custom templates take priority
+            // over generic seeds. seed_if_empty() then fills any remaining gaps.
             if let Ok(import_dir) = std::env::var("WORKSPACE_IMPORT_DIR") {
                 let import_path = std::path::Path::new(&import_dir);
                 match ws.import_from_directory(import_path).await {
@@ -691,6 +687,13 @@ impl AppBuilder {
                             e
                         );
                     }
+                }
+            }
+
+            match ws.seed_if_empty().await {
+                Ok(_) => {}
+                Err(e) => {
+                    tracing::warn!("Failed to seed workspace: {}", e);
                 }
             }
 


### PR DESCRIPTION
## Summary

- Swap the order of `import_from_directory()` and `seed_if_empty()` in workspace initialization
- Custom workspace templates from `WORKSPACE_IMPORT_DIR` now take priority over generic seeds
- `seed_if_empty()` fills any remaining gaps after import

Previously, `seed_if_empty()` ran first and created all default files (AGENTS.md, SOUL.md, etc.), causing `import_from_directory()` to skip everything since the files already existed in the DB. This made `WORKSPACE_IMPORT_DIR` effectively broken for any file that overlaps with the seed templates.

Safe for existing users: both steps use "skip if exists" logic, so users with files already in DB see no change.

## Test plan

- [ ] Verify existing workspaces are unaffected (both steps skip when files exist)
- [ ] Verify new workspace without `WORKSPACE_IMPORT_DIR`: generic seeds created as before
- [ ] Verify new workspace with `WORKSPACE_IMPORT_DIR`: custom templates imported, seeds fill gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)