### PR TITLE
fix(ci): use GitHub App token for release-plz PR to trigger CI

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -58,10 +58,18 @@ jobs:
       - *checkout
       - *install-rust
       - uses: Swatinem/rust-cache@v2
+      # Use GitHub App token so the PR triggers CI workflows.
+      # PRs created by GITHUB_TOKEN don't trigger `pull_request` events.
+      - name: Generate GitHub token
+        uses: actions/create-github-app-token@v2
+        id: generate-token
+        with:
+          app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}
+          private-key: ${{ secrets.GH_RELEASES_MANAGER_APP_PRIVATE_KEY }}
       - name: Run release-plz
         uses: release-plz/action@v0.5
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- PRs created by `GITHUB_TOKEN` don't fire `pull_request` events (GitHub's anti-recursion policy)
- The release-plz PR job was using `GITHUB_TOKEN`, so the required checks (Code Style, Run Tests) never ran on release PRs — blocking merge
- Switch to the same GitHub App token already used by the release job

## Test plan
- [ ] Merge this PR, then verify the next release-plz PR triggers CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)