### PR TITLE
fix(registry): bump versions for github, web-search, and discord

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -2,7 +2,7 @@
   "name": "discord",
   "display_name": "Discord Channel",
   "kind": "channel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Discord",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "GitHub integration for issues, PRs, repos, and code search",
   "keywords": [

--- a/registry/tools/web-search.json
+++ b/registry/tools/web-search.json
@@ -2,7 +2,7 @@
   "name": "web-search",
   "display_name": "Web Search",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Search the web using Brave Search API",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `registry/tools/github.json` version from 0.2.0 to 0.2.1
- Bump `registry/tools/web-search.json` version from 0.2.0 to 0.2.1
- Bump `registry/channels/discord.json` version from 0.2.0 to 0.2.1

These source directories had changes without corresponding registry version bumps, causing `check-version-bumps.sh` to fail in CI.

## Test plan
- [x] `./scripts/check-version-bumps.sh` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)