### PR TITLE
fix(telegram): preserve polling after secret-blocked updates

### DIFF
--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -3131,7 +3131,7 @@ fn extract_host_from_url(url: &str) -> Option<String> {
 }
 
 fn should_skip_response_leak_scan(url: &str) -> bool {
-    url::Url::parse(url).map_or(false, |parsed| {
+    url::Url::parse(url).is_ok_and(|parsed| {
         matches!(parsed.scheme(), "http" | "https")
             && parsed
                 .host_str()


### PR DESCRIPTION
Allow Telegram polling responses to advance past secret-containing updates instead of getting stuck in a retry loop.

Fixes #1329.