### PR TITLE
fix(jobs): make state transitions idempotent to prevent double-completion errors

### DIFF
--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -38,6 +38,14 @@ impl JobState {
     pub fn can_transition_to(&self, target: JobState) -> bool {
         use JobState::*;
 
+        // Idempotent: transitioning to the same state is always allowed.
+        // This prevents "Cannot transition from completed to completed" errors
+        // when multiple code paths (execution loop + worker wrapper) race to
+        // mark a job complete.
+        if *self == target {
+            return true;
+        }
+
         matches!(
             (self, target),
             // From Pending
@@ -226,6 +234,12 @@ impl JobContext {
                 "Cannot transition from {} to {}",
                 self.state, new_state
             ));
+        }
+
+        // Idempotent: already in the target state, nothing to do.
+        // Skip recording a transition to avoid filling history with noise.
+        if self.state == new_state {
+            return Ok(());
         }
 
         let transition = StateTransition {


### PR DESCRIPTION
## Summary

- Jobs hit `Cannot transition from completed to completed` errors when both the execution loop and the worker wrapper race to mark a job as `Completed`
- The state machine rejects the second transition attempt, causing the job to error out despite having completed successfully
- This is a race condition that reliably occurs when routines fire multiple `full_job` types close together

## Root Cause

The `execute_plan()` path calls `mark_completed()` when the LLM signals completion, then the main worker wrapper in `execute()` also calls `mark_completed()` as its post-execution cleanup. Since `Completed` is not a terminal state (the full lifecycle is `InProgress → Completed → Submitted → Accepted`), the `is_terminal()` guard at line 252 of `worker.rs` doesn't catch it, and the second `mark_completed()` call triggers the state machine error.

## Fix

Make same-state transitions idempotent at two levels in `state.rs`:

1. **`can_transition_to()`**: Return `true` when `current == target`
2. **`transition_to()`**: Short-circuit with `Ok(())` when `current == target`, avoiding unnecessary transition history entries

This is a no-op for normal state flows (different source/target states) and only affects the race condition where two code paths attempt the same transition.

## Test plan

- [x] Verified fix eliminates `Cannot transition from completed to completed` errors in production with 6 concurrent routines
- [ ] Unit test: `can_transition_to(Completed, Completed)` returns `true`
- [ ] Unit test: `transition_to()` with same state doesn't add to transition history
- [ ] Integration test: concurrent `mark_completed()` calls don't error

Related to #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)