### PR TITLE
fix: resolve CI failures from missing builder field and stale E2E selector

### DIFF
--- a/tests/e2e/scenarios/test_telegram_hot_activation.py
+++ b/tests/e2e/scenarios/test_telegram_hot_activation.py
@@ -34,8 +34,9 @@ _TELEGRAM_ACTIVE = {
 
 
 async def go_to_extensions(page):
-    await page.locator(SEL["tab_button"].format(tab="extensions")).click()
-    await page.locator(SEL["tab_panel"].format(tab="extensions")).wait_for(
+    await page.locator(SEL["tab_button"].format(tab="settings")).click()
+    await page.locator(SEL["settings_subtab"].format(subtab="extensions")).click()
+    await page.locator(SEL["settings_subpanel"].format(subtab="extensions")).wait_for(
         state="visible", timeout=5000
     )
     await page.locator(

--- a/tests/e2e_telegram_message_routing.rs
+++ b/tests/e2e_telegram_message_routing.rs
@@ -198,6 +198,7 @@ mod tests {
             http_interceptor: None,
             transcription: None,
             document_extraction: None,
+            builder: None,
         };
 
         let gateway = Arc::new(TestChannel::new());


### PR DESCRIPTION
## Summary
- Add missing `builder: None` field to `AgentDeps` initializer in `e2e_telegram_message_routing` test (field added in #712 but test not updated — caused compilation failure in 8 CI jobs)
- Update `go_to_extensions()` in `test_telegram_hot_activation.py` to navigate via settings tab → extensions subtab, matching the current UI layout (caused timeout in 2 E2E jobs)

## Test plan
- [x] `cargo check --tests` passes
- [x] `cargo fmt` / `cargo clippy --all --benches --tests --examples --all-features` clean
- [x] `cargo test` — all tests pass
- [ ] CI should pass on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)