### PR TITLE
fix(safety): allow image-only messages without text content

### DIFF
--- a/crates/ironclaw_safety/src/validator.rs
+++ b/crates/ironclaw_safety/src/validator.rs
@@ -540,11 +540,8 @@ mod tests {
         #[test]
         fn zwsp_not_counted_as_whitespace() {
             let validator = Validator::new();
-            // 200 chars of ZWSP (\u{200B}) — char::is_whitespace() returns
-            // false for ZWSP, so whitespace ratio should be ~0, not ~1.
             let input = "\u{200B}".repeat(200);
             let result = validator.validate(&input);
-            // Should NOT warn about high whitespace ratio
             assert!(
                 !result.warnings.iter().any(|w| w.contains("whitespace")),
                 "ZWSP should not count as whitespace (char::is_whitespace returns false)"
@@ -554,8 +551,6 @@ mod tests {
         #[test]
         fn zwnj_not_counted_as_whitespace() {
             let validator = Validator::new();
-            // 200 chars of ZWNJ (\u{200C}) — char::is_whitespace() returns
-            // false for ZWNJ, same as ZWSP.
             let input = "\u{200C}".repeat(200);
             let result = validator.validate(&input);
             assert!(
@@ -567,11 +562,8 @@ mod tests {
         #[test]
         fn zwnj_in_forbidden_pattern() {
             let validator = Validator::new().forbid_pattern("evil");
-            // ZWNJ inserted into "evil": "ev\u{200C}il"
             let input = "some text ev\u{200C}il command here";
             let result = validator.validate_non_empty_input(input, "test");
-            // to_lowercase() preserves ZWNJ. The substring "evil" is broken
-            // by ZWNJ so forbidden pattern check should NOT match.
             assert!(
                 result.is_valid,
                 "ZWNJ breaks forbidden pattern substring match — known bypass"
@@ -581,8 +573,6 @@ mod tests {
         #[test]
         fn zwj_not_counted_as_whitespace() {
             let validator = Validator::new();
-            // 200 chars of ZWJ (\u{200D}) — char::is_whitespace() returns
-            // false for ZWJ.
             let input = "\u{200D}".repeat(200);
             let result = validator.validate(&input);
             assert!(
@@ -594,7 +584,6 @@ mod tests {
         #[test]
         fn actual_whitespace_padding_attack() {
             let validator = Validator::new();
-            // 95% spaces + 5% text, >100 chars — should trigger whitespace warning
             let input = format!("{}{}", " ".repeat(190), "real content");
             assert!(input.len() > 100);
             let result = validator.validate(&input);
@@ -606,20 +595,12 @@ mod tests {
 
         #[test]
         fn combining_diacriticals_in_repetition() {
-            // "a" + combining accent repeated — each visual char is 2 code points
             let input = "a\u{0301}".repeat(30);
-            // has_excessive_repetition checks char-by-char; alternating 'a' and
-            // combining char means max_repeat stays at 1 — should NOT trigger
             assert!(!has_excessive_repetition(&input));
         }
 
         #[test]
         fn base_char_plus_50_distinct_combining_diacriticals() {
-            // Single base char followed by 50 DIFFERENT combining diacriticals.
-            // Each combining mark is a distinct code point, so max_repeat stays
-            // at 1 throughout — should NOT trigger excessive repetition.
-            // This matches issue #1025: "combining marks are distinct chars,
-            // so this should NOT trigger."
             let combining_marks: Vec<char> =
                 (0x0300u32..=0x0331).filter_map(char::from_u32).collect();
             assert!(combining_marks.len() >= 50);
@@ -633,13 +614,9 @@ mod tests {
 
         #[test]
         fn multibyte_chars_at_max_length_boundary() {
-            // Validator uses input.len() (byte length) for max_length check.
-            // A 3-byte CJK char at the boundary: the string is over the limit
-            // in bytes even though char count is under.
             let max_len = 100;
             let validator = Validator::new().with_max_length(max_len);
 
-            // 34 CJK chars × 3 bytes = 102 bytes > max_len of 100
             let input = "中".repeat(34);
             assert_eq!(input.len(), 102);
             let result = validator.validate(&input);
@@ -655,7 +632,6 @@ mod tests {
                 "should produce TooLong error"
             );
 
-            // 33 CJK chars × 3 bytes = 99 bytes < max_len of 100
             let input = "中".repeat(33);
             assert_eq!(input.len(), 99);
             let result = validator.validate(&input);
@@ -670,7 +646,6 @@ mod tests {
 
         #[test]
         fn four_byte_emoji_at_max_length_boundary() {
-            // 4-byte emoji at the boundary: 25 emojis = 100 bytes exactly
             let max_len = 100;
             let validator = Validator::new().with_max_length(max_len);
 
@@ -685,7 +660,6 @@ mod tests {
                 "exactly 100 bytes should not exceed max_length=100"
             );
 
-            // 26 emojis = 104 bytes > 100
             let input = "🔑".repeat(26);
             assert_eq!(input.len(), 104);
             let result = validator.validate(&input);
@@ -700,7 +674,6 @@ mod tests {
 
         #[test]
         fn single_codepoint_emoji_repetition() {
-            // Same emoji repeated 25 times — should trigger excessive repetition
             let input = "😀".repeat(25);
             assert!(
                 has_excessive_repetition(&input),
@@ -711,13 +684,6 @@ mod tests {
         #[test]
         fn multibyte_input_whitespace_ratio_uses_len_not_chars() {
             let validator = Validator::new();
-            // Key insight: whitespace_ratio divides char count by byte length
-            // (input.len()), not char count. With 3-byte chars, the ratio is
-            // artificially low. This documents the behavior.
-            //
-            // 50 spaces (50 bytes) + 50 "中" chars (150 bytes) = 200 bytes total
-            // char-based whitespace count = 50, input.len() = 200
-            // ratio = 50/200 = 0.25 (not high)
             let input = format!("{}{}", " ".repeat(50), "中".repeat(50));
             let result = validator.validate(&input);
             assert!(
@@ -729,10 +695,8 @@ mod tests {
         #[test]
         fn rtl_override_in_forbidden_pattern() {
             let validator = Validator::new().forbid_pattern("evil");
-            // RTL override before "evil"
             let input = "some text \u{202E}evil command here";
             let result = validator.validate_non_empty_input(input, "test");
-            // to_lowercase() preserves RTL char; "evil" substring is still present
             assert!(
                 !result.is_valid,
                 "RTL override should not prevent forbidden pattern detection"
@@ -750,7 +714,6 @@ mod tests {
                     char::from(byte)
                 );
                 let _result = validator.validate(&input);
-                // Primary assertion: no panic
             }
         }
 
@@ -767,9 +730,7 @@ mod tests {
 
         #[test]
         fn control_chars_in_repetition_check() {
-            // Control char repeated 25 times
             let input = "\x07".repeat(55);
-            // Should not panic; may or may not trigger repetition warning
             let _ = has_excessive_repetition(&input);
         }
     }

--- a/crates/ironclaw_safety/src/validator.rs
+++ b/crates/ironclaw_safety/src/validator.rs
@@ -540,8 +540,11 @@ mod tests {
         #[test]
         fn zwsp_not_counted_as_whitespace() {
             let validator = Validator::new();
+            // 200 chars of ZWSP (\u{200B}) — char::is_whitespace() returns
+            // false for ZWSP, so whitespace ratio should be ~0, not ~1.
             let input = "\u{200B}".repeat(200);
             let result = validator.validate(&input);
+            // Should NOT warn about high whitespace ratio
             assert!(
                 !result.warnings.iter().any(|w| w.contains("whitespace")),
                 "ZWSP should not count as whitespace (char::is_whitespace returns false)"
@@ -551,6 +554,8 @@ mod tests {
         #[test]
         fn zwnj_not_counted_as_whitespace() {
             let validator = Validator::new();
+            // 200 chars of ZWNJ (\u{200C}) — char::is_whitespace() returns
+            // false for ZWNJ, same as ZWSP.
             let input = "\u{200C}".repeat(200);
             let result = validator.validate(&input);
             assert!(
@@ -562,8 +567,11 @@ mod tests {
         #[test]
         fn zwnj_in_forbidden_pattern() {
             let validator = Validator::new().forbid_pattern("evil");
+            // ZWNJ inserted into "evil": "ev\u{200C}il"
             let input = "some text ev\u{200C}il command here";
             let result = validator.validate_non_empty_input(input, "test");
+            // to_lowercase() preserves ZWNJ. The substring "evil" is broken
+            // by ZWNJ so forbidden pattern check should NOT match.
             assert!(
                 result.is_valid,
                 "ZWNJ breaks forbidden pattern substring match — known bypass"
@@ -573,6 +581,8 @@ mod tests {
         #[test]
         fn zwj_not_counted_as_whitespace() {
             let validator = Validator::new();
+            // 200 chars of ZWJ (\u{200D}) — char::is_whitespace() returns
+            // false for ZWJ.
             let input = "\u{200D}".repeat(200);
             let result = validator.validate(&input);
             assert!(
@@ -584,6 +594,7 @@ mod tests {
         #[test]
         fn actual_whitespace_padding_attack() {
             let validator = Validator::new();
+            // 95% spaces + 5% text, >100 chars — should trigger whitespace warning
             let input = format!("{}{}", " ".repeat(190), "real content");
             assert!(input.len() > 100);
             let result = validator.validate(&input);
@@ -595,12 +606,20 @@ mod tests {
 
         #[test]
         fn combining_diacriticals_in_repetition() {
+            // "a" + combining accent repeated — each visual char is 2 code points
             let input = "a\u{0301}".repeat(30);
+            // has_excessive_repetition checks char-by-char; alternating 'a' and
+            // combining char means max_repeat stays at 1 — should NOT trigger
             assert!(!has_excessive_repetition(&input));
         }
 
         #[test]
         fn base_char_plus_50_distinct_combining_diacriticals() {
+            // Single base char followed by 50 DIFFERENT combining diacriticals.
+            // Each combining mark is a distinct code point, so max_repeat stays
+            // at 1 throughout — should NOT trigger excessive repetition.
+            // This matches issue #1025: "combining marks are distinct chars,
+            // so this should NOT trigger."
             let combining_marks: Vec<char> =
                 (0x0300u32..=0x0331).filter_map(char::from_u32).collect();
             assert!(combining_marks.len() >= 50);
@@ -614,9 +633,13 @@ mod tests {
 
         #[test]
         fn multibyte_chars_at_max_length_boundary() {
+            // Validator uses input.len() (byte length) for max_length check.
+            // A 3-byte CJK char at the boundary: the string is over the limit
+            // in bytes even though char count is under.
             let max_len = 100;
             let validator = Validator::new().with_max_length(max_len);
 
+            // 34 CJK chars × 3 bytes = 102 bytes > max_len of 100
             let input = "中".repeat(34);
             assert_eq!(input.len(), 102);
             let result = validator.validate(&input);
@@ -632,6 +655,7 @@ mod tests {
                 "should produce TooLong error"
             );
 
+            // 33 CJK chars × 3 bytes = 99 bytes < max_len of 100
             let input = "中".repeat(33);
             assert_eq!(input.len(), 99);
             let result = validator.validate(&input);
@@ -646,6 +670,7 @@ mod tests {
 
         #[test]
         fn four_byte_emoji_at_max_length_boundary() {
+            // 4-byte emoji at the boundary: 25 emojis = 100 bytes exactly
             let max_len = 100;
             let validator = Validator::new().with_max_length(max_len);
 
@@ -660,6 +685,7 @@ mod tests {
                 "exactly 100 bytes should not exceed max_length=100"
             );
 
+            // 26 emojis = 104 bytes > 100
             let input = "🔑".repeat(26);
             assert_eq!(input.len(), 104);
             let result = validator.validate(&input);
@@ -674,6 +700,7 @@ mod tests {
 
         #[test]
         fn single_codepoint_emoji_repetition() {
+            // Same emoji repeated 25 times — should trigger excessive repetition
             let input = "😀".repeat(25);
             assert!(
                 has_excessive_repetition(&input),
@@ -684,6 +711,13 @@ mod tests {
         #[test]
         fn multibyte_input_whitespace_ratio_uses_len_not_chars() {
             let validator = Validator::new();
+            // Key insight: whitespace_ratio divides char count by byte length
+            // (input.len()), not char count. With 3-byte chars, the ratio is
+            // artificially low. This documents the behavior.
+            //
+            // 50 spaces (50 bytes) + 50 "中" chars (150 bytes) = 200 bytes total
+            // char-based whitespace count = 50, input.len() = 200
+            // ratio = 50/200 = 0.25 (not high)
             let input = format!("{}{}", " ".repeat(50), "中".repeat(50));
             let result = validator.validate(&input);
             assert!(
@@ -695,8 +729,10 @@ mod tests {
         #[test]
         fn rtl_override_in_forbidden_pattern() {
             let validator = Validator::new().forbid_pattern("evil");
+            // RTL override before "evil"
             let input = "some text \u{202E}evil command here";
             let result = validator.validate_non_empty_input(input, "test");
+            // to_lowercase() preserves RTL char; "evil" substring is still present
             assert!(
                 !result.is_valid,
                 "RTL override should not prevent forbidden pattern detection"
@@ -714,6 +750,7 @@ mod tests {
                     char::from(byte)
                 );
                 let _result = validator.validate(&input);
+                // Primary assertion: no panic
             }
         }
 
@@ -730,7 +767,9 @@ mod tests {
 
         #[test]
         fn control_chars_in_repetition_check() {
+            // Control char repeated 25 times
             let input = "\x07".repeat(55);
+            // Should not panic; may or may not trigger repetition warning
             let _ = has_excessive_repetition(&input);
         }
     }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -308,8 +308,16 @@ impl Agent {
             }
         }
 
-        // Safety validation for user input
-        let validation = self.safety().validate_input(content);
+        // Safety validation for user input.
+        // Skip empty-content check when the message has attachments (e.g., image-only messages).
+        // The attachment pipeline (augment_with_attachments) will provide content downstream.
+        let has_attachments = !message.attachments.is_empty();
+        let validation = if content.is_empty() && has_attachments {
+            // Image/file-only message — bypass empty-input validation
+            ironclaw_safety::ValidationResult::ok()
+        } else {
+            self.safety().validate_input(content)
+        };
         if !validation.is_valid {
             let details = validation
                 .errors

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -2371,8 +2371,6 @@ mod tests {
 
     /// Build a minimal `Agent` for thread_ops unit tests (no DB, no workspace).
     fn make_thread_ops_test_agent() -> crate::agent::Agent {
-        use std::time::Duration;
-
         use async_trait::async_trait;
         use rust_decimal::Decimal;
 
@@ -2449,27 +2447,14 @@ mod tests {
             transcription: None,
             document_extraction: None,
             owner_id: "test-owner".to_string(),
+            sandbox_readiness: crate::agent::routine_engine::SandboxReadiness::DisabledByConfig,
             builder: None,
+            llm_backend: "test".to_string(),
+            tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(4, 2)),
         };
 
         crate::agent::Agent::new(
-            AgentConfig {
-                name: "test-agent".to_string(),
-                max_parallel_jobs: 1,
-                job_timeout: Duration::from_secs(60),
-                stuck_threshold: Duration::from_secs(60),
-                repair_check_interval: Duration::from_secs(30),
-                max_repair_attempts: 1,
-                use_planning: false,
-                session_idle_timeout: Duration::from_secs(300),
-                allow_local_tools: false,
-                max_cost_per_day_cents: None,
-                max_actions_per_hour: None,
-                max_tool_iterations: 50,
-                auto_approve_tools: false,
-                default_timezone: "UTC".to_string(),
-                max_tokens_per_job: 0,
-            },
+            AgentConfig::for_testing(),
             deps,
             Arc::new(ChannelManager::new()),
             None,
@@ -2477,6 +2462,19 @@ mod tests {
             None,
             Some(Arc::new(ContextManager::new(1))),
             None,
+        )
+    }
+
+    /// Build a `TenantCtx` matching `make_thread_ops_test_agent` (no DB, no workspace).
+    fn make_test_tenant() -> crate::tenant::TenantCtx {
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+
+        crate::tenant::TenantCtx::new(
+            "test-user",
+            None,
+            None,
+            Arc::new(CostGuard::new(CostGuardConfig::default())),
+            Arc::new(crate::tenant::TenantRateState::new(4, 2)),
         )
     }
 
@@ -2510,7 +2508,7 @@ mod tests {
         });
 
         let result = agent
-            .process_user_input(&message, session, thread_id, "")
+            .process_user_input(&message, make_test_tenant(), session, thread_id, "")
             .await;
 
         // The call may fail downstream (no DB, no real LLM), but it must NOT
@@ -2542,7 +2540,7 @@ mod tests {
         let message = IncomingMessage::new("test", "test-user", "");
 
         let result = agent
-            .process_user_input(&message, session, thread_id, "")
+            .process_user_input(&message, make_test_tenant(), session, thread_id, "")
             .await;
 
         match result {
@@ -2587,7 +2585,13 @@ mod tests {
         });
 
         let result = agent
-            .process_user_input(&message, session, thread_id, "describe this image")
+            .process_user_input(
+                &message,
+                make_test_tenant(),
+                session,
+                thread_id,
+                "describe this image",
+            )
             .await;
 
         // Non-empty content with a valid message should NOT be rejected by safety.
@@ -2600,6 +2604,56 @@ mod tests {
             }
             _ => {
                 // Passed safety — expected.
+            }
+        }
+    }
+
+    /// Regression: malicious content in attachment `extracted_text` must be
+    /// caught by the post-augmentation safety check. An oversized transcript
+    /// flowing through `augment_with_attachments` into `effective_content`
+    /// should trigger the max-length validation.
+    #[tokio::test]
+    async fn test_process_user_input_rejects_malicious_attachment_content() {
+        use crate::channels::{AttachmentKind, IncomingAttachment};
+
+        let agent = make_thread_ops_test_agent();
+
+        let mut session = Session::new("test-user");
+        let thread = session.create_thread();
+        let thread_id = thread.id;
+
+        let session = Arc::new(Mutex::new(session));
+
+        let mut message = IncomingMessage::new("test", "test-user", "");
+        message.attachments.push(IncomingAttachment {
+            id: "audio-1".to_string(),
+            kind: AttachmentKind::Audio,
+            mime_type: "audio/mp3".to_string(),
+            filename: Some("voice.mp3".to_string()),
+            size_bytes: Some(5000),
+            source_url: None,
+            storage_key: None,
+            // Oversized transcript exceeding max_length (100,000 bytes default)
+            extracted_text: Some("A".repeat(100_001)),
+            data: vec![],
+            duration_secs: Some(10),
+        });
+
+        let result = agent
+            .process_user_input(&message, make_test_tenant(), session, thread_id, "")
+            .await;
+
+        match &result {
+            Ok(crate::agent::submission::SubmissionResult::Error { message }) => {
+                assert!(
+                    message.contains("Attachment content rejected"),
+                    "Expected post-augmentation safety rejection, got: {message}"
+                );
+            }
+            other => {
+                panic!(
+                    "Expected SubmissionResult::Error for oversized extracted_text, got: {other:?}"
+                );
             }
         }
     }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -309,46 +309,50 @@ impl Agent {
         }
 
         // Safety validation for user input.
-        // Skip empty-content check when the message has attachments (e.g., image-only messages).
-        // The attachment pipeline (augment_with_attachments) will provide content downstream.
+        // Skip all safety checks when the message has attachments but no text
+        // content (e.g., image-only messages). An empty string carries no
+        // injection payload, and the attachment pipeline
+        // (augment_with_attachments) will provide content downstream.
+        // Non-empty messages always go through the full safety pipeline.
         let has_attachments = !message.attachments.is_empty();
-        let validation = if content.is_empty() && has_attachments {
-            // Image/file-only message — bypass empty-input validation
-            ironclaw_safety::ValidationResult::ok()
-        } else {
-            self.safety().validate_input(content)
-        };
-        if !validation.is_valid {
-            let details = validation
-                .errors
+        // Intentionally `is_empty()`, not `trim().is_empty()` — whitespace-only
+        // content should still go through safety validation.
+        let skip_safety = content.is_empty() && has_attachments;
+
+        if !skip_safety {
+            let validation = self.safety().validate_input(content);
+            if !validation.is_valid {
+                let details = validation
+                    .errors
+                    .iter()
+                    .map(|e| format!("{}: {}", e.field, e.message))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Ok(SubmissionResult::error(format!(
+                    "Input rejected by safety validation: {}",
+                    details
+                )));
+            }
+
+            let violations = self.safety().check_policy(content);
+            if violations
                 .iter()
-                .map(|e| format!("{}: {}", e.field, e.message))
-                .collect::<Vec<_>>()
-                .join("; ");
-            return Ok(SubmissionResult::error(format!(
-                "Input rejected by safety validation: {}",
-                details
-            )));
-        }
+                .any(|rule| rule.action == crate::safety::PolicyAction::Block)
+            {
+                return Ok(SubmissionResult::error("Input rejected by safety policy."));
+            }
 
-        let violations = self.safety().check_policy(content);
-        if violations
-            .iter()
-            .any(|rule| rule.action == crate::safety::PolicyAction::Block)
-        {
-            return Ok(SubmissionResult::error("Input rejected by safety policy."));
-        }
-
-        // Scan inbound messages for secrets (API keys, tokens).
-        // Catching them here prevents the LLM from echoing them back, which
-        // would trigger the outbound leak detector and create error loops.
-        if let Some(warning) = self.safety().scan_inbound_for_secrets(content) {
-            tracing::warn!(
-                user = %message.user_id,
-                channel = %message.channel,
-                "Inbound message blocked: contains leaked secret"
-            );
-            return Ok(SubmissionResult::error(warning));
+            // Scan inbound messages for secrets (API keys, tokens).
+            // Catching them here prevents the LLM from echoing them back, which
+            // would trigger the outbound leak detector and create error loops.
+            if let Some(warning) = self.safety().scan_inbound_for_secrets(content) {
+                tracing::warn!(
+                    user = %message.user_id,
+                    channel = %message.channel,
+                    "Inbound message blocked: contains leaked secret"
+                );
+                return Ok(SubmissionResult::error(warning));
+            }
         }
 
         // Handle explicit commands (starting with /) directly
@@ -419,13 +423,56 @@ impl Agent {
             );
         }
 
-        // Augment content with attachment context (transcripts, metadata, images)
+        // Augment content with attachment context (transcripts, metadata, images).
         let augmented =
             crate::agent::attachments::augment_with_attachments(content, &message.attachments);
         let (effective_content, image_parts) = match &augmented {
             Some(result) => (result.text.as_str(), result.image_parts.clone()),
             None => (content, Vec::new()),
         };
+
+        // Safety-validate the augmented content when attachments introduced new
+        // text (e.g., image transcripts, PDF extracted text, audio transcripts).
+        // This closes the gap where attacker-controlled content embedded in
+        // attachments could bypass the pre-augmentation safety checks above.
+        if augmented.is_some() && !effective_content.is_empty() {
+            let validation = self.safety().validate_input(effective_content);
+            if !validation.is_valid {
+                let details = validation
+                    .errors
+                    .iter()
+                    .map(|e| format!("{}: {}", e.field, e.message))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                return Ok(SubmissionResult::error(format!(
+                    "Attachment content rejected by safety validation: {}",
+                    details
+                )));
+            }
+
+            let violations = self.safety().check_policy(effective_content);
+            if violations
+                .iter()
+                .any(|rule| rule.action == crate::safety::PolicyAction::Block)
+            {
+                return Ok(SubmissionResult::error(
+                    "Attachment content rejected by safety policy.",
+                ));
+            }
+
+            if let Some(_warning) = self.safety().scan_inbound_for_secrets(effective_content) {
+                tracing::warn!(
+                    user = %message.user_id,
+                    channel = %message.channel,
+                    "Augmented content blocked: contains leaked secret"
+                );
+                return Ok(SubmissionResult::error(
+                    "Attachment content appears to contain a secret (API key, token, or credential). \
+                     For security, it was not sent to the AI. Please remove the secret from the \
+                     attachment and try again.",
+                ));
+            }
+        }
 
         // Start the turn and get messages
         let turn_messages = {
@@ -2319,6 +2366,241 @@ mod tests {
             Ok(Some(msg))
         } else {
             Ok(None)
+        }
+    }
+
+    /// Build a minimal `Agent` for thread_ops unit tests (no DB, no workspace).
+    fn make_thread_ops_test_agent() -> crate::agent::Agent {
+        use std::time::Duration;
+
+        use async_trait::async_trait;
+        use rust_decimal::Decimal;
+
+        use crate::agent::agent_loop::AgentDeps;
+        use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+        use crate::channels::ChannelManager;
+        use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
+        use crate::context::ContextManager;
+        use crate::hooks::HookRegistry;
+        use crate::llm::{
+            CompletionRequest, CompletionResponse, FinishReason, LlmProvider,
+            ToolCompletionRequest, ToolCompletionResponse,
+        };
+        use crate::safety::SafetyLayer;
+        use crate::tools::ToolRegistry;
+
+        struct StaticLlm;
+
+        #[async_trait]
+        impl LlmProvider for StaticLlm {
+            fn model_name(&self) -> &str {
+                "test"
+            }
+            fn cost_per_token(&self) -> (Decimal, Decimal) {
+                (Decimal::ZERO, Decimal::ZERO)
+            }
+            async fn complete(
+                &self,
+                _req: CompletionRequest,
+            ) -> Result<CompletionResponse, crate::error::LlmError> {
+                Ok(CompletionResponse {
+                    content: "ok".to_string(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    finish_reason: FinishReason::Stop,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                })
+            }
+            async fn complete_with_tools(
+                &self,
+                _req: ToolCompletionRequest,
+            ) -> Result<ToolCompletionResponse, crate::error::LlmError> {
+                Ok(ToolCompletionResponse {
+                    content: Some("ok".to_string()),
+                    tool_calls: Vec::new(),
+                    input_tokens: 0,
+                    output_tokens: 0,
+                    finish_reason: FinishReason::Stop,
+                    cache_read_input_tokens: 0,
+                    cache_creation_input_tokens: 0,
+                })
+            }
+        }
+
+        let deps = AgentDeps {
+            store: None,
+            llm: Arc::new(StaticLlm),
+            cheap_llm: None,
+            safety: Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 100_000,
+                injection_check_enabled: true,
+            })),
+            tools: Arc::new(ToolRegistry::new()),
+            workspace: None,
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: SkillsConfig::default(),
+            hooks: Arc::new(HookRegistry::new()),
+            cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
+            sse_tx: None,
+            http_interceptor: None,
+            transcription: None,
+            document_extraction: None,
+            owner_id: "test-owner".to_string(),
+            builder: None,
+        };
+
+        crate::agent::Agent::new(
+            AgentConfig {
+                name: "test-agent".to_string(),
+                max_parallel_jobs: 1,
+                job_timeout: Duration::from_secs(60),
+                stuck_threshold: Duration::from_secs(60),
+                repair_check_interval: Duration::from_secs(30),
+                max_repair_attempts: 1,
+                use_planning: false,
+                session_idle_timeout: Duration::from_secs(300),
+                allow_local_tools: false,
+                max_cost_per_day_cents: None,
+                max_actions_per_hour: None,
+                max_tool_iterations: 50,
+                auto_approve_tools: false,
+                default_timezone: "UTC".to_string(),
+                max_tokens_per_job: 0,
+            },
+            deps,
+            Arc::new(ChannelManager::new()),
+            None,
+            None,
+            None,
+            Some(Arc::new(ContextManager::new(1))),
+            None,
+        )
+    }
+
+    /// Regression: empty content + attachments must NOT be rejected by safety
+    /// validation. Before this fix, `validate_input("")` returned an error
+    /// and blocked image-only messages.
+    #[tokio::test]
+    async fn test_process_user_input_allows_attachment_only_messages() {
+        use crate::channels::{AttachmentKind, IncomingAttachment};
+
+        let agent = make_thread_ops_test_agent();
+
+        let mut session = Session::new("test-user");
+        let thread = session.create_thread();
+        let thread_id = thread.id;
+
+        let session = Arc::new(Mutex::new(session));
+
+        let mut message = IncomingMessage::new("test", "test-user", "");
+        message.attachments.push(IncomingAttachment {
+            id: "photo-1".to_string(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/jpeg".to_string(),
+            filename: Some("photo.jpg".to_string()),
+            size_bytes: Some(1024),
+            source_url: None,
+            storage_key: None,
+            extracted_text: None,
+            data: vec![],
+            duration_secs: None,
+        });
+
+        let result = agent
+            .process_user_input(&message, session, thread_id, "")
+            .await;
+
+        // The call may fail downstream (no DB, no real LLM), but it must NOT
+        // fail on safety validation. Any error containing "safety" would mean
+        // the bypass didn't work.
+        match &result {
+            Ok(crate::agent::submission::SubmissionResult::Error { message }) => {
+                assert!(
+                    !message.to_lowercase().contains("safety"),
+                    "Attachment-only message was blocked by safety: {message}"
+                );
+            }
+            _ => {
+                // Either succeeded or failed for a non-safety reason — both OK.
+            }
+        }
+    }
+
+    /// Control test: empty content WITHOUT attachments must still be rejected.
+    #[tokio::test]
+    async fn test_process_user_input_rejects_empty_without_attachments() {
+        let agent = make_thread_ops_test_agent();
+
+        let mut session = Session::new("test-user");
+        let thread = session.create_thread();
+        let thread_id = thread.id;
+
+        let session = Arc::new(Mutex::new(session));
+        let message = IncomingMessage::new("test", "test-user", "");
+
+        let result = agent
+            .process_user_input(&message, session, thread_id, "")
+            .await;
+
+        match result {
+            Ok(crate::agent::submission::SubmissionResult::Error { message }) => {
+                assert!(
+                    message.contains("safety validation"),
+                    "Expected safety validation error, got: {message}"
+                );
+            }
+            other => {
+                panic!("Expected SubmissionResult::Error for empty input, got: {other:?}");
+            }
+        }
+    }
+
+    /// Non-empty content + attachments must still go through full safety
+    /// validation (the bypass only fires for empty content).
+    #[tokio::test]
+    async fn test_process_user_input_validates_nonempty_with_attachments() {
+        use crate::channels::{AttachmentKind, IncomingAttachment};
+
+        let agent = make_thread_ops_test_agent();
+
+        let mut session = Session::new("test-user");
+        let thread = session.create_thread();
+        let thread_id = thread.id;
+
+        let session = Arc::new(Mutex::new(session));
+
+        let mut message = IncomingMessage::new("test", "test-user", "describe this image");
+        message.attachments.push(IncomingAttachment {
+            id: "photo-2".to_string(),
+            kind: AttachmentKind::Image,
+            mime_type: "image/png".to_string(),
+            filename: Some("screenshot.png".to_string()),
+            size_bytes: Some(2048),
+            source_url: None,
+            storage_key: None,
+            extracted_text: None,
+            data: vec![],
+            duration_secs: None,
+        });
+
+        let result = agent
+            .process_user_input(&message, session, thread_id, "describe this image")
+            .await;
+
+        // Non-empty content with a valid message should NOT be rejected by safety.
+        match &result {
+            Ok(crate::agent::submission::SubmissionResult::Error { message }) => {
+                assert!(
+                    !message.to_lowercase().contains("safety"),
+                    "Non-empty content with attachment was blocked by safety: {message}"
+                );
+            }
+            _ => {
+                // Passed safety — expected.
+            }
         }
     }
 }


### PR DESCRIPTION
## Problem

Messages with attachments (photos, files) but no text caption are rejected by safety validation:

```
Input rejected by safety validation: input: Input cannot be empty
```

This affects all channels (Telegram, web, etc.) when users send image-only messages.

**Root cause:** `SafetyLayer::validate_input(content)` in `thread_ops.rs` rejects empty strings. For image-only messages, `content` is empty because the text portion has no caption — but the message has valid attachments that get processed downstream by `augment_with_attachments()`.

## Fix

Skip the empty-input validation check when the message has attachments. The attachment pipeline will provide content (image descriptions, extracted text) downstream. Non-empty text messages still go through full safety validation.

```rust
let has_attachments = !message.attachments.is_empty();
let validation = if content.is_empty() && has_attachments {
    ironclaw_safety::ValidationResult::ok()
} else {
    self.safety().validate_input(content)
};
```

## Testing

- Verified locally with Telegram channel sending photos without captions
- All existing tests pass (`cargo test`)
- Clippy clean (`cargo clippy --all-features`)