### PR TITLE
fix(ci): cherry-pick CI cleanup onto staging

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,6 +28,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: "ironclaw-ci[bot]"
           claude_args: "--max-turns 50 --model claude-haiku-4-5-20251001 --allowedTools 'Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git blame:*),Bash(git log:*),Bash(git diff:*)'"
           prompt: |
             Code review this pull request. Follow these steps precisely:

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,8 @@
 name: Code Style
 on:
   pull_request:
+    branches:
+      - main
 
 jobs:
   format:

--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -115,7 +115,6 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}
@@ -230,7 +229,6 @@ jobs:
 
       - name: Generate GitHub App token
         id: app-token
-        continue-on-error: true
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.GH_RELEASES_MANAGER_APP_ID }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Run Tests
 on:
   workflow_call:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

Cherry-pick of #794 onto staging so promotion PRs have the fix:

- Remove `continue-on-error` hack from app token steps
- Skip test.yml and code_style.yml on PRs targeting staging
- Allow `ironclaw-ci[bot]` in Claude Code review

Without this, promotion PRs cut from staging don't have `allowed_bots` and Claude review rejects them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)