### PR TITLE
fix(ci): repair staging-ci workflow parsing

### DIFF
--- a/.github/workflows/staging-ci.yml
+++ b/.github/workflows/staging-ci.yml
@@ -194,8 +194,7 @@ jobs:
             COMMIT_COUNT=$(echo "$COMMIT_LIST" | wc -l | tr -d ' ')
             if [ "$COMMIT_COUNT" -gt "$MAX_COMMITS" ]; then
               COMMIT_MD=$(echo "$COMMIT_LIST" | head -n "$MAX_COMMITS" | sed 's/^/- /')
-              COMMIT_MD="${COMMIT_MD}
-- ... and $((COMMIT_COUNT - MAX_COMMITS)) more (see compare view)"
+              COMMIT_MD+=$'\n'"- ... and $((COMMIT_COUNT - MAX_COMMITS)) more (see compare view)"
             else
               COMMIT_MD=$(echo "$COMMIT_LIST" | sed 's/^/- /')
             fi


### PR DESCRIPTION
This repairs the `staging-ci.yml` parse failure introduced in `c7dec64`.

The workflow was failing before any jobs were created because a multiline shell assignment in the promotion PR commit-summary block broke YAML parsing.

Validation:
- `actionlint -ignore 'SC2001|SC2129' .github/workflows/staging-ci.yml .github/workflows/test.yml .github/workflows/e2e.yml`