### PR TITLE
feat(sandbox): add retry logic for transient container failures

### DIFF
--- a/src/sandbox/manager.rs
+++ b/src/sandbox/manager.rs
@@ -677,9 +677,9 @@ mod tests {
 
     #[test]
     fn non_transient_errors_are_not_retryable() {
-        assert!(!super::is_transient_sandbox_error(
-            &SandboxError::Timeout(std::time::Duration::from_secs(30))
-        ));
+        assert!(!super::is_transient_sandbox_error(&SandboxError::Timeout(
+            std::time::Duration::from_secs(30)
+        )));
         assert!(!super::is_transient_sandbox_error(
             &SandboxError::ExecutionFailed {
                 reason: "exit code 1".to_string()
@@ -690,10 +690,8 @@ mod tests {
                 reason: "policy violation".to_string()
             }
         ));
-        assert!(!super::is_transient_sandbox_error(
-            &SandboxError::Config {
-                reason: "bad config".to_string()
-            }
-        ));
+        assert!(!super::is_transient_sandbox_error(&SandboxError::Config {
+            reason: "bad config".to_string()
+        }));
     }
 }


### PR DESCRIPTION
## Summary

Adds retry logic for transient Docker container failures (#1224).

`SandboxManager::execute_with_policy()` previously had no retry logic -- transient Docker errors (daemon restart, container creation race, cgroup conflicts) caused immediate job failure.

**Changes:**
- Extract container execution into `try_execute_in_container()` helper
- Wrap in retry loop: up to 2 retries (3 total attempts) with exponential backoff (2s, 4s)
- Add `is_transient_sandbox_error()` classifier for retry-eligible errors
- Only retry: `DockerNotAvailable`, `ContainerCreationFailed`, `ContainerStartFailed`
- Never retry: `Timeout`, `ExecutionFailed`, `NetworkBlocked`, `Config`, etc.
- Container cleanup is safe: `ContainerRunner::execute()` always force-removes before returning

## Test plan

- [x] `transient_errors_are_retryable` -- verifies all 3 transient variants
- [x] `non_transient_errors_are_not_retryable` -- verifies Timeout, ExecutionFailed, NetworkBlocked, Config
- [x] All 10 sandbox::manager tests pass
- [x] `cargo clippy --all --all-features` -- zero warnings

Closes #1224