### PR TITLE
fix(llm): report zero cost for OpenRouter free-tier models

### DIFF
--- a/src/llm/costs.rs
+++ b/src/llm/costs.rs
@@ -10,6 +10,12 @@ use rust_decimal_macros::dec;
 ///
 /// Returns `Some((input_cost, output_cost))` for known models, `None` otherwise.
 pub fn model_cost(model_id: &str) -> Option<(Decimal, Decimal)> {
+    // OpenRouter free-tier models: `:free` suffix or the `openrouter/free` router
+    // should always report zero cost (see #463).
+    if model_id.ends_with(":free") || model_id == "openrouter/free" || model_id == "free" {
+        return Some((Decimal::ZERO, Decimal::ZERO));
+    }
+
     // Normalize: strip provider prefixes (e.g., "openai/gpt-4o" -> "gpt-4o")
     let id = model_id
         .rsplit_once('/')
@@ -146,5 +152,45 @@ mod tests {
     fn test_provider_prefix_stripped() {
         // "openai/gpt-4o" should resolve to same as "gpt-4o"
         assert_eq!(model_cost("openai/gpt-4o"), model_cost("gpt-4o"));
+    }
+
+    #[test]
+    fn test_openrouter_free_suffix_zero_cost() {
+        // Models with `:free` suffix should report zero cost (#463)
+        let (input, output) = model_cost("stepfun/step-3.5-flash:free").unwrap();
+        assert_eq!(input, Decimal::ZERO);
+        assert_eq!(output, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_openrouter_free_router_zero_cost() {
+        // The "openrouter/free" router model should report zero cost (#463)
+        let (input, output) = model_cost("openrouter/free").unwrap();
+        assert_eq!(input, Decimal::ZERO);
+        assert_eq!(output, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_bare_free_zero_cost() {
+        // Edge case: bare "free" after prefix stripping
+        let (input, output) = model_cost("free").unwrap();
+        assert_eq!(input, Decimal::ZERO);
+        assert_eq!(output, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_free_suffix_various_providers() {
+        // Various provider-prefixed free models
+        for model in &[
+            "google/gemma-3-27b-it:free",
+            "meta-llama/llama-4-maverick:free",
+            "microsoft/phi-4:free",
+            "nousresearch/deephermes-3-llama-3-8b-preview:free",
+        ] {
+            let (input, output) =
+                model_cost(model).unwrap_or_else(|| panic!("{model} should return Some"));
+            assert_eq!(input, Decimal::ZERO, "{model} input cost should be zero");
+            assert_eq!(output, Decimal::ZERO, "{model} output cost should be zero");
+        }
     }
 }


### PR DESCRIPTION
## Problem

OpenRouter free-tier models report GPT-4o default pricing (~$2.50/$10.00 per 1M tokens) instead of $0 in the IronClaw UI.

Fixes #463.

## Root Cause

`model_cost()` in `src/llm/costs.rs` normalizes model identifiers by stripping the provider prefix via `rsplit_once("/")`. For OpenRouter free-tier models this produces identifiers that don't match any entry in the cost table:

| User-configured model | After prefix strip | Match? |
|-|-|-|
| `stepfun/step-3.5-flash:free` | `step-3.5-flash:free` | ❌ No match |
| `openrouter/free` | `free` | ❌ No match |

Neither matches any known model name nor the `is_local_model()` heuristic, so they fall through to `default_cost()` — which returns GPT-4o pricing.

## Fix

Add an early return **before** the prefix-stripping normalization that checks for:
- The `:free` suffix (covers all `provider/model:free` patterns)
- The literal `openrouter/free` and bare `free` identifiers

All matching models return `(Decimal::ZERO, Decimal::ZERO)`.

The check is placed before prefix stripping intentionally — the `:free` suffix is part of the OpenRouter routing convention and would be lost or misinterpreted if we stripped first and matched later.

## Tests

4 new test cases added:
- `test_openrouter_free_suffix_zero_cost` — `:free` suffix model
- `test_openrouter_free_router_zero_cost` — `openrouter/free` router
- `test_bare_free_zero_cost` — edge case: bare `free`
- `test_free_suffix_various_providers` — parametric test across 4 different provider-prefixed free models

## Changes

- `src/llm/costs.rs`: 6-line early return + 40 lines of tests