### PR TITLE
fix: skip NEAR AI session check when backend is not nearai

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -33,7 +33,7 @@ pub async fn run_doctor_command() -> anyhow::Result<()> {
 
     check(
         "NEAR AI session",
-        check_nearai_session().await,
+        check_nearai_session(&settings).await,
         &mut passed,
         &mut failed,
         &mut skipped,
@@ -215,7 +215,22 @@ fn check_settings_file() -> CheckResult {
 
 // ── NEAR AI session ─────────────────────────────────────────
 
-async fn check_nearai_session() -> CheckResult {
+async fn check_nearai_session(settings: &Settings) -> CheckResult {
+    // Skip entirely when the configured backend is not NEAR AI.
+    let llm_config = match crate::config::LlmConfig::resolve(settings) {
+        Ok(config) => config,
+        Err(e) => {
+            // check_llm_config will report the full error; just skip here.
+            return CheckResult::Skip(format!("LLM config error: {e}"));
+        }
+    };
+    if llm_config.backend != "nearai" {
+        return CheckResult::Skip(format!(
+            "not using NEAR AI backend (backend={})",
+            llm_config.backend
+        ));
+    }
+
     // Check if session file exists
     let session_path = crate::config::llm::default_session_path();
     if !session_path.exists() {
@@ -620,9 +635,49 @@ mod tests {
 
     #[tokio::test]
     async fn check_nearai_session_does_not_panic() {
-        let result = check_nearai_session().await;
+        let settings = Settings::default();
+        let result = check_nearai_session(&settings).await;
         match result {
             CheckResult::Pass(_) | CheckResult::Fail(_) | CheckResult::Skip(_) => {}
+        }
+    }
+
+    #[tokio::test]
+    async fn check_nearai_session_skips_for_non_nearai_backend() {
+        struct EnvGuard(&'static str, Option<String>);
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                // SAFETY: Under ENV_MUTEX.
+                unsafe {
+                    match &self.1 {
+                        Some(val) => std::env::set_var(self.0, val),
+                        None => std::env::remove_var(self.0),
+                    }
+                }
+            }
+        }
+
+        let _mutex = crate::config::helpers::ENV_MUTEX.lock().expect("env mutex");
+        let prev = std::env::var("LLM_BACKEND").ok();
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe {
+            std::env::set_var("LLM_BACKEND", "anthropic");
+        }
+        let _env_guard = EnvGuard("LLM_BACKEND", prev);
+
+        let settings = Settings::default();
+        let result = check_nearai_session(&settings).await;
+        match result {
+            CheckResult::Skip(msg) => {
+                assert!(
+                    msg.contains("backend=anthropic"),
+                    "expected backend name in skip message, got: {msg}"
+                );
+            }
+            other => panic!(
+                "expected Skip for non-nearai backend, got: {}",
+                format_result(&other)
+            ),
         }
     }
 


### PR DESCRIPTION
## Summary

When a user configures a non-NEAR AI backend (e.g. Anthropic), the
doctor command was incorrectly failing with "session file not found"
even though no NEAR AI session is needed. The check now skips with a
descriptive message when `LLM_BACKEND` is not nearai/near_ai/near.

## Change Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

None

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [x] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

None

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

None

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

`ironclaw doctor` - potential breakage risk should be low.

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

Straightforward git revert

---

**Review track**: B <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
