### PR TITLE
perf(safety): single-pass escape_xml_attr

### DIFF
--- a/crates/ironclaw_safety/src/lib.rs
+++ b/crates/ironclaw_safety/src/lib.rs
@@ -252,8 +252,7 @@ mod tests {
         let safety = SafetyLayer::new(&config);
 
         let wrapped = safety.wrap_for_llm("bad&\"<>name", "ok", false);
-        // safety: test assertion in #[cfg(test)] module
-        assert!(wrapped.contains("name=\"bad&amp;&quot;&lt;&gt;name\""));
+        assert!(wrapped.contains("name=\"bad&amp;&quot;&lt;&gt;name\"")); // safety: test assertion in #[cfg(test)] module
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #1024 and Gemini review feedback.

## Changes
- Replace chained .replace(...) calls in escape_xml_attr with a single-pass char loop
- Preserve escaping behavior for &, ", <, >
- Add a unit test for attribute escaping in wrap_for_llm

## Validation
- cargo test -q -p ironclaw_safety
