### PR TITLE
fix: enable libsql remote + tls features for Turso cloud sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ rustls = { version = "0.23", optional = true, default-features = false }
 rustls-native-certs = { version = "0.8", optional = true }
 
 # Database - libSQL/Turso (optional embedded database)
-libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication"] }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 
 # Error handling
 thiserror = "2"


### PR DESCRIPTION
## Summary

The onboard wizard offers Turso cloud sync (`Enable Turso cloud sync (remote replica)?`), but the libsql dependency is compiled without the `remote` and `tls` features.

This causes a panic at runtime when `LIBSQL_URL` is set:

```
thread 'main' panicked at libsql-0.6.0/src/database.rs:644:5:
The `tls` feature is disabled, you must provide your own http connector
```

## Fix

```diff
- libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication"] }
+ libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
```