### PR TITLE
Make no-panics CI check test-aware

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -86,6 +86,9 @@ jobs:
       uses: actions/checkout@v6
       with:
         fetch-depth: 0
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
     - name: Check for .unwrap(), .expect(), assert!() in production code
       run: |
         BASE="${{ github.event.pull_request.base.sha }}"

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -266,6 +266,7 @@ def main() -> int:
 
     print("::error::Found panic-style calls outside test-only Rust code.")
     print("Production code must use proper error handling instead of panicking.")
+    print("Suppress false positives with an inline '// safety: <reason>' comment.")
     print("")
     for path, line_no, line in violations[:20]:
         print(f"{path}:{line_no}: {line}")


### PR DESCRIPTION
## Summary
Replace the grep-based `No panics in production code` check with a small Rust-aware Python script.

## Why
The existing job scans added lines only and produces false positives for `assert!` / `expect()` inside `#[cfg(test)]` modules in `src/**/*.rs`.

## What changed
- add `scripts/check_no_panics.py`
- map added Rust line numbers from `git diff`
- track `#[cfg(test)]`, `#[test]`, and `mod tests` scopes with brace-aware parsing
- keep honoring inline `// safety:` suppressions for explicit local invariants
- call the script from `.github/workflows/code_style.yml`

## Validation
- `python3 scripts/check_no_panics.py --self-test`
- `python3 scripts/check_no_panics.py --base origin/staging --head HEAD`
- `python3 -m py_compile scripts/check_no_panics.py`
