### PR TITLE
fix: e2e coverage suite reliability

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run E2E tests
         run: |
-          pytest tests/e2e/ -v -x --timeout=120
+          pytest tests/e2e/ -v --timeout=120
         env:
           RUST_LOG: ironclaw=info
           RUST_BACKTRACE: "1"


### PR DESCRIPTION
## Summary

- **Remove `-x` from coverage pytest** — a single flaky test (`test_builtin_echo_tool` timeout) was stopping the entire e2e coverage suite, preventing 118+ remaining tests from running and generating coverage data
- **Increase tool execution test timeout** from 30s to 60s — the coverage-instrumented binary is slower, and the tool execution flow requires multiple LLM round-trips that exceed 30s

Fixes issue observed in: https://github.com/nearai/ironclaw/actions/runs/23202828897/job/67429773156

## Test plan

- [ ] Re-run coverage workflow — all tests should run to completion even if one fails
- [ ] `test_builtin_echo_tool` should pass with 60s timeout on instrumented builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)