### PR TITLE
fix(web): prevent Safari IME composition Enter from sending message

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -1688,8 +1688,9 @@ chatInput.addEventListener('keydown', (e) => {
     }
   }
 
-  // keyCode 229 (VK_PROCESS) filters out IME-handled Enter on Safari, where
-  // compositionend fires before keydown leaving e.isComposing already false.
+  // Safari fires compositionend before keydown, so e.isComposing is already false
+  // when Enter confirms IME input. keyCode 229 (VK_PROCESS) catches this case.
+  // See https://bugs.webkit.org/show_bug.cgi?id=165004
   if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
     e.preventDefault();
     hideSlashAutocomplete();


### PR DESCRIPTION
Fixes #1139

## Problem

On Safari (macOS), pressing **Enter** to confirm CJK (Chinese/Japanese/Korean) IME input in the chat textarea sends the message immediately instead of just committing the composed text.

**Root cause:** Safari fires `compositionend` *before* `keydown` — the opposite of Chrome and Firefox. By the time the `keydown` handler runs, `e.isComposing` is already `false`, so the existing guard is bypassed.

Reference: [WebKit bug 165004](https://bugs.webkit.org/show_bug.cgi?id=165004)

## Fix

Safari sets `e.keyCode` to `229` (`VK_PROCESS`) on every `keydown` event processed by the IME, including the confirmation Enter. This value is defined in the W3C UIEvents spec as the IME-processing sentinel and is never generated by a physical key on any keyboard layout.

```diff
- if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+ // keyCode 229 (VK_PROCESS) filters out IME-handled Enter on Safari, where
+ // compositionend fires before keydown leaving e.isComposing already false.
+ if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
```

## Impact

- **Safari + CJK IME:** IME confirmation Enter no longer sends the message ✓
- **Chrome / Firefox:** `e.isComposing` already handles these correctly; `keyCode !== 229` is a no-op ✓
- **All keyboard layouts / locales:** `keyCode 229` is never produced by a physical key; no regression risk ✓

## Test Plan

- [ ] macOS Safari — type with Chinese/Japanese/Korean input method, press Enter to confirm candidate → message should NOT send
- [ ] macOS Safari — press Enter normally (no IME active) → message should send
- [ ] Chrome / Firefox — same two cases above → behavior unchanged