### PR TITLE
fix(routines): add bounded retry for transient lightweight failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
 ]
 
 [[package]]
@@ -1731,7 +1731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
- "crossterm",
+ "crossterm 0.29.0",
  "once_cell",
  "serde",
  "strict",
@@ -1743,7 +1743,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
- "crossterm",
+ "crossterm 0.29.0",
  "proc-macro2",
  "quote",
  "strict",
@@ -1816,6 +1816,22 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm_winapi",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
 
 [[package]]
 name = "crossterm"
@@ -2477,6 +2493,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3118,7 +3149,6 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3131,6 +3161,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3410,7 +3456,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "cron",
- "crossterm",
+ "crossterm 0.28.1",
  "deadpool-postgres",
  "dirs 6.0.0",
  "dotenvy",
@@ -4090,6 +4136,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe 0.2.1",
+ "openssl-sys",
+ "schannel",
+ "security-framework 3.7.0",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4312,6 +4375,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl"
+version = "0.10.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4322,6 +4411,18 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.112"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -5312,11 +5413,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5328,6 +5431,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -5338,7 +5442,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6672,6 +6775,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-postgres"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7353,6 +7466,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,7 +1510,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
 ]
 
 [[package]]
@@ -1731,7 +1731,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
- "crossterm 0.29.0",
+ "crossterm",
  "once_cell",
  "serde",
  "strict",
@@ -1743,7 +1743,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
  "proc-macro2",
  "quote",
  "strict",
@@ -1816,22 +1816,6 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
 
 [[package]]
 name = "crossterm"
@@ -2493,21 +2477,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3149,6 +3118,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -3161,22 +3131,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
 ]
 
 [[package]]
@@ -3456,7 +3410,7 @@ dependencies = [
  "clap_complete",
  "criterion",
  "cron",
- "crossterm 0.28.1",
+ "crossterm",
  "deadpool-postgres",
  "dirs 6.0.0",
  "dotenvy",
@@ -4136,23 +4090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4375,32 +4312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4411,18 +4322,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "option-ext"
@@ -5413,13 +5312,11 @@ dependencies = [
  "http-body-util",
  "hyper 1.8.1",
  "hyper-rustls 0.27.7",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -5431,7 +5328,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.4",
  "tokio-util",
  "tower 0.5.3",
@@ -5442,6 +5338,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]
@@ -6775,16 +6672,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-postgres"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7466,12 +7353,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1097,6 +1097,15 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
 
     let result = {
         let mut attempt = 0u32;
+        let mut accumulated_tokens: i32 = 0;
+        let uses_tools = matches!(
+            routine.action,
+            RoutineAction::Lightweight {
+                use_tools: true,
+                ..
+            }
+        ) && ctx.config.lightweight_tools_enabled;
+
         loop {
             let execution_result = match &routine.action {
                 RoutineAction::Lightweight {
@@ -1132,9 +1141,39 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
             };
 
             match execution_result {
-                Ok(outcome) => break Ok(outcome),
+                Ok((status, summary, tokens)) => {
+                    // Accumulate tokens from this attempt with any previous attempts
+                    let total = Some(accumulated_tokens + tokens.unwrap_or(0));
+                    break Ok((status, summary, total));
+                }
                 Err(ref e) if is_lightweight && e.is_retryable() && attempt < MAX_RETRIES => {
+                    // Accumulate any partial tokens from the failed attempt
+                    if let RoutineError::LlmFailed {
+                        partial_tokens: Some(t),
+                        ..
+                    } = e
+                    {
+                        accumulated_tokens += t;
+                    }
+
                     attempt += 1;
+
+                    // NOTE: When retrying a tools-enabled routine, the entire
+                    // execute_lightweight() call is re-run, which means
+                    // already-executed tool calls will be repeated. This is a
+                    // known limitation — restructuring the retry to wrap only
+                    // the LLM call would require splitting the tool loop from
+                    // the LLM call, which is too invasive for the current
+                    // architecture.
+                    if uses_tools {
+                        tracing::warn!(
+                            routine = %routine.name,
+                            attempt = attempt,
+                            "Retrying tools-enabled routine; previously executed tool calls \
+                             may be repeated causing duplicate side effects"
+                        );
+                    }
+
                     let delay = Duration::from_millis(
                         BASE_DELAY_MS.saturating_mul(2u64.saturating_pow(attempt - 1)),
                     );
@@ -1547,6 +1586,7 @@ async fn execute_lightweight_no_tools(
         .await
         .map_err(|e| RoutineError::LlmFailed {
             reason: e.to_string(),
+            partial_tokens: None,
         })?;
 
     handle_text_response(
@@ -1651,13 +1691,13 @@ async fn execute_lightweight_with_tools(
                 .with_max_tokens(effective_max_tokens)
                 .with_temperature(0.3);
 
-            let response =
-                ctx.llm
-                    .complete(request)
-                    .await
-                    .map_err(|e| RoutineError::LlmFailed {
-                        reason: e.to_string(),
-                    })?;
+            let response = ctx.llm.complete(request).await.map_err(|e| {
+                let partial = (total_input_tokens + total_output_tokens) as i32;
+                RoutineError::LlmFailed {
+                    reason: e.to_string(),
+                    partial_tokens: if partial > 0 { Some(partial) } else { None },
+                }
+            })?;
 
             total_input_tokens += response.input_tokens;
             total_output_tokens += response.output_tokens;
@@ -1684,8 +1724,10 @@ async fn execute_lightweight_with_tools(
                 .with_temperature(0.3);
 
             let response = ctx.llm.complete_with_tools(request).await.map_err(|e| {
+                let partial = (total_input_tokens + total_output_tokens) as i32;
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
+                    partial_tokens: if partial > 0 { Some(partial) } else { None },
                 }
             })?;
 
@@ -2554,12 +2596,52 @@ mod tests {
         let transient_errors: Vec<RoutineError> = vec![
             RoutineError::LlmFailed {
                 reason: "rate limit".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "network timeout".into(),
+                partial_tokens: Some(42),
             },
             RoutineError::EmptyResponse,
             RoutineError::TruncatedResponse,
         ];
         for err in &transient_errors {
             assert!(err.is_retryable(), "{} should be retryable", err);
+        }
+
+        // Permanent LLM failures that should NOT be retried
+        let permanent_llm_errors: Vec<RoutineError> = vec![
+            RoutineError::LlmFailed {
+                reason: "Authentication failed for provider openai".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "invalid_api_key: bad key".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "content policy violation".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "content_filter triggered".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "context length exceeded: 150000 tokens used, 128000 allowed".into(),
+                partial_tokens: Some(100),
+            },
+            RoutineError::LlmFailed {
+                reason: "model not available on provider anthropic".into(),
+                partial_tokens: None,
+            },
+            RoutineError::LlmFailed {
+                reason: "content moderation flagged".into(),
+                partial_tokens: None,
+            },
+        ];
+        for err in &permanent_llm_errors {
+            assert!(!err.is_retryable(), "{} should NOT be retryable", err);
         }
 
         // Hard failures (never retried)

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1095,9 +1095,13 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
 
     let is_lightweight = matches!(routine.action, RoutineAction::Lightweight { .. });
 
-    let result = {
+    // The retry block returns both the execution result and any accumulated
+    // token count so that usage is preserved even on final failure.
+    let (result, accumulated_tokens) = {
         let mut attempt = 0u32;
-        let mut accumulated_tokens: i32 = 0;
+        // Track accumulated tokens as Option to preserve None semantics:
+        // None = no attempt reported tokens; Some(n) = at least one attempt did.
+        let mut accumulated_tokens: Option<i32> = None;
         let uses_tools = matches!(
             routine.action,
             RoutineAction::Lightweight {
@@ -1105,6 +1109,33 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
                 ..
             }
         ) && ctx.config.lightweight_tools_enabled;
+
+        /// Extract partial_tokens from any RoutineError variant that carries them.
+        fn extract_partial_tokens(e: &RoutineError) -> Option<i32> {
+            match e {
+                RoutineError::LlmFailed {
+                    partial_tokens: Some(t),
+                    ..
+                }
+                | RoutineError::EmptyResponse {
+                    partial_tokens: Some(t),
+                }
+                | RoutineError::TruncatedResponse {
+                    partial_tokens: Some(t),
+                } => Some(*t),
+                _ => None,
+            }
+        }
+
+        /// Merge an optional partial token count into the accumulator,
+        /// only materializing Some when at least one source had Some.
+        fn accumulate(acc: Option<i32>, partial: Option<i32>) -> Option<i32> {
+            match (acc, partial) {
+                (Some(a), Some(p)) => Some(a.saturating_add(p)),
+                (Some(a), None) => Some(a),
+                (None, p) => p,
+            }
+        }
 
         loop {
             let execution_result = match &routine.action {
@@ -1142,24 +1173,22 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
 
             match execution_result {
                 Ok((status, summary, tokens)) => {
-                    // Accumulate tokens from this attempt with any previous attempts
-                    let total = Some(accumulated_tokens.saturating_add(tokens.unwrap_or(0)));
-                    break Ok((status, summary, total));
+                    // Merge tokens: only produce Some when at least one source had Some.
+                    let total = accumulate(accumulated_tokens, tokens);
+                    break (Ok((status, summary, total)), accumulated_tokens);
                 }
                 Err(ref e)
                     if is_lightweight
                         && !uses_tools
                         && e.is_retryable()
+                        // Skip outer retry for LlmFailed — RetryProvider already
+                        // retries transient LLM errors with its own budget. Retrying
+                        // here would create a multiplicative retry count.
+                        && !matches!(e, RoutineError::LlmFailed { .. })
                         && attempt < MAX_RETRIES =>
                 {
-                    // Accumulate any partial tokens from the failed attempt
-                    if let RoutineError::LlmFailed {
-                        partial_tokens: Some(t),
-                        ..
-                    } = e
-                    {
-                        accumulated_tokens = accumulated_tokens.saturating_add(*t);
-                    }
+                    // Accumulate partial tokens from the failed attempt.
+                    accumulated_tokens = accumulate(accumulated_tokens, extract_partial_tokens(e));
 
                     attempt += 1;
 
@@ -1169,7 +1198,11 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
                     tracing::event!(target: "transient_routine_errors", tracing::Level::WARN, routine = %routine.name, attempt = attempt, max_retries = MAX_RETRIES, delay_ms = delay.as_millis() as u64, "Transient routine error, retrying: {}", e);
                     tokio::time::sleep(delay).await;
                 }
-                Err(e) => break Err(e),
+                Err(e) => {
+                    // Accumulate tokens from the final failed attempt.
+                    accumulated_tokens = accumulate(accumulated_tokens, extract_partial_tokens(&e));
+                    break (Err(e), accumulated_tokens);
+                }
             }
         }
     };
@@ -1177,12 +1210,13 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
     // Decrement running count
     ctx.running_count.fetch_sub(1, Ordering::Relaxed);
 
-    // Process result
+    // Process result — on failure, preserve accumulated token total from
+    // earlier retry attempts so usage reporting stays accurate.
     let (status, summary, tokens) = match result {
         Ok(execution) => execution,
         Err(e) => {
             tracing::error!(routine = %routine.name, "Execution failed: {}", e);
-            (RunStatus::Failed, Some(e.to_string()), None)
+            (RunStatus::Failed, Some(e.to_string()), accumulated_tokens)
         }
     };
 
@@ -1591,12 +1625,18 @@ fn handle_text_response(
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
     let content = content.trim();
 
-    // Empty content guard
+    // Empty content guard — carry consumed tokens so the retry loop can
+    // accumulate them even when the response shape is invalid.
     if content.is_empty() {
+        let consumed = Some((total_input_tokens + total_output_tokens) as i32);
         return if finish_reason == FinishReason::Length {
-            Err(RoutineError::TruncatedResponse)
+            Err(RoutineError::TruncatedResponse {
+                partial_tokens: consumed,
+            })
         } else {
-            Err(RoutineError::EmptyResponse)
+            Err(RoutineError::EmptyResponse {
+                partial_tokens: consumed,
+            })
         };
     }
 
@@ -2591,8 +2631,12 @@ mod tests {
                 partial_tokens: Some(42),
                 retryable: true,
             },
-            RoutineError::EmptyResponse,
-            RoutineError::TruncatedResponse,
+            RoutineError::EmptyResponse {
+                partial_tokens: None,
+            },
+            RoutineError::TruncatedResponse {
+                partial_tokens: Some(100),
+            },
         ];
         for err in &transient_errors {
             assert!(err.is_retryable(), "{} should be retryable", err);

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1089,36 +1089,66 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
     // Increment running count (atomic: survives panics in the execution below)
     ctx.running_count.fetch_add(1, Ordering::Relaxed);
 
-    let result = match &routine.action {
-        RoutineAction::Lightweight {
-            prompt,
-            context_paths,
-            max_tokens,
-            use_tools,
-            max_tool_rounds,
-        } => {
-            execute_lightweight(
-                &ctx,
-                &routine,
-                prompt,
-                context_paths,
-                *max_tokens,
-                *use_tools,
-                *max_tool_rounds,
-            )
-            .await
-        }
-        RoutineAction::FullJob {
-            title,
-            description,
-            max_iterations,
-        } => {
-            let execution = FullJobExecutionConfig {
-                title,
-                description,
-                max_iterations: *max_iterations,
+    // Retry constants for transient lightweight execution failures.
+    const MAX_RETRIES: u32 = 3;
+    const BASE_DELAY_MS: u64 = 1000;
+
+    let is_lightweight = matches!(routine.action, RoutineAction::Lightweight { .. });
+
+    let result = {
+        let mut attempt = 0u32;
+        loop {
+            let execution_result = match &routine.action {
+                RoutineAction::Lightweight {
+                    prompt,
+                    context_paths,
+                    max_tokens,
+                    use_tools,
+                    max_tool_rounds,
+                } => {
+                    execute_lightweight(
+                        &ctx,
+                        &routine,
+                        prompt,
+                        context_paths,
+                        *max_tokens,
+                        *use_tools,
+                        *max_tool_rounds,
+                    )
+                    .await
+                }
+                RoutineAction::FullJob {
+                    title,
+                    description,
+                    max_iterations,
+                } => {
+                    let execution = FullJobExecutionConfig {
+                        title,
+                        description,
+                        max_iterations: *max_iterations,
+                    };
+                    execute_full_job(&ctx, &routine, &run, &execution).await
+                }
             };
-            execute_full_job(&ctx, &routine, &run, &execution).await
+
+            match execution_result {
+                Ok(outcome) => break Ok(outcome),
+                Err(ref e) if is_lightweight && e.is_retryable() && attempt < MAX_RETRIES => {
+                    attempt += 1;
+                    let delay = Duration::from_millis(
+                        BASE_DELAY_MS.saturating_mul(2u64.saturating_pow(attempt - 1)),
+                    );
+                    tracing::warn!(
+                        routine = %routine.name,
+                        attempt = attempt,
+                        max_retries = MAX_RETRIES,
+                        delay_ms = delay.as_millis() as u64,
+                        "Transient routine error, retrying: {}", e
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+                Err(e) => break Err(e),
+            }
         }
     };
 
@@ -1828,6 +1858,7 @@ async fn execute_routine_tool(
 }
 
 /// Send a notification based on the routine's notify config and run status.
+#[allow(clippy::too_many_arguments)]
 async fn send_notification(
     tx: &mpsc::Sender<OutgoingResponse>,
     notify: &NotifyConfig,
@@ -2510,6 +2541,50 @@ mod tests {
                 "{:?} should not finalize the routine run",
                 state
             );
+        }
+    }
+
+    /// Regression test for #1320: transient errors are retried for lightweight
+    /// routines but not for full-job routines or hard failures.
+    #[test]
+    fn test_retry_classification_for_routine_errors() {
+        use crate::error::RoutineError;
+
+        // Transient errors (retryable for lightweight routines)
+        let transient_errors: Vec<RoutineError> = vec![
+            RoutineError::LlmFailed {
+                reason: "rate limit".into(),
+            },
+            RoutineError::EmptyResponse,
+            RoutineError::TruncatedResponse,
+        ];
+        for err in &transient_errors {
+            assert!(err.is_retryable(), "{} should be retryable", err);
+        }
+
+        // Hard failures (never retried)
+        let hard_errors: Vec<RoutineError> = vec![
+            RoutineError::Disabled {
+                name: "test".into(),
+            },
+            RoutineError::NotFound {
+                id: uuid::Uuid::new_v4(),
+            },
+            RoutineError::NotAuthorized {
+                id: uuid::Uuid::new_v4(),
+            },
+            RoutineError::MaxConcurrent {
+                name: "test".into(),
+            },
+            RoutineError::JobDispatchFailed {
+                reason: "no docker".into(),
+            },
+            RoutineError::Database {
+                reason: "connection refused".into(),
+            },
+        ];
+        for err in &hard_errors {
+            assert!(!err.is_retryable(), "{} should NOT be retryable", err);
         }
     }
 

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1143,36 +1143,20 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
             match execution_result {
                 Ok((status, summary, tokens)) => {
                     // Accumulate tokens from this attempt with any previous attempts
-                    let total = Some(accumulated_tokens + tokens.unwrap_or(0));
+                    let total = Some(accumulated_tokens.saturating_add(tokens.unwrap_or(0)));
                     break Ok((status, summary, total));
                 }
-                Err(ref e) if is_lightweight && e.is_retryable() && attempt < MAX_RETRIES => {
+                Err(ref e) if is_lightweight && !uses_tools && e.is_retryable() && attempt < MAX_RETRIES => {
                     // Accumulate any partial tokens from the failed attempt
                     if let RoutineError::LlmFailed {
                         partial_tokens: Some(t),
                         ..
                     } = e
                     {
-                        accumulated_tokens += t;
+                        accumulated_tokens = accumulated_tokens.saturating_add(*t);
                     }
 
                     attempt += 1;
-
-                    // NOTE: When retrying a tools-enabled routine, the entire
-                    // execute_lightweight() call is re-run, which means
-                    // already-executed tool calls will be repeated. This is a
-                    // known limitation — restructuring the retry to wrap only
-                    // the LLM call would require splitting the tool loop from
-                    // the LLM call, which is too invasive for the current
-                    // architecture.
-                    if uses_tools {
-                        tracing::warn!(
-                            routine = %routine.name,
-                            attempt = attempt,
-                            "Retrying tools-enabled routine; previously executed tool calls \
-                             may be repeated causing duplicate side effects"
-                        );
-                    }
 
                     let delay = Duration::from_millis(
                         BASE_DELAY_MS.saturating_mul(2u64.saturating_pow(attempt - 1)),
@@ -1578,9 +1562,13 @@ async fn execute_lightweight_no_tools(
         .llm
         .complete(request)
         .await
-        .map_err(|e| RoutineError::LlmFailed {
-            reason: e.to_string(),
-            partial_tokens: None,
+        .map_err(|e| {
+            let retryable = crate::llm::retry::is_retryable(&e);
+            RoutineError::LlmFailed {
+                reason: e.to_string(),
+                partial_tokens: None,
+                retryable,
+            }
         })?;
 
     handle_text_response(
@@ -1687,9 +1675,11 @@ async fn execute_lightweight_with_tools(
 
             let response = ctx.llm.complete(request).await.map_err(|e| {
                 let partial = (total_input_tokens + total_output_tokens) as i32;
+                let retryable = crate::llm::retry::is_retryable(&e);
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
                     partial_tokens: if partial > 0 { Some(partial) } else { None },
+                    retryable,
                 }
             })?;
 
@@ -1719,9 +1709,11 @@ async fn execute_lightweight_with_tools(
 
             let response = ctx.llm.complete_with_tools(request).await.map_err(|e| {
                 let partial = (total_input_tokens + total_output_tokens) as i32;
+                let retryable = crate::llm::retry::is_retryable(&e);
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
                     partial_tokens: if partial > 0 { Some(partial) } else { None },
+                    retryable,
                 }
             })?;
 
@@ -2591,10 +2583,12 @@ mod tests {
             RoutineError::LlmFailed {
                 reason: "rate limit".into(),
                 partial_tokens: None,
+                retryable: true,
             },
             RoutineError::LlmFailed {
                 reason: "network timeout".into(),
                 partial_tokens: Some(42),
+                retryable: true,
             },
             RoutineError::EmptyResponse,
             RoutineError::TruncatedResponse,
@@ -2604,34 +2598,42 @@ mod tests {
         }
 
         // Permanent LLM failures that should NOT be retried
+        // (retryable: false is set at conversion time by llm::retry::is_retryable)
         let permanent_llm_errors: Vec<RoutineError> = vec![
             RoutineError::LlmFailed {
                 reason: "Authentication failed for provider openai".into(),
                 partial_tokens: None,
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "invalid_api_key: bad key".into(),
                 partial_tokens: None,
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "content policy violation".into(),
                 partial_tokens: None,
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "content_filter triggered".into(),
                 partial_tokens: None,
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "context length exceeded: 150000 tokens used, 128000 allowed".into(),
                 partial_tokens: Some(100),
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "model not available on provider anthropic".into(),
                 partial_tokens: None,
+                retryable: false,
             },
             RoutineError::LlmFailed {
                 reason: "content moderation flagged".into(),
                 partial_tokens: None,
+                retryable: false,
             },
         ];
         for err in &permanent_llm_errors {

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1146,7 +1146,12 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
                     let total = Some(accumulated_tokens.saturating_add(tokens.unwrap_or(0)));
                     break Ok((status, summary, total));
                 }
-                Err(ref e) if is_lightweight && !uses_tools && e.is_retryable() && attempt < MAX_RETRIES => {
+                Err(ref e)
+                    if is_lightweight
+                        && !uses_tools
+                        && e.is_retryable()
+                        && attempt < MAX_RETRIES =>
+                {
                     // Accumulate any partial tokens from the failed attempt
                     if let RoutineError::LlmFailed {
                         partial_tokens: Some(t),
@@ -1558,18 +1563,14 @@ async fn execute_lightweight_no_tools(
         .with_max_tokens(effective_max_tokens)
         .with_temperature(0.3);
 
-    let response = ctx
-        .llm
-        .complete(request)
-        .await
-        .map_err(|e| {
-            let retryable = crate::llm::retry::is_retryable(&e);
-            RoutineError::LlmFailed {
-                reason: e.to_string(),
-                partial_tokens: None,
-                retryable,
-            }
-        })?;
+    let response = ctx.llm.complete(request).await.map_err(|e| {
+        let retryable = crate::llm::retry::is_retryable(&e);
+        RoutineError::LlmFailed {
+            reason: e.to_string(),
+            partial_tokens: None,
+            retryable,
+        }
+    })?;
 
     handle_text_response(
         &response.content,

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1090,7 +1090,14 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
     ctx.running_count.fetch_add(1, Ordering::Relaxed);
 
     // Retry constants for transient lightweight execution failures.
-    const MAX_RETRIES: u32 = 3;
+    //
+    // NOTE: Multiplicative retry budgets — `ctx.llm` is wrapped in `RetryProvider`
+    // which has its own retry budget (default 3). Although `LlmFailed` errors are
+    // excluded from outer retry (only `EmptyResponse`/`TruncatedResponse` retry
+    // here), be aware that each outer attempt triggers a full inner retry budget
+    // for the LLM call itself. With MAX_RETRIES=2, worst case is 2 outer x 3 inner
+    // = 6 LLM calls per routine run.
+    const MAX_RETRIES: u32 = 2;
     const BASE_DELAY_MS: u64 = 1000;
 
     let is_lightweight = matches!(routine.action, RoutineAction::Lightweight { .. });
@@ -1601,6 +1608,9 @@ async fn execute_lightweight_no_tools(
         let retryable = crate::llm::retry::is_retryable(&e);
         RoutineError::LlmFailed {
             reason: e.to_string(),
+            // No partial tokens: the LLM call itself failed, so the response
+            // (and its token counts) is unavailable. If providers start returning
+            // partial usage on error responses, this should be updated.
             partial_tokens: None,
             retryable,
         }
@@ -1612,6 +1622,17 @@ async fn execute_lightweight_no_tools(
         response.input_tokens,
         response.output_tokens,
     )
+}
+
+/// Convert raw `u32` token counts into `Option<i32>`, preserving `None` semantics.
+///
+/// Providers that don't report token usage return `(0, 0)`. Wrapping that in
+/// `Some(0)` would change the stored meaning from "unknown/not tracked" to "zero",
+/// leaking incorrect data to downstream reporting. Only materialize `Some` when
+/// at least one count is non-zero.
+fn tokens_to_option(input: u32, output: u32) -> Option<i32> {
+    let total = input.saturating_add(output);
+    if total > 0 { Some(total as i32) } else { None }
 }
 
 /// Handle a text-only LLM response in lightweight routine execution.
@@ -1628,7 +1649,7 @@ fn handle_text_response(
     // Empty content guard — carry consumed tokens so the retry loop can
     // accumulate them even when the response shape is invalid.
     if content.is_empty() {
-        let consumed = Some((total_input_tokens + total_output_tokens) as i32);
+        let consumed = tokens_to_option(total_input_tokens, total_output_tokens);
         return if finish_reason == FinishReason::Length {
             Err(RoutineError::TruncatedResponse {
                 partial_tokens: consumed,
@@ -1642,11 +1663,11 @@ fn handle_text_response(
 
     // Check for the "nothing to do" sentinel (exact match on trimmed content).
     if content == "ROUTINE_OK" {
-        let total_tokens = Some((total_input_tokens + total_output_tokens) as i32);
+        let total_tokens = tokens_to_option(total_input_tokens, total_output_tokens);
         return Ok((RunStatus::Ok, None, total_tokens));
     }
 
-    let total_tokens = Some((total_input_tokens + total_output_tokens) as i32);
+    let total_tokens = tokens_to_option(total_input_tokens, total_output_tokens);
     Ok((
         RunStatus::Attention,
         Some(content.to_string()),
@@ -1715,11 +1736,10 @@ async fn execute_lightweight_with_tools(
                 .with_temperature(0.3);
 
             let response = ctx.llm.complete(request).await.map_err(|e| {
-                let partial = (total_input_tokens + total_output_tokens) as i32;
                 let retryable = crate::llm::retry::is_retryable(&e);
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
-                    partial_tokens: if partial > 0 { Some(partial) } else { None },
+                    partial_tokens: tokens_to_option(total_input_tokens, total_output_tokens),
                     retryable,
                 }
             })?;
@@ -1749,11 +1769,10 @@ async fn execute_lightweight_with_tools(
                 .with_temperature(0.3);
 
             let response = ctx.llm.complete_with_tools(request).await.map_err(|e| {
-                let partial = (total_input_tokens + total_output_tokens) as i32;
                 let retryable = crate::llm::retry::is_retryable(&e);
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
-                    partial_tokens: if partial > 0 { Some(partial) } else { None },
+                    partial_tokens: tokens_to_option(total_input_tokens, total_output_tokens),
                     retryable,
                 }
             })?;

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1177,13 +1177,7 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
                     let delay = Duration::from_millis(
                         BASE_DELAY_MS.saturating_mul(2u64.saturating_pow(attempt - 1)),
                     );
-                    tracing::warn!(
-                        routine = %routine.name,
-                        attempt = attempt,
-                        max_retries = MAX_RETRIES,
-                        delay_ms = delay.as_millis() as u64,
-                        "Transient routine error, retrying: {}", e
-                    );
+                    tracing::event!(target: "transient_routine_errors", tracing::Level::WARN, routine = %routine.name, attempt = attempt, max_retries = MAX_RETRIES, delay_ms = delay.as_millis() as u64, "Transient routine error, retrying: {}", e);
                     tokio::time::sleep(delay).await;
                 }
                 Err(e) => break Err(e),

--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -981,7 +981,7 @@ mod tests {
         assert!(alice_stats.last_active_at.is_some());
 
         // Bob has no LLM calls so doesn't appear in summary stats
-        assert!(stats.iter().find(|s| s.user_id == "bob").is_none());
+        assert!(!stats.iter().any(|s| s.user_id == "bob"));
 
         // Filter to single user
         let alice_only = db.user_summary_stats(Some("alice")).await.unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -407,6 +407,21 @@ pub enum RoutineError {
     TruncatedResponse,
 }
 
+impl RoutineError {
+    /// Whether this error is transient and worth retrying with backoff.
+    ///
+    /// Retryable: LLM failures, empty responses, truncated responses.
+    /// Non-retryable: configuration errors, authorization, resource limits, DB errors.
+    pub fn is_retryable(&self) -> bool {
+        matches!(
+            self,
+            RoutineError::LlmFailed { .. }
+                | RoutineError::EmptyResponse
+                | RoutineError::TruncatedResponse
+        )
+    }
+}
+
 /// Result type alias for the agent.
 pub type Result<T> = std::result::Result<T, Error>;
 
@@ -512,6 +527,66 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("bad format"), "Should mention reason: {msg}");
+    }
+
+    #[test]
+    fn routine_error_retryable_classification() {
+        // Transient errors should be retryable
+        assert!(
+            RoutineError::LlmFailed {
+                reason: "timeout".into()
+            }
+            .is_retryable()
+        );
+        assert!(RoutineError::EmptyResponse.is_retryable());
+        assert!(RoutineError::TruncatedResponse.is_retryable());
+
+        // Hard failures should NOT be retryable
+        assert!(!RoutineError::Disabled {
+            name: "test".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::JobDispatchFailed {
+            reason: "no docker".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::Database {
+            reason: "conn refused".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::NotFound {
+            id: Uuid::new_v4()
+        }
+        .is_retryable());
+        assert!(!RoutineError::NotAuthorized {
+            id: Uuid::new_v4()
+        }
+        .is_retryable());
+        assert!(!RoutineError::MaxConcurrent {
+            name: "test".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::UnknownTriggerType {
+            trigger_type: "x".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::UnknownActionType {
+            action_type: "x".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::MissingField {
+            context: "c".into(),
+            field: "f".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::InvalidCron {
+            reason: "bad".into()
+        }
+        .is_retryable());
+        assert!(!RoutineError::UnknownRunStatus {
+            status: "bad".into()
+        }
+        .is_retryable());
     }
 
     #[test]

--- a/src/error.rs
+++ b/src/error.rs
@@ -400,6 +400,11 @@ pub enum RoutineError {
         /// Partial token count consumed before the failure (if any).
         /// Used to accumulate usage across retry attempts.
         partial_tokens: Option<i32>,
+        /// Whether the underlying LLM error was classified as retryable.
+        /// Set at the `LlmError` → `RoutineError` conversion site using
+        /// `crate::llm::retry::is_retryable()`, avoiding fragile substring
+        /// matching on the stringified reason.
+        retryable: bool,
     },
 
     #[error("Failed to dispatch full job: {reason}")]
@@ -413,40 +418,16 @@ pub enum RoutineError {
 }
 
 impl RoutineError {
-    /// Known permanent failure substrings in LLM error reasons.
-    ///
-    /// These map to `LlmError` variants that the LLM retry layer already
-    /// considers non-retryable (`AuthFailed`, `ContextLengthExceeded`,
-    /// `ModelNotAvailable`) plus content-policy rejections surfaced as
-    /// provider-level `RequestFailed` with descriptive messages.
-    const PERMANENT_LLM_PATTERNS: &'static [&'static str] = &[
-        "auth",
-        "authentication",
-        "invalid_api_key",
-        "content policy",
-        "content_policy",
-        "content_filter",
-        "context length",
-        "context_length",
-        "model not available",
-        "model_not_available",
-        "moderation",
-    ];
-
     /// Whether this error is transient and worth retrying with backoff.
     ///
-    /// Retryable: LLM failures (unless the reason matches a known permanent
-    /// pattern), empty responses, truncated responses.
+    /// Retryable: LLM failures where the underlying `LlmError` was classified
+    /// as retryable by `crate::llm::retry::is_retryable()`, empty responses,
+    /// and truncated responses.
     /// Non-retryable: configuration errors, authorization, resource limits,
     /// DB errors, and LLM failures caused by auth/content-policy/context-length.
     pub fn is_retryable(&self) -> bool {
         match self {
-            RoutineError::LlmFailed { reason, .. } => {
-                let lower = reason.to_ascii_lowercase();
-                !Self::PERMANENT_LLM_PATTERNS
-                    .iter()
-                    .any(|pat| lower.contains(pat))
-            }
+            RoutineError::LlmFailed { retryable, .. } => *retryable,
             RoutineError::EmptyResponse | RoutineError::TruncatedResponse => true,
             _ => false,
         }
@@ -567,6 +548,16 @@ mod tests {
             RoutineError::LlmFailed {
                 reason: "timeout".into(),
                 partial_tokens: None,
+                retryable: true,
+            }
+            .is_retryable()
+        );
+        // Non-retryable LLM error
+        assert!(
+            !RoutineError::LlmFailed {
+                reason: "timeout".into(),
+                partial_tokens: None,
+                retryable: false,
             }
             .is_retryable()
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -411,10 +411,16 @@ pub enum RoutineError {
     JobDispatchFailed { reason: String },
 
     #[error("LLM returned empty content")]
-    EmptyResponse,
+    EmptyResponse {
+        /// Tokens consumed by the call that produced the empty response.
+        partial_tokens: Option<i32>,
+    },
 
     #[error("LLM response truncated (finish_reason=length) with no content")]
-    TruncatedResponse,
+    TruncatedResponse {
+        /// Tokens consumed by the call that produced the truncated response.
+        partial_tokens: Option<i32>,
+    },
 }
 
 impl RoutineError {
@@ -428,7 +434,7 @@ impl RoutineError {
     pub fn is_retryable(&self) -> bool {
         match self {
             RoutineError::LlmFailed { retryable, .. } => *retryable,
-            RoutineError::EmptyResponse | RoutineError::TruncatedResponse => true,
+            RoutineError::EmptyResponse { .. } | RoutineError::TruncatedResponse { .. } => true,
             _ => false,
         }
     }
@@ -561,8 +567,18 @@ mod tests {
             }
             .is_retryable()
         );
-        assert!(RoutineError::EmptyResponse.is_retryable());
-        assert!(RoutineError::TruncatedResponse.is_retryable());
+        assert!(
+            RoutineError::EmptyResponse {
+                partial_tokens: None
+            }
+            .is_retryable()
+        );
+        assert!(
+            RoutineError::TruncatedResponse {
+                partial_tokens: None
+            }
+            .is_retryable()
+        );
 
         // Hard failures should NOT be retryable
         assert!(

--- a/src/error.rs
+++ b/src/error.rs
@@ -395,7 +395,12 @@ pub enum RoutineError {
     Database { reason: String },
 
     #[error("LLM call failed: {reason}")]
-    LlmFailed { reason: String },
+    LlmFailed {
+        reason: String,
+        /// Partial token count consumed before the failure (if any).
+        /// Used to accumulate usage across retry attempts.
+        partial_tokens: Option<i32>,
+    },
 
     #[error("Failed to dispatch full job: {reason}")]
     JobDispatchFailed { reason: String },
@@ -408,17 +413,43 @@ pub enum RoutineError {
 }
 
 impl RoutineError {
+    /// Known permanent failure substrings in LLM error reasons.
+    ///
+    /// These map to `LlmError` variants that the LLM retry layer already
+    /// considers non-retryable (`AuthFailed`, `ContextLengthExceeded`,
+    /// `ModelNotAvailable`) plus content-policy rejections surfaced as
+    /// provider-level `RequestFailed` with descriptive messages.
+    const PERMANENT_LLM_PATTERNS: &'static [&'static str] = &[
+        "auth",
+        "authentication",
+        "invalid_api_key",
+        "content policy",
+        "content_policy",
+        "content_filter",
+        "context length",
+        "context_length",
+        "model not available",
+        "model_not_available",
+        "moderation",
+    ];
+
     /// Whether this error is transient and worth retrying with backoff.
     ///
-    /// Retryable: LLM failures, empty responses, truncated responses.
-    /// Non-retryable: configuration errors, authorization, resource limits, DB errors.
+    /// Retryable: LLM failures (unless the reason matches a known permanent
+    /// pattern), empty responses, truncated responses.
+    /// Non-retryable: configuration errors, authorization, resource limits,
+    /// DB errors, and LLM failures caused by auth/content-policy/context-length.
     pub fn is_retryable(&self) -> bool {
-        matches!(
-            self,
-            RoutineError::LlmFailed { .. }
-                | RoutineError::EmptyResponse
-                | RoutineError::TruncatedResponse
-        )
+        match self {
+            RoutineError::LlmFailed { reason, .. } => {
+                let lower = reason.to_ascii_lowercase();
+                !Self::PERMANENT_LLM_PATTERNS
+                    .iter()
+                    .any(|pat| lower.contains(pat))
+            }
+            RoutineError::EmptyResponse | RoutineError::TruncatedResponse => true,
+            _ => false,
+        }
     }
 }
 
@@ -534,7 +565,8 @@ mod tests {
         // Transient errors should be retryable
         assert!(
             RoutineError::LlmFailed {
-                reason: "timeout".into()
+                reason: "timeout".into(),
+                partial_tokens: None,
             }
             .is_retryable()
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -542,51 +542,63 @@ mod tests {
         assert!(RoutineError::TruncatedResponse.is_retryable());
 
         // Hard failures should NOT be retryable
-        assert!(!RoutineError::Disabled {
-            name: "test".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::JobDispatchFailed {
-            reason: "no docker".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::Database {
-            reason: "conn refused".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::NotFound {
-            id: Uuid::new_v4()
-        }
-        .is_retryable());
-        assert!(!RoutineError::NotAuthorized {
-            id: Uuid::new_v4()
-        }
-        .is_retryable());
-        assert!(!RoutineError::MaxConcurrent {
-            name: "test".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::UnknownTriggerType {
-            trigger_type: "x".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::UnknownActionType {
-            action_type: "x".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::MissingField {
-            context: "c".into(),
-            field: "f".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::InvalidCron {
-            reason: "bad".into()
-        }
-        .is_retryable());
-        assert!(!RoutineError::UnknownRunStatus {
-            status: "bad".into()
-        }
-        .is_retryable());
+        assert!(
+            !RoutineError::Disabled {
+                name: "test".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::JobDispatchFailed {
+                reason: "no docker".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::Database {
+                reason: "conn refused".into()
+            }
+            .is_retryable()
+        );
+        assert!(!RoutineError::NotFound { id: Uuid::new_v4() }.is_retryable());
+        assert!(!RoutineError::NotAuthorized { id: Uuid::new_v4() }.is_retryable());
+        assert!(
+            !RoutineError::MaxConcurrent {
+                name: "test".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownTriggerType {
+                trigger_type: "x".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownActionType {
+                action_type: "x".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::MissingField {
+                context: "c".into(),
+                field: "f".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::InvalidCron {
+                reason: "bad".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownRunStatus {
+                status: "bad".into()
+            }
+            .is_retryable()
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds `RoutineError::is_retryable()` classifying `LlmFailed`, `EmptyResponse`, and `TruncatedResponse` as transient (retryable); all other variants as hard failures
- Wraps lightweight routine execution in a retry loop: up to 3 retries with exponential backoff (1s, 2s, 4s)
- Full-job routines skip retry (they have their own `FullJobWatcher` recovery mechanism)
- Non-retryable errors fail immediately without wasting retry budget

Closes #1320

## Test plan
- [x] Clippy clean with `--all-features`
- [x] Comprehensive `is_retryable()` test covering all 11 `RoutineError` variants
- [x] Regression test for retry behavior
- [x] Both default and libsql features compile cleanly