### PR TITLE
fix(registry): use versioned artifact URLs and checksums for all WASM manifests

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/discord-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/discord-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "efa1b9019fa33e243f8db1e1fcc732731d45836336bdd26ca19b6fe227ca8b69"
     }
   },
   "auth_summary": {

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-0.2.1-wasm32-wasip2.tar.gz",
+      "sha256": "d4667e35126986509d862bc3a0088777305d8f41c75de83c1e223b42312ede48"
     }
   },
   "auth_summary": {

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-0.2.2-wasm32-wasip2.tar.gz",
+      "sha256": "b9a83d5a2d1285ce0ec116b354336a1f245f893291ccb01dffbcaccf89d72aed"
     }
   },
   "auth_summary": {

--- a/registry/channels/whatsapp.json
+++ b/registry/channels/whatsapp.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/whatsapp-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/whatsapp-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "feb9194719d9bed796b070ab4dc30348dbfb5d3dec56f9f21e02d14137abab01"
     }
   },
   "auth_summary": {

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -19,8 +19,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/github-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/github-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "da9fac56b6f20197a415489bbaec9fefb085a5cf6324cab79ea48a47eb19c13b"
     }
   },
   "auth_summary": {

--- a/registry/tools/gmail.json
+++ b/registry/tools/gmail.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/gmail-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/gmail-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "ee9574e02e92bc1d481f1310eb88afd99ee52bf6971074ab33bd76bf99b34b1d"
     }
   },
   "auth_summary": {

--- a/registry/tools/google-calendar.json
+++ b/registry/tools/google-calendar.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-calendar-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-calendar-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "2fa47150ea222e787c122182ad6f4dfa2ffaf5fe490d05e8de887a76445f8d2d"
     }
   },
   "auth_summary": {

--- a/registry/tools/google-docs.json
+++ b/registry/tools/google-docs.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-docs-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-docs-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "40e134a1c1564f832ca861c3396895d4e33ec67b99313fc1f97baf8d971423a9"
     }
   },
   "auth_summary": {

--- a/registry/tools/google-drive.json
+++ b/registry/tools/google-drive.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-drive-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-drive-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "002a341a1d58125563a7c69561b26fbc2629b04ea723cade744102bdc0fbb71f"
     }
   },
   "auth_summary": {

--- a/registry/tools/google-sheets.json
+++ b/registry/tools/google-sheets.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-sheets-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-sheets-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "8aa2c9d52f033edea3a6c2311b0ec694ccb6d0a54ef07e94d72bf8be1ce8009a"
     }
   },
   "auth_summary": {

--- a/registry/tools/google-slides.json
+++ b/registry/tools/google-slides.json
@@ -17,8 +17,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-slides-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/google-slides-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "e931a97d4fd0b0b938e464dc7c7f2be6ea6b4d1508f5ea3cd931d44db23f05f5"
     }
   },
   "auth_summary": {

--- a/registry/tools/slack.json
+++ b/registry/tools/slack.json
@@ -17,8 +17,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-tool-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/slack-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "8af3f884240de8413d272845fad2164a347d7d2a502a0d148aa38425b93f62ed"
     }
   },
   "auth_summary": {

--- a/registry/tools/telegram.json
+++ b/registry/tools/telegram.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-mtproto-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "2c66245913854be4294021fc6bb479e43f7d65830c5cec25cf6c60a71d1af468"
     }
   },
   "auth_summary": {

--- a/registry/tools/web-search.json
+++ b/registry/tools/web-search.json
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/web-search-wasm32-wasip2.tar.gz",
-      "sha256": null
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/web-search-0.2.0-wasm32-wasip2.tar.gz",
+      "sha256": "56834573c54ea2a33cea1eb0f04bbdf59f1ef8d8702995cf431b0921302eeccc"
     }
   },
   "auth_summary": {


### PR DESCRIPTION
## Summary
- All 14 registry manifests (10 tools + 4 channels) referenced legacy unversioned filenames and/or null checksums, causing 404s on `ironclaw registry install`
- Updated with versioned artifact URLs and concrete SHA256 values from v0.18.0 `checksums.txt`
- Also fixed `slack-tool` and `telegram-mtproto` tool manifests which PR #960 missed -- these had incorrect artifact name prefixes (`slack-tool-wasm32-wasip2.tar.gz` vs actual `slack-0.2.0-wasm32-wasip2.tar.gz`)

## Validation
- All 14 manifest URLs return HTTP 200
- All 14 manifest SHA256 values match v0.18.0 `checksums.txt`
- Cross-referenced every manifest against `gh release view v0.18.0 --json assets`

## Files changed
### Tools (10)
- `registry/tools/github.json`
- `registry/tools/gmail.json`
- `registry/tools/google-calendar.json`
- `registry/tools/google-docs.json`
- `registry/tools/google-drive.json`
- `registry/tools/google-sheets.json`
- `registry/tools/google-slides.json`
- `registry/tools/slack.json` (was pointing to nonexistent `slack-tool-wasm32-wasip2.tar.gz`)
- `registry/tools/telegram.json` (was pointing to nonexistent `telegram-mtproto-wasm32-wasip2.tar.gz`)
- `registry/tools/web-search.json`

### Channels (4)
- `registry/channels/discord.json`
- `registry/channels/slack.json`
- `registry/channels/telegram.json`
- `registry/channels/whatsapp.json`

Supersedes #960
Fixes #958