### PR TITLE
chore(agent): add debug_assert invariant checks to critical code paths (#1215)

### DIFF
--- a/src/llm/circuit_breaker.rs
+++ b/src/llm/circuit_breaker.rs
@@ -167,7 +167,12 @@ impl CircuitBreakerProvider {
                 }
             }
             CircuitState::Open => {
-                // Shouldn't get here (check_allowed blocks Open), but recover
+                debug_assert!(
+                    false,
+                    "BUG: record_success() called while circuit breaker is Open \
+                     — check_allowed() was bypassed"
+                );
+                // Graceful recovery in release: close the circuit
                 state.state = CircuitState::Closed;
                 state.consecutive_failures = 0;
                 state.opened_at = None;

--- a/src/tools/execute.rs
+++ b/src/tools/execute.rs
@@ -22,6 +22,10 @@ pub async fn execute_tool_with_safety(
     params: &serde_json::Value,
     job_ctx: &JobContext,
 ) -> Result<String, Error> {
+    debug_assert!(
+        !tool_name.is_empty(),
+        "BUG: execute_tool_with_safety called with empty tool_name"
+    );
     let tool = tools
         .get(tool_name)
         .await


### PR DESCRIPTION
## Summary

Add `debug_assert!` invariant assertions to two critical code paths that
currently rely on runtime `Result` returns to handle internal logic bugs. These
assertions fire only in debug builds (all tests run in debug mode) and compile
away completely in release, giving zero runtime cost with early bug detection.

Closes #1215

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Changes

### `src/tools/execute.rs` — `execute_tool_with_safety()`

Added `debug_assert!(!tool_name.is_empty(), ...)` at function entry. An empty
tool name indicates a bug in the LLM response parser or tool call dispatch, not
a user error. The existing `tools.get()` lookup would return `NotFound`, but
the assert catches the problem at the point of origin.

### `src/llm/circuit_breaker.rs` — `record_success()`

Added `debug_assert!(false, ...)` in the `CircuitState::Open` match arm. This
arm is unreachable in correct code — `check_allowed()` blocks all calls when
the circuit is Open. The existing graceful recovery is preserved in release.

### Note: `src/context/state.rs` omitted

The issue proposed adding `debug_assert!` to `JobContext::transition_to()`, but
testing revealed this would break `CancelJobTool` which legitimately calls
`transition_to(Cancelled)` on completed jobs and handles the `Err` return
gracefully (returning "Cannot cancel job" to the user). Since `transition_to()`
is designed to return `Result::Err` for invalid transitions as part of normal
operation (not just for internal bugs), adding `debug_assert!` here violates the
issue's own guideline: *"Do NOT use `debug_assert!` for conditions that can
happen due to user input."*

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples -- -D warnings` (zero warnings)
- [x] `cargo test` — 3196 passed, 2 pre-existing failures (network/DNS tests unrelated to this change), 0 new failures
- [x] No `debug_assert!` on paths that can legitimately trigger from user
      input, LLM responses, or network errors

## Feature Parity

`FEATURE_PARITY.md` not updated; no tracked capability behavior changed.

## Blast Radius

Two files, +10 lines, −1 line (comment update). Zero runtime behavioral change.
Debug-only assertions that compile away in release builds.
