### PR TITLE
feat(orchestrator): read ORCHESTRATOR_PORT env var for configurable API port

### DIFF
--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -164,12 +164,19 @@ pub async fn setup_orchestrator(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
 
-    /// Env-var tests must run sequentially since they mutate shared process state.
+    /// Serialize access to `ORCHESTRATOR_PORT` env var across test threads.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn resolve_orchestrator_port_from_env() {
-        // Safety: single test function, no parallel mutation of this env var.
+        let _guard = ENV_LOCK.lock().unwrap();
+
+        // Safety: env-var mutation requires unsafe in edition 2024;
+        // ENV_LOCK serializes concurrent access from other test threads.
 
         // Absent env var → default 50051
         unsafe { std::env::remove_var("ORCHESTRATOR_PORT") };


### PR DESCRIPTION
## Summary

- The orchestrator internal API port was **hardcoded to 50051** in `setup_orchestrator()`, both for `ContainerJobConfig` and the `OrchestratorApi::start()` call. This makes it impossible to run multiple instances on the same host — the second gets `Address already in use`.
- `NETWORK_SECURITY.md` already documents `ORCHESTRATOR_PORT` as configurable, and `ContainerJobConfig.orchestrator_port` is correctly propagated to worker containers via `IRONCLAW_ORCHESTRATOR_URL`, but the env var was **never actually read**.
- Extract `resolve_orchestrator_port()` that reads `ORCHESTRATOR_PORT` env var with fallback to 50051. Single function, single file change.

## Changes

**`src/orchestrator/mod.rs`**
- Add `resolve_orchestrator_port()` — reads `ORCHESTRATOR_PORT` env var, falls back to 50051
- Use it in `setup_orchestrator()` for both `ContainerJobConfig` and `OrchestratorApi::start()`
- Add test covering: default (no env var), valid custom port, non-numeric fallback, out-of-range fallback

## Motivation

Running two IronClaw instances on a single server (e.g., dual-user deployment with separate `IRONCLAW_BASE_DIR`, databases, and gateway ports). Without this fix, the second instance cannot start its orchestrator — sandbox functionality is completely broken for that instance.

## Test plan

- [ ] `cargo test -p ironclaw --lib orchestrator::tests` — new test passes
- [ ] `cargo clippy --all --all-features` — zero warnings
- [ ] Verify no `.unwrap()` / `.expect()` in production code paths
- [ ] Manual: set `ORCHESTRATOR_PORT=50052` → orchestrator binds to 50052, workers connect via correct URL