### PR TITLE
fix: auto-convert 5-field unix cron to 6-field quartz format

### DIFF
--- a/src/tools/builtin/routine.rs
+++ b/src/tools/builtin/routine.rs
@@ -129,6 +129,13 @@ impl Tool for RoutineCreateTool {
                                 "cron trigger requires 'schedule'".to_string(),
                             )
                         })?;
+                // Auto-convert 5-field unix cron to 6-field quartz (prepend seconds=0)
+                let schedule = if schedule.split_whitespace().count() == 5 {
+                    std::borrow::Cow::Owned(format!("0 {schedule}"))
+                } else {
+                    std::borrow::Cow::Borrowed(schedule)
+                };
+                let schedule = schedule.as_ref();
                 // Validate cron expression
                 next_cron_fire(schedule).map_err(|e| {
                     ToolError::InvalidParameters(format!("invalid cron schedule: {e}"))
@@ -425,6 +432,13 @@ impl Tool for RoutineUpdateTool {
         }
 
         if let Some(schedule) = params.get("schedule").and_then(|v| v.as_str()) {
+            // Auto-convert 5-field unix cron to 6-field quartz (prepend seconds=0)
+            let schedule = if schedule.split_whitespace().count() == 5 {
+                std::borrow::Cow::Owned(format!("0 {schedule}"))
+            } else {
+                std::borrow::Cow::Borrowed(schedule)
+            };
+            let schedule = schedule.as_ref();
             // Validate
             next_cron_fire(schedule)
                 .map_err(|e| ToolError::InvalidParameters(format!("invalid cron schedule: {e}")))?;


### PR DESCRIPTION
The tool description in RoutineCreateTool includes the example '0 9 * * MON-FRI' (5 fields), but the underlying cron crate requires 6-field quartz format (sec min hour day month weekday). This mismatch causes LLMs to consistently generate 5-field expressions that fail validation with an opaque 'invalid cron schedule' error.

Fix: detect 5-field input and prepend '0' (seconds) automatically, applied to both RoutineCreateTool and RoutineUpdateTool. 6-field expressions are passed through unchanged, so existing routines and users who already know the format are unaffected.

Reproducer: ask the agent to create a daily routine at 9am — any LLM will generate '0 9 * * *' (standard unix cron), which previously failed silently with no actionable error message.Now it's silently normalized to 0 0 9 * * *.