### PR TITLE
perf(mcp): eliminate SSE buffer churn in streaming parser

### DIFF
--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -212,9 +212,10 @@ impl HttpMcpTransport {
                     }
                 }
             }
-            // Keep only the unprocessed trailing fragment.
+            // Keep only the unprocessed trailing fragment without allocating
+            // a new String each iteration.
             if remaining_start > 0 {
-                buffer = buffer[remaining_start..].to_string();
+                buffer.drain(..remaining_start);
             }
         }
 


### PR DESCRIPTION
## Summary
- replace per-chunk trailing-slice reallocation (`buffer = buffer[remaining_start..].to_string()`) with in-place compaction (`buffer.drain(..remaining_start)`)
- keep SSE parser behavior unchanged while removing repeated allocations in the hot streaming loop

## Why
Issue #1142 identified avoidable allocation churn in `parse_sse_response` for large/many chunks. Reallocating a new `String` each loop iteration is unnecessary and can degrade throughput.

This change keeps the same parser semantics but reuses the existing buffer capacity.

Closes #1142

## Validation
- `cargo fmt --all`
- `cargo test -p ironclaw tools::mcp::http_transport::tests::test_http_transport_creation -- --nocapture`
- `cargo clippy -p ironclaw --all-targets -- -D warnings`
