### PR TITLE
fix(service): set CLI_ENABLED=false in macOS launchd plist

### DIFF
--- a/src/service.rs
+++ b/src/service.rs
@@ -374,7 +374,6 @@ mod tests {
     fn macos_plist_sets_cli_enabled_false() {
         let plist = macos_plist_content("/tmp/ironclaw", "/tmp/stdout.log", "/tmp/stderr.log");
         assert!(plist.contains("<key>EnvironmentVariables</key>"));
-        assert!(plist.contains("<key>CLI_ENABLED</key>"));
-        assert!(plist.contains("<string>false</string>"));
+        assert!(plist.contains("    <key>CLI_ENABLED</key>\n    <string>false</string>"));
     }
 }


### PR DESCRIPTION
## Summary
- add `EnvironmentVariables` to the macOS launchd plist generated by `ironclaw service install`
- set `CLI_ENABLED=false` for macOS services to match Linux systemd behavior
- add a unit test to assert the plist includes the `CLI_ENABLED=false` environment value

## Why
Linux service installation already disables the interactive CLI via `Environment="CLI_ENABLED=false"`, but macOS launchd installation did not. This creates inconsistent daemon behavior across platforms.

Closes #989
