### PR TITLE
docs(extensions): document required relay manager init order

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -57,6 +57,17 @@ struct ChannelRuntimeState {
 }
 
 /// Central manager for extension lifecycle operations.
+///
+/// # Initialization Order
+///
+/// Relay-channel restoration depends on a channel manager being injected first.
+/// Call one of the following before `restore_relay_channels()`:
+///
+/// 1. [`ExtensionManager::set_channel_runtime`] (also sets relay manager), or
+/// 2. [`ExtensionManager::set_relay_channel_manager`].
+///
+/// If `restore_relay_channels()` runs first, each restore attempt fails with
+/// "Channel manager not initialized" and channels remain inactive.
 pub struct ExtensionManager {
     registry: ExtensionRegistry,
     discovery: OnlineDiscovery,
@@ -300,6 +311,9 @@ impl ExtensionManager {
     ///
     /// Call this when WASM channel runtime is not available but relay channels
     /// still need to be hot-added.
+    ///
+    /// This must be called before [`ExtensionManager::restore_relay_channels`]
+    /// unless [`ExtensionManager::set_channel_runtime`] was already called.
     pub async fn set_relay_channel_manager(&self, channel_manager: Arc<ChannelManager>) {
         *self.relay_channel_manager.write().await = Some(channel_manager);
     }
@@ -316,7 +330,10 @@ impl ExtensionManager {
     ///
     /// Loads the persisted active channel list, filters to relay types (those with
     /// a stored stream token), and activates each via `activate_stored_relay()`.
-    /// Skips channels that are already active. Call this after `set_relay_channel_manager()`.
+    /// Skips channels that are already active.
+    ///
+    /// Call this only after `set_relay_channel_manager()` or `set_channel_runtime()`.
+    /// Otherwise, each activation attempt fails with "Channel manager not initialized".
     pub async fn restore_relay_channels(&self) {
         let persisted = self.load_persisted_active_channels().await;
         let already_active = self.active_channel_names.read().await.clone();


### PR DESCRIPTION
## Summary
- document the required initialization order for relay-channel restoration in `ExtensionManager`
- explicitly call out that `set_channel_runtime()` or `set_relay_channel_manager()` must run before `restore_relay_channels()`
- document the concrete failure mode ("Channel manager not initialized") when the order is violated

## Before
- `ExtensionManager` rustdoc had no initialization-order section
- `restore_relay_channels()` only had a brief single-line call-order note
- failure behavior for wrong order was undocumented for integrators

## After
- `ExtensionManager` rustdoc includes a dedicated **Initialization Order** section
- `set_relay_channel_manager()` docs now state it is required before restore unless channel runtime is already wired
- `restore_relay_channels()` docs now describe valid prerequisites and explicit failure mode

## Validation
- `cargo test -p ironclaw test_remove_relay_shuts_down_via_relay_channel_manager`
- `~/.local/ironclaw/bin/ironclaw service status` (smoke check; service remains running/loaded)

Closes #909
