### PR TITLE
fix(ci): exclude ironclaw_safety from release automation

### DIFF
--- a/crates/ironclaw_safety/Cargo.toml
+++ b/crates/ironclaw_safety/Cargo.toml
@@ -6,6 +6,12 @@ rust-version = "1.92"
 description = "Prompt injection defense, input validation, secret leak detection, and safety policy enforcement"
 authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
+homepage = "https://github.com/nearai/ironclaw"
+repository = "https://github.com/nearai/ironclaw"
+publish = false
+
+[package.metadata.dist]
+dist = false
 
 [dependencies]
 aho-corasick = "1"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,6 @@
 [workspace]
 git_release_enable = false
+
+[[package]]
+name = "ironclaw_safety"
+release = false


### PR DESCRIPTION
## Summary

- add missing repository and homepage metadata to `crates/ironclaw_safety/Cargo.toml`
- mark `ironclaw_safety` as `publish = false` and `dist = false` so cargo-dist will not try to release it
- configure `release-plz` with `release = false` for `ironclaw_safety` so package-specific release tags are not generated
- keep the change scoped to release metadata only; no runtime behavior changes

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [x] Relevant tests pass: `cargo check -p ironclaw_safety`
- [ ] Manual testing: not run

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches release metadata for the extracted `ironclaw_safety` workspace crate and the `release-plz` package config. The main risk is only to release automation for that crate and future package-tag generation.

## Rollback Plan

Revert commit `87935a9` to restore the previous release behavior.

---

**Review track**: C