### PR TITLE
feat(workspace): add snapshot/hydration for disaster recovery (#167)

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -256,6 +256,7 @@ pub struct Agent {
     pub(super) context_monitor: ContextMonitor,
     pub(super) heartbeat_config: Option<HeartbeatConfig>,
     pub(super) hygiene_config: Option<crate::config::HygieneConfig>,
+    pub(super) snapshot_config: Option<crate::config::SnapshotConfig>,
     pub(super) routine_config: Option<RoutineConfig>,
     /// Shared routine-engine slot used for internal event matching and for exposing
     /// the engine to gateway/manual trigger entry points.
@@ -290,6 +291,7 @@ impl Agent {
         channels: Arc<ChannelManager>,
         heartbeat_config: Option<HeartbeatConfig>,
         hygiene_config: Option<crate::config::HygieneConfig>,
+        snapshot_config: Option<crate::config::SnapshotConfig>,
         routine_config: Option<RoutineConfig>,
         context_manager: Option<Arc<ContextManager>>,
         session_manager: Option<Arc<SessionManager>>,
@@ -333,6 +335,7 @@ impl Agent {
             context_monitor: ContextMonitor::new(),
             heartbeat_config,
             hygiene_config,
+            snapshot_config,
             routine_config,
             routine_engine_slot: Arc::new(tokio::sync::RwLock::new(None)),
             mission_manager_slot: Arc::new(tokio::sync::RwLock::new(None)),
@@ -969,11 +972,15 @@ impl Agent {
                         .map(|h| h.to_workspace_config())
                         .unwrap_or_default();
 
+                    let snapshot_config =
+                        self.snapshot_config.as_ref().cloned().unwrap_or_default();
+
                     if config.multi_tenant {
                         if let Some(system) = self.system_store() {
                             Some(spawn_multi_user_heartbeat(
                                 config,
                                 hygiene,
+                                snapshot_config,
                                 self.cheap_llm().clone(),
                                 Some(notify_tx),
                                 system,
@@ -983,9 +990,11 @@ impl Agent {
                             None
                         }
                     } else {
+                        let snapshot = snapshot_config.to_workspace_config(workspace.user_id());
                         Some(spawn_heartbeat(
                             config,
                             hygiene,
+                            snapshot,
                             workspace.clone(),
                             self.cheap_llm().clone(),
                             Some(notify_tx),
@@ -2282,6 +2291,7 @@ mod tests {
             },
             deps,
             Arc::new(crate::channels::ChannelManager::new()),
+            None,
             None,
             None,
             None,

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -363,6 +363,12 @@ impl Agent {
         let runner = crate::agent::HeartbeatRunner::new(
             crate::agent::HeartbeatConfig::default(),
             crate::workspace::hygiene::HygieneConfig::default(),
+            crate::workspace::snapshot::SnapshotConfig {
+                enabled: false, // manual heartbeat only runs check, not snapshot
+                cadence_hours: 24,
+                snapshot_path: std::path::PathBuf::new(),
+                state_path: std::path::PathBuf::new(),
+            },
             workspace.clone(),
             self.llm().clone(),
         );

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -2122,6 +2122,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::new(ContextManager::new(1))),
             None,
         )
@@ -2429,6 +2430,7 @@ mod tests {
             },
             deps,
             Arc::new(ChannelManager::new()),
+            None,
             None,
             None,
             None,
@@ -3419,6 +3421,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::new(ContextManager::new(1))),
             None,
         )
@@ -3568,6 +3571,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::new(ContextManager::new(1))),
             None,
         );
@@ -3700,6 +3704,7 @@ mod tests {
                 },
                 deps,
                 Arc::new(ChannelManager::new()),
+                None,
                 None,
                 None,
                 None,

--- a/src/agent/heartbeat.rs
+++ b/src/agent/heartbeat.rs
@@ -179,6 +179,7 @@ fn duration_until_next_fire(fire_at: chrono::NaiveTime, tz: Tz) -> Duration {
 pub struct HeartbeatRunner {
     config: HeartbeatConfig,
     hygiene_config: HygieneConfig,
+    snapshot_config: crate::workspace::snapshot::SnapshotConfig,
     workspace: Arc<Workspace>,
     llm: Arc<dyn LlmProvider>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
@@ -191,12 +192,14 @@ impl HeartbeatRunner {
     pub fn new(
         config: HeartbeatConfig,
         hygiene_config: HygieneConfig,
+        snapshot_config: crate::workspace::snapshot::SnapshotConfig,
         workspace: Arc<Workspace>,
         llm: Arc<dyn LlmProvider>,
     ) -> Self {
         Self {
             config,
             hygiene_config,
+            snapshot_config,
             workspace,
             llm,
             response_tx: None,
@@ -266,11 +269,15 @@ impl HeartbeatRunner {
                 continue;
             }
 
-            // Run memory hygiene in the background so it never delays the
-            // heartbeat checklist. Failures are logged inside run_if_due.
+            // Run memory hygiene and workspace snapshot in the background.
+            // Sequential: hygiene cleans stale docs first, then snapshot
+            // captures clean state. Snapshot has its own cadence/guard and
+            // runs regardless of hygiene outcome.
             let hygiene_workspace = Arc::clone(&self.workspace);
             let hygiene_config = self.hygiene_config.clone();
+            let snap_config = self.snapshot_config.clone();
             tokio::spawn(async move {
+                // 1. Hygiene: best-effort cleanup (failures logged inside run_if_due).
                 let report =
                     crate::workspace::hygiene::run_if_due(&hygiene_workspace, &hygiene_config)
                         .await;
@@ -280,6 +287,23 @@ impl HeartbeatRunner {
                         versions_pruned = report.versions_pruned,
                         "heartbeat: memory hygiene deleted stale documents"
                     );
+                }
+
+                // 2. Snapshot: independent cadence/guard, runs regardless of hygiene outcome.
+                match crate::workspace::snapshot::snapshot_if_due(&hygiene_workspace, &snap_config)
+                    .await
+                {
+                    Ok(r) if !r.skipped => {
+                        tracing::info!(
+                            documents_exported = r.documents_exported,
+                            path = ?r.snapshot_path,
+                            "heartbeat: workspace snapshot exported"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        tracing::warn!("heartbeat: workspace snapshot failed: {e}");
+                    }
                 }
             });
 
@@ -497,12 +521,13 @@ fn strip_html_comments(content: &str) -> String {
 pub fn spawn_heartbeat(
     config: HeartbeatConfig,
     hygiene_config: HygieneConfig,
+    snapshot_config: crate::workspace::snapshot::SnapshotConfig,
     workspace: Arc<Workspace>,
     llm: Arc<dyn LlmProvider>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
     store: Option<SystemScope>,
 ) -> tokio::task::JoinHandle<()> {
-    let mut runner = HeartbeatRunner::new(config, hygiene_config, workspace, llm);
+    let mut runner = HeartbeatRunner::new(config, hygiene_config, snapshot_config, workspace, llm);
     if let Some(tx) = response_tx {
         runner = runner.with_response_channel(tx);
     }
@@ -522,6 +547,7 @@ pub fn spawn_heartbeat(
 pub fn spawn_multi_user_heartbeat(
     config: HeartbeatConfig,
     hygiene_config: HygieneConfig,
+    snapshot_config: crate::config::SnapshotConfig,
     llm: Arc<dyn LlmProvider>,
     response_tx: Option<mpsc::Sender<OutgoingResponse>>,
     store: SystemScope,
@@ -608,6 +634,7 @@ pub fn spawn_multi_user_heartbeat(
                 let mut cfg = config.clone();
                 cfg.notify_user_id = None;
                 let hyg = hygiene_config.clone();
+                let snapshot = snapshot_config.to_workspace_config(workspace.user_id());
                 let llm_clone = llm.clone();
                 let tx = response_tx.clone();
                 let system_store = store.clone();
@@ -625,7 +652,25 @@ pub fn spawn_multi_user_heartbeat(
                         );
                     }
 
-                    let mut runner = HeartbeatRunner::new(cfg, hyg, workspace, llm_clone);
+                    match crate::workspace::snapshot::snapshot_if_due(&workspace, &snapshot).await {
+                        Ok(r) if !r.skipped => {
+                            tracing::info!(
+                                user_id = uid,
+                                documents_exported = r.documents_exported,
+                                path = ?r.snapshot_path,
+                                "multi-user heartbeat: workspace snapshot exported"
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => {
+                            tracing::warn!(
+                                user_id = uid,
+                                "multi-user heartbeat: snapshot failed: {e}"
+                            );
+                        }
+                    }
+
+                    let mut runner = HeartbeatRunner::new(cfg, hyg, snapshot, workspace, llm_clone);
                     if let Some(tx) = tx {
                         runner = runner.with_response_channel(tx);
                     }
@@ -905,6 +950,7 @@ mod tests {
         let _fn_ptr: fn(
             HeartbeatConfig,
             HygieneConfig,
+            crate::workspace::snapshot::SnapshotConfig,
             Arc<crate::workspace::Workspace>,
             Arc<dyn crate::llm::LlmProvider>,
             Option<tokio::sync::mpsc::Sender<crate::channels::OutgoingResponse>>,

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -2878,6 +2878,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::new(crate::context::ContextManager::new(1))),
             None,
         );
@@ -3446,6 +3447,7 @@ mod tests {
             },
             deps,
             Arc::new(manager),
+            None,
             None,
             None,
             None,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1075,8 +1075,45 @@ impl AppBuilder {
             }
         }
 
-        // Seed workspace and backfill embeddings
+        // Startup recovery chain: hydrate → import → seed → backfill
+        // Each step is best-effort — failure only warns, never blocks subsequent steps.
         if let Some(ref ws) = workspace {
+            // Hydrate from snapshot if workspace is empty and a snapshot file exists.
+            let snap_cfg = self.config.snapshot.to_workspace_config(ws.user_id());
+            if snap_cfg.enabled && snap_cfg.snapshot_path.exists() {
+                match ws.list_all().await {
+                    Ok(docs) if docs.is_empty() => {
+                        match crate::workspace::snapshot::hydrate_from_snapshot(
+                            ws,
+                            &snap_cfg.snapshot_path,
+                        )
+                        .await
+                        {
+                            Ok(report) => {
+                                tracing::info!(
+                                    "Hydrated {} document(s) from snapshot {}",
+                                    report.restored,
+                                    snap_cfg.snapshot_path.display()
+                                );
+                            }
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to hydrate from snapshot {}: {}",
+                                    snap_cfg.snapshot_path.display(),
+                                    e
+                                );
+                            }
+                        }
+                    }
+                    Ok(_) => {
+                        // Workspace is not empty — skip hydration.
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to list workspace docs for hydration check: {}", e);
+                    }
+                }
+            }
+
             // Import workspace files from disk FIRST if WORKSPACE_IMPORT_DIR is set.
             // This lets Docker images / deployment scripts ship customized
             // workspace templates (e.g., AGENTS.md, TOOLS.md) that override

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -6296,6 +6296,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::new(crate::context::ContextManager::new(1))),
             None,
         );
@@ -7348,6 +7349,7 @@ mod tests {
             },
             deps,
             Arc::new(manager),
+            None,
             None,
             None,
             None,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,6 +38,7 @@ mod sandbox;
 mod search;
 mod secrets;
 mod skills;
+pub(crate) mod snapshot;
 mod transcription;
 mod tunnel;
 mod wasm;
@@ -71,6 +72,7 @@ pub use self::sandbox::{AcpModeConfig, ClaudeCodeConfig, SandboxModeConfig};
 pub use self::search::WorkspaceSearchConfig;
 pub use self::secrets::SecretsConfig;
 pub use self::skills::SkillsConfig;
+pub use self::snapshot::SnapshotConfig;
 pub use self::transcription::TranscriptionConfig;
 pub use self::tunnel::TunnelConfig;
 pub use self::wasm::WasmConfig;
@@ -114,6 +116,7 @@ pub struct Config {
     pub builder: BuilderModeConfig,
     pub heartbeat: HeartbeatConfig,
     pub hygiene: HygieneConfig,
+    pub snapshot: SnapshotConfig,
     pub routines: RoutineConfig,
     pub sandbox: SandboxModeConfig,
     pub claude_code: ClaudeCodeConfig,
@@ -226,6 +229,7 @@ impl Config {
             },
             heartbeat: HeartbeatConfig::default(),
             hygiene: HygieneConfig::default(),
+            snapshot: SnapshotConfig::default(),
             routines: RoutineConfig {
                 enabled: false,
                 ..RoutineConfig::default()
@@ -485,6 +489,7 @@ impl Config {
             builder: BuilderModeConfig::resolve(settings)?,
             heartbeat: HeartbeatConfig::resolve(settings)?,
             hygiene: HygieneConfig::resolve(settings)?,
+            snapshot: SnapshotConfig::resolve()?,
             routines: RoutineConfig::resolve(settings)?,
             sandbox: SandboxModeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,

--- a/src/config/snapshot.rs
+++ b/src/config/snapshot.rs
@@ -1,0 +1,169 @@
+use std::path::PathBuf;
+
+use crate::bootstrap::ironclaw_base_dir;
+use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::error::ConfigError;
+
+/// Workspace snapshot configuration.
+///
+/// Controls periodic export of core workspace documents to a Markdown
+/// snapshot file and startup hydration from that snapshot.
+#[derive(Debug, Clone)]
+pub struct SnapshotConfig {
+    /// Whether snapshot is enabled. Env: `SNAPSHOT_ENABLED` (default: false).
+    pub enabled: bool,
+    /// Minimum hours between snapshot passes. Env: `SNAPSHOT_CADENCE_HOURS` (default: 24).
+    pub cadence_hours: u32,
+    /// Path template with optional `{user_id}` placeholder.
+    /// Env: `SNAPSHOT_PATH`.
+    /// Default: `<ironclaw_base_dir>/MEMORY_SNAPSHOT_{user_id}.md`.
+    ///
+    /// When the template does not contain `{user_id}`, a warning is logged.
+    /// This is an intentional single-user compatibility escape hatch —
+    /// it does NOT provide multi-user isolation guarantees.
+    ///
+    /// **Security:** The snapshot file at this path stores sensitive workspace
+    /// content (identity files, memory, context documents) in plaintext.
+    /// Ensure the path points to a user-controlled directory with restricted
+    /// access. On Unix, files are written with 0600 permissions automatically.
+    pub path_template: String,
+}
+
+impl Default for SnapshotConfig {
+    fn default() -> Self {
+        let base = ironclaw_base_dir();
+        Self {
+            enabled: false,
+            cadence_hours: 24,
+            path_template: format!("{}/MEMORY_SNAPSHOT_{{user_id}}.md", base.display()),
+        }
+    }
+}
+
+impl SnapshotConfig {
+    /// Resolve from environment variables (no `settings` needed, same as HygieneConfig).
+    pub(crate) fn resolve() -> Result<Self, ConfigError> {
+        let default = Self::default();
+        Ok(Self {
+            enabled: parse_bool_env("SNAPSHOT_ENABLED", false)?,
+            cadence_hours: parse_optional_env("SNAPSHOT_CADENCE_HOURS", 24)?,
+            path_template: optional_env("SNAPSHOT_PATH")?.unwrap_or(default.path_template),
+        })
+    }
+
+    /// Convert to workspace-side config, resolving paths for a specific user.
+    pub fn to_workspace_config(&self, user_id: &str) -> crate::workspace::snapshot::SnapshotConfig {
+        let safe_id = sanitize_user_id(user_id);
+
+        if !self.path_template.contains("{user_id}") {
+            tracing::warn!(
+                "SNAPSHOT_PATH does not contain {{user_id}} placeholder; \
+                 multi-user environments may experience snapshot file collisions"
+            );
+        }
+
+        let path_str = self.path_template.replace("{user_id}", &safe_id);
+        let snapshot_path = PathBuf::from(path_str);
+
+        // A relative filename such as `snapshot.md` has no meaningful parent;
+        // place cadence state next to the current working directory in that case.
+        let state_dir = snapshot_path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| std::path::Path::new("."));
+        let state_path = state_dir.join(format!("snapshot_state_{safe_id}.json"));
+
+        crate::workspace::snapshot::SnapshotConfig {
+            enabled: self.enabled,
+            cadence_hours: self.cadence_hours,
+            snapshot_path,
+            state_path,
+        }
+    }
+}
+
+/// Sanitize user_id for safe use in file paths.
+///
+/// Only retains `[a-zA-Z0-9_-]`, replaces everything else with `_`.
+/// Empty input falls back to `"unknown"`.
+fn sanitize_user_id(user_id: &str) -> String {
+    if user_id.is_empty() {
+        return "unknown".to_string();
+    }
+    user_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_reasonable() {
+        let cfg = SnapshotConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.cadence_hours, 24);
+        assert!(cfg.path_template.contains("{user_id}"));
+    }
+
+    #[test]
+    fn sanitize_normal_user_id() {
+        assert_eq!(sanitize_user_id("alice"), "alice");
+        assert_eq!(sanitize_user_id("user-123"), "user-123");
+        assert_eq!(sanitize_user_id("user_name"), "user_name");
+    }
+
+    #[test]
+    fn sanitize_dangerous_user_id() {
+        assert_eq!(sanitize_user_id("../admin"), "___admin");
+        assert_eq!(sanitize_user_id("john doe"), "john_doe");
+        assert_eq!(sanitize_user_id("a/b\\c"), "a_b_c");
+    }
+
+    #[test]
+    fn sanitize_empty_user_id() {
+        assert_eq!(sanitize_user_id(""), "unknown");
+    }
+
+    #[test]
+    fn to_workspace_config_resolves_paths() {
+        let cfg = SnapshotConfig {
+            enabled: true,
+            cadence_hours: 12,
+            path_template: "/tmp/test/SNAPSHOT_{user_id}.md".to_string(),
+        };
+        let ws_cfg = cfg.to_workspace_config("alice");
+        assert_eq!(
+            ws_cfg.snapshot_path,
+            PathBuf::from("/tmp/test/SNAPSHOT_alice.md")
+        );
+        assert_eq!(
+            ws_cfg.state_path,
+            PathBuf::from("/tmp/test/snapshot_state_alice.json")
+        );
+        assert!(ws_cfg.enabled);
+        assert_eq!(ws_cfg.cadence_hours, 12);
+    }
+
+    #[test]
+    fn to_workspace_config_sanitizes_user_id_in_path() {
+        let cfg = SnapshotConfig {
+            enabled: true,
+            cadence_hours: 24,
+            path_template: "/tmp/SNAPSHOT_{user_id}.md".to_string(),
+        };
+        let ws_cfg = cfg.to_workspace_config("../admin");
+        assert_eq!(
+            ws_cfg.snapshot_path,
+            PathBuf::from("/tmp/SNAPSHOT____admin.md")
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1297,6 +1297,7 @@ async fn async_main() -> anyhow::Result<()> {
         channels,
         Some(config.heartbeat.clone()),
         Some(config.hygiene.clone()),
+        Some(config.snapshot.clone()),
         Some(config.routines.clone()),
         Some(components.context_manager),
         Some(session_manager),

--- a/src/workspace/README.md
+++ b/src/workspace/README.md
@@ -35,6 +35,10 @@ workspace/
 └── ...
 ```
 
+### Snapshot Security
+
+The snapshot file (`MEMORY_SNAPSHOT_{user_id}.md`) contains sensitive workspace content in plaintext, including identity files, memory, heartbeat configuration, tool notes, and context documents. On Unix systems, snapshot files are written with 0600 permissions (owner read/write only). Ensure the snapshot path (`SNAPSHOT_PATH` env var) points to a user-controlled directory.
+
 ## Using the Workspace
 
 ```rust

--- a/src/workspace/README.md
+++ b/src/workspace/README.md
@@ -128,13 +128,27 @@ Proactive periodic execution (default: 30 minutes):
 4. If nothing, agent replies "HEARTBEAT_OK" (no notification)
 
 ```rust
+use std::path::PathBuf;
+use std::time::Duration;
+
 use crate::agent::{HeartbeatConfig, spawn_heartbeat};
+use crate::workspace::hygiene::HygieneConfig;
+use crate::workspace::snapshot::SnapshotConfig as WsSnapshotConfig;
 
 let config = HeartbeatConfig::default()
     .with_interval(Duration::from_secs(60 * 30))
     .with_notify("user_123", "telegram");
 
-spawn_heartbeat(config, workspace, llm, response_tx);
+let hygiene_config = HygieneConfig::default();
+let snapshot = WsSnapshotConfig {
+    enabled: false,
+    cadence_hours: 24,
+    snapshot_path: PathBuf::new(),
+    state_path: PathBuf::new(),
+};
+let store: Option<crate::tenant::SystemScope> = None;
+
+spawn_heartbeat(config, hygiene_config, snapshot, workspace, llm, response_tx, store);
 ```
 
 ## Chunking Strategy

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -55,6 +55,7 @@ mod search;
 pub mod settings_adapter;
 pub use settings_adapter::WorkspaceSettingsAdapter;
 pub mod settings_schemas;
+pub mod snapshot;
 
 pub use chunker::{ChunkConfig, chunk_document};
 pub use document::{

--- a/src/workspace/snapshot.rs
+++ b/src/workspace/snapshot.rs
@@ -70,15 +70,13 @@ static SNAPSHOT_RUNNING: AtomicBool = AtomicBool::new(false);
 
 /// Regex matching well-formed begin markers with numeric length.
 static BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    // safety: hardcoded regex literal, cannot fail
-    Regex::new(r"<!-- begin: (.+) length:(\d+) -->").expect("BEGIN_RE")
+    Regex::new(r"<!-- begin: (.+) length:(\d+) -->").expect("BEGIN_RE") // safety: hardcoded literal
 });
 
 /// Regex matching begin markers with any (possibly non-numeric) length value.
 /// Used to detect malformed markers that `BEGIN_RE` would silently skip.
 static MALFORMED_BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    // safety: hardcoded regex literal, cannot fail
-    Regex::new(r"<!-- begin: .+ length:\S+ -->").expect("MALFORMED_BEGIN_RE")
+    Regex::new(r"<!-- begin: .+ length:\S+ -->").expect("MALFORMED_BEGIN_RE") // safety: hardcoded literal
 });
 
 /// Workspace-side snapshot configuration (paths already resolved for a user).

--- a/src/workspace/snapshot.rs
+++ b/src/workspace/snapshot.rs
@@ -70,13 +70,15 @@ static SNAPSHOT_RUNNING: AtomicBool = AtomicBool::new(false);
 
 /// Regex matching well-formed begin markers with numeric length.
 static BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"<!-- begin: (.+) length:(\d+) -->").expect("BEGIN_RE") // safety: hardcoded literal
+    // safety: hardcoded regex literal, cannot fail
+    Regex::new(r"<!-- begin: (.+) length:(\d+) -->").expect("BEGIN_RE")
 });
 
 /// Regex matching begin markers with any (possibly non-numeric) length value.
 /// Used to detect malformed markers that `BEGIN_RE` would silently skip.
 static MALFORMED_BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"<!-- begin: .+ length:\S+ -->").expect("MALFORMED_BEGIN_RE") // safety: hardcoded literal
+    // safety: hardcoded regex literal, cannot fail
+    Regex::new(r"<!-- begin: .+ length:\S+ -->").expect("MALFORMED_BEGIN_RE")
 });
 
 /// Workspace-side snapshot configuration (paths already resolved for a user).

--- a/src/workspace/snapshot.rs
+++ b/src/workspace/snapshot.rs
@@ -1,0 +1,977 @@
+//! Workspace snapshot and hydration for disaster recovery.
+//!
+//! Periodically exports core workspace documents (identity files + MEMORY.md,
+//! HEARTBEAT.md, TOOLS.md, and context/\*\*) to a structured Markdown file on
+//! disk. On startup, if the workspace database is empty and a snapshot exists,
+//! documents are restored.
+//!
+//! The snapshot format uses byte-length–prefixed sections so that document
+//! content containing any HTML comments, Markdown headers, or other markup
+//! round-trips exactly (byte-level fidelity).
+//!
+//! # Security
+//!
+//! The snapshot file contains sensitive workspace content in plaintext,
+//! including identity files (IDENTITY.md, SOUL.md, USER.md, AGENTS.md),
+//! memory (MEMORY.md), heartbeat configuration (HEARTBEAT.md), tool notes
+//! (TOOLS.md), and all context/\*\* documents. On Unix systems, snapshot and
+//! state files are automatically written with 0600 permissions (owner
+//! read/write only). The snapshot path should be in a user-controlled
+//! directory with appropriate access restrictions.
+//!
+//! ```text
+//! ┌───────────────────────────────────────────────┐
+//! │            Snapshot Pass                       │
+//! │                                               │
+//! │  0. Acquire SNAPSHOT_RUNNING guard             │
+//! │  1. Check cadence (skip if ran recently)       │
+//! │  2. Validate user_id marker safety             │
+//! │  3. Collect allowlist docs + context/**         │
+//! │  4. Render length-prefixed Markdown             │
+//! │  5. Atomic write (tmp + rename)                │
+//! │  6. Update cadence state (only on success)     │
+//! └───────────────────────────────────────────────┘
+//! ```
+
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+use crate::error::WorkspaceError;
+use crate::workspace::Workspace;
+use crate::workspace::document::paths;
+
+/// Root documents included in snapshot (exact match).
+const SNAPSHOT_DOCS: &[&str] = &[
+    paths::MEMORY,
+    paths::IDENTITY,
+    paths::SOUL,
+    paths::AGENTS,
+    paths::USER,
+    paths::HEARTBEAT,
+    paths::TOOLS,
+];
+
+/// Directory prefixes included in snapshot (prefix match on list_all results).
+const SNAPSHOT_PREFIXES: &[&str] = &["context/"];
+
+/// Current snapshot format version.
+const SNAPSHOT_VERSION: &str = "v1";
+
+/// Global guard preventing concurrent snapshot passes.
+/// Independent of hygiene's `RUNNING` guard.
+static SNAPSHOT_RUNNING: AtomicBool = AtomicBool::new(false);
+
+/// Regex matching well-formed begin markers with numeric length.
+static BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<!-- begin: (.+) length:(\d+) -->").expect("BEGIN_RE") // safety: hardcoded literal
+});
+
+/// Regex matching begin markers with any (possibly non-numeric) length value.
+/// Used to detect malformed markers that `BEGIN_RE` would silently skip.
+static MALFORMED_BEGIN_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"<!-- begin: .+ length:\S+ -->").expect("MALFORMED_BEGIN_RE") // safety: hardcoded literal
+});
+
+/// Workspace-side snapshot configuration (paths already resolved for a user).
+#[derive(Debug, Clone)]
+pub struct SnapshotConfig {
+    pub enabled: bool,
+    pub cadence_hours: u32,
+    pub snapshot_path: PathBuf,
+    pub state_path: PathBuf,
+}
+
+/// Report from a snapshot pass.
+#[derive(Debug)]
+pub struct SnapshotReport {
+    /// Number of documents exported.
+    pub documents_exported: u32,
+    /// Path of the snapshot file written (None if skipped).
+    pub snapshot_path: Option<PathBuf>,
+    /// True if the pass was skipped (disabled, cadence, or concurrent guard).
+    pub skipped: bool,
+}
+
+/// Report from a hydration pass.
+#[derive(Debug)]
+pub struct HydrationReport {
+    /// Number of documents restored from snapshot.
+    pub restored: u32,
+    /// Number of documents skipped (already exist in workspace).
+    pub skipped: u32,
+    /// Number of documents rejected (outside allowlist or invalid).
+    pub rejected: u32,
+}
+
+/// Errors specific to snapshot operations.
+#[derive(Debug, Error)]
+pub enum SnapshotError {
+    #[error("IO error: {reason}")]
+    Io { reason: String },
+    #[error("workspace error: {0}")]
+    Workspace(#[from] WorkspaceError),
+    #[error("invalid snapshot format: {reason}")]
+    Format { reason: String },
+    #[error("user ID mismatch: snapshot has '{snapshot}', workspace has '{workspace}'")]
+    UserMismatch { snapshot: String, workspace: String },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct SnapshotState {
+    last_run: DateTime<Utc>,
+}
+
+struct SnapshotMetadata {
+    version: String,
+    user_id: String,
+    created: DateTime<Utc>,
+    sha256: String,
+}
+
+// ─── Public API ──────────────────────────────────────────────────────
+
+/// Run a snapshot pass if the cadence has elapsed.
+///
+/// Best-effort for individual documents: read failures are logged and skipped.
+/// `list_all()` and file I/O failures propagate as errors.
+///
+/// Cadence state is updated ONLY after the snapshot file is successfully
+/// written (atomic rename). This differs from hygiene's pre-write strategy
+/// because missing a backup window is costlier than repeating a cleanup.
+pub async fn snapshot_if_due(
+    workspace: &Workspace,
+    config: &SnapshotConfig,
+) -> Result<SnapshotReport, SnapshotError> {
+    let skipped = || {
+        Ok(SnapshotReport {
+            documents_exported: 0,
+            snapshot_path: None,
+            skipped: true,
+        })
+    };
+
+    if !config.enabled {
+        return skipped();
+    }
+
+    // Acquire process-level concurrency guard.
+    if SNAPSHOT_RUNNING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        tracing::debug!("workspace snapshot: skipping (another pass is running)");
+        return skipped();
+    }
+    let _guard = SnapshotRunningGuard;
+
+    // Check cadence.
+    if let Some(state) = load_state(&config.state_path).await {
+        let elapsed = Utc::now().signed_duration_since(state.last_run);
+        let cadence = chrono::Duration::hours(i64::from(config.cadence_hours));
+        if elapsed < cadence {
+            tracing::debug!(
+                hours_since_last = elapsed.num_hours(),
+                cadence_hours = config.cadence_hours,
+                "workspace snapshot: skipping (cadence not elapsed)"
+            );
+            return skipped();
+        }
+    }
+
+    // Validate user_id for marker safety (fail the entire snapshot if unsafe).
+    // Whitespace in user_id would break metadata parsing (split_whitespace).
+    validate_marker_safe(workspace.user_id(), "user_id")?;
+    if workspace.user_id().contains(char::is_whitespace) {
+        return Err(SnapshotError::Format {
+            reason: format!(
+                "user_id contains whitespace, which is unsafe for snapshot metadata: {:?}",
+                workspace.user_id()
+            ),
+        });
+    }
+
+    // Collect documents.
+    let mut documents: Vec<(String, String)> = Vec::new();
+
+    // Root allowlist documents (exact match).
+    for &path in SNAPSHOT_DOCS {
+        match workspace.read(path).await {
+            Ok(doc) => {
+                if let Err(e) = validate_marker_safe(path, "path") {
+                    tracing::warn!(path, "snapshot: skipping, unsafe path: {e}");
+                    continue;
+                }
+                documents.push((path.to_string(), doc.content));
+            }
+            Err(WorkspaceError::DocumentNotFound { .. }) => {}
+            Err(e) => tracing::warn!(path, "snapshot: read failed, skipping: {e}"),
+        }
+    }
+
+    // context/** via list_all + prefix filter (covers nested dirs).
+    let all_paths = workspace.list_all().await?;
+    for path in all_paths
+        .iter()
+        .filter(|p| SNAPSHOT_PREFIXES.iter().any(|pfx| p.starts_with(pfx)))
+    {
+        if let Err(e) = validate_marker_safe(path, "path") {
+            tracing::warn!(path, "snapshot: skipping, unsafe path: {e}");
+            continue;
+        }
+        match workspace.read(path).await {
+            Ok(doc) => documents.push((path.clone(), doc.content)),
+            Err(e) => tracing::warn!(path, "snapshot: read failed, skipping: {e}"),
+        }
+    }
+
+    let count = documents.len() as u32;
+
+    // Render snapshot.
+    let snapshot_text = render_snapshot(workspace.user_id(), &documents);
+
+    // Atomic write: .tmp → rename.
+    let tmp_path = config.snapshot_path.with_extension("md.tmp");
+    if let Some(dir) = config.snapshot_path.parent() {
+        tokio::fs::create_dir_all(dir)
+            .await
+            .map_err(|e| SnapshotError::Io {
+                reason: format!("create dir {}: {e}", dir.display()),
+            })?;
+    }
+    tokio::fs::write(&tmp_path, &snapshot_text)
+        .await
+        .map_err(|e| SnapshotError::Io {
+            reason: format!("write {}: {e}", tmp_path.display()),
+        })?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        tokio::fs::set_permissions(&tmp_path, perms)
+            .await
+            .map_err(|e| SnapshotError::Io {
+                reason: format!("set permissions {}: {e}", tmp_path.display()),
+            })?;
+    }
+
+    if let Err(e) = tokio::fs::rename(&tmp_path, &config.snapshot_path).await {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(SnapshotError::Io {
+            reason: format!("rename to {}: {e}", config.snapshot_path.display()),
+        });
+    }
+
+    // Update cadence ONLY after successful write.
+    save_state(&config.state_path).await;
+
+    tracing::info!(
+        documents_exported = count,
+        path = %config.snapshot_path.display(),
+        "workspace snapshot exported"
+    );
+
+    Ok(SnapshotReport {
+        documents_exported: count,
+        snapshot_path: Some(config.snapshot_path.clone()),
+        skipped: false,
+    })
+}
+
+/// Restore workspace documents from a snapshot file.
+///
+/// Idempotent: documents that already exist in the workspace are skipped.
+/// Validates snapshot version and user_id ownership before restoring.
+/// Paths outside the snapshot allowlist are rejected.
+pub async fn hydrate_from_snapshot(
+    workspace: &Workspace,
+    path: &Path,
+) -> Result<HydrationReport, SnapshotError> {
+    // Snapshot files are expected to contain bounded recovery state:
+    // identity docs, MEMORY.md, HEARTBEAT.md, TOOLS.md, and context/**. We
+    // read the file as one string so the full-body checksum can be verified
+    // before any document is hydrated.
+    let text = tokio::fs::read_to_string(path)
+        .await
+        .map_err(|e| SnapshotError::Io {
+            reason: format!("read {}: {e}", path.display()),
+        })?;
+
+    // Parse and validate metadata.
+    let first_line = text.lines().next().ok_or_else(|| SnapshotError::Format {
+        reason: "empty snapshot file".into(),
+    })?;
+    let metadata = parse_metadata(first_line)?;
+    verify_snapshot_checksum(&text, &metadata.sha256)?;
+    let _snapshot_created_at = &metadata.created;
+
+    if metadata.version != SNAPSHOT_VERSION {
+        return Err(SnapshotError::Format {
+            reason: format!(
+                "unsupported version '{}', expected '{SNAPSHOT_VERSION}'",
+                metadata.version
+            ),
+        });
+    }
+    if metadata.user_id != workspace.user_id() {
+        return Err(SnapshotError::UserMismatch {
+            snapshot: metadata.user_id,
+            workspace: workspace.user_id().to_string(),
+        });
+    }
+
+    // Parse documents (strict: any format error → SnapshotError::Format).
+    let sections = parse_snapshot_documents(&text)?;
+
+    // Restore each document.
+    let mut report = HydrationReport {
+        restored: 0,
+        skipped: 0,
+        rejected: 0,
+    };
+    for (doc_path, content) in sections {
+        // Validate allowlist.
+        if !is_snapshot_path(&doc_path) {
+            tracing::warn!(
+                path = doc_path.as_str(),
+                "snapshot hydration: path outside allowlist, rejecting"
+            );
+            report.rejected += 1;
+            continue;
+        }
+        // Skip if already exists (idempotent).
+        match workspace.exists(&doc_path).await {
+            Ok(true) => {
+                report.skipped += 1;
+                continue;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!(
+                    path = doc_path.as_str(),
+                    "snapshot hydration: exists check failed: {e}"
+                );
+                report.rejected += 1;
+                continue;
+            }
+        }
+        // Write to workspace.
+        match workspace.write(&doc_path, &content).await {
+            Ok(_) => report.restored += 1,
+            Err(e) => {
+                tracing::warn!(
+                    path = doc_path.as_str(),
+                    "snapshot hydration: write failed: {e}"
+                );
+                report.rejected += 1;
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────
+
+/// RAII guard that clears `SNAPSHOT_RUNNING` on drop.
+struct SnapshotRunningGuard;
+
+impl Drop for SnapshotRunningGuard {
+    fn drop(&mut self) {
+        SNAPSHOT_RUNNING.store(false, Ordering::SeqCst);
+    }
+}
+
+/// Check if a path is in the snapshot allowlist.
+fn is_snapshot_path(path: &str) -> bool {
+    SNAPSHOT_DOCS.contains(&path)
+        || SNAPSHOT_PREFIXES
+            .iter()
+            .any(|prefix| path.starts_with(prefix))
+}
+
+/// Reject values that would break HTML comment syntax or line-based parsing.
+///
+/// The ` length:` check is a format-level constraint: the length-prefixed
+/// snapshot format uses ` length:` as the separator between path and byte
+/// count in begin markers, so paths containing this substring create
+/// ambiguity that neither greedy nor lazy regex matching can resolve.
+fn validate_marker_safe(value: &str, label: &str) -> Result<(), SnapshotError> {
+    if value.contains("-->")
+        || value.contains('\n')
+        || value.contains('\r')
+        || value.contains('\0')
+        || value.chars().any(|c| c.is_control())
+    {
+        return Err(SnapshotError::Format {
+            reason: format!("{label} contains characters unsafe for snapshot markers: {value:?}"),
+        });
+    }
+    if value.contains(" length:") {
+        return Err(SnapshotError::Format {
+            reason: format!(
+                "{label} contains ' length:' which is ambiguous in the length-prefixed snapshot format: {value:?}"
+            ),
+        });
+    }
+    Ok(())
+}
+
+async fn load_state(path: &Path) -> Option<SnapshotState> {
+    let data = tokio::fs::read_to_string(path).await.ok()?;
+    serde_json::from_str(&data).ok()
+}
+
+/// Save cadence state using atomic write (temp + rename).
+async fn save_state(path: &Path) {
+    let state = SnapshotState {
+        last_run: Utc::now(),
+    };
+    if let Some(dir) = path.parent()
+        && let Err(e) = tokio::fs::create_dir_all(dir).await
+    {
+        tracing::warn!("snapshot: failed to create state dir: {e}");
+        return;
+    }
+    let json = match serde_json::to_string_pretty(&state) {
+        Ok(json) => json,
+        Err(e) => {
+            tracing::warn!("snapshot: failed to serialize state: {e}");
+            return;
+        }
+    };
+    let tmp_path = path.with_extension("json.tmp");
+    if let Err(e) = tokio::fs::write(&tmp_path, &json).await {
+        tracing::warn!("snapshot: failed to write temp state: {e}");
+        return;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o600);
+        if let Err(e) = tokio::fs::set_permissions(&tmp_path, perms).await {
+            tracing::warn!("snapshot: failed to set state file permissions: {e}");
+        }
+    }
+    if let Err(e) = tokio::fs::rename(&tmp_path, path).await {
+        tracing::warn!("snapshot: failed to rename state file: {e}");
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+    }
+}
+
+/// Render snapshot with length-prefixed sections.
+fn render_snapshot(user_id: &str, documents: &[(String, String)]) -> String {
+    let body = render_snapshot_body(documents);
+    let sha256 = sha256_hex(&body);
+    format!(
+        "<!-- ironclaw-snapshot {} user_id={} created={} sha256={} -->\n{}",
+        SNAPSHOT_VERSION,
+        user_id,
+        Utc::now().to_rfc3339(),
+        sha256,
+        body
+    )
+}
+
+fn render_snapshot_body(documents: &[(String, String)]) -> String {
+    let mut out = String::from("\n");
+    for (path, content) in documents {
+        let byte_len = content.len();
+        out.push_str(&format!("\n<!-- begin: {} length:{} -->\n", path, byte_len));
+        out.push_str(content);
+        out.push_str(&format!("\n<!-- end: {} -->\n", path));
+    }
+    out
+}
+
+fn snapshot_body(text: &str) -> Result<&str, SnapshotError> {
+    let Some(first_newline) = text.find('\n') else {
+        return Err(SnapshotError::Format {
+            reason: "snapshot metadata line is not newline-terminated".into(),
+        });
+    };
+    Ok(&text[first_newline + 1..])
+}
+
+fn sha256_hex(text: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(text.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+fn verify_snapshot_checksum(text: &str, expected: &str) -> Result<(), SnapshotError> {
+    let body = snapshot_body(text)?;
+    let actual = sha256_hex(body);
+    if actual == expected {
+        return Ok(());
+    }
+    Err(SnapshotError::Format {
+        reason: format!("snapshot checksum mismatch: expected {expected}, got {actual}"),
+    })
+}
+
+/// Parse metadata from the first line of a snapshot file.
+///
+/// Expected format:
+/// `<!-- ironclaw-snapshot v1 user_id=alice created=2026-03-15T12:00:00Z sha256=<hex> -->`
+fn parse_metadata(line: &str) -> Result<SnapshotMetadata, SnapshotError> {
+    let inner = line
+        .strip_prefix("<!-- ironclaw-snapshot ")
+        .and_then(|s| s.strip_suffix(" -->"))
+        .ok_or_else(|| SnapshotError::Format {
+            reason: format!("invalid metadata line: {line}"),
+        })?;
+
+    let mut version = None;
+    let mut user_id = None;
+    let mut created = None;
+    let mut sha256 = None;
+
+    for token in inner.split_whitespace() {
+        if let Some(val) = token.strip_prefix("user_id=") {
+            user_id = Some(val.to_string());
+        } else if let Some(val) = token.strip_prefix("created=") {
+            created = Some(
+                DateTime::parse_from_rfc3339(val)
+                    .map(|dt| dt.with_timezone(&Utc))
+                    .map_err(|e| SnapshotError::Format {
+                        reason: format!("invalid created timestamp: {e}"),
+                    })?,
+            );
+        } else if let Some(val) = token.strip_prefix("sha256=") {
+            if val.len() != 64 || !val.chars().all(|c| c.is_ascii_hexdigit()) {
+                return Err(SnapshotError::Format {
+                    reason: format!("invalid sha256 digest in metadata: {val}"),
+                });
+            }
+            sha256 = Some(val.to_ascii_lowercase());
+        } else if version.is_none() {
+            version = Some(token.to_string());
+        }
+    }
+
+    Ok(SnapshotMetadata {
+        version: version.ok_or_else(|| SnapshotError::Format {
+            reason: "missing version".into(),
+        })?,
+        user_id: user_id.ok_or_else(|| SnapshotError::Format {
+            reason: "missing user_id".into(),
+        })?,
+        created: created.ok_or_else(|| SnapshotError::Format {
+            reason: "missing created timestamp".into(),
+        })?,
+        sha256: sha256.ok_or_else(|| SnapshotError::Format {
+            reason: "missing sha256 checksum".into(),
+        })?,
+    })
+}
+
+/// Parse documents by byte-length framing.
+///
+/// Strict: all format errors produce `SnapshotError::Format`.
+fn parse_snapshot_documents(text: &str) -> Result<Vec<(String, String)>, SnapshotError> {
+    let mut results = Vec::new();
+    let mut pos = 0;
+
+    // Scan forward through text, using length to skip content regions so
+    // that fake markers embedded inside document content are never matched.
+    while pos < text.len() {
+        let Some(cap) = BEGIN_RE.captures(&text[pos..]) else {
+            // No more strict matches. Check for malformed begin markers in
+            // remaining text — if any exist, the snapshot is damaged.
+            if MALFORMED_BEGIN_RE.is_match(&text[pos..]) {
+                return Err(SnapshotError::Format {
+                    reason: "malformed begin marker with non-numeric length".into(),
+                });
+            }
+            break;
+        };
+        let full_match = cap.get(0).ok_or_else(|| SnapshotError::Format {
+            reason: "regex match without capture group 0".into(),
+        })?;
+        let path = cap[1].to_string();
+        let length: usize = cap[2].parse().map_err(|e| SnapshotError::Format {
+            reason: format!("invalid length for '{path}': {e}"),
+        })?;
+
+        // Validate path marker safety.
+        validate_marker_safe(&path, "path")?;
+
+        // Content starts after the newline following the begin marker.
+        let marker_end_abs = pos + full_match.end();
+        let content_start = marker_end_abs + 1; // +1 for the \n
+        if content_start > text.len() {
+            return Err(SnapshotError::Format {
+                reason: format!("unexpected EOF after begin marker for '{path}'"),
+            });
+        }
+
+        let content_end = content_start + length;
+        if content_end > text.len() {
+            return Err(SnapshotError::Format {
+                reason: format!(
+                    "content truncated for '{path}': expected {length} bytes, \
+                     but only {} available",
+                    text.len() - content_start
+                ),
+            });
+        }
+
+        // Verify char boundaries (defensive check for corrupted files).
+        if !text.is_char_boundary(content_start) {
+            return Err(SnapshotError::Format {
+                reason: format!(
+                    "content start offset {content_start} is not on a UTF-8 char boundary for '{path}'"
+                ),
+            });
+        }
+        if !text.is_char_boundary(content_end) {
+            return Err(SnapshotError::Format {
+                reason: format!(
+                    "content end offset {content_end} is not on a UTF-8 char boundary for '{path}'"
+                ),
+            });
+        }
+
+        let content = &text[content_start..content_end];
+        results.push((path, content.to_string()));
+
+        // Advance past the content and the end marker line.
+        pos = content_end;
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ─── Format rendering / parsing ─────────────────────────────────
+
+    #[test]
+    fn render_and_parse_round_trip() {
+        let docs = vec![
+            (
+                "MEMORY.md".to_string(),
+                "# Memory\n\nSome notes.".to_string(),
+            ),
+            (
+                "IDENTITY.md".to_string(),
+                "# Identity\n\n- **Name:** Test".to_string(),
+            ),
+            (
+                "context/vision.md".to_string(),
+                "## Vision\n\nOur vision.".to_string(),
+            ),
+        ];
+
+        let snapshot = render_snapshot("alice", &docs);
+        let metadata = parse_metadata(snapshot.lines().next().unwrap()).expect("metadata");
+        verify_snapshot_checksum(&snapshot, &metadata.sha256).expect("checksum should match");
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse should succeed");
+
+        assert_eq!(parsed.len(), 3);
+        for (i, (path, content)) in parsed.iter().enumerate() {
+            assert_eq!(path, &docs[i].0);
+            assert_eq!(content, &docs[i].1, "content mismatch for {path}");
+        }
+    }
+
+    #[test]
+    fn round_trip_content_with_h2_headers() {
+        let docs = vec![(
+            "MEMORY.md".to_string(),
+            "## Header inside content\n\n## Another header".to_string(),
+        )];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(parsed[0].1, docs[0].1);
+    }
+
+    #[test]
+    fn round_trip_content_with_fake_begin_end_markers() {
+        let content = "<!-- begin: MEMORY.md length:99 -->\nfake content\n<!-- end: MEMORY.md -->"
+            .to_string();
+        let docs = vec![("IDENTITY.md".to_string(), content.clone())];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].0, "IDENTITY.md");
+        assert_eq!(parsed[0].1, content);
+    }
+
+    #[test]
+    fn round_trip_empty_document() {
+        let docs = vec![("MEMORY.md".to_string(), String::new())];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].1, "");
+    }
+
+    #[test]
+    fn round_trip_leading_trailing_newlines() {
+        let content = "\n\nsome content\n\n".to_string();
+        let docs = vec![("MEMORY.md".to_string(), content.clone())];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(
+            parsed[0].1, content,
+            "leading/trailing newlines must be preserved"
+        );
+    }
+
+    #[test]
+    fn round_trip_unicode_content() {
+        let content = "中文内容 🎉 café résumé naïve 组合变音符: a\u{0300}\u{0301}".to_string();
+        let docs = vec![("context/notes.md".to_string(), content.clone())];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(parsed[0].1, content);
+    }
+
+    #[test]
+    fn round_trip_context_non_md_file() {
+        let docs = vec![("context/notes.txt".to_string(), "plain text".to_string())];
+        let snapshot = render_snapshot("test", &docs);
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse");
+        assert_eq!(parsed[0].0, "context/notes.txt");
+        assert_eq!(parsed[0].1, "plain text");
+    }
+
+    // ─── Metadata parsing ───────────────────────────────────────────
+
+    #[test]
+    fn parse_metadata_valid() {
+        let line = "<!-- ironclaw-snapshot v1 user_id=alice created=2026-03-15T12:00:00+00:00 sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef -->";
+        let metadata = parse_metadata(line).expect("parse");
+        assert_eq!(metadata.version, "v1");
+        assert_eq!(metadata.user_id, "alice");
+        assert_eq!(metadata.created.timestamp(), 1_773_576_000);
+        assert_eq!(
+            metadata.sha256,
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+        );
+    }
+
+    #[test]
+    fn parse_metadata_rejects_corrupted() {
+        assert!(parse_metadata("not a valid header").is_err());
+        assert!(parse_metadata("<!-- ironclaw-snapshot -->").is_err());
+        assert!(
+            parse_metadata(
+                "<!-- ironclaw-snapshot v1 user_id=alice created=2026-03-15T12:00:00+00:00 -->"
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn verify_checksum_rejects_body_corruption() {
+        let docs = vec![("MEMORY.md".to_string(), "original".to_string())];
+        let snapshot = render_snapshot("alice", &docs);
+        let corrupted = snapshot.replace("original", "corrupt!");
+        let metadata = parse_metadata(corrupted.lines().next().unwrap()).expect("metadata");
+        assert!(verify_snapshot_checksum(&corrupted, &metadata.sha256).is_err());
+    }
+
+    #[ignore = "large snapshot performance guard; run manually when changing snapshot parsing"]
+    #[test]
+    fn large_snapshot_round_trip_perf_guard() {
+        let mut docs = Vec::new();
+        for i in 0..128 {
+            let content = if i % 32 == 0 {
+                format!("large-{i}\n{}", "x".repeat(1024 * 1024 + i))
+            } else {
+                format!("small document {i}\n{}", "body\n".repeat(16))
+            };
+            docs.push((format!("context/generated-{i}.md"), content));
+        }
+
+        let snapshot = render_snapshot("alice", &docs);
+        let metadata = parse_metadata(snapshot.lines().next().unwrap()).expect("metadata");
+        verify_snapshot_checksum(&snapshot, &metadata.sha256).expect("checksum should match");
+        let parsed = parse_snapshot_documents(&snapshot).expect("parse should succeed");
+        assert_eq!(parsed, docs);
+    }
+
+    // ─── Parse strictness ───────────────────────────────────────────
+
+    #[test]
+    fn parse_rejects_non_numeric_length() {
+        let text = "<!-- ironclaw-snapshot v1 user_id=a created=2026-01-01T00:00:00+00:00 -->\n\n<!-- begin: MEMORY.md length:abc -->\ncontent\n<!-- end: MEMORY.md -->\n";
+        assert!(parse_snapshot_documents(text).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_truncated_content() {
+        let text = "<!-- ironclaw-snapshot v1 user_id=a created=2026-01-01T00:00:00+00:00 -->\n\n<!-- begin: MEMORY.md length:9999 -->\nshort\n<!-- end: MEMORY.md -->\n";
+        assert!(parse_snapshot_documents(text).is_err());
+    }
+
+    // ─── Marker safety ──────────────────────────────────────────────
+
+    #[test]
+    fn marker_rejects_path_with_arrow() {
+        assert!(validate_marker_safe("path-->bad", "path").is_err());
+    }
+
+    #[test]
+    fn marker_rejects_path_with_newline() {
+        assert!(validate_marker_safe("path\nwith\nnewline", "path").is_err());
+    }
+
+    #[test]
+    fn marker_allows_space_in_path() {
+        // Spaces are valid in document paths (e.g. "context/project notes.md").
+        assert!(validate_marker_safe("context/project notes.md", "path").is_ok());
+    }
+
+    #[test]
+    fn marker_rejects_tab() {
+        // Tabs are control chars and break both metadata and marker parsing.
+        assert!(validate_marker_safe("alice\tbob", "user_id").is_err());
+    }
+
+    #[test]
+    fn marker_rejects_control_chars() {
+        assert!(validate_marker_safe("path\x00null", "path").is_err());
+        assert!(validate_marker_safe("path\x01soh", "path").is_err());
+    }
+
+    #[test]
+    fn marker_allows_normal_paths() {
+        assert!(validate_marker_safe("MEMORY.md", "path").is_ok());
+        assert!(validate_marker_safe("context/projects/deep/notes.txt", "path").is_ok());
+        assert!(validate_marker_safe("context/中文.md", "path").is_ok());
+    }
+
+    // ─── Allowlist ──────────────────────────────────────────────────
+
+    #[test]
+    fn is_snapshot_path_allows_identity_docs() {
+        assert!(is_snapshot_path("MEMORY.md"));
+        assert!(is_snapshot_path("IDENTITY.md"));
+        assert!(is_snapshot_path("SOUL.md"));
+        assert!(is_snapshot_path("AGENTS.md"));
+        assert!(is_snapshot_path("USER.md"));
+        assert!(is_snapshot_path("HEARTBEAT.md"));
+        assert!(is_snapshot_path("TOOLS.md"));
+    }
+
+    #[test]
+    fn is_snapshot_path_allows_context() {
+        assert!(is_snapshot_path("context/vision.md"));
+        assert!(is_snapshot_path("context/projects/deep/notes.txt"));
+    }
+
+    #[test]
+    fn is_snapshot_path_rejects_non_allowlist() {
+        assert!(!is_snapshot_path("README.md"));
+        assert!(!is_snapshot_path("BOOTSTRAP.md"));
+        assert!(!is_snapshot_path("daily/2026-01-01.md"));
+        assert!(!is_snapshot_path("conversations/chat.md"));
+    }
+
+    // ─── State persistence ──────────────────────────────────────────
+
+    #[tokio::test]
+    async fn save_and_load_state_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("snapshot_state.json");
+
+        save_state(&path).await;
+        let state = load_state(&path).await.expect("state should be loadable");
+        let elapsed = Utc::now().signed_duration_since(state.last_run);
+        assert!(elapsed.num_seconds() < 2);
+    }
+
+    #[tokio::test]
+    async fn save_state_atomic_no_tmp_residue() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        let tmp = dir.path().join("state.json.tmp");
+
+        save_state(&path).await;
+        assert!(path.exists());
+        assert!(!tmp.exists(), "temp file should be cleaned up");
+    }
+
+    #[tokio::test]
+    async fn save_state_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("deep").join("state.json");
+        save_state(&path).await;
+        assert!(path.exists());
+    }
+
+    // ─── Cadence / concurrency ──────────────────────────────────────
+
+    #[test]
+    fn running_guard_releases_on_drop() {
+        SNAPSHOT_RUNNING.store(false, Ordering::SeqCst);
+        {
+            assert!(
+                SNAPSHOT_RUNNING
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_ok()
+            );
+            let _guard = SnapshotRunningGuard;
+            assert!(
+                SNAPSHOT_RUNNING
+                    .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                    .is_err()
+            );
+        }
+        // After guard dropped, should be acquirable again.
+        assert!(
+            SNAPSHOT_RUNNING
+                .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+                .is_ok()
+        );
+        SNAPSHOT_RUNNING.store(false, Ordering::SeqCst);
+    }
+
+    // ─── Hydration behaviour (unit-level) ───────────────────────────
+
+    #[test]
+    fn hydration_rejects_wrong_version() {
+        let text = "<!-- ironclaw-snapshot v99 user_id=test created=2026-01-01T00:00:00+00:00 sha256=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef -->\n";
+        // We can only test parse_metadata + version check at unit level.
+        let metadata = parse_metadata(text.lines().next().unwrap()).unwrap();
+        assert_ne!(metadata.version, SNAPSHOT_VERSION);
+    }
+
+    #[test]
+    fn marker_rejects_path_with_length_keyword() {
+        let result = validate_marker_safe("context/ length:42 notes.md", "path");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("length:"),
+            "error should mention 'length:': {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn save_state_sets_0600_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("state.json");
+        save_state(&path).await;
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        let mode = metadata.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "state file should have 0600 permissions");
+    }
+}

--- a/tests/e2e_routine_heartbeat.rs
+++ b/tests/e2e_routine_heartbeat.rs
@@ -977,8 +977,20 @@ mod tests {
             state_dir: _tmp.path().to_path_buf(),
         };
 
-        let runner = HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm)
-            .with_response_channel(tx);
+        let snapshot_config = ironclaw::workspace::snapshot::SnapshotConfig {
+            enabled: false,
+            cadence_hours: 24,
+            snapshot_path: std::path::PathBuf::new(),
+            state_path: std::path::PathBuf::new(),
+        };
+        let runner = HeartbeatRunner::new(
+            HeartbeatConfig::default(),
+            hygiene_config,
+            snapshot_config,
+            ws,
+            llm,
+        )
+        .with_response_channel(tx);
 
         let result = runner.check_heartbeat().await;
         match result {
@@ -1023,7 +1035,19 @@ mod tests {
             state_dir: _tmp.path().to_path_buf(),
         };
 
-        let runner = HeartbeatRunner::new(HeartbeatConfig::default(), hygiene_config, ws, llm);
+        let snapshot_config = ironclaw::workspace::snapshot::SnapshotConfig {
+            enabled: false,
+            cadence_hours: 24,
+            snapshot_path: std::path::PathBuf::new(),
+            state_path: std::path::PathBuf::new(),
+        };
+        let runner = HeartbeatRunner::new(
+            HeartbeatConfig::default(),
+            hygiene_config,
+            snapshot_config,
+            ws,
+            llm,
+        );
 
         let result = runner.check_heartbeat().await;
         assert!(

--- a/tests/e2e_telegram_message_routing.rs
+++ b/tests/e2e_telegram_message_routing.rs
@@ -226,6 +226,7 @@ mod tests {
             None,
             None,
             None,
+            None,
             Some(Arc::clone(&components.context_manager)),
             None,
         );

--- a/tests/heartbeat_integration.rs
+++ b/tests/heartbeat_integration.rs
@@ -94,7 +94,13 @@ async fn test_heartbeat_end_to_end() {
 
     let hb_config = ironclaw::agent::HeartbeatConfig::default();
     let hygiene_config = ironclaw::workspace::hygiene::HygieneConfig::default();
-    let runner = HeartbeatRunner::new(hb_config, hygiene_config, workspace, llm);
+    let snapshot_config = ironclaw::workspace::snapshot::SnapshotConfig {
+        enabled: false,
+        cadence_hours: 24,
+        snapshot_path: std::path::PathBuf::new(),
+        state_path: std::path::PathBuf::new(),
+    };
+    let runner = HeartbeatRunner::new(hb_config, hygiene_config, snapshot_config, workspace, llm);
 
     let result = runner.check_heartbeat().await;
 

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -292,6 +292,7 @@ impl GatewayWorkflowHarness {
             channels,
             None,
             None,
+            None,
             Some(RoutineConfig {
                 enabled: true,
                 cron_check_interval_secs: 60,

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -1389,6 +1389,7 @@ impl TestRigBuilder {
             channels,
             None, // heartbeat_config
             None, // hygiene_config
+            None, // snapshot_config
             routine_config,
             Some(Arc::clone(&components.context_manager)),
             Some(Arc::clone(&session_manager_ref)),


### PR DESCRIPTION


## Summary

<!-- 2-5 bullet points: what changed and why -->
  - Add periodic export of identity docs + context/** to length-prefixed Markdown file on disk
  - Add startup hydration: restore from snapshot when workspace database is empty
  - Use byte-length framing so embedded markers/HTML in content round-trip exactly
  - Validate user_id has no whitespace before writing metadata (split_whitespace safety)
  - Validate marker values reject control chars and --> to prevent format injection
  - Detect malformed begin markers with non-numeric length as explicit format errors
  - Skip content regions during parsing so fake markers inside documents are never matched
  - Guard concurrent snapshot passes with AtomicBool; update cadence state only on success
  - Wire snapshot config through Agent, HeartbeatRunner, and spawn_heartbeat
  - Insert hydration step in app.rs startup chain: hydrate → import → seed → backfill
  - Each recovery step is best-effort — failure warns but never blocks subsequent steps
  - Add 31 unit tests covering round-trip fidelity, parse strictness, marker safety, and concurrency

## Change Type

<!-- Check one -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

Closes #167

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- x ] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

  Security Impact: Writes sensitive workspace content to local disk for recovery. Files remain plaintext; Unix permissions are
  restricted to `0600`. No encryption/signing/attestation in this PR.

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

None

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
