### PR TITLE
fix(ci): secrets can't be used in step if conditions

### DIFF
--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -115,7 +115,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        if: ${{ secrets.GH_RELEASES_MANAGER_APP_ID != '' }}
+        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}
@@ -230,7 +230,7 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        if: ${{ secrets.GH_RELEASES_MANAGER_APP_ID != '' }}
+        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}


### PR DESCRIPTION
Hotfix: GitHub Actions step-level if conditions don't have access to the secrets context. Replaces if: secrets.X \!= '' with continue-on-error: true. Without this fix, staging-ci.yml fails to parse on every branch.