### PR TITLE
fix: f32→f64 precision artifact in temperature causes provider 400 errors

### DIFF
--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -112,6 +112,17 @@ impl<M: CompletionModel> RigAdapter<M> {
 
 // -- Type conversion helpers --
 
+/// Round an f32 to f64 without precision artifacts.
+///
+/// Direct `f32 as f64` preserves the binary representation, producing values
+/// like `0.699999988079071` instead of `0.7`. Some providers (e.g. Zhipu/GLM)
+/// reject these values with a 400 error. Rounding to 6 decimal places removes
+/// the artifact while preserving all meaningful precision for temperature/top_p.
+fn round_f32_to_f64(val: f32) -> f64 {
+    let s = format!("{:.6}", val);
+    s.parse::<f64>().unwrap_or(val as f64)
+}
+
 /// Normalize a JSON Schema for OpenAI strict mode compliance.
 ///
 /// OpenAI strict function calling requires:
@@ -542,7 +553,7 @@ fn build_rig_request(
         chat_history,
         documents: Vec::new(),
         tools,
-        temperature: temperature.map(|t| t as f64),
+        temperature: temperature.map(|t| round_f32_to_f64(t)),
         max_tokens: max_tokens.map(|t| t as u64),
         tool_choice,
         additional_params,
@@ -766,6 +777,18 @@ fn normalize_tool_name(name: &str, known_tools: &HashSet<String>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_round_f32_to_f64_no_precision_artifacts() {
+        // Direct f32->f64 cast produces 0.699999988079071 instead of 0.7
+        assert_eq!(round_f32_to_f64(0.7_f32), 0.7_f64);
+        assert_eq!(round_f32_to_f64(0.5_f32), 0.5_f64);
+        assert_eq!(round_f32_to_f64(1.0_f32), 1.0_f64);
+        assert_eq!(round_f32_to_f64(0.0_f32), 0.0_f64);
+        // Original cast produces artifacts — our fix should not
+        assert_ne!(0.7_f32 as f64, 0.7_f64);
+        assert_eq!(round_f32_to_f64(0.7_f32), 0.7_f64);
+    }
 
     #[test]
     fn test_convert_messages_system_to_preamble() {


### PR DESCRIPTION
## Problem

`f32 as f64` preserves the binary representation, producing values like `0.699999988079071` instead of `0.7`. Some OpenAI-compatible providers (e.g. Zhipu GLM-5) reject these with a 400 error ("API 调用参数有误").

## Fix

Added `round_f32_to_f64()` helper that formats to 6 decimal places before parsing back to `f64`. Applied to the `temperature` field in `build_rig_request()`.

## Test

Regression test `test_round_f32_to_f64_no_precision_artifacts` verifies:
- `round_f32_to_f64(0.7_f32) == 0.7` (no artifact)
- `0.7_f32 as f64 != 0.7` (confirms the original bug exists)

## Impact

This affects all providers using `RigAdapter` (OpenAI, Anthropic, Ollama, Tinfoil, OpenAI-compatible). The fix is purely cosmetic for providers that tolerate the artifact, and unblocks providers that don't.