### PR TITLE
fix(tools): add items schema for array-type parameters

### DIFF
--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -706,19 +706,20 @@ mod tests {
     }
 
     #[test]
-    fn test_http_tool_schema_body_is_freeform() {
+    fn test_http_tool_schema_body_has_type_and_items() {
         let schema = HttpTool::new().parameters_schema();
         let body = schema
             .get("properties")
             .and_then(|p| p.get("body"))
             .expect("body schema missing");
 
-        // Body is intentionally freeform (no "type" constraint) for OpenAI
-        // compatibility. OpenAI rejects union types containing "array" unless
-        // "items" is also specified, and body accepts any JSON value.
+        // Body uses a union type with items:{} so strict schema validators
+        // (e.g. OpenAI) accept array-typed parameters.
+        let type_val = body.get("type").expect("body should have 'type'");
+        assert!(type_val.is_array(), "body type should be a union array");
         assert!(
-            body.get("type").is_none(),
-            "body schema should not have a 'type' to be freeform for OpenAI compatibility"
+            body.get("items").is_some(),
+            "body should have 'items' for array type compatibility"
         );
     }
 

--- a/src/tools/builtin/json.rs
+++ b/src/tools/builtin/json.rs
@@ -272,19 +272,20 @@ mod tests {
     }
 
     #[test]
-    fn test_json_tool_schema_data_is_freeform() {
+    fn test_json_tool_schema_data_has_type_and_items() {
         let schema = JsonTool.parameters_schema();
         let data = schema
             .get("properties")
             .and_then(|p| p.get("data"))
             .expect("data schema missing");
 
-        // Data is intentionally freeform (no "type" constraint) for OpenAI
-        // compatibility. OpenAI rejects union types containing "array" unless
-        // "items" is also specified.
+        // Data uses a union type with items:{} so strict schema validators
+        // (e.g. OpenAI) accept array-typed parameters.
+        let type_val = data.get("type").expect("data should have 'type'");
+        assert!(type_val.is_array(), "data type should be a union array");
         assert!(
-            data.get("type").is_none(),
-            "data schema should not have a 'type' to be freeform for OpenAI compatibility"
+            data.get("items").is_some(),
+            "data should have 'items' for array type compatibility"
         );
     }
 }


### PR DESCRIPTION
## Summary

The `body` parameter in `HttpTool` and the `data` parameter in `JsonTool` accept arrays among other types, but their JSON Schema declarations were missing both the `type` constraint and the `items` property. Strict JSON Schema validators (e.g. OpenAI's structured output validation) reject array-type schemas without `items`.

Adds `"type"` (union of all JSON types) and `"items": {}` (accepts any array element) to both parameters. Preserves upstream's descriptions and `source_tool_call_id` field.

## Changes

- `src/tools/builtin/http.rs` — Add `type` array and `items: {}` to `body` parameter schema
- `src/tools/builtin/json.rs` — Add `type` array and `items: {}` to `data` parameter schema

## Test plan

- [ ] Validate the schema output against a strict JSON Schema validator
- [ ] Verify HttpTool accepts body as object, array, string, number, boolean, null
- [ ] Verify JsonTool accepts data as all the same types