### PR TITLE
  Add Z.AI provider support for GLM-5

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -245,7 +245,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Ollama (local) | ✅ | ✅ | - | via `rig::providers::ollama` (full support) |
 | Perplexity | ✅ | ❌ | P3 | Freshness parameter for web_search |
 | MiniMax | ✅ | ❌ | P3 | Regional endpoint selection |
-| GLM-5 | ✅ | ❌ | P3 | |
+| GLM-5 | ✅ | ✅ | P3 | Via Z.AI provider (`zai`) using OpenAI-compatible chat completions |
 | node-llama-cpp | ✅ | ➖ | - | N/A for Rust |
 | llama.cpp (native) | ❌ | 🔮 | P3 | Rust bindings |
 

--- a/providers.json
+++ b/providers.json
@@ -239,6 +239,26 @@
     }
   },
   {
+    "id": "zai",
+    "aliases": [
+      "bigmodel"
+    ],
+    "protocol": "open_ai_completions",
+    "default_base_url": "https://api.z.ai/api/paas/v4",
+    "api_key_env": "ZAI_API_KEY",
+    "api_key_required": true,
+    "model_env": "ZAI_MODEL",
+    "default_model": "glm-5",
+    "description": "Z.AI GLM inference API",
+    "setup": {
+      "kind": "api_key",
+      "secret_name": "llm_zai_api_key",
+      "key_url": "https://z.ai/manage-apikey/apikey-list",
+      "display_name": "Z.AI",
+      "can_list_models": false
+    }
+  },
+  {
     "id": "cerebras",
     "aliases": [],
     "protocol": "open_ai_completions",

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -638,6 +638,31 @@ mod tests {
     }
 
     #[test]
+    fn registry_provider_alias_resolves_zai() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::remove_var("ZAI_API_KEY");
+            std::env::remove_var("ZAI_MODEL");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("bigmodel".to_string()),
+            selected_model: Some("glm-5".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        assert_eq!(cfg.backend, "zai");
+        let provider = cfg.provider.expect("provider config should be present");
+        assert_eq!(provider.provider_id, "zai");
+        assert_eq!(provider.model, "glm-5");
+        assert_eq!(provider.base_url, "https://api.z.ai/api/paas/v4");
+        assert_eq!(provider.protocol, ProviderProtocol::OpenAiCompletions);
+    }
+
+    #[test]
     fn nearai_backend_has_no_registry_provider() {
         let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
         // SAFETY: Under ENV_MUTEX.


### PR DESCRIPTION


## Summary

<!-- 2-5 bullet points: what changed and why -->

  - add a minimal `zai` registry provider using the existing OpenAI-compatible chat completions path
  - configure default Z.AI endpoint, API key env vars, default model, and setup wizard key URL
  - add a config regression test covering `bigmodel` alias resolution and canonical backend normalization
  - update FEATURE_PARITY.md to mark GLM-5 as supported via the new provider

  Value:
  - makes GLM-5 a first-class provider instead of requiring manual openai_compatible setup
  - keeps the implementation low-risk by reusing the existing provider registry and adapter path
  - improves onboarding and discoverability for Z.AI users with no behavioral changes to other providers

## Change Type

<!-- Check one -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

None

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

None

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

None

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
