### PR TITLE
fix(channels): use live owner binding during wasm hot activation

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -4766,16 +4766,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_current_channel_owner_id_uses_runtime_state() {
+    async fn test_current_channel_owner_id_uses_runtime_state() -> Result<(), String> {
         let manager = make_manager_with_temp_dirs();
-        assert_eq!(manager.current_channel_owner_id("telegram").await, None);
+        if manager.current_channel_owner_id("telegram").await.is_some() {
+            return Err("expected no owner id for telegram before runtime setup".to_string());
+        }
 
         let channels = Arc::new(crate::channels::ChannelManager::new());
         let runtime = Arc::new(
             crate::channels::wasm::WasmChannelRuntime::new(
                 crate::channels::wasm::WasmChannelRuntimeConfig::default(),
             )
-            .expect("runtime"),
+            .map_err(|e| format!("runtime init failed: {e}"))?,
         );
         let pairing_store = Arc::new(crate::pairing::PairingStore::new());
         let router = Arc::new(crate::channels::wasm::WasmChannelRouter::new());
@@ -4786,11 +4788,101 @@ mod tests {
             .set_channel_runtime(channels, runtime, pairing_store, router, owner_ids)
             .await;
 
-        assert_eq!(
-            manager.current_channel_owner_id("telegram").await,
-            Some(12345_i64)
+        if manager.current_channel_owner_id("telegram").await != Some(12345_i64) {
+            return Err("expected runtime owner id fast-path for telegram".to_string());
+        }
+        if manager.current_channel_owner_id("slack").await.is_some() {
+            return Err("expected no owner id for slack".to_string());
+        }
+
+        Ok(())
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_current_channel_owner_id_uses_store_fallback() -> Result<(), String> {
+        use crate::db::{Database, SettingsStore};
+
+        let dir = tempfile::tempdir().map_err(|e| format!("tempdir failed: {e}"))?;
+        let db_path = dir.path().join("owner-id.db");
+
+        let db = Arc::new(
+            crate::db::libsql::LibSqlBackend::new_local(&db_path)
+                .await
+                .map_err(|e| format!("create local libsql backend failed: {e}"))?,
         );
-        assert_eq!(manager.current_channel_owner_id("slack").await, None);
+        db.run_migrations()
+            .await
+            .map_err(|e| format!("run libsql migrations failed: {e}"))?;
+
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = dir.path().join("channels");
+        std::fs::create_dir_all(&tools_dir).ok();
+        std::fs::create_dir_all(&channels_dir).ok();
+
+        use crate::secrets::{InMemorySecretsStore, SecretsCrypto};
+        use crate::testing::credentials::TEST_CRYPTO_KEY;
+        use crate::tools::ToolRegistry;
+        use crate::tools::mcp::process::McpProcessManager;
+        use crate::tools::mcp::session::McpSessionManager;
+
+        let master_key = secrecy::SecretString::from(TEST_CRYPTO_KEY.to_string());
+        let crypto = Arc::new(
+            SecretsCrypto::new(master_key)
+                .map_err(|e| format!("create secrets crypto failed: {e}"))?,
+        );
+
+        let manager = ExtensionManager::new(
+            Arc::new(McpSessionManager::new()),
+            Arc::new(McpProcessManager::new()),
+            Arc::new(InMemorySecretsStore::new(crypto)),
+            Arc::new(ToolRegistry::new()),
+            None,
+            None,
+            tools_dir,
+            channels_dir,
+            None,
+            "test".to_string(),
+            Some(db.clone() as Arc<dyn crate::db::Database>),
+            Vec::new(),
+        );
+
+        if manager.current_channel_owner_id("telegram").await.is_some() {
+            return Err("expected no owner id before settings seed".to_string());
+        }
+
+        db.set_setting(
+            "test",
+            "channels.wasm_channel_owner_ids.telegram",
+            &serde_json::json!(54321_i64),
+        )
+        .await
+        .map_err(|e| format!("persist owner id in settings failed: {e}"))?;
+
+        if manager.current_channel_owner_id("telegram").await != Some(54321_i64) {
+            return Err("expected store fallback owner id for telegram".to_string());
+        }
+
+        let channels = Arc::new(crate::channels::ChannelManager::new());
+        let runtime = Arc::new(
+            crate::channels::wasm::WasmChannelRuntime::new(
+                crate::channels::wasm::WasmChannelRuntimeConfig::default(),
+            )
+            .map_err(|e| format!("runtime init failed: {e}"))?,
+        );
+        let pairing_store = Arc::new(crate::pairing::PairingStore::new());
+        let router = Arc::new(crate::channels::wasm::WasmChannelRouter::new());
+        let mut owner_ids = std::collections::HashMap::new();
+        owner_ids.insert("telegram".to_string(), 12345_i64);
+        manager
+            .set_channel_runtime(channels, runtime, pairing_store, router, owner_ids)
+            .await;
+
+        if manager.current_channel_owner_id("telegram").await != Some(12345_i64) {
+            return Err("expected runtime fast-path owner id precedence".to_string());
+        }
+
+        Ok(())
     }
 
     // ── resolve_env_credentials tests ────────────────────────────────────


### PR DESCRIPTION
## Summary
- fix hot activation to resolve WASM channel owner_id from live settings (`channels.wasm_channel_owner_ids.<name>`) instead of only using the startup snapshot
- keep existing fast path via in-memory runtime owner map, then fall back to persisted settings
- add regression test for owner-id resolution path used during hot activation

## Why
`activate_wasm_channel()` previously read owner bindings only from `set_channel_runtime()` state captured at startup. If owner binding changed after startup, hot-activated channels could miss owner_id and regress to pairing state.

Fixes #1052

## Validation
- `cargo fmt --all`
- `cargo test test_current_channel_owner_id_uses_runtime_state --quiet`
