### PR TITLE
fix: preserve AuthError type in oauth_http_client cache

### DIFF
--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -1517,7 +1517,7 @@ mod tests {
         let cloned = original.clone();
 
         match cloned {
-            AuthError::Http(message) => assert_eq!(message, "builder failed"),
+            AuthError::Http(message) => assert_eq!(message, "builder failed"), // safety: test assertion in #[cfg(test)] module; not production panic path
             other => panic!("expected AuthError::Http variant, got {other:?}"),
         }
     }


### PR DESCRIPTION
## Summary
- change `oauth_http_client()` static cache type from `Result<Client, String>` to `Result<Client, AuthError>`
- map reqwest client build failures directly to `AuthError::Http`
- return cached errors via clone without string round-tripping

## Why
Issue #1141 reported that we were storing stringified errors in the static cache and only re-wrapping at read time. This loses typed error context in the cache path and adds unnecessary conversion.

Fixes #1141

## Validation
- `cargo test -p ironclaw tools::mcp::auth::tests::test_auth_error_display_strings -- --nocapture`
- `cargo clippy -p ironclaw --all-targets -- -D warnings`
