### PR TITLE
fix: align release-plz publish config for ironclaw_safety

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,4 +3,5 @@ git_release_enable = false
 
 [[package]]
 name = "ironclaw_safety"
+publish = false
 release = false


### PR DESCRIPTION
Summary
- mark ironclaw_safety as publish = false in release-plz.toml
- align release-plz config with crates/ironclaw_safety/Cargo.toml
- unblock the failed chore: release v0.19.0 (#973) release workflow

Why
The Release-plz release workflow failed on commit 1ad1335fea49927e91c2b13e18b60d96b0b86861 because ironclaw_safety is publish = false in Cargo metadata, but release-plz still treated it as publishable.

Verification
- reproduced the original failure from GitHub Actions logs
- local release-plz dry-run no longer hit the ironclaw_safety publish-config mismatch after this change