### PR TITLE
fix(safety): allow empty string tool params

### DIFF
--- a/src/safety/validator.rs
+++ b/src/safety/validator.rs
@@ -384,10 +384,7 @@ mod tests {
 
         assert!(result.is_valid);
         assert!(
-            result
-                .warnings
-                .iter()
-                .any(|w| w.contains("repetition")),
+            result.warnings.iter().any(|w| w.contains("repetition")),
             "expected repetition warning for tool params, got: {:?}",
             result.warnings
         );
@@ -403,10 +400,7 @@ mod tests {
 
         assert!(result.is_valid);
         assert!(
-            result
-                .warnings
-                .iter()
-                .any(|w| w.contains("whitespace")),
+            result.warnings.iter().any(|w| w.contains("whitespace")),
             "expected whitespace warning for tool params, got: {:?}",
             result.warnings
         );


### PR DESCRIPTION
Fixes #847

## Summary

This PR fixes a validation mismatch that prevented `memory_tree` from accepting `path: ""` as workspace root.

Before this change, the shared safety validator recursively applied normal text-input validation to all tool parameter strings. As a result, empty-string tool params were rejected before execution, even when the tool contract explicitly allowed them.

## Root Cause

The bug was caused by a shared validator making a semantic decision it should not own.

- `memory_tree` allows `path: ""`
- the workspace layer already supports `""` as root
- shared tool-param validation rejected all empty strings before tool execution

That made the global validator stricter than the tool contract.

## What Changed

In [`src/safety/validator.rs`](../../src/safety/validator.rs):

- preserved `validate()` behavior for normal free-text input
- extracted reusable generic string safety checks into a helper
- updated `validate_tool_params()` so empty strings are not rejected generically
- kept generic checks for non-empty tool strings, including null bytes and forbidden patterns
- added focused regression tests for the new behavior

## Why This Approach

This keeps validation responsibilities better separated:

- shared safety validation handles generic safety concerns
- individual tools own semantic rules for their own fields

That is a better fit than adding a one-off `memory_tree.path` exception to the shared validator.

## Behavior Change

Before:

```json
{
  "depth": 2,
  "path": ""
}
```

failed during shared validation with:

```text
Invalid tool parameters: input: Input cannot be empty
```

After:

the same input passes shared validation and reaches `memory_tree` execution as intended.

## Tests

Added regression coverage for:

- allowing empty strings in tool params
- still rejecting null bytes in tool params
- still rejecting forbidden patterns in tool params

## Scope And Non-Goals

This PR intentionally does not standardize non-empty validation for all built-in tools.

That follow-up question is tracked in the issue:

- some tools likely should enforce non-empty strings at the semantic layer
- this PR only removes the incorrect blanket rule from shared validation

## Review Focus

The main thing to review here is the validation boundary:

- should shared tool-param validation remain semantically neutral about empty strings?
- should tool-specific non-empty enforcement be handled separately, tool by tool?

My view is yes on both points, and this PR is scoped to only the first part.