### PR TITLE
test: expand rate_limit_cascade to hit consecutive-rate-limit threshold (#605)

### DIFF
--- a/tests/e2e_worker_coverage.rs
+++ b/tests/e2e_worker_coverage.rs
@@ -215,6 +215,14 @@ mod tests {
     // -----------------------------------------------------------------------
     // Test 5: rate_limit_cascade
     // -----------------------------------------------------------------------
+    //
+    // Exercises the stuck-detection path by making 11 consecutive
+    // `stub_rate_limit` tool calls (all of which return
+    // `ToolError::RateLimited`), exceeding the 10-call threshold.
+    // The fixture ends with a text response forced by the iteration
+    // limit so the agent can still produce a final message.
+    //
+    // References: Issue #605, PR #593 review comments.
 
     #[tokio::test]
     async fn rate_limit_cascade() {
@@ -227,27 +235,37 @@ mod tests {
         let rig = TestRigBuilder::new()
             .with_trace(trace.clone())
             .with_extra_tools(vec![Arc::new(StubRateLimitTool) as Arc<dyn Tool>])
+            // Raise iteration limit so the agent can attempt all 11 tool
+            // calls before being forced to produce a text response.
+            .with_max_tool_iterations(14)
             .build()
             .await;
 
         rig.send_message("Call the rate limited tool").await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
+        let responses = rig.wait_for_responses(1, Duration::from_secs(30)).await;
 
         rig.verify_trace_expects(&trace, &responses);
 
-        // Both calls should have failed due to rate limiting.
+        // All 11 stub_rate_limit calls should have been attempted and failed.
         let completed = rig.tool_calls_completed();
         let rl_calls: Vec<_> = completed
             .iter()
             .filter(|(name, _)| name == "stub_rate_limit")
             .collect();
         assert!(
-            !rl_calls.is_empty(),
-            "Expected stub_rate_limit calls: {completed:?}"
+            rl_calls.len() >= 10,
+            "Expected >= 10 stub_rate_limit calls to hit the cascade threshold, got {}: {completed:?}",
+            rl_calls.len()
         );
         assert!(
             rl_calls.iter().all(|(_, ok)| !ok),
             "All stub_rate_limit calls should fail: {rl_calls:?}"
+        );
+
+        // Verify the agent still produced a final response despite the cascade.
+        assert!(
+            !responses.is_empty(),
+            "Agent should produce a response even after rate-limit cascade"
         );
 
         rig.shutdown();

--- a/tests/fixtures/llm_traces/worker/rate_limit_cascade.json
+++ b/tests/fixtures/llm_traces/worker/rate_limit_cascade.json
@@ -36,10 +36,136 @@
     },
     {
       "response": {
-        "type": "text",
-        "content": "The tool is rate limited. I was unable to complete the request due to repeated rate limiting.",
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_3",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
         "input_tokens": 300,
         "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_4",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 400,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_5",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 500,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_6",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 600,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_7",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 700,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_8",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 800,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_9",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 900,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_10",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 1000,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_11",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 1100,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "text",
+        "content": "I have been rate limited repeatedly and cannot complete this request. The tool is consistently unavailable due to rate limiting after 11 consecutive attempts.",
+        "input_tokens": 1200,
+        "output_tokens": 40
       }
     }
   ]


### PR DESCRIPTION
## Summary

Expand the `rate_limit_cascade` test fixture from 2 to 11 consecutive `stub_rate_limit` tool calls, enough to exceed the 10-call threshold referenced in the stuck-detection logic. This addresses the gap identified in PR #593 review (comment IDs 2893751216, 2893861186).

## Changes

### Fixture (`rate_limit_cascade.json`)
- Expanded from 2 → 11 consecutive `stub_rate_limit` tool call steps
- Final step remains a text response so the agent can produce a closing message

### Test (`e2e_worker_coverage.rs`)
- Set `max_tool_iterations(14)` so all 11 tool calls can execute before the iteration limit forces a text response
- Assert `>= 10` rate-limited tool calls occurred (previously only asserted non-empty)
- Increased timeout from 15s → 30s to accommodate the longer trace
- Added assertion that the agent still produces a response after the cascade
- Added doc comments referencing #605 and PR #593

## What this exercises

The test now verifies that the agent can handle a sustained cascade of rate-limited tool failures (11 consecutive) without panicking or losing the ability to produce a final response. Previously only 2 calls were made, which did not stress the cascade/stuck-detection code path.

Closes #605