### PR TITLE
fix: revert WASM artifact SHA256 checksums to null

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/discord-wasm32-wasip2.tar.gz",
-      "sha256": "27d83724c22cac2658c5f4e04dfe761206270e65d599e8f08cc8148c3d9bbe86"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-wasm32-wasip2.tar.gz",
-      "sha256": "600fdb6f25f42bd635d3cf28217778c780e781b780c7250a57bebcf889616209"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-wasm32-wasip2.tar.gz",
-      "sha256": "1c3028052f680e2efa7d857d50bcb57dbc171ad197d2527875b9c3cd22f0c830"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/channels/whatsapp.json
+++ b/registry/channels/whatsapp.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/whatsapp-wasm32-wasip2.tar.gz",
-      "sha256": "33ba508576bdcf757ba5d27a1c94fb9f3546bfe489adf68e5fb17db3b2db7bac"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -20,7 +20,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/github-wasm32-wasip2.tar.gz",
-      "sha256": "d1305ad85a3722a1cfa7dbc8449ebb6c277083d887c513e6e4dd84814637dbcd"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/gmail.json
+++ b/registry/tools/gmail.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/gmail-wasm32-wasip2.tar.gz",
-      "sha256": "f0899b243cb175fcfc07f5a431abb28fac73fc6893c9932d32ce2bd17bc72763"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/google-calendar.json
+++ b/registry/tools/google-calendar.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-calendar-wasm32-wasip2.tar.gz",
-      "sha256": "f236cd8b63aafc95fa5c7f6c9f4ef05d34273d34b4afeb3fde6af51f54fa1350"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/google-docs.json
+++ b/registry/tools/google-docs.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-docs-wasm32-wasip2.tar.gz",
-      "sha256": "37cecb81190703b010df11ad3b507ade570fa486c891b24f48105c34bc7a6f10"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/google-drive.json
+++ b/registry/tools/google-drive.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-drive-wasm32-wasip2.tar.gz",
-      "sha256": "36d5116c7faaaf34b91f98e92573ed230ce0d85e261f05a996a02d14ae4715c4"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/google-sheets.json
+++ b/registry/tools/google-sheets.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-sheets-wasm32-wasip2.tar.gz",
-      "sha256": "77c966f0e18faa2b43361ad8abe90144d53b163272e96d2ed5106f480e698d64"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/google-slides.json
+++ b/registry/tools/google-slides.json
@@ -18,7 +18,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-slides-wasm32-wasip2.tar.gz",
-      "sha256": "68365b764f2366142d1f5388189ab1bd7f826f4ac6540547efc6750bde1591d3"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/slack.json
+++ b/registry/tools/slack.json
@@ -18,7 +18,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-tool-wasm32-wasip2.tar.gz",
-      "sha256": "600fdb6f25f42bd635d3cf28217778c780e781b780c7250a57bebcf889616209"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/telegram.json
+++ b/registry/tools/telegram.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-mtproto-wasm32-wasip2.tar.gz",
-      "sha256": "1c3028052f680e2efa7d857d50bcb57dbc171ad197d2527875b9c3cd22f0c830"
+      "sha256": null
     }
   },
   "auth_summary": {

--- a/registry/tools/web-search.json
+++ b/registry/tools/web-search.json
@@ -19,7 +19,7 @@
   "artifacts": {
     "wasm32-wasip2": {
       "url": "https://github.com/nearai/ironclaw/releases/latest/download/web-search-wasm32-wasip2.tar.gz",
-      "sha256": "8e62c9c3efaa90db92dbf421289cd9a8ba83a64613481d0f2bf9070f0403e801"
+      "sha256": null
     }
   },
   "auth_summary": {


### PR DESCRIPTION
## Summary

- Reverts SHA256 checksums added in fe4c3c5 back to `null` across all 14 registry JSON files
- Fixes production breakage where WASM tools (`web-search`) and channels (`telegram`) fail with WIT version mismatch: `component imports instance 'near:agent/host@0.2.0', but a matching implementation was not found in the linker`

## Root cause

The baked-in checksums block the runtime install path when the host binary's WIT doesn't match the artifacts at `/releases/latest/`. Setting sha256 to null unblocks `ExtensionManager::install()` (which doesn't validate checksums) and allows the next release-plz run to publish matching host + artifact pairs.

## Test plan

- [x] `cargo test registry` — 113 passed, 0 failed
- [ ] After merge: release-plz creates new release → new WASM artifacts compiled against current WIT → `/releases/latest/` matches new binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)