### PR TITLE
fix: skip NEAR AI session check when backend is not nearai

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -642,8 +642,8 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn check_nearai_session_skips_for_non_nearai_backend() {
+    #[test]
+    fn check_nearai_session_skips_for_non_nearai_backend() {
         struct EnvGuard(&'static str, Option<String>);
         impl Drop for EnvGuard {
             fn drop(&mut self) {
@@ -666,7 +666,8 @@ mod tests {
         let _env_guard = EnvGuard("LLM_BACKEND", prev);
 
         let settings = Settings::default();
-        let result = check_nearai_session(&settings).await;
+        let rt = tokio::runtime::Runtime::new().expect("tokio runtime");
+        let result = rt.block_on(check_nearai_session(&settings));
         match result {
             CheckResult::Skip(msg) => {
                 assert!(


### PR DESCRIPTION
## Summary

When a user configures a non-NEAR AI backend (e.g. Anthropic), the
doctor command was incorrectly failing with "session file not found"
even though no NEAR AI session is needed. The check now skips with a
descriptive message when `LLM_BACKEND` is not nearai/near_ai/near.

Continuation of #1388 (by @doismellburning) with a clippy fix: converted
the test from `#[tokio::test]` to `#[test]` with `block_on()` to avoid
holding a sync `MutexGuard` across an await point.

## Change Type

- [x] Bug fix

## Linked Issue

Supersedes #1388

## Validation

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] All 19 doctor tests pass
- [x] clippy::await_holding_lock resolved

## Security Impact

None

## Database Impact

None

## Blast Radius

`ironclaw doctor` — low risk.

## Rollback Plan

Straightforward git revert

---

**Review track**: B

🤖 Generated with [Claude Code](https://claude.com/claude-code)