### PR TITLE
fix(ci): flush profraw coverage data in E2E teardown

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -131,6 +131,18 @@ jobs:
           RUST_LOG: ironclaw=info
           RUST_BACKTRACE: "1"
 
+      - name: Verify profraw files exist
+        if: always()
+        run: |
+          echo "LLVM_PROFILE_FILE=${LLVM_PROFILE_FILE}"
+          echo "CARGO_LLVM_COV_TARGET_DIR=${CARGO_LLVM_COV_TARGET_DIR}"
+          profraw_count=$(find target/ -name '*.profraw' 2>/dev/null | wc -l)
+          echo "Found ${profraw_count} .profraw files under target/"
+          find target/ -name '*.profraw' 2>/dev/null || true
+          if [ "$profraw_count" -eq 0 ]; then
+            echo "::warning::No .profraw files found — coverage report will fail"
+          fi
+
       - name: Generate coverage report
         if: always()
         run: cargo llvm-cov report --lcov --output-path e2e-coverage.info

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -133,9 +133,12 @@ async def ironclaw_server(ironclaw_binary, mock_llm_server):
         )
     finally:
         if proc.returncode is None:
-            proc.send_signal(signal.SIGTERM)
+            # Use SIGINT (not SIGTERM) so tokio's ctrl_c handler triggers a
+            # graceful shutdown.  This lets the LLVM coverage runtime run its
+            # atexit handler and flush .profraw files for cargo-llvm-cov.
+            proc.send_signal(signal.SIGINT)
             try:
-                await asyncio.wait_for(proc.wait(), timeout=5)
+                await asyncio.wait_for(proc.wait(), timeout=10)
             except asyncio.TimeoutError:
                 proc.kill()
 


### PR DESCRIPTION
## Summary

- **Root cause**: The ironclaw binary handles SIGINT (`tokio::signal::ctrl_c`) but not SIGTERM. When `conftest.py` sent SIGTERM during E2E teardown, the OS killed the process without running atexit handlers, so LLVM never flushed `.profraw` files. `cargo llvm-cov report` then found zero profraw files and failed with: `not found *.profraw files in target/`
- **Fix**: Send SIGINT instead of SIGTERM so the existing ctrl_c handler triggers graceful shutdown → `main()` returns → atexit runs → profraw flushed. Also increased shutdown timeout from 5s to 10s.
- **Diagnostics**: Added a verification step before `cargo llvm-cov report` that logs env vars and profraw file count, making future issues immediately visible in CI logs.

## Test plan

- [ ] E2E coverage job in CI passes (profraw files generated, `cargo llvm-cov report` succeeds)
- [ ] Codecov upload succeeds with `e2e` flag
- [ ] Coverage gate job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)