### PR TITLE
chore: bump telegram channel version to 0.2.5

### DIFF
--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [


### PR DESCRIPTION
## Summary
- Bump `registry/channels/telegram.json` version from 0.2.4 to 0.2.5 to pass `check-version-bumps.sh` after `channels-src/telegram/` changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)