### PR TITLE
fix(registry): bump telegram channel version for capabilities change

### DIFF
--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [
@@ -18,7 +18,7 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-0.2.2-wasm32-wasip2.tar.gz",
+      "url": "https://github.com/nearai/ironclaw/releases/latest/download/telegram-0.2.3-wasm32-wasip2.tar.gz",
       "sha256": "b9a83d5a2d1285ce0ec116b354336a1f245f893291ccb01dffbcaccf89d72aed"
     }
   },


### PR DESCRIPTION
## Summary
- Bumps telegram channel version 0.2.2 -> 0.2.3 to match the `validation_endpoint` addition in `telegram.capabilities.json`
- Unblocks staging promotion PR #1032 which fails the version-check CI gate

## Test plan
- [ ] CI version-check passes
- [ ] Staging promote #1032 can be re-run after merge

Generated with [Claude Code](https://claude.com/claude-code)