### PR TITLE
docs: mention MiniMax as built-in provider in READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,20 @@ written to `~/.ironclaw/.env` so they are available before the database connects
 
 ### Alternative LLM Providers
 
-IronClaw defaults to NEAR AI but works with any OpenAI-compatible endpoint.
-Popular options include **OpenRouter** (300+ models), **Together AI**, **Fireworks AI**,
-**Ollama** (local), and self-hosted servers like **vLLM** or **LiteLLM**.
+IronClaw defaults to NEAR AI but supports many LLM providers out of the box.
+Built-in providers include **Anthropic**, **OpenAI**, **Google Gemini**, **MiniMax**,
+**Mistral**, and **Ollama** (local). OpenAI-compatible services like **OpenRouter**
+(300+ models), **Together AI**, **Fireworks AI**, and self-hosted servers (**vLLM**,
+**LiteLLM**) are also supported.
 
-Select *"OpenAI-compatible"* in the wizard, or set environment variables directly:
+Select your provider in the wizard, or set environment variables directly:
 
 ```env
+# Example: MiniMax (built-in, 204K context)
+LLM_BACKEND=minimax
+MINIMAX_API_KEY=...
+
+# Example: OpenAI-compatible endpoint
 LLM_BACKEND=openai_compatible
 LLM_BASE_URL=https://openrouter.ai/api/v1
 LLM_API_KEY=sk-or-...

--- a/README.ru.md
+++ b/README.ru.md
@@ -163,12 +163,20 @@ ironclaw onboard
 
 ### Альтернативные LLM-провайдеры
 
-IronClaw по умолчанию использует NEAR AI, но работает с любыми OpenAI-совместимыми эндпоинтами.
-Популярные варианты включают **OpenRouter** (300+ моделей), **Together AI**, **Fireworks AI**, **Ollama** (локально) и собственные серверы, такие как **vLLM** или **LiteLLM**.
+IronClaw по умолчанию использует NEAR AI, но поддерживает множество LLM-провайдеров из коробки.
+Встроенные провайдеры включают **Anthropic**, **OpenAI**, **Google Gemini**, **MiniMax**,
+**Mistral** и **Ollama** (локально). Также поддерживаются OpenAI-совместимые сервисы:
+**OpenRouter** (300+ моделей), **Together AI**, **Fireworks AI** и собственные серверы
+(**vLLM**, **LiteLLM**).
 
-Выберите *"OpenAI-compatible"* в мастере настройки или установите переменные окружения напрямую:
+Выберите провайдера в мастере настройки или установите переменные окружения напрямую:
 
 ```env
+# Пример: MiniMax (встроенный, контекст 204K)
+LLM_BACKEND=minimax
+MINIMAX_API_KEY=...
+
+# Пример: OpenAI-совместимый эндпоинт
 LLM_BACKEND=openai_compatible
 LLM_BASE_URL=https://openrouter.ai/api/v1
 LLM_API_KEY=sk-or-...

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,12 +163,17 @@ ironclaw onboard
 
 ### 替代 LLM 提供商
 
-IronClaw 默认使用 NEAR AI，但兼容任何 OpenAI 兼容的端点。
-常用选项包括 **OpenRouter**（300+ 模型）、**Together AI**、**Fireworks AI**、**Ollama**（本地部署）以及自托管服务器如 **vLLM** 或 **LiteLLM**。
+IronClaw 默认使用 NEAR AI，但开箱即用地支持多种 LLM 提供商。
+内置提供商包括 **Anthropic**、**OpenAI**、**Google Gemini**、**MiniMax**、**Mistral** 和 **Ollama**（本地部署）。同时也支持 OpenAI 兼容服务，如 **OpenRouter**（300+ 模型）、**Together AI**、**Fireworks AI** 以及自托管服务器（**vLLM**、**LiteLLM**）。
 
-在向导中选择 *"OpenAI-compatible"*，或直接设置环境变量：
+在向导中选择你的提供商，或直接设置环境变量：
 
 ```env
+# 示例：MiniMax（内置，204K 上下文）
+LLM_BACKEND=minimax
+MINIMAX_API_KEY=...
+
+# 示例：OpenAI 兼容端点
 LLM_BACKEND=openai_compatible
 LLM_BASE_URL=https://openrouter.ai/api/v1
 LLM_API_KEY=sk-or-...


### PR DESCRIPTION
## Summary

MiniMax was added as a first-class built-in provider in #940, but the "Alternative LLM Providers" section in all three README files (EN, ZH-CN, RU) still only listed OpenRouter, Together AI, Fireworks AI, and Ollama.

This PR updates the section to:
- List all built-in providers (Anthropic, OpenAI, Google Gemini, **MiniMax**, Mistral, Ollama) alongside the OpenAI-compatible options
- Add a quick-start `LLM_BACKEND=minimax` env example so users can get started without reading the full provider guide
- Keep all three language variants consistent

## Test plan
- [x] Verified `providers.json` already contains the MiniMax provider entry
- [x] Verified `docs/LLM_PROVIDERS.md` already has a dedicated MiniMax section
- [x] README.md, README.zh-CN.md, and README.ru.md updated consistently
- [ ] Visual review of rendered markdown