### PR TITLE
fix(ci): patch correct manifest when tools/channels share filename (#939)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,19 +156,29 @@ jobs:
           while IFS= read -r line; do
             sha256=$(echo "$line" | awk '{print $1}')
             filename=$(echo "$line" | awk '{print $2}')
-            # Strip -{version}-wasm32-wasip2.tar.gz to get the extension name.
-            # Use '.*' (greedy) so pre-release suffixes like -alpha.1 are consumed too.
-            name=$(echo "$filename" | sed 's/-[0-9].*-wasm32-wasip2\.tar\.gz$//')
+            manifest=$(echo "$line" | awk '{print $3}')
             url="https://github.com/nearai/ironclaw/releases/download/${RELEASE_TAG}/${filename}"
 
-            for manifest in registry/tools/${name}.json registry/channels/${name}.json; do
-              if [ -f "$manifest" ]; then
-                jq --arg sha "$sha256" --arg url "$url" \
-                  '.artifacts["wasm32-wasip2"].sha256 = $sha | .artifacts["wasm32-wasip2"].url = $url' \
-                  "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
-                echo "Patched $manifest with sha256=$sha256 url=$url"
-              fi
-            done
+            if [ -z "$manifest" ]; then
+              # Backwards compat: old checksums.txt without manifest column.
+              # Fall back to name-based lookup (pre-#939 format).
+              name=$(echo "$filename" | sed 's/-[0-9].*-wasm32-wasip2\.tar\.gz$//')
+              for m in registry/tools/${name}.json registry/channels/${name}.json; do
+                if [ -f "$m" ]; then
+                  manifest="$m"
+                  break
+                fi
+              done
+            fi
+
+            if [ -f "$manifest" ]; then
+              jq --arg sha "$sha256" --arg url "$url" \
+                '.artifacts["wasm32-wasip2"].sha256 = $sha | .artifacts["wasm32-wasip2"].url = $url' \
+                "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
+              echo "Patched $manifest with sha256=$sha256 url=$url"
+            else
+              echo "::warning::No manifest found for $filename, skipping"
+            fi
           done < "$CHECKSUMS"
       - name: Install dependencies
         run: |
@@ -349,9 +359,11 @@ jobs:
               tar czf "${file_stem}-${ext_version}-wasm32-wasip2.tar.gz" "${ext_name}.wasm"
             fi)
 
-            # Compute SHA256
+            # Compute SHA256 — include the manifest path as a third column so the
+            # patch step can target the exact manifest without reverse-engineering
+            # the extension name from the bundle filename (#939).
             sha256=$(sha256sum "$bundle" | cut -d' ' -f1)
-            echo "$sha256  ${file_stem}-${ext_version}-wasm32-wasip2.tar.gz" >> target/wasm-bundles/checksums.txt
+            echo "$sha256  ${file_stem}-${ext_version}-wasm32-wasip2.tar.gz  ${manifest}" >> target/wasm-bundles/checksums.txt
 
             # Clean up intermediate files
             rm -f "target/wasm-bundles/${ext_name}.wasm" "target/wasm-bundles/${ext_name}.capabilities.json"
@@ -474,19 +486,28 @@ jobs:
           while IFS= read -r line; do
             sha256=$(echo "$line" | awk '{print $1}')
             filename=$(echo "$line" | awk '{print $2}')
-            # Strip -{version}-wasm32-wasip2.tar.gz to get the extension name.
-            # Use '.*' (greedy) so pre-release suffixes like -alpha.1 are consumed too.
-            name=$(echo "$filename" | sed 's/-[0-9].*-wasm32-wasip2\.tar\.gz$//')
+            manifest=$(echo "$line" | awk '{print $3}')
             url="https://github.com/nearai/ironclaw/releases/download/${RELEASE_TAG}/${filename}"
 
-            for manifest in registry/tools/${name}.json registry/channels/${name}.json; do
-              if [ -f "$manifest" ]; then
-                jq --arg sha "$sha256" --arg url "$url" \
-                  '.artifacts["wasm32-wasip2"].sha256 = $sha | .artifacts["wasm32-wasip2"].url = $url' \
-                  "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
-                echo "Patched $manifest with sha256=$sha256 url=$url"
-              fi
-            done
+            if [ -z "$manifest" ]; then
+              # Backwards compat: old checksums.txt without manifest column.
+              name=$(echo "$filename" | sed 's/-[0-9].*-wasm32-wasip2\.tar\.gz$//')
+              for m in registry/tools/${name}.json registry/channels/${name}.json; do
+                if [ -f "$m" ]; then
+                  manifest="$m"
+                  break
+                fi
+              done
+            fi
+
+            if [ -f "$manifest" ]; then
+              jq --arg sha "$sha256" --arg url "$url" \
+                '.artifacts["wasm32-wasip2"].sha256 = $sha | .artifacts["wasm32-wasip2"].url = $url' \
+                "$manifest" > "${manifest}.tmp" && mv "${manifest}.tmp" "$manifest"
+              echo "Patched $manifest with sha256=$sha256 url=$url"
+            else
+              echo "::warning::No manifest found for $filename, skipping"
+            fi
           done < "$CHECKSUMS"
       - name: Create PR with updated manifests
         run: |


### PR DESCRIPTION


## Summary

<!-- 2-5 bullet points: what changed and why -->

 The release workflow writes checksums.txt with only filename and sha256,
  then reverse-engineers the extension name from the bundle filename to
  locate the manifest. When a tool manifest filename matches a channel
  manifest filename (e.g. registry/tools/telegram.json for telegram-mtproto
  and registry/channels/telegram.json for telegram), both manifests get
  patched by the same checksum entry, and the later iteration silently
  overwrites the earlier one with the wrong checksum.

  Fix by recording the exact manifest path as a third column in
  checksums.txt during the WASM build step, then using it directly in both
  patch steps (build-local-artifacts and update-registry-checksums).
  Includes backwards-compatible fallback for old-format checksums.txt
  without the manifest column.



## Change Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

  Fixes #939

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

None

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

None

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
