### PR TITLE
feat(embeddings): add EMBEDDING_BASE_URL for OpenAI-compatible embedding providers

### DIFF
--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -137,6 +137,11 @@ impl EmbeddingsConfig {
             }
             _ => {
                 if let Some(api_key) = self.openai_api_key() {
+                    let mut provider = crate::workspace::OpenAiEmbeddings::with_model(
+                        api_key,
+                        &self.model,
+                        self.dimension,
+                    );
                     if let Some(ref base_url) = self.openai_base_url {
                         tracing::debug!(
                             "Embeddings enabled via OpenAI (model: {}, base_url: {}, dim: {})",
@@ -144,20 +149,13 @@ impl EmbeddingsConfig {
                             base_url,
                             self.dimension,
                         );
+                        provider = provider.with_base_url(base_url);
                     } else {
                         tracing::debug!(
                             "Embeddings enabled via OpenAI (model: {}, dim: {})",
                             self.model,
                             self.dimension,
                         );
-                    }
-                    let mut provider = crate::workspace::OpenAiEmbeddings::with_model(
-                        api_key,
-                        &self.model,
-                        self.dimension,
-                    );
-                    if let Some(ref base_url) = self.openai_base_url {
-                        provider = provider.with_base_url(base_url);
                     }
                     Some(Arc::new(provider))
                 } else {

--- a/src/workspace/embeddings.rs
+++ b/src/workspace/embeddings.rs
@@ -133,7 +133,7 @@ impl OpenAiEmbeddings {
         let url = base_url.trim();
 
         // Auto-prepend https:// if no scheme is present.
-        let url = if !url.starts_with("http://") && !url.starts_with("https://") {
+        let mut url = if !url.starts_with("http://") && !url.starts_with("https://") {
             tracing::debug!(
                 "No scheme in embedding base URL '{}', prepending https://",
                 url
@@ -143,7 +143,11 @@ impl OpenAiEmbeddings {
             url.to_string()
         };
 
-        self.base_url = url.trim_end_matches('/').to_string();
+        while url.ends_with('/') {
+            url.pop();
+        }
+
+        self.base_url = url;
         self
     }
 }


### PR DESCRIPTION
## Summary

Adds configurable base URL support for OpenAI-compatible embedding providers, enabling use with OpenRouter, LiteLLM, Azure, and other compatible endpoints.

- **`EMBEDDING_BASE_URL` env var** — overrides the default `https://api.openai.com`
- **`with_base_url()` builder** — programmatic configuration with URL validation
- **Auto-prepends `https://`** for schemeless URLs (e.g. `openrouter.ai/api` → `https://openrouter.ai/api`)
- **Strips trailing slashes** for consistent URL formatting
- **Extracted `OPENAI_API_BASE_URL` constant** — no more magic strings

Supersedes #378 — rebased and rewritten from scratch on current `main` to address all review feedback.

### Review feedback addressed
- Extracted hardcoded URL to `OPENAI_API_BASE_URL` constant (Gemini)
- No silent fallback on invalid scheme — auto-prepends `https://` instead (@serrrfirat)
- `clear_embedding_env()` now cleans `EMBEDDING_BASE_URL` (@zmanian)
- Debug log includes custom base URL when set (@zmanian)
- Unit tests for `with_base_url()`: valid URL, trailing slash strip, http scheme, schemeless auto-prepend (@serrrfirat)
- Config tests for env var parsing and default-to-None (@serrrfirat)
- Removed unnecessary `.clone()` (Gemini)

## Changes
- `src/workspace/embeddings.rs` — `base_url` field, `OPENAI_API_BASE_URL` const, `with_base_url()`, updated `embed_batch()`
- `src/config/embeddings.rs` — `openai_base_url` field, `EMBEDDING_BASE_URL` env var, debug logging

## Test plan
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo fmt --check` — clean
- [x] 4 new unit tests for `with_base_url()` behavior
- [x] 2 new config tests for env var parsing
- [x] All existing embedding tests pass
- [ ] Manual: set `EMBEDDING_BASE_URL=https://openrouter.ai/api` and verify embeddings work