### PR TITLE
fix(security): replace .unwrap() panics in pairing store with proper error handling

### DIFF
--- a/src/pairing/store.rs
+++ b/src/pairing/store.rs
@@ -30,6 +30,9 @@ pub enum PairingStoreError {
     #[error("Invalid channel: {0}")]
     InvalidChannel(String),
 
+    #[error("Invalid path: {0}")]
+    InvalidPath(String),
+
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
 
@@ -224,7 +227,10 @@ impl PairingStore {
         meta: Option<serde_json::Value>,
     ) -> Result<UpsertResult, PairingStoreError> {
         let path = pairing_path(&self.base_dir, channel)?;
-        fs::create_dir_all(path.parent().unwrap())?;
+        let parent = path.parent().ok_or_else(|| {
+            PairingStoreError::InvalidPath(format!("path has no parent: {}", path.display()))
+        })?;
+        fs::create_dir_all(parent)?;
 
         let mut file = fs::OpenOptions::new()
             .read(true)
@@ -319,7 +325,10 @@ impl PairingStore {
 
     fn record_failed_approve(&self, channel: &str) -> Result<(), PairingStoreError> {
         let path = approve_attempts_path(&self.base_dir, channel)?;
-        fs::create_dir_all(path.parent().unwrap())?;
+        let parent = path.parent().ok_or_else(|| {
+            PairingStoreError::InvalidPath(format!("path has no parent: {}", path.display()))
+        })?;
+        fs::create_dir_all(parent)?;
 
         // Open (or create) and lock before reading so concurrent callers
         // don't clobber each other's writes.
@@ -462,7 +471,10 @@ impl PairingStore {
         }
 
         let path = allow_from_path(&self.base_dir, channel)?;
-        fs::create_dir_all(path.parent().unwrap())?;
+        let parent = path.parent().ok_or_else(|| {
+            PairingStoreError::InvalidPath(format!("path has no parent: {}", path.display()))
+        })?;
+        fs::create_dir_all(parent)?;
 
         let file = fs::OpenOptions::new()
             .read(true)


### PR DESCRIPTION
## Summary

- **Fixed 3 `.unwrap()` calls on `path.parent()` in `src/pairing/store.rs`** that could panic if a path has no parent (root path or empty), creating a potential denial-of-service vector if an attacker can influence the path
- **Added `InvalidPath` variant to `PairingStoreError`** for proper error propagation instead of panicking
- Follows the project's no-panics-in-production policy (`"Never use .unwrap() or .expect() in production code"`)

### Locations fixed

| Function | Original | Fix |
|----------|----------|-----|
| `upsert_request` (line ~227) | `path.parent().unwrap()` | `path.parent().ok_or_else(\|\| PairingStoreError::InvalidPath(...))` |
| `record_failed_approve` (line ~322) | `path.parent().unwrap()` | `path.parent().ok_or_else(\|\| PairingStoreError::InvalidPath(...))` |
| `add_allow_from` (line ~465) | `path.parent().unwrap()` | `path.parent().ok_or_else(\|\| PairingStoreError::InvalidPath(...))` |

All remaining `.unwrap()` calls in `src/pairing/store.rs` are in `#[cfg(test)]` only, which is acceptable per project policy.

## Test plan

- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test pairing` — all 22 tests pass (18 unit + 4 integration)
- [x] Verified no production `.unwrap()` or `.expect()` remain in `src/pairing/`
- [ ] Reviewer confirms error messages are clear and actionable

🤖 Generated with [Claude Code](https://claude.com/claude-code)