### PR TITLE
fix(security): resolve DNS once and reuse for SSRF validation to prevent rebinding

### DIFF
--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -431,8 +431,7 @@ impl Tool for HttpTool {
             self.secrets_store.as_ref(),
         ) {
             let cred_host = parsed_url.host_str().unwrap_or("");
-            let matched: Vec<crate::secrets::CredentialMapping> =
-                registry.find_for_host(cred_host);
+            let matched: Vec<crate::secrets::CredentialMapping> = registry.find_for_host(cred_host);
             for mapping in &matched {
                 match store
                     .get_decrypted(&ctx.user_id, &mapping.secret_name)
@@ -506,9 +505,7 @@ impl Tool for HttpTool {
                 let hop_addrs = validate_and_resolve_url(&parsed_url).await?;
                 let hop_host = parsed_url
                     .host_str()
-                    .ok_or_else(|| {
-                        ToolError::InvalidParameters("URL missing host".into())
-                    })?
+                    .ok_or_else(|| ToolError::InvalidParameters("URL missing host".into()))?
                     .to_string();
                 let hop_client = build_pinned_client(
                     &hop_host,
@@ -1172,7 +1169,10 @@ mod tests {
 
     #[test]
     fn test_build_pinned_client_succeeds() {
-        let addrs = vec![SocketAddr::new(IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)), 443)];
+        let addrs = vec![SocketAddr::new(
+            IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34)),
+            443,
+        )];
         let client = build_pinned_client(
             "example.com",
             &addrs,


### PR DESCRIPTION
## Summary

- **Fixes DNS TOCTOU (Time-of-Check-Time-of-Use) vulnerability** in SSRF protection for both `http` and `web_fetch` tools
- DNS is now resolved once via `tokio::net::lookup_host`, validated against the SSRF blocklist, and pinned into a per-request reqwest `Client` via `ClientBuilder::resolve()` -- preventing reqwest from independently re-resolving to a potentially different (private) IP
- `WebFetchTool` builds a fresh pinned client per redirect hop, ensuring DNS rebinding cannot occur at any point in a redirect chain

## Problem

The previous SSRF protection in `validate_url()` resolved DNS to check resolved IPs against a blocklist (private ranges, loopback, link-local, cloud metadata endpoints). However, `reqwest` then independently re-resolved DNS when `.send()` was called. Between those two lookups, a DNS rebinding attacker could flip a hostname's DNS record from a public IP (passes validation) to a private IP like `169.254.169.254` (AWS metadata endpoint), bypassing the SSRF protection entirely.

## Solution

Split URL validation into two distinct phases:

1. **`validate_url()`** -- Synchronous URL structure checks only (scheme, localhost, IP literals). No DNS resolution.
2. **`validate_and_resolve_url()`** -- Async DNS resolution via `tokio::net::lookup_host`, validates all resolved IPs against the blocklist, returns `Vec<SocketAddr>`.
3. **`build_pinned_client()`** -- Constructs a per-request `reqwest::Client` with `resolve()` pinning so reqwest connects directly to the pre-validated IPs without a second DNS lookup.

### Files changed

- `src/tools/builtin/http.rs` -- Refactored `validate_url`, added `validate_and_resolve_url` and `build_pinned_client`, removed stored `Client` from `HttpTool`, per-request pinned client construction, 3 new tests
- `src/tools/builtin/web_fetch.rs` -- Removed stored `Client` from `WebFetchTool`, per-hop DNS pinning in redirect loop

## Test plan

- [x] All 28 existing `http::tests` pass (including URL validation, approval, credential injection)
- [x] All 8 existing `web_fetch::tests` pass
- [x] New test: `test_validate_and_resolve_rejects_loopback_hostname` -- verifies loopback IPs are rejected at the DNS resolution layer
- [x] New test: `test_validate_and_resolve_accepts_public_host` -- verifies public hostnames (example.com) resolve and pass validation
- [x] New test: `test_build_pinned_client_succeeds` -- verifies pinned client construction works
- [x] `cargo clippy --all --all-features` -- zero warnings
- [x] No `.unwrap()` or `.expect()` in production code

Generated with [Claude Code](https://claude.com/claude-code)