### PR TITLE
fix: bump channel registry versions for promotion

### DIFF
--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [


### PR DESCRIPTION
Summary:
- bump Feishu registry version from 0.1.0 to 0.1.1
- bump Telegram registry version from 0.2.3 to 0.2.4
- unblock the version-bump CI check on #1197

Verification:
- ./scripts/check-version-bumps.sh