### PR TITLE
fix(routines): refresh event cache after web mutations and on ticker

### DIFF
--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1270,12 +1270,14 @@ pub fn spawn_cron_ticker(
     tokio::spawn(async move {
         // Run one check immediately so routines due at startup don't wait
         // an extra full polling interval.
+        engine.refresh_event_cache().await;
         engine.check_cron_triggers().await;
 
         let mut ticker = tokio::time::interval(interval);
 
         loop {
             ticker.tick().await;
+            engine.refresh_event_cache().await;
             engine.check_cron_triggers().await;
         }
     })

--- a/src/channels/web/handlers/routines.rs
+++ b/src/channels/web/handlers/routines.rs
@@ -215,10 +215,7 @@ pub async fn routines_toggle_handler(
         .update_routine(&routine)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    // Refresh the in-memory event trigger cache so event/system_event
-    // routines reflect the new enabled state immediately (issue #1076).
-    if let Some(engine) = state.routine_engine.read().await.as_ref() {
+    if let Some(engine) = state.routine_engine.read().await.as_ref().cloned() {
         engine.refresh_event_cache().await;
     }
 
@@ -246,12 +243,9 @@ pub async fn routines_delete_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     if deleted {
-        // Refresh the in-memory event trigger cache so deleted event/system_event
-        // routines stop firing immediately (issue #1076).
-        if let Some(engine) = state.routine_engine.read().await.as_ref() {
+        if let Some(engine) = state.routine_engine.read().await.as_ref().cloned() {
             engine.refresh_event_cache().await;
         }
-
         Ok(Json(serde_json::json!({
             "status": "deleted",
             "routine_id": routine_id,

--- a/tests/e2e_routine_heartbeat.rs
+++ b/tests/e2e_routine_heartbeat.rs
@@ -17,7 +17,7 @@ mod tests {
     use ironclaw::agent::routine::{
         NotifyConfig, Routine, RoutineAction, RoutineGuardrails, Trigger,
     };
-    use ironclaw::agent::routine_engine::RoutineEngine;
+    use ironclaw::agent::routine_engine::{RoutineEngine, spawn_cron_ticker};
     use ironclaw::agent::{HeartbeatConfig, HeartbeatRunner};
     use ironclaw::channels::IncomingMessage;
     use ironclaw::config::{RoutineConfig, SafetyConfig};
@@ -498,6 +498,102 @@ mod tests {
             fired_filter_case, 1,
             "Expected case-insensitive match on filter values"
         );
+    }
+
+    #[tokio::test]
+    async fn out_of_band_event_enable_converges_via_ticker_refresh() {
+        let (db, _tmp) = create_test_db().await;
+        let ws = create_workspace(&db);
+
+        let trace = LlmTrace::single_turn(
+            "test-system-event-out-of-band-enable",
+            "event",
+            vec![TraceStep {
+                request_hint: None,
+                response: TraceResponse::Text {
+                    content: "System event handled".to_string(),
+                    input_tokens: 40,
+                    output_tokens: 8,
+                },
+                expected_tool_results: vec![],
+            }],
+        );
+        let llm = Arc::new(TraceLlm::from_trace(trace));
+        let (notify_tx, _notify_rx) = tokio::sync::mpsc::channel(16);
+
+        let tools = Arc::new(ToolRegistry::new());
+        let safety_config = SafetyConfig {
+            max_output_length: 100_000,
+            injection_check_enabled: true,
+        };
+        let safety = Arc::new(SafetyLayer::new(&safety_config));
+
+        let engine = Arc::new(RoutineEngine::new(
+            RoutineConfig::default(),
+            db.clone(),
+            llm,
+            ws,
+            notify_tx,
+            None,
+            tools,
+            safety,
+        ));
+
+        let routine = make_routine(
+            "out-of-band-system-event",
+            Trigger::SystemEvent {
+                source: "github".to_string(),
+                event_type: "issue.opened".to_string(),
+                filters: std::collections::HashMap::new(),
+            },
+            "Summarize event",
+        );
+        db.create_routine(&routine).await.expect("create_routine");
+
+        // Start with routine disabled and refresh cache (so it is absent).
+        let mut disabled = routine.clone();
+        disabled.enabled = false;
+        db.update_routine(&disabled).await.expect("disable routine");
+        engine.refresh_event_cache().await;
+
+        let fired_disabled = engine
+            .emit_system_event(
+                "github",
+                "issue.opened",
+                &serde_json::json!({"repository": "nearai/ironclaw"}),
+                Some("default"),
+            )
+            .await;
+        assert_eq!(fired_disabled, 0, "disabled routine should not fire");
+
+        // Start ticker with short interval and enable routine out-of-band via DB.
+        let ticker = spawn_cron_ticker(Arc::clone(&engine), Duration::from_millis(100));
+        let mut enabled = disabled;
+        enabled.enabled = true;
+        db.update_routine(&enabled).await.expect("enable routine");
+
+        // Wait for periodic refresh to converge cache state.
+        let mut fired_enabled = 0usize;
+        for _ in 0..20 {
+            fired_enabled = engine
+                .emit_system_event(
+                    "github",
+                    "issue.opened",
+                    &serde_json::json!({"repository": "nearai/ironclaw"}),
+                    Some("default"),
+                )
+                .await;
+            if fired_enabled >= 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            fired_enabled >= 1,
+            "enabled out-of-band routine should fire after periodic refresh"
+        );
+
+        ticker.abort();
     }
 
     #[tokio::test]

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -260,4 +260,102 @@ mod tests {
         harness.shutdown().await;
         mock.shutdown().await;
     }
+
+    #[tokio::test]
+    async fn web_toggle_disables_system_event_routine_without_restart() {
+        let mock = MockOpenAiServerBuilder::new()
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "create webhook routine",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_create_webhook_1",
+                    "routine_create",
+                    serde_json::json!({
+                        "name": "wf-toggle-system-event",
+                        "description": "System event toggle regression test",
+                        "trigger_type": "system_event",
+                        "event_source": "github",
+                        "event_type": "issue.opened",
+                        "event_filters": {"repository": "nearai/ironclaw"},
+                        "action_type": "lightweight",
+                        "prompt": "summarize issue"
+                    }),
+                )]),
+            ))
+            .with_default_response(MockOpenAiResponse::Text("ack".to_string()))
+            .start()
+            .await;
+
+        let harness =
+            GatewayWorkflowHarness::start_openai_compatible(&mock.openai_base_url(), "mock-model")
+                .await;
+
+        let thread_id = harness.create_thread().await;
+        harness
+            .send_chat(&thread_id, "create webhook routine")
+            .await;
+        harness
+            .wait_for_turns(&thread_id, 1, Duration::from_secs(10))
+            .await;
+
+        let routine = harness
+            .routine_by_name("wf-toggle-system-event")
+            .await
+            .expect("routine should exist");
+        let routine_id = routine
+            .get("id")
+            .and_then(|v| v.as_str())
+            .expect("routine id missing");
+
+        let runs_before = harness.routine_runs(routine_id).await;
+        let before_count = runs_before["runs"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or_default();
+
+        // Disable through web API (non-tool mutation path).
+        harness
+            .client
+            .post(format!(
+                "{}/api/routines/{routine_id}/toggle",
+                harness.base_url()
+            ))
+            .bearer_auth(&harness.auth_token)
+            .json(&serde_json::json!({ "enabled": false }))
+            .send()
+            .await
+            .expect("disable toggle request failed")
+            .error_for_status()
+            .expect("disable toggle non-2xx");
+
+        let hook = harness
+            .github_webhook(
+                "issues",
+                serde_json::json!({
+                    "action": "opened",
+                    "repository": {"full_name": "nearai/ironclaw"},
+                    "issue": {"number": 881, "title": "Toggle disable regression"}
+                }),
+            )
+            .await;
+        assert_eq!(hook["status"], "accepted");
+        assert_eq!(hook["emitted_events"], 1);
+        assert_eq!(
+            hook["fired_routines"].as_u64().unwrap_or(0),
+            0,
+            "disabled routine should not fire after web toggle"
+        );
+
+        let runs_after = harness.routine_runs(routine_id).await;
+        let after_count = runs_after["runs"]
+            .as_array()
+            .map(|a| a.len())
+            .unwrap_or_default();
+        assert_eq!(
+            after_count, before_count,
+            "run count should not increase for disabled routine"
+        );
+
+        harness.shutdown().await;
+        mock.shutdown().await;
+    }
 }


### PR DESCRIPTION
## Summary
- refresh the routine engine event cache after web routine toggle/delete mutations
- add periodic event-cache refresh to the routine ticker loop for convergence on out-of-band DB/CLI changes
- add regression coverage for:
  - non-tool mutation path (`/api/routines/{id}/toggle` disabling a system_event routine)
  - out-of-band mutation path (direct DB enable converges via ticker refresh)

## Why
Issue #1076 identified stale in-memory event matcher state when routine mutations happen outside built-in routine tools. This caused inconsistent behavior in long-running agents.

Closes #1076
