### PR TITLE
fix(web): make approval requests appear without page reload (#996)

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -1003,7 +1003,7 @@ function finalizeActivityGroup() {
 
 function showApproval(data) {
   // Avoid duplicate cards on reconnect/history refresh.
-  const existing = document.querySelector('.approval-card[data-request-id="' + data.request_id + '"]');
+  const existing = document.querySelector('.approval-card[data-request-id="' + CSS.escape(data.request_id) + '"]');
   if (existing) return;
 
   const container = document.getElementById('chat-messages');


### PR DESCRIPTION
## Summary
- handle `approval_needed` events even when `thread_id` is absent (show approval card immediately)
- for background-thread approvals, update unread counts and refresh thread list instead of dropping the event silently
- refresh Extensions tab on approval events so setup state updates in real time
- dedupe approval cards by `request_id` to avoid duplicates on reconnect/history refresh

## Why
Issue #996 reports users needing to reload before approval UI appears. The frontend previously dropped `approval_needed` when `thread_id` was missing/mismatched, and did not refresh Extensions state on approval events.

## Validation
- manual code-path review of SSE approval flow and history fallback

Closes #996
