### PR TITLE
fix(ci): persist all cargo-llvm-cov env vars for E2E coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -106,7 +106,9 @@ jobs:
           # CARGO_INCREMENTAL, LLVM_PROFILE_FILE, etc.) so the build step
           # compiles an instrumented binary regardless of cargo-llvm-cov version.
           cargo llvm-cov show-env >> "$GITHUB_ENV"
-          cargo llvm-cov clean --workspace
+
+      - name: Clean coverage workspace
+        run: cargo llvm-cov clean --workspace
 
       - name: Build instrumented binary
         run: cargo build --no-default-features --features libsql

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -99,11 +99,12 @@ async def ironclaw_server(ironclaw_binary, mock_llm_server):
         "ONBOARD_COMPLETED": "true",
     }
     # Forward LLVM coverage instrumentation env vars when present
-    # (allows cargo-llvm-cov to collect profraw data from E2E runs)
-    for key in ("LLVM_PROFILE_FILE", "CARGO_LLVM_COV", "CARGO_LLVM_COV_SHOW_ENV",
-                "CARGO_LLVM_COV_TARGET_DIR", "CARGO_ENCODED_RUSTFLAGS"):
-        val = os.environ.get(key)
-        if val is not None:
+    # (allows cargo-llvm-cov to collect profraw data from E2E runs).
+    # Use prefix matching to stay resilient to cargo-llvm-cov changes.
+    COV_ENV_PREFIXES = ("CARGO_LLVM_COV", "LLVM_")
+    COV_ENV_EXTRAS = ("CARGO_ENCODED_RUSTFLAGS", "CARGO_INCREMENTAL")
+    for key, val in os.environ.items():
+        if key.startswith(COV_ENV_PREFIXES) or key in COV_ENV_EXTRAS:
             env[key] = val
     proc = await asyncio.create_subprocess_exec(
         ironclaw_binary, "--no-onboard",


### PR DESCRIPTION
## Summary

- Newer `cargo-llvm-cov` versions output `CARGO_ENCODED_RUSTFLAGS` instead of `RUSTFLAGS` from `show-env`. The E2E coverage workflow was cherry-picking specific env vars to persist to `$GITHUB_ENV`, missing `CARGO_ENCODED_RUSTFLAGS` entirely — so the build step compiled a **non-instrumented** binary and produced zero `.profraw` files.
- Replace the 5 manual `echo` lines with `cargo llvm-cov show-env >> "$GITHUB_ENV"` to forward **all** vars (including `CARGO_ENCODED_RUSTFLAGS`, `CARGO_INCREMENTAL=0`, etc.) regardless of `cargo-llvm-cov` version.
- Also forward `CARGO_ENCODED_RUSTFLAGS` in the E2E conftest subprocess env for completeness.

## Test plan

- [ ] Trigger the `Code Coverage` workflow on this branch and verify the "Verify profraw files exist" step finds >0 `.profraw` files
- [ ] Verify the "Generate coverage report" step succeeds and produces `e2e-coverage.info`

🤖 Generated with [Claude Code](https://claude.com/claude-code)