### PR TITLE
feat(gateway): show IronClaw version in status popover

### DIFF
--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2319,6 +2319,7 @@ async fn gateway_status_handler(
         .unwrap_or(false);
 
     Json(GatewayStatusResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
         sse_connections,
         ws_connections,
         total_connections: sse_connections + ws_connections,
@@ -2340,6 +2341,7 @@ struct ModelUsageEntry {
 
 #[derive(serde::Serialize)]
 struct GatewayStatusResponse {
+    version: String,
     sse_connections: u64,
     ws_connections: u64,
     total_connections: u64,

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -3294,6 +3294,12 @@ function fetchGatewayStatus() {
     var popover = document.getElementById('gateway-popover');
     var html = '';
 
+    // Version
+    if (data.version) {
+      html += '<div class="gw-section-label">IronClaw v' + escapeHtml(data.version) + '</div>';
+      html += '<div class="gw-divider"></div>';
+    }
+
     // Connection info
     html += '<div class="gw-section-label">Connections</div>';
     html += '<div class="gw-stat"><span>SSE</span><span>' + (data.sse_connections || 0) + '</span></div>';


### PR DESCRIPTION
## Summary
- Adds `version` field to the `/api/gateway/status` response, sourced from `Cargo.toml` at compile time via `env!("CARGO_PKG_VERSION")`
- Displays the version (e.g. "IronClaw v0.16.1") at the top of the hover popover on the "Connected" status indicator in the web gateway

## Test plan
- [ ] Open the web gateway, hover over "Connected" — version should appear at the top of the popover
- [ ] Verify the `/api/gateway/status` JSON response includes the `version` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)