### PR TITLE
fix(ci): clean up staging pipeline — remove hacks, skip redundant checks

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,6 +28,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "ironclaw-ci[bot]"
           claude_args: "--max-turns 50 --model claude-haiku-4-5-20251001 --allowedTools 'Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git blame:*),Bash(git log:*),Bash(git diff:*)'"
           prompt: |
             Code review this pull request. Follow these steps precisely:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,8 @@
 name: Code Style
 on:
   pull_request:
+    branches:
+      - main
 
 jobs:
   format:

--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -115,7 +115,6 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}
@@ -230,7 +229,6 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Run Tests
 on:
   workflow_call:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Remove `continue-on-error: true` hack from staging-ci.yml app token steps (secrets are now configured)
- Skip `test.yml` and `code_style.yml` on PRs targeting staging (staging-ci.yml already runs tests before promoting, and the promotion PR gets full CI on main)
- Allow `ironclaw-ci[bot]` in Claude Code review so bot-created promotion PRs get reviewed

## Test plan

- [ ] PR targeting staging skips test.yml and code_style.yml
- [ ] PR targeting main runs full CI as before
- [ ] Re-run promotion PR #792 Claude review — bot is allowed


🤖 Generated with [Claude Code](https://claude.com/claude-code)