### PR TITLE
feat: enhance HTTP tool parameter parsing

### DIFF
--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -601,7 +601,7 @@ impl Tool for HttpTool {
                 let hop_client = build_pinned_client(
                     &hop_host,
                     &hop_addrs,
-                    Duration::from_secs(30),
+                    effective_timeout,
                     reqwest::redirect::Policy::none(),
                 )?;
 
@@ -615,7 +615,7 @@ impl Tool for HttpTool {
                     .await
                     .map_err(|e| {
                         if e.is_timeout() {
-                            ToolError::Timeout(Duration::from_secs(30))
+                            ToolError::Timeout(effective_timeout)
                         } else {
                             ToolError::ExternalService(e.to_string())
                         }
@@ -679,7 +679,7 @@ impl Tool for HttpTool {
         } else {
             let resp = request.send().await.map_err(|e| {
                 if e.is_timeout() {
-                    ToolError::Timeout(Duration::from_secs(30))
+                    ToolError::Timeout(effective_timeout)
                 } else {
                     ToolError::ExternalService(e.to_string())
                 }
@@ -1292,6 +1292,8 @@ mod tests {
             "url": "https://r.jina.ai/http://news.baidu.com/"
         });
         let _ = tool.requires_approval(&req);
+    }
+
     // ── DNS pinning tests ─────────────────────────────────────────────
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

  - Improve the built-in http tool to tolerate common LLM-generated parameter shape issues instead of
    failing on valid intent with invalid typing.
  - Add support for stringified headers JSON values such as "[]" or stringified header arrays/objects.
  - Accept timeout_secs as either an integer or a numeric string, and apply the parsed timeout to the
    outgoing request.
  - Treat empty-string save_to and empty-string body as unset values to avoid unnecessary validation
    failures on GET requests.
  - Add unit tests covering the new parsing behavior and the reported malformed tool-call payload shape.

  ## Change Type

  - [x] Bug fix
  - [ ] New feature
  - [ ] Refactor
  - [ ] Documentation
  - [ ] CI/Infrastructure
  - [ ] Security
  - [ ] Dependencies

  ## Linked Issue

  None

  ## Validation

  - [x] cargo fmt
  - [x] cargo clippy --all --benches --tests --examples --all-features
  - [x] Relevant tests pass:
      - env -u http_proxy -u https_proxy -u HTTP_PROXY -u HTTPS_PROXY -u ALL_PROXY -u all_proxy cargo test
        tools::builtin::http::tests --lib
  - [ ] Manual testing: not performed

  ## Security Impact

  Low. This change only relaxes input normalization for the existing built-in http tool. It does not broaden
  URL allowlists, approval policy, secret injection behavior, or file-write scope. save_to still requires a
  validated path under /tmp/.

  ## Database Impact

  None

  ## Blast Radius

  Touches only the built-in HTTP tool parameter parsing and request construction path. Potential regressions
  are limited to:

  - normalization of malformed tool-call params
  - request timeout handling
  - save_to detection for file-download responses

  Core HTTP safety checks, approval behavior, and path validation remain unchanged.

  ## Rollback Plan

  Revert the changes in src/tools/builtin/http.rs to restore strict parameter handling. No migrations,
  config changes, or data rollback are required.

  ———

  Review track: B