### PR TITLE
Fix duplicate LLM responses for matched event routines

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -7,7 +7,6 @@
 //! - `commands` - System commands and job handlers
 //! - `thread_ops` - Thread/session operations (user input, undo, approval, persistence)
 
-use std::borrow::Cow;
 use std::sync::Arc;
 
 use futures::StreamExt;
@@ -114,28 +113,6 @@ async fn resolve_routine_notification_target(
     .await
 }
 
-fn routine_trigger_message<'a>(
-    message: &'a IncomingMessage,
-    submission: &'a Submission,
-) -> Option<Cow<'a, IncomingMessage>> {
-    if message.is_internal {
-        return None;
-    }
-
-    match submission {
-        Submission::UserInput { content } => {
-            if content == &message.content {
-                Some(Cow::Borrowed(message))
-            } else {
-                let mut rewritten = message.clone();
-                rewritten.content = content.clone();
-                Some(Cow::Owned(rewritten))
-            }
-        }
-        _ => None,
-    }
-}
-
 fn should_fallback_routine_notification(error: &ChannelError) -> bool {
     !matches!(error, ChannelError::MissingRoutingTarget { .. })
 }
@@ -187,7 +164,7 @@ pub struct Agent {
     /// Shared routine-engine slot used for internal event matching and for exposing
     /// the engine to gateway/manual trigger entry points.
     pub(super) routine_engine_slot:
-        Option<Arc<tokio::sync::RwLock<Option<Arc<crate::agent::routine_engine::RoutineEngine>>>>>,
+        Arc<tokio::sync::RwLock<Option<Arc<crate::agent::routine_engine::RoutineEngine>>>>,
 }
 
 impl Agent {
@@ -252,21 +229,21 @@ impl Agent {
             heartbeat_config,
             hygiene_config,
             routine_config,
-            routine_engine_slot: Some(Arc::new(tokio::sync::RwLock::new(None))),
+            routine_engine_slot: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 
-    /// Set the routine engine slot for exposing the engine to the gateway.
+    /// Replace the routine-engine slot with a shared one so the gateway and
+    /// agent reference the same engine.
     pub fn set_routine_engine_slot(
         &mut self,
         slot: Arc<tokio::sync::RwLock<Option<Arc<crate::agent::routine_engine::RoutineEngine>>>>,
     ) {
-        self.routine_engine_slot = Some(slot);
+        self.routine_engine_slot = slot;
     }
 
     async fn routine_engine(&self) -> Option<Arc<crate::agent::routine_engine::RoutineEngine>> {
-        let slot = self.routine_engine_slot.as_ref()?;
-        slot.read().await.clone()
+        self.routine_engine_slot.read().await.clone()
     }
 
     // Convenience accessors
@@ -662,9 +639,7 @@ impl Agent {
                     // via a local to use in the message loop below.
 
                     // Expose engine to gateway for manual triggering
-                    if let Some(ref slot) = self.routine_engine_slot {
-                        *slot.write().await = Some(Arc::clone(&engine));
-                    }
+                    *self.routine_engine_slot.write().await = Some(Arc::clone(&engine));
 
                     tracing::debug!(
                         "Routines enabled: cron ticker every {}s, max {} concurrent",
@@ -1035,10 +1010,13 @@ impl Agent {
             message.content.len()
         );
 
-        if let Some(trigger_message) = routine_trigger_message(message, &submission)
+        if !message.is_internal
+            && let Submission::UserInput { ref content } = submission
             && let Some(engine) = self.routine_engine().await
         {
-            let fired = engine.check_event_triggers(trigger_message.as_ref()).await;
+            let fired = engine
+                .check_event_triggers(&message.user_id, &message.channel, content)
+                .await;
             if fired > 0 {
                 tracing::debug!(
                     channel = %message.channel,
@@ -1137,11 +1115,10 @@ impl Agent {
 #[cfg(test)]
 mod tests {
     use super::{
-        resolve_routine_notification_user, routine_trigger_message,
-        should_fallback_routine_notification, truncate_for_preview,
+        resolve_routine_notification_user, should_fallback_routine_notification,
+        truncate_for_preview,
     };
-    use crate::{agent::submission::Submission, channels::IncomingMessage, error::ChannelError};
-    use std::borrow::Cow;
+    use crate::error::ChannelError;
 
     #[test]
     fn test_truncate_short_input() {
@@ -1234,46 +1211,6 @@ mod tests {
         });
 
         assert_eq!(resolve_routine_notification_user(&metadata), None); // safety: test-only assertion
-    }
-
-    #[test]
-    fn routine_trigger_message_borrows_original_user_input() {
-        let message = IncomingMessage::new("test", "user1", "bug: original");
-        let submission = Submission::UserInput {
-            content: "bug: original".to_string(),
-        };
-
-        let trigger_message = routine_trigger_message(&message, &submission)
-            .expect("user input should be routable for event trigger checks");
-
-        assert!(matches!(trigger_message, Cow::Borrowed(_)));
-        assert_eq!(trigger_message.as_ref().content, "bug: original");
-    }
-
-    #[test]
-    fn routine_trigger_message_uses_modified_user_input_content() {
-        let message = IncomingMessage::new("test", "user1", "redacted");
-        let submission = Submission::UserInput {
-            content: "bug: original".to_string(),
-        };
-
-        let trigger_message = routine_trigger_message(&message, &submission)
-            .expect("user input should be routable for event trigger checks");
-
-        assert!(matches!(trigger_message, Cow::Owned(_)));
-        assert_eq!(trigger_message.as_ref().content, "bug: original");
-        assert_eq!(trigger_message.as_ref().channel, "test");
-        assert_eq!(trigger_message.as_ref().user_id, "user1");
-    }
-
-    #[test]
-    fn routine_trigger_message_skips_internal_messages() {
-        let message = IncomingMessage::new("test", "user1", "bug: original").into_internal();
-        let submission = Submission::UserInput {
-            content: "bug: original".to_string(),
-        };
-
-        assert!(routine_trigger_message(&message, &submission).is_none());
     }
 
     #[test]

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -23,7 +23,7 @@ use crate::agent::Scheduler;
 use crate::agent::routine::{
     NotifyConfig, Routine, RoutineAction, RoutineRun, RunStatus, Trigger, next_cron_fire,
 };
-use crate::channels::{IncomingMessage, OutgoingResponse};
+use crate::channels::OutgoingResponse;
 use crate::config::RoutineConfig;
 use crate::context::JobContext;
 use crate::db::Database;
@@ -135,9 +135,9 @@ impl RoutineEngine {
 
     /// Check incoming message against event triggers. Returns number of routines fired.
     ///
-    /// Called synchronously from the main loop after handle_message(). The actual
-    /// execution is spawned async so this returns quickly.
-    pub async fn check_event_triggers(&self, message: &IncomingMessage) -> usize {
+    /// Accepts only the three fields needed for matching (user scope, channel,
+    /// message content) so callers never need to clone a full `IncomingMessage`.
+    pub async fn check_event_triggers(&self, user_id: &str, channel: &str, content: &str) -> usize {
         let cache = self.event_cache.read().await;
         let mut fired = 0;
 
@@ -173,7 +173,7 @@ impl RoutineEngine {
                 EventMatcher::System { .. } => continue,
             };
 
-            if routine.user_id != message.user_id {
+            if routine.user_id != user_id {
                 continue;
             }
 
@@ -181,13 +181,13 @@ impl RoutineEngine {
             if let Trigger::Event {
                 channel: Some(ch), ..
             } = &routine.trigger
-                && ch != &message.channel
+                && ch != channel
             {
                 continue;
             }
 
             // Regex match
-            if !re.is_match(&message.content) {
+            if !re.is_match(content) {
                 continue;
             }
 
@@ -210,7 +210,7 @@ impl RoutineEngine {
                 continue;
             }
 
-            let detail = truncate(&message.content, 200);
+            let detail = truncate(content, 200);
             self.spawn_fire(routine.clone(), "event", Some(detail));
             fired += 1;
         }

--- a/tests/e2e_routine_heartbeat.rs
+++ b/tests/e2e_routine_heartbeat.rs
@@ -238,7 +238,13 @@ mod tests {
             "default",
             "deploy to production now",
         );
-        let fired = engine.check_event_triggers(&matching_msg).await;
+        let fired = engine
+            .check_event_triggers(
+                &matching_msg.user_id,
+                &matching_msg.channel,
+                &matching_msg.content,
+            )
+            .await;
         assert!(
             fired >= 1,
             "Expected >= 1 routine fired on match, got {fired}"
@@ -255,7 +261,13 @@ mod tests {
             "default",
             "check the staging environment",
         );
-        let fired_neg = engine.check_event_triggers(&non_matching_msg).await;
+        let fired_neg = engine
+            .check_event_triggers(
+                &non_matching_msg.user_id,
+                &non_matching_msg.channel,
+                &non_matching_msg.content,
+            )
+            .await;
         assert_eq!(fired_neg, 0, "Expected 0 routines fired on non-match");
     }
 
@@ -315,7 +327,9 @@ mod tests {
             "guest-sender",
             "deploy to production now",
         );
-        let guest_fired = engine.check_event_triggers(&guest_msg).await;
+        let guest_fired = engine
+            .check_event_triggers(&guest_msg.user_id, &guest_msg.channel, &guest_msg.content)
+            .await;
         assert_eq!(
             guest_fired, 0,
             "Guest scope must not fire owner event routines"
@@ -338,7 +352,9 @@ mod tests {
             "owner-sender",
             "deploy to production now",
         );
-        let owner_fired = engine.check_event_triggers(&owner_msg).await;
+        let owner_fired = engine
+            .check_event_triggers(&owner_msg.user_id, &owner_msg.channel, &owner_msg.content)
+            .await;
         assert!(
             owner_fired >= 1,
             "Owner scope should fire matching owner event routine"
@@ -562,7 +578,9 @@ mod tests {
             "default",
             "test-cooldown trigger",
         );
-        let fired1 = engine.check_event_triggers(&msg).await;
+        let fired1 = engine
+            .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+            .await;
         assert!(fired1 >= 1, "First fire should work");
 
         // Give spawn time, then update last_run_at to simulate recent execution.
@@ -577,7 +595,9 @@ mod tests {
         engine.refresh_event_cache().await;
 
         // Second fire should be blocked by cooldown.
-        let fired2 = engine.check_event_triggers(&msg).await;
+        let fired2 = engine
+            .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+            .await;
         assert_eq!(fired2, 0, "Second fire should be blocked by cooldown");
     }
 
@@ -745,7 +765,9 @@ mod tests {
         engine.refresh_event_cache().await;
 
         let msg = IncomingMessage::new("test", "default", "DISABLE_ME");
-        let fired_before = engine.check_event_triggers(&msg).await;
+        let fired_before = engine
+            .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+            .await;
         assert!(fired_before >= 1, "Expected routine to fire before disable");
 
         // Simulate what routines_toggle_handler now does: update DB, then refresh.
@@ -754,7 +776,9 @@ mod tests {
         db.update_routine(&routine).await.expect("update_routine");
         engine.refresh_event_cache().await;
 
-        let fired_after = engine.check_event_triggers(&msg).await;
+        let fired_after = engine
+            .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+            .await;
         assert_eq!(
             fired_after, 0,
             "Disabled routine must not fire after cache refresh"
@@ -780,7 +804,10 @@ mod tests {
 
         let msg = IncomingMessage::new("test", "default", "DELETE_ME");
         assert!(
-            engine.check_event_triggers(&msg).await >= 1,
+            engine
+                .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+                .await
+                >= 1,
             "Expected routine to fire before delete"
         );
 
@@ -789,7 +816,9 @@ mod tests {
         engine.refresh_event_cache().await;
 
         assert_eq!(
-            engine.check_event_triggers(&msg).await,
+            engine
+                .check_event_triggers(&msg.user_id, &msg.channel, &msg.content)
+                .await,
             0,
             "Deleted routine must not fire after cache refresh"
         );


### PR DESCRIPTION
## Summary
- consume matched event-triggered user messages before they enter the normal chat pipeline
- prevent Telegram and gateway-style inbound matches from producing both a routine run and a separate assistant reply
- update routine event trace coverage to assert the matched message only produces the routine-driven LLM turn

## Testing
- cargo test --features libsql routine_event_trigger_