### PR TITLE
feat: add MiniMax as a built-in LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BASE_URL=https://api.fireworks.ai/inference/v1
 # LLM_API_KEY=fw_...
 
+# === MiniMax ===
+# LLM_BACKEND=minimax
+# MINIMAX_API_KEY=...
+# MINIMAX_MODEL=MiniMax-M2.5
+# MINIMAX_BASE_URL=https://api.minimax.io/v1   # default (global); use https://api.minimaxi.com/v1 for China
+
 # === Anthropic Direct ===
 # LLM_BACKEND=anthropic
 # ANTHROPIC_MODEL=claude-sonnet-4-6

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -15,6 +15,7 @@ configurations.
 | io.net | `ionet` | `IONET_API_KEY` | Intelligence API |
 | Mistral | `mistral` | `MISTRAL_API_KEY` | Mistral models |
 | Yandex AI Studio | `yandex` | `YANDEX_API_KEY` | YandexGPT models |
+| MiniMax | `minimax` | `MINIMAX_API_KEY` | MiniMax-M2.5 models |
 | Cloudflare Workers AI | `cloudflare` | `CLOUDFLARE_API_KEY` | Access to Workers AI |
 | Ollama | `ollama` | No | Local inference |
 | AWS Bedrock | `bedrock` | AWS credentials | Native Converse API |
@@ -71,6 +72,25 @@ OLLAMA_MODEL=llama3.2
 ```
 
 Pull a model first: `ollama pull llama3.2`
+
+---
+
+## MiniMax
+
+[MiniMax](https://platform.minimax.io) provides high-performance language models with 204,800 token context windows.
+
+```env
+LLM_BACKEND=minimax
+MINIMAX_API_KEY=...
+```
+
+Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed`
+
+To use the China mainland endpoint, set:
+
+```env
+MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+```
 
 ---
 

--- a/providers.json
+++ b/providers.json
@@ -363,6 +363,27 @@
     }
   },
   {
+    "id": "minimax",
+    "aliases": [
+      "mini_max"
+    ],
+    "protocol": "open_ai_completions",
+    "default_base_url": "https://api.minimax.io/v1",
+    "api_key_env": "MINIMAX_API_KEY",
+    "api_key_required": true,
+    "base_url_env": "MINIMAX_BASE_URL",
+    "model_env": "MINIMAX_MODEL",
+    "default_model": "MiniMax-M2.5",
+    "description": "MiniMax API (MiniMax-M2.5 and MiniMax-M2.5-highspeed models)",
+    "setup": {
+      "kind": "api_key",
+      "secret_name": "llm_minimax_api_key",
+      "key_url": "https://platform.minimax.io",
+      "display_name": "MiniMax",
+      "can_list_models": false
+    }
+  },
+  {
     "id": "cloudflare",
     "aliases": [
       "cloudflare_ai",


### PR DESCRIPTION
## Summary

- Add MiniMax to the built-in provider registry (`providers.json`) with OpenAI-compatible protocol
- Update `docs/LLM_PROVIDERS.md` with MiniMax setup instructions
- Add MiniMax configuration to `.env.example`

### Available Models

| Model | Description |
|-------|-------------|
| `MiniMax-M2.5` (default) | Peak performance, 204,800 token context |
| `MiniMax-M2.5-highspeed` | Same performance, faster inference |

### Configuration

```env
LLM_BACKEND=minimax
MINIMAX_API_KEY=<your-key>
# Optional: use China mainland endpoint
# MINIMAX_BASE_URL=https://api.minimaxi.com/v1
```

## Changes

- `providers.json`: Added MiniMax provider definition (OpenAI-compatible, `api.minimax.io/v1`)
- `docs/LLM_PROVIDERS.md`: Added MiniMax to provider overview table and dedicated setup section
- `.env.example`: Added MiniMax configuration template

## Test plan

- [ ] Verify `providers.json` is valid JSON
- [ ] Set `LLM_BACKEND=minimax` and `MINIMAX_API_KEY` to confirm provider loads correctly
- [ ] Send a chat completion request to verify end-to-end functionality