### PR TITLE
fix(ci): checkout promotion PR head for metadata refresh

### DIFF
--- a/.github/workflows/staging-promotion-metadata.yml
+++ b/.github/workflows/staging-promotion-metadata.yml
@@ -31,10 +31,12 @@ jobs:
       github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout base branch
+      - name: Checkout workflow source
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.event.pull_request.base.ref }}
+          # For chained promotion PRs, the script lives on the trusted PR head,
+          # not necessarily on the older promotion branch used as the PR base.
+          ref: ${{ github.event_name == 'workflow_dispatch' && 'main' || github.event.pull_request.head.sha }}
           fetch-depth: 0
           fetch-tags: true
 


### PR DESCRIPTION
## Summary
Fix `staging-promotion-metadata.yml` for chained promotion PRs by checking out the trusted PR head SHA on `pull_request_target` runs instead of the PR base ref.

## Root cause
For chained promotion PRs like `#1096`, the PR base is an older `staging-promote/*` branch that may not contain `.github/scripts/update-staging-promotion-body.sh`. The metadata workflow was checking out that base branch, so the refresh step failed with `bash: .github/scripts/update-staging-promotion-body.sh: No such file or directory`.

## Change
- keep `workflow_dispatch` on `main`
- use `github.event.pull_request.head.sha` for the trusted same-repo `pull_request_target` path
- rename the checkout step to reflect that it is checking out workflow source rather than the PR base

## Validation
- `actionlint .github/workflows/staging-promotion-metadata.yml`
- YAML parse of `.github/workflows/staging-promotion-metadata.yml`

## Follow-up
After merge, re-run the failed metadata workflow for `#1096` and confirm the PR body refresh succeeds.