### PR TITLE
test(html_to_markdown): refresh golden files after html-to-markdown-rs bump

### DIFF
--- a/tests/test-pages/medium/expected.md
+++ b/tests/test-pages/medium/expected.md
@@ -308,4 +308,4 @@ We’re trying out some new shoes. And while they’re not self-lacing, and
 
 [**pippin@pippinlee.com**](mailto:pippinblee@gmail.com)
 
-*This isn’t supposed to be a****manifesto™©*** *we just think it’s pretty cool to share what we’ve learned so far, and hope you’ll do the same. We’re all in this together.*
+*This isn’t supposed to be a* ***manifesto™©*** *we just think it’s pretty cool to share what we’ve learned so far, and hope you’ll do the same. We’re all in this together.*

--- a/tests/test-pages/yahoo/expected.md
+++ b/tests/test-pages/yahoo/expected.md
@@ -43,4 +43,4 @@ Already a hit on the Oculus Rift, this space dogfighting game was one of the fir
 - [Review: ‘Madden NFL 17’ runs hard, plays it safe](https://www.yahoo.com/tech/review-madden-nfl-17-runs-000000394.html)
 
 
-*Ben Silverman is on Twitter at*[*ben_silverman*](https://twitter.com/ben_silverman)*.*
+*Ben Silverman is on Twitter at* [*ben_silverman*](https://twitter.com/ben_silverman)*.*


### PR DESCRIPTION
Fixes the current red `staging` batch after the `html-to-markdown-rs` bump in the #758 range changed markdown rendering slightly.

This updates two golden files to match current converter output:
- `tests/test-pages/yahoo/expected.md`
- `tests/test-pages/medium/expected.md`

Validation:
- `cargo test --test html_to_markdown convert_test_pages_to_markdown -- --exact --nocapture`