### PR TITLE
chore(ci): enforce test requirement for state machine and resilience changes (#1230)

### DIFF
--- a/.github/workflows/regression-test-check.yml
+++ b/.github/workflows/regression-test-check.yml
@@ -43,12 +43,42 @@ jobs:
             fi
           fi
 
-          if [ "$IS_FIX" = false ]; then
-            echo "Not a fix PR — skipping regression test check."
+          # --- 1b. Does this PR touch high-risk state machine or resilience code? ---
+          CHANGED_FILES=$(git diff --name-only "${BASE_REF}...${HEAD_REF}")
+
+          TOUCHES_HIGH_RISK=false
+          HIGH_RISK_PATTERNS=(
+            "src/context/state.rs"
+            "src/agent/session.rs"
+            "src/llm/circuit_breaker.rs"
+            "src/llm/retry.rs"
+            "src/llm/failover.rs"
+            "src/agent/self_repair.rs"
+            "src/agent/agentic_loop.rs"
+            "src/tools/execute.rs"
+            "crates/ironclaw_safety/src/"
+          )
+
+          for pattern in "${HIGH_RISK_PATTERNS[@]}"; do
+            if echo "$CHANGED_FILES" | grep -q "$pattern"; then
+              TOUCHES_HIGH_RISK=true
+              echo "High-risk file matched: $pattern"
+              break
+            fi
+          done
+
+          # Skip only if NEITHER condition holds — no double-firing on fix PRs
+          if [ "$IS_FIX" = false ] && [ "$TOUCHES_HIGH_RISK" = false ]; then
+            echo "Not a fix PR and no high-risk files changed — skipping."
             exit 0
           fi
 
-          echo "Fix PR detected."
+          if [ "$IS_FIX" = true ]; then
+            echo "Fix PR detected."
+          fi
+          if [ "$TOUCHES_HIGH_RISK" = true ]; then
+            echo "High-risk state machine or resilience code modified."
+          fi
 
           # --- 2. Skip label or commit message marker ---
           if grep -qF ',skip-regression-check,' <<< ",$PR_LABELS,"; then
@@ -63,8 +93,6 @@ jobs:
           fi
 
           # --- 3. Exempt static-only / docs-only changes ---
-          CHANGED_FILES=$(git diff --name-only "${BASE_REF}...${HEAD_REF}")
-
           if [ -z "$CHANGED_FILES" ]; then
             echo "No changed files — skipping."
             exit 0
@@ -110,5 +138,12 @@ jobs:
           fi
 
           # --- 5. No tests found ---
-          echo "::warning::This PR looks like a bug fix but contains no test changes. Every fix should include a regression test. Add a #[test] or #[tokio::test], or apply the 'skip-regression-check' label if not feasible."
+          if [ "$IS_FIX" = true ]; then
+            echo "::warning::This PR looks like a bug fix but contains no test changes."
+          fi
+          if [ "$TOUCHES_HIGH_RISK" = true ]; then
+            echo "::warning::This PR modifies high-risk state machine or resilience code but includes no test changes."
+          fi
+          echo "::warning::Please add tests exercising the changed behavior, or apply the 'skip-regression-check' label if not feasible."
           exit 1
+


### PR DESCRIPTION
## Summary

- Extend regression-test-check to enforce tests when high-risk state machine or resilience files are modified
- Add 9 high-risk file patterns: state.rs, session.rs, circuit_breaker.rs, retry.rs, failover.rs, self_repair.rs, agentic_loop.rs, execute.rs, and `crates/ironclaw_safety/src/`
- Check runs for ALL PR types (feat, refactor, chore), not just fixes
- Same bypass mechanism: `skip-regression-check` label or `[skip-regression-check]` in commit message

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #1230

## Validation

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [x] YAML syntax validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Shell logic preserves existing behavior: fix PRs still checked, non-fix/non-high-risk PRs still skipped
- [x] No double-firing: single combined conditional `IS_FIX=false && TOUCHES_HIGH_RISK=false`

## Security Impact

None. This change only adds CI workflow logic that checks for test presence. No runtime, permissions, or secrets changes.

## Database Impact

None.

## Blast Radius

- **CI workflow only** (`.github/workflows/regression-test-check.yml`): Extended shell logic within existing job
- **No runtime code changes**: Zero impact on IronClaw binary
- **Backward compatible**: Existing fix-PR detection behavior preserved; new check only adds coverage for high-risk file modifications

## Rollback Plan

Revert the single commit to restore the original workflow file. The `skip-regression-check` label can bypass the check without code changes.

---

**Review track**: A (CI/chore)
