### PR TITLE
fix(routines): resolve message tool channel/target from per-job metadata

### DIFF
--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -488,9 +488,6 @@ async fn execute_full_job(
             reason: "scheduler not available".to_string(),
         })?;
 
-    // Notify config is carried in job metadata (populated below) and read by
-    // MessageTool::execute from JobContext — no global state mutation needed.
-
     let mut metadata = serde_json::json!({ "max_iterations": max_iterations });
     // Carry the routine's notify config in job metadata so the message tool
     // can resolve channel/target per-job without global state mutation.

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -224,7 +224,7 @@ impl Tool for MessageTool {
             // No channel specified — broadcast to all channels (routine with notify.channel = None)
             let results = self.channel_manager.broadcast_all(&target, response).await;
             let mut succeeded = Vec::new();
-            let mut failed = Vec::new();
+            let mut failed: Vec<&str> = Vec::new();
             for (ch, result) in &results {
                 match result {
                     Ok(()) => succeeded.push(ch.as_str()),
@@ -239,11 +239,10 @@ impl Tool for MessageTool {
                 }
             }
             if succeeded.is_empty() {
-                let available = self.channel_manager.channel_names().await.join(", ");
-                let err_msg = if available.is_empty() {
+                let err_msg = if failed.is_empty() {
                     "No channels connected.".to_string()
                 } else {
-                    format!("All channels failed. Available: {}", available)
+                    format!("All channels failed: {}", failed.join(", "))
                 };
                 Err(ToolError::ExecutionFailed(err_msg))
             } else {


### PR DESCRIPTION
## Summary
- When a routine's `notify.channel` is `None`, the message tool in full-job workers failed with "No target specified and no active conversation" because `set_message_tool_context()` was only called when channel was `Some`
- The previous approach also mutated shared global state (`Arc<RwLock>` on `MessageTool`) which raced with concurrent routine jobs (flagged by an existing TODO)
- Now the routine's notify config is carried in per-job metadata JSON, and `MessageTool::execute` uses a 3-tier fallback: explicit params → conversation defaults → `JobContext.metadata`

## Test plan
- [x] `message_tool_falls_back_to_job_metadata` — verifies metadata fallback resolves channel/target without conversation context
- [x] `message_tool_no_metadata_still_errors` — verifies clean error when nothing is configured
- [x] All 19 existing message tool tests pass (no regressions)
- [x] `cargo clippy --all --all-features` — zero warnings
- [ ] Manual: run a routine with `notify.channel = None` and verify the message tool no longer errors with "No target specified"

🤖 Generated with [Claude Code](https://claude.com/claude-code)