### PR TITLE
feat(llm): cross-provider failover

### DIFF
--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -140,6 +140,15 @@ pub struct LlmConfig {
     pub openai_compatible: Option<OpenAiCompatibleConfig>,
     /// Tinfoil config (populated when backend=tinfoil)
     pub tinfoil: Option<TinfoilConfig>,
+    /// Cross-provider fallback configuration.
+    ///
+    /// When set, a secondary provider on a *different* backend is created and
+    /// wrapped in a `FailoverProvider`. This enables automatic failover across
+    /// completely independent providers (e.g. CLIProxyAPI → OpenRouter).
+    ///
+    /// Configured via `FALLBACK_BACKEND`, `FALLBACK_BASE_URL`, `FALLBACK_API_KEY`,
+    /// `FALLBACK_MODEL`, and optionally `FALLBACK_EXTRA_HEADERS`.
+    pub fallback: Option<Box<LlmConfig>>,
 }
 
 /// NEAR AI configuration.
@@ -226,6 +235,7 @@ impl LlmConfig {
             ollama: None,
             openai_compatible: None,
             tinfoil: None,
+            fallback: None,
         }
     }
 
@@ -392,7 +402,135 @@ impl LlmConfig {
             ollama,
             openai_compatible,
             tinfoil,
+            fallback: Self::resolve_fallback(settings)?,
         })
