### PR TITLE
chore(registry): align manifest versions with published artifact URLs

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -2,7 +2,7 @@
   "name": "discord",
   "display_name": "Discord Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Discord",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "wit_version": "0.3.0",
   "description": "GitHub integration for issues, PRs, repos, and code search",
   "keywords": [

--- a/registry/tools/web-search.json
+++ b/registry/tools/web-search.json
@@ -2,7 +2,7 @@
   "name": "web-search",
   "display_name": "Web Search",
   "kind": "tool",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "wit_version": "0.3.0",
   "description": "Search the web using Brave Search API",
   "keywords": [


### PR DESCRIPTION
## Summary
Align three registry manifests so declared `version` matches the artifact URL version for published `v0.18.0` assets.

Updated:
- `registry/channels/discord.json`
- `registry/tools/github.json`
- `registry/tools/web-search.json`

All three now declare `"version": "0.2.0"`, matching their `...-0.2.0-wasm32-wasip2.tar.gz` artifact URLs.

## Why
Staging CI flagged a mismatch where manifest versions were `0.2.1` but URLs still pointed to `0.2.0` artifacts.

## Validation
- Verified `v0.18.0` release assets for these entries are currently:
  - `discord-0.2.0-wasm32-wasip2.tar.gz`
  - `github-0.2.0-wasm32-wasip2.tar.gz`
  - `web-search-0.2.0-wasm32-wasip2.tar.gz`
- Verified each updated manifest has matching `version` and artifact URL suffix.

Closes #1150
