### PR TITLE
feat(jobs): per-job MCP server filtering and max_iterations cap

### DIFF
--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -5,3 +5,8 @@ mod util;
 
 pub use event::{AppEvent, ToolDecisionDto};
 pub use util::truncate_preview;
+
+/// Maximum worker agent loop iterations. Used by the orchestrator (server-side
+/// clamp in `create_job_inner`) and the worker runtime (`worker/job.rs`).
+/// A single source of truth prevents the two from drifting.
+pub const MAX_WORKER_ITERATIONS: u32 = 500;

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -448,9 +448,10 @@ pub async fn jobs_restart_handler(
                     &task,
                     Some(project_dir),
                     mode,
-                    credential_grants,
-                    None,
-                    None,
+                    crate::orchestrator::job_manager::JobCreationParams {
+                        credential_grants,
+                        ..Default::default()
+                    },
                 )
                 .await
                 .map_err(|e| {

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -449,6 +449,8 @@ pub async fn jobs_restart_handler(
                     Some(project_dir),
                     mode,
                     credential_grants,
+                    None,
+                    None,
                 )
                 .await
                 .map_err(|e| {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -288,7 +288,7 @@ pub enum Command {
         orchestrator_url: String,
 
         /// Maximum iterations before stopping.
-        #[arg(long, default_value = "50")]
+        #[arg(long, env = "IRONCLAW_MAX_ITERATIONS", default_value = "50")]
         max_iterations: u32,
     },
 

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -16,6 +16,9 @@ use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
 use crate::sandbox::connect_docker;
 
+/// Path to the master worker MCP config on the host.
+const WORKER_MCP_CONFIG_PATH: &str = "/opt/ironclaw/config/worker/mcp-servers.json";
+
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JobMode {
@@ -348,15 +351,16 @@ impl ContainerJobManager {
             env_vec.push("IRONCLAW_WORKSPACE=/workspace".to_string());
         }
 
-        // Inject max_iterations if specified.
-        if let Some(iters) = max_iterations {
+        // Inject max_iterations if specified (only for Worker mode — ClaudeCode uses max_turns).
+        if let Some(iters) = max_iterations
+            && mode == JobMode::Worker
+        {
             env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", iters));
         }
 
         // Mount per-job MCP config when the feature is enabled.
         if self.config.mcp_per_job_enabled {
-            let mcp_config_host =
-                std::path::Path::new("/opt/ironclaw/config/worker/mcp-servers.json");
+            let mcp_config_host = std::path::Path::new(WORKER_MCP_CONFIG_PATH);
             match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)? {
                 Some(config_path) => {
                     binds.push(format!(
@@ -627,17 +631,20 @@ impl ContainerJobManager {
     /// Remove a completed job handle from memory (called after result is read).
     pub async fn cleanup_job(&self, job_id: Uuid) {
         // Clean up per-job MCP config temp file if one was written.
+        // Use remove_file directly — avoids TOCTOU race with exists() check.
         let tmp_path = std::env::temp_dir()
             .join("ironclaw-mcp-configs")
             .join(format!("{}.json", job_id));
-        if tmp_path.exists()
-            && let Err(e) = std::fs::remove_file(&tmp_path)
-        {
-            tracing::warn!(
-                job_id = %job_id,
-                error = %e,
-                "Failed to remove per-job MCP config temp file"
-            );
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // No temp file — normal
+            Err(e) => {
+                tracing::warn!(
+                    job_id = %job_id,
+                    error = %e,
+                    "Failed to remove per-job MCP config temp file"
+                );
+            }
         }
 
         self.containers.write().await.remove(&job_id);
@@ -739,7 +746,7 @@ fn generate_worker_mcp_config(
             let schema_version = master
                 .get("schema_version")
                 .cloned()
-                .unwrap_or(serde_json::json!(0));
+                .unwrap_or(serde_json::json!(1));
             let filtered = serde_json::json!({
                 "servers": servers,
                 "schema_version": schema_version
@@ -754,13 +761,17 @@ fn generate_worker_mcp_config(
             })?;
 
             let tmp_path = tmp_dir.join(format!("{}.json", job_id));
-            std::fs::write(
-                &tmp_path,
-                serde_json::to_string_pretty(&filtered).unwrap_or_else(|_| "{}".to_string()),
-            )
-            .map_err(|e| OrchestratorError::ContainerCreationFailed {
-                job_id,
-                reason: format!("failed to write per-job MCP config: {e}"),
+            let config_json = serde_json::to_string_pretty(&filtered).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to serialize filtered MCP config: {e}"),
+                }
+            })?;
+            std::fs::write(&tmp_path, config_json).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to write per-job MCP config: {e}"),
+                }
             })?;
 
             Ok(Some(tmp_path))

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -19,10 +19,7 @@ use crate::sandbox::connect_docker;
 /// Path to the master worker MCP config on the host.
 const WORKER_MCP_CONFIG_PATH: &str = "/opt/ironclaw/config/worker/mcp-servers.json";
 
-/// Maximum worker agent loop iterations. Must match `MAX_WORKER_ITERATIONS` in
-/// `src/worker/job.rs`. Applied server-side in `create_job_inner` so that even
-/// a direct API call (bypassing tool parameter parsing) is capped.
-const MAX_WORKER_ITERATIONS: u32 = 500;
+use ironclaw_common::MAX_WORKER_ITERATIONS;
 
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -378,7 +375,9 @@ impl ContainerJobManager {
         // Mount per-job MCP config when the feature is enabled.
         if self.config.mcp_per_job_enabled {
             let mcp_config_host = std::path::Path::new(WORKER_MCP_CONFIG_PATH);
-            match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)? {
+            match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)
+                .await?
+            {
                 Some(config_path) => {
                     binds.push(format!(
                         "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
@@ -704,12 +703,12 @@ impl ContainerJobManager {
 ///
 /// Temp files are written to `<temp_dir>/ironclaw-mcp-configs/` and cleaned up
 /// in `cleanup_job`.
-fn generate_worker_mcp_config(
+async fn generate_worker_mcp_config(
     master_path: &std::path::Path,
     server_names: Option<&[String]>,
     job_id: Uuid,
 ) -> Result<Option<std::path::PathBuf>, OrchestratorError> {
-    if !master_path.exists() {
+    if !tokio::fs::try_exists(master_path).await.unwrap_or(false) {
         return Ok(None);
     }
 
@@ -738,7 +737,7 @@ fn generate_worker_mcp_config(
                 }
             }
 
-            let content = std::fs::read_to_string(master_path).map_err(|e| {
+            let content = tokio::fs::read_to_string(master_path).await.map_err(|e| {
                 OrchestratorError::ContainerCreationFailed {
                     job_id,
                     reason: format!("failed to read master MCP config: {e}"),
@@ -786,7 +785,7 @@ fn generate_worker_mcp_config(
             });
 
             let tmp_dir = std::env::temp_dir().join("ironclaw-mcp-configs");
-            std::fs::create_dir_all(&tmp_dir).map_err(|e| {
+            tokio::fs::create_dir_all(&tmp_dir).await.map_err(|e| {
                 OrchestratorError::ContainerCreationFailed {
                     job_id,
                     reason: format!("failed to create MCP config temp dir: {e}"),
@@ -798,7 +797,9 @@ fn generate_worker_mcp_config(
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                let _ = std::fs::set_permissions(&tmp_dir, std::fs::Permissions::from_mode(0o700));
+                let _ =
+                    tokio::fs::set_permissions(&tmp_dir, std::fs::Permissions::from_mode(0o700))
+                        .await;
             }
 
             let tmp_path = tmp_dir.join(format!("{}.json", job_id));
@@ -808,12 +809,12 @@ fn generate_worker_mcp_config(
                     reason: format!("failed to serialize filtered MCP config: {e}"),
                 }
             })?;
-            std::fs::write(&tmp_path, config_json).map_err(|e| {
-                OrchestratorError::ContainerCreationFailed {
+            tokio::fs::write(&tmp_path, config_json)
+                .await
+                .map_err(|e| OrchestratorError::ContainerCreationFailed {
                     job_id,
                     reason: format!("failed to write per-job MCP config: {e}"),
-                }
-            })?;
+                })?;
 
             Ok(Some(tmp_path))
         }
@@ -917,34 +918,35 @@ mod tests {
 
     // ── generate_worker_mcp_config tests ────────────────────────────
 
-    #[test]
-    fn test_mcp_config_none_filter_returns_master_path() {
+    #[tokio::test]
+    async fn test_mcp_config_none_filter_returns_master_path() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
-        let result = generate_worker_mcp_config(tmp.path(), None, Uuid::new_v4());
+        let result = generate_worker_mcp_config(tmp.path(), None, Uuid::new_v4()).await;
         assert_eq!(result.unwrap(), Some(tmp.path().to_path_buf()));
     }
 
-    #[test]
-    fn test_mcp_config_empty_filter_returns_none() {
+    #[tokio::test]
+    async fn test_mcp_config_empty_filter_returns_none() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
-        let result = generate_worker_mcp_config(tmp.path(), Some(&[]), Uuid::new_v4());
+        let result = generate_worker_mcp_config(tmp.path(), Some(&[]), Uuid::new_v4()).await;
         assert_eq!(result.unwrap(), None);
     }
 
-    #[test]
-    fn test_mcp_config_missing_master_returns_none() {
+    #[tokio::test]
+    async fn test_mcp_config_missing_master_returns_none() {
         let result = generate_worker_mcp_config(
             std::path::Path::new("/nonexistent/mcp.json"),
             None,
             Uuid::new_v4(),
-        );
+        )
+        .await;
         assert_eq!(result.unwrap(), None);
     }
 
-    #[test]
-    fn test_mcp_config_filters_to_named_servers() {
+    #[tokio::test]
+    async fn test_mcp_config_filters_to_named_servers() {
         let job_id = Uuid::new_v4();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -958,7 +960,7 @@ mod tests {
         .unwrap();
 
         let names = vec!["serpstat".to_string(), "disabled".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         let out_path = result.unwrap().expect("should produce a filtered config");
 
         let content: serde_json::Value =
@@ -974,8 +976,8 @@ mod tests {
         let _ = std::fs::remove_file(&out_path);
     }
 
-    #[test]
-    fn test_mcp_config_no_match_returns_none() {
+    #[tokio::test]
+    async fn test_mcp_config_no_match_returns_none() {
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
             tmp.path(),
@@ -984,12 +986,12 @@ mod tests {
         .unwrap();
 
         let names = vec!["nonexistent".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4());
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4()).await;
         assert_eq!(result.unwrap(), None);
     }
 
-    #[test]
-    fn test_mcp_config_case_insensitive_match() {
+    #[tokio::test]
+    async fn test_mcp_config_case_insensitive_match() {
         let job_id = Uuid::new_v4();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -999,7 +1001,7 @@ mod tests {
         .unwrap();
 
         let names = vec!["serpstat".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         let out_path = result.unwrap().expect("case-insensitive match should work");
         let _ = std::fs::remove_file(&out_path);
     }
@@ -1046,8 +1048,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_mcp_server_name_validation_rejects_path_separators() {
+    #[tokio::test]
+    async fn test_mcp_server_name_validation_rejects_path_separators() {
         let job_id = Uuid::new_v4();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -1058,26 +1060,38 @@ mod tests {
 
         // Path separator should be rejected
         let names = vec!["../../etc/passwd".to_string()];
-        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
 
         // Null byte should be rejected
         let names = vec!["test\0evil".to_string()];
-        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
 
         // Excessively long name should be rejected
         let names = vec!["a".repeat(129)];
-        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
 
         // Valid name should pass
         let names = vec!["test".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         assert!(result.is_ok());
     }
 
     // ── Regression tests (CI-required) ────────────────────────────────
 
-    #[test]
-    fn test_filtered_config_contains_only_requested_server() {
+    #[tokio::test]
+    async fn test_filtered_config_contains_only_requested_server() {
         let job_id = Uuid::new_v4();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -1091,7 +1105,7 @@ mod tests {
         .unwrap();
 
         let names = vec!["serpstat".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         let out_path = result.unwrap().expect("should produce a filtered config");
 
         let content: serde_json::Value =
@@ -1116,8 +1130,8 @@ mod tests {
         let _ = std::fs::remove_file(&out_path);
     }
 
-    #[test]
-    fn test_feature_flag_disabled_skips_mcp_filtering() {
+    #[tokio::test]
+    async fn test_feature_flag_disabled_skips_mcp_filtering() {
         // When MCP_PER_JOB_ENABLED is false (the default), the mcp_servers
         // parameter should be ignored and no filtered config should be created.
         let config = ContainerJobConfig::default();
@@ -1135,8 +1149,8 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_temp_file_cleanup_removes_per_job_config() {
+    #[tokio::test]
+    async fn test_temp_file_cleanup_removes_per_job_config() {
         let job_id = Uuid::new_v4();
         let tmp = tempfile::NamedTempFile::new().unwrap();
         std::fs::write(
@@ -1146,7 +1160,7 @@ mod tests {
         .unwrap();
 
         let names = vec!["serpstat".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         let out_path = result.unwrap().expect("should produce a filtered config");
         assert!(
             out_path.exists(),
@@ -1179,8 +1193,8 @@ mod tests {
     }
 
     #[cfg(unix)]
-    #[test]
-    fn test_temp_dir_has_restrictive_permissions() {
+    #[tokio::test]
+    async fn test_temp_dir_has_restrictive_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let job_id = Uuid::new_v4();
@@ -1192,7 +1206,7 @@ mod tests {
         .unwrap();
 
         let names = vec!["test".to_string()];
-        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
         let out_path = result.unwrap().expect("should produce a filtered config");
 
         let dir_path = out_path.parent().unwrap();

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -66,6 +66,9 @@ pub struct ContainerJobConfig {
     pub claude_code_memory_limit_mb: u64,
     /// Allowed tool patterns for Claude Code (passed as CLAUDE_CODE_ALLOWED_TOOLS env var).
     pub claude_code_allowed_tools: Vec<String>,
+    /// Whether per-job MCP server filtering is enabled.
+    /// When false, `mcp_servers` param on `create_job` is ignored.
+    pub mcp_per_job_enabled: bool,
 }
 
 impl Default for ContainerJobConfig {
@@ -81,6 +84,7 @@ impl Default for ContainerJobConfig {
             claude_code_max_turns: 50,
             claude_code_memory_limit_mb: 4096,
             claude_code_allowed_tools: crate::config::ClaudeCodeConfig::default().allowed_tools,
+            mcp_per_job_enabled: false,
         }
     }
 }
@@ -248,6 +252,7 @@ impl ContainerJobManager {
     /// before the container is created. Credential grants are stored in the
     /// TokenStore and served on-demand via the `/credentials` endpoint.
     /// Returns the auth token for the worker.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_job(
         &self,
         job_id: Uuid,
@@ -255,6 +260,8 @@ impl ContainerJobManager {
         project_dir: Option<PathBuf>,
         mode: JobMode,
         credential_grants: Vec<CredentialGrant>,
+        mcp_servers: Option<Vec<String>>,
+        max_iterations: Option<u32>,
     ) -> Result<String, OrchestratorError> {
         // Generate auth token (stored in TokenStore, never logged)
         let token = self.token_store.create_token(job_id).await;
@@ -282,7 +289,14 @@ impl ContainerJobManager {
         // Run the actual container creation. On any failure, revoke the token
         // and remove the handle so we don't leak resources.
         match self
-            .create_job_inner(job_id, &token, project_dir, mode)
+            .create_job_inner(
+                job_id,
+                &token,
+                project_dir,
+                mode,
+                mcp_servers,
+                max_iterations,
+            )
             .await
         {
             Ok(()) => Ok(token),
@@ -295,12 +309,15 @@ impl ContainerJobManager {
     }
 
     /// Inner implementation of container creation (separated for cleanup).
+    #[allow(clippy::too_many_arguments)]
     async fn create_job_inner(
         &self,
         job_id: Uuid,
         token: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
+        mcp_servers: Option<Vec<String>>,
+        max_iterations: Option<u32>,
     ) -> Result<(), OrchestratorError> {
         // Connect to Docker (reuses cached connection)
         let docker = self.docker().await?;
@@ -329,6 +346,36 @@ impl ContainerJobManager {
             let canonical = validate_bind_mount_path(dir, job_id)?;
             binds.push(format!("{}:/workspace:rw", canonical.display()));
             env_vec.push("IRONCLAW_WORKSPACE=/workspace".to_string());
+        }
+
+        // Inject max_iterations if specified.
+        if let Some(iters) = max_iterations {
+            env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", iters));
+        }
+
+        // Mount per-job MCP config when the feature is enabled.
+        if self.config.mcp_per_job_enabled {
+            let mcp_config_host =
+                std::path::Path::new("/opt/ironclaw/config/worker/mcp-servers.json");
+            match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)? {
+                Some(config_path) => {
+                    binds.push(format!(
+                        "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
+                        config_path.display()
+                    ));
+                    tracing::debug!(
+                        job_id = %job_id,
+                        filtered = mcp_servers.is_some(),
+                        "Mounted MCP config into container"
+                    );
+                }
+                None => {
+                    tracing::debug!(
+                        job_id = %job_id,
+                        "No MCP config to mount (master missing or empty filter list)"
+                    );
+                }
+            }
         }
 
         // Claude Code mode: auth + tool allowlist.
@@ -579,6 +626,19 @@ impl ContainerJobManager {
 
     /// Remove a completed job handle from memory (called after result is read).
     pub async fn cleanup_job(&self, job_id: Uuid) {
+        // Clean up per-job MCP config temp file if one was written.
+        let tmp_path =
+            std::path::Path::new("/tmp/ironclaw-mcp-configs").join(format!("{}.json", job_id));
+        if tmp_path.exists()
+            && let Err(e) = std::fs::remove_file(&tmp_path)
+        {
+            tracing::warn!(
+                job_id = %job_id,
+                error = %e,
+                "Failed to remove per-job MCP config temp file"
+            );
+        }
+
         self.containers.write().await.remove(&job_id);
     }
 
@@ -608,6 +668,102 @@ impl ContainerJobManager {
     /// Get a reference to the token store.
     pub fn token_store(&self) -> &TokenStore {
         &self.token_store
+    }
+}
+
+/// Generate a per-job MCP config file, optionally filtering to specific servers.
+///
+/// - `None` → mount the full master config as-is
+/// - `Some([])` → no MCP config (no mount)
+/// - `Some(["serpstat"])` → filtered config with only matching servers
+///
+/// Temp files are written to `/tmp/ironclaw-mcp-configs/` and cleaned up
+/// in `cleanup_job`.
+fn generate_worker_mcp_config(
+    master_path: &std::path::Path,
+    server_names: Option<&[String]>,
+    job_id: Uuid,
+) -> Result<Option<std::path::PathBuf>, OrchestratorError> {
+    if !master_path.exists() {
+        return Ok(None);
+    }
+
+    match server_names {
+        // No filter → use master config as-is
+        None => Ok(Some(master_path.to_path_buf())),
+
+        // Empty list → no MCP
+        Some([]) => Ok(None),
+
+        // Filter to specific servers
+        Some(names) => {
+            let content = std::fs::read_to_string(master_path).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to read master MCP config: {e}"),
+                }
+            })?;
+
+            let master: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to parse master MCP config: {e}"),
+                }
+            })?;
+
+            let servers = master["servers"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|s| {
+                    let name_matches = s["name"]
+                        .as_str()
+                        .map(|n| names.iter().any(|req| req == n))
+                        .unwrap_or(false);
+                    let is_enabled = s["enabled"].as_bool().unwrap_or(true);
+                    name_matches && is_enabled
+                })
+                .collect::<Vec<_>>();
+
+            if servers.is_empty() {
+                tracing::warn!(
+                    job_id = %job_id,
+                    requested = ?names,
+                    "No matching MCP servers found in master config; skipping MCP mount"
+                );
+                return Ok(None);
+            }
+
+            let schema_version = master
+                .get("schema_version")
+                .cloned()
+                .unwrap_or(serde_json::json!(0));
+            let filtered = serde_json::json!({
+                "servers": servers,
+                "schema_version": schema_version
+            });
+
+            let tmp_dir = std::path::Path::new("/tmp/ironclaw-mcp-configs");
+            std::fs::create_dir_all(tmp_dir).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to create MCP config temp dir: {e}"),
+                }
+            })?;
+
+            let tmp_path = tmp_dir.join(format!("{}.json", job_id));
+            std::fs::write(
+                &tmp_path,
+                serde_json::to_string_pretty(&filtered).unwrap_or_else(|_| "{}".to_string()),
+            )
+            .map_err(|e| OrchestratorError::ContainerCreationFailed {
+                job_id,
+                reason: format!("failed to write per-job MCP config: {e}"),
+            })?;
+
+            Ok(Some(tmp_path))
+        }
     }
 }
 
@@ -704,5 +860,78 @@ mod tests {
         let handle = mgr.get_handle(job_id).await.unwrap();
         assert_eq!(handle.worker_iteration, 3);
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 3"));
+    }
+
+    // ── generate_worker_mcp_config tests ────────────────────────────
+
+    #[test]
+    fn test_mcp_config_none_filter_returns_master_path() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), None, Uuid::new_v4());
+        assert_eq!(result.unwrap(), Some(tmp.path().to_path_buf()));
+    }
+
+    #[test]
+    fn test_mcp_config_empty_filter_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), Some(&[]), Uuid::new_v4());
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_mcp_config_missing_master_returns_none() {
+        let result = generate_worker_mcp_config(
+            std::path::Path::new("/nonexistent/mcp.json"),
+            None,
+            Uuid::new_v4(),
+        );
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_mcp_config_filters_to_named_servers() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":1,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"disabled","enabled":false,"url":"http://localhost:9999"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string(), "disabled".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        // "disabled" should be excluded because enabled=false
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert_eq!(content["schema_version"], 1);
+
+        // cleanup
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn test_mcp_config_no_match_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["nonexistent".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4());
+        assert_eq!(result.unwrap(), None);
     }
 }

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -760,6 +760,14 @@ fn generate_worker_mcp_config(
                 }
             })?;
 
+            // Restrict directory permissions to owner-only (0o700) to prevent
+            // other users on the host from reading filtered MCP configs.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ = std::fs::set_permissions(&tmp_dir, std::fs::Permissions::from_mode(0o700));
+            }
+
             let tmp_path = tmp_dir.join(format!("{}.json", job_id));
             let config_json = serde_json::to_string_pretty(&filtered).map_err(|e| {
                 OrchestratorError::ContainerCreationFailed {
@@ -981,5 +989,137 @@ mod tests {
             "cli/mod.rs must have env = \"IRONCLAW_MAX_ITERATIONS\" on the max_iterations arg"
         );
         drop(mgr);
+    }
+
+    // ── Regression tests (CI-required) ────────────────────────────────
+
+    #[test]
+    fn test_filtered_config_contains_only_requested_server() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":2,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"archon","enabled":true,"url":"http://localhost:8064"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        assert_eq!(servers.len(), 1, "only serpstat should be present");
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert!(
+            !servers.iter().any(|s| s["name"] == "notion"),
+            "notion must not leak into filtered config"
+        );
+        assert!(
+            !servers.iter().any(|s| s["name"] == "archon"),
+            "archon must not leak into filtered config"
+        );
+        assert_eq!(
+            content["schema_version"], 2,
+            "schema_version must be preserved"
+        );
+
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn test_feature_flag_disabled_skips_mcp_filtering() {
+        // When MCP_PER_JOB_ENABLED is false (the default), the mcp_servers
+        // parameter should be ignored and no filtered config should be created.
+        let config = ContainerJobConfig::default();
+        assert!(
+            !config.mcp_per_job_enabled,
+            "mcp_per_job_enabled must default to false"
+        );
+
+        // Verify the gate in create_job_inner: the mcp_per_job_enabled field
+        // controls whether generate_worker_mcp_config is called at all.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("if self.config.mcp_per_job_enabled"),
+            "create_job_inner must gate MCP filtering on config.mcp_per_job_enabled"
+        );
+    }
+
+    #[test]
+    fn test_temp_file_cleanup_removes_per_job_config() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let out_path = result.unwrap().expect("should produce a filtered config");
+        assert!(
+            out_path.exists(),
+            "temp config file should exist after creation"
+        );
+
+        // Simulate what cleanup_job does
+        let expected_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
+        assert_eq!(
+            out_path, expected_path,
+            "temp path must match cleanup expectation"
+        );
+        std::fs::remove_file(&out_path).unwrap();
+        assert!(!out_path.exists(), "temp file should be gone after cleanup");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_job_is_idempotent() {
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        let job_id = Uuid::new_v4();
+
+        // cleanup_job should not panic or error when called for a job
+        // that has no temp file and no container handle.
+        mgr.cleanup_job(job_id).await;
+        // Second call should also be fine (idempotent).
+        mgr.cleanup_job(job_id).await;
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_temp_dir_has_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let dir_path = out_path.parent().unwrap();
+        let mode = std::fs::metadata(dir_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "ironclaw-mcp-configs dir must be 0700, got {:o}",
+            mode
+        );
+
+        let _ = std::fs::remove_file(&out_path);
     }
 }

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -627,8 +627,9 @@ impl ContainerJobManager {
     /// Remove a completed job handle from memory (called after result is read).
     pub async fn cleanup_job(&self, job_id: Uuid) {
         // Clean up per-job MCP config temp file if one was written.
-        let tmp_path =
-            std::path::Path::new("/tmp/ironclaw-mcp-configs").join(format!("{}.json", job_id));
+        let tmp_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
         if tmp_path.exists()
             && let Err(e) = std::fs::remove_file(&tmp_path)
         {
@@ -677,7 +678,7 @@ impl ContainerJobManager {
 /// - `Some([])` → no MCP config (no mount)
 /// - `Some(["serpstat"])` → filtered config with only matching servers
 ///
-/// Temp files are written to `/tmp/ironclaw-mcp-configs/` and cleaned up
+/// Temp files are written to `<temp_dir>/ironclaw-mcp-configs/` and cleaned up
 /// in `cleanup_job`.
 fn generate_worker_mcp_config(
     master_path: &std::path::Path,
@@ -719,7 +720,7 @@ fn generate_worker_mcp_config(
                 .filter(|s| {
                     let name_matches = s["name"]
                         .as_str()
-                        .map(|n| names.iter().any(|req| req == n))
+                        .map(|n| names.iter().any(|req| req.eq_ignore_ascii_case(n)))
                         .unwrap_or(false);
                     let is_enabled = s["enabled"].as_bool().unwrap_or(true);
                     name_matches && is_enabled
@@ -744,8 +745,8 @@ fn generate_worker_mcp_config(
                 "schema_version": schema_version
             });
 
-            let tmp_dir = std::path::Path::new("/tmp/ironclaw-mcp-configs");
-            std::fs::create_dir_all(tmp_dir).map_err(|e| {
+            let tmp_dir = std::env::temp_dir().join("ironclaw-mcp-configs");
+            std::fs::create_dir_all(&tmp_dir).map_err(|e| {
                 OrchestratorError::ContainerCreationFailed {
                     job_id,
                     reason: format!("failed to create MCP config temp dir: {e}"),
@@ -933,5 +934,41 @@ mod tests {
         let names = vec!["nonexistent".to_string()];
         let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4());
         assert_eq!(result.unwrap(), None);
+    }
+
+    #[test]
+    fn test_mcp_config_case_insensitive_match() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"Serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        let out_path = result.unwrap().expect("case-insensitive match should work");
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn test_max_iterations_env_var_injected() {
+        // Verify the IRONCLAW_MAX_ITERATIONS env var name matches what the
+        // worker CLI reads via clap's `env` attribute.
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        // We can't test actual container creation without Docker, but we can
+        // verify the env var name matches the clap definition.
+        // The clap definition uses: #[arg(long, env = "IRONCLAW_MAX_ITERATIONS")]
+        // The create_job_inner injects: format!("IRONCLAW_MAX_ITERATIONS={}", iters)
+        // This test ensures the constant isn't accidentally changed in either place.
+        let env_var_in_job = "IRONCLAW_MAX_ITERATIONS";
+        let source = include_str!("../cli/mod.rs");
+        assert!(
+            source.contains(&format!("env = \"{}\"", env_var_in_job)),
+            "cli/mod.rs must have env = \"IRONCLAW_MAX_ITERATIONS\" on the max_iterations arg"
+        );
+        drop(mgr);
     }
 }

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -19,6 +19,11 @@ use crate::sandbox::connect_docker;
 /// Path to the master worker MCP config on the host.
 const WORKER_MCP_CONFIG_PATH: &str = "/opt/ironclaw/config/worker/mcp-servers.json";
 
+/// Maximum worker agent loop iterations. Must match `MAX_WORKER_ITERATIONS` in
+/// `src/worker/job.rs`. Applied server-side in `create_job_inner` so that even
+/// a direct API call (bypassing tool parameter parsing) is capped.
+const MAX_WORKER_ITERATIONS: u32 = 500;
+
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JobMode {
@@ -41,6 +46,19 @@ impl std::fmt::Display for JobMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
     }
+}
+
+/// Parameters for creating a container job, bundled to avoid positional
+/// argument proliferation on `create_job` / `execute_sandbox`.
+#[derive(Debug, Clone, Default)]
+pub struct JobCreationParams {
+    /// Credential grants for the worker (served via `/credentials`).
+    pub credential_grants: Vec<CredentialGrant>,
+    /// Optional filter: which MCP servers to mount into the container.
+    /// `None` = full master config, `Some([])` = no MCP, `Some(["name"])` = filtered.
+    pub mcp_servers: Option<Vec<String>>,
+    /// Optional cap on worker agent loop iterations (clamped to 1..=500 server-side).
+    pub max_iterations: Option<u32>,
 }
 
 /// Configuration for the container job manager.
@@ -255,23 +273,20 @@ impl ContainerJobManager {
     /// before the container is created. Credential grants are stored in the
     /// TokenStore and served on-demand via the `/credentials` endpoint.
     /// Returns the auth token for the worker.
-    #[allow(clippy::too_many_arguments)]
     pub async fn create_job(
         &self,
         job_id: Uuid,
         task: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
-        mcp_servers: Option<Vec<String>>,
-        max_iterations: Option<u32>,
+        params: JobCreationParams,
     ) -> Result<String, OrchestratorError> {
         // Generate auth token (stored in TokenStore, never logged)
         let token = self.token_store.create_token(job_id).await;
 
         // Store credential grants (revoked automatically when the token is revoked)
         self.token_store
-            .store_grants(job_id, credential_grants)
+            .store_grants(job_id, params.credential_grants)
             .await;
 
         // Record the handle
@@ -297,8 +312,8 @@ impl ContainerJobManager {
                 &token,
                 project_dir,
                 mode,
-                mcp_servers,
-                max_iterations,
+                params.mcp_servers,
+                params.max_iterations,
             )
             .await
         {
@@ -312,7 +327,6 @@ impl ContainerJobManager {
     }
 
     /// Inner implementation of container creation (separated for cleanup).
-    #[allow(clippy::too_many_arguments)]
     async fn create_job_inner(
         &self,
         job_id: Uuid,
@@ -352,10 +366,13 @@ impl ContainerJobManager {
         }
 
         // Inject max_iterations if specified (only for Worker mode — ClaudeCode uses max_turns).
+        // Server-side clamp ensures the cap is enforced even if the tool parsing
+        // layer is bypassed (e.g., direct API call via the web restart handler).
         if let Some(iters) = max_iterations
             && mode == JobMode::Worker
         {
-            env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", iters));
+            let capped = iters.clamp(1, MAX_WORKER_ITERATIONS);
+            env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", capped));
         }
 
         // Mount per-job MCP config when the feature is enabled.
@@ -705,6 +722,22 @@ fn generate_worker_mcp_config(
 
         // Filter to specific servers
         Some(names) => {
+            // Validate server names: reject path separators, null bytes, and
+            // excessively long names to prevent misuse if names are ever used
+            // in file paths or shell commands.
+            for name in names {
+                if name.len() > 128
+                    || name.contains('/')
+                    || name.contains('\\')
+                    || name.contains('\0')
+                {
+                    return Err(OrchestratorError::ContainerCreationFailed {
+                        job_id,
+                        reason: format!("invalid MCP server name: {:?}", name),
+                    });
+                }
+            }
+
             let content = std::fs::read_to_string(master_path).map_err(|e| {
                 OrchestratorError::ContainerCreationFailed {
                     job_id,
@@ -989,6 +1022,56 @@ mod tests {
             "cli/mod.rs must have env = \"IRONCLAW_MAX_ITERATIONS\" on the max_iterations arg"
         );
         drop(mgr);
+    }
+
+    #[test]
+    fn test_max_iterations_not_injected_for_claude_code() {
+        // ClaudeCode mode uses its own `max_turns`, not IRONCLAW_MAX_ITERATIONS.
+        // Verify the gate in create_job_inner only injects for Worker mode.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("mode == JobMode::Worker"),
+            "create_job_inner must gate IRONCLAW_MAX_ITERATIONS on JobMode::Worker \
+             (ClaudeCode has its own max_turns)"
+        );
+    }
+
+    #[test]
+    fn test_server_side_max_iterations_clamp() {
+        // Verify the server-side clamp uses the same constant as worker/job.rs
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("iters.clamp(1, MAX_WORKER_ITERATIONS)"),
+            "create_job_inner must clamp max_iterations server-side using MAX_WORKER_ITERATIONS"
+        );
+    }
+
+    #[test]
+    fn test_mcp_server_name_validation_rejects_path_separators() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        // Path separator should be rejected
+        let names = vec!["../../etc/passwd".to_string()];
+        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+
+        // Null byte should be rejected
+        let names = vec!["test\0evil".to_string()];
+        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+
+        // Excessively long name should be rejected
+        let names = vec!["a".repeat(129)];
+        assert!(generate_worker_mcp_config(tmp.path(), Some(&names), job_id).is_err());
+
+        // Valid name should pass
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id);
+        assert!(result.is_ok());
     }
 
     // ── Regression tests (CI-required) ────────────────────────────────

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -122,6 +122,9 @@ pub async fn setup_orchestrator(
             claude_code_max_turns: config.claude_code.max_turns,
             claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
             claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
+            mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
         };
         let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
 

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -355,6 +355,7 @@ impl CreateJobTool {
     }
 
     /// Execute via sandboxed Docker container.
+    #[allow(clippy::too_many_arguments)]
     async fn execute_sandbox(
         &self,
         task: &str,
@@ -362,6 +363,8 @@ impl CreateJobTool {
         wait: bool,
         mode: JobMode,
         credential_grants: Vec<CredentialGrant>,
+        mcp_servers: Option<Vec<String>>,
+        max_iterations: Option<u32>,
         ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
@@ -431,7 +434,15 @@ impl CreateJobTool {
 
         // Create the container job with the pre-determined job_id.
         let _token = jm
-            .create_job(job_id, task, Some(project_dir), mode, credential_grants)
+            .create_job(
+                job_id,
+                task,
+                Some(project_dir),
+                mode,
+                credential_grants,
+                mcp_servers,
+                max_iterations,
+            )
             .await
             .map_err(|e| {
                 self.update_status(
@@ -849,6 +860,18 @@ impl Tool for CreateJobTool {
                                         secrets store (via 'ironclaw tool auth' or web UI). Example: \
                                         {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
                         "additionalProperties": { "type": "string" }
+                    },
+                    "mcp_servers": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of MCP server names to make available in the container. \
+                                        If omitted, the full master config is mounted. If empty, no MCP servers \
+                                        are available. Only effective when MCP_PER_JOB_ENABLED=true."
+                    },
+                    "max_iterations": {
+                        "type": "integer",
+                        "description": "Maximum number of agent loop iterations for the worker. \
+                                        Defaults to 50, capped at 500. Use lower values for simple tasks."
                     }
                 },
                 "required": ["title", "description"]
@@ -909,10 +932,33 @@ impl Tool for CreateJobTool {
             // Parse and validate credential grants
             let credential_grants = self.parse_credentials(&params, &ctx.user_id).await?;
 
+            // Parse optional MCP server filter and iteration cap.
+            let mcp_servers: Option<Vec<String>> = params
+                .get("mcp_servers")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                });
+            let max_iterations: Option<u32> = params
+                .get("max_iterations")
+                .and_then(|v| v.as_u64())
+                .map(|n| n.min(500) as u32);
+
             // Combine title and description into the task prompt for the sub-agent.
             let task = format!("{}\n\n{}", title, description);
-            self.execute_sandbox(&task, explicit_dir, wait, mode, credential_grants, ctx)
-                .await
+            self.execute_sandbox(
+                &task,
+                explicit_dir,
+                wait,
+                mode,
+                credential_grants,
+                mcp_servers,
+                max_iterations,
+                ctx,
+            )
+            .await
         } else {
             self.execute_local(title, description, ctx).await
         }
@@ -1569,6 +1615,8 @@ mod tests {
                 false,
                 JobMode::Worker,
                 vec![],
+                None,
+                None,
                 &JobContext::default(),
             )
             .await;

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -21,7 +21,7 @@ use crate::context::{ContextManager, JobContext, JobState};
 use crate::db::Database;
 use crate::history::SandboxJobRecord;
 use crate::orchestrator::auth::CredentialGrant;
-use crate::orchestrator::job_manager::{ContainerJobManager, JobMode};
+use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
 use crate::secrets::SecretsStore;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 use ironclaw_common::AppEvent;
@@ -355,16 +355,13 @@ impl CreateJobTool {
     }
 
     /// Execute via sandboxed Docker container.
-    #[allow(clippy::too_many_arguments)]
     async fn execute_sandbox(
         &self,
         task: &str,
         explicit_dir: Option<PathBuf>,
         wait: bool,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
-        mcp_servers: Option<Vec<String>>,
-        max_iterations: Option<u32>,
+        params: JobCreationParams,
         ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
@@ -379,7 +376,7 @@ impl CreateJobTool {
         let project_dir_str = project_dir.display().to_string();
 
         // Serialize credential grants so restarts can reload them.
-        let credential_grants_json = match serde_json::to_string(&credential_grants) {
+        let credential_grants_json = match serde_json::to_string(&params.credential_grants) {
             Ok(json) => json,
             Err(e) => {
                 tracing::warn!(
@@ -434,15 +431,7 @@ impl CreateJobTool {
 
         // Create the container job with the pre-determined job_id.
         let _token = jm
-            .create_job(
-                job_id,
-                task,
-                Some(project_dir),
-                mode,
-                credential_grants,
-                mcp_servers,
-                max_iterations,
-            )
+            .create_job(job_id, task, Some(project_dir), mode, params)
             .await
             .map_err(|e| {
                 self.update_status(
@@ -962,9 +951,11 @@ impl Tool for CreateJobTool {
                 explicit_dir,
                 wait,
                 mode,
-                credential_grants,
-                mcp_servers,
-                max_iterations,
+                JobCreationParams {
+                    credential_grants,
+                    mcp_servers,
+                    max_iterations,
+                },
                 ctx,
             )
             .await
@@ -1623,9 +1614,7 @@ mod tests {
                 None,
                 false,
                 JobMode::Worker,
-                vec![],
-                None,
-                None,
+                JobCreationParams::default(),
                 &JobContext::default(),
             )
             .await;

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -933,18 +933,27 @@ impl Tool for CreateJobTool {
             let credential_grants = self.parse_credentials(&params, &ctx.user_id).await?;
 
             // Parse optional MCP server filter and iteration cap.
-            let mcp_servers: Option<Vec<String>> = params
-                .get("mcp_servers")
-                .and_then(|v| v.as_array())
-                .map(|arr| {
+            // Validate types: warn if present but wrong type so callers know why it was ignored.
+            let mcp_servers: Option<Vec<String>> = match params.get("mcp_servers") {
+                Some(v) if v.is_array() => v.as_array().map(|arr| {
                     arr.iter()
                         .filter_map(|v| v.as_str().map(String::from))
                         .collect()
-                });
-            let max_iterations: Option<u32> = params
-                .get("max_iterations")
-                .and_then(|v| v.as_u64())
-                .map(|n| n.clamp(1, 500) as u32);
+                }),
+                Some(_) => {
+                    tracing::warn!("mcp_servers parameter is not an array — ignoring");
+                    None
+                }
+                None => None,
+            };
+            let max_iterations: Option<u32> = match params.get("max_iterations") {
+                Some(v) if v.is_u64() || v.is_i64() => v.as_u64().map(|n| n.clamp(1, 500) as u32),
+                Some(_) => {
+                    tracing::warn!("max_iterations parameter is not a number — ignoring");
+                    None
+                }
+                None => None,
+            };
 
             // Combine title and description into the task prompt for the sub-agent.
             let task = format!("{}\n\n{}", title, description);

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -944,7 +944,7 @@ impl Tool for CreateJobTool {
             let max_iterations: Option<u32> = params
                 .get("max_iterations")
                 .and_then(|v| v.as_u64())
-                .map(|n| n.min(500) as u32);
+                .map(|n| n.clamp(1, 500) as u32);
 
             // Combine title and description into the task prompt for the sub-agent.
             let task = format!("{}\n\n{}", title, description);

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -314,7 +314,6 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         reasoning: &Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
-        const MAX_WORKER_ITERATIONS: usize = 500;
         let max_iterations = self
             .context_manager()
             .get_context(self.job_id)
@@ -322,7 +321,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .ok()
             .and_then(|ctx| ctx.metadata.get("max_iterations").and_then(|v| v.as_u64()))
             .unwrap_or(50) as usize;
-        let max_iterations = max_iterations.min(MAX_WORKER_ITERATIONS);
+        let max_iterations = max_iterations.min(ironclaw_common::MAX_WORKER_ITERATIONS as usize);
 
         // Initial tool definitions for planning (will be refreshed in loop)
         reason_ctx.available_tools = self.tools().tool_definitions().await;


### PR DESCRIPTION
## Summary

- Add `mcp_servers` and `max_iterations` optional parameters to `create_job` tool
- `mcp_servers` filters which MCP servers are mounted into worker containers, gated behind `MCP_PER_JOB_ENABLED` env var (default false)
- `max_iterations` caps the worker agent loop iteration count (default 50, max 500)
- Per-job MCP configs written to temp files, mounted read-only, cleaned up on job completion

## Motivation

Deployments running multiple MCP servers need per-job scoping — a research job should only access research tools, not production APIs. Simple data-gathering jobs shouldn't burn 50 iterations when 10 suffice.

## Test plan

- [x] `cargo test --lib` passes (3155 tests)
- [x] `cargo clippy --all --all-features` zero warnings
- [x] `cargo fmt --check` clean
- [ ] Manual: create job with `mcp_servers: ["serpstat"]` → only serpstat in container config
- [ ] Manual: create job with `max_iterations: 5` → worker exits at 5
- [ ] Manual: create job without params → full config mounted (backward compatible)
- [ ] Verify `MCP_PER_JOB_ENABLED=false` (default) ignores `mcp_servers` param

🤖 Generated with [Claude Code](https://claude.com/claude-code)