### PR TITLE
feat(groq): add Groq LPU inference provider

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -3,6 +3,7 @@
 This document tracks feature parity between IronClaw (Rust implementation) and OpenClaw (TypeScript reference implementation). Use this to coordinate work across developers.
 
 **Legend:**
+
 - ✅ Implemented
 - 🚧 Partial (in progress or incomplete)
 - ❌ Not implemented
@@ -215,6 +216,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | NEAR AI | ✅ | ✅ | - | Primary provider |
 | Anthropic (Claude) | ✅ | 🚧 | - | Via NEAR AI proxy; Opus 4.5, Sonnet 4, Sonnet 4.6 |
 | OpenAI | ✅ | 🚧 | - | Via NEAR AI proxy |
+| Groq | ✅ | ✅ | - | Native LPU inference provider |
 | AWS Bedrock | ✅ | ❌ | P3 | |
 | Google Gemini | ✅ | ❌ | P3 | |
 | NVIDIA API | ✅ | ❌ | P3 | New provider |
@@ -497,6 +499,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 ## Implementation Priorities
 
 ### P0 - Core (Already Done)
+
 - ✅ TUI channel with approval overlays
 - ✅ HTTP webhook channel
 - ✅ DM pairing (ironclaw pairing list/approve, host APIs)
@@ -524,6 +527,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 - ✅ OpenAI-compatible / OpenRouter provider support
 
 ### P1 - High Priority
+
 - ❌ Slack channel (real implementation)
 - ✅ Telegram channel (WASM, DM pairing, caption, /start)
 - ❌ WhatsApp channel
@@ -531,6 +535,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 - ✅ Hooks system (core lifecycle hooks + bundled/plugin/workspace hooks + outbound webhooks)
 
 ### P2 - Medium Priority
+
 - ❌ Media handling (images, PDFs)
 - ✅ Ollama/local model support (via rig::providers::ollama)
 - ❌ Configuration hot-reload
@@ -539,6 +544,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 - ❌ Partial output preservation on abort
 
 ### P3 - Lower Priority
+
 - ❌ Discord channel
 - ❌ Matrix channel
 - ❌ Other messaging platforms

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -12,6 +12,7 @@ configurations.
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` | Claude models |
 | OpenAI | `openai` | `OPENAI_API_KEY` | GPT models |
 | Ollama | `ollama` | No | Local inference |
+| Groq | `groq` | `GROQ_API_KEY` | Fast LPU inference |
 | OpenRouter | `openai_compatible` | `LLM_API_KEY` | 300+ models |
 | Together AI | `openai_compatible` | `LLM_API_KEY` | Fast inference |
 | Fireworks AI | `openai_compatible` | `LLM_API_KEY` | Fast inference |
@@ -65,6 +66,24 @@ OLLAMA_MODEL=llama3.2
 ```
 
 Pull a model first: `ollama pull llama3.2`
+
+---
+
+## Groq (LPU Inference)
+
+Groq provides ultra-fast inference for open-source models (Llama 3, GPT-OSS).
+
+```env
+LLM_BACKEND=groq
+GROQ_API_KEY=gsk-...
+```
+
+Popular models:
+
+- Llama 3.3 70B: `llama-3.3-70b-versatile`
+- OpenAI GPT-OSS 120B: `gpt-oss-120b`
+
+Get your API key at [console.groq.com/keys](https://console.groq.com/keys).
 
 ---
 

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -24,6 +24,8 @@ pub enum LlmBackend {
     Ollama,
     /// Any OpenAI-compatible endpoint (e.g. vLLM, LiteLLM, Together)
     OpenAiCompatible,
+    /// Groq LPU inference
+    Groq,
     /// Tinfoil private inference
     Tinfoil,
 }
@@ -38,9 +40,10 @@ impl std::str::FromStr for LlmBackend {
             "anthropic" | "claude" => Ok(Self::Anthropic),
             "ollama" => Ok(Self::Ollama),
             "openai_compatible" | "openai-compatible" | "compatible" => Ok(Self::OpenAiCompatible),
+            "groq" => Ok(Self::Groq),
             "tinfoil" => Ok(Self::Tinfoil),
             _ => Err(format!(
-                "invalid LLM backend '{}', expected one of: nearai, openai, anthropic, ollama, openai_compatible, tinfoil",
+                "invalid LLM backend '{}', expected one of: nearai, openai, anthropic, ollama, openai_compatible, groq, tinfoil",
                 s
             )),
         }
@@ -55,6 +58,7 @@ impl std::fmt::Display for LlmBackend {
             Self::Anthropic => write!(f, "anthropic"),
             Self::Ollama => write!(f, "ollama"),
             Self::OpenAiCompatible => write!(f, "openai_compatible"),
+            Self::Groq => write!(f, "groq"),
             Self::Tinfoil => write!(f, "tinfoil"),
         }
     }
@@ -72,6 +76,7 @@ impl LlmBackend {
             Self::Anthropic => "ANTHROPIC_MODEL",
             Self::Ollama => "OLLAMA_MODEL",
             Self::OpenAiCompatible => "LLM_MODEL",
+            Self::Groq => "GROQ_MODEL",
             Self::Tinfoil => "TINFOIL_MODEL",
         }
     }
@@ -113,6 +118,13 @@ pub struct OpenAiCompatibleConfig {
     pub extra_headers: Vec<(String, String)>,
 }
 
+/// Configuration for Groq LPU inference.
+#[derive(Debug, Clone)]
+pub struct GroqConfig {
+    pub api_key: Option<SecretString>,
+    pub model: String,
+}
+
 /// Configuration for Tinfoil private inference.
 #[derive(Debug, Clone)]
 pub struct TinfoilConfig {
@@ -138,6 +150,8 @@ pub struct LlmConfig {
     pub ollama: Option<OllamaConfig>,
     /// OpenAI-compatible config (populated when backend=openai_compatible)
     pub openai_compatible: Option<OpenAiCompatibleConfig>,
+    /// Groq config (populated when backend=groq)
+    pub groq: Option<GroqConfig>,
     /// Tinfoil config (populated when backend=tinfoil)
     pub tinfoil: Option<TinfoilConfig>,
 }
@@ -350,6 +364,15 @@ impl LlmConfig {
             None
         };
 
+        let groq = if backend == LlmBackend::Groq {
+            let api_key = optional_env("GROQ_API_KEY")?
+                .map(SecretString::from);
+            let model = Self::resolve_model("GROQ_MODEL", settings, "llama-3.3-70b-versatile")?;
+            Some(GroqConfig { api_key, model })
+        } else {
+            None
+        };
+
         Ok(Self {
             backend,
             nearai,
@@ -357,6 +380,7 @@ impl LlmConfig {
             anthropic,
             ollama,
             openai_compatible,
+            groq,
             tinfoil,
         })
     }
@@ -581,6 +605,69 @@ mod tests {
         // SAFETY: Under ENV_MUTEX.
         unsafe {
             std::env::remove_var("OLLAMA_MODEL");
+        }
+    }
+
+    /// Clear all groq-related env vars.
+    fn clear_groq_env() {
+        // SAFETY: Only called under ENV_MUTEX in tests.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::remove_var("GROQ_API_KEY");
+            std::env::remove_var("GROQ_MODEL");
+        }
+    }
+
+    #[test]
+    fn groq_uses_selected_model_when_groq_model_unset() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_groq_env();
+        // Set API key because it's required during parsing when backend=groq
+        unsafe {
+            std::env::set_var("GROQ_API_KEY", "test-key");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("groq".to_string()),
+            selected_model: Some("llama-3.1-8b-instant".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        let groq = cfg.groq.expect("groq config should be present");
+
+        assert_eq!(groq.model, "llama-3.1-8b-instant");
+
+        unsafe {
+            std::env::remove_var("GROQ_API_KEY");
+        }
+    }
+
+    #[test]
+    fn groq_model_env_overrides_selected_model() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_groq_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("GROQ_API_KEY", "test-key");
+            std::env::set_var("GROQ_MODEL", "llama-3.3-70b-versatile");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("groq".to_string()),
+            selected_model: Some("llama-3.1-8b-instant".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        let groq = cfg.groq.expect("groq config should be present");
+
+        assert_eq!(groq.model, "llama-3.3-70b-versatile");
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("GROQ_API_KEY");
+            std::env::remove_var("GROQ_MODEL");
         }
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -220,6 +220,7 @@ pub async fn inject_llm_keys_from_secrets(
         ("llm_anthropic_api_key", "ANTHROPIC_API_KEY"),
         ("llm_compatible_api_key", "LLM_API_KEY"),
         ("llm_nearai_api_key", "NEARAI_API_KEY"),
+        ("llm_groq_api_key", "GROQ_API_KEY"),
     ];
 
     let mut injected = HashMap::new();

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -544,6 +544,7 @@ INSERT OR IGNORE INTO leak_detection_patterns (id, name, pattern, severity, acti
     ('550e8400-e29b-41d4-a716-44665544000f', 'twilio_api_key', 'SK[a-fA-F0-9]{32}', 'high', 'block', 1, datetime('now')),
     ('550e8400-e29b-41d4-a716-446655440010', 'sendgrid_api_key', 'SG\.[a-zA-Z0-9_-]{22}\.[a-zA-Z0-9_-]{43}', 'high', 'block', 1, datetime('now')),
     ('550e8400-e29b-41d4-a716-446655440011', 'mailchimp_api_key', '[a-f0-9]{32}-us[0-9]{1,2}', 'medium', 'block', 1, datetime('now')),
-    ('550e8400-e29b-41d4-a716-446655440012', 'high_entropy_hex', '(?<![a-fA-F0-9])[a-fA-F0-9]{64}(?![a-fA-F0-9])', 'medium', 'warn', 1, datetime('now'));
+    ('550e8400-e29b-41d4-a716-446655440012', 'high_entropy_hex', '(?<![a-fA-F0-9])[a-fA-F0-9]{64}(?![a-fA-F0-9])', 'medium', 'warn', 1, datetime('now')),
+    ('550e8400-e29b-41d4-a716-446655440013', 'groq_api_key', 'gsk_[a-zA-Z0-9]{48,}', 'critical', 'block', 1, datetime('now'));
 
 "#;

--- a/src/llm/costs.rs
+++ b/src/llm/costs.rs
@@ -67,6 +67,17 @@ pub fn model_cost(model_id: &str) -> Option<(Decimal, Decimal)> {
         | "claude-3-5-haiku-latest" => Some((dec!(0.0000008), dec!(0.000004))),
         "claude-3-haiku-20240307" => Some((dec!(0.00000025), dec!(0.00000125))),
 
+        // Groq
+        "llama-3.1-8b-instant" => Some((dec!(0.00000005), dec!(0.00000008))),
+        "llama-3.3-70b-versatile" => Some((dec!(0.00000059), dec!(0.00000079))),
+        "llama-4-scout-17b-16e-instruct" => Some((dec!(0.00000011), dec!(0.00000034))),
+        "llama-prompt-guard-2-22m" => Some((dec!(0.00000003), dec!(0.00000003))),
+        "llama-prompt-guard-2-86m" => Some((dec!(0.00000004), dec!(0.00000004))),
+        "gpt-oss-120b" => Some((dec!(0.00000015), dec!(0.0000006))),
+        "gpt-oss-20b" | "gpt-oss-safeguard-20b" => Some((dec!(0.000000075), dec!(0.0000003))),
+        "kimi-k2-instruct-0905" => Some((dec!(0.000001), dec!(0.000003))),
+        "qwen3-32b" => Some((dec!(0.00000029), dec!(0.00000059))),
+
         // Ollama / local models -- free
         _ if is_local_model(id) => Some((Decimal::ZERO, Decimal::ZERO)),
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -59,6 +59,7 @@ pub fn create_llm_provider(
         LlmBackend::Anthropic => create_anthropic_provider(config),
         LlmBackend::Ollama => create_ollama_provider(config),
         LlmBackend::OpenAiCompatible => create_openai_compatible_provider(config),
+        LlmBackend::Groq => create_groq_provider(config),
         LlmBackend::Tinfoil => create_tinfoil_provider(config),
     }
 }
@@ -179,6 +180,37 @@ fn create_ollama_provider(config: &LlmConfig) -> Result<Arc<dyn LlmProvider>, Ll
         oll.model
     );
     Ok(Arc::new(RigAdapter::new(model, &oll.model)))
+}
+
+fn create_groq_provider(config: &LlmConfig) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    let groq = config.groq.as_ref().ok_or_else(|| LlmError::AuthFailed {
+        provider: "groq".to_string(),
+    })?;
+
+    let api_key = groq
+        .api_key
+        .as_ref()
+        .ok_or_else(|| LlmError::AuthFailed {
+            provider: "groq".to_string(),
+        })?;
+
+    use rig::providers::openai;
+
+    // Groq fully implements the OpenAI Chat Completions API.
+    // Base URL is https://api.groq.com/openai/v1
+    let client: openai::CompletionsClient = openai::Client::builder()
+        .base_url("https://api.groq.com/openai/v1")
+        .api_key(api_key.expose_secret())
+        .build()
+        .map_err(|e| LlmError::RequestFailed {
+            provider: "groq".to_string(),
+            reason: format!("Failed to create Groq client: {}", e),
+        })?
+        .completions_api();
+
+    let model = client.completion_model(&groq.model);
+    tracing::info!("Using Groq LPU inference (model: {})", groq.model);
+    Ok(Arc::new(RigAdapter::new(model, &groq.model)))
 }
 
 const TINFOIL_BASE_URL: &str = "https://inference.tinfoil.sh/v1";
@@ -471,6 +503,7 @@ mod tests {
             anthropic: None,
             ollama: None,
             openai_compatible: None,
+            groq: None,
             tinfoil: None,
         }
     }

--- a/src/safety/leak_detector.rs
+++ b/src/safety/leak_detector.rs
@@ -428,6 +428,13 @@ fn default_patterns() -> Vec<LeakPattern> {
             severity: LeakSeverity::Critical,
             action: LeakAction::Block,
         },
+        // Groq API keys
+        LeakPattern {
+            name: "groq_api_key".to_string(),
+            regex: Regex::new(r"gsk_[a-zA-Z0-9]{48,}").unwrap(),
+            severity: LeakSeverity::Critical,
+            action: LeakAction::Block,
+        },
         // AWS Access Key ID
         LeakPattern {
             name: "aws_access_key".to_string(),
@@ -736,6 +743,16 @@ mod tests {
         let content = format!("Here's the key: {key}");
         let result = detector.scan(&content);
         assert!(!result.is_clean(), "Anthropic key not detected");
+        assert!(result.should_block);
+    }
+
+    #[test]
+    fn test_detect_groq_key() {
+        let detector = LeakDetector::new();
+        let key = format!("gsk_{}", "a".repeat(48));
+        let content = format!("Here's the key: {key}");
+        let result = detector.scan(&content);
+        assert!(!result.is_clean(), "Groq key not detected");
         assert!(result.should_block);
     }
 

--- a/src/sandbox/config.rs
+++ b/src/sandbox/config.rs
@@ -156,6 +156,7 @@ pub fn default_allowlist() -> Vec<String> {
         "api.openai.com".to_string(),
         "api.anthropic.com".to_string(),
         "api.near.ai".to_string(),
+        "api.groq.com".to_string(),
     ]
 }
 
@@ -167,6 +168,7 @@ pub fn default_credential_mappings() -> Vec<crate::secrets::CredentialMapping> {
         CredentialMapping::bearer("OPENAI_API_KEY", "api.openai.com"),
         CredentialMapping::header("ANTHROPIC_API_KEY", "x-api-key", "api.anthropic.com"),
         CredentialMapping::bearer("NEARAI_API_KEY", "api.near.ai"),
+        CredentialMapping::bearer("GROQ_API_KEY", "api.groq.com"),
     ]
 }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -799,6 +799,7 @@ impl SetupWizard {
                     "openai" => "OpenAI",
                     "ollama" => "Ollama (local)",
                     "openai_compatible" => "OpenAI-compatible endpoint",
+                    "groq" => "Groq LPU Inference",
                     other => other,
                 }
             };
@@ -807,7 +808,7 @@ impl SetupWizard {
 
             let is_known = matches!(
                 current.as_str(),
-                "nearai" | "anthropic" | "openai" | "ollama" | "openai_compatible"
+                "nearai" | "anthropic" | "openai" | "ollama" | "openai_compatible" | "groq"
             );
 
             if is_known && confirm("Keep current provider?", true).map_err(SetupError::Io)? {
@@ -821,6 +822,7 @@ impl SetupWizard {
                     "openai" => return self.setup_openai().await,
                     "ollama" => return self.setup_ollama(),
                     "openai_compatible" => return self.setup_openai_compatible().await,
+                    "groq" => return self.setup_groq().await,
                     _ => {
                         return Err(SetupError::Config(format!(
                             "Unhandled provider: {}",
@@ -847,6 +849,7 @@ impl SetupWizard {
             "OpenAI           - GPT models (direct API key)",
             "Ollama           - local models, no API key needed",
             "OpenRouter       - 200+ models via single API key",
+            "Groq             - Ultra-fast LPU inference (direct API key)",
             "OpenAI-compatible - custom endpoint (vLLM, LiteLLM, etc.)",
         ];
 
@@ -858,7 +861,8 @@ impl SetupWizard {
             2 => self.setup_openai().await?,
             3 => self.setup_ollama()?,
             4 => self.setup_openrouter().await?,
-            5 => self.setup_openai_compatible().await?,
+            5 => self.setup_groq().await?,
+            6 => self.setup_openai_compatible().await?,
             _ => return Err(SetupError::Config("Invalid provider selection".to_string())),
         }
 
@@ -1062,6 +1066,19 @@ impl SetupWizard {
         .await
     }
 
+    /// Groq provider setup.
+    async fn setup_groq(&mut self) -> Result<(), SetupError> {
+        self.setup_api_key_provider(
+            "groq",
+            "GROQ_API_KEY",
+            "llm_groq_api_key",
+            "Groq API key",
+            "https://console.groq.com/keys",
+            None,
+        )
+        .await
+    }
+
     /// OpenAI-compatible provider setup: base URL + optional API key.
     async fn setup_openai_compatible(&mut self) -> Result<(), SetupError> {
         self.settings.llm_backend = Some("openai_compatible".to_string());
@@ -1151,6 +1168,14 @@ impl SetupWizard {
                     .as_ref()
                     .map(|k| k.expose_secret().to_string());
                 let models = fetch_openai_models(cached.as_deref()).await;
+                self.select_from_model_list(&models)?;
+            }
+            "groq" => {
+                let cached = self
+                    .llm_api_key
+                    .as_ref()
+                    .map(|k| k.expose_secret().to_string());
+                let models = fetch_groq_models(cached.as_deref()).await;
                 self.select_from_model_list(&models)?;
             }
             "ollama" => {
@@ -1277,6 +1302,7 @@ impl SetupWizard {
             anthropic: None,
             ollama: None,
             openai_compatible: None,
+            groq: None,
             tinfoil: None,
         };
 
@@ -2532,6 +2558,75 @@ async fn fetch_openai_models(cached_key: Option<&str>) -> Vec<(String, String)> 
                 return static_defaults;
             }
             sort_openai_models(&mut models);
+            models
+        }
+        Err(_) => static_defaults,
+    }
+}
+
+/// Fetch models from the Groq API.
+///
+/// Returns `(model_id, display_label)` pairs. Falls back to static defaults on error.
+async fn fetch_groq_models(cached_key: Option<&str>) -> Vec<(String, String)> {
+    let static_defaults = vec![
+        (
+            "llama-3.3-70b-versatile".into(),
+            "Llama 3.3 70B Versatile (default, fast)".into(),
+        ),
+        (
+            "llama-3.1-8b-instant".into(),
+            "Llama 3.1 8B Instant".into(),
+        ),
+        ("gpt-oss-120b".into(), "OpenAI GPT-OSS 120B".into()),
+    ];
+
+    let api_key = cached_key
+        .map(String::from)
+        .or_else(|| std::env::var("GROQ_API_KEY").ok())
+        .filter(|k| !k.is_empty());
+
+    let api_key = match api_key {
+        Some(k) => k,
+        None => return static_defaults,
+    };
+
+    let client = reqwest::Client::new();
+    let resp = match client
+        .get("https://api.groq.com/openai/v1/models")
+        .bearer_auth(&api_key)
+        .timeout(std::time::Duration::from_secs(5))
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r,
+        _ => return static_defaults,
+    };
+
+    #[derive(serde::Deserialize)]
+    struct ModelEntry {
+        id: String,
+    }
+    #[derive(serde::Deserialize)]
+    struct ModelsResponse {
+        data: Vec<ModelEntry>,
+    }
+
+    match resp.json::<ModelsResponse>().await {
+        Ok(body) => {
+            let mut models: Vec<(String, String)> = body
+                .data
+                .into_iter()
+                .filter(|m| !m.id.contains("whisper")) // filter out audio models
+                .map(|m| {
+                    let label = m.id.clone();
+                    (m.id, label)
+                })
+                .collect();
+            if models.is_empty() {
+                return static_defaults;
+            }
+            // Sort models alphabetically
+            models.sort_by(|a, b| a.1.cmp(&b.1));
             models
         }
         Err(_) => static_defaults,

--- a/src/tools/wasm/allowlist.rs
+++ b/src/tools/wasm/allowlist.rs
@@ -264,6 +264,7 @@ mod tests {
             EndpointPattern::host("api.anthropic.com")
                 .with_path_prefix("/v1/messages")
                 .with_methods(vec!["POST".to_string()]),
+            EndpointPattern::host("api.groq.com").with_path_prefix("/openai/v1/"),
             EndpointPattern::host("*.example.com"),
         ])
     }

--- a/src/tools/wasm/capabilities.rs
+++ b/src/tools/wasm/capabilities.rs
@@ -368,6 +368,7 @@ mod tests {
 
         assert!(cap.is_allowed("openai_key"));
         assert!(!cap.is_allowed("anthropic_key"));
+        assert!(!cap.is_allowed("groq_key"));
     }
 
     #[test]
@@ -379,6 +380,7 @@ mod tests {
         assert!(cap.is_allowed("openai_key"));
         assert!(cap.is_allowed("openai_org"));
         assert!(!cap.is_allowed("anthropic_key"));
+        assert!(!cap.is_allowed("groq_key"));
     }
 
     #[test]


### PR DESCRIPTION
# feat: add Groq LPU inference provider

## Summary

Adds Groq as a first-class LLM backend, enabling ultra-fast inference via Groq's LPU hardware.
Groq exposes an OpenAI-compatible Chat Completions API, so the implementation reuses the existing
`rig::providers::openai` client pointed at `https://api.groq.com/openai/v1`.

## Changes

### Configuration (`src/config/llm.rs`)

- Added `LlmBackend::Groq` variant and `GroqConfig` struct with `api_key: Option<SecretString>` and `model: String`.
- `api_key` is intentionally `Option` — the key is loaded from the encrypted secrets store after DB init; requiring it at initial `Config::from_env()` would fail before secrets are injected (same pattern as NearAI).
- `GROQ_API_KEY` and `GROQ_MODEL` env vars parsed in `LlmConfig::resolve()`.
- `model_env_var()` returns `GROQ_MODEL` for the Groq backend.
- Added 2 unit tests: `groq_uses_selected_model_when_groq_model_unset`, `groq_model_env_overrides_selected_model`.

### Secrets injection (`src/config/mod.rs`)

- Added `("llm_groq_api_key", "GROQ_API_KEY")` mapping to `inject_llm_keys_from_secrets()` so keys stored during onboarding are available at runtime.

### LLM provider factory (`src/llm/mod.rs`)

- Added `create_groq_provider()` — creates an `openai::CompletionsClient` with base URL `https://api.groq.com/openai/v1`, validates that `api_key` is present (returns `LlmError::AuthFailed` if missing).
- Wired `LlmBackend::Groq` into `create_llm_provider()` dispatch.

### Cost tracking (`src/llm/costs.rs`)

- Added per-token pricing for current Groq production and preview models:
  `llama-3.1-8b-instant`, `llama-3.3-70b-versatile`, `llama-4-scout-17b-16e-instruct`,
  `llama-prompt-guard-2-{22m,86m}`, `gpt-oss-{120b,20b}`, `gpt-oss-safeguard-20b`,
  `kimi-k2-instruct-0905`, `qwen3-32b`.
- Prices sourced from [GroqCloud Supported Models](https://console.groq.com/docs/models).

### CLI onboarding wizard (`src/setup/wizard.rs`)

- Added "Groq (LPU Inference)" to provider selection menu.
- Implemented `fetch_groq_models(cached_key)` — fetches available models from `GET /openai/v1/models`,
  filters to chat-capable models, falls back to static defaults on error.
- Groq setup delegates to `setup_api_key_provider()` (shared with OpenAI/Anthropic) — saves key to encrypted secrets store.

### Security & sandbox

| File | Change |
|------|--------|
| [leak_detector.rs](src/safety/leak_detector.rs) | Added `groq_api_key` pattern `gsk_[a-zA-Z0-9]{48,}` with `Block` action + unit test |
| [libsql_migrations.rs](src/db/libsql_migrations.rs) | Added `groq_api_key` to `leak_detection_patterns` seed data |
| [config.rs](src/sandbox/config.rs) | Added `api.groq.com` to network allowlist + `GROQ_API_KEY` credential mapping |
| [allowlist.rs](src/tools/wasm/allowlist.rs) | Added `EndpointPattern::host("api.groq.com").with_path_prefix("/openai/v1/")` |
| [capabilities.rs](src/tools/wasm/capabilities.rs) | Extended `SecretsCapability` tests to cover `groq_key` |

### Documentation

| File | Change |
|------|--------|
| [LLM_PROVIDERS.md](docs/LLM_PROVIDERS.md) | Added Groq section with setup instructions and popular models |
| [FEATURE_PARITY.md](FEATURE_PARITY.md) | Added Groq row to provider comparison table (✅ OpenClaw, ✅ IronClaw) |

## Testing

- `cargo test --lib` — **1872 passed**, 0 failed
- `cargo clippy --all --all-features` — **0 warnings**
- Manual: ran `ironclaw onboard` → Groq → entered API key → selected `llama-3.3-70b-versatile` → `cargo run` → agent responded successfully (with expected 429 retries from Groq rate limits)
