### PR TITLE
feat(web): add core release check popup

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -179,7 +179,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `sandbox` | ✅ | ✅ | - | WASM sandbox |
 | `doctor` | ✅ | 🚧 | P2 | 16 subsystem checks |
 | `logs` | ✅ | 🚧 | P3 | `logs` (gateway.log tail), `--follow` (SSE live stream), `--level` (get/set). No DB-persisted log history. |
-| `update` | ✅ | ❌ | P3 | Self-update |
+| `update` | ✅ | 🚧 | P3 | Read-only version check in CLI/web UI; core self-update still missing |
 | `completion` | ✅ | ✅ | - | Shell completion |
 | `/subagents spawn` | ✅ | ❌ | P3 | Spawn subagents from chat |
 | `/export-session` | ✅ | ❌ | P3 | Export current session transcript |

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -5592,7 +5592,7 @@ mod tests {
             capabilities,
             std::collections::HashMap::new(),
             Vec::new(),
-            Arc::new(PairingStore::new()),
+            Arc::new(PairingStore::new_noop()),
         );
 
         let result = super::near::agent::channel_host::Host::http_request(

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -138,6 +138,7 @@ Browser-facing HTTP API and SSE/WebSocket real-time streaming. Axum-based, singl
 | GET | `/api/pairing/{channel}` | Admin-only list of pending pairing requests |
 | POST | `/api/pairing/{channel}/approve` | Authenticated user self-claims a pairing code |
 | GET | `/api/gateway/status` | Server uptime, connected clients, config |
+| GET | `/api/gateway/update` | Read-only latest stable IronClaw release check |
 | POST | `/v1/chat/completions` | OpenAI-compatible LLM proxy |
 | GET | `/v1/models` | OpenAI-compatible model list |
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -72,6 +72,7 @@ use crate::channels::web::util::{build_turns_from_db_messages, truncate_preview}
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::orchestrator::job_manager::ContainerJobManager;
+use crate::release::{check_for_update, current_version};
 use crate::tools::ToolRegistry;
 use crate::workspace::Workspace;
 
@@ -729,6 +730,7 @@ pub async fn start_server(
         )
         // Gateway control plane
         .route("/api/gateway/status", get(gateway_status_handler))
+        .route("/api/gateway/update", get(gateway_update_handler))
         // OpenAI-compatible API
         .route(
             "/v1/chat/completions",
@@ -3217,6 +3219,41 @@ async fn gateway_status_handler(
         llm_model: state.active_config.llm_model.clone(),
         enabled_channels: state.active_config.enabled_channels.clone(),
     })
+}
+
+async fn gateway_update_handler() -> Json<GatewayUpdateResponse> {
+    let current = match current_version() {
+        Ok(version) => version,
+        Err(err) => {
+            return Json(GatewayUpdateResponse {
+                current_version: env!("CARGO_PKG_VERSION").to_string(),
+                latest_version: None,
+                update_available: false,
+                release_name: None,
+                release_url: None,
+                error: Some(err.to_string()),
+            });
+        }
+    };
+
+    match check_for_update(current.clone()).await {
+        Ok(check) => Json(GatewayUpdateResponse {
+            current_version: check.current.to_string(),
+            latest_version: Some(check.latest.to_string()),
+            update_available: check.update_available(),
+            release_name: check.release_name,
+            release_url: Some(check.release_url),
+            error: None,
+        }),
+        Err(err) => Json(GatewayUpdateResponse {
+            current_version: current.to_string(),
+            latest_version: None,
+            update_available: false,
+            release_name: None,
+            release_url: None,
+            error: Some(err.to_string()),
+        }),
+    }
 }
 
 #[derive(serde::Serialize)]

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -5263,6 +5263,9 @@ document.getElementById('users-create-submit')?.addEventListener('click', functi
 // --- Gateway status widget ---
 
 let gatewayStatusInterval = null;
+let gatewayStatusData = null;
+let gatewayUpdateData = null;
+let gatewayUpdatePromise = null;
 
 function startGatewayStatusPolling() {
   fetchGatewayStatus();
@@ -5291,59 +5294,134 @@ function shortModelName(model) {
   return m;
 }
 
+function renderGatewayUpdateSection() {
+  if (gatewayUpdateData === null && !gatewayUpdatePromise) return '';
+
+  var html = '';
+  html += '<div class="gw-divider"></div>';
+  html += '<div class="gw-section-label">Update</div>';
+
+  if (gatewayUpdatePromise && gatewayUpdateData === null) {
+    html += '<div class="gw-update-message">Checking for newer release…</div>';
+    return html;
+  }
+
+  if (!gatewayUpdateData) return html;
+
+  if (gatewayUpdateData.error) {
+    html += '<div class="gw-update-message gw-update-error">' + escapeHtml(gatewayUpdateData.error) + '</div>';
+    return html;
+  }
+
+  html += '<div class="gw-stat"><span>Current</span><span>' + escapeHtml(gatewayUpdateData.current_version || 'unknown') + '</span></div>';
+  if (gatewayUpdateData.latest_version) {
+    html += '<div class="gw-stat"><span>Latest</span><span>' + escapeHtml(gatewayUpdateData.latest_version) + '</span></div>';
+  }
+
+  if (gatewayUpdateData.update_available) {
+    html += '<div class="gw-update-message gw-update-available">Update available</div>';
+    if (gatewayUpdateData.release_name || gatewayUpdateData.release_url) {
+      var releaseLabel = gatewayUpdateData.release_name ? escapeHtml(gatewayUpdateData.release_name) : 'Open release notes';
+      var releaseHref = escapeHtml(gatewayUpdateData.release_url || '#');
+      html += '<div class="gw-update-link-row">'
+        + '<a class="gw-update-link" href="' + releaseHref + '" target="_blank" rel="noopener noreferrer">'
+        + releaseLabel
+        + '</a>'
+        + '</div>';
+    }
+  } else {
+    html += '<div class="gw-update-message gw-update-ok">Up to date</div>';
+  }
+
+  return html;
+}
+
+function renderGatewayPopover() {
+  var popover = document.getElementById('gateway-popover');
+  if (!popover) return;
+
+  var data = gatewayStatusData || {};
+  var html = '';
+
+  // Version
+  if (data.version) {
+    html += '<div class="gw-section-label">IronClaw v' + escapeHtml(data.version) + '</div>';
+    html += '<div class="gw-divider"></div>';
+  }
+
+  // Update check
+  html += renderGatewayUpdateSection();
+
+  // Connection info
+  html += '<div class="gw-section-label">' + I18n.t('dashboard.connections') + '</div>';
+  html += '<div class="gw-stat"><span>' + I18n.t('dashboard.sse') + '</span><span>' + (data.sse_connections || 0) + '</span></div>';
+  html += '<div class="gw-stat"><span>' + I18n.t('dashboard.websocket') + '</span><span>' + (data.ws_connections || 0) + '</span></div>';
+  html += '<div class="gw-stat"><span>' + I18n.t('dashboard.uptime') + '</span><span>' + formatDuration(data.uptime_secs) + '</span></div>';
+
+  // Cost tracker
+  if (data.daily_cost != null) {
+    html += '<div class="gw-divider"></div>';
+    html += '<div class="gw-section-label">' + I18n.t('dashboard.costToday') + '</div>';
+    html += '<div class="gw-stat"><span>' + I18n.t('dashboard.spent') + '</span><span>' + formatCost(data.daily_cost) + '</span></div>';
+    if (data.actions_this_hour != null) {
+      html += '<div class="gw-stat"><span>' + I18n.t('dashboard.actionsPerHour') + '</span><span>' + data.actions_this_hour + '</span></div>';
+    }
+  }
+
+  // Per-model token usage
+  if (data.model_usage && data.model_usage.length > 0) {
+    html += '<div class="gw-divider"></div>';
+    html += '<div class="gw-section-label">Token Usage</div>';
+    data.model_usage.sort(function(a, b) {
+      return (b.input_tokens + b.output_tokens) - (a.input_tokens + a.output_tokens);
+    });
+    for (var i = 0; i < data.model_usage.length; i++) {
+      var m = data.model_usage[i];
+      var name = escapeHtml(shortModelName(m.model));
+      html += '<div class="gw-model-row">'
+        + '<span class="gw-model-name">' + name + '</span>'
+        + '<span class="gw-model-cost">' + escapeHtml(formatCost(m.cost)) + '</span>'
+        + '</div>';
+      html += '<div class="gw-token-detail">'
+        + '<span>in: ' + formatTokenCount(m.input_tokens) + '</span>'
+        + '<span>out: ' + formatTokenCount(m.output_tokens) + '</span>'
+        + '</div>';
+    }
+  }
+
+  popover.innerHTML = html;
+}
+
+function fetchGatewayUpdateStatus() {
+  if (gatewayUpdatePromise) return gatewayUpdatePromise;
+
+  gatewayUpdatePromise = apiFetch('/api/gateway/update').then(function(data) {
+    gatewayUpdateData = data;
+    gatewayUpdatePromise = null;
+    renderGatewayPopover();
+    return data;
+  }).catch(function(err) {
+    gatewayUpdateData = {
+      current_version: gatewayStatusData && gatewayStatusData.version ? gatewayStatusData.version : null,
+      update_available: false,
+      error: err.message || String(err)
+    };
+    gatewayUpdatePromise = null;
+    renderGatewayPopover();
+    return gatewayUpdateData;
+  });
+
+  renderGatewayPopover();
+  return gatewayUpdatePromise;
+}
+
 function fetchGatewayStatus() {
   apiFetch('/api/gateway/status').then(function(data) {
+    gatewayStatusData = data;
     // Update restart button visibility
     restartEnabled = data.restart_enabled || false;
     updateRestartButtonVisibility();
-
-    var popover = document.getElementById('gateway-popover');
-    var html = '';
-
-    // Version
-    if (data.version) {
-      html += '<div class="gw-section-label">IronClaw v' + escapeHtml(data.version) + '</div>';
-      html += '<div class="gw-divider"></div>';
-    }
-
-    // Connection info
-    html += '<div class="gw-section-label">' + I18n.t('dashboard.connections') + '</div>';
-    html += '<div class="gw-stat"><span>' + I18n.t('dashboard.sse') + '</span><span>' + (data.sse_connections || 0) + '</span></div>';
-    html += '<div class="gw-stat"><span>' + I18n.t('dashboard.websocket') + '</span><span>' + (data.ws_connections || 0) + '</span></div>';
-    html += '<div class="gw-stat"><span>' + I18n.t('dashboard.uptime') + '</span><span>' + formatDuration(data.uptime_secs) + '</span></div>';
-
-    // Cost tracker
-    if (data.daily_cost != null) {
-      html += '<div class="gw-divider"></div>';
-      html += '<div class="gw-section-label">' + I18n.t('dashboard.costToday') + '</div>';
-      html += '<div class="gw-stat"><span>' + I18n.t('dashboard.spent') + '</span><span>' + formatCost(data.daily_cost) + '</span></div>';
-      if (data.actions_this_hour != null) {
-        html += '<div class="gw-stat"><span>' + I18n.t('dashboard.actionsPerHour') + '</span><span>' + data.actions_this_hour + '</span></div>';
-      }
-    }
-
-    // Per-model token usage
-    if (data.model_usage && data.model_usage.length > 0) {
-      html += '<div class="gw-divider"></div>';
-      html += '<div class="gw-section-label">Token Usage</div>';
-      data.model_usage.sort(function(a, b) {
-        return (b.input_tokens + b.output_tokens) - (a.input_tokens + a.output_tokens);
-      });
-      for (var i = 0; i < data.model_usage.length; i++) {
-        var m = data.model_usage[i];
-        var name = escapeHtml(shortModelName(m.model));
-        html += '<div class="gw-model-row">'
-          + '<span class="gw-model-name">' + name + '</span>'
-          + '<span class="gw-model-cost">' + escapeHtml(formatCost(m.cost)) + '</span>'
-          + '</div>';
-        html += '<div class="gw-token-detail">'
-          + '<span>in: ' + formatTokenCount(m.input_tokens) + '</span>'
-          + '<span>out: ' + formatTokenCount(m.output_tokens) + '</span>'
-          + '</div>';
-      }
-    }
-
-    popover.innerHTML = html;
+    renderGatewayPopover();
   }).catch(function() {});
 }
 
@@ -6975,7 +7053,20 @@ document.getElementById('auth-connect-btn').addEventListener('click', () => auth
 document.getElementById('user-avatar-btn').addEventListener('click', function(e) {
   e.stopPropagation();
   var dd = document.getElementById('user-dropdown');
-  if (dd) dd.style.display = dd.style.display === 'none' ? '' : 'none';
+  var popover = document.getElementById('gateway-popover');
+  var opening = dd && dd.style.display === 'none';
+  if (dd) dd.style.display = opening ? '' : 'none';
+  if (popover) {
+    if (opening) {
+      popover.classList.add('visible');
+      renderGatewayPopover();
+      if (!gatewayUpdateData && !gatewayUpdatePromise) {
+        fetchGatewayUpdateStatus();
+      }
+    } else {
+      popover.classList.remove('visible');
+    }
+  }
 });
 // Close dropdown on click outside.
 document.addEventListener('click', function(e) {
@@ -6983,6 +7074,8 @@ document.addEventListener('click', function(e) {
   var account = document.getElementById('user-account');
   if (dd && account && !account.contains(e.target)) {
     dd.style.display = 'none';
+    var popover = document.getElementById('gateway-popover');
+    if (popover) popover.classList.remove('visible');
   }
 });
 // Logout handler.

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -5265,6 +5265,7 @@ document.getElementById('users-create-submit')?.addEventListener('click', functi
 let gatewayStatusInterval = null;
 let gatewayStatusData = null;
 let gatewayUpdateData = null;
+let gatewayUpdateError = null;
 let gatewayUpdatePromise = null;
 
 function startGatewayStatusPolling() {
@@ -5294,15 +5295,32 @@ function shortModelName(model) {
   return m;
 }
 
+function safeExternalUrl(url) {
+  if (!url) return null;
+  try {
+    var parsed = new URL(url, window.location.origin);
+    var protocol = parsed.protocol.toLowerCase();
+    if (protocol === 'http:' || protocol === 'https:') {
+      return parsed.href;
+    }
+  } catch (e) {}
+  return null;
+}
+
 function renderGatewayUpdateSection() {
-  if (gatewayUpdateData === null && !gatewayUpdatePromise) return '';
+  if (gatewayUpdateData === null && !gatewayUpdatePromise && !gatewayUpdateError) return '';
 
   var html = '';
   html += '<div class="gw-divider"></div>';
   html += '<div class="gw-section-label">Update</div>';
 
-  if (gatewayUpdatePromise && gatewayUpdateData === null) {
+  if (gatewayUpdatePromise && gatewayUpdateData === null && !gatewayUpdateError) {
     html += '<div class="gw-update-message">Checking for newer release…</div>';
+    return html;
+  }
+
+  if (gatewayUpdateError && gatewayUpdateData === null) {
+    html += '<div class="gw-update-message gw-update-error">' + escapeHtml(gatewayUpdateError) + '</div>';
     return html;
   }
 
@@ -5322,12 +5340,16 @@ function renderGatewayUpdateSection() {
     html += '<div class="gw-update-message gw-update-available">Update available</div>';
     if (gatewayUpdateData.release_name || gatewayUpdateData.release_url) {
       var releaseLabel = gatewayUpdateData.release_name ? escapeHtml(gatewayUpdateData.release_name) : 'Open release notes';
-      var releaseHref = escapeHtml(gatewayUpdateData.release_url || '#');
-      html += '<div class="gw-update-link-row">'
-        + '<a class="gw-update-link" href="' + releaseHref + '" target="_blank" rel="noopener noreferrer">'
-        + releaseLabel
-        + '</a>'
-        + '</div>';
+      var releaseHref = safeExternalUrl(gatewayUpdateData.release_url);
+      if (releaseHref) {
+        html += '<div class="gw-update-link-row">'
+          + '<a class="gw-update-link" href="' + escapeHtml(releaseHref) + '" target="_blank" rel="noopener noreferrer">'
+          + releaseLabel
+          + '</a>'
+          + '</div>';
+      } else {
+        html += '<div class="gw-update-message">' + releaseLabel + '</div>';
+      }
     }
   } else {
     html += '<div class="gw-update-message gw-update-ok">Up to date</div>';
@@ -5395,20 +5417,19 @@ function renderGatewayPopover() {
 function fetchGatewayUpdateStatus() {
   if (gatewayUpdatePromise) return gatewayUpdatePromise;
 
+  gatewayUpdateError = null;
   gatewayUpdatePromise = apiFetch('/api/gateway/update').then(function(data) {
     gatewayUpdateData = data;
     gatewayUpdatePromise = null;
+    gatewayUpdateError = null;
     renderGatewayPopover();
     return data;
   }).catch(function(err) {
-    gatewayUpdateData = {
-      current_version: gatewayStatusData && gatewayStatusData.version ? gatewayStatusData.version : null,
-      update_available: false,
-      error: err.message || String(err)
-    };
+    gatewayUpdateData = null;
+    gatewayUpdateError = err.message || String(err);
     gatewayUpdatePromise = null;
     renderGatewayPopover();
-    return gatewayUpdateData;
+    return null;
   });
 
   renderGatewayPopover();

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -4506,6 +4506,39 @@ mark {
   padding: 1px 0 4px 0;
 }
 
+.gw-update-message {
+  font-size: 11px;
+  color: var(--text-secondary);
+  padding: 3px 0 2px 0;
+}
+
+.gw-update-message.gw-update-available {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.gw-update-message.gw-update-error {
+  color: var(--danger, #f87171);
+}
+
+.gw-update-message.gw-update-ok {
+  color: var(--text-secondary);
+}
+
+.gw-update-link-row {
+  margin-top: 2px;
+}
+
+.gw-update-link {
+  color: var(--accent);
+  font-size: 11px;
+  text-decoration: none;
+}
+
+.gw-update-link:hover {
+  text-decoration: underline;
+}
+
 /* --- Extension install form --- */
 
 .ext-install-form {

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -109,6 +109,20 @@ pub struct PendingGateInfo {
     pub resume_kind: serde_json::Value,
 }
 
+#[derive(Debug, Serialize)]
+pub struct GatewayUpdateResponse {
+    pub current_version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latest_version: Option<String>,
+    pub update_available: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub release_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
 // --- Approval ---
 
 #[derive(Debug, Deserialize)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -11,6 +11,7 @@
 //! - Managing OS service (`service install`, `service start`, `service stop`)
 //! - Listing configured channels (`channels list`)
 //! - Active health diagnostics (`doctor`)
+//! - Checking for core IronClaw updates (`update`)
 //! - Viewing gateway logs (`logs`)
 //! - Checking system health (`status`)
 
@@ -35,6 +36,7 @@ mod service;
 mod skills;
 pub mod status;
 mod tool;
+mod update;
 
 pub use acp::{AcpCommand, run_acp_command};
 pub use channels::{ChannelsCommand, run_channels_command};
@@ -56,6 +58,7 @@ pub use service::{ServiceCommand, run_service_command};
 pub use skills::{SkillsCommand, run_skills_command};
 pub use status::run_status_command;
 pub use tool::{ToolCommand, run_tool_command};
+pub use update::run_update_command;
 
 use std::sync::Arc;
 
@@ -243,6 +246,13 @@ pub enum Command {
         long_about = "Checks dependencies and config validity.\nExample: ironclaw doctor"
     )]
     Doctor,
+
+    /// Check whether a newer IronClaw release is available
+    #[command(
+        about = "Check for a newer IronClaw release",
+        long_about = "Queries GitHub Releases for the latest stable IronClaw version and compares it to the running binary.\nExample: ironclaw update"
+    )]
+    Update,
 
     /// View and manage gateway logs
     #[command(

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -23,6 +23,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics
+  update      Check for a newer IronClaw release
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -26,6 +26,7 @@ Commands:
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
   doctor      Run diagnostics
+  update      Check for a newer IronClaw release
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -1,0 +1,41 @@
+//! Core IronClaw update checker.
+//!
+//! This command is intentionally read-only. It checks GitHub Releases for the
+//! latest stable IronClaw version and reports whether the running binary is
+//! outdated. It does not mutate the installation.
+
+use crate::release::{check_for_update, current_version};
+
+pub async fn run_update_command() -> anyhow::Result<()> {
+    println!("IronClaw Update Check");
+    println!("=====================\n");
+
+    let current = current_version()?;
+    match check_for_update(current.clone()).await {
+        Ok(check) => {
+            println!("  Current:     v{}", check.current);
+            println!("  Latest:      v{}", check.latest);
+
+            if check.update_available() {
+                println!("  Status:      update available");
+                if let Some(name) = check.release_name {
+                    println!("  Release:     {}", name);
+                }
+                println!("  Release URL: {}", check.release_url);
+                println!(
+                    "\n  IronClaw does not currently self-update in place. \
+                     Use the platform-specific release installer to upgrade."
+                );
+            } else {
+                println!("  Status:      up to date");
+            }
+        }
+        Err(err) => {
+            println!("  Current:     v{}", current);
+            println!("  Status:      unable to check for updates");
+            println!("  Error:       {}", err);
+        }
+    }
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub mod ownership;
 pub mod pairing;
 pub mod profile;
 pub mod registry;
+pub mod release;
 pub mod safety;
 pub mod sandbox;
 pub mod secrets;

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use ironclaw::{
     },
     cli::{
         Cli, Command, run_mcp_command, run_pairing_command, run_service_command,
-        run_status_command, run_tool_command,
+        run_status_command, run_tool_command, run_update_command,
     },
     config::Config,
     hooks::bootstrap_hooks,
@@ -150,6 +150,10 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Command::Doctor) => {
             init_cli_tracing();
             return ironclaw::cli::run_doctor_command().await;
+        }
+        Some(Command::Update) => {
+            init_cli_tracing();
+            return run_update_command().await;
         }
         Some(Command::Status) => {
             init_cli_tracing();

--- a/src/release.rs
+++ b/src/release.rs
@@ -4,6 +4,7 @@
 
 use semver::Version;
 use serde::Deserialize;
+use std::time::Duration;
 
 const GITHUB_LATEST_RELEASE_URL: &str =
     "https://api.github.com/repos/nearai/ironclaw/releases/latest";
@@ -54,6 +55,7 @@ pub async fn check_for_update(current: Version) -> anyhow::Result<ReleaseCheck> 
 
 async fn fetch_latest_release() -> anyhow::Result<GitHubRelease> {
     let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
         .user_agent(format!(
             "{}/{}",
             env!("CARGO_PKG_NAME"),

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,132 @@
+//! Release version helpers.
+//!
+//! Shared utilities for checking whether a newer stable IronClaw release exists.
+
+use semver::Version;
+use serde::Deserialize;
+
+const GITHUB_LATEST_RELEASE_URL: &str =
+    "https://api.github.com/repos/nearai/ironclaw/releases/latest";
+
+#[derive(Debug, Deserialize)]
+struct GitHubRelease {
+    tag_name: String,
+    html_url: String,
+    name: Option<String>,
+    prerelease: bool,
+    draft: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseCheck {
+    pub current: Version,
+    pub latest: Version,
+    pub release_name: Option<String>,
+    pub release_url: String,
+}
+
+impl ReleaseCheck {
+    pub fn update_available(&self) -> bool {
+        self.latest > self.current
+    }
+}
+
+pub fn current_version() -> anyhow::Result<Version> {
+    Version::parse(env!("CARGO_PKG_VERSION")).map_err(|e| {
+        anyhow::anyhow!(
+            "invalid built-in version '{}': {e}",
+            env!("CARGO_PKG_VERSION")
+        )
+    })
+}
+
+pub async fn check_for_update(current: Version) -> anyhow::Result<ReleaseCheck> {
+    let release = fetch_latest_release().await?;
+    let latest = parse_release_version(&release.tag_name)?;
+
+    Ok(ReleaseCheck {
+        current,
+        latest,
+        release_name: release.name,
+        release_url: release.html_url,
+    })
+}
+
+async fn fetch_latest_release() -> anyhow::Result<GitHubRelease> {
+    let client = reqwest::Client::builder()
+        .user_agent(format!(
+            "{}/{}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION")
+        ))
+        .build()
+        .map_err(|e| anyhow::anyhow!("failed to build HTTP client: {e}"))?;
+
+    let response = client
+        .get(GITHUB_LATEST_RELEASE_URL)
+        .header(reqwest::header::ACCEPT, "application/vnd.github+json")
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to query GitHub releases: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        return Err(anyhow::anyhow!(
+            "GitHub releases request failed with HTTP {}",
+            status
+        ));
+    }
+
+    let release = response
+        .json::<GitHubRelease>()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to parse GitHub release response: {e}"))?;
+
+    if release.draft || release.prerelease {
+        return Err(anyhow::anyhow!(
+            "latest GitHub release response is not a stable release"
+        ));
+    }
+
+    Ok(release)
+}
+
+fn parse_release_version(tag_name: &str) -> anyhow::Result<Version> {
+    let trimmed = tag_name.strip_prefix('v').unwrap_or(tag_name);
+    Version::parse(trimmed).map_err(|e| {
+        anyhow::anyhow!(
+            "latest release tag '{}' is not a semver version: {e}",
+            tag_name
+        )
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_v_prefixed_release_tags() {
+        let version = parse_release_version("v0.18.0").expect("version should parse");
+        assert_eq!(version, Version::new(0, 18, 0));
+    }
+
+    #[test]
+    fn parses_plain_release_tags() {
+        let version = parse_release_version("0.19.1").expect("version should parse");
+        assert_eq!(version, Version::new(0, 19, 1));
+    }
+
+    #[test]
+    fn rejects_non_semver_tags() {
+        let err = parse_release_version("release-latest").expect_err("tag should be rejected");
+        assert!(err.to_string().contains("not a semver version"));
+    }
+
+    #[test]
+    fn compares_versions_correctly() {
+        let current = Version::new(0, 18, 0);
+        let latest = Version::new(0, 19, 0);
+        assert!(latest > current);
+    }
+}

--- a/src/release.rs
+++ b/src/release.rs
@@ -8,6 +8,7 @@ use std::time::Duration;
 
 const GITHUB_LATEST_RELEASE_URL: &str =
     "https://api.github.com/repos/nearai/ironclaw/releases/latest";
+const GITHUB_RELEASE_CHECK_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Debug, Deserialize)]
 struct GitHubRelease {
@@ -42,7 +43,8 @@ pub fn current_version() -> anyhow::Result<Version> {
 }
 
 pub async fn check_for_update(current: Version) -> anyhow::Result<ReleaseCheck> {
-    let release = fetch_latest_release().await?;
+    let release =
+        fetch_latest_release_at(GITHUB_LATEST_RELEASE_URL, GITHUB_RELEASE_CHECK_TIMEOUT).await?;
     let latest = parse_release_version(&release.tag_name)?;
 
     Ok(ReleaseCheck {
@@ -53,9 +55,9 @@ pub async fn check_for_update(current: Version) -> anyhow::Result<ReleaseCheck> 
     })
 }
 
-async fn fetch_latest_release() -> anyhow::Result<GitHubRelease> {
+async fn fetch_latest_release_at(url: &str, timeout: Duration) -> anyhow::Result<GitHubRelease> {
     let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
+        .timeout(timeout)
         .user_agent(format!(
             "{}/{}",
             env!("CARGO_PKG_NAME"),
@@ -65,7 +67,7 @@ async fn fetch_latest_release() -> anyhow::Result<GitHubRelease> {
         .map_err(|e| anyhow::anyhow!("failed to build HTTP client: {e}"))?;
 
     let response = client
-        .get(GITHUB_LATEST_RELEASE_URL)
+        .get(url)
         .header(reqwest::header::ACCEPT, "application/vnd.github+json")
         .send()
         .await
@@ -106,6 +108,34 @@ fn parse_release_version(tag_name: &str) -> anyhow::Result<Version> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddr;
+    use std::time::Instant;
+    use tokio::io::AsyncReadExt;
+    use tokio::net::TcpListener;
+    use tokio::time::sleep;
+
+    async fn spawn_stalled_release_server(
+        stall_delay: Duration,
+    ) -> anyhow::Result<(SocketAddr, tokio::task::JoinHandle<()>)> {
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+
+        let handle = tokio::spawn(async move {
+            loop {
+                let Ok((stream, _)) = listener.accept().await else {
+                    break;
+                };
+                tokio::spawn(async move {
+                    let mut stream = stream;
+                    let mut buf = [0u8; 1024];
+                    let _ = stream.read(&mut buf).await;
+                    sleep(stall_delay).await;
+                });
+            }
+        });
+
+        Ok((addr, handle))
+    }
 
     #[test]
     fn parses_v_prefixed_release_tags() {
@@ -130,5 +160,24 @@ mod tests {
         let current = Version::new(0, 18, 0);
         let latest = Version::new(0, 19, 0);
         assert!(latest > current);
+    }
+
+    #[tokio::test]
+    async fn fetch_latest_release_times_out_on_slow_server() {
+        let (addr, _server) = spawn_stalled_release_server(Duration::from_millis(200))
+            .await
+            .expect("test server should start");
+        let url = format!("http://{addr}/repos/nearai/ironclaw/releases/latest");
+
+        let started = Instant::now();
+        let err = fetch_latest_release_at(&url, Duration::from_millis(50))
+            .await
+            .expect_err("slow server should time out");
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "request should have been bounded, took {elapsed:?} and returned {err}"
+        );
     }
 }


### PR DESCRIPTION
Closes #1480\n\nSummary:\n- Adds a read-only core release check shared between CLI and web UI\n- Reuses the existing top-right gateway hover popover to show current/latest IronClaw versions\n- Exposes a protected /api/gateway/update endpoint for on-demand release checks\n- Keeps self-update itself out of scope for now; this surfaces availability only\n\nValidation:\n- cargo fmt --all -- --check\n- cargo test -p ironclaw cli::tests -- --nocapture\n- cargo test -p ironclaw --lib release::tests -- --nocapture\n- cargo clippy -p ironclaw --lib --tests --all-features -- -D warnings (fails on pre-existing duplicated-attributes in src/llm/codex_test_helpers.rs)