### PR TITLE
fix(skill): treat empty url param as absent when installing skills

### DIFF
--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -301,7 +301,11 @@ impl Tool for SkillInstallTool {
         let content = if let Some(raw) = params.get("content").and_then(|v| v.as_str()) {
             // Direct content provided
             raw.to_string()
-        } else if let Some(url) = params.get("url").and_then(|v| v.as_str()) {
+        } else if let Some(url) = params
+            .get("url")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+        {
             // Fetch from explicit URL
             fetch_skill_content(url).await?
         } else {
@@ -1296,5 +1300,24 @@ mod tests {
                 url
             );
         }
+    }
+
+    #[test]
+    fn test_empty_url_param_is_treated_as_absent() {
+        // LLMs sometimes pass "" for optional parameters instead of omitting them.
+        // Before the fix, url: "" would match Some("") and attempt to fetch from an
+        // empty URL (failing with an invalid URL error) instead of falling through to
+        // the catalog lookup. The full execute path cannot be tested here without a
+        // real catalog and database, so this test verifies the parameter filtering
+        // behaviour directly.
+        let params = serde_json::json!({"name": "my-skill", "url": ""});
+        let url = params
+            .get("url")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
+        assert!(
+            url.is_none(),
+            "empty url string should be treated as absent"
+        );
     }
 }


### PR DESCRIPTION
## Problem

LLMs sometimes pass `""` for optional parameters instead of omitting them. Passing `url: ""` to `skill_install` caused the explicit-URL branch to match, attempting to fetch from an empty string and failing with an invalid URL error — instead of falling through to the catalog lookup as intended.

## Fix

Add `.filter(|s| !s.is_empty())` to the `url` parameter extraction so an empty string is treated the same as a missing field.

## Tests

A unit test verifies the parameter filtering behaviour directly. The full execute path (catalog lookup + install) requires a real catalog and database and cannot be covered at the unit level.

## Related

This is the same class of issue described in #1126 — LLMs expressing "optional param not provided" as `""` rather than omitting the field. That issue covers `time` / `routine`; this PR addresses the same pattern in `skill_install`.

PR #1127 fixes the `time` tool variant. Open to feedback on whether a more centralised normalisation layer (as explored in #755) would be preferred over per-tool fixes.