### PR TITLE
fix(ci): prevent staging-ci tag failure and chained PR auto-close

### DIFF
--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -406,6 +406,10 @@ jobs:
             echo "passed=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Only merge PRs targeting main. Chained PRs (targeting another
+      # promotion branch) stay open — when the base PR merges into main,
+      # GitHub auto-retargets the chained PR. Merging chained PRs would
+      # trigger delete_branch_on_merge, auto-closing downstream PRs.
       - name: Merge promotion PR
         id: merge
         if: steps.evaluate.outputs.passed == 'true'
@@ -414,12 +418,15 @@ jobs:
           PR_NUMBER: ${{ needs.create-promotion-pr.outputs.pr_number }}
         run: |
           if [ -n "$PR_NUMBER" ]; then
-            echo "Merging promotion PR #${PR_NUMBER}"
-            # Do NOT use --delete-branch: deleting a promotion branch closes
-            # any chained PRs that use it as their base (verified in ironclaw-ci-test).
-            # Stale promotion branches are cleaned up separately.
-            gh pr merge "$PR_NUMBER" --merge
-            echo "merged=true" >> "$GITHUB_OUTPUT"
+            BASE=$(gh pr view "$PR_NUMBER" --json baseRefName --jq '.baseRefName')
+            if [ "$BASE" = "main" ]; then
+              echo "Merging promotion PR #${PR_NUMBER} (targets main)"
+              gh pr merge "$PR_NUMBER" --merge
+              echo "merged=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "PR #${PR_NUMBER} targets '${BASE}' (not main) — leaving open for chain resolution"
+              echo "merged=false" >> "$GITHUB_OUTPUT"
+            fi
           fi
 
   # ── Update tested tag (always, so next batch covers only new commits) ──
@@ -437,7 +444,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: staging
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Update staging-tested tag
         run: |


### PR DESCRIPTION
## Summary

- **Fix update-tag shallow clone**: Changed `fetch-depth: 1` to `fetch-depth: 0` in the `update-tag` job so the `current_head` SHA (captured by `check-changes`) is always available, even if staging receives new commits during the CI run. Previously failed with `fatal: cannot update ref 'refs/tags/staging-tested': trying to write ref with nonexistent object`.

- **Only merge promotion PRs targeting main**: The gate now checks the PR's base branch before merging. Chained PRs (targeting another promotion branch) are left open instead of merged. This prevents `delete_branch_on_merge` from auto-deleting the head branch and cascading closures of downstream chained PRs. When the bottom of the chain merges into main, GitHub auto-retargets the next chained PR.

## Test plan

- [ ] Trigger staging CI manually and verify `update-tag` succeeds
- [ ] Verify chained PRs are NOT merged when gate passes (log shows "leaving open for chain resolution")
- [ ] Verify PRs targeting `main` ARE still merged when gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)