### PR TITLE
fix(setup): validate channel credentials during setup

### DIFF
--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -867,12 +867,8 @@ async fn substitute_validation_placeholders(
     secrets: &SecretsContext,
     validation_endpoint: &str,
 ) -> Result<String, ChannelSetupError> {
-    let placeholder_re = regex::Regex::new(r"\{([A-Za-z0-9_]+)\}").map_err(|e| {
-        ChannelSetupError::Validation(format!("Invalid validation placeholder regex: {}", e))
-    })?;
-
     let mut resolved = validation_endpoint.to_string();
-    let placeholder_names: std::collections::BTreeSet<String> = placeholder_re
+    let placeholder_names: std::collections::BTreeSet<String> = validation_placeholder_regex()
         .captures_iter(validation_endpoint)
         .filter_map(|caps| caps.get(1).map(|m| m.as_str().to_string()))
         .collect();
@@ -1014,6 +1010,14 @@ fn normalize_ip(ip: std::net::IpAddr) -> std::net::IpAddr {
 
 fn normalize_validation_domain(host: &str) -> &str {
     host.trim_end_matches('.')
+}
+
+fn validation_placeholder_regex() -> &'static regex::Regex {
+    static PLACEHOLDER_RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    PLACEHOLDER_RE.get_or_init(|| {
+        regex::Regex::new(r"\{([A-Za-z0-9_]+)\}")
+            .expect("validation placeholder regex must compile")
+    })
 }
 
 fn validation_target_display(parsed: &Url) -> String {


### PR DESCRIPTION
## Summary
- implement setup-time credential validation for WASM channels that declare a `validation_endpoint`
- substitute saved secrets into the validation URL, enforce public HTTPS targets only, and issue a short validation request
- warn on validation failures without blocking setup, and add focused regression tests for placeholder substitution and URL safety checks

## Scope
This PR intentionally covers only the first half of issue #651: channel credential validation during setup.

It does **not** implement the routine webhook trigger endpoint from the same issue, to keep the change small and reviewer-friendly.

## Why
Right now the setup wizard accepts channel secrets blindly, so users often only discover a bad token after the channel fails to start. This change moves that feedback into setup while still keeping the flow forgiving.

## Behavior
- if a channel declares `validation_endpoint`, setup now validates credentials immediately after saving them
- validation endpoint placeholders like `{telegram_bot_token}` are replaced from the secrets store
- final URLs must be public `https` targets; localhost, private IPs, and hostnames resolving to private IPs are rejected
- validation failures show a warning and setup continues

## Tests
- `cargo test --lib test_substitute_validation_placeholders`
- `target/debug/deps/ironclaw-ec6ff0546cc1c6a3 --exact setup::channels::tests::test_validate_public_https_url_rejects_localhost`
- `target/debug/deps/ironclaw-ec6ff0546cc1c6a3 --exact setup::channels::tests::test_validate_public_https_url_rejects_private_ip`
- `target/debug/deps/ironclaw-ec6ff0546cc1c6a3 --exact setup::channels::tests::test_validate_public_https_url_rejects_http`
- `target/debug/deps/ironclaw-ec6ff0546cc1c6a3 --exact setup::channels::tests::test_validate_public_https_url_accepts_public_https_literal_ip`
- `cargo fmt --check`
- `cargo clippy --lib --tests -- -D warnings`

## Notes
I used a constrained `clippy` run (`lib + tests`) instead of a fresh full `all-features` rebuild because disk pressure on this machine makes repeated full rebuilds unreliable, but the paths touched here are covered by the targeted test and lint runs above.

Made with [Cursor](https://cursor.com)