+    }
+
+    /// Resolve cross-provider fallback configuration from `FALLBACK_*` env vars.
+    ///
+    /// Returns `None` when `FALLBACK_BACKEND` is not set, meaning no cross-provider
+    /// failover is desired. This is completely independent of the NearAI-only
+    /// `NEARAI_FALLBACK_MODEL` mechanism.
+    fn resolve_fallback(settings: &Settings) -> Result<Option<Box<LlmConfig>>, ConfigError> {
+        let Some(fb_backend_str) = optional_env("FALLBACK_BACKEND")? else {
+            return Ok(None);
+        };
+
+        let fb_backend: LlmBackend = fb_backend_str.parse().map_err(|e| ConfigError::InvalidValue {
+            key: "FALLBACK_BACKEND".to_string(),
+            message: e,
+        })?;
+
+        // Build a minimal NearAiConfig for the fallback (carries shared settings
+        // like retry/cooldown/circuit-breaker from the primary).
+        let fb_nearai = NearAiConfig {
+            model: "fallback".to_string(),
+            cheap_model: None,
+            base_url: "https://private.near.ai".to_string(),
+            auth_base_url: "https://private.near.ai".to_string(),
+            session_path: default_session_path(),
+            api_key: None,
+            fallback_model: None,
+            max_retries: parse_optional_env("NEARAI_MAX_RETRIES", 3)?,
+            circuit_breaker_threshold: None,
+            circuit_breaker_recovery_secs: 30,
+            response_cache_enabled: false,
+            response_cache_ttl_secs: 3600,
+            response_cache_max_entries: 1000,
+            failover_cooldown_secs: parse_optional_env("LLM_FAILOVER_COOLDOWN_SECS", 300)?,
+            failover_cooldown_threshold: parse_optional_env("LLM_FAILOVER_THRESHOLD", 3)?,
+            smart_routing_cascade: false,
+        };
+
+        let fb_openai = if fb_backend == LlmBackend::OpenAi {
+            let api_key = optional_env("FALLBACK_API_KEY")?
+                .map(SecretString::from)
+                .ok_or_else(|| ConfigError::MissingRequired {
+                    key: "FALLBACK_API_KEY".to_string(),
+                    hint: "Set FALLBACK_API_KEY when FALLBACK_BACKEND=openai".to_string(),
+                })?;
+            let model = optional_env("FALLBACK_MODEL")?
+                .or_else(|| settings.selected_model.clone())
+                .unwrap_or_else(|| "gpt-4o".to_string());
+            let base_url = optional_env("FALLBACK_BASE_URL")?;
+            Some(OpenAiDirectConfig { api_key, model, base_url })
+        } else {
+            None
+        };
+
+        let fb_anthropic = if fb_backend == LlmBackend::Anthropic {
+            let api_key = optional_env("FALLBACK_API_KEY")?
+                .map(SecretString::from)
+                .ok_or_else(|| ConfigError::MissingRequired {
+                    key: "FALLBACK_API_KEY".to_string(),
+                    hint: "Set FALLBACK_API_KEY when FALLBACK_BACKEND=anthropic".to_string(),
+                })?;
+            let model = optional_env("FALLBACK_MODEL")?
+                .unwrap_or_else(|| "claude-sonnet-4-20250514".to_string());
+            let base_url = optional_env("FALLBACK_BASE_URL")?;
+            Some(AnthropicDirectConfig { api_key, model, base_url })
+        } else {
+            None
+        };
+
+        let fb_ollama = if fb_backend == LlmBackend::Ollama {
+            let base_url = optional_env("FALLBACK_BASE_URL")?
+                .unwrap_or_else(|| "http://localhost:11434".to_string());
+            let model = optional_env("FALLBACK_MODEL")?
+                .unwrap_or_else(|| "llama3".to_string());
+            Some(OllamaConfig { base_url, model })
+        } else {
+            None
+        };
+
+        let fb_openai_compatible = if fb_backend == LlmBackend::OpenAiCompatible {
+            let base_url = optional_env("FALLBACK_BASE_URL")?
+                .ok_or_else(|| ConfigError::MissingRequired {
+                    key: "FALLBACK_BASE_URL".to_string(),
+                    hint: "Set FALLBACK_BASE_URL when FALLBACK_BACKEND=openai_compatible".to_string(),
+                })?;
+            let api_key = optional_env("FALLBACK_API_KEY")?.map(SecretString::from);
+            let model = optional_env("FALLBACK_MODEL")?
+                .unwrap_or_else(|| "default".to_string());
+            let extra_headers = optional_env("FALLBACK_EXTRA_HEADERS")?
+                .map(|val| parse_extra_headers(&val))
+                .transpose()?
+                .unwrap_or_default();
+            Some(OpenAiCompatibleConfig { base_url, api_key, model, extra_headers })
+        } else {
+            None
+        };
+
+        let fb_tinfoil = if fb_backend == LlmBackend::Tinfoil {
+            let api_key = optional_env("FALLBACK_API_KEY")?
+                .map(SecretString::from)
+                .ok_or_else(|| ConfigError::MissingRequired {
+                    key: "FALLBACK_API_KEY".to_string(),
+                    hint: "Set FALLBACK_API_KEY when FALLBACK_BACKEND=tinfoil".to_string(),
+                })?;
+            let model = optional_env("FALLBACK_MODEL")?
+                .unwrap_or_else(|| "kimi-k2-5".to_string());
+            Some(TinfoilConfig { api_key, model })
+        } else {
+            None
+        };
+
+        tracing::info!(
+            fallback_backend = %fb_backend,
+            fallback_model = optional_env("FALLBACK_MODEL")?.as_deref().unwrap_or("(default)"),
+            "Cross-provider fallback configured"
+        );
+
+        Ok(Some(Box::new(LlmConfig {
+            backend: fb_backend,
+            nearai: fb_nearai,
+            openai: fb_openai,
+            anthropic: fb_anthropic,
+            ollama: fb_ollama,
+            openai_compatible: fb_openai_compatible,
+            tinfoil: fb_tinfoil,
+            fallback: None, // no nested fallback
+        })))
     }
 }
 
@@ -639,5 +777,122 @@ mod tests {
             compat.model, "llama3.2",
             "model name with dot must not be truncated"
         );
