### PR TITLE
fix(ci): discord missing attachments field + Dockerfile crates/ copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ WORKDIR /app
 
 # Copy manifests first for layer caching
 COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
 
 # Copy source, build script, tests, and supporting directories
 COPY build.rs build.rs

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
 COPY build.rs build.rs
 COPY src/ src/
 COPY tests/ tests/

--- a/channels-src/discord/Cargo.lock
+++ b/channels-src/discord/Cargo.lock
@@ -121,7 +121,7 @@ dependencies = [
 
 [[package]]
 name = "discord-channel"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ed25519-dalek",
  "hex",

--- a/channels-src/discord/src/lib.rs
+++ b/channels-src/discord/src/lib.rs
@@ -642,6 +642,7 @@ fn poll_channel_mentions(channel_id: &str, bot_id: &str) {
             },
             thread_id: None,
             metadata_json,
+            attachments: vec![],
         });
 
         remember_processed_id(&mut recent_ids, &msg.id);


### PR DESCRIPTION
## Summary
- Add missing `attachments: vec![]` field to `EmittedMessage` in discord channel (`channels-src/discord/src/lib.rs`) — the other two call sites already had it
- Add `COPY crates/ crates/` to `Dockerfile` and `Dockerfile.test` so the extracted `ironclaw_safety` crate is available during Docker builds

Fixes staging CI run [#23035039465](https://github.com/nearai/ironclaw/actions/runs/23035039465) (5 failing jobs).

## Test plan
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test` — all tests pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)