### PR TITLE
Fix/single message auto exit

### DIFF
--- a/src/channels/repl.rs
+++ b/src/channels/repl.rs
@@ -301,6 +301,9 @@ impl Channel for ReplChannel {
             if let Some(msg) = single_message {
                 let incoming = IncomingMessage::new("repl", "default", &msg);
                 let _ = tx.blocking_send(incoming);
+                // Ensure the agent exits after handling exactly one turn in -m mode,
+                // even when other channels (gateway/http) are enabled.
+                let _ = tx.blocking_send(IncomingMessage::new("repl", "default", "/quit"));
                 return;
             }
 
@@ -612,5 +615,31 @@ impl Channel for ReplChannel {
 
     async fn shutdown(&self) -> Result<(), ChannelError> {
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::StreamExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn single_message_mode_sends_message_then_quit() {
+        let repl = ReplChannel::with_message("hi".to_string());
+        let mut stream = repl.start().await.expect("repl start should succeed");
+
+        let first = stream.next().await.expect("first message missing");
+        assert_eq!(first.channel, "repl");
+        assert_eq!(first.content, "hi");
+
+        let second = stream.next().await.expect("quit message missing");
+        assert_eq!(second.channel, "repl");
+        assert_eq!(second.content, "/quit");
+
+        assert!(
+            stream.next().await.is_none(),
+            "stream should end after /quit"
+        );
     }
 }


### PR DESCRIPTION
  Closes #718

  This PR fixes single-message CLI behavior so IronClaw exits automatically after handling one
  prompt.

  - Problem: -m/--message sends one user message, but process may stay alive when background
    channels (HTTP/Gateway) are enabled.
  - Root cause: REPL single-message path enqueues only the user message and never triggers shutdown.
  - Fix: In single-message mode, enqueue internal "/quit" immediately after the user message.
  - Scope: Minimal and localized to REPL single-message flow only.
  - Test added: single_message_mode_sends_message_then_quit verifies stream order is user message
    -> /quit -> end.
  - Value: Restores one-shot CLI contract, improves scripting/CI reliability, avoids unexpected
    long-running processes and occupied ports.
  - Risk: Low. No behavior change for interactive REPL mode.