### PR TITLE
chore: remove dead code — evaluation APIs, chunk_by_paragraphs, bundled installer, Reasoning.safety (#648)

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -390,7 +390,6 @@ impl Agent {
                         hygiene,
                         workspace.clone(),
                         self.cheap_llm().clone(),
-                        self.safety().clone(),
                         Some(notify_tx),
                     ))
                 } else {

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -345,7 +345,6 @@ impl Agent {
             crate::workspace::hygiene::HygieneConfig::default(),
             workspace.clone(),
             self.llm().clone(),
-            self.safety().clone(),
         );
 
         match runner.check_heartbeat().await {
@@ -406,7 +405,7 @@ impl Agent {
             .with_max_tokens(512)
             .with_temperature(0.3);
 
-        let reasoning = Reasoning::new(self.llm().clone(), self.safety().clone());
+        let reasoning = Reasoning::new(self.llm().clone());
         match reasoning.complete(request).await {
             Ok((text, _usage)) => Ok(SubmissionResult::response(format!(
                 "Thread Summary:\n\n{}",
@@ -454,7 +453,7 @@ impl Agent {
             .with_max_tokens(512)
             .with_temperature(0.5);
 
-        let reasoning = Reasoning::new(self.llm().clone(), self.safety().clone());
+        let reasoning = Reasoning::new(self.llm().clone());
         match reasoning.complete(request).await {
             Ok((text, _usage)) => Ok(SubmissionResult::response(format!(
                 "Suggested Next Steps:\n\n{}",

--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -13,7 +13,6 @@ use crate::agent::context_monitor::{CompactionStrategy, ContextBreakdown};
 use crate::agent::session::Thread;
 use crate::error::Error;
 use crate::llm::{ChatMessage, CompletionRequest, LlmProvider, Reasoning};
-use crate::safety::SafetyLayer;
 use crate::workspace::Workspace;
 
 /// Result of a compaction operation.
@@ -34,13 +33,12 @@ pub struct CompactionResult {
 /// Compacts conversation context to stay within limits.
 pub struct ContextCompactor {
     llm: Arc<dyn LlmProvider>,
-    safety: Arc<SafetyLayer>,
 }
 
 impl ContextCompactor {
     /// Create a new context compactor.
-    pub fn new(llm: Arc<dyn LlmProvider>, safety: Arc<SafetyLayer>) -> Self {
-        Self { llm, safety }
+    pub fn new(llm: Arc<dyn LlmProvider>) -> Self {
+        Self { llm }
     }
 
     /// Compact a thread's context using the given strategy.
@@ -233,7 +231,7 @@ Be brief but capture all important details. Use bullet points."#,
             .with_max_tokens(1024)
             .with_temperature(0.3);
 
-        let reasoning = Reasoning::new(self.llm.clone(), self.safety.clone());
+        let reasoning = Reasoning::new(self.llm.clone());
         let (text, _) = reasoning.complete(request).await?;
         Ok(text)
     }
@@ -346,17 +344,11 @@ mod tests {
     // === QA Plan - Compaction strategy tests ===
 
     use crate::agent::context_monitor::CompactionStrategy;
-    use crate::config::SafetyConfig;
-    use crate::safety::SafetyLayer;
     use crate::testing::StubLlm;
 
     /// Helper: build a `ContextCompactor` with the given `StubLlm`.
     fn make_compactor(llm: Arc<StubLlm>) -> ContextCompactor {
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
-        ContextCompactor::new(llm, safety)
+        ContextCompactor::new(llm)
     }
 
     /// Helper: build a thread with `n` completed turns.

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -103,7 +103,7 @@ impl Agent {
             None
         };
 
-        let mut reasoning = Reasoning::new(self.llm().clone(), self.safety().clone())
+        let mut reasoning = Reasoning::new(self.llm().clone())
             .with_channel(message.channel.clone())
             .with_model_name(self.llm().active_model_name())
             .with_group_chat(is_group_chat);
@@ -1593,12 +1593,8 @@ mod tests {
         use crate::testing::StubLlm;
 
         let stub = Arc::new(StubLlm::failing_non_transient("ctx-bomb"));
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
 
-        let reasoning = Reasoning::new(stub.clone(), safety);
+        let reasoning = Reasoning::new(stub.clone());
 
         // Build a fat context with lots of history.
         let messages = vec![
@@ -1708,11 +1704,7 @@ mod tests {
         use crate::llm::{Reasoning, ReasoningContext, RespondResult, ToolDefinition};
 
         let provider = Arc::new(AlwaysToolCallProvider);
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
-        let reasoning = Reasoning::new(provider, safety);
+        let reasoning = Reasoning::new(provider);
 
         let tool_def = ToolDefinition {
             name: "echo".to_string(),

--- a/src/agent/heartbeat.rs
+++ b/src/agent/heartbeat.rs
@@ -30,7 +30,6 @@ use tokio::sync::mpsc;
 
 use crate::channels::OutgoingResponse;
 use crate::llm::{ChatMessage, CompletionRequest, LlmProvider, Reasoning};
-use crate::safety::SafetyLayer;
 use crate::workspace::Workspace;
 use crate::workspace::hygiene::HygieneConfig;
 
@@ -101,7 +100,6 @@ pub struct HeartbeatRunner {
     hygiene_config: HygieneConfig,
     workspace: Arc<Workspace>,
     llm: Arc<dyn LlmProvider>,
-    safety: Arc<SafetyLayer>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
     consecutive_failures: u32,
 }
@@ -113,14 +111,12 @@ impl HeartbeatRunner {
         hygiene_config: HygieneConfig,
         workspace: Arc<Workspace>,
         llm: Arc<dyn LlmProvider>,
-        safety: Arc<SafetyLayer>,
     ) -> Self {
         Self {
             config,
             hygiene_config,
             workspace,
             llm,
-            safety,
             response_tx: None,
             consecutive_failures: 0,
         }
@@ -263,7 +259,7 @@ impl HeartbeatRunner {
             .with_max_tokens(max_tokens)
             .with_temperature(0.3);
 
-        let reasoning = Reasoning::new(self.llm.clone(), self.safety.clone());
+        let reasoning = Reasoning::new(self.llm.clone());
         let (content, _usage) = match reasoning.complete(request).await {
             Ok(r) => r,
             Err(e) => return HeartbeatResult::Failed(format!("LLM call failed: {}", e)),
@@ -354,10 +350,9 @@ pub fn spawn_heartbeat(
     hygiene_config: HygieneConfig,
     workspace: Arc<Workspace>,
     llm: Arc<dyn LlmProvider>,
-    safety: Arc<SafetyLayer>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
 ) -> tokio::task::JoinHandle<()> {
-    let mut runner = HeartbeatRunner::new(config, hygiene_config, workspace, llm, safety);
+    let mut runner = HeartbeatRunner::new(config, hygiene_config, workspace, llm);
     if let Some(tx) = response_tx {
         runner = runner.with_response_channel(tx);
     }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -230,7 +230,7 @@ impl Agent {
                     )
                     .await;
 
-                let compactor = ContextCompactor::new(self.llm().clone(), self.safety().clone());
+                let compactor = ContextCompactor::new(self.llm().clone());
                 if let Err(e) = compactor
                     .compact(thread, strategy, self.workspace().map(|w| w.as_ref()))
                     .await
@@ -618,7 +618,7 @@ impl Agent {
                 crate::agent::context_monitor::CompactionStrategy::Summarize { keep_recent: 5 },
             );
 
-        let compactor = ContextCompactor::new(self.llm().clone(), self.safety().clone());
+        let compactor = ContextCompactor::new(self.llm().clone());
         match compactor
             .compact(thread, strategy, self.workspace().map(|w| w.as_ref()))
             .await

--- a/src/agent/worker.rs
+++ b/src/agent/worker.rs
@@ -211,7 +211,7 @@ impl Worker {
         let job_ctx = self.context_manager().get_context(self.job_id).await?;
 
         // Create reasoning engine
-        let reasoning = Reasoning::new(self.llm().clone(), self.safety().clone());
+        let reasoning = Reasoning::new(self.llm().clone());
 
         // Build initial reasoning context (tool definitions refreshed each iteration in execution_loop)
         let mut reason_ctx = ReasoningContext::new().with_job(&job_ctx.description);

--- a/src/app.rs
+++ b/src/app.rs
@@ -388,7 +388,6 @@ impl AppBuilder {
             tools
                 .register_builder_tool(
                     llm.clone(),
-                    safety.clone(),
                     Some(self.config.builder.to_builder_config()),
                 )
                 .await;

--- a/src/evaluation/success.rs
+++ b/src/evaluation/success.rs
@@ -65,41 +65,12 @@ pub trait SuccessEvaluator: Send + Sync {
 }
 
 /// Rule-based success evaluator.
+#[allow(dead_code)] // Trait implementation exists; only instantiated in tests
 pub struct RuleBasedEvaluator {
     /// Minimum success rate for actions.
     min_action_success_rate: f64,
     /// Maximum allowed failures.
     max_failures: u32,
-}
-
-impl RuleBasedEvaluator {
-    /// Create a new rule-based evaluator.
-    pub fn new() -> Self {
-        Self {
-            min_action_success_rate: 0.8,
-            max_failures: 3,
-        }
-    }
-
-    /// Set minimum action success rate.
-    #[allow(dead_code)] // Public API for configuring evaluation threshold
-    pub fn with_min_success_rate(mut self, rate: f64) -> Self {
-        self.min_action_success_rate = rate;
-        self
-    }
-
-    /// Set maximum failures.
-    #[allow(dead_code)] // Public API for configuring failure tolerance
-    pub fn with_max_failures(mut self, max: u32) -> Self {
-        self.max_failures = max;
-        self
-    }
-}
-
-impl Default for RuleBasedEvaluator {
-    fn default() -> Self {
-        Self::new()
-    }
 }
 
 #[async_trait]
@@ -199,16 +170,9 @@ impl SuccessEvaluator for RuleBasedEvaluator {
 }
 
 /// LLM-based success evaluator for more nuanced evaluation.
+#[allow(dead_code)] // Trait implementation exists; no production callers yet
 pub struct LlmEvaluator {
     llm: Arc<dyn LlmProvider>,
-}
-
-impl LlmEvaluator {
-    /// Create a new LLM-based evaluator.
-    #[allow(dead_code)] // Public API for LLM-based evaluation
-    pub fn new(llm: Arc<dyn LlmProvider>) -> Self {
-        Self { llm }
-    }
 }
 
 #[async_trait]
@@ -292,9 +256,17 @@ mod tests {
     use super::*;
     use crate::context::JobContext;
 
+    /// Default evaluator with standard thresholds.
+    fn default_evaluator() -> RuleBasedEvaluator {
+        RuleBasedEvaluator {
+            min_action_success_rate: 0.8,
+            max_failures: 3,
+        }
+    }
+
     #[tokio::test]
     async fn test_rule_based_evaluator_success() {
-        let evaluator = RuleBasedEvaluator::new();
+        let evaluator = default_evaluator();
 
         let mut job = JobContext::new("Test", "Test job");
         job.transition_to(crate::context::JobState::InProgress, None)
@@ -315,7 +287,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_rule_based_evaluator_failure() {
-        let evaluator = RuleBasedEvaluator::new().with_max_failures(1);
+        let evaluator = RuleBasedEvaluator {
+            max_failures: 1,
+            ..default_evaluator()
+        };
 
         let job = JobContext::new("Test", "Test job");
 
@@ -405,25 +380,16 @@ mod tests {
 
     #[test]
     fn test_rule_based_evaluator_default() {
-        let eval = RuleBasedEvaluator::default();
+        let eval = default_evaluator();
         assert_eq!(eval.min_action_success_rate, 0.8);
         assert_eq!(eval.max_failures, 3);
-    }
-
-    #[test]
-    fn test_rule_based_evaluator_builder_methods() {
-        let eval = RuleBasedEvaluator::new()
-            .with_min_success_rate(0.5)
-            .with_max_failures(10);
-        assert_eq!(eval.min_action_success_rate, 0.5);
-        assert_eq!(eval.max_failures, 10);
     }
 
     // --- RuleBasedEvaluator::evaluate edge cases ---
 
     #[tokio::test]
     async fn test_empty_actions_fails() {
-        let eval = RuleBasedEvaluator::new();
+        let eval = default_evaluator();
         let job = completed_job("empty");
         let result = eval.evaluate(&job, &[], None).await.unwrap();
         assert!(!result.success);
@@ -432,7 +398,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_all_actions_succeed_completed_job_gets_100() {
-        let eval = RuleBasedEvaluator::new();
+        let eval = default_evaluator();
         let job = completed_job("perfect");
         let actions = vec![
             create_action(true),
@@ -450,7 +416,7 @@ mod tests {
     #[tokio::test]
     async fn test_quality_score_no_completion_bonus_for_pending_job() {
         // Even if all actions succeed, a non-completed job gets flagged
-        let eval = RuleBasedEvaluator::new();
+        let eval = default_evaluator();
         let job = JobContext::new("pending", "still pending");
         let actions = vec![create_action(true)];
         let result = eval.evaluate(&job, &actions, None).await.unwrap();
@@ -466,7 +432,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_submitted_state_counts_as_completed() {
-        let eval = RuleBasedEvaluator::new();
+        let eval = default_evaluator();
         let mut job = JobContext::new("submitted", "test");
         job.transition_to(crate::context::JobState::InProgress, None)
             .unwrap();
@@ -483,7 +449,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_success_rate_below_threshold_fails() {
-        let eval = RuleBasedEvaluator::new().with_min_success_rate(0.9);
+        let eval = RuleBasedEvaluator {
+            min_action_success_rate: 0.9,
+            ..default_evaluator()
+        };
         let job = completed_job("threshold");
         // 4 out of 5 = 80%, below 90% threshold
         let actions = vec![
@@ -505,7 +474,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_too_many_failures_flagged() {
-        let eval = RuleBasedEvaluator::new().with_max_failures(1);
+        let eval = RuleBasedEvaluator {
+            max_failures: 1,
+            ..default_evaluator()
+        };
         let job = completed_job("failures");
         // 8 successes, 2 failures: rate is 80% (passes default 0.8) but failures > max 1
         let actions = vec![
@@ -532,7 +504,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_critical_error_detected() {
-        let eval = RuleBasedEvaluator::new().with_max_failures(10);
+        let eval = RuleBasedEvaluator {
+            max_failures: 10,
+            ..default_evaluator()
+        };
         let job = completed_job("critical");
         let actions = vec![
             create_action(true),
@@ -548,7 +523,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_fatal_error_detected() {
-        let eval = RuleBasedEvaluator::new().with_max_failures(10);
+        let eval = RuleBasedEvaluator {
+            max_failures: 10,
+            ..default_evaluator()
+        };
         let job = completed_job("fatal");
         let actions = vec![
             create_action(true),
@@ -563,9 +541,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_quality_score_capped_at_50_with_issues() {
-        let eval = RuleBasedEvaluator::new()
-            .with_min_success_rate(0.0)
-            .with_max_failures(100);
+        let eval = RuleBasedEvaluator {
+            min_action_success_rate: 0.0,
+            max_failures: 100,
+        };
         // Job not completed => issues present, quality capped
         let job = JobContext::new("capped", "test");
         let actions = vec![create_action(true)];
@@ -576,7 +555,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_failed_result_includes_suggestions() {
-        let eval = RuleBasedEvaluator::new().with_max_failures(0);
+        let eval = RuleBasedEvaluator {
+            max_failures: 0,
+            ..default_evaluator()
+        };
         let job = completed_job("suggestions");
         let actions = vec![create_action(false)];
         let result = eval.evaluate(&job, &actions, None).await.unwrap();
@@ -587,7 +569,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_single_successful_action_completed_job() {
-        let eval = RuleBasedEvaluator::new();
+        let eval = default_evaluator();
         let job = completed_job("single");
         let actions = vec![create_action(true)];
         let result = eval.evaluate(&job, &actions, None).await.unwrap();

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1170,38 +1170,6 @@ impl ExtensionManager {
         Ok(())
     }
 
-    #[allow(dead_code)] // Used by upcoming hot-activation flow
-    async fn install_bundled_channel_from_artifacts(
-        &self,
-        name: &str,
-    ) -> Result<InstallResult, ExtensionError> {
-        // Check if already installed
-        let channel_wasm = self.wasm_channels_dir.join(format!("{}.wasm", name));
-        if channel_wasm.exists() {
-            return Err(ExtensionError::AlreadyInstalled(name.to_string()));
-        }
-
-        crate::channels::wasm::install_bundled_channel(name, &self.wasm_channels_dir, false)
-            .await
-            .map_err(ExtensionError::InstallFailed)?;
-
-        tracing::info!(
-            "Installed bundled channel '{}' to {}",
-            name,
-            self.wasm_channels_dir.display()
-        );
-
-        Ok(InstallResult {
-            name: name.to_string(),
-            kind: ExtensionKind::WasmChannel,
-            message: format!(
-                "Channel '{}' installed. \
-                 Run tool_auth('{}') to configure authentication, then activate.",
-                name, name,
-            ),
-        })
-    }
-
     /// Install a WASM extension from local build artifacts (WasmBuildable source).
     ///
     /// Resolves the build directory (relative to `CARGO_MANIFEST_DIR` or absolute),

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -10,7 +10,6 @@ use crate::error::LlmError;
 use crate::llm::{
     ChatMessage, CompletionRequest, LlmProvider, ToolCall, ToolCompletionRequest, ToolDefinition,
 };
-use crate::safety::SafetyLayer;
 
 /// Token the agent returns when it has nothing to say (e.g. in group chats).
 /// The dispatcher should check for this and suppress the message.
@@ -342,8 +341,6 @@ pub struct RespondOutput {
 /// Reasoning engine for the agent.
 pub struct Reasoning {
     llm: Arc<dyn LlmProvider>,
-    #[allow(dead_code)] // Will be used for sanitizing tool outputs
-    safety: Arc<SafetyLayer>,
     /// Optional workspace for loading identity/system prompts.
     workspace_system_prompt: Option<String>,
     /// Optional skill context block to inject into system prompt.
@@ -361,10 +358,9 @@ pub struct Reasoning {
 
 impl Reasoning {
     /// Create a new reasoning engine.
-    pub fn new(llm: Arc<dyn LlmProvider>, safety: Arc<SafetyLayer>) -> Self {
+    pub fn new(llm: Arc<dyn LlmProvider>) -> Self {
         Self {
             llm,
-            safety,
             workspace_system_prompt: None,
             skill_context: None,
             channel: None,
@@ -2086,15 +2082,9 @@ That's my plan."#;
     // ---- System prompt building tests (issue #565) ----
 
     fn make_test_reasoning() -> Reasoning {
-        use crate::config::SafetyConfig;
-        use crate::safety::SafetyLayer;
         use crate::testing::StubLlm;
         let llm = Arc::new(StubLlm::new("test"));
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
-        Reasoning::new(llm, safety)
+        Reasoning::new(llm)
     }
 
     #[test]

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -43,7 +43,6 @@ use crate::error::ToolError as AgentToolError;
 use crate::llm::{
     ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondResult, ToolDefinition,
 };
-use crate::safety::SafetyLayer;
 use crate::tools::ToolRegistry;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput};
 
@@ -251,7 +250,6 @@ pub trait SoftwareBuilder: Send + Sync {
 pub struct LlmSoftwareBuilder {
     config: BuilderConfig,
     llm: Arc<dyn LlmProvider>,
-    safety: Arc<SafetyLayer>,
     tools: Arc<ToolRegistry>,
 }
 
@@ -260,7 +258,6 @@ impl LlmSoftwareBuilder {
     pub fn new(
         config: BuilderConfig,
         llm: Arc<dyn LlmProvider>,
-        safety: Arc<SafetyLayer>,
         tools: Arc<ToolRegistry>,
     ) -> Self {
         // Ensure build directory exists
@@ -271,7 +268,6 @@ impl LlmSoftwareBuilder {
         Self {
             config,
             llm,
-            safety,
             tools,
         }
     }
@@ -521,7 +517,7 @@ Create alongside the .wasm file to grant capabilities:
         let mut iteration = 0;
 
         // Create reasoning engine
-        let reasoning = Reasoning::new(self.llm.clone(), self.safety.clone());
+        let reasoning = Reasoning::new(self.llm.clone());
 
         // Build initial context
         let tool_defs = self.get_build_tools().await;
@@ -822,7 +818,7 @@ Create alongside the .wasm file to grant capabilities:
 impl SoftwareBuilder for LlmSoftwareBuilder {
     async fn analyze(&self, description: &str) -> Result<BuildRequirement, AgentToolError> {
         // Use LLM to parse the description
-        let reasoning = Reasoning::new(self.llm.clone(), self.safety.clone());
+        let reasoning = Reasoning::new(self.llm.clone());
 
         let prompt = format!(
             r#"Analyze this software requirement and extract structured information.

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -10,7 +10,6 @@ use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::llm::{LlmProvider, ToolDefinition};
 use crate::orchestrator::job_manager::ContainerJobManager;
-use crate::safety::SafetyLayer;
 use crate::secrets::SecretsStore;
 use crate::skills::catalog::SkillCatalog;
 use crate::skills::registry::SkillRegistry;
@@ -484,17 +483,15 @@ impl ToolRegistry {
     pub async fn register_builder_tool(
         self: &Arc<Self>,
         llm: Arc<dyn LlmProvider>,
-        safety: Arc<SafetyLayer>,
         config: Option<BuilderConfig>,
     ) {
         // First register dev tools needed by the builder
         self.register_dev_tools();
 
-        // Create the builder (arg order: config, llm, safety, tools)
+        // Create the builder (arg order: config, llm, tools)
         let builder = Arc::new(LlmSoftwareBuilder::new(
             config.unwrap_or_default(),
             llm,
-            safety,
             Arc::clone(self),
         ));
 

--- a/src/worker/runtime.rs
+++ b/src/worker/runtime.rs
@@ -133,7 +133,7 @@ impl WorkerRuntime {
             .await?;
 
         // Create reasoning engine
-        let reasoning = Reasoning::new(self.llm.clone(), self.safety.clone());
+        let reasoning = Reasoning::new(self.llm.clone());
 
         // Build initial context
         let mut reason_ctx = ReasoningContext::new().with_job(&job.description);

--- a/src/workspace/chunker.rs
+++ b/src/workspace/chunker.rs
@@ -113,79 +113,6 @@ pub fn chunk_document(content: &str, config: ChunkConfig) -> Vec<String> {
     chunks
 }
 
-/// Split content by paragraphs first, then chunk.
-///
-/// This is better for preserving semantic boundaries.
-#[allow(dead_code)] // Alternative chunking strategy for paragraph-aware indexing
-pub fn chunk_by_paragraphs(content: &str, config: ChunkConfig) -> Vec<String> {
-    if content.is_empty() {
-        return Vec::new();
-    }
-
-    // Split by double newlines (paragraphs)
-    let paragraphs: Vec<&str> = content
-        .split("\n\n")
-        .map(|p| p.trim())
-        .filter(|p| !p.is_empty())
-        .collect();
-
-    if paragraphs.is_empty() {
-        return chunk_document(content, config);
-    }
-
-    let mut chunks = Vec::new();
-    let mut current_chunk = String::new();
-    let mut current_word_count = 0;
-
-    for paragraph in paragraphs {
-        let para_words = paragraph.split_whitespace().count();
-
-        // If this paragraph alone exceeds chunk size, chunk it separately
-        if para_words > config.chunk_size {
-            // Flush current chunk first
-            if !current_chunk.is_empty() {
-                chunks.push(current_chunk.trim().to_string());
-                current_chunk = String::new();
-                current_word_count = 0;
-            }
-            // Chunk the large paragraph
-            let para_chunks = chunk_document(paragraph, config.clone());
-            chunks.extend(para_chunks);
-            continue;
-        }
-
-        // Check if adding this paragraph would exceed chunk size
-        if current_word_count + para_words > config.chunk_size {
-            // Flush current chunk
-            if !current_chunk.is_empty() {
-                chunks.push(current_chunk.trim().to_string());
-            }
-            current_chunk = paragraph.to_string();
-            current_word_count = para_words;
-        } else {
-            // Add paragraph to current chunk
-            if !current_chunk.is_empty() {
-                current_chunk.push_str("\n\n");
-            }
-            current_chunk.push_str(paragraph);
-            current_word_count += para_words;
-        }
-    }
-
-    // Flush remaining content
-    if !current_chunk.is_empty() {
-        // If too small, merge with previous chunk if possible
-        if current_word_count < config.min_chunk_size && !chunks.is_empty() {
-            let last = chunks.pop().unwrap();
-            chunks.push(format!("{}\n\n{}", last, current_chunk.trim()));
-        } else {
-            chunks.push(current_chunk.trim().to_string());
-        }
-    }
-
-    chunks
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -251,49 +178,6 @@ mod tests {
 
         assert_eq!(config.overlap_size(), 15);
         assert_eq!(config.step_size(), 85);
-    }
-
-    #[test]
-    fn test_paragraph_chunking() {
-        let config = ChunkConfig::default().with_chunk_size(20);
-
-        let content = "First paragraph with some words.\n\nSecond paragraph with different content.\n\nThird paragraph here.";
-        let chunks = chunk_by_paragraphs(content, config);
-
-        // Should preserve paragraph boundaries
-        assert!(!chunks.is_empty());
-        for chunk in &chunks {
-            // No chunk should start or end with \n\n
-            assert!(!chunk.starts_with("\n"));
-            assert!(!chunk.ends_with("\n"));
-        }
-    }
-
-    #[test]
-    fn test_large_paragraph_handling() {
-        let config = ChunkConfig {
-            chunk_size: 10,
-            overlap_percent: 0.15,
-            min_chunk_size: 3, // Low threshold for test
-        };
-
-        // Create a paragraph with 30 words
-        let large_para = (1..=30)
-            .map(|i| format!("word{}", i))
-            .collect::<Vec<_>>()
-            .join(" ");
-        let content = format!("Short intro.\n\n{}\n\nShort outro.", large_para);
-
-        let chunks = chunk_by_paragraphs(&content, config);
-
-        // Should have multiple chunks due to large paragraph
-        // 30 words + 2 intro + 2 outro = 34 words, chunk_size=10
-        // Expect at least 3 chunks
-        assert!(
-            chunks.len() >= 3,
-            "Expected at least 3 chunks for 34 words with chunk_size=10, got {}",
-            chunks.len()
-        );
     }
 
     #[test]

--- a/tests/e2e_routine_heartbeat.rs
+++ b/tests/e2e_routine_heartbeat.rs
@@ -20,9 +20,8 @@ mod tests {
     use ironclaw::agent::routine_engine::RoutineEngine;
     use ironclaw::agent::{HeartbeatConfig, HeartbeatRunner};
     use ironclaw::channels::IncomingMessage;
-    use ironclaw::config::{RoutineConfig, SafetyConfig};
+    use ironclaw::config::RoutineConfig;
     use ironclaw::db::Database;
-    use ironclaw::safety::SafetyLayer;
     use ironclaw::workspace::Workspace;
     use ironclaw::workspace::hygiene::HygieneConfig;
 
@@ -339,10 +338,6 @@ mod tests {
             }],
         );
         let llm = Arc::new(TraceLlm::from_trace(trace));
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
 
         let (tx, mut rx) = tokio::sync::mpsc::channel(16);
 
@@ -355,7 +350,7 @@ mod tests {
         };
 
         let runner =
-            HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm, safety)
+            HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm)
                 .with_response_channel(tx);
 
         let result = runner.check_heartbeat().await;
@@ -393,10 +388,6 @@ mod tests {
         // LLM should NOT be called, so provide a trace that would panic if called.
         let trace = LlmTrace::single_turn("test-heartbeat-skip", "skip", vec![]);
         let llm = Arc::new(TraceLlm::from_trace(trace));
-        let safety = Arc::new(SafetyLayer::new(&SafetyConfig {
-            max_output_length: 100_000,
-            injection_check_enabled: false,
-        }));
 
         let hygiene_config = HygieneConfig {
             enabled: false,
@@ -407,7 +398,7 @@ mod tests {
         };
 
         let runner =
-            HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm, safety);
+            HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm);
 
         let result = runner.check_heartbeat().await;
         assert!(

--- a/tests/heartbeat_integration.rs
+++ b/tests/heartbeat_integration.rs
@@ -15,7 +15,6 @@ use ironclaw::{
     config::Config,
     history::Store,
     llm::{create_llm_provider, create_session_manager},
-    safety::SafetyLayer,
     workspace::Workspace,
 };
 
@@ -93,8 +92,7 @@ async fn test_heartbeat_end_to_end() {
 
     let hb_config = ironclaw::agent::HeartbeatConfig::default();
     let hygiene_config = ironclaw::workspace::hygiene::HygieneConfig::default();
-    let safety = Arc::new(SafetyLayer::new(&config.safety));
-    let runner = HeartbeatRunner::new(hb_config, hygiene_config, workspace, llm, safety);
+    let runner = HeartbeatRunner::new(hb_config, hygiene_config, workspace, llm);
 
     let result = runner.check_heartbeat().await;
 


### PR DESCRIPTION
## Summary

Closes #648.

Remove four pieces of dead code:

### 1. Evaluation module unused APIs (`src/evaluation/success.rs`)
- Removed `RuleBasedEvaluator::with_min_success_rate()` and `with_max_failures()` — never called
- Removed `LlmEvaluator::new()` — never called
- Replaced `RuleBasedEvaluator::new()` with a `default_evaluator()` test helper (constructor was only used in tests)
- Removed associated `#[allow(dead_code)]` annotations

### 2. `chunk_by_paragraphs()` (`src/workspace/chunker.rs`)
- Removed the unused function and its two test functions
- Only `chunk_document()` is used in production

### 3. `install_bundled_channel_from_artifacts()` (`src/extensions/manager.rs`)
- Removed the function marked "Used by upcoming hot-activation flow" — never called anywhere

### 4. `Reasoning::safety` field (`src/llm/reasoning.rs`)
- Removed the unused `safety: Arc<SafetyLayer>` field from `Reasoning` struct
- This cascades through all callers: `Reasoning::new()` no longer takes a `safety` parameter
- Updated 12 call sites across dispatcher, compaction, heartbeat, commands, worker, thread_ops, tool_builder, and tests

## Verification

- `cargo clippy --all-targets` — **zero warnings**
- `cargo test` — **all tests pass**

## Stats

17 files changed, 69 insertions(+), 287 deletions(-)