### PR TITLE
chore: add __pycache__ and *.pyc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,10 @@
 
 target/
 
+# Python
+__pycache__/
+*.pyc
+
 # Benchmark results (local runs, not committed)
 bench-results/
 


### PR DESCRIPTION
## Summary
- Add `__pycache__/` and `*.pyc` to `.gitignore` to prevent Python bytecode from being committed
- Several open PRs (#1166) accidentally included `__pycache__/` directories

## Test plan
- [x] Verify `__pycache__/` directories are ignored by git after this change

Generated with [Claude Code](https://claude.com/claude-code)