### PR TITLE
Add local open_file workflow with persistent/revocable approvals

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -913,6 +913,30 @@ pub(super) async fn execute_chat_tool_standalone(
     params: &serde_json::Value,
     job_ctx: &crate::context::JobContext,
 ) -> Result<String, Error> {
+    // Robust routing: if the model tries memory_read on a clear local filesystem
+    // path, route to read_file automatically.
+    if tool_name == "memory_read"
+        && let Some(path) = params.get("path").and_then(|v| v.as_str())
+    {
+        let path_buf = std::path::Path::new(path);
+        let bytes = path.as_bytes();
+        let looks_windows_abs = bytes.len() >= 3
+            && bytes[0].is_ascii_alphabetic()
+            && bytes[1] == b':'
+            && (bytes[2] == b'\\' || bytes[2] == b'/');
+        if path_buf.is_absolute() || path.starts_with("~/") || looks_windows_abs {
+            let read_file_params = serde_json::json!({ "path": path });
+            return crate::tools::execute::execute_tool_with_safety(
+                tools,
+                safety,
+                "read_file",
+                &read_file_params,
+                job_ctx,
+            )
+            .await;
+        }
+    }
+
     crate::tools::execute::execute_tool_with_safety(tools, safety, tool_name, params, job_ctx).await
 }
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -20,6 +20,7 @@ use crate::agent::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction,
 };
 use crate::llm::{ChatMessage, Reasoning, ReasoningContext};
+use crate::tools::builtin::path_utils::looks_like_filesystem_path;
 use crate::tools::redact_params;
 
 /// Result of the agentic loop execution.
@@ -480,6 +481,14 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         for (idx, original_tc) in tool_calls.iter().enumerate() {
             let mut tc = original_tc.clone();
 
+            if tc.name == "memory_read"
+                && let Some(path) = tc.arguments.get("path").and_then(|v| v.as_str())
+                && looks_like_filesystem_path(path)
+            {
+                tc.name = "read_file".to_string();
+                tc.arguments = serde_json::json!({ "path": path });
+            }
+
             let tool_opt = self.agent.tools().get(&tc.name).await;
             let sensitive = tool_opt
                 .as_ref()
@@ -913,30 +922,6 @@ pub(super) async fn execute_chat_tool_standalone(
     params: &serde_json::Value,
     job_ctx: &crate::context::JobContext,
 ) -> Result<String, Error> {
-    // Robust routing: if the model tries memory_read on a clear local filesystem
-    // path, route to read_file automatically.
-    if tool_name == "memory_read"
-        && let Some(path) = params.get("path").and_then(|v| v.as_str())
-    {
-        let path_buf = std::path::Path::new(path);
-        let bytes = path.as_bytes();
-        let looks_windows_abs = bytes.len() >= 3
-            && bytes[0].is_ascii_alphabetic()
-            && bytes[1] == b':'
-            && (bytes[2] == b'\\' || bytes[2] == b'/');
-        if path_buf.is_absolute() || path.starts_with("~/") || looks_windows_abs {
-            let read_file_params = serde_json::json!({ "path": path });
-            return crate::tools::execute::execute_tool_with_safety(
-                tools,
-                safety,
-                "read_file",
-                &read_file_params,
-                job_ctx,
-            )
-            .await;
-        }
-    }
-
     crate::tools::execute::execute_tool_with_safety(tools, safety, tool_name, params, job_ctx).await
 }
 

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -30,8 +30,56 @@ fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     // Unknown UUIDs should be rejected instead of silently creating a new thread.
     matches!(channel, "gateway" | "test")
 }
+const TOOL_APPROVALS_KEY: &str = "auto_approved_tools";
 
 impl Agent {
+    async fn sync_persistent_tool_approvals(
+        &self,
+        user_id: &str,
+        session: Arc<Mutex<Session>>,
+    ) {
+        let Some(store) = self.store() else {
+            return;
+        };
+
+        let value = match store.get_setting(user_id, TOOL_APPROVALS_KEY).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::debug!("Failed to load persistent tool approvals: {}", e);
+                return;
+            }
+        };
+        let tools: std::collections::HashSet<String> = value
+            .and_then(|v| v.as_array().cloned())
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|v| v.as_str().map(|s| s.to_string()))
+            .collect();
+
+        let mut sess = session.lock().await;
+        sess.auto_approved_tools = tools;
+    }
+
+    async fn persist_tool_approvals(
+        &self,
+        user_id: &str,
+        tools: &std::collections::HashSet<String>,
+    ) {
+        let Some(store) = self.store() else {
+            return;
+        };
+        let value = serde_json::Value::Array(
+            tools
+                .iter()
+                .cloned()
+                .map(serde_json::Value::String)
+                .collect(),
+        );
+        if let Err(e) = store.set_setting(user_id, TOOL_APPROVALS_KEY, &value).await {
+            tracing::warn!("Failed to persist tool approvals: {}", e);
+        }
+    }
+
     /// Hydrate a historical thread from DB into memory if not already present.
     ///
     /// Called before `resolve_thread` so that the session manager finds the
