### PR TITLE
fix(ci): run fmt + clippy on staging PRs, skip Windows clippy

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, labeled]
+    types: [labeled]
 
 permissions:
   contents: read

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,8 +1,6 @@
 name: Code Style
 on:
   pull_request:
-    branches:
-      - main
 
 jobs:
   format:
@@ -46,6 +44,7 @@ jobs:
 
   clippy-windows:
     name: Clippy Windows (${{ matrix.name }})
+    if: github.base_ref == 'main'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -78,7 +77,12 @@ jobs:
     needs: [format, clippy, clippy-windows]
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.clippy-windows.result }}" != "success" ]]; then
+          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" ]]; then
             echo "One or more jobs failed"
+            exit 1
+          fi
+          # clippy-windows only runs on main PRs, so skip/success are both acceptable
+          if [[ "${{ needs.clippy-windows.result }}" == "failure" ]]; then
+            echo "Windows clippy failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Run `code_style.yml` on all PRs (not just main) so staging PRs get fmt + clippy checks (~4 min)
- Skip Windows clippy on staging PRs via `if: github.base_ref == 'main'` (saves ~20 min)
- Simplify `claude-review.yml` to only trigger on `labeled` event (avoids duplicate cancelled runs)

Needs cherry-pick to staging after merge.

## Test plan

- [ ] PR targeting staging runs fmt + Linux clippy, skips Windows clippy
- [ ] PR targeting main runs full matrix as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)