### PR TITLE
test(worker): expand rate_limit_cascade fixture to hit consecutive threshold (#605)

### DIFF
--- a/tests/e2e_worker_coverage.rs
+++ b/tests/e2e_worker_coverage.rs
@@ -235,7 +235,7 @@ mod tests {
 
         rig.verify_trace_expects(&trace, &responses);
 
-        // Both calls should have failed due to rate limiting.
+        // All calls should have failed due to rate limiting.
         let completed = rig.tool_calls_completed();
         let rl_calls: Vec<_> = completed
             .iter()
@@ -248,6 +248,16 @@ mod tests {
         assert!(
             rl_calls.iter().all(|(_, ok)| !ok),
             "All stub_rate_limit calls should fail: {rl_calls:?}"
+        );
+
+        // Verify we accumulated enough consecutive rate-limited failures
+        // to exercise the cascade path rather than stopping after just 2 calls.
+        // With 11 tool_calls in the fixture and max_tool_iterations=10 (default),
+        // the worker completes ~9 calls before hitting the iteration limit.
+        assert!(
+            rl_calls.len() >= 8,
+            "Expected >= 8 rate-limited tool calls to hit threshold, got {}",
+            rl_calls.len()
         );
 
         rig.shutdown();

--- a/tests/fixtures/llm_traces/worker/rate_limit_cascade.json
+++ b/tests/fixtures/llm_traces/worker/rate_limit_cascade.json
@@ -36,9 +36,135 @@
     },
     {
       "response": {
-        "type": "text",
-        "content": "The tool is rate limited. I was unable to complete the request due to repeated rate limiting.",
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_3",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
         "input_tokens": 300,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_4",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 400,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_5",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 500,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_6",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 600,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_7",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 700,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_8",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 800,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_9",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 900,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_10",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 1000,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_rl_11",
+            "name": "stub_rate_limit",
+            "arguments": {}
+          }
+        ],
+        "input_tokens": 1100,
+        "output_tokens": 25
+      }
+    },
+    {
+      "response": {
+        "type": "text",
+        "content": "The tool is persistently rate limited. Giving up after too many failed attempts.",
+        "input_tokens": 1200,
         "output_tokens": 25
       }
     }


### PR DESCRIPTION
## Summary

Expand the `rate_limit_cascade` test fixture from 2 to 11 consecutive
`stub_rate_limit` tool calls, exercising the worker's iteration-limit
handling under sustained rate limiting. Add an assertion verifying the
worker reaches the threshold (≥ 8 completed rate-limited calls) instead
of stopping early after just 2.

Closes #605

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Changes

### `tests/fixtures/llm_traces/worker/rate_limit_cascade.json`

Expanded from 2 to 11 `stub_rate_limit` tool_calls steps (`call_rl_1`
through `call_rl_11`). The final text step is retained as a fallback
response for when the worker exhausts all iterations.

### `tests/e2e_worker_coverage.rs`

- Updated comment to reflect the expanded fixture ("All calls" vs "Both calls")
- Added assertion: `rl_calls.len() >= 8` with explanatory comment noting
  that `max_tool_iterations=10` (default) yields ~9 completed tool calls
  before the iteration limit fires

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples -- -D warnings` (zero warnings)
- [x] `cargo test --test e2e_worker_coverage rate_limit_cascade` — passes
      with 9 rate-limited tool calls (well above the ≥ 8 threshold)

## Feature Parity

No tracked capability changed; `FEATURE_PARITY.md` not updated.

## Blast Radius

Test-only changes (1 JSON fixture + 1 assertion). Zero production code modified.
