### PR TITLE
fix(safety): remove sanitized attr from tool_output, narrow shell_injection pattern

### DIFF
--- a/src/safety/mod.rs
+++ b/src/safety/mod.rs
@@ -159,11 +159,10 @@ impl SafetyLayer {
     ///
     /// This creates a clear structural boundary between trusted instructions
     /// and untrusted external data.
-    pub fn wrap_for_llm(&self, tool_name: &str, content: &str, sanitized: bool) -> String {
+    pub fn wrap_for_llm(&self, tool_name: &str, content: &str, _sanitized: bool) -> String {
         format!(
-            "<tool_output name=\"{}\" sanitized=\"{}\">\n{}\n</tool_output>",
+            "<tool_output name=\"{}\">\n{}\n</tool_output>",
             escape_xml_attr(tool_name),
-            sanitized,
             escape_xml_content(content)
         )
     }
@@ -234,7 +233,7 @@ mod tests {
 
         let wrapped = safety.wrap_for_llm("test_tool", "Hello <world>", true);
         assert!(wrapped.contains("name=\"test_tool\""));
-        assert!(wrapped.contains("sanitized=\"true\""));
+        assert!(!wrapped.contains("sanitized="));
         assert!(wrapped.contains("Hello &lt;world&gt;"));
     }
 


### PR DESCRIPTION
## Summary

Two changes to the safety layer to reduce information leakage and false positives:

### 1. Remove `sanitized` attribute from `<tool_output>` wrapper

`wrap_for_llm` emitted `<tool_output name="..." sanitized="true/false">`, exposing safety pipeline decisions to the LLM. This is problematic:
- `sanitized="false"` signals "raw/unfiltered" to injected payloads
- `sanitized="true"` could make the LLM treat content as less trustworthy
- Leaks implementation details about the safety pipeline

The `_sanitized` parameter is kept in the signature for call-site compatibility.

### 2. Remove backtick pattern from `shell_injection` rule

The shell injection policy rule included a backtick pattern that triggered false positives on legitimate tool output containing inline code references (e.g. Notion pages mentioning `` `n8n` `` or `` `cargo` ``).

Remaining patterns (`;rm -rf`, `;curl ... | sh`, `$()` subshells) still cover actual shell injection threats.

## Changes

- `src/safety/sanitizer.rs` — remove `sanitized` attribute from XML wrapper
- `src/safety/policy.rs` — remove backtick pattern from `shell_injection` rule

## Test plan

- [ ] `wrap_for_llm` output does not contain `sanitized=`
- [ ] Legitimate content with backticks passes without being blocked
- [ ] Actual shell injection patterns are still blocked

## Breaking changes

None. The `sanitized` attribute was not part of any documented API contract.