### PR TITLE
 fix(test): add missing `builder` field in e2e telegram routing test

### DIFF
--- a/tests/e2e_telegram_message_routing.rs
+++ b/tests/e2e_telegram_message_routing.rs
@@ -198,6 +198,7 @@ mod tests {
             http_interceptor: None,
             transcription: None,
             document_extraction: None,
+            builder: None,
         };
 
         let gateway = Arc::new(TestChannel::new());


### PR DESCRIPTION


## Summary
  PR #712 added the `builder` field to `AgentDeps` but did not update the
  test initializer in e2e_telegram_message_routing, causing compilation
  failure under `--features integration`.

  - Add `builder: None` to the AgentDeps initializer to restore compilation

-

## Change Type

<!-- Check one -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
