### PR TITLE
feat: integrate 13-dimension complexity scorer into smart routing

### DIFF
--- a/docs/smart-routing-spec.md
+++ b/docs/smart-routing-spec.md
@@ -40,8 +40,8 @@ User Message
          │ tier
          ▼
 ┌──────────────────┐
-│  Model Selection │  ← Config maps tier → model (e.g., flash → "haiku-latest")
-└────────┬─────────┘
+│  Model Selection │  ← Currently: cheap provider (Flash/Standard/Pro) vs primary (Frontier)
+└────────┬─────────┘    Target: per-tier model mapping via config
          │
          ▼
     LLM Provider

--- a/src/llm/smart_routing.rs
+++ b/src/llm/smart_routing.rs
@@ -238,7 +238,13 @@ pub struct ScorerConfig {
 }
 
 /// Build a domain regex from a keyword list, with fallback on invalid patterns.
+///
+/// An empty keyword list falls back to the default keywords so scoring
+/// doesn't break when `domain_keywords: Some(vec![])` is configured.
 fn build_domain_regex(keywords: &[&str]) -> Regex {
+    if keywords.is_empty() {
+        return RE_DOMAIN_DEFAULT.clone();
+    }
     let pattern = format!(r"(?i)\b({})\b", keywords.join("|"));
     Regex::new(&pattern).unwrap_or_else(|e| {
         tracing::warn!(error = %e, "Invalid domain keywords pattern, using minimal fallback");
@@ -360,10 +366,13 @@ static DEFAULT_OVERRIDES: LazyLock<Vec<PatternOverride>> = LazyLock::new(|| {
             .expect("greeting pattern is valid"),
             tier: Tier::Flash,
         },
-        // Flash tier: quick lookups
+        // Flash tier: quick lookups (end-anchored to avoid matching complex questions
+        // like "What time complexity is merge sort?")
         PatternOverride {
-            regex: Regex::new(r"(?i)^what.*(time|date|day|weather)")
-                .expect("lookup pattern is valid"),
+            regex: Regex::new(
+                r"(?i)^what(?:'s|\s+is)?\s+(?:the\s+)?(time|date|day|weather)\b(?:\s+(?:is\s+it|today|now|in\s+\S+))?[?.!]*$",
+            )
+            .expect("lookup pattern is valid"),
             tier: Tier::Flash,
         },
         // Frontier tier: security audits
@@ -1374,6 +1383,48 @@ mod tests {
         let req = CompletionRequest::new(vec![ChatMessage::user("What time is it?")]);
         let complexity = provider.classify(&req);
         assert_eq!(complexity, TaskComplexity::Simple);
+    }
+
+    #[test]
+    fn pattern_override_time_does_not_match_complex_questions() {
+        // The quick-lookup override regex should NOT match "What time complexity..."
+        // because it's end-anchored. Verify the regex itself doesn't fire.
+        let overrides = &*DEFAULT_OVERRIDES;
+        let lookup_override = overrides
+            .iter()
+            .find(|po| po.tier == Tier::Flash && po.regex.as_str().contains("time"))
+            .expect("time lookup override exists");
+
+        assert!(
+            !lookup_override
+                .regex
+                .is_match("What time complexity is merge sort?"),
+            "Time override should not match 'What time complexity is merge sort?'"
+        );
+        // But it should still match actual time lookups
+        assert!(lookup_override.regex.is_match("What time is it?"));
+        assert!(lookup_override.regex.is_match("what's the date today?"));
+    }
+
+    #[test]
+    fn empty_domain_keywords_uses_defaults() {
+        // An empty custom keywords list should fall back to defaults, not produce
+        // a broken regex that matches empty strings everywhere.
+        let config = ScorerConfig {
+            domain_keywords: Some(vec![]),
+            ..ScorerConfig::default()
+        };
+        let result = score_complexity_with_config("deploy kubernetes to mainnet", &config);
+        // Should still detect domain keywords via the default fallback
+        assert!(
+            result
+                .components
+                .get("domain_specific")
+                .copied()
+                .unwrap_or(0)
+                > 0,
+            "Empty custom keywords should fall back to defaults"
+        );
     }
 
     // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Continuation of #208 by @onlyamicrowave.

Integrates the 13-dimension complexity scorer and pattern override system from PR #208 into the existing `SmartRoutingProvider` in `smart_routing.rs`, replacing the simpler keyword-based classifier while preserving the cascade routing, stats tracking, and `LlmProvider` decorator chain.

## Changes from original

- Merged with latest main (resolved Cargo.lock conflict)
- Folded `src/llm/routing/` module (scorer.rs, router.rs, mod.rs) into existing `src/llm/smart_routing.rs` instead of keeping a separate directory
- Replaced `lazy_static` dependency with `std::sync::LazyLock` (Rust 1.93+ / edition 2024)
- Added 4-tier system (Flash/Standard/Pro/Frontier) mapped to existing `TaskComplexity` enum
- Integrated 13-dimension scorer with configurable weights and domain keywords
- Added regex pattern overrides for fast-path classification (greetings, security audits, production deploys)
- Added tier hints via `[tier:flash]` syntax in prompts
- Added multi-dimensional boost (+30% when 3+ dimensions score above threshold)
- Used `tracing::error` + safe fallback instead of `unreachable!()` in production code
- Cached domain keyword regex as `LazyLock` static to avoid rebuilding on every call
- Removed unused `lazy_static` from `Cargo.toml`
- Updated spec doc status to "Implemented"
- 44 tests covering all scoring dimensions, tier boundaries, pattern overrides, tier hints, custom domain keywords, edge cases, uncertainty detection, and provider routing

## Original PR

#208 - feat(llm): add smart model routing based on request complexity

## Review comments addressed

- All 4 Gemini review comments were already resolved by the original author in later commits
- Deep review found 11 issues (critical: unnecessary lazy_static dep, high: module not integrated, high: regex rebuilt per call, medium: unreachable!() in production) — all fixed

## Test plan

- [x] All 44 smart_routing tests pass (`cargo test smart_routing`)
- [x] Full test suite passes (1874 tests, 1 pre-existing failure in html_to_markdown unrelated to this PR)
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo fmt --check` — clean

---

Co-Authored-By: onlyamicrowave <onlyamicrowave@users.noreply.github.com>

Generated with [Claude Code](https://claude.com/claude-code)