+    }
+
+    fn clear_fallback_env() {
+        // SAFETY: Only called under ENV_MUTEX in tests.
+        unsafe {
+            std::env::remove_var("FALLBACK_BACKEND");
+            std::env::remove_var("FALLBACK_BASE_URL");
+            std::env::remove_var("FALLBACK_API_KEY");
+            std::env::remove_var("FALLBACK_MODEL");
+            std::env::remove_var("FALLBACK_EXTRA_HEADERS");
+        }
+    }
+
+    #[test]
+    fn no_fallback_when_env_unset() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_openai_compatible_env();
+        clear_fallback_env();
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://127.0.0.1:8317/v1".to_string()),
+            selected_model: Some("gpt-5.4".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        assert!(cfg.fallback.is_none(), "fallback should be None when FALLBACK_BACKEND is unset");
+    }
+
+    #[test]
+    fn cross_provider_fallback_openai_compatible() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_openai_compatible_env();
+        clear_fallback_env();
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("FALLBACK_BACKEND", "openai_compatible");
+            std::env::set_var("FALLBACK_BASE_URL", "https://openrouter.ai/api/v1");
+            std::env::set_var("FALLBACK_API_KEY", "sk-or-test-key");
+            std::env::set_var("FALLBACK_MODEL", "qwen/qwen3-coder:free");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://127.0.0.1:8317/v1".to_string()),
+            selected_model: Some("gpt-5.4".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+
+        let primary = cfg.openai_compatible.expect("primary should be openai_compatible");
+        assert_eq!(primary.base_url, "http://127.0.0.1:8317/v1");
+        assert_eq!(primary.model, "gpt-5.4");
+
+        let fallback = cfg.fallback.expect("fallback should be configured");
+        assert_eq!(fallback.backend, LlmBackend::OpenAiCompatible);
+        let fb_compat = fallback.openai_compatible.as_ref().expect("fallback compat config");
+        assert_eq!(fb_compat.base_url, "https://openrouter.ai/api/v1");
+        assert_eq!(fb_compat.model, "qwen/qwen3-coder:free");
+        assert!(fallback.fallback.is_none(), "nested fallback should be None");
+
+        // Cleanup
+        clear_fallback_env();
+    }
+
+    #[test]
+    fn cross_provider_fallback_missing_base_url_errors() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_openai_compatible_env();
+        clear_fallback_env();
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("FALLBACK_BACKEND", "openai_compatible");
+            std::env::set_var("FALLBACK_MODEL", "some-model");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://127.0.0.1:8317/v1".to_string()),
+            selected_model: Some("gpt-5.4".to_string()),
+            ..Default::default()
+        };
+
+        let result = LlmConfig::resolve(&settings);
+        assert!(result.is_err(), "should fail when FALLBACK_BASE_URL is missing");
+
+        // Cleanup
+        clear_fallback_env();
+    }
+
+    #[test]
+    fn cross_provider_fallback_invalid_backend_errors() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_openai_compatible_env();
+        clear_fallback_env();
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("FALLBACK_BACKEND", "nonexistent_provider");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://127.0.0.1:8317/v1".to_string()),
+            selected_model: Some("gpt-5.4".to_string()),
+            ..Default::default()
+        };
+
+        let result = LlmConfig::resolve(&settings);
+        assert!(result.is_err(), "should fail with invalid FALLBACK_BACKEND value");
+
+        // Cleanup
+        clear_fallback_env();
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -369,35 +369,69 @@ pub fn build_provider_chain(
     };
 
     // 3. Failover
-    let llm: Arc<dyn LlmProvider> = if let Some(ref fallback_model) = config.nearai.fallback_model {
-        if fallback_model == &config.nearai.model {
-            tracing::warn!(
-                "fallback_model is the same as primary model, failover may not be effective"
+    //
+    // Builds a provider chain with up to three tiers:
+    //   1. Primary provider (always present)
+    //   2. Same-backend fallback (NEARAI_FALLBACK_MODEL): swap model, keep provider
+    //   3. Cross-provider fallback (FALLBACK_BACKEND + FALLBACK_*): entirely
+    //      different backend for last-resort resilience
+    //
+    // The FailoverProvider tries each in order on retryable errors, with
+    // per-provider cooldown so degraded providers are skipped.
+    let llm: Arc<dyn LlmProvider> = {
+        let mut providers: Vec<Arc<dyn LlmProvider>> = vec![llm];
+
+        // (a) Same-backend fallback: different model, same base_url/api_key
+        if let Some(ref fallback_model) = config.nearai.fallback_model {
+            if fallback_model == &config.nearai.model {
+                tracing::warn!(
+                    "fallback_model is the same as primary model, failover may not be effective"
+                );
+            }
+            let mut fb_config = config.nearai.clone();
+            fb_config.model = fallback_model.clone();
+            let fb = create_llm_provider_with_config(&fb_config, session.clone())?;
+            tracing::info!(
+                primary = %providers[0].model_name(),
+                same_backend_fallback = %fb.model_name(),
+                "Same-backend LLM failover enabled"
             );
+            let fb: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
+                Arc::new(RetryProvider::new(fb, retry_config.clone()))
+            } else {
+                fb
+            };
+            providers.push(fb);
         }
-        let mut fallback_config = config.nearai.clone();
-        fallback_config.model = fallback_model.clone();
-        let fallback = create_llm_provider_with_config(&fallback_config, session.clone())?;
-        tracing::info!(
-            primary = %llm.model_name(),
-            fallback = %fallback.model_name(),
-            "LLM failover enabled"
-        );
-        let fallback: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
-            Arc::new(RetryProvider::new(fallback, retry_config.clone()))
+
+        // (b) Cross-provider fallback: entirely different backend
+        if let Some(ref fallback_config) = config.fallback {
+            let fb = create_llm_provider(fallback_config, session.clone())?;
+            tracing::info!(
+                primary = %providers[0].model_name(),
+                cross_provider_fallback = %fb.model_name(),
+                fallback_backend = %fallback_config.backend,
+                "Cross-provider LLM failover enabled"
+            );
+            let fb: Arc<dyn LlmProvider> = if retry_config.max_retries > 0 {
+                Arc::new(RetryProvider::new(fb, retry_config.clone()))
+            } else {
+                fb
+            };
+            providers.push(fb);
+        }
+
+        if providers.len() > 1 {
+            let cooldown_config = CooldownConfig {
+                cooldown_duration: std::time::Duration::from_secs(
+                    config.nearai.failover_cooldown_secs,
+                ),
+                failure_threshold: config.nearai.failover_cooldown_threshold,
+            };
+            Arc::new(FailoverProvider::with_cooldown(providers, cooldown_config)?)
         } else {
-            fallback
-        };
-        let cooldown_config = CooldownConfig {
-            cooldown_duration: std::time::Duration::from_secs(config.nearai.failover_cooldown_secs),
-            failure_threshold: config.nearai.failover_cooldown_threshold,
-        };
-        Arc::new(FailoverProvider::with_cooldown(
-            vec![llm, fallback],
-            cooldown_config,
-        )?)
-    } else {
-        llm
+            providers.into_iter().next().unwrap()
+        }
     };
 
     // 4. Circuit breaker
@@ -489,6 +523,7 @@ mod tests {
             ollama: None,
             openai_compatible: None,
             tinfoil: None,
+            fallback: None,
         }
     }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -1278,6 +1278,7 @@ impl SetupWizard {
             ollama: None,
             openai_compatible: None,
             tinfoil: None,
+            fallback: None,
         };
 
         match create_llm_provider(&config, session) {


### PR DESCRIPTION
## Summary

Currently IronClaw only supports same-backend failover via `NEARAI_FALLBACK_MODEL` — you can swap models but stay on the same provider. If the provider itself goes down (API outage, network issue, rate-limited), there's no recovery path.

This PR adds cross-provider failover: a secondary LLM backend that kicks in when the primary provider fails entirely. Think CLIProxyAPI → OpenRouter, or Anthropic → OpenAI as a last resort.

Configured through env vars:

```
FALLBACK_BACKEND=openai_compatible
FALLBACK_BASE_URL=https://openrouter.ai/api/v1
FALLBACK_API_KEY=sk-or-...
FALLBACK_MODEL=stepfun/step-3.5-flash:free
FALLBACK_EXTRA_HEADERS=HTTP-Referer:https://example.com,X-Title:IronClaw
```

When none of these are set, nothing changes — fully backward compatible.

## How it works

`build_provider_chain` now supports up to 3 tiers in the `FailoverProvider`:

1. Primary provider
2. Same-backend fallback (`NEARAI_FALLBACK_MODEL`, if set)
3. Cross-provider fallback (`FALLBACK_BACKEND`, if set)

Both fallback layers are optional and independent. The existing cooldown mechanism (atomic, lock-free) applies to all providers uniformly.

On the config side, `LlmConfig` gets a `fallback: Option<Box<LlmConfig>>` field, populated by a new `resolve_fallback()` that reads `FALLBACK_*` env vars. Supports all backend types.

## Context

Ran into this during the 2026-03-02 Anthropic outage — similar to the gap described in OpenClaw#32533. Seemed like a useful addition for anyone running IronClaw against third-party providers.

## Changes

- `src/config/llm.rs` — `fallback` field + `resolve_fallback()` + 4 unit tests
- `src/llm/mod.rs` — 3-tier failover chain in `build_provider_chain`
- `src/setup/wizard.rs` — trivial: `fallback: None` in hardcoded config

All 17 `config::llm` tests pass, release build clean on macOS arm64.