### PR TITLE
fix(ci): serialize env-mutating OAuth wildcard tests with ENV_MUTEX

### DIFF
--- a/src/llm/oauth_helpers.rs
+++ b/src/llm/oauth_helpers.rs
@@ -390,7 +390,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn bind_rejects_wildcard_ipv4() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
         let original = std::env::var("OAUTH_CALLBACK_HOST").ok();
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
         unsafe { std::env::set_var("OAUTH_CALLBACK_HOST", "0.0.0.0") };
@@ -414,7 +414,7 @@ mod tests {
     #[allow(clippy::await_holding_lock)]
     #[tokio::test]
     async fn bind_rejects_wildcard_ipv6() {
-        let _guard = ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
         let original = std::env::var("OAUTH_CALLBACK_HOST").ok();
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
         unsafe { std::env::set_var("OAUTH_CALLBACK_HOST", "::") };


### PR DESCRIPTION
## Summary
- Fixes flaky `bind_rejects_wildcard_ipv4` / `bind_rejects_wildcard_ipv6` tests that race on `OAUTH_CALLBACK_HOST` env var in parallel CI runs
- Changes `ENV_MUTEX.lock().unwrap_or_else(|e| e.into_inner())` to `ENV_MUTEX.lock().expect("env mutex poisoned")` to prevent silent recovery from poisoned mutex, which defeated serialization guarantees

Closes #1280

## Test plan
- [x] Tests pass single-threaded (`--test-threads=1`)
- [x] Tests pass in parallel (default)
- [x] Clippy clean with `--all-features`