### PR TITLE
fix(llm): persist refreshed Anthropic OAuth token after Keychain re-read

### DIFF
--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -696,19 +696,13 @@ mod tests {
         let token = std::sync::RwLock::new(original);
 
         // Read the original
-        assert_eq!(
-            token.read().unwrap().expose_secret(),
-            "old_token"
-        );
+        assert_eq!(token.read().unwrap().expose_secret(), "old_token");
 
         // Simulate a successful refresh
         let refreshed = SecretString::from("new_token".to_string());
         *token.write().unwrap() = refreshed;
 
         // Subsequent reads see the updated token
-        assert_eq!(
-            token.read().unwrap().expose_secret(),
-            "new_token"
-        );
+        assert_eq!(token.read().unwrap().expose_secret(), "new_token");
     }
 }


### PR DESCRIPTION
## Summary

Fixes intermittent auth failures when Anthropic OAuth tokens expire (#1136).

**Root cause:** The OAuth token was stored as an immutable `SecretString`. When a 401 triggered a Keychain re-read:
1. The fresh token was used for a single retry
2. But `self.token` was **never updated**
3. Every subsequent request reused the expired original token
4. Causing repeated 401s with no recovery

**Fix:**
- Wrap `token` in `RwLock<SecretString>` (matches existing pattern for `active_model`)
- Call `update_token()` after a successful retry with the refreshed token
- Add 500ms delay before Keychain re-read to reduce race window with Claude Code's async refresh

## Test plan

- [x] New regression test: `test_token_update_persists` — verifies RwLock token updates are visible to subsequent reads
- [x] All 7 anthropic_oauth tests pass
- [x] `cargo clippy --all --all-features` — zero warnings
- [ ] Manual: run with Anthropic OAuth, let token expire, verify automatic recovery

Closes #1136