### PR TITLE
fix: sort tool_definitions() for deterministic LLM tool ordering

### DIFF
--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -805,6 +805,9 @@ mod tests {
         let defs = registry.tool_definitions().await;
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
         assert_eq!(names, vec!["alpha", "middle", "zebra"]);
+    }
+
+    #[tokio::test]
     async fn test_retain_only_filters_tools() {
         let registry = ToolRegistry::new();
         registry.register_builtin_tools();


### PR DESCRIPTION
## Summary
- Sort `ToolRegistry::tool_definitions()` alphabetically by tool name before returning to the LLM
- `HashMap` iteration order is non-deterministic, causing position bias in tool selection across sessions
- Added regression test that registers tools in non-alphabetical order and asserts sorted output

Closes #566

## Test plan
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib test_tool_definitions_sorted` — passes
- [x] Existing registry tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)