### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BASE_URL=https://api.fireworks.ai/inference/v1
 # LLM_API_KEY=fw_...
 
+# === MiniMax ===
+# LLM_BACKEND=minimax
+# MINIMAX_API_KEY=...
+# MINIMAX_MODEL=MiniMax-M2.5
+# MINIMAX_BASE_URL=https://api.minimax.io/v1   # default (global); use https://api.minimaxi.com/v1 for China
+
 # === Anthropic Direct ===
 # LLM_BACKEND=anthropic
 # ANTHROPIC_MODEL=claude-sonnet-4-6

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -244,7 +244,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | OpenAI-compatible | ❌ | ✅ | - | Generic OpenAI-compatible endpoint (RigAdapter) |
 | Ollama (local) | ✅ | ✅ | - | via `rig::providers::ollama` (full support) |
 | Perplexity | ✅ | ❌ | P3 | Freshness parameter for web_search |
-| MiniMax | ✅ | ❌ | P3 | Regional endpoint selection |
+| MiniMax | ✅ | ✅ | - | OpenAI-compatible; regional endpoint via `MINIMAX_BASE_URL` |
 | GLM-5 | ✅ | ❌ | P3 | |
 | node-llama-cpp | ✅ | ➖ | - | N/A for Rust |
 | llama.cpp (native) | ❌ | 🔮 | P3 | Rust bindings |

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -15,6 +15,7 @@ configurations.
 | io.net | `ionet` | `IONET_API_KEY` | Intelligence API |
 | Mistral | `mistral` | `MISTRAL_API_KEY` | Mistral models |
 | Yandex AI Studio | `yandex` | `YANDEX_API_KEY` | YandexGPT models |
+| MiniMax | `minimax` | `MINIMAX_API_KEY` | MiniMax-M2.5 models |
 | Cloudflare Workers AI | `cloudflare` | `CLOUDFLARE_API_KEY` | Access to Workers AI |
 | Ollama | `ollama` | No | Local inference |
 | AWS Bedrock | `bedrock` | AWS credentials | Native Converse API |
@@ -71,6 +72,25 @@ OLLAMA_MODEL=llama3.2
 ```
 
 Pull a model first: `ollama pull llama3.2`
+
+---
+
+## MiniMax
+
+[MiniMax](https://platform.minimax.io) provides high-performance language models with 204,800 token context windows.
+
+```env
+LLM_BACKEND=minimax
+MINIMAX_API_KEY=...
+```
+
+Available models: `MiniMax-M2.5` (default), `MiniMax-M2.5-highspeed`
+
+To use the China mainland endpoint, set:
+
+```env
+MINIMAX_BASE_URL=https://api.minimaxi.com/v1
+```
 
 ---
 

--- a/providers.json
+++ b/providers.json
@@ -363,6 +363,27 @@
     }
   },
   {
+    "id": "minimax",
+    "aliases": [
+      "mini_max"
+    ],
+    "protocol": "open_ai_completions",
+    "default_base_url": "https://api.minimax.io/v1",
+    "api_key_env": "MINIMAX_API_KEY",
+    "api_key_required": true,
+    "base_url_env": "MINIMAX_BASE_URL",
+    "model_env": "MINIMAX_MODEL",
+    "default_model": "MiniMax-M2.5",
+    "description": "MiniMax API (MiniMax-M2.5 and MiniMax-M2.5-highspeed models)",
+    "setup": {
+      "kind": "api_key",
+      "secret_name": "llm_minimax_api_key",
+      "key_url": "https://platform.minimax.io",
+      "display_name": "MiniMax",
+      "can_list_models": false
+    }
+  },
+  {
     "id": "cloudflare",
     "aliases": [
       "cloudflare_ai",

--- a/src/llm/costs.rs
+++ b/src/llm/costs.rs
@@ -73,6 +73,10 @@ pub fn model_cost(model_id: &str) -> Option<(Decimal, Decimal)> {
         | "claude-3-5-haiku-latest" => Some((dec!(0.0000008), dec!(0.000004))),
         "claude-3-haiku-20240307" => Some((dec!(0.00000025), dec!(0.00000125))),
 
+        // MiniMax
+        "MiniMax-M2.5" => Some((dec!(0.0000003), dec!(0.0000012))),
+        "MiniMax-M2.5-highspeed" => Some((dec!(0.0000006), dec!(0.0000024))),
+
         // Ollama / local models -- free
         _ if is_local_model(id) => Some((Decimal::ZERO, Decimal::ZERO)),
 
@@ -134,6 +138,16 @@ mod tests {
         let (input, output) = model_cost("mistral:latest").unwrap();
         assert_eq!(input, Decimal::ZERO);
         assert_eq!(output, Decimal::ZERO);
+    }
+
+    #[test]
+    fn test_minimax_costs() {
+        let (input, output) = model_cost("MiniMax-M2.5").unwrap();
+        assert!(input > Decimal::ZERO);
+        assert!(output > input);
+        let (input_hs, output_hs) = model_cost("MiniMax-M2.5-highspeed").unwrap();
+        assert!(input_hs > input); // highspeed is more expensive
+        assert!(output_hs > output);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Add MiniMax as a new built-in LLM provider using the OpenAI-compatible API.

## Supported Models
- `MiniMax-M2.5` (default) - Peak Performance. Ultimate Value. Master the Complex. 204,800 token context window.
- `MiniMax-M2.5-highspeed` - Same performance, faster and more agile.

## Changes
- **providers.json**: Add MiniMax provider entry with OpenAI-compatible protocol
- **src/llm/costs.rs**: Add per-token cost entries for MiniMax models + unit test
- **docs/LLM_PROVIDERS.md**: Add MiniMax configuration section with regional endpoint info
- **.env.example**: Add MiniMax environment variable examples
- **FEATURE_PARITY.md**: Update MiniMax status from ❌ to ✅

## Configuration
```env
LLM_BACKEND=minimax
MINIMAX_API_KEY=<your-key>
# Optional: China mainland endpoint
MINIMAX_BASE_URL=https://api.minimaxi.com/v1
```

## Notes
- MiniMax reasoning model detection (`minimax-m2*`) was already present in `reasoning_models.rs`
- No Rust code changes needed — the declarative provider registry handles everything
- Regional endpoint selection via `MINIMAX_BASE_URL` env var

## API Documentation
- OpenAI Compatible: https://platform.minimax.io/docs/api-reference/text-openai-api

## Testing
- [x] `providers.json` is valid JSON
- [x] Cost entries follow existing patterns (input/output per-token pricing)
- [x] Documentation matches provider registry configuration