### PR TITLE
fix: prevent irreversible context loss when compaction archive write fails

### DIFF
--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -665,7 +665,11 @@ mod tests {
         let workspace = make_unmigrated_workspace().await;
 
         let result = compactor
-            .compact(&mut thread, CompactionStrategy::MoveToWorkspace, Some(&workspace))
+            .compact(
+                &mut thread,
+                CompactionStrategy::MoveToWorkspace,
+                Some(&workspace),
+            )
             .await
             .expect("compact should succeed even when workspace write fails");
 


### PR DESCRIPTION
## Summary
Compaction currently truncates old turns even when archival writes fail. That creates irreversible context loss exactly in the failure path and can silently destroy conversation history.

This PR makes truncation conditional on successful archival persistence.

## What changed
- `Summarize` compaction now preserves turns when `write_summary_to_workspace` fails.
- `MoveToWorkspace` compaction now preserves turns when `write_context_to_workspace` fails.
- Updated warning logs to explicitly state turns are preserved on write failure.
- Added regression tests covering both failure paths.

## Why this is severe
When storage is unavailable or partially failing, the prior behavior deleted context without backup. This is a data-loss bug in a reliability-critical path (automatic context management under pressure).

## Validation
- `OPENSSL_DIR=/usr OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu OPENSSL_INCLUDE_DIR=/usr/include cargo test --lib agent::compaction::tests`
- Result: 20 passed, 0 failed