### PR TITLE
fix(ci): run gated test jobs during staging CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,8 +42,8 @@ jobs:
   telegram-tests:
     name: Telegram Channel Tests
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.base_ref != 'staging')
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -57,8 +57,8 @@ jobs:
   windows-build:
     name: Windows Build (${{ matrix.name }})
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.base_ref != 'staging')
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'staging'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -84,8 +84,8 @@ jobs:
   wasm-wit-compat:
     name: WASM WIT Compatibility
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.base_ref != 'staging')
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -107,8 +107,8 @@ jobs:
   docker-build:
     name: Docker Build
     if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && github.base_ref != 'staging')
+      github.event_name != 'pull_request' ||
+      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Four test jobs (`telegram-tests`, `windows-build`, `wasm-wit-compat`, `docker-build`) were **skipped** during staging CI because their `if` conditions only matched `push` and `pull_request` events
- When `staging-ci.yml` calls `test.yml` via `workflow_call`, `github.event_name` is `schedule` (inherited from the caller), matching neither condition
- Inverted the conditions to blocklist the one case we want to skip (PRs targeting staging) instead of allowlisting specific events

## Test plan
- [ ] Verify the four jobs run on the next scheduled staging CI (or manual `workflow_dispatch`)
- [ ] Verify the jobs are still skipped on PRs targeting staging
- [ ] Verify the jobs still run on PRs targeting main and pushes to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)