### PR TITLE
feat(config): add conflict detection warnings when env vars override user-configured settings

### DIFF
--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,7 +1,9 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    optional_env, parse_bool_env, parse_optional_env, warn_if_env_shadows,
+};
 use crate::error::ConfigError;
 
 /// Builder mode configuration.
@@ -34,6 +36,18 @@ impl Default for BuilderModeConfig {
 impl BuilderModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let bs = &settings.builder;
+        let defaults = crate::settings::BuilderSettings::default();
+        warn_if_env_shadows("BUILDER_ENABLED", &bs.enabled, &defaults.enabled);
+        warn_if_env_shadows(
+            "BUILDER_MAX_ITERATIONS",
+            &bs.max_iterations,
+            &defaults.max_iterations,
+        );
+        warn_if_env_shadows(
+            "BUILDER_TIMEOUT_SECS",
+            &bs.timeout_secs,
+            &defaults.timeout_secs,
+        );
         Ok(Self {
             enabled: parse_bool_env("BUILDER_ENABLED", bs.enabled)?,
             build_dir: optional_env("BUILDER_DIR")?

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    optional_env, parse_bool_env, parse_optional_env, warn_if_env_shadows,
+};
 use crate::error::ConfigError;
 use crate::settings::Settings;
 use secrecy::SecretString;
@@ -123,6 +125,23 @@ impl ChannelsConfig {
 
         let http_enabled_by_env =
             optional_env("HTTP_PORT")?.is_some() || optional_env("HTTP_HOST")?.is_some();
+        if http_enabled_by_env && !cs.http_enabled {
+            tracing::warn!(
+                "HTTP channel implicitly enabled by HTTP_PORT/HTTP_HOST env var, \
+                 but http_enabled is false in settings"
+            );
+        }
+        let cs_defaults = crate::settings::ChannelSettings::default();
+        if let Some(ref sp) = cs.http_port {
+            warn_if_env_shadows("HTTP_PORT", sp, &cs_defaults.http_port.unwrap_or(8080));
+        }
+        if let Some(ref gp) = cs.gateway_port {
+            warn_if_env_shadows(
+                "GATEWAY_PORT",
+                gp,
+                &cs_defaults.gateway_port.unwrap_or(DEFAULT_GATEWAY_PORT),
+            );
+        }
         let http = if http_enabled_by_env || cs.http_enabled {
             Some(HttpConfig {
                 host: optional_env("HTTP_HOST")?

--- a/src/config/heartbeat.rs
+++ b/src/config/heartbeat.rs
@@ -57,6 +57,15 @@ impl HeartbeatConfig {
             })
             .transpose()?;
 
+        let interval_secs_set = optional_env("HEARTBEAT_INTERVAL_SECS")?.is_some()
+            || settings.heartbeat.interval_secs != 1800;
+        if fire_at.is_some() && interval_secs_set {
+            tracing::warn!(
+                "both heartbeat fire_at and interval_secs are configured; \
+                 interval_secs is ignored when fire_at is active"
+            );
+        }
+
         Ok(Self {
             enabled: parse_bool_env("HEARTBEAT_ENABLED", settings.heartbeat.enabled)?,
             interval_secs: parse_optional_env(

--- a/src/config/helpers.rs
+++ b/src/config/helpers.rs
@@ -331,6 +331,32 @@ pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), Confi
     Ok(())
 }
 
+/// Log a warning when an env var overrides a user-configured setting.
+///
+/// Only warns when `settings_val != default_val` (user explicitly changed it)
+/// AND the env var is set to a different value. This avoids false positives
+/// on fields the user never touched via `config set` or TOML.
+pub(crate) fn warn_if_env_shadows<T: PartialEq + std::fmt::Display>(
+    env_key: &str,
+    settings_val: &T,
+    default_val: &T,
+) {
+    if settings_val == default_val {
+        return;
+    }
+    if let Ok(Some(ref env_str)) = optional_env(env_key) {
+        let settings_str = settings_val.to_string();
+        if *env_str != settings_str {
+            tracing::warn!(
+                env_var = env_key,
+                env_value = %env_str,
+                setting_value = %settings_val,
+                "environment variable overrides user-configured setting"
+            );
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/config/safety.rs
+++ b/src/config/safety.rs
@@ -1,4 +1,4 @@
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{parse_bool_env, parse_optional_env, warn_if_env_shadows};
 use crate::error::ConfigError;
 
 pub use ironclaw_safety::SafetyConfig;
@@ -7,6 +7,17 @@ pub(crate) fn resolve_safety_config(
     settings: &crate::settings::Settings,
 ) -> Result<SafetyConfig, ConfigError> {
     let ss = &settings.safety;
+    let defaults = crate::settings::SafetySettings::default();
+    warn_if_env_shadows(
+        "SAFETY_MAX_OUTPUT_LENGTH",
+        &ss.max_output_length,
+        &defaults.max_output_length,
+    );
+    warn_if_env_shadows(
+        "SAFETY_INJECTION_CHECK_ENABLED",
+        &ss.injection_check_enabled,
+        &defaults.injection_check_enabled,
+    );
     Ok(SafetyConfig {
         max_output_length: parse_optional_env("SAFETY_MAX_OUTPUT_LENGTH", ss.max_output_length)?,
         injection_check_enabled: parse_bool_env(

--- a/src/config/sandbox.rs
+++ b/src/config/sandbox.rs
@@ -1,4 +1,6 @@
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env, parse_string_env};
+use crate::config::helpers::{
+    optional_env, parse_bool_env, parse_optional_env, parse_string_env, warn_if_env_shadows,
+};
 use crate::error::ConfigError;
 
 /// Docker sandbox configuration.
@@ -54,6 +56,15 @@ impl Default for SandboxModeConfig {
 impl SandboxModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ss = &settings.sandbox;
+        let defaults = crate::settings::SandboxSettings::default();
+        warn_if_env_shadows("SANDBOX_ENABLED", &ss.enabled, &defaults.enabled);
+        warn_if_env_shadows("SANDBOX_POLICY", &ss.policy, &defaults.policy);
+        warn_if_env_shadows(
+            "SANDBOX_TIMEOUT_SECS",
+            &ss.timeout_secs,
+            &defaults.timeout_secs,
+        );
+        warn_if_env_shadows("SANDBOX_IMAGE", &ss.image, &defaults.image);
 
         let extra_domains = optional_env("SANDBOX_EXTRA_DOMAINS")?
             .map(|s| s.split(',').map(|d| d.trim().to_string()).collect())

--- a/src/config/tunnel.rs
+++ b/src/config/tunnel.rs
@@ -84,6 +84,13 @@ impl TunnelConfig {
             })
         };
 
+        if public_url.is_some() && provider.is_some() {
+            tracing::warn!(
+                "both TUNNEL_URL and TUNNEL_PROVIDER are configured; \
+                 the managed provider may overwrite the static URL at runtime"
+            );
+        }
+
         Ok(Self {
             public_url,
             provider,

--- a/src/config/wasm.rs
+++ b/src/config/wasm.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    optional_env, parse_bool_env, parse_optional_env, warn_if_env_shadows,
+};
 use crate::error::ConfigError;
 
 /// WASM sandbox configuration.
@@ -46,6 +48,18 @@ fn default_tools_dir() -> PathBuf {
 impl WasmConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ws = &settings.wasm;
+        let defaults = crate::settings::WasmSettings::default();
+        warn_if_env_shadows("WASM_ENABLED", &ws.enabled, &defaults.enabled);
+        warn_if_env_shadows(
+            "WASM_DEFAULT_MEMORY_LIMIT",
+            &ws.default_memory_limit,
+            &defaults.default_memory_limit,
+        );
+        warn_if_env_shadows(
+            "WASM_DEFAULT_TIMEOUT_SECS",
+            &ws.default_timeout_secs,
+            &defaults.default_timeout_secs,
+        );
         Ok(Self {
             enabled: parse_bool_env("WASM_ENABLED", ws.enabled)?,
             tools_dir: optional_env("WASM_TOOLS_DIR")?


### PR DESCRIPTION


 

## Summary

 Phase 3 of config unification (#1119). After Phase 1-2 established the
  env > settings > default resolution chain, users still get no feedback
  when an env var silently overrides a value they explicitly set via
  `config set` or TOML — leading to confusion when settings appear to
  have no effect.

  - Add warn_if_env_shadows() helper that detects when an env var overrides a non-default setting value
  - Warn when HTTP channel is implicitly enabled by HTTP_PORT/HTTP_HOST env var despite http_enabled=false in settings
  - Warn when both TUNNEL_URL and TUNNEL_PROVIDER are configured (managed provider may overwrite static URL)
  - Warn when both heartbeat fire_at and interval_secs are set (interval_secs is silently ignored)
  - Add env-vs-settings override detection for key fields in wasm, sandbox, builder, and safety modules
  - Pure tracing::warn() additions — no changes to resolution logic or final config values

  Ref #1119

## Change Type

<!-- Check one -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] Manual testing: <!-- describe what you tested -->

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