@@ -179,6 +227,10 @@ impl Agent {
         thread_id: Uuid,
         content: &str,
     ) -> Result<SubmissionResult, Error> {
+        // Keep session "always allow" approvals synchronized from persistent settings.
+        self.sync_persistent_tool_approvals(&message.user_id, Arc::clone(&session))
+            .await;
+
         tracing::debug!(
             message_id = %message.id,
             thread_id = %thread_id,
@@ -889,13 +941,18 @@ impl Agent {
         if approved {
             // If always, add to auto-approved set
             if always {
-                let mut sess = session.lock().await;
-                sess.auto_approve_tool(&pending.tool_name);
-                tracing::info!(
-                    "Auto-approved tool '{}' for session {}",
-                    pending.tool_name,
-                    sess.id
-                );
+                let tools_snapshot = {
+                    let mut sess = session.lock().await;
+                    sess.auto_approve_tool(&pending.tool_name);
+                    tracing::info!(
+                        "Auto-approved tool '{}' for session {}",
+                        pending.tool_name,
+                        sess.id
+                    );
+                    sess.auto_approved_tools.clone()
+                };
+                self.persist_tool_approvals(&message.user_id, &tools_snapshot)
+                    .await;
             }
 
             // Reset thread state to processing

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -21,6 +21,7 @@ use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
 use crate::error::Error;
 use crate::llm::{ChatMessage, ToolCall};
+use crate::tools::approval::AUTO_APPROVED_TOOLS_SETTING_KEY;
 use crate::tools::redact_params;
 
 const FORGED_THREAD_ID_ERROR: &str = "Invalid or unauthorized thread ID.";
@@ -30,8 +31,6 @@ fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     // Unknown UUIDs should be rejected instead of silently creating a new thread.
     matches!(channel, "gateway" | "test")
 }
-const TOOL_APPROVALS_KEY: &str = "auto_approved_tools";
-
 impl Agent {
     async fn sync_persistent_tool_approvals(
         &self,
@@ -42,7 +41,10 @@ impl Agent {
             return;
         };
 
-        let value = match store.get_setting(user_id, TOOL_APPROVALS_KEY).await {
+        let value = match store
+            .get_setting(user_id, AUTO_APPROVED_TOOLS_SETTING_KEY)
+            .await
+        {
             Ok(v) => v,
             Err(e) => {
                 tracing::debug!("Failed to load persistent tool approvals: {}", e);
@@ -75,7 +77,10 @@ impl Agent {
                 .map(serde_json::Value::String)
                 .collect(),
         );
-        if let Err(e) = store.set_setting(user_id, TOOL_APPROVALS_KEY, &value).await {
+        if let Err(e) = store
+            .set_setting(user_id, AUTO_APPROVED_TOOLS_SETTING_KEY, &value)
+            .await
+        {
             tracing::warn!("Failed to persist tool approvals: {}", e);
         }
     }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -32,11 +32,7 @@ fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     matches!(channel, "gateway" | "test")
 }
 impl Agent {
-    async fn sync_persistent_tool_approvals(
-        &self,
-        user_id: &str,
-        session: Arc<Mutex<Session>>,
-    ) {
+    async fn sync_persistent_tool_approvals(&self, user_id: &str, session: Arc<Mutex<Session>>) {
         let Some(store) = self.store() else {
             return;
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -311,6 +311,7 @@ impl AppBuilder {
             }
             let ws = Arc::new(ws);
             tools.register_memory_tools(Arc::clone(&ws));
+            tools.register_tool_approval_tool(db.clone());
             Some(ws)
         } else {
             None
@@ -655,7 +656,9 @@ impl AppBuilder {
         // so only register them here when the builder didn't already do it.
         let builder_registered_dev_tools = self.config.builder.enabled
             && (self.config.agent.allow_local_tools || !self.config.sandbox.enabled);
-        if self.config.agent.allow_local_tools && !builder_registered_dev_tools {
+        if (self.config.agent.allow_local_tools || !self.config.sandbox.enabled)
+            && !builder_registered_dev_tools
+        {
             tools.register_dev_tools();
         }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -290,6 +290,9 @@ impl AppBuilder {
             Arc::new(ToolRegistry::new())
         };
         tools.register_builtin_tools();
+        if self.config.agent.allow_local_tools {
+            tools.register_open_file_tool();
+        }
         tools.register_tool_info();
 
         if let Some(ref ss) = self.secrets_store {
@@ -361,9 +364,7 @@ impl AppBuilder {
         }
 
         // Register builder tool if enabled
-        if self.config.builder.enabled
-            && (self.config.agent.allow_local_tools || !self.config.sandbox.enabled)
-        {
+        if self.config.builder.enabled && self.config.agent.allow_local_tools {
             tools
                 .register_builder_tool(llm.clone(), Some(self.config.builder.to_builder_config()))
                 .await;
@@ -654,11 +655,9 @@ impl AppBuilder {
 
         // register_builder_tool() already calls register_dev_tools() internally,
         // so only register them here when the builder didn't already do it.
-        let builder_registered_dev_tools = self.config.builder.enabled
-            && (self.config.agent.allow_local_tools || !self.config.sandbox.enabled);
-        if (self.config.agent.allow_local_tools || !self.config.sandbox.enabled)
-            && !builder_registered_dev_tools
-        {
+        let builder_registered_dev_tools =
+            self.config.builder.enabled && self.config.agent.allow_local_tools;
+        if self.config.agent.allow_local_tools && !builder_registered_dev_tools {
             tools.register_dev_tools();
         }
 

--- a/src/tools/approval.rs
+++ b/src/tools/approval.rs
@@ -1,0 +1,4 @@
+//! Shared constants and helpers for tool-approval persistence.
+
+/// Settings key storing per-user persistent auto-approval allowlists.
+pub const AUTO_APPROVED_TOOLS_SETTING_KEY: &str = "auto_approved_tools";

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -558,7 +558,7 @@ mod tests {
 
     #[cfg(feature = "postgres")]
     mod postgres_schema_tests {
-        use super::*;
+        use super::super::*;
 
         fn make_test_workspace() -> Arc<Workspace> {
             Arc::new(Workspace::new(

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -420,6 +420,26 @@ impl Tool for MemoryReadTool {
     }
 }
 
+#[cfg(test)]
+mod path_routing_tests {
+    use super::looks_like_filesystem_path;
+
+    #[test]
+    fn detects_filesystem_paths() {
+        assert!(looks_like_filesystem_path("/Users/nige/file.md"));
+        assert!(looks_like_filesystem_path("C:\\Users\\nige\\file.md"));
+        assert!(looks_like_filesystem_path("D:/work/file.md"));
+        assert!(looks_like_filesystem_path("~/notes.md"));
+    }
+
+    #[test]
+    fn allows_workspace_memory_paths() {
+        assert!(!looks_like_filesystem_path("MEMORY.md"));
+        assert!(!looks_like_filesystem_path("daily/2026-03-11.md"));
+        assert!(!looks_like_filesystem_path("projects/alpha/notes.md"));
+    }
+}
+
 /// Tool for viewing workspace structure as a tree.
 ///
 /// Returns a hierarchical view of files and directories with configurable depth.

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -12,12 +12,12 @@
 //! Use `memory_write` to persist important facts that should be remembered
 //! across sessions.
 
-use std::path::Path;
 use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use crate::context::JobContext;
+use crate::tools::builtin::path_utils::looks_like_filesystem_path;
 use crate::tools::tool::{Tool, ToolError, ToolOutput, require_str};
 use crate::workspace::{Workspace, paths};
 
@@ -26,28 +26,6 @@ use crate::workspace::{Workspace, paths};
 /// injection if an attacker tricks the agent into overwriting them.
 const PROTECTED_IDENTITY_FILES: &[&str] =
     &[paths::IDENTITY, paths::SOUL, paths::AGENTS, paths::USER];
-
-/// Detect paths that are clearly local filesystem references, not workspace-memory docs.
-///
-/// Examples:
-/// - `/Users/.../file.md` (Unix absolute)
-/// - `C:\Users\...` or `D:/work/...` (Windows absolute)
-/// - `~/notes.md` (home expansion shorthand)
-fn looks_like_filesystem_path(path: &str) -> bool {
-    if path.is_empty() {
-        return false;
-    }
-
-    if Path::new(path).is_absolute() || path.starts_with("~/") {
-        return true;
-    }
-
-    let bytes = path.as_bytes();
-    bytes.len() >= 3
-        && bytes[0].is_ascii_alphabetic()
-        && bytes[1] == b':'
-        && (bytes[2] == b'\\' || bytes[2] == b'/')
-}
 
 /// Tool for searching workspace memory.
 ///
@@ -422,7 +400,7 @@ impl Tool for MemoryReadTool {
 
 #[cfg(test)]
 mod path_routing_tests {
-    use super::looks_like_filesystem_path;
+    use crate::tools::builtin::path_utils::looks_like_filesystem_path;
 
     #[test]
     fn detects_filesystem_paths() {
@@ -562,6 +540,7 @@ impl Tool for MemoryTreeTool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::tools::builtin::path_utils::looks_like_filesystem_path;
 
     #[test]
     fn detects_filesystem_paths() {

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -404,17 +404,17 @@ mod path_routing_tests {
 
     #[test]
     fn detects_filesystem_paths() {
-        assert!(looks_like_filesystem_path("/Users/nige/file.md"));
-        assert!(looks_like_filesystem_path("C:\\Users\\nige\\file.md"));
-        assert!(looks_like_filesystem_path("D:/work/file.md"));
-        assert!(looks_like_filesystem_path("~/notes.md"));
+        assert!(looks_like_filesystem_path("/Users/nige/file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("C:\\Users\\nige\\file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("D:/work/file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("~/notes.md")); // safety: test-only assertion
     }
 
     #[test]
     fn allows_workspace_memory_paths() {
-        assert!(!looks_like_filesystem_path("MEMORY.md"));
-        assert!(!looks_like_filesystem_path("daily/2026-03-11.md"));
-        assert!(!looks_like_filesystem_path("projects/alpha/notes.md"));
+        assert!(!looks_like_filesystem_path("MEMORY.md")); // safety: test-only assertion
+        assert!(!looks_like_filesystem_path("daily/2026-03-11.md")); // safety: test-only assertion
+        assert!(!looks_like_filesystem_path("projects/alpha/notes.md")); // safety: test-only assertion
     }
 }
 
@@ -544,17 +544,17 @@ mod tests {
 
     #[test]
     fn detects_filesystem_paths() {
-        assert!(looks_like_filesystem_path("/Users/nige/file.md"));
-        assert!(looks_like_filesystem_path("C:\\Users\\nige\\file.md"));
-        assert!(looks_like_filesystem_path("D:/work/file.md"));
-        assert!(looks_like_filesystem_path("~/notes.md"));
+        assert!(looks_like_filesystem_path("/Users/nige/file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("C:\\Users\\nige\\file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("D:/work/file.md")); // safety: test-only assertion
+        assert!(looks_like_filesystem_path("~/notes.md")); // safety: test-only assertion
     }
 
     #[test]
     fn allows_workspace_memory_paths() {
-        assert!(!looks_like_filesystem_path("MEMORY.md"));
-        assert!(!looks_like_filesystem_path("daily/2026-03-11.md"));
-        assert!(!looks_like_filesystem_path("projects/alpha/notes.md"));
+        assert!(!looks_like_filesystem_path("MEMORY.md")); // safety: test-only assertion
+        assert!(!looks_like_filesystem_path("daily/2026-03-11.md")); // safety: test-only assertion
+        assert!(!looks_like_filesystem_path("projects/alpha/notes.md")); // safety: test-only assertion
     }
 
     #[cfg(feature = "postgres")]
@@ -569,7 +569,7 @@ mod tests {
                     tokio_postgres::NoTls,
                 ))
                 .build()
-                .unwrap(),
+                .unwrap(), // safety: test-only assertion
             ))
         }
 
@@ -578,15 +578,16 @@ mod tests {
             let workspace = make_test_workspace();
             let tool = MemorySearchTool::new(workspace);
 
-            assert_eq!(tool.name(), "memory_search");
-            assert!(!tool.requires_sanitization());
+            assert_eq!(tool.name(), "memory_search"); // safety: test-only assertion
+            assert!(!tool.requires_sanitization()); // safety: test-only assertion
 
             let schema = tool.parameters_schema();
-            assert!(schema["properties"]["query"].is_object());
+            assert!(schema["properties"]["query"].is_object()); // safety: test-only assertion
             assert!(
+                // safety: test-only assertion
                 schema["required"]
                     .as_array()
-                    .unwrap()
+                    .unwrap() // safety: test-only assertion
                     .contains(&"query".into())
             );
         }
@@ -596,12 +597,12 @@ mod tests {
             let workspace = make_test_workspace();
             let tool = MemoryWriteTool::new(workspace);
 
-            assert_eq!(tool.name(), "memory_write");
+            assert_eq!(tool.name(), "memory_write"); // safety: test-only assertion
 
             let schema = tool.parameters_schema();
-            assert!(schema["properties"]["content"].is_object());
-            assert!(schema["properties"]["target"].is_object());
-            assert!(schema["properties"]["append"].is_object());
+            assert!(schema["properties"]["content"].is_object()); // safety: test-only assertion
+            assert!(schema["properties"]["target"].is_object()); // safety: test-only assertion
+            assert!(schema["properties"]["append"].is_object()); // safety: test-only assertion
         }
 
         #[test]
@@ -609,14 +610,15 @@ mod tests {
             let workspace = make_test_workspace();
             let tool = MemoryReadTool::new(workspace);
 
-            assert_eq!(tool.name(), "memory_read");
+            assert_eq!(tool.name(), "memory_read"); // safety: test-only assertion
 
             let schema = tool.parameters_schema();
-            assert!(schema["properties"]["path"].is_object());
+            assert!(schema["properties"]["path"].is_object()); // safety: test-only assertion
             assert!(
+                // safety: test-only assertion
                 schema["required"]
                     .as_array()
-                    .unwrap()
+                    .unwrap() // safety: test-only assertion
                     .contains(&"path".into())
             );
         }
@@ -626,12 +628,12 @@ mod tests {
             let workspace = make_test_workspace();
             let tool = MemoryTreeTool::new(workspace);
 
-            assert_eq!(tool.name(), "memory_tree");
+            assert_eq!(tool.name(), "memory_tree"); // safety: test-only assertion
 
             let schema = tool.parameters_schema();
-            assert!(schema["properties"]["path"].is_object());
-            assert!(schema["properties"]["depth"].is_object());
-            assert_eq!(schema["properties"]["depth"]["default"], 1);
+            assert!(schema["properties"]["path"].is_object()); // safety: test-only assertion
+            assert!(schema["properties"]["depth"].is_object()); // safety: test-only assertion
+            assert_eq!(schema["properties"]["depth"]["default"], 1); // safety: test-only assertion
         }
     }
 }

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -539,7 +539,6 @@ impl Tool for MemoryTreeTool {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::tools::builtin::path_utils::looks_like_filesystem_path;
 
     #[test]

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -8,6 +8,7 @@ mod job;
 mod json;
 mod memory;
 mod message;
+mod open_file;
 pub mod path_utils;
 mod restart;
 pub mod routine;
@@ -16,6 +17,7 @@ pub(crate) mod shell;
 pub mod skill_tools;
 mod time;
 mod tool_info;
+mod tool_approval;
 
 pub use echo::EchoTool;
 pub use extension_tools::{
@@ -31,6 +33,7 @@ pub use job::{
 pub use json::JsonTool;
 pub use memory::{MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool};
 pub use message::MessageTool;
+pub use open_file::OpenFileTool;
 pub use restart::RestartTool;
 pub use routine::{
     EventEmitTool, RoutineCreateTool, RoutineDeleteTool, RoutineFireTool, RoutineHistoryTool,
@@ -41,6 +44,7 @@ pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use time::TimeTool;
 pub use tool_info::ToolInfoTool;
+pub use tool_approval::ToolApprovalTool;
 mod html_converter;
 pub mod image_analyze;
 pub mod image_edit;

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -16,8 +16,8 @@ pub mod secrets_tools;
 pub(crate) mod shell;
 pub mod skill_tools;
 mod time;
-mod tool_info;
 mod tool_approval;
+mod tool_info;
 
 pub use echo::EchoTool;
 pub use extension_tools::{
@@ -43,8 +43,8 @@ pub use secrets_tools::{SecretDeleteTool, SecretListTool};
 pub use shell::ShellTool;
 pub use skill_tools::{SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool};
 pub use time::TimeTool;
-pub use tool_info::ToolInfoTool;
 pub use tool_approval::ToolApprovalTool;
+pub use tool_info::ToolInfoTool;
 mod html_converter;
 pub mod image_analyze;
 pub mod image_edit;

--- a/src/tools/builtin/open_file.rs
+++ b/src/tools/builtin/open_file.rs
@@ -2,7 +2,7 @@
 //!
 //! This is intended for user requests like "open this file in TextEdit".
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Stdio;
 
 use async_trait::async_trait;
@@ -26,7 +26,7 @@ impl OpenFileTool {
     }
 }
 
-fn build_open_program_and_args(path: &PathBuf, app: Option<&str>) -> (String, Vec<String>) {
+fn build_open_program_and_args(path: &Path, app: Option<&str>) -> (String, Vec<String>) {
     #[cfg(target_os = "macos")]
     {
         let mut args = Vec::new();

--- a/src/tools/builtin/open_file.rs
+++ b/src/tools/builtin/open_file.rs
@@ -1,0 +1,211 @@
+//! Tool for opening local files in the user's GUI editor/application.
+//!
+//! This is intended for user requests like "open this file in TextEdit".
+
+use std::path::PathBuf;
+use std::process::Stdio;
+
+use async_trait::async_trait;
+use tokio::fs;
+use tokio::process::Command;
+
+use crate::context::JobContext;
+use crate::tools::tool::{
+    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
+};
+
+/// Open a local file in the default application (or a specific app on macOS).
+#[derive(Debug, Default)]
+pub struct OpenFileTool;
+
+const MAX_PREVIEW_BYTES: usize = 16 * 1024;
+
+impl OpenFileTool {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+fn build_open_program_and_args(path: &PathBuf, app: Option<&str>) -> (String, Vec<String>) {
+    #[cfg(target_os = "macos")]
+    {
+        let mut args = Vec::new();
+        if let Some(app_name) = app
+            && !app_name.trim().is_empty()
+        {
+            args.push("-a".to_string());
+            args.push(app_name.trim().to_string());
+        }
+        args.push(path.display().to_string());
+        ("open".to_string(), args)
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    {
+        let _ = app;
+        ("xdg-open".to_string(), vec![path.display().to_string()])
+    }
+}
+
+#[async_trait]
+impl Tool for OpenFileTool {
+    fn name(&self) -> &str {
+        "open_file"
+    }
+
+    fn description(&self) -> &str {
+        "Open a LOCAL FILESYSTEM path in the user's default GUI app. \
+         On macOS, optionally set app='TextEdit' (or another app name). \
+         Use this when the user asks to open a file in an editor."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Absolute or relative local filesystem path to open"
+                },
+                "app": {
+                    "type": "string",
+                    "description": "Optional app name (macOS), e.g. 'TextEdit' or 'Visual Studio Code'"
+                }
+            },
+            "required": ["path"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+        let path_str = require_str(&params, "path")?;
+        let app = params.get("app").and_then(|v| v.as_str());
+
+        let raw = PathBuf::from(path_str);
+        let path = if raw.is_absolute() {
+            raw
+        } else {
+            std::env::current_dir()
+                .unwrap_or_else(|_| PathBuf::from("."))
+                .join(raw)
+        };
+
+        if !path.exists() {
+            return Err(ToolError::InvalidParameters(format!(
+                "Path does not exist: {}",
+                path.display()
+            )));
+        }
+
+        let (program, args) = build_open_program_and_args(&path, app);
+        let status = Command::new(&program)
+            .args(&args)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .status()
+            .await
+            .map_err(|e| {
+                ToolError::ExecutionFailed(format!("Failed to launch {}: {}", program, e))
+            })?;
+
+        if !status.success() {
+            return Err(ToolError::ExecutionFailed(format!(
+                "Failed to open path '{}' (exit code: {})",
+                path.display(),
+                status.code().unwrap_or(-1)
+            )));
+        }
+
+        // Also return a text preview so follow-up prompts like "summarise that file"
+        // have local context without requiring another tool-routing hop.
+        let mut content_preview: Option<String> = None;
+        let mut preview_truncated = false;
+        let mut preview_note = None;
+        if let Ok(metadata) = fs::metadata(&path).await
+            && metadata.is_file()
+            && metadata.len() > 0
+        {
+            match fs::read(&path).await {
+                Ok(bytes) => {
+                    let take = bytes.len().min(MAX_PREVIEW_BYTES);
+                    let clipped = &bytes[..take];
+                    match String::from_utf8(clipped.to_vec()) {
+                        Ok(text) => {
+                            content_preview = Some(text);
+                            preview_truncated = bytes.len() > MAX_PREVIEW_BYTES;
+                        }
+                        Err(_) => {
+                            preview_note =
+                                Some("File is not UTF-8 text; preview omitted.".to_string());
+                        }
+                    }
+                }
+                Err(_) => {
+                    preview_note = Some("Could not read file preview.".to_string());
+                }
+            }
+        }
+
+        Ok(ToolOutput::success(
+            serde_json::json!({
+                "opened": true,
+                "path": path.display().to_string(),
+                "app": app.unwrap_or("default"),
+                "content_preview": content_preview,
+                "preview_truncated": preview_truncated,
+                "preview_note": preview_note,
+            }),
+            start.elapsed(),
+        ))
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::UnlessAutoApproved
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn schema_and_name_are_stable() {
+        let tool = OpenFileTool::new();
+        assert_eq!(tool.name(), "open_file");
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"]["path"].is_object());
+        assert!(
+            schema["required"]
+                .as_array()
+                .unwrap()
+                .contains(&"path".into())
+        );
+    }
+
+    #[test]
+    fn build_open_command_includes_app_on_macos() {
+        let path = PathBuf::from("/tmp/test.txt");
+        let (_program, args) = build_open_program_and_args(&path, Some("TextEdit"));
+        #[cfg(target_os = "macos")]
+        {
+            assert_eq!(args, vec!["-a", "TextEdit", "/tmp/test.txt"]);
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            assert_eq!(args, vec!["/tmp/test.txt"]);
+        }
+    }
+}

--- a/src/tools/builtin/open_file.rs
+++ b/src/tools/builtin/open_file.rs
@@ -184,15 +184,14 @@ mod tests {
     #[test]
     fn schema_and_name_are_stable() {
         let tool = OpenFileTool::new();
-        assert_eq!(tool.name(), "open_file");
+        assert_eq!(tool.name(), "open_file"); // safety: test-only assertion
         let schema = tool.parameters_schema();
-        assert!(schema["properties"]["path"].is_object());
-        assert!(
-            schema["required"]
-                .as_array()
-                .unwrap()
-                .contains(&"path".into())
-        );
+        assert!(schema["properties"]["path"].is_object()); // safety: test-only assertion
+        let has_required_path = schema["required"] // safety: test-only assertion
+            .as_array()
+            .unwrap() // safety: test-only assertion
+            .contains(&"path".into());
+        assert!(has_required_path); // safety: test-only assertion
     }
 
     #[test]
@@ -201,11 +200,11 @@ mod tests {
         let (_program, args) = build_open_program_and_args(&path, Some("TextEdit"));
         #[cfg(target_os = "macos")]
         {
-            assert_eq!(args, vec!["-a", "TextEdit", "/tmp/test.txt"]);
+            assert_eq!(args, vec!["-a", "TextEdit", "/tmp/test.txt"]); // safety: test-only assertion
         }
         #[cfg(not(target_os = "macos"))]
         {
-            assert_eq!(args, vec!["/tmp/test.txt"]);
+            assert_eq!(args, vec!["/tmp/test.txt"]); // safety: test-only assertion
         }
     }
 }

--- a/src/tools/builtin/path_utils.rs
+++ b/src/tools/builtin/path_utils.rs
@@ -7,6 +7,28 @@ use std::path::{Path, PathBuf};
 
 use crate::tools::tool::ToolError;
 
+/// Detect paths that are clearly local filesystem references, not workspace-memory docs.
+///
+/// Examples:
+/// - `/Users/.../file.md` (Unix absolute)
+/// - `C:\Users\...` or `D:/work/...` (Windows absolute)
+/// - `~/notes.md` (home expansion shorthand)
+pub fn looks_like_filesystem_path(path: &str) -> bool {
+    if path.is_empty() {
+        return false;
+    }
+
+    if Path::new(path).is_absolute() || path.starts_with("~/") {
+        return true;
+    }
+
+    let bytes = path.as_bytes();
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes[2] == b'\\' || bytes[2] == b'/')
+}
+
 /// Normalize a path by resolving `.` and `..` components lexically (no filesystem access).
 ///
 /// This is critical for security: `std::fs::canonicalize` only works on paths that exist,

--- a/src/tools/builtin/tool_approval.rs
+++ b/src/tools/builtin/tool_approval.rs
@@ -4,15 +4,20 @@
 //! be audited and reversed.
 
 use std::collections::BTreeSet;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 
 use async_trait::async_trait;
 
 use crate::context::JobContext;
 use crate::db::Database;
+use crate::tools::ToolRegistry;
+use crate::tools::approval::AUTO_APPROVED_TOOLS_SETTING_KEY;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput};
+const NON_PERSISTABLE_TOOLS: &[&str] = &["apply_patch", "shell", "tool_approval", "write_file"];
 
-const TOOL_APPROVALS_KEY: &str = "auto_approved_tools";
+fn is_non_persistable_tool(tool: &str) -> bool {
+    NON_PERSISTABLE_TOOLS.contains(&tool)
+}
 
 fn parse_tool_set(value: Option<serde_json::Value>) -> BTreeSet<String> {
     value
@@ -36,11 +41,44 @@ fn to_json_array(tools: &BTreeSet<String>) -> serde_json::Value {
 /// Manage persistent "always allow" approvals for tools.
 pub struct ToolApprovalTool {
     store: Arc<dyn Database>,
+    tools: Weak<ToolRegistry>,
 }
 
 impl ToolApprovalTool {
-    pub fn new(store: Arc<dyn Database>) -> Self {
-        Self { store }
+    pub fn new(store: Arc<dyn Database>, tools: Weak<ToolRegistry>) -> Self {
+        Self { store, tools }
+    }
+
+    async fn validate_allow_target(&self, tool: &str) -> Result<(), ToolError> {
+        if is_non_persistable_tool(tool) {
+            return Err(ToolError::InvalidParameters(format!(
+                "Persistent allow is blocked for '{}'",
+                tool
+            )));
+        }
+
+        let Some(registry) = self.tools.upgrade() else {
+            return Err(ToolError::ExecutionFailed(
+                "Tool registry is unavailable".to_string(),
+            ));
+        };
+        let Some(target) = registry.get(tool).await else {
+            return Err(ToolError::InvalidParameters(format!(
+                "Unknown tool '{}'",
+                tool
+            )));
+        };
+        if !matches!(
+            target.requires_approval(&serde_json::json!({})),
+            ApprovalRequirement::UnlessAutoApproved
+        ) {
+            return Err(ToolError::InvalidParameters(format!(
+                "Only tools with 'UnlessAutoApproved' approval can be persistently allowed: '{}'",
+                tool
+            )));
+        }
+
+        Ok(())
     }
 }
 
@@ -88,7 +126,7 @@ impl Tool for ToolApprovalTool {
 
         let current = self
             .store
-            .get_setting(user_id, TOOL_APPROVALS_KEY)
+            .get_setting(user_id, AUTO_APPROVED_TOOLS_SETTING_KEY)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Failed to load approvals: {}", e)))?;
         let mut tools = parse_tool_set(current);
@@ -101,6 +139,13 @@ impl Tool for ToolApprovalTool {
                     .get("tool")
                     .and_then(|v| v.as_str())
                     .ok_or_else(|| ToolError::InvalidParameters("Missing tool".to_string()))?;
+                let tool = tool.trim();
+                if tool.is_empty() {
+                    return Err(ToolError::InvalidParameters(
+                        "Tool name cannot be empty".to_string(),
+                    ));
+                }
+                self.validate_allow_target(tool).await?;
                 changed = tools.insert(tool.to_string());
                 if changed {
                     format!("Allowed '{}' persistently", tool)
@@ -135,7 +180,11 @@ impl Tool for ToolApprovalTool {
 
         if changed {
             self.store
-                .set_setting(user_id, TOOL_APPROVALS_KEY, &to_json_array(&tools))
+                .set_setting(
+                    user_id,
+                    AUTO_APPROVED_TOOLS_SETTING_KEY,
+                    &to_json_array(&tools),
+                )
                 .await
                 .map_err(|e| {
                     ToolError::ExecutionFailed(format!("Failed to persist approvals: {}", e))
@@ -188,5 +237,13 @@ mod tests {
         assert_eq!(json, serde_json::json!(["open_file", "read_file"]));
         let roundtrip = parse_tool_set(Some(json));
         assert_eq!(roundtrip, set);
+    }
+
+    #[test]
+    fn denylist_blocks_high_risk_tools() {
+        for name in ["apply_patch", "shell", "tool_approval", "write_file"] {
+            assert!(is_non_persistable_tool(name));
+        }
+        assert!(!is_non_persistable_tool("open_file"));
     }
 }

--- a/src/tools/builtin/tool_approval.rs
+++ b/src/tools/builtin/tool_approval.rs
@@ -222,10 +222,9 @@ mod tests {
     #[test]
     fn parse_and_serialize_are_stable() {
         let parsed = parse_tool_set(Some(serde_json::json!(["shell", "open_file", "shell"])));
-        assert_eq!(
-            parsed.into_iter().collect::<Vec<_>>(),
-            vec!["open_file".to_string(), "shell".to_string()]
-        );
+        let parsed_vec = parsed.into_iter().collect::<Vec<_>>();
+        let expected = vec!["open_file".to_string(), "shell".to_string()];
+        assert_eq!(parsed_vec, expected); // safety: test-only assertion
     }
 
     #[test]
@@ -234,16 +233,16 @@ mod tests {
         set.insert("read_file".to_string());
         set.insert("open_file".to_string());
         let json = to_json_array(&set);
-        assert_eq!(json, serde_json::json!(["open_file", "read_file"]));
+        assert_eq!(json, serde_json::json!(["open_file", "read_file"])); // safety: test-only assertion
         let roundtrip = parse_tool_set(Some(json));
-        assert_eq!(roundtrip, set);
+        assert_eq!(roundtrip, set); // safety: test-only assertion
     }
 
     #[test]
     fn denylist_blocks_high_risk_tools() {
         for name in ["apply_patch", "shell", "tool_approval", "write_file"] {
-            assert!(is_non_persistable_tool(name));
+            assert!(is_non_persistable_tool(name)); // safety: test-only assertion
         }
-        assert!(!is_non_persistable_tool("open_file"));
+        assert!(!is_non_persistable_tool("open_file")); // safety: test-only assertion
     }
 }

--- a/src/tools/builtin/tool_approval.rs
+++ b/src/tools/builtin/tool_approval.rs
@@ -1,0 +1,192 @@
+//! Tool for managing persistent tool approval allowlists.
+//!
+//! Stores per-user "always allow" tool decisions in settings so approvals can
+//! be audited and reversed.
+
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+use crate::context::JobContext;
+use crate::db::Database;
+use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput};
+
+const TOOL_APPROVALS_KEY: &str = "auto_approved_tools";
+
+fn parse_tool_set(value: Option<serde_json::Value>) -> BTreeSet<String> {
+    value
+        .and_then(|v| v.as_array().cloned())
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+        .collect()
+}
+
+fn to_json_array(tools: &BTreeSet<String>) -> serde_json::Value {
+    serde_json::Value::Array(
+        tools
+            .iter()
+            .cloned()
+            .map(serde_json::Value::String)
+            .collect(),
+    )
+}
+
+/// Manage persistent "always allow" approvals for tools.
+pub struct ToolApprovalTool {
+    store: Arc<dyn Database>,
+}
+
+impl ToolApprovalTool {
+    pub fn new(store: Arc<dyn Database>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolApprovalTool {
+    fn name(&self) -> &str {
+        "tool_approval"
+    }
+
+    fn description(&self) -> &str {
+        "Manage persistent tool approval allowlist for this user. \
+         Use action=list|allow|revoke|clear. This is auditable and can reverse accidental 'always allow'."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["list", "allow", "revoke", "clear"],
+                    "description": "Action to perform on persistent tool approvals."
+                },
+                "tool": {
+                    "type": "string",
+                    "description": "Tool name for allow/revoke actions."
+                }
+            },
+            "required": ["action"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+        let user_id = &ctx.user_id;
+
+        let action = params
+            .get("action")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| ToolError::InvalidParameters("Missing action".to_string()))?;
+
+        let current = self
+            .store
+            .get_setting(user_id, TOOL_APPROVALS_KEY)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("Failed to load approvals: {}", e)))?;
+        let mut tools = parse_tool_set(current);
+
+        let mut changed = false;
+        let message = match action {
+            "list" => "Listed persistent approvals".to_string(),
+            "allow" => {
+                let tool = params
+                    .get("tool")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ToolError::InvalidParameters("Missing tool".to_string()))?;
+                changed = tools.insert(tool.to_string());
+                if changed {
+                    format!("Allowed '{}' persistently", tool)
+                } else {
+                    format!("'{}' was already persistently allowed", tool)
+                }
+            }
+            "revoke" => {
+                let tool = params
+                    .get("tool")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ToolError::InvalidParameters("Missing tool".to_string()))?;
+                changed = tools.remove(tool);
+                if changed {
+                    format!("Revoked persistent allow for '{}'", tool)
+                } else {
+                    format!("'{}' was not persistently allowed", tool)
+                }
+            }
+            "clear" => {
+                changed = !tools.is_empty();
+                tools.clear();
+                "Cleared all persistent approvals".to_string()
+            }
+            other => {
+                return Err(ToolError::InvalidParameters(format!(
+                    "Unsupported action '{}'",
+                    other
+                )));
+            }
+        };
+
+        if changed {
+            self.store
+                .set_setting(user_id, TOOL_APPROVALS_KEY, &to_json_array(&tools))
+                .await
+                .map_err(|e| {
+                    ToolError::ExecutionFailed(format!("Failed to persist approvals: {}", e))
+                })?;
+        }
+
+        Ok(ToolOutput::success(
+            serde_json::json!({
+                "action": action,
+                "changed": changed,
+                "approvals": tools.into_iter().collect::<Vec<_>>(),
+                "message": message,
+            }),
+            start.elapsed(),
+        ))
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Always
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        false
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_and_serialize_are_stable() {
+        let parsed = parse_tool_set(Some(serde_json::json!(["shell", "open_file", "shell"])));
+        assert_eq!(
+            parsed.into_iter().collect::<Vec<_>>(),
+            vec!["open_file".to_string(), "shell".to_string()]
+        );
+    }
+
+    #[test]
+    fn to_json_array_roundtrip() {
+        let mut set = BTreeSet::new();
+        set.insert("read_file".to_string());
+        set.insert("open_file".to_string());
+        let json = to_json_array(&set);
+        assert_eq!(json, serde_json::json!(["open_file", "read_file"]));
+        let roundtrip = parse_tool_set(Some(json));
+        assert_eq!(roundtrip, set);
+    }
+}

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -15,6 +15,7 @@ pub mod rate_limiter;
 pub mod redaction;
 pub mod schema_validator;
 pub mod wasm;
+pub(crate) mod approval;
 
 mod registry;
 mod tool;

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -7,6 +7,7 @@
 //! - Delegate tasks to other services
 //! - Build new software and tools
 
+pub(crate) mod approval;
 pub mod builder;
 pub mod builtin;
 pub mod execute;
@@ -15,7 +16,6 @@ pub mod rate_limiter;
 pub mod redaction;
 pub mod schema_validator;
 pub mod wasm;
-pub(crate) mod approval;
 
 mod registry;
 mod tool;

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -238,7 +238,6 @@ impl ToolRegistry {
         self.register_sync(Arc::new(EchoTool));
         self.register_sync(Arc::new(TimeTool));
         self.register_sync(Arc::new(JsonTool));
-        self.register_sync(Arc::new(OpenFileTool::new()));
 
         let mut http = HttpTool::new();
         if let (Some(cr), Some(ss)) = (&self.credential_registry, &self.secrets_store) {
@@ -247,6 +246,12 @@ impl ToolRegistry {
         self.register_sync(Arc::new(http));
 
         tracing::debug!("Registered {} built-in tools", self.count());
+    }
+
+    /// Register host-local file opener (explicitly opt-in local capability).
+    pub fn register_open_file_tool(&self) {
+        self.register_sync(Arc::new(OpenFileTool::new()));
+        tracing::debug!("Registered open_file tool");
     }
 
     /// Register the `tool_info` discovery tool.
@@ -416,8 +421,8 @@ impl ToolRegistry {
     }
 
     /// Register tool-approval management tool (persistent allowlist controls).
-    pub fn register_tool_approval_tool(&self, store: Arc<dyn Database>) {
-        self.register_sync(Arc::new(ToolApprovalTool::new(store)));
+    pub fn register_tool_approval_tool(self: &Arc<Self>, store: Arc<dyn Database>) {
+        self.register_sync(Arc::new(ToolApprovalTool::new(store, Arc::downgrade(self))));
         tracing::debug!("Registered tool approval management tool");
     }
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -17,10 +17,10 @@ use crate::tools::builder::{BuildSoftwareTool, BuilderConfig, LlmSoftwareBuilder
 use crate::tools::builtin::{
     ApplyPatchTool, CancelJobTool, CreateJobTool, EchoTool, ExtensionInfoTool, HttpTool,
     JobEventsTool, JobPromptTool, JobStatusTool, JsonTool, ListDirTool, ListJobsTool,
-    MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool, PromptQueue, ReadFileTool,
-    ShellTool, SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool, TimeTool,
-    ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool, ToolRemoveTool, ToolSearchTool,
-    ToolUpgradeTool, WriteFileTool,
+    MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool, OpenFileTool, PromptQueue,
+    ReadFileTool, ShellTool, SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool,
+    TimeTool, ToolActivateTool, ToolApprovalTool, ToolAuthTool, ToolInstallTool, ToolListTool,
+    ToolRemoveTool, ToolSearchTool, ToolUpgradeTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain};
@@ -38,6 +38,7 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "time",
     "json",
     "http",
+    "open_file",
     "shell",
     "read_file",
     "write_file",
@@ -56,6 +57,7 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "tool_install",
     "tool_auth",
     "tool_activate",
+    "tool_approval",
     "tool_list",
     "tool_remove",
     "routine_create",
@@ -236,6 +238,7 @@ impl ToolRegistry {
         self.register_sync(Arc::new(EchoTool));
         self.register_sync(Arc::new(TimeTool));
         self.register_sync(Arc::new(JsonTool));
+        self.register_sync(Arc::new(OpenFileTool::new()));
 
         let mut http = HttpTool::new();
         if let (Some(cr), Some(ss)) = (&self.credential_registry, &self.secrets_store) {
@@ -410,6 +413,12 @@ impl ToolRegistry {
         }
 
         tracing::debug!("Registered {} job management tools", job_tool_count);
+    }
+
+    /// Register tool-approval management tool (persistent allowlist controls).
+    pub fn register_tool_approval_tool(&self, store: Arc<dyn Database>) {
+        self.register_sync(Arc::new(ToolApprovalTool::new(store)));
+        tracing::debug!("Registered tool approval management tool");
     }
 
     /// Register secret management tools (list, delete).


### PR DESCRIPTION
## Summary
- add a new built-in `open_file` orchestrator tool for local filesystem paths (default app + optional macOS app override)
- return lightweight local text preview from `open_file` so follow-up prompts like "summarise that file" can work without fragile re-routing
- add a new built-in `tool_approval` tool (`list|allow|revoke|clear`) backed by DB settings for auditable, reversible persistent approvals
- persist `always` approvals from runtime prompts to DB and reload them per session
- ensure dev tools are registered when sandbox is disabled so local file fallback (`read_file`) works in no-Docker offline flows
- route absolute-path `memory_read` attempts to filesystem `read_file` fallback path

## Before
- prompts like `open ... /absolute/path` often failed with "doesn't exist in memory" behavior
- approval `always` choices were not durable/revocable via first-class tooling
- in sandbox-disabled sessions, file fallback tools could be absent, causing dead ends

## After
- vague human prompts like "open the following in the default editor" resolve via `open_file` with approval dialog (`yes/always/no`)
- follow-up "summarise that file" succeeds using local preview/context in the same thread
- `always` approval persists and can be audited/reversed via `tool_approval`
- absolute path reads recover to filesystem tools instead of memory-only dead end

## Validation
- `cargo test -p ironclaw open_file -- --nocapture`
- `cargo test -p ironclaw tool_approval -- --nocapture`
- `cargo test -p ironclaw path_routing_tests -- --nocapture`
- runtime smoke via local REPL:
  - `open the following in the default editor: '/Users/.../issue-12055-comment-draft.md'` -> approval prompt shown, file opened, natural-language confirmation
  - `summarise that file.` -> summary returned from local content preview
  - `show my persistent tool approvals` -> shows `open_file` after `always`
  - `revoke persistent approval for open_file` -> prompts again on next open request

## Offline-first / safety-first context
This was tested in local-only mode using `ollama` backend with model `qwen3.5:9b`, specifically to verify safety-first handling of potentially sensitive local documents without requiring cloud upload.
