### PR TITLE
fix: relax timing thresholds in policy adversarial tests

### DIFF
--- a/crates/ironclaw_safety/src/policy.rs
+++ b/crates/ironclaw_safety/src/policy.rs
@@ -324,7 +324,7 @@ mod tests {
             let violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "excessive_urls pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -349,7 +349,7 @@ mod tests {
             let violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "obfuscated_string pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -370,7 +370,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "shell_injection pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -387,7 +387,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "sql_pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -405,7 +405,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "crypto_private_key pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -423,7 +423,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "system_file_access pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );
@@ -441,7 +441,7 @@ mod tests {
             let _violations = policy.check(&payload);
             let elapsed = start.elapsed();
             assert!(
-                elapsed.as_millis() < 100,
+                elapsed.as_millis() < 500,
                 "encoded_exploit pattern took {}ms on 100KB near-miss",
                 elapsed.as_millis()
             );


### PR DESCRIPTION
## Summary
- Increases the timing threshold in 7 policy adversarial tests from 100ms to 500ms
- These tests guard against catastrophic regex backtracking (would take seconds/minutes), not 12ms differences
- CI runners with coverage instrumentation (`cargo-llvm-cov`) consistently exceed 100ms due to overhead, causing flaky failures (e.g., `encoded_exploit_pattern_100kb_near_miss` took 112ms)

## Test plan
- [x] `cargo test -p ironclaw_safety policy::tests::adversarial` — all 14 tests pass
- CI should no longer flake on these timing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)