### PR TITLE
style(agent): remove unnecessary Worker re-export (fix #891)

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -32,7 +32,6 @@ pub mod task;
 mod thread_ops;
 pub mod undo;
 
-pub use crate::worker::{Worker, WorkerDeps};
 pub(crate) use agent_loop::truncate_for_preview;
 pub use agent_loop::{Agent, AgentDeps};
 pub use compaction::{CompactionResult, ContextCompactor};


### PR DESCRIPTION
## Summary
Removes an unnecessary public re-export from `src/agent/mod.rs` to satisfy issue #891 and align with the project style guideline (no facade re-exports unless needed by downstream consumers).

- Removed: `pub use crate::worker::{Worker, WorkerDeps};`

## Issue
- Closes #891

## Reproduction (before)
On `staging`, the redundant re-export exists:

```bash
git show staging:src/agent/mod.rs | rg "pub use crate::worker::\{Worker, WorkerDeps\};"
# -> match found
```

And there are no in-repo consumers via the facade path:

```bash
rg "crate::agent::Worker|crate::agent::WorkerDeps" src tests
# -> no matches
```

## Behavior (after)
The re-export is removed from `src/agent/mod.rs`:

```bash
rg "pub use crate::worker::\{Worker, WorkerDeps\};" src/agent/mod.rs
# -> no matches
```

No internal imports depended on the removed facade path.

## Validation
Targeted tests:

```bash
cargo test -q agent::session::tests::test_auto_approved_tools -- --nocapture
cargo test -q agent::dispatcher::tests::test_auto_approved_tool_is_respected -- --nocapture
```

Build sanity:

```bash
cargo check -q
```

All passed locally.

## Scope
Minimal, single-line deletion in one file; no behavioral/runtime logic changes.
