### PR TITLE
Added: import convo history base infra

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -165,6 +165,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `agents` | ✅ | ❌ | P3 | Multi-agent management |
 | `sessions` | ✅ | ❌ | P3 | Session listing (shows subagent models) |
 | `memory` | ✅ | ✅ | - | Memory search CLI |
+| `import` | ✅ | 🚧 | P1 | Generic conversation import infra + onboarding integration; onboarding only surfaces sources with implemented parsers, legacy `openclaw` source retained, source-specific parsers pending |
 | `skills` | ✅ | ✅ | - | CLI subcommands (list, search, info) + agent tools + web API endpoints |
 | `pairing` | ✅ | ✅ | - | list/approve, account selector |
 | `nodes` | ✅ | ❌ | P3 | Device management, remove/clear flows |

--- a/migrations/V14__conversation_message_sequence.sql
+++ b/migrations/V14__conversation_message_sequence.sql
@@ -1,0 +1,22 @@
+ALTER TABLE conversation_messages
+    ADD COLUMN sequence_num INTEGER;
+
+WITH ranked_messages AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY conversation_id
+            ORDER BY created_at ASC, id ASC
+        ) - 1 AS sequence_num
+    FROM conversation_messages
+)
+UPDATE conversation_messages AS message
+SET sequence_num = ranked.sequence_num
+FROM ranked_messages AS ranked
+WHERE message.id = ranked.id;
+
+ALTER TABLE conversation_messages
+    ALTER COLUMN sequence_num SET NOT NULL;
+
+CREATE UNIQUE INDEX idx_conversation_messages_sequence
+    ON conversation_messages(conversation_id, sequence_num);

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1937,6 +1937,7 @@ mod tests {
             role: role.to_string(),
             content: content.to_string(),
             created_at: chrono::Utc::now(),
+            sequence_num: 0,
         }
     }
 

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -14,7 +14,10 @@ use uuid::Uuid;
 use crate::channels::IncomingMessage;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
-use crate::channels::web::util::{build_turns_from_db_messages, truncate_preview};
+use crate::channels::web::util::{
+    build_turns_from_db_messages, history_cursor_from_message, parse_history_cursor,
+    truncate_preview,
+};
 
 pub async fn chat_send_handler(
     State(state): State<Arc<GatewayState>>,
@@ -288,14 +291,12 @@ pub async fn chat_history_handler(
         .before
         .as_deref()
         .map(|s| {
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map(|dt| dt.with_timezone(&chrono::Utc))
-                .map_err(|_| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "Invalid 'before' timestamp".to_string(),
-                    )
-                })
+            parse_history_cursor(s).map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Invalid 'before' cursor".to_string(),
+                )
+            })
         })
         .transpose()?;
 
@@ -334,7 +335,7 @@ pub async fn chat_history_handler(
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
+        let oldest_timestamp = messages.first().map(history_cursor_from_message);
         let turns = build_turns_from_db_messages(&messages);
         return Ok(Json(HistoryResponse {
             thread_id,
@@ -410,7 +411,7 @@ pub async fn chat_history_handler(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
         if !messages.is_empty() {
-            let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
+            let oldest_timestamp = messages.first().map(history_cursor_from_message);
             let turns = build_turns_from_db_messages(&messages);
             return Ok(Json(HistoryResponse {
                 thread_id,
@@ -598,24 +599,28 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Hi there!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "user".to_string(),
                 content: "How are you?".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(2),
+                sequence_num: 2,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Doing well!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(3),
+                sequence_num: 3,
             },
         ];
 
@@ -637,18 +642,21 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Hi!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "user".to_string(),
                 content: "Lost message".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(2),
+                sequence_num: 2,
             },
         ];
 
@@ -672,18 +680,21 @@ mod tests {
                 role: "user".to_string(),
                 content: "List files".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "tool_calls".to_string(),
                 content: tool_calls_json.to_string(),
                 created_at: now + chrono::TimeDelta::milliseconds(500),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Here are the files".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 2,
             },
         ];
 
@@ -713,18 +724,21 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "tool_calls".to_string(),
                 content: "not valid json".to_string(),
                 created_at: now + chrono::TimeDelta::milliseconds(500),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Done".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 2,
             },
         ];
 
@@ -744,12 +758,14 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Hi!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 1,
             },
         ];
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -46,7 +46,10 @@ use crate::channels::web::handlers::skills::{
 use crate::channels::web::log_layer::LogBroadcaster;
 use crate::channels::web::sse::SseManager;
 use crate::channels::web::types::*;
-use crate::channels::web::util::{build_turns_from_db_messages, truncate_preview};
+use crate::channels::web::util::{
+    build_turns_from_db_messages, history_cursor_from_message, parse_history_cursor,
+    truncate_preview,
+};
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::orchestrator::job_manager::ContainerJobManager;
@@ -1412,14 +1415,12 @@ async fn chat_history_handler(
         .before
         .as_deref()
         .map(|s| {
-            chrono::DateTime::parse_from_rfc3339(s)
-                .map(|dt| dt.with_timezone(&chrono::Utc))
-                .map_err(|_| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "Invalid 'before' timestamp".to_string(),
-                    )
-                })
+            parse_history_cursor(s).map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Invalid 'before' cursor".to_string(),
+                )
+            })
         })
         .transpose()?;
 
@@ -1456,7 +1457,7 @@ async fn chat_history_handler(
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
+        let oldest_timestamp = messages.first().map(history_cursor_from_message);
         let turns = build_turns_from_db_messages(&messages);
         return Ok(Json(HistoryResponse {
             thread_id,
@@ -1528,7 +1529,7 @@ async fn chat_history_handler(
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
         if !messages.is_empty() {
-            let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
+            let oldest_timestamp = messages.first().map(history_cursor_from_message);
             let turns = build_turns_from_db_messages(&messages);
             return Ok(Json(HistoryResponse {
                 thread_id,
@@ -2663,24 +2664,28 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Hi there!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "user".to_string(),
                 content: "How are you?".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(2),
+                sequence_num: 2,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Doing well!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(3),
+                sequence_num: 3,
             },
         ];
 
@@ -2702,18 +2707,21 @@ mod tests {
                 role: "user".to_string(),
                 content: "Hello".to_string(),
                 created_at: now,
+                sequence_num: 0,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "assistant".to_string(),
                 content: "Hi!".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(1),
+                sequence_num: 1,
             },
             crate::history::ConversationMessage {
                 id: Uuid::new_v4(),
                 role: "user".to_string(),
                 content: "Lost message".to_string(),
                 created_at: now + chrono::TimeDelta::seconds(2),
+                sequence_num: 2,
             },
         ];
 

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -83,7 +83,7 @@ pub struct HistoryResponse {
     /// Whether there are older messages available.
     #[serde(default)]
     pub has_more: bool,
-    /// Cursor for the next page (ISO8601 timestamp of the oldest message returned).
+    /// Opaque cursor for the next page of older messages.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oldest_timestamp: Option<String>,
     /// Pending tool approval that needs user action (re-rendered on thread switch).

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -1,6 +1,7 @@
 //! Shared utility functions for the web gateway.
 
 use crate::channels::web::types::{ToolCallInfo, TurnInfo};
+use crate::db::ConversationPageCursor;
 
 /// Truncate a string to at most `max_bytes` bytes at a char boundary, appending "...".
 ///
@@ -113,6 +114,23 @@ pub fn build_turns_from_db_messages(
     turns
 }
 
+pub fn history_cursor_from_message(message: &crate::history::ConversationMessage) -> String {
+    message.pagination_cursor()
+}
+
+pub fn parse_history_cursor(raw: &str) -> Result<ConversationPageCursor, String> {
+    if let Some(sequence) = raw.strip_prefix("seq:") {
+        return sequence
+            .parse::<i64>()
+            .map(ConversationPageCursor::Sequence)
+            .map_err(|_| "Invalid 'before' cursor".to_string());
+    }
+
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| ConversationPageCursor::Timestamp(dt.with_timezone(&chrono::Utc)))
+        .map_err(|_| "Invalid 'before' cursor".to_string())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -208,6 +226,7 @@ mod tests {
             role: role.to_string(),
             content: content.to_string(),
             created_at: chrono::Utc::now() + chrono::TimeDelta::milliseconds(offset_ms),
+            sequence_num: offset_ms,
         }
     }
 

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,59 +1,723 @@
-//! Import command for migrating data from other AI systems.
+//! Conversation history import infrastructure and import CLI command.
 
-use std::path::PathBuf;
+use std::cmp::Reverse;
+use std::collections::hash_map::DefaultHasher;
+use std::fs;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
-use clap::Subcommand;
+use chrono::{DateTime, Utc};
+use clap::{Args, Subcommand, ValueEnum};
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
 
 #[cfg(feature = "import")]
 use crate::import::ImportOptions;
 #[cfg(feature = "import")]
 use crate::import::openclaw::OpenClawImporter;
 
+/// A single message parsed from an external source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedMessage {
+    /// "user", "assistant", "system", "tool"
+    pub role: String,
+    pub content: String,
+    pub created_at: DateTime<Utc>,
+}
+
+/// A conversation parsed from an external source.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImportedConversation {
+    /// Stable ID from the source (for dedup on re-import).
+    pub source_id: String,
+    /// Human-readable title.
+    pub title: Option<String>,
+    /// Ordered messages.
+    pub messages: Vec<ImportedMessage>,
+    /// Source timestamp normalized to UTC.
+    pub created_at: DateTime<Utc>,
+    /// Last activity timestamp normalized to UTC.
+    pub last_activity: DateTime<Utc>,
+    /// Source-specific metadata preserved verbatim.
+    pub source_metadata: serde_json::Value,
+}
+
+/// Supported conversation-history sources.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ImportSource {
+    /// Local Claude Code CLI history (~/.claude/projects/).
+    #[value(name = "claude-code")]
+    ClaudeCode,
+    /// Claude.ai browser export ZIP.
+    #[value(name = "claude-web")]
+    ClaudeWeb,
+    /// Local OpenAI Codex CLI history.
+    #[value(name = "codex-cli")]
+    CodexCli,
+    /// ChatGPT data export ZIP.
+    #[value(name = "chatgpt")]
+    ChatGpt,
+    /// Google Takeout Gemini export.
+    #[value(name = "gemini")]
+    Gemini,
+}
+
+impl ImportSource {
+    pub fn source_key(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "claude_code",
+            Self::ClaudeWeb => "claude_web",
+            Self::CodexCli => "codex_cli",
+            Self::ChatGpt => "chatgpt",
+            Self::Gemini => "gemini",
+        }
+    }
+
+    pub fn display_name(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "Claude Code",
+            Self::ClaudeWeb => "Claude Web",
+            Self::CodexCli => "Codex CLI",
+            Self::ChatGpt => "ChatGPT",
+            Self::Gemini => "Gemini",
+        }
+    }
+
+    /// Whether this build includes a parser for this history source.
+    pub fn supports_history_import(self) -> bool {
+        match self {
+            Self::ClaudeCode | Self::ClaudeWeb | Self::CodexCli | Self::ChatGpt | Self::Gemini => {
+                false
+            }
+        }
+    }
+}
+
+/// Source candidate discovered during onboarding auto-detection.
+#[derive(Debug, Clone)]
+pub struct AutoDetectedImportSource {
+    pub source: ImportSource,
+    pub path: PathBuf,
+    pub note: String,
+}
+
+/// Trait that all source-specific parsers implement.
+pub trait Importer: Send + Sync {
+    /// Human-readable name for progress messages.
+    fn source_name(&self) -> &str;
+
+    /// Parse the input path into conversations.
+    /// Must not touch the database.
+    fn parse(&self, path: &Path) -> Result<Vec<ImportedConversation>, ImportError>;
+}
+
+/// Import parser / orchestration errors.
+#[derive(Debug, thiserror::Error)]
+pub enum ImportError {
+    #[error("file not found: {path}")]
+    NotFound { path: String },
+    #[error("unsupported format: {reason}")]
+    UnsupportedFormat { reason: String },
+    #[error("parse error: {reason}")]
+    Parse { reason: String },
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("database error: {0}")]
+    Database(String),
+    #[error("ZIP error: {0}")]
+    Zip(String),
+}
+
+/// Shared flags for conversation-history import commands.
+#[derive(Args, Debug, Clone)]
+pub struct HistoryImportArgs {
+    /// Path to export file, directory, or ZIP.
+    /// If omitted, uses the default location for the source.
+    pub path: Option<PathBuf>,
+
+    /// User ID to associate imported conversations with.
+    #[arg(long, default_value = "default")]
+    pub user_id: String,
+
+    /// Skip conversations that have already been imported.
+    #[arg(long, default_value_t = true, action = clap::ArgAction::Set)]
+    pub dedup: bool,
+
+    /// Also write conversations to workspace memory as markdown.
+    #[arg(long)]
+    pub to_workspace: bool,
+
+    /// Dry run: parse and report without writing.
+    #[arg(long)]
+    pub dry_run: bool,
+}
+
 /// Import data from other AI systems.
 #[derive(Subcommand, Debug, Clone)]
 pub enum ImportCommand {
-    /// Import from OpenClaw (memory, history, settings, credentials)
+    /// Import conversation history from local Claude Code sessions.
+    #[command(name = "claude-code")]
+    ClaudeCode(HistoryImportArgs),
+
+    /// Import conversation history from a Claude.ai export ZIP.
+    #[command(name = "claude-web")]
+    ClaudeWeb(HistoryImportArgs),
+
+    /// Import conversation history from local Codex CLI sessions.
+    #[command(name = "codex-cli")]
+    CodexCli(HistoryImportArgs),
+
+    /// Import conversation history from a ChatGPT export ZIP.
+    #[command(name = "chatgpt")]
+    ChatGpt(HistoryImportArgs),
+
+    /// Import conversation history from Google Takeout Gemini exports.
+    #[command(name = "gemini")]
+    Gemini(HistoryImportArgs),
+
+    /// Import from OpenClaw (memory, history, settings, credentials).
     #[cfg(feature = "import")]
     Openclaw {
-        /// Path to OpenClaw directory (default: ~/.openclaw)
+        /// Path to OpenClaw directory (default: ~/.openclaw).
         #[arg(long)]
         path: Option<PathBuf>,
 
-        /// Dry-run mode: show what would be imported without writing
+        /// Dry-run mode: show what would be imported without writing.
         #[arg(long)]
         dry_run: bool,
 
-        /// Re-embed memory if dimensions don't match target provider
+        /// Re-embed memory if dimensions don't match target provider.
         #[arg(long)]
         re_embed: bool,
 
-        /// User ID for imported data (default: 'default')
+        /// User ID for imported data (default: 'default').
         #[arg(long)]
         user_id: Option<String>,
     },
 }
 
-/// Run an import command.
-#[cfg(feature = "import")]
-pub async fn run_import_command(
-    cmd: &ImportCommand,
-    config: &crate::config::Config,
-) -> anyhow::Result<()> {
-    match cmd {
-        ImportCommand::Openclaw {
-            path,
-            dry_run,
-            re_embed,
-            user_id,
-        } => run_import_openclaw(config, path.clone(), *dry_run, *re_embed, user_id.clone()).await,
+impl ImportCommand {
+    fn as_history_request(&self) -> Option<(ImportSource, &HistoryImportArgs)> {
+        match self {
+            Self::ClaudeCode(args) => Some((ImportSource::ClaudeCode, args)),
+            Self::ClaudeWeb(args) => Some((ImportSource::ClaudeWeb, args)),
+            Self::CodexCli(args) => Some((ImportSource::CodexCli, args)),
+            Self::ChatGpt(args) => Some((ImportSource::ChatGpt, args)),
+            Self::Gemini(args) => Some((ImportSource::Gemini, args)),
+            #[cfg(feature = "import")]
+            Self::Openclaw { .. } => None,
+        }
     }
 }
 
-/// Run the OpenClaw import.
+#[derive(Debug, Default)]
+struct ImportStats {
+    parsed_conversations: usize,
+    parsed_messages: usize,
+    imported_conversations: usize,
+    imported_messages: usize,
+    skipped_duplicates: usize,
+}
+
+/// Run `ironclaw import ...`.
+pub async fn run_import_command(
+    cmd: &ImportCommand,
+    config: &Config,
+    no_db: bool,
+) -> anyhow::Result<()> {
+    #[cfg(feature = "import")]
+    if let ImportCommand::Openclaw {
+        path,
+        dry_run,
+        re_embed,
+        user_id,
+    } = cmd
+    {
+        if no_db {
+            return Err(anyhow::anyhow!(
+                "--no-db is not supported for the openclaw import source"
+            ));
+        }
+        return run_import_openclaw(config, path.clone(), *dry_run, *re_embed, user_id.clone())
+            .await;
+    }
+
+    let (source, args) = cmd
+        .as_history_request()
+        .ok_or_else(|| anyhow::anyhow!("Unsupported import command"))?;
+    run_history_import_command(source, args, config, no_db).await
+}
+
+async fn run_history_import_command(
+    source: ImportSource,
+    args: &HistoryImportArgs,
+    config: &Config,
+    no_db: bool,
+) -> anyhow::Result<()> {
+    if args.dry_run {
+        let (_, stats) = parse_history_source(source, args)?;
+        println!(
+            "Dry run: parsed {} conversation(s), {} message(s) from {}",
+            stats.parsed_conversations,
+            stats.parsed_messages,
+            source.display_name()
+        );
+        return Ok(());
+    }
+
+    if no_db {
+        return Err(anyhow::anyhow!(
+            "--no-db is only supported with --dry-run for history imports"
+        ));
+    }
+
+    let db = crate::db::connect_from_config(&config.database)
+        .await
+        .map_err(|err| anyhow::anyhow!("Failed to initialize database: {}", err))?;
+
+    run_import_command_with_db(source, args, db).await
+}
+
+pub async fn run_import_command_with_db(
+    source: ImportSource,
+    args: &HistoryImportArgs,
+    db: Arc<dyn crate::db::Database>,
+) -> anyhow::Result<()> {
+    let (conversations, mut stats) = parse_history_source(source, args)?;
+    if args.dry_run {
+        println!(
+            "Dry run: parsed {} conversation(s), {} message(s) from {}",
+            stats.parsed_conversations,
+            stats.parsed_messages,
+            source.display_name()
+        );
+        return Ok(());
+    }
+
+    let workspace = if args.to_workspace {
+        Some(crate::workspace::Workspace::new_with_db(
+            args.user_id.clone(),
+            db.clone(),
+        ))
+    } else {
+        None
+    };
+
+    for conversation in conversations {
+        if args.dedup {
+            let existing = db
+                .find_conversation_by_import_source(
+                    &args.user_id,
+                    source.source_key(),
+                    &conversation.source_id,
+                )
+                .await
+                .map_err(|err| anyhow::anyhow!("Dedup query failed: {}", err))?;
+            if existing.is_some() {
+                stats.skipped_duplicates += 1;
+                continue;
+            }
+        }
+
+        let metadata = serde_json::json!({
+            "import_source": source.source_key(),
+            "import_source_id": conversation.source_id,
+            "import_title": conversation.title,
+            "import_created_at": conversation.created_at.to_rfc3339(),
+            "import_last_activity": conversation.last_activity.to_rfc3339(),
+            "import_metadata": conversation.source_metadata,
+        });
+
+        let conversation_id = db
+            .create_conversation_with_metadata_and_timestamps(
+                "imported",
+                &args.user_id,
+                &metadata,
+                conversation.created_at,
+                conversation.last_activity,
+            )
+            .await
+            .map_err(|err| anyhow::anyhow!("Failed to create imported conversation: {}", err))?;
+
+        for (index, message) in conversation.messages.iter().enumerate() {
+            db.add_conversation_message_with_metadata(
+                conversation_id,
+                &message.role,
+                &message.content,
+                message.created_at,
+                Some(index as i64),
+            )
+            .await
+            .map_err(|err| anyhow::anyhow!("Failed to add imported message: {}", err))?;
+            stats.imported_messages += 1;
+        }
+
+        stats.imported_conversations += 1;
+
+        if let Some(workspace) = workspace.as_ref() {
+            write_conversation_to_workspace(workspace, source, &conversation)
+                .await
+                .map_err(|err| anyhow::anyhow!("Failed writing workspace memory: {}", err))?;
+        }
+    }
+
+    print_history_import_summary(source, &stats);
+
+    Ok(())
+}
+
+fn parse_history_source(
+    source: ImportSource,
+    args: &HistoryImportArgs,
+) -> anyhow::Result<(Vec<ImportedConversation>, ImportStats)> {
+    let source_path = resolve_source_path(source, args.path.as_deref())?;
+    let importer = importer_for_source(source);
+    let conversations = importer
+        .parse(&source_path)
+        .map_err(|err| anyhow::anyhow!(err.to_string()))?;
+    let stats = ImportStats {
+        parsed_conversations: conversations.len(),
+        parsed_messages: conversations
+            .iter()
+            .map(|conversation| conversation.messages.len())
+            .sum(),
+        ..ImportStats::default()
+    };
+    Ok((conversations, stats))
+}
+
+fn print_history_import_summary(source: ImportSource, stats: &ImportStats) {
+    println!(
+        "Imported {} conversation(s) ({} messages) from {}. Skipped {} duplicate(s).",
+        stats.imported_conversations,
+        stats.imported_messages,
+        source.display_name(),
+        stats.skipped_duplicates
+    );
+    println!(
+        "Parsed total: {} conversation(s), {} message(s)",
+        stats.parsed_conversations, stats.parsed_messages
+    );
+}
+
+/// Auto-detect likely import sources for onboarding.
+pub fn autodetect_import_sources() -> Vec<AutoDetectedImportSource> {
+    let mut detected = Vec::new();
+
+    if ImportSource::ClaudeCode.supports_history_import()
+        && let Some(path) = default_claude_code_path().filter(|path| path.exists())
+    {
+        let file_count = count_files_with_extension(&path, "jsonl", 10_000);
+        if file_count > 0 {
+            detected.push(AutoDetectedImportSource {
+                source: ImportSource::ClaudeCode,
+                path,
+                note: format!("{} JSONL file(s)", file_count),
+            });
+        }
+    }
+
+    if ImportSource::CodexCli.supports_history_import()
+        && let Some(path) = default_codex_cli_path().filter(|path| path.exists())
+    {
+        let file_count = count_files_with_extension(&path, "jsonl", 10_000)
+            + count_files_with_extension(&path, "json", 10_000);
+        if file_count > 0 {
+            detected.push(AutoDetectedImportSource {
+                source: ImportSource::CodexCli,
+                path,
+                note: format!("{} history file(s)", file_count),
+            });
+        }
+    }
+
+    if ImportSource::ClaudeWeb.supports_history_import()
+        && let Some(path) = detect_latest_zip(|name| {
+            let lower = name.to_ascii_lowercase();
+            lower.contains("claude") && lower.ends_with(".zip")
+        })
+    {
+        detected.push(AutoDetectedImportSource {
+            source: ImportSource::ClaudeWeb,
+            path,
+            note: "Found matching ZIP in Downloads".to_string(),
+        });
+    }
+
+    if ImportSource::ChatGpt.supports_history_import()
+        && let Some(path) = detect_latest_zip(|name| {
+            let lower = name.to_ascii_lowercase();
+            (lower.contains("chatgpt") || lower.contains("openai")) && lower.ends_with(".zip")
+        })
+    {
+        detected.push(AutoDetectedImportSource {
+            source: ImportSource::ChatGpt,
+            path,
+            note: "Found matching ZIP in Downloads".to_string(),
+        });
+    }
+
+    if ImportSource::Gemini.supports_history_import()
+        && let Some(path) = detect_latest_zip(|name| {
+            let lower = name.to_ascii_lowercase();
+            (lower.contains("takeout") || lower.contains("gemini")) && lower.ends_with(".zip")
+        })
+    {
+        detected.push(AutoDetectedImportSource {
+            source: ImportSource::Gemini,
+            path,
+            note: "Found matching ZIP in Downloads".to_string(),
+        });
+    }
+
+    detected
+}
+
+pub fn has_supported_history_import_sources() -> bool {
+    [
+        ImportSource::ClaudeCode,
+        ImportSource::ClaudeWeb,
+        ImportSource::CodexCli,
+        ImportSource::ChatGpt,
+        ImportSource::Gemini,
+    ]
+    .into_iter()
+    .any(ImportSource::supports_history_import)
+}
+
+fn resolve_source_path(
+    source: ImportSource,
+    explicit: Option<&Path>,
+) -> Result<PathBuf, ImportError> {
+    if let Some(path) = explicit {
+        return Ok(path.to_path_buf());
+    }
+
+    match source {
+        ImportSource::ClaudeCode => {
+            default_claude_code_path().ok_or_else(|| ImportError::NotFound {
+                path: "~/.claude/projects".to_string(),
+            })
+        }
+        ImportSource::CodexCli => default_codex_cli_path().ok_or_else(|| ImportError::NotFound {
+            path: "~/.codex/sessions or ~/.config/codex/sessions".to_string(),
+        }),
+        ImportSource::ClaudeWeb | ImportSource::ChatGpt | ImportSource::Gemini => {
+            autodetect_import_sources()
+                .into_iter()
+                .find(|source_candidate| source_candidate.source == source)
+                .map(|source_candidate| source_candidate.path)
+                .ok_or_else(|| ImportError::NotFound {
+                    path: "~/Downloads/*.zip".to_string(),
+                })
+        }
+    }
+}
+
+fn importer_for_source(source: ImportSource) -> Box<dyn Importer> {
+    Box::new(UnimplementedImporter { source })
+}
+
+struct UnimplementedImporter {
+    source: ImportSource,
+}
+
+impl Importer for UnimplementedImporter {
+    fn source_name(&self) -> &str {
+        self.source.display_name()
+    }
+
+    fn parse(&self, _path: &Path) -> Result<Vec<ImportedConversation>, ImportError> {
+        Err(ImportError::UnsupportedFormat {
+            reason: format!(
+                "{} parser is not implemented yet. Add source parser in its dedicated issue.",
+                self.source_name()
+            ),
+        })
+    }
+}
+
+fn default_claude_code_path() -> Option<PathBuf> {
+    home_dir().map(|home| home.join(".claude").join("projects"))
+}
+
+fn default_codex_cli_path() -> Option<PathBuf> {
+    let home = home_dir()?;
+    let primary = home.join(".codex").join("sessions");
+    if primary.exists() {
+        return Some(primary);
+    }
+
+    let fallback = home.join(".config").join("codex").join("sessions");
+    if fallback.exists() {
+        return Some(fallback);
+    }
+
+    Some(primary)
+}
+
+fn home_dir() -> Option<PathBuf> {
+    dirs::home_dir()
+}
+
+fn detect_latest_zip(predicate: impl Fn(&str) -> bool) -> Option<PathBuf> {
+    let downloads_dir = home_dir()?.join("Downloads");
+    let entries = fs::read_dir(downloads_dir).ok()?;
+
+    let mut matches = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(name) = path.file_name().and_then(|value| value.to_str()) else {
+            continue;
+        };
+        if !predicate(name) {
+            continue;
+        }
+
+        let modified = entry
+            .metadata()
+            .ok()
+            .and_then(|metadata| metadata.modified().ok())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        matches.push((modified, path));
+    }
+
+    matches.sort_by_key(|(modified, _)| Reverse(*modified));
+    matches.into_iter().map(|(_, path)| path).next()
+}
+
+fn count_files_with_extension(root: &Path, extension: &str, limit: usize) -> usize {
+    let mut stack = vec![root.to_path_buf()];
+    let mut count = 0usize;
+
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+
+            if path
+                .extension()
+                .and_then(|value| value.to_str())
+                .map(|value| value.eq_ignore_ascii_case(extension))
+                .unwrap_or(false)
+            {
+                count += 1;
+                if count >= limit {
+                    return count;
+                }
+            }
+        }
+    }
+
+    count
+}
+
+async fn write_conversation_to_workspace(
+    workspace: &crate::workspace::Workspace,
+    source: ImportSource,
+    conversation: &ImportedConversation,
+) -> Result<(), ImportError> {
+    let path = workspace_document_path(source, conversation);
+
+    let mut body = String::new();
+    body.push_str("# ");
+    body.push_str(
+        conversation
+            .title
+            .as_deref()
+            .filter(|title| !title.trim().is_empty())
+            .unwrap_or("Imported Conversation"),
+    );
+    body.push_str("\n\n");
+    body.push_str("- Source: ");
+    body.push_str(source.display_name());
+    body.push('\n');
+    body.push_str("- Source ID: ");
+    body.push_str(&conversation.source_id);
+    body.push('\n');
+    body.push_str("- Created At: ");
+    body.push_str(&conversation.created_at.to_rfc3339());
+    body.push('\n');
+    body.push_str("- Last Activity: ");
+    body.push_str(&conversation.last_activity.to_rfc3339());
+    body.push_str("\n\n");
+
+    for message in &conversation.messages {
+        body.push_str("## ");
+        body.push_str(&message.role);
+        body.push_str("\n\n");
+        body.push_str(&message.content);
+        body.push_str("\n\n");
+    }
+
+    workspace
+        .write(&path, &body)
+        .await
+        .map_err(|err| ImportError::Database(err.to_string()))?;
+
+    Ok(())
+}
+
+fn workspace_document_path(source: ImportSource, conversation: &ImportedConversation) -> String {
+    let slug_base = conversation
+        .title
+        .as_deref()
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or(&conversation.source_id);
+
+    format!(
+        "imported/{}/{}-{}.md",
+        source.source_key(),
+        slugify(slug_base),
+        source_id_suffix(&conversation.source_id)
+    )
+}
+
+fn source_id_suffix(source_id: &str) -> String {
+    let mut hasher = DefaultHasher::new();
+    source_id.hash(&mut hasher);
+    format!("{:012x}", hasher.finish() & 0x0000_ffff_ffff_ffff)
+}
+
+fn slugify(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut previous_dash = false;
+
+    for character in input.chars() {
+        if character.is_ascii_alphanumeric() {
+            output.push(character.to_ascii_lowercase());
+            previous_dash = false;
+        } else if !previous_dash {
+            output.push('-');
+            previous_dash = true;
+        }
+    }
+
+    let output = output.trim_matches('-');
+    if output.is_empty() {
+        "conversation".to_string()
+    } else {
+        output.to_string()
+    }
+}
+
 #[cfg(feature = "import")]
 async fn run_import_openclaw(
-    config: &crate::config::Config,
+    config: &Config,
     openclaw_path: Option<PathBuf>,
     dry_run: bool,
     re_embed: bool,
@@ -61,7 +725,6 @@ async fn run_import_openclaw(
 ) -> anyhow::Result<()> {
     use secrecy::SecretString;
 
-    // Determine OpenClaw path
     let openclaw_path = if let Some(path) = openclaw_path {
         path
     } else if let Some(path) = OpenClawImporter::detect() {
@@ -73,7 +736,7 @@ async fn run_import_openclaw(
 
     let user_id = user_id.unwrap_or_else(|| "default".to_string());
 
-    println!("🔍 OpenClaw Import");
+    println!("OpenClaw Import");
     println!("  Path: {}", openclaw_path.display());
     println!("  User: {}", user_id);
     if dry_run {
@@ -81,15 +744,13 @@ async fn run_import_openclaw(
     }
     println!();
 
-    // Initialize database
     let db = crate::db::connect_from_config(&config.database)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to initialize database: {}", e))?;
 
-    // Initialize secrets store with master key from env or keychain
     let secrets_crypto = if let Ok(master_key_hex) = std::env::var("SECRETS_MASTER_KEY") {
         Arc::new(
-            crate::secrets::SecretsCrypto::new(SecretString::from(master_key_hex))
+            crate::secrets::SecretsCrypto::new(secrecy::SecretString::from(master_key_hex))
                 .map_err(|e| anyhow::anyhow!("Failed to initialize secrets: {}", e))?,
         )
     } else {
@@ -113,7 +774,6 @@ async fn run_import_openclaw(
         crate::secrets::InMemorySecretsStore::new(secrets_crypto.clone()),
     );
 
-    // Initialize workspace
     let workspace = crate::workspace::Workspace::new_with_db(user_id.clone(), db.clone());
 
     let opts = ImportOptions {
@@ -126,7 +786,6 @@ async fn run_import_openclaw(
     let importer = OpenClawImporter::new(db, workspace, secrets, opts);
     let stats = importer.import().await?;
 
-    // Print results
     println!("Import Complete");
     println!();
     println!("Summary:");
@@ -153,10 +812,111 @@ async fn run_import_openclaw(
     Ok(())
 }
 
-#[cfg(not(feature = "import"))]
-pub async fn run_import_command(
-    _cmd: &ImportCommand,
-    _config: &crate::config::Config,
-) -> anyhow::Result<()> {
-    anyhow::bail!("Import feature not enabled. Compile with --features import")
+#[cfg(test)]
+mod tests {
+    use super::workspace_document_path;
+    use chrono::DateTime;
+    use clap::ValueEnum;
+
+    use crate::cli::import::{ImportSource, autodetect_import_sources};
+    use crate::cli::import::{ImportedConversation, ImportedMessage, slugify};
+    use chrono::Utc;
+
+    #[test]
+    fn imported_conversation_serde_roundtrip() {
+        let created_at = DateTime::parse_from_rfc3339("2024-01-15T10:00:00Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+        let last_activity = DateTime::parse_from_rfc3339("2024-01-15T10:05:00Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+
+        let conversation = ImportedConversation {
+            source_id: "conv-123".to_string(),
+            title: Some("Hello".to_string()),
+            messages: vec![ImportedMessage {
+                role: "user".to_string(),
+                content: "Hi".to_string(),
+                created_at,
+            }],
+            created_at,
+            last_activity,
+            source_metadata: serde_json::json!({"k": "v"}),
+        };
+
+        let encoded = serde_json::to_string(&conversation).expect("serialize");
+        let decoded: ImportedConversation = serde_json::from_str(&encoded).expect("deserialize");
+
+        assert_eq!(decoded.source_id, conversation.source_id);
+        assert_eq!(decoded.title, conversation.title);
+        assert_eq!(decoded.messages.len(), 1);
+        assert_eq!(decoded.messages[0].role, "user");
+        assert_eq!(decoded.messages[0].content, "Hi");
+        assert_eq!(decoded.created_at, conversation.created_at);
+        assert_eq!(decoded.last_activity, conversation.last_activity);
+        assert_eq!(decoded.source_metadata["k"], "v");
+    }
+
+    #[test]
+    fn slugify_basic() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+        assert_eq!(slugify("   "), "conversation");
+    }
+
+    #[test]
+    fn import_source_kebab_names_are_stable() {
+        let values = ImportSource::value_variants()
+            .iter()
+            .filter_map(|value| value.to_possible_value())
+            .map(|value| value.get_name().to_string())
+            .collect::<Vec<_>>();
+
+        assert!(values.contains(&"claude-code".to_string()));
+        assert!(values.contains(&"claude-web".to_string()));
+        assert!(values.contains(&"codex-cli".to_string()));
+        assert!(values.contains(&"chatgpt".to_string()));
+        assert!(values.contains(&"gemini".to_string()));
+    }
+
+    #[test]
+    fn autodetect_is_safe_when_nothing_exists() {
+        let detected = autodetect_import_sources();
+        assert!(detected.len() <= 5);
+        assert!(
+            detected
+                .iter()
+                .all(|candidate| candidate.source.supports_history_import())
+        );
+    }
+
+    #[test]
+    fn workspace_document_paths_are_unique_for_duplicate_titles() {
+        let timestamp = DateTime::parse_from_rfc3339("2026-01-01T00:00:00Z")
+            .expect("valid timestamp")
+            .with_timezone(&Utc);
+
+        let first = ImportedConversation {
+            source_id: "conv-1".to_string(),
+            title: Some("Repeated Title".to_string()),
+            messages: Vec::new(),
+            created_at: timestamp,
+            last_activity: timestamp,
+            source_metadata: serde_json::json!({}),
+        };
+        let second = ImportedConversation {
+            source_id: "conv-2".to_string(),
+            title: Some("Repeated Title".to_string()),
+            messages: Vec::new(),
+            created_at: timestamp,
+            last_activity: timestamp,
+            source_metadata: serde_json::json!({}),
+        };
+
+        let first_path = workspace_document_path(ImportSource::ChatGpt, &first);
+        let second_path = workspace_document_path(ImportSource::ChatGpt, &second);
+
+        assert!(first_path.starts_with("imported/chatgpt/repeated-title-"));
+        assert!(second_path.starts_with("imported/chatgpt/repeated-title-"));
+        assert_ne!(first_path, second_path);
+    }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,6 @@ mod channels;
 mod completion;
 mod config;
 mod doctor;
-#[cfg(feature = "import")]
 pub mod import;
 mod logs;
 mod mcp;
@@ -36,7 +35,6 @@ pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
-#[cfg(feature = "import")]
 pub use import::{ImportCommand, run_import_command};
 pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
@@ -101,7 +99,7 @@ pub enum Command {
     /// Interactive onboarding wizard
     #[command(
         about = "Run interactive setup wizard",
-        long_about = "Guides through initial configuration.\nExamples:\n  ironclaw onboard --skip-auth  # Skip auth step\n  ironclaw onboard --channels-only  # Reconfigure channels\n  ironclaw onboard --provider-only  # Change LLM provider and model"
+        long_about = "Guides through initial configuration.\nExamples:\n  ironclaw onboard --skip-auth  # Skip auth step\n  ironclaw onboard --channels-only  # Reconfigure channels\n  ironclaw onboard --provider-only  # Change LLM provider and model\n  ironclaw onboard --import-history  # Force the import step"
     )]
     Onboard {
         /// Skip authentication (use existing session)
@@ -119,6 +117,10 @@ pub enum Command {
         /// Quick setup: auto-defaults everything except LLM provider and model
         #[arg(long, conflicts_with_all = ["channels_only", "provider_only"])]
         quick: bool,
+
+        /// Force the conversation-history import step even if nothing is detected
+        #[arg(long)]
+        import_history: bool,
     },
 
     /// Manage configuration settings
@@ -231,11 +233,10 @@ pub enum Command {
     Completion(Completion),
 
     /// Import data from other AI systems
-    #[cfg(feature = "import")]
     #[command(
         subcommand,
         about = "Import from other AI systems",
-        long_about = "Migrate data from other AI assistants like OpenClaw.\nExample: ironclaw import openclaw"
+        long_about = "Import conversation history or migrate data from other AI assistants.\nExamples:\n  ironclaw import claude-code\n  ironclaw import chatgpt ~/Downloads/export.zip\n  ironclaw import openclaw"
     )]
     Import(ImportCommand),
 

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -23,6 +23,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
+  import      Import from other AI systems
   login       Authenticate with a provider
   help        Print this message or the help of the given subcommand(s)
 

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -26,6 +26,7 @@ Commands:
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
+  import      Import from other AI systems
   login       Authenticate with a provider
   help        Print this message or the help of the given subcommand(s)
 

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -6,7 +6,7 @@ use libsql::params;
 use uuid::Uuid;
 
 use super::{LibSqlBackend, fmt_ts, get_i64, get_json, get_opt_text, get_text, get_ts, opt_text};
-use crate::db::ConversationStore;
+use crate::db::{ConversationPageCursor, ConversationStore};
 use crate::error::DatabaseError;
 use crate::history::{ConversationMessage, ConversationSummary};
 
@@ -48,17 +48,103 @@ impl ConversationStore for LibSqlBackend {
         role: &str,
         content: &str,
     ) -> Result<Uuid, DatabaseError> {
+        self.add_conversation_message_with_metadata(
+            conversation_id,
+            role,
+            content,
+            Utc::now(),
+            None,
+        )
+        .await
+    }
+
+    async fn add_conversation_message_with_metadata(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+        created_at: DateTime<Utc>,
+        sequence_num: Option<i64>,
+    ) -> Result<Uuid, DatabaseError> {
         let conn = self.connect().await?;
-        let id = Uuid::new_v4();
-        let now = fmt_ts(&Utc::now());
-        conn.execute(
-                "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
-                params![id.to_string(), conversation_id.to_string(), role, content, now],
+        let conversation_id_str = conversation_id.to_string();
+        let created_at_str = fmt_ts(&created_at);
+
+        conn.execute("BEGIN IMMEDIATE", params![])
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let result: Result<Uuid, DatabaseError> = async {
+            let next_sequence = match sequence_num {
+                Some(sequence_num) => sequence_num,
+                None => {
+                    let mut rows = conn
+                        .query(
+                            r#"
+                            SELECT COALESCE(MAX(sequence_num), -1) + 1
+                            FROM conversation_messages
+                            WHERE conversation_id = ?1
+                            "#,
+                            params![conversation_id_str.clone()],
+                        )
+                        .await
+                        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+                    match rows
+                        .next()
+                        .await
+                        .map_err(|e| DatabaseError::Query(e.to_string()))?
+                    {
+                        Some(row) => row.get::<i64>(0).unwrap_or(0),
+                        None => 0,
+                    }
+                }
+            };
+
+            let id = Uuid::new_v4();
+            conn.execute(
+                "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at, sequence_num) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    id.to_string(),
+                    conversation_id_str.clone(),
+                    role,
+                    content,
+                    created_at_str.clone(),
+                    next_sequence
+                ],
             )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
-        self.touch_conversation(conversation_id).await?;
-        Ok(id)
+
+            conn.execute(
+                r#"
+                UPDATE conversations
+                SET last_activity = CASE
+                    WHEN last_activity > ?2 THEN last_activity
+                    ELSE ?2
+                END
+                WHERE id = ?1
+                "#,
+                params![conversation_id_str.clone(), created_at_str.clone()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+            Ok(id)
+        }
+        .await;
+
+        match &result {
+            Ok(_) => {
+                conn.execute("COMMIT", params![])
+                    .await
+                    .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            }
+            Err(_) => {
+                let _ = conn.execute("ROLLBACK", params![]).await;
+            }
+        }
+
+        result
     }
 
     async fn ensure_conversation(
@@ -106,7 +192,7 @@ impl ConversationStore for LibSqlBackend {
                     (SELECT substr(m2.content, 1, 100)
                      FROM conversation_messages m2
                      WHERE m2.conversation_id = c.id AND m2.role = 'user'
-                     ORDER BY m2.created_at ASC, m2.rowid ASC
+                     ORDER BY m2.sequence_num ASC, m2.created_at ASC, m2.id ASC
                      LIMIT 1
                     ) AS title
                 FROM conversations c
@@ -173,7 +259,7 @@ impl ConversationStore for LibSqlBackend {
                     (SELECT substr(m2.content, 1, 100)
                      FROM conversation_messages m2
                      WHERE m2.conversation_id = c.id AND m2.role = 'user'
-                     ORDER BY m2.created_at ASC, m2.rowid ASC
+                     ORDER BY m2.sequence_num ASC, m2.created_at ASC, m2.id ASC
                      LIMIT 1
                     ) AS title
                 FROM conversations c
@@ -402,52 +488,124 @@ impl ConversationStore for LibSqlBackend {
         user_id: &str,
         metadata: &serde_json::Value,
     ) -> Result<Uuid, DatabaseError> {
+        let now = Utc::now();
+        self.create_conversation_with_metadata_and_timestamps(channel, user_id, metadata, now, now)
+            .await
+    }
+
+    async fn create_conversation_with_metadata_and_timestamps(
+        &self,
+        channel: &str,
+        user_id: &str,
+        metadata: &serde_json::Value,
+        started_at: DateTime<Utc>,
+        last_activity: DateTime<Utc>,
+    ) -> Result<Uuid, DatabaseError> {
         let conn = self.connect().await?;
         let id = Uuid::new_v4();
-        let now = fmt_ts(&Utc::now());
         conn.execute(
-            "INSERT INTO conversations (id, channel, user_id, metadata, started_at, last_activity) VALUES (?1, ?2, ?3, ?4, ?5, ?5)",
-            params![id.to_string(), channel, user_id, metadata.to_string(), now],
+            "INSERT INTO conversations (id, channel, user_id, metadata, started_at, last_activity) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                id.to_string(),
+                channel,
+                user_id,
+                metadata.to_string(),
+                fmt_ts(&started_at),
+                fmt_ts(&last_activity)
+            ],
         )
         .await
         .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(id)
     }
 
+    async fn find_conversation_by_import_source(
+        &self,
+        user_id: &str,
+        source: &str,
+        source_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id
+                FROM conversations
+                WHERE user_id = ?1
+                  AND json_extract(metadata, '$.import_source') = ?2
+                  AND json_extract(metadata, '$.import_source_id') = ?3
+                LIMIT 1
+                "#,
+                params![user_id, source, source_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            let id = get_text(&row, 0);
+            let parsed = id.parse().map_err(|e| {
+                DatabaseError::Serialization(format!("invalid conversation id '{}': {}", id, e))
+            })?;
+            return Ok(Some(parsed));
+        }
+
+        Ok(None)
+    }
+
     async fn list_conversation_messages_paginated(
         &self,
         conversation_id: Uuid,
-        before: Option<DateTime<Utc>>,
+        before: Option<ConversationPageCursor>,
         limit: i64,
     ) -> Result<(Vec<ConversationMessage>, bool), DatabaseError> {
         let conn = self.connect().await?;
         let fetch_limit = limit + 1;
         let cid = conversation_id.to_string();
 
-        let mut rows = if let Some(before_ts) = before {
-            conn.query(
-                r#"
-                    SELECT id, role, content, created_at
-                    FROM conversation_messages
-                    WHERE conversation_id = ?1 AND created_at < ?2
-                    ORDER BY created_at DESC, rowid DESC
-                    LIMIT ?3
-                    "#,
-                params![cid, fmt_ts(&before_ts), fetch_limit],
-            )
-            .await
-        } else {
-            conn.query(
-                r#"
-                    SELECT id, role, content, created_at
-                    FROM conversation_messages
-                    WHERE conversation_id = ?1
-                    ORDER BY created_at DESC, rowid DESC
-                    LIMIT ?2
-                    "#,
-                params![cid, fetch_limit],
-            )
-            .await
+        let mut rows = match before {
+            Some(ConversationPageCursor::Sequence(before_sequence)) => {
+                conn.query(
+                    r#"
+                        SELECT id, role, content, created_at, sequence_num
+                        FROM conversation_messages
+                        WHERE conversation_id = ?1 AND sequence_num < ?2
+                        ORDER BY sequence_num DESC
+                        LIMIT ?3
+                        "#,
+                    params![cid, before_sequence, fetch_limit],
+                )
+                .await
+            }
+            Some(ConversationPageCursor::Timestamp(before_ts)) => {
+                conn.query(
+                    r#"
+                        SELECT id, role, content, created_at, sequence_num
+                        FROM conversation_messages
+                        WHERE conversation_id = ?1 AND created_at < ?2
+                        ORDER BY created_at DESC, sequence_num DESC, id DESC
+                        LIMIT ?3
+                        "#,
+                    params![cid, fmt_ts(&before_ts), fetch_limit],
+                )
+                .await
+            }
+            None => {
+                conn.query(
+                    r#"
+                        SELECT id, role, content, created_at, sequence_num
+                        FROM conversation_messages
+                        WHERE conversation_id = ?1
+                        ORDER BY sequence_num DESC
+                        LIMIT ?2
+                        "#,
+                    params![cid, fetch_limit],
+                )
+                .await
+            }
         }
         .map_err(|e| DatabaseError::Query(e.to_string()))?;
 
@@ -462,6 +620,7 @@ impl ConversationStore for LibSqlBackend {
                 role: get_text(&row, 1),
                 content: get_text(&row, 2),
                 created_at: get_ts(&row, 3),
+                sequence_num: get_i64(&row, 4),
             });
         }
 
@@ -520,10 +679,10 @@ impl ConversationStore for LibSqlBackend {
         let mut rows = conn
             .query(
                 r#"
-                SELECT id, role, content, created_at
+                SELECT id, role, content, created_at, sequence_num
                 FROM conversation_messages
                 WHERE conversation_id = ?1
-                ORDER BY created_at ASC, rowid ASC
+                ORDER BY sequence_num ASC
                 "#,
                 params![conversation_id.to_string()],
             )
@@ -541,6 +700,7 @@ impl ConversationStore for LibSqlBackend {
                 role: get_text(&row, 1),
                 content: get_text(&row, 2),
                 created_at: get_ts(&row, 3),
+                sequence_num: get_i64(&row, 4),
             });
         }
         Ok(messages)
@@ -689,5 +849,36 @@ mod tests {
             id1, id2,
             "Expected same heartbeat conversation on repeated calls"
         );
+    }
+
+    #[tokio::test]
+    async fn test_find_conversation_by_import_source() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_import_dedup.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let metadata = serde_json::json!({
+            "import_source": "chatgpt",
+            "import_source_id": "conv-abc-123",
+            "import_title": "Imported conversation",
+        });
+
+        let created = backend
+            .create_conversation_with_metadata("imported", "user-1", &metadata)
+            .await
+            .unwrap();
+
+        let found = backend
+            .find_conversation_by_import_source("user-1", "chatgpt", "conv-abc-123")
+            .await
+            .unwrap();
+        assert_eq!(found, Some(created));
+
+        let missing = backend
+            .find_conversation_by_import_source("user-1", "chatgpt", "does-not-exist")
+            .await
+            .unwrap();
+        assert!(missing.is_none());
     }
 }

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -10,6 +10,12 @@ use crate::db::{ConversationPageCursor, ConversationStore};
 use crate::error::DatabaseError;
 use crate::history::{ConversationMessage, ConversationSummary};
 
+async fn rollback_with_warning(conn: &libsql::Connection, context: &'static str) {
+    if let Err(err) = conn.execute("ROLLBACK", params![]).await {
+        tracing::warn!(context, error = %err, "libSQL rollback failed");
+    }
+}
+
 #[async_trait]
 impl ConversationStore for LibSqlBackend {
     async fn create_conversation(
@@ -140,7 +146,7 @@ impl ConversationStore for LibSqlBackend {
                     .map_err(|e| DatabaseError::Query(e.to_string()))?;
             }
             Err(_) => {
-                let _ = conn.execute("ROLLBACK", params![]).await;
+                rollback_with_warning(&conn, "add_conversation_message_with_metadata").await;
             }
         }
 
@@ -370,7 +376,7 @@ impl ConversationStore for LibSqlBackend {
                     .map_err(|e| DatabaseError::Query(e.to_string()))?;
             }
             Err(_) => {
-                let _ = conn.execute("ROLLBACK", params![]).await;
+                rollback_with_warning(&conn, "get_or_create_routine_conversation").await;
             }
         }
         result
@@ -432,7 +438,7 @@ impl ConversationStore for LibSqlBackend {
                     .map_err(|e| DatabaseError::Query(e.to_string()))?;
             }
             Err(_) => {
-                let _ = conn.execute("ROLLBACK", params![]).await;
+                rollback_with_warning(&conn, "get_or_create_heartbeat_conversation").await;
             }
         }
         result

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -54,6 +54,7 @@ pub(crate) const ROUTINE_RUN_COLUMNS: &str = "\
 /// Stores the `Database` handle in an `Arc` so that the same underlying
 /// database can be shared with stores (SecretsStore, WasmToolStore) that
 /// create their own connections per-operation.
+#[derive(Clone)]
 pub struct LibSqlBackend {
     db: Arc<LibSqlDatabase>,
 }

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -725,6 +725,35 @@ CREATE INDEX IF NOT EXISTS idx_routines_event_triggers
 PRAGMA foreign_keys=ON;
 "#,
     ),
+    (
+        14,
+        "conversation_message_sequence",
+        // Add stable sequence numbers to preserve message order independently
+        // from timestamps, then backfill existing rows in chronological order.
+        r#"
+ALTER TABLE conversation_messages ADD COLUMN sequence_num INTEGER;
+
+WITH ranked AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY conversation_id
+            ORDER BY created_at ASC, id ASC
+        ) - 1 AS sequence_num
+    FROM conversation_messages
+)
+UPDATE conversation_messages
+SET sequence_num = (
+    SELECT ranked.sequence_num
+    FROM ranked
+    WHERE ranked.id = conversation_messages.id
+)
+WHERE sequence_num IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_conversation_messages_sequence
+    ON conversation_messages(conversation_id, sequence_num);
+"#,
+    ),
 ];
 
 /// Run incremental migrations that haven't been applied yet.
@@ -791,4 +820,116 @@ pub async fn run_incremental(conn: &libsql::Connection) -> Result<(), crate::err
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_v14_backfills_conversation_message_sequence_from_v13_state() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("legacy_v13.db");
+        let db = libsql::Builder::new_local(&path).build().await.unwrap();
+        let conn = db.connect().unwrap();
+
+        conn.execute_batch(
+            r#"
+            CREATE TABLE _migrations (
+                version INTEGER PRIMARY KEY,
+                name TEXT NOT NULL,
+                applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            );
+
+            CREATE TABLE conversations (
+                id TEXT PRIMARY KEY,
+                channel TEXT NOT NULL,
+                user_id TEXT NOT NULL,
+                thread_id TEXT,
+                started_at TEXT NOT NULL,
+                last_activity TEXT NOT NULL,
+                metadata TEXT NOT NULL DEFAULT '{}'
+            );
+
+            CREATE TABLE conversation_messages (
+                id TEXT PRIMARY KEY,
+                conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+                role TEXT NOT NULL,
+                content TEXT NOT NULL,
+                created_at TEXT NOT NULL
+            );
+
+            INSERT INTO _migrations (version, name) VALUES
+                (9, 'flexible_embedding_dimension'),
+                (12, 'job_token_budget'),
+                (13, 'routine_notify_user_nullable');
+            "#,
+        )
+        .await
+        .unwrap();
+
+        let conversation_id = "00000000-0000-0000-0000-000000000100";
+        conn.execute(
+            "INSERT INTO conversations (id, channel, user_id, started_at, last_activity, metadata)
+             VALUES (?1, 'imported', 'legacy-user', '2024-01-15T10:00:00.000Z', '2024-01-15T10:10:00.000Z', '{}')",
+            libsql::params![conversation_id],
+        )
+        .await
+        .unwrap();
+
+        conn.execute(
+            "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at)
+             VALUES (?1, ?2, 'assistant', 'second', '2024-01-15T10:00:05.000Z')",
+            libsql::params!["00000000-0000-0000-0000-000000000002", conversation_id],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at)
+             VALUES (?1, ?2, 'user', 'first', '2024-01-15T10:00:05.000Z')",
+            libsql::params!["00000000-0000-0000-0000-000000000001", conversation_id],
+        )
+        .await
+        .unwrap();
+        conn.execute(
+            "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at)
+             VALUES (?1, ?2, 'user', 'third', '2024-01-15T10:04:30.000Z')",
+            libsql::params!["00000000-0000-0000-0000-000000000003", conversation_id],
+        )
+        .await
+        .unwrap();
+
+        run_incremental(&conn).await.unwrap();
+
+        let mut rows = conn
+            .query(
+                "SELECT content, sequence_num FROM conversation_messages ORDER BY sequence_num ASC",
+                (),
+            )
+            .await
+            .unwrap();
+
+        let mut actual = Vec::new();
+        while let Some(row) = rows.next().await.unwrap() {
+            actual.push((
+                row.get::<String>(0).unwrap_or_default(),
+                row.get::<i64>(1).unwrap_or_default(),
+            ));
+        }
+
+        assert_eq!(
+            actual,
+            vec![
+                ("first".to_string(), 0),
+                ("second".to_string(), 1),
+                ("third".to_string(), 2),
+            ]
+        );
+
+        let mut migration_rows = conn
+            .query("SELECT 1 FROM _migrations WHERE version = 14", ())
+            .await
+            .unwrap();
+        assert!(migration_rows.next().await.unwrap().is_some());
+    }
 }

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -728,10 +728,19 @@ PRAGMA foreign_keys=ON;
     (
         14,
         "conversation_message_sequence",
-        // Add stable sequence numbers to preserve message order independently
-        // from timestamps, then backfill existing rows in chronological order.
+        // Rebuild conversation_messages with a NOT NULL sequence_num column so
+        // both fresh and migrated databases enforce stable ordering in schema.
         r#"
-ALTER TABLE conversation_messages ADD COLUMN sequence_num INTEGER;
+ALTER TABLE conversation_messages RENAME TO conversation_messages_old;
+
+CREATE TABLE conversation_messages (
+    id TEXT PRIMARY KEY,
+    conversation_id TEXT NOT NULL REFERENCES conversations(id) ON DELETE CASCADE,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    sequence_num INTEGER NOT NULL
+);
 
 WITH ranked AS (
     SELECT
@@ -740,15 +749,23 @@ WITH ranked AS (
             PARTITION BY conversation_id
             ORDER BY created_at ASC, id ASC
         ) - 1 AS sequence_num
-    FROM conversation_messages
+    FROM conversation_messages_old
 )
-UPDATE conversation_messages
-SET sequence_num = (
-    SELECT ranked.sequence_num
-    FROM ranked
-    WHERE ranked.id = conversation_messages.id
-)
-WHERE sequence_num IS NULL;
+INSERT INTO conversation_messages (id, conversation_id, role, content, created_at, sequence_num)
+SELECT
+    old.id,
+    old.conversation_id,
+    old.role,
+    old.content,
+    old.created_at,
+    ranked.sequence_num
+FROM conversation_messages_old AS old
+JOIN ranked ON ranked.id = old.id;
+
+DROP TABLE conversation_messages_old;
+
+CREATE INDEX IF NOT EXISTS idx_conversation_messages_conversation
+    ON conversation_messages(conversation_id);
 
 CREATE UNIQUE INDEX IF NOT EXISTS uq_conversation_messages_sequence
     ON conversation_messages(conversation_id, sequence_num);
@@ -924,6 +941,23 @@ mod tests {
                 ("second".to_string(), 1),
                 ("third".to_string(), 2),
             ]
+        );
+
+        let mut schema_rows = conn
+            .query("PRAGMA table_info(conversation_messages)", ())
+            .await
+            .unwrap();
+        let mut sequence_num_not_null = false;
+        while let Some(row) = schema_rows.next().await.unwrap() {
+            let name = row.get::<String>(1).unwrap_or_default();
+            if name == "sequence_num" {
+                sequence_num_not_null = row.get::<i64>(3).unwrap_or_default() == 1;
+                break;
+            }
+        }
+        assert!(
+            sequence_num_not_null,
+            "sequence_num should be enforced as NOT NULL after V14"
         );
 
         let mut migration_rows = conn

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -330,6 +330,14 @@ pub trait ConversationStore: Send + Sync {
         role: &str,
         content: &str,
     ) -> Result<Uuid, DatabaseError>;
+    async fn add_conversation_message_with_metadata(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+        created_at: DateTime<Utc>,
+        sequence_num: Option<i64>,
+    ) -> Result<Uuid, DatabaseError>;
     async fn ensure_conversation(
         &self,
         id: Uuid,
@@ -369,10 +377,24 @@ pub trait ConversationStore: Send + Sync {
         user_id: &str,
         metadata: &serde_json::Value,
     ) -> Result<Uuid, DatabaseError>;
+    async fn create_conversation_with_metadata_and_timestamps(
+        &self,
+        channel: &str,
+        user_id: &str,
+        metadata: &serde_json::Value,
+        started_at: DateTime<Utc>,
+        last_activity: DateTime<Utc>,
+    ) -> Result<Uuid, DatabaseError>;
+    async fn find_conversation_by_import_source(
+        &self,
+        user_id: &str,
+        source: &str,
+        source_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError>;
     async fn list_conversation_messages_paginated(
         &self,
         conversation_id: Uuid,
-        before: Option<DateTime<Utc>>,
+        before: Option<ConversationPageCursor>,
         limit: i64,
     ) -> Result<(Vec<ConversationMessage>, bool), DatabaseError>;
     async fn update_conversation_metadata_field(
@@ -394,6 +416,12 @@ pub trait ConversationStore: Send + Sync {
         conversation_id: Uuid,
         user_id: &str,
     ) -> Result<bool, DatabaseError>;
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConversationPageCursor {
+    Sequence(i64),
+    Timestamp(DateTime<Utc>),
 }
 
 #[async_trait]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -16,8 +16,8 @@ use crate::agent::routine::{Routine, RoutineRun, RunStatus};
 use crate::config::DatabaseConfig;
 use crate::context::{ActionRecord, JobContext, JobState};
 use crate::db::{
-    ConversationStore, Database, JobStore, RoutineStore, SandboxStore, SettingsStore,
-    ToolFailureStore, WorkspaceStore,
+    ConversationPageCursor, ConversationStore, Database, JobStore, RoutineStore, SandboxStore,
+    SettingsStore, ToolFailureStore, WorkspaceStore,
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
@@ -44,6 +44,13 @@ impl PgBackend {
         let store = Store::new(config).await?;
         let repo = Repository::new(store.pool());
         Ok(Self { store, repo })
+    }
+
+    /// Create a backend from an existing pool.
+    pub fn from_pool(pool: Pool) -> Self {
+        let store = Store::from_pool(pool.clone());
+        let repo = Repository::new(pool);
+        Self { store, repo }
     }
 
     /// Get a clone of the connection pool.
@@ -90,6 +97,25 @@ impl ConversationStore for PgBackend {
     ) -> Result<Uuid, DatabaseError> {
         self.store
             .add_conversation_message(conversation_id, role, content)
+            .await
+    }
+
+    async fn add_conversation_message_with_metadata(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+        created_at: DateTime<Utc>,
+        sequence_num: Option<i64>,
+    ) -> Result<Uuid, DatabaseError> {
+        self.store
+            .add_conversation_message_with_metadata(
+                conversation_id,
+                role,
+                content,
+                created_at,
+                sequence_num,
+            )
             .await
     }
 
@@ -167,10 +193,39 @@ impl ConversationStore for PgBackend {
             .await
     }
 
+    async fn create_conversation_with_metadata_and_timestamps(
+        &self,
+        channel: &str,
+        user_id: &str,
+        metadata: &serde_json::Value,
+        started_at: DateTime<Utc>,
+        last_activity: DateTime<Utc>,
+    ) -> Result<Uuid, DatabaseError> {
+        self.store
+            .create_conversation_with_metadata_and_timestamps(
+                channel,
+                user_id,
+                metadata,
+                started_at,
+                last_activity,
+            )
+            .await
+    }
+
+    async fn find_conversation_by_import_source(
+        &self,
+        user_id: &str,
+        source: &str,
+        source_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        self.store
+            .find_conversation_by_import_source(user_id, source, source_id)
+            .await
+    }
     async fn list_conversation_messages_paginated(
         &self,
         conversation_id: Uuid,
-        before: Option<DateTime<Utc>>,
+        before: Option<ConversationPageCursor>,
         limit: i64,
     ) -> Result<(Vec<ConversationMessage>, bool), DatabaseError> {
         self.store

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -96,10 +96,11 @@ impl Store {
     ) -> Result<Uuid, DatabaseError> {
         let conn = self.conn().await?;
         let id = Uuid::new_v4();
+        let now = Utc::now();
 
         conn.execute(
-            "INSERT INTO conversations (id, channel, user_id, thread_id) VALUES ($1, $2, $3, $4)",
-            &[&id, &channel, &user_id, &thread_id],
+            "INSERT INTO conversations (id, channel, user_id, thread_id, started_at, last_activity) VALUES ($1, $2, $3, $4, $5, $5)",
+            &[&id, &channel, &user_id, &thread_id, &now],
         )
         .await?;
 
@@ -124,18 +125,65 @@ impl Store {
         role: &str,
         content: &str,
     ) -> Result<Uuid, DatabaseError> {
-        let conn = self.conn().await?;
+        self.add_conversation_message_with_metadata(
+            conversation_id,
+            role,
+            content,
+            Utc::now(),
+            None,
+        )
+        .await
+    }
+
+    /// Add a message with explicit source timestamp and optional sequence number.
+    pub async fn add_conversation_message_with_metadata(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+        created_at: DateTime<Utc>,
+        sequence_num: Option<i64>,
+    ) -> Result<Uuid, DatabaseError> {
+        let mut conn = self.conn().await?;
+        let tx = conn.transaction().await?;
         let id = Uuid::new_v4();
 
-        conn.execute(
-            "INSERT INTO conversation_messages (id, conversation_id, role, content) VALUES ($1, $2, $3, $4)",
-            &[&id, &conversation_id, &role, &content],
+        tx.query_opt(
+            "SELECT 1 FROM conversations WHERE id = $1 FOR UPDATE",
+            &[&conversation_id],
         )
         .await?;
 
-        // Update conversation activity
-        self.touch_conversation(conversation_id).await?;
+        let next_sequence = match sequence_num {
+            Some(sequence_num) => sequence_num,
+            None => {
+                let row = tx
+                    .query_one(
+                        "SELECT COALESCE(MAX(sequence_num), -1) + 1 AS next_sequence
+                         FROM conversation_messages
+                         WHERE conversation_id = $1",
+                        &[&conversation_id],
+                    )
+                    .await?;
+                row.get::<_, i64>("next_sequence")
+            }
+        };
 
+        tx.execute(
+            "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at, sequence_num) VALUES ($1, $2, $3, $4, $5, $6)",
+            &[&id, &conversation_id, &role, &content, &created_at, &next_sequence],
+        )
+        .await?;
+
+        tx.execute(
+            "UPDATE conversations
+             SET last_activity = GREATEST(last_activity, $2)
+             WHERE id = $1",
+            &[&conversation_id, &created_at],
+        )
+        .await?;
+
+        tx.commit().await?;
         Ok(id)
     }
 
@@ -1453,6 +1501,13 @@ pub struct ConversationMessage {
     pub role: String,
     pub content: String,
     pub created_at: DateTime<Utc>,
+    pub sequence_num: i64,
+}
+
+impl ConversationMessage {
+    pub fn pagination_cursor(&self) -> String {
+        format!("seq:{}", self.sequence_num)
+    }
 }
 
 #[cfg(feature = "postgres")]
@@ -1507,7 +1562,7 @@ impl Store {
                     (SELECT LEFT(m2.content, 100)
                      FROM conversation_messages m2
                      WHERE m2.conversation_id = c.id AND m2.role = 'user'
-                     ORDER BY m2.created_at ASC
+                     ORDER BY m2.sequence_num ASC, m2.created_at ASC, m2.id ASC
                      LIMIT 1
                     ) AS title
                 FROM conversations c
@@ -1567,7 +1622,7 @@ impl Store {
                     (SELECT LEFT(m2.content, 100)
                      FROM conversation_messages m2
                      WHERE m2.conversation_id = c.id AND m2.role = 'user'
-                     ORDER BY m2.created_at ASC
+                     ORDER BY m2.sequence_num ASC, m2.created_at ASC, m2.id ASC
                      LIMIT 1
                     ) AS title
                 FROM conversations c
@@ -1751,16 +1806,54 @@ impl Store {
         user_id: &str,
         metadata: &serde_json::Value,
     ) -> Result<Uuid, DatabaseError> {
+        let now = Utc::now();
+        self.create_conversation_with_metadata_and_timestamps(channel, user_id, metadata, now, now)
+            .await
+    }
+
+    /// Create a conversation with metadata and explicit timestamps.
+    pub async fn create_conversation_with_metadata_and_timestamps(
+        &self,
+        channel: &str,
+        user_id: &str,
+        metadata: &serde_json::Value,
+        started_at: DateTime<Utc>,
+        last_activity: DateTime<Utc>,
+    ) -> Result<Uuid, DatabaseError> {
         let conn = self.conn().await?;
         let id = Uuid::new_v4();
 
         conn.execute(
-            "INSERT INTO conversations (id, channel, user_id, metadata) VALUES ($1, $2, $3, $4)",
-            &[&id, &channel, &user_id, metadata],
+            "INSERT INTO conversations (id, channel, user_id, metadata, started_at, last_activity) VALUES ($1, $2, $3, $4, $5, $6)",
+            &[&id, &channel, &user_id, metadata, &started_at, &last_activity],
         )
         .await?;
 
         Ok(id)
+    }
+
+    /// Find an imported conversation by source tuple.
+    pub async fn find_conversation_by_import_source(
+        &self,
+        user_id: &str,
+        source: &str,
+        source_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                r#"
+                SELECT id
+                FROM conversations
+                WHERE user_id = $1
+                  AND metadata->>'import_source' = $2
+                  AND metadata->>'import_source_id' = $3
+                LIMIT 1
+                "#,
+                &[&user_id, &source, &source_id],
+            )
+            .await?;
+        Ok(row.map(|row| row.get("id")))
     }
 
     /// Check whether a conversation belongs to the given user.
@@ -1786,36 +1879,52 @@ impl Store {
     pub async fn list_conversation_messages_paginated(
         &self,
         conversation_id: Uuid,
-        before: Option<DateTime<Utc>>,
+        before: Option<crate::db::ConversationPageCursor>,
         limit: i64,
     ) -> Result<(Vec<ConversationMessage>, bool), DatabaseError> {
         let conn = self.conn().await?;
         let fetch_limit = limit + 1; // Fetch one extra to determine has_more
 
-        let rows = if let Some(before_ts) = before {
-            conn.query(
-                r#"
-                SELECT id, role, content, created_at
-                FROM conversation_messages
-                WHERE conversation_id = $1 AND created_at < $2
-                ORDER BY created_at DESC
-                LIMIT $3
-                "#,
-                &[&conversation_id, &before_ts, &fetch_limit],
-            )
-            .await?
-        } else {
-            conn.query(
-                r#"
-                SELECT id, role, content, created_at
-                FROM conversation_messages
-                WHERE conversation_id = $1
-                ORDER BY created_at DESC
-                LIMIT $2
-                "#,
-                &[&conversation_id, &fetch_limit],
-            )
-            .await?
+        let rows = match before {
+            Some(crate::db::ConversationPageCursor::Sequence(before_sequence)) => {
+                conn.query(
+                    r#"
+                    SELECT id, role, content, created_at, sequence_num
+                    FROM conversation_messages
+                    WHERE conversation_id = $1 AND sequence_num < $2
+                    ORDER BY sequence_num DESC
+                    LIMIT $3
+                    "#,
+                    &[&conversation_id, &before_sequence, &fetch_limit],
+                )
+                .await?
+            }
+            Some(crate::db::ConversationPageCursor::Timestamp(before_ts)) => {
+                conn.query(
+                    r#"
+                    SELECT id, role, content, created_at, sequence_num
+                    FROM conversation_messages
+                    WHERE conversation_id = $1 AND created_at < $2
+                    ORDER BY created_at DESC, sequence_num DESC, id DESC
+                    LIMIT $3
+                    "#,
+                    &[&conversation_id, &before_ts, &fetch_limit],
+                )
+                .await?
+            }
+            None => {
+                conn.query(
+                    r#"
+                    SELECT id, role, content, created_at, sequence_num
+                    FROM conversation_messages
+                    WHERE conversation_id = $1
+                    ORDER BY sequence_num DESC
+                    LIMIT $2
+                    "#,
+                    &[&conversation_id, &fetch_limit],
+                )
+                .await?
+            }
         };
 
         let has_more = rows.len() as i64 > limit;
@@ -1830,6 +1939,7 @@ impl Store {
                 role: r.get("role"),
                 content: r.get("content"),
                 created_at: r.get("created_at"),
+                sequence_num: r.get("sequence_num"),
             })
             .collect();
         messages.reverse();
@@ -1875,10 +1985,10 @@ impl Store {
         let rows = conn
             .query(
                 r#"
-                SELECT id, role, content, created_at
+                SELECT id, role, content, created_at, sequence_num
                 FROM conversation_messages
                 WHERE conversation_id = $1
-                ORDER BY created_at ASC
+                ORDER BY sequence_num ASC
                 "#,
                 &[&conversation_id],
             )
@@ -1891,6 +2001,7 @@ impl Store {
                 role: r.get("role"),
                 content: r.get("content"),
                 created_at: r.get("created_at"),
+                sequence_num: r.get("sequence_num"),
             })
             .collect())
     }
@@ -2232,5 +2343,56 @@ mod tests {
         conn.execute("DELETE FROM agent_jobs WHERE id = $1", &[&ctx.job_id])
             .await
             .unwrap();
+    }
+
+    /// Regression test for import dedup metadata lookup.
+    /// Requires a running PostgreSQL instance (integration tier).
+    #[cfg(feature = "postgres")]
+    #[tokio::test]
+    #[ignore]
+    async fn test_find_conversation_by_import_source() {
+        use crate::config::Config;
+
+        let _ = dotenvy::dotenv();
+        let config = Config::from_env().await.expect("Failed to load config");
+        let store = Store::new(&config.database)
+            .await
+            .expect("Failed to connect to database");
+        store
+            .run_migrations()
+            .await
+            .expect("Failed to run migrations");
+
+        let user_id = "test-user-import";
+        let metadata = serde_json::json!({
+            "import_source": "chatgpt",
+            "import_source_id": "conv-xyz-123",
+            "import_title": "Imported chat",
+        });
+
+        let conversation_id = store
+            .create_conversation_with_metadata("imported", user_id, &metadata)
+            .await
+            .unwrap();
+
+        let found = store
+            .find_conversation_by_import_source(user_id, "chatgpt", "conv-xyz-123")
+            .await
+            .unwrap();
+        assert_eq!(found, Some(conversation_id));
+
+        let missing = store
+            .find_conversation_by_import_source(user_id, "chatgpt", "missing-id")
+            .await
+            .unwrap();
+        assert_eq!(missing, None);
+
+        let conn = store.conn().await.unwrap();
+        conn.execute(
+            "DELETE FROM conversations WHERE id = $1",
+            &[&conversation_id],
+        )
+        .await
+        .unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,11 +110,10 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return completion.run();
         }
-        #[cfg(feature = "import")]
         Some(Command::Import(import_cmd)) => {
             init_cli_tracing();
             let config = ironclaw::config::Config::from_env().await?;
-            return ironclaw::cli::run_import_command(import_cmd, &config).await;
+            return ironclaw::cli::run_import_command(import_cmd, &config, cli.no_db).await;
         }
         Some(Command::Worker {
             job_id,
@@ -185,6 +184,7 @@ async fn async_main() -> anyhow::Result<()> {
             channels_only,
             provider_only,
             quick,
+            import_history,
         }) => {
             #[cfg(any(feature = "postgres", feature = "libsql"))]
             {
@@ -193,6 +193,7 @@ async fn async_main() -> anyhow::Result<()> {
                     channels_only: *channels_only,
                     provider_only: *provider_only,
                     quick: *quick,
+                    import_history: *import_history,
                 };
                 let mut wizard =
                     SetupWizard::try_with_config_and_toml(config, cli.config.as_deref())?;
@@ -200,7 +201,13 @@ async fn async_main() -> anyhow::Result<()> {
             }
             #[cfg(not(any(feature = "postgres", feature = "libsql")))]
             {
-                let _ = (skip_auth, channels_only, provider_only, quick);
+                let _ = (
+                    skip_auth,
+                    channels_only,
+                    provider_only,
+                    quick,
+                    import_history,
+                );
                 eprintln!("Onboarding wizard requires the 'postgres' or 'libsql' feature.");
             }
             return Ok(());

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -10,7 +10,7 @@ file first, then adjust the code to match.
 ## Entry Points
 
 ```
-ironclaw onboard [--skip-auth] [--channels-only] [--provider-only] [--quick]
+ironclaw onboard [--skip-auth] [--channels-only] [--provider-only] [--quick] [--import-history]
 ```
 
 Explicit invocation. Loads `.env` files, runs the wizard, exits.
@@ -22,6 +22,7 @@ ironclaw          (first run, no database configured)
 Auto-detection via `check_onboard_needed()` in `main.rs`. Skips onboarding
 when `ONBOARD_COMPLETED` env var is set (written to `~/.ironclaw/.env` by
 the wizard). Otherwise triggers when no database is configured:
+
 - `DATABASE_URL` env var is set
 - `LIBSQL_PATH` env var is set
 - `~/.ironclaw/ironclaw.db` exists on disk
@@ -60,9 +61,10 @@ the LLM provider and model selection.
 
 ```
 auto_setup_database()    → libsql at ~/.ironclaw/ironclaw.db (zero prompts)
+Step 1/3: Import History      ← optional, only if detected or forced
 auto_setup_security()    → keychain or env var (zero prompts)
-Step 1/2: Inference Provider  ← only interactive step
-Step 2/2: Model Selection     ← only interactive step
+Step 2/3: Inference Provider  ← only required interactive step
+Step 3/3: Model Selection
        ↓
    save_and_summarize()      → includes tip to run `ironclaw onboard`
 ```
@@ -82,29 +84,30 @@ except unavoidable macOS keychain dialogs.
 `upsert_bootstrap_vars()` instead of `save_bootstrap_env()`, preserving
 user-added variables like `HTTP_HOST` across re-onboarding.
 
-The full 9-step wizard remains available via `ironclaw onboard`.
+The full wizard remains available via `ironclaw onboard`.
 
 ---
 
-## The 9-Step Wizard
+## The 10-Step Wizard
 
 ### Overview
 
 ```
 Step 1: Database Connection
-Step 2: Security (master key)
-Step 3: Inference Provider          ← skipped if --skip-auth
-Step 4: Model Selection
-Step 5: Embeddings
-Step 6: Channel Configuration
-Step 7: Extensions (tools)
-Step 8: Docker Sandbox
-Step 9: Background Tasks (heartbeat)
+Step 2: Import Conversation History ← optional, auto-detected or forced
+Step 3: Security (master key)
+Step 4: Inference Provider          ← skipped if --skip-auth
+Step 5: Model Selection
+Step 6: Embeddings
+Step 7: Channel Configuration
+Step 8: Extensions (tools)
+Step 9: Docker Sandbox
+Step 10: Background Tasks (heartbeat)
        ↓
    save_and_summarize()
 ```
 
-`--channels-only` mode runs only Step 6, skipping everything else.
+`--channels-only` mode runs only Step 7, skipping everything else.
 
 **Personal onboarding** happens conversationally during the user's first interaction
 with the running assistant (not during the wizard). The `## First-Run Bootstrap` block in
@@ -139,22 +142,46 @@ Both features compiled?
 ```
 
 **PostgreSQL path:**
+
 1. Check `DATABASE_URL` from env or settings
 2. Test connection via `connect_without_migrations()` (validates version, pgvector)
 3. Optionally run migrations
 
 **libSQL path:**
+
 1. Offer local path (default: `~/.ironclaw/ironclaw.db`)
 2. Optional Turso cloud sync (URL + auth token)
 3. Test connection via `connect_without_migrations()`
 4. Always run migrations (idempotent CREATE IF NOT EXISTS)
 
-**Invariant:** After Step 1, `self.db` is `Some(Arc<dyn Database>)`.
+**Invariant:** After Step 1, the wizard has a live database handle
+(`self.db_pool` for PostgreSQL and/or `self.db_backend` for libSQL).
 This is required for settings persistence in `save_and_summarize()`.
 
 ---
 
-### Step 2: Security (Master Key)
+### Step 2: Import Conversation History (Optional)
+
+**Module:** `wizard.rs` → `step_import_history()`
+
+**Goal:** Offer a one-shot import of conversation history from supported external
+sources as soon as the database is available.
+
+**Behavior:**
+
+1. If nothing is detected and `--import-history` was not passed, skip silently.
+2. If nothing is detected but `--import-history` was passed, show an informational message.
+3. Onboarding only offers sources whose parsers are implemented in the current build.
+4. If candidates are found, offer `Import all`, `Select sources`, or `Skip`.
+5. Imports run with `dedup = true` and `to_workspace = true`.
+6. Individual source failures are reported but do not abort onboarding.
+
+**Placement rationale:** This step runs immediately after database setup, before
+security/provider configuration, because import only needs DB access.
+
+---
+
+### Step 3: Security (Master Key)
 
 **Module:** `wizard.rs` → `step_security()`
 
@@ -179,6 +206,7 @@ SECRETS_MASTER_KEY env var set?
 
 On macOS, `security_framework::get_generic_password()` can trigger TWO
 system dialogs:
+
 1. "Enter your password to unlock the keychain" (keychain locked)
 2. "Allow ironclaw to access this keychain item" (per-app authorization)
 
@@ -212,27 +240,29 @@ env-var mode or skipped secrets.
 
 **Providers:**
 
-| Provider | Auth Method | Secret Name | Env Var |
-|----------|-------------|-------------|---------|
-| NEAR AI Chat | Browser OAuth or session token | - | `NEARAI_SESSION_TOKEN` |
-| NEAR AI Cloud | API key | `llm_nearai_api_key` | `NEARAI_API_KEY` |
-| Anthropic | API key | `anthropic_api_key` | `ANTHROPIC_API_KEY` |
-| OpenAI | API key | `openai_api_key` | `OPENAI_API_KEY` |
-| Ollama | None | - | - |
-| OpenRouter | API key | `llm_openrouter_api_key` | `OPENROUTER_API_KEY` |
-| OpenAI-compatible | Optional API key | `llm_compatible_api_key` | `LLM_API_KEY` |
-| AWS Bedrock | AWS credentials (IAM, SSO, instance roles) | - | - |
+| Provider          | Auth Method                                | Secret Name              | Env Var                |
+| ----------------- | ------------------------------------------ | ------------------------ | ---------------------- |
+| NEAR AI Chat      | Browser OAuth or session token             | -                        | `NEARAI_SESSION_TOKEN` |
+| NEAR AI Cloud     | API key                                    | `llm_nearai_api_key`     | `NEARAI_API_KEY`       |
+| Anthropic         | API key                                    | `anthropic_api_key`      | `ANTHROPIC_API_KEY`    |
+| OpenAI            | API key                                    | `openai_api_key`         | `OPENAI_API_KEY`       |
+| Ollama            | None                                       | -                        | -                      |
+| OpenRouter        | API key                                    | `llm_openrouter_api_key` | `OPENROUTER_API_KEY`   |
+| OpenAI-compatible | Optional API key                           | `llm_compatible_api_key` | `LLM_API_KEY`          |
+| AWS Bedrock       | AWS credentials (IAM, SSO, instance roles) | -                        | -                      |
 
 **OpenRouter** is a standalone registry provider (`providers.json` id `"openrouter"`)
 with its own secret name and env var. It is **not** stored as `openai_compatible`.
 
 **OpenRouter** (`setup.kind = "api_key"` in `providers.json`):
+
 - Standalone provider with base URL `https://openrouter.ai/api/v1`
 - Delegates to `setup_api_key_provider()` with display name "OpenRouter"
 - API key is required (`api_key_required: true`)
 - Default model: `openai/gpt-4o`
 
 **API-key providers** (`setup_api_key_provider`):
+
 1. Check env var → if set, ask to reuse, persist to secrets store
 2. Otherwise prompt for key entry via `secret_input()`
 3. Store encrypted in secrets via `init_secrets_context()`
@@ -241,6 +271,7 @@ with its own secret name and env var. It is **not** stored as `openai_compatible
    switching to a different backend
 
 **NEAR AI** (`setup_nearai`):
+
 - Calls `session_manager.ensure_authenticated()` which shows the auth menu:
   - Options 1-2 (GitHub/Google): browser OAuth → **NEAR AI Chat** mode
     (Responses API at `private.near.ai`, session token auth)
@@ -268,6 +299,7 @@ mutating environment variables.
 **Goal:** Choose which model to use.
 
 **Flow:**
+
 1. If model already set → offer to keep it
 2. Fetch models from provider API (5-second timeout)
 3. On timeout or error → use static fallback list
@@ -275,6 +307,7 @@ mutating environment variables.
 5. Store in `self.settings.selected_model`
 
 **Model fetchers pass the cached API key explicitly:**
+
 ```rust
 let cached = self.llm_api_key.as_ref().map(|k| k.expose_secret().to_string());
 let models = fetch_anthropic_models(cached.as_deref()).await;
@@ -292,6 +325,7 @@ key first, then falls back to the standard env var.
 **Goal:** Configure semantic search for workspace memory.
 
 **Flow:**
+
 1. Ask "Enable semantic search?" (default: yes)
 2. Detect available providers:
    - NEAR AI: if backend is `nearai` OR valid session exists
@@ -304,7 +338,7 @@ key first, then falls back to the standard env var.
 
 ---
 
-### Step 6: Channel Configuration
+### Step 7: Channel Configuration
 
 **Module:** `wizard.rs` → `step_channels()`, delegating to `channels.rs`
 
@@ -313,52 +347,59 @@ key first, then falls back to the standard env var.
 **Sub-steps:**
 
 ```
-6a. Tunnel setup (if webhook channels needed)
-6b. Discover WASM channels from ~/.ironclaw/channels/
-6c. Build channel options: discovered + bundled + registry catalog
-6d. Multi-select: CLI/TUI, HTTP, all available channels
-6e. Install missing bundled channels (copy WASM binaries)
-6f. Install missing registry channels (download artifacts, fallback to source build)
-6g. Initialize SecretsContext (for token storage)
-6h. Setup HTTP webhook (if selected)
-6i. Setup each WASM channel (secrets, owner binding)
+7a. Tunnel setup (if webhook channels needed)
+7b. Discover WASM channels from ~/.ironclaw/channels/
+7c. Build channel options: discovered + bundled + registry catalog
+7d. Multi-select: CLI/TUI, HTTP, all available channels
+7e. Install missing bundled channels (copy WASM binaries)
+7f. Install missing registry channels (download artifacts, fallback to source build)
+7g. Initialize SecretsContext (for token storage)
+7h. Setup HTTP webhook (if selected)
+7i. Setup each WASM channel (secrets, owner binding)
 ```
 
 **Channel sources** (priority order for installation):
+
 1. Already installed in `~/.ironclaw/channels/`
 2. Bundled channels (pre-compiled in `channels-src/`)
 3. Registry channels (`registry/channels/*.json`, download-first with source fallback)
 
 **Tunnel setup** (`setup_tunnel`):
+
 - Options: ngrok, Cloudflare Tunnel, localtunnel, custom URL
 - Validates HTTPS requirement
 - Stored in `self.settings.tunnel.public_url`
 
 **WASM channel setup** (`setup_wasm_channel`):
+
 - Reads `capabilities.json` for `setup.required_secrets`
 - For each secret: check existing, prompt or auto-generate, validate regex
 - Save each secret via `SecretsContext`
 
 **Telegram special case** (`setup_telegram`):
+
 - Validates bot token via Telegram `getMe` API
 - Owner binding: polls `getUpdates` for 120s to capture sender's user ID
 - Optional webhook secret generation
 
 **SecretsContext creation** (`init_secrets_context`):
+
 1. Check `self.secrets_crypto` (set in Step 2) → use if available
 2. Else try `SECRETS_MASTER_KEY` env var
 3. Else try `get_master_key()` from keychain (only in `channels_only` mode)
-4. Create secrets store using `self.db` (`Arc<dyn Database>`)
+4. Create a secrets store using the active backend handle (`self.db_pool`
+   for PostgreSQL or `self.db_backend` for libSQL)
 
 ---
 
-### Step 7: Extensions (Tools)
+### Step 8: Extensions (Tools)
 
 **Module:** `wizard.rs` → `step_extensions()`
 
 **Goal:** Install WASM tools from the extension registry.
 
 **Flow:**
+
 1. Load `RegistryCatalog` from `registry/` directory
 2. If registry not found, print info and skip
 3. List all tool manifests from the catalog
@@ -373,19 +414,30 @@ key first, then falls back to the standard env var.
 
 **Registry lookup** (`load_registry_catalog`):
 Searches for `registry/` directory in order:
+
 1. Current working directory
 2. Next to the executable
 3. `CARGO_MANIFEST_DIR` (compile-time, dev builds)
 
 ---
 
-### Step 8: Heartbeat
+### Step 9: Docker Sandbox
+
+**Module:** `wizard.rs` → `step_docker_sandbox()`
+
+**Goal:** Configure whether IronClaw should use the local Docker sandbox for
+tool execution and worker isolation.
+
+---
+
+### Step 10: Background Tasks
 
 **Module:** `wizard.rs` → `step_heartbeat()`
 
 **Goal:** Configure periodic background execution.
 
 **Flow:**
+
 1. Ask "Enable heartbeat?" (default: no)
 2. If yes: interval in minutes (default: 30), notification channel
 3. Store in `self.settings.heartbeat`
@@ -411,6 +463,7 @@ LLM_BASE_URL="http://my-vllm:8000/v1"
 ```
 
 Or for PostgreSQL + NEAR AI:
+
 ```env
 DATABASE_BACKEND="postgres"
 DATABASE_URL="postgres://user:pass@localhost/ironclaw"
@@ -418,6 +471,7 @@ LLM_BACKEND="nearai"
 ```
 
 Or for Ollama:
+
 ```env
 LLM_BACKEND="ollama"
 OLLAMA_BASE_URL="http://localhost:11434"
@@ -433,6 +487,7 @@ All other settings are stored as key-value pairs in the `settings` table,
 keyed by `(user_id, key)`. Written by `set_all_settings()`.
 
 Settings are serialized via `Settings::to_db_map()` as dotted paths:
+
 ```
 database_backend = "libsql"
 llm_backend = "nearai"
@@ -451,6 +506,7 @@ This prevents data loss if a later step fails (e.g., the user enters an
 API key in step 3 but step 5 crashes — they won't need to re-enter it).
 
 **`persist_after_step()`** is called after each step in `run()` and:
+
 1. Writes bootstrap vars to `~/.ironclaw/.env` via `write_bootstrap_env()`
 2. Writes all current settings to the database via `persist_settings()`
 3. Silently ignores errors (e.g., if called before Step 1 establishes a DB)
@@ -471,6 +527,7 @@ persist_after_step()                   → save merged state
 ```
 
 This ordering ensures:
+
 - Prior progress (steps 2-7 from a previous partial run) is recovered
 - Fresh Step 1 choices override stale DB values (not the reverse)
 - The first DB persist doesn't clobber prior settings with defaults
@@ -488,6 +545,7 @@ Final step of the wizard:
 ```
 
 Bootstrap vars written to `~/.ironclaw/.env`:
+
 - `DATABASE_BACKEND` (always)
 - `DATABASE_URL` (if postgres)
 - `LIBSQL_PATH` (if libsql)
@@ -504,6 +562,7 @@ write fails, the wizard returns an error and the `.env` file is not written.
 ### Legacy Migration
 
 `bootstrap.rs` handles one-time upgrades from older config formats:
+
 - `bootstrap.json` → extracts `DATABASE_URL`, writes `.env`, renames to `.migrated`
 - `settings.json` → migrated to database via `migrate_disk_to_db()`
 
@@ -524,25 +583,25 @@ pub struct Settings {
     pub libsql_path: Option<String>,
     pub libsql_url: Option<String>,
 
-    // Step 2: Security
+    // Step 3: Security
     pub secrets_master_key_source: KeySource, // Keychain | Env | None
 
-    // Step 3: Inference
+    // Step 4: Inference
     pub llm_backend: Option<String>,         // "nearai" | "anthropic" | "openai" | "ollama" | "openai_compatible" | "bedrock"
     pub ollama_base_url: Option<String>,
     pub openai_compatible_base_url: Option<String>,
 
-    // Step 4: Model
+    // Step 5: Model
     pub selected_model: Option<String>,
 
-    // Step 5: Embeddings
+    // Step 6: Embeddings
     pub embeddings: EmbeddingsSettings,      // enabled, provider, model
 
-    // Step 6: Channels
+    // Step 7: Channels
     pub tunnel: TunnelSettings,              // provider, public_url
     pub channels: ChannelSettings,           // http config, telegram owner, etc.
 
-    // Step 7: Heartbeat
+    // Step 10: Background Tasks
     pub heartbeat: HeartbeatSettings,        // enabled, interval, notify
 
     // Advanced (not in wizard, set via `ironclaw config set`)
@@ -572,6 +631,7 @@ pub struct SecretsContext {
 ```
 
 Created by `init_secrets_context()` which:
+
 1. Gets `SecretsCrypto` from `self.secrets_crypto` or loads from keychain/env
 2. Creates the appropriate backend store:
    - If both features compiled: respects `self.settings.database_backend`
@@ -595,19 +655,19 @@ anthropic_api_key     → encrypted API key
 
 **Module:** `prompts.rs`
 
-| Function | Description |
-|----------|-------------|
-| `select_one(label, options)` | Numbered single-choice menu |
-| `select_many(label, options, defaults)` | Checkbox multi-select (raw terminal mode) |
-| `input(label)` | Single line text input |
-| `optional_input(label, hint)` | Text input that can be empty |
-| `secret_input(label)` | Hidden input (shows `*` per char), returns `SecretString` |
-| `confirm(label, default)` | `[Y/n]` or `[y/N]` prompt |
-| `print_header(text)` | Bold section header with underline |
-| `print_step(n, total, text)` | `[1/7] Step Name` |
-| `print_success(text)` | Green `✓` prefix (ANSI color), message in default color |
-| `print_error(text)` | Red `✗` prefix (ANSI color), message in default color |
-| `print_info(text)` | Blue `ℹ` prefix (ANSI color), message in default color |
+| Function                                | Description                                               |
+| --------------------------------------- | --------------------------------------------------------- |
+| `select_one(label, options)`            | Numbered single-choice menu                               |
+| `select_many(label, options, defaults)` | Checkbox multi-select (raw terminal mode)                 |
+| `input(label)`                          | Single line text input                                    |
+| `optional_input(label, hint)`           | Text input that can be empty                              |
+| `secret_input(label)`                   | Hidden input (shows `*` per char), returns `SecretString` |
+| `confirm(label, default)`               | `[Y/n]` or `[y/N]` prompt                                 |
+| `print_header(text)`                    | Bold section header with underline                        |
+| `print_step(n, total, text)`            | `[1/7] Step Name`                                         |
+| `print_success(text)`                   | Green `✓` prefix (ANSI color), message in default color   |
+| `print_error(text)`                     | Red `✗` prefix (ANSI color), message in default color     |
+| `print_info(text)`                      | Blue `ℹ` prefix (ANSI color), message in default color    |
 
 `select_many` uses `crossterm` raw mode for arrow key navigation.
 Must properly restore terminal state on all exit paths.
@@ -683,6 +743,7 @@ Tests live in `mod tests {}` at the bottom of each file.
   don't panic
 
 **Run setup tests:**
+
 ```bash
 cargo test --lib -- setup
 cargo test --lib -- bootstrap

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -2,14 +2,15 @@
 //!
 //! The wizard guides users through:
 //! 1. Database connection
-//! 2. Security (secrets master key)
-//! 3. Inference provider (NEAR AI, Anthropic, OpenAI, OpenAI Codex, Ollama, OpenAI-compatible)
-//! 4. Model selection
-//! 5. Embeddings
-//! 6. Channel configuration
-//! 7. Extensions (tool installation from registry)
-//! 8. Docker sandbox
-//! 9. Heartbeat (background tasks)
+//! 2. Conversation history import (optional)
+//! 3. Security (secrets master key)
+//! 4. Inference provider (NEAR AI, Anthropic, OpenAI, OpenAI Codex, Ollama, OpenAI-compatible)
+//! 5. Model selection
+//! 6. Embeddings
+//! 7. Channel configuration
+//! 8. Extensions (tool installation from registry)
+//! 9. Docker sandbox
+//! 10. Heartbeat (background tasks)
 
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -84,6 +85,8 @@ pub struct SetupConfig {
     pub provider_only: bool,
     /// Quick setup: auto-defaults everything except LLM provider and model.
     pub quick: bool,
+    /// Force showing the conversation import step even if nothing is auto-detected.
+    pub import_history: bool,
 }
 
 /// Interactive setup wizard for IronClaw.
@@ -214,6 +217,15 @@ impl SetupWizard {
             self.try_load_existing_settings().await;
             self.settings.merge_from(&step1_settings);
 
+            let show_import_step = self.config.import_history
+                || !crate::cli::import::autodetect_import_sources().is_empty();
+            let total_steps = if show_import_step { 3 } else { 2 };
+
+            if show_import_step {
+                print_step(1, total_steps, "Import Conversation History");
+                self.step_import_history().await?;
+            }
+
             self.auto_setup_security().await?;
             self.persist_after_step().await;
 
@@ -255,16 +267,27 @@ impl SetupWizard {
                 }
                 self.persist_after_step().await;
             } else {
-                print_step(1, 2, "Inference Provider");
+                print_step(
+                    if show_import_step { 2 } else { 1 },
+                    total_steps,
+                    "Inference Provider",
+                );
                 self.step_inference_provider().await?;
                 self.persist_after_step().await;
 
-                print_step(2, 2, "Model Selection");
+                print_step(
+                    if show_import_step { 3 } else { 2 },
+                    total_steps,
+                    "Model Selection",
+                );
                 self.step_model_selection().await?;
                 self.persist_after_step().await;
             }
         } else {
-            let total_steps = 9;
+            let show_import_step = self.config.import_history
+                || !crate::cli::import::autodetect_import_sources().is_empty();
+            let step_offset = if show_import_step { 1 } else { 0 };
+            let total_steps = 9 + step_offset;
 
             // Step 1: Database
             print_step(1, total_steps, "Database Connection");
@@ -282,46 +305,51 @@ impl SetupWizard {
 
             self.persist_after_step().await;
 
-            // Step 2: Security
-            print_step(2, total_steps, "Security");
+            if show_import_step {
+                print_step(2, total_steps, "Import Conversation History");
+                self.step_import_history().await?;
+            }
+
+            // Step 2/3: Security
+            print_step(2 + step_offset, total_steps, "Security");
             self.step_security().await?;
             self.persist_after_step().await;
 
-            // Step 3: Inference provider selection (unless skipped)
+            // Step 3/4: Inference provider selection (unless skipped)
             if !self.config.skip_auth {
-                print_step(3, total_steps, "Inference Provider");
+                print_step(3 + step_offset, total_steps, "Inference Provider");
                 self.step_inference_provider().await?;
             } else {
                 print_info("Skipping inference provider setup (using existing config)");
             }
             self.persist_after_step().await;
 
-            // Step 4: Model selection
-            print_step(4, total_steps, "Model Selection");
+            // Step 4/5: Model selection
+            print_step(4 + step_offset, total_steps, "Model Selection");
             self.step_model_selection().await?;
             self.persist_after_step().await;
 
-            // Step 5: Embeddings
-            print_step(5, total_steps, "Embeddings (Semantic Search)");
+            // Step 5/6: Embeddings
+            print_step(5 + step_offset, total_steps, "Embeddings (Semantic Search)");
             self.step_embeddings()?;
             self.persist_after_step().await;
 
-            // Step 6: Channel configuration
-            print_step(6, total_steps, "Channel Configuration");
+            // Step 6/7: Channel configuration
+            print_step(6 + step_offset, total_steps, "Channel Configuration");
             self.step_channels().await?;
             self.persist_after_step().await;
 
-            // Step 7: Extensions (tools)
-            print_step(7, total_steps, "Extensions");
+            // Step 7/8: Extensions (tools)
+            print_step(7 + step_offset, total_steps, "Extensions");
             self.step_extensions().await?;
 
-            // Step 8: Docker Sandbox
-            print_step(8, total_steps, "Docker Sandbox");
+            // Step 8/9: Docker Sandbox
+            print_step(8 + step_offset, total_steps, "Docker Sandbox");
             self.step_docker_sandbox().await?;
             self.persist_after_step().await;
 
-            // Step 9: Heartbeat
-            print_step(9, total_steps, "Background Tasks");
+            // Step 9/10: Heartbeat
+            print_step(9 + step_offset, total_steps, "Background Tasks");
             self.step_heartbeat()?;
             self.persist_after_step().await;
 
@@ -816,7 +844,126 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 2: Security (secrets master key).
+    /// Optional onboarding step: import conversation history from other tools.
+    ///
+    /// Auto-detects known source locations and lets users import all, select
+    /// sources, or skip. If nothing is detected, this step is silent unless
+    /// `--import-history` forced it.
+    async fn step_import_history(&mut self) -> Result<(), SetupError> {
+        let detected = crate::cli::import::autodetect_import_sources();
+        if detected.is_empty() {
+            if self.config.import_history {
+                if crate::cli::import::has_supported_history_import_sources() {
+                    print_info("No conversation history exports were detected.");
+                    print_info("You can still import later with: ironclaw import <source> [path]");
+                } else {
+                    print_info("No source-specific history importers are available yet.");
+                    print_info(
+                        "This build only includes the shared import infrastructure; source-specific parser integrations are not available yet.",
+                    );
+                }
+            }
+            return Ok(());
+        }
+
+        print_info("Found conversation history from:");
+        for source in &detected {
+            print_info(&format!(
+                "• {} ({}) — {}",
+                source.source.display_name(),
+                source.note,
+                source.path.display()
+            ));
+        }
+
+        let choice = select_one(
+            "Choose an action:",
+            &["Import all", "Select sources", "Skip"],
+        )
+        .map_err(SetupError::Io)?;
+
+        let selected_indices = match choice {
+            0 => (0..detected.len()).collect::<Vec<_>>(),
+            1 => {
+                let options = detected
+                    .iter()
+                    .map(|source| {
+                        (
+                            format!(
+                                "{} ({}) — {}",
+                                source.source.display_name(),
+                                source.note,
+                                source.path.display()
+                            ),
+                            true,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+                let options_refs = options
+                    .iter()
+                    .map(|(label, selected)| (label.as_str(), *selected))
+                    .collect::<Vec<_>>();
+                select_many("Select sources to import:", &options_refs).map_err(SetupError::Io)?
+            }
+            _ => Vec::new(),
+        };
+
+        if selected_indices.is_empty() {
+            print_info("Skipped conversation history import.");
+            return Ok(());
+        }
+
+        let db = self.import_database()?;
+
+        for index in selected_indices {
+            let source = &detected[index];
+            let args = crate::cli::import::HistoryImportArgs {
+                path: Some(source.path.clone()),
+                user_id: self.owner_id().to_string(),
+                dedup: true,
+                to_workspace: true,
+                dry_run: false,
+            };
+
+            print_info(&format!(
+                "Importing {} from {}...",
+                source.source.display_name(),
+                source.path.display()
+            ));
+
+            if let Err(err) =
+                crate::cli::import::run_import_command_with_db(source.source, &args, db.clone())
+                    .await
+            {
+                print_error(&format!(
+                    "Import failed for {}: {}",
+                    source.source.display_name(),
+                    err
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn import_database(&self) -> Result<Arc<dyn crate::db::Database>, SetupError> {
+        #[cfg(feature = "postgres")]
+        if let Some(ref pool) = self.db_pool {
+            return Ok(Arc::new(crate::db::postgres::PgBackend::from_pool(
+                pool.clone(),
+            )));
+        }
+
+        #[cfg(feature = "libsql")]
+        if let Some(ref backend) = self.db_backend {
+            return Ok(Arc::new((*backend).clone()));
+        }
+
+        Err(SetupError::Database(
+            "Database is not available for import. Complete Step 1 first.".to_string(),
+        ))
+    }
+    /// Step 3: Security (secrets master key).
     async fn step_security(&mut self) -> Result<(), SetupError> {
         // Check current configuration
         let env_key_exists = std::env::var("SECRETS_MASTER_KEY").is_ok();
@@ -1060,7 +1207,7 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 3: Inference provider selection.
+    /// Step 4: Inference provider selection.
     ///
     /// Uses the provider registry to dynamically build the selection menu.
     /// NearAI is always first (special auth), then all registry providers
@@ -1697,7 +1844,7 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 4: Model selection.
+    /// Step 5: Model selection.
     ///
     /// Branches on the selected LLM backend and fetches models from the
     /// appropriate provider API, with static defaults as fallback.
@@ -1891,7 +2038,7 @@ impl SetupWizard {
         }
     }
 
-    /// Step 5: Embeddings configuration.
+    /// Step 6: Embeddings configuration.
     fn step_embeddings(&mut self) -> Result<(), SetupError> {
         print_info("Embeddings enable semantic search in your workspace memory.");
         println!();
@@ -2094,7 +2241,7 @@ impl SetupWizard {
         }
     }
 
-    /// Step 6: Channel configuration.
+    /// Step 7: Channel configuration.
     async fn step_channels(&mut self) -> Result<(), SetupError> {
         // First, configure tunnel (shared across all channels that need webhooks)
         match setup_tunnel(&self.settings).await {
@@ -2301,7 +2448,7 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 7: Extensions (tools) installation from registry.
+    /// Step 8: Extensions (tools) installation from registry.
     async fn step_extensions(&mut self) -> Result<(), SetupError> {
         let catalog = match load_registry_catalog() {
             Some(c) => c,
@@ -2427,7 +2574,7 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 8: Docker Sandbox -- check Docker installation and availability.
+    /// Step 9: Docker Sandbox -- check Docker installation and availability.
     async fn step_docker_sandbox(&mut self) -> Result<(), SetupError> {
         print_info("IronClaw can execute code, run builds, and use tools inside Docker");
         print_info("containers. This keeps your system safe -- commands from the LLM run");
@@ -2566,7 +2713,7 @@ impl SetupWizard {
         Ok(())
     }
 
-    /// Step 9: Heartbeat configuration.
+    /// Step 10: Heartbeat configuration.
     fn step_heartbeat(&mut self) -> Result<(), SetupError> {
         print_info("Heartbeat runs periodic background tasks (e.g., checking your calendar,");
         print_info("monitoring for notifications, running scheduled workflows).");
@@ -3409,6 +3556,7 @@ mod tests {
             channels_only: false,
             provider_only: false,
             quick: false,
+            import_history: false,
         };
         let wizard = SetupWizard::with_config(config);
         assert!(wizard.config.skip_auth);

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -780,6 +780,32 @@ mod tests {
             .expect("page 1");
         assert_eq!(page1.len(), 3, "first page should have 3 messages");
         assert!(has_more, "should indicate more messages exist");
+        assert_eq!(
+            page1
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["msg 2", "msg 3", "msg 4"]
+        );
+
+        let (page2, has_more) = db
+            .list_conversation_messages_paginated(
+                conv_id,
+                Some(crate::db::ConversationPageCursor::Sequence(
+                    page1.first().expect("page1 first message").sequence_num,
+                )),
+                3,
+            )
+            .await
+            .expect("page 2");
+        assert_eq!(
+            page2
+                .iter()
+                .map(|message| message.content.as_str())
+                .collect::<Vec<_>>(),
+            vec!["msg 0", "msg 1"]
+        );
+        assert!(!has_more, "second page should exhaust the conversation");
 
         // Verify all messages can be retrieved with a large limit.
         let (all, _) = db
@@ -791,10 +817,101 @@ mod tests {
         // Messages are returned oldest-first (ascending created_at).
         for w in all.windows(2) {
             assert!(
-                w[0].created_at <= w[1].created_at,
-                "messages should be in ascending created_at order"
+                w[0].sequence_num < w[1].sequence_num,
+                "messages should be in ascending explicit sequence order"
             );
         }
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_imported_messages_preserve_timestamps_and_sequence_order() {
+        use chrono::TimeZone as _;
+
+        let harness = TestHarnessBuilder::new().build().await;
+        let db = &harness.db;
+
+        let started_at = chrono::Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 0).unwrap();
+        let last_activity = chrono::Utc.with_ymd_and_hms(2024, 1, 15, 10, 5, 0).unwrap();
+        let shared_timestamp = chrono::Utc.with_ymd_and_hms(2024, 1, 15, 10, 0, 5).unwrap();
+        let final_timestamp = chrono::Utc
+            .with_ymd_and_hms(2024, 1, 15, 10, 4, 30)
+            .unwrap();
+
+        let conversation_id = db
+            .create_conversation_with_metadata_and_timestamps(
+                "imported",
+                "import-user",
+                &serde_json::json!({
+                    "import_source": "chatgpt",
+                    "import_source_id": "conv-preserve-1",
+                }),
+                started_at,
+                last_activity,
+            )
+            .await
+            .expect("create imported conversation");
+
+        db.add_conversation_message_with_metadata(
+            conversation_id,
+            "user",
+            "first",
+            shared_timestamp,
+            Some(0),
+        )
+        .await
+        .expect("insert first imported message");
+        db.add_conversation_message_with_metadata(
+            conversation_id,
+            "assistant",
+            "second",
+            shared_timestamp,
+            Some(1),
+        )
+        .await
+        .expect("insert second imported message");
+        db.add_conversation_message_with_metadata(
+            conversation_id,
+            "user",
+            "third",
+            final_timestamp,
+            Some(2),
+        )
+        .await
+        .expect("insert third imported message");
+
+        let summary = db
+            .list_conversations_all_channels("import-user", 10)
+            .await
+            .expect("list imported conversations")
+            .into_iter()
+            .find(|conversation| conversation.id == conversation_id)
+            .expect("imported conversation summary");
+        assert_eq!(summary.started_at, started_at);
+        assert_eq!(summary.last_activity, last_activity);
+
+        let messages = db
+            .list_conversation_messages(conversation_id)
+            .await
+            .expect("list imported messages");
+        assert_eq!(
+            messages
+                .iter()
+                .map(|message| (
+                    message.sequence_num,
+                    message.role.as_str(),
+                    message.content.as_str()
+                ))
+                .collect::<Vec<_>>(),
+            vec![
+                (0, "user", "first"),
+                (1, "assistant", "second"),
+                (2, "user", "third")
+            ]
+        );
+        assert_eq!(messages[0].created_at, shared_timestamp);
+        assert_eq!(messages[1].created_at, shared_timestamp);
+        assert_eq!(messages[2].created_at, final_timestamp);
     }
 
     #[cfg(feature = "libsql")]


### PR DESCRIPTION
## Summary

Implements the shared conversation history import infrastructure for #149.

This PR adds:
- shared `Importer` trait and normalized import types
- `ironclaw import <source> [path]` CLI entrypoint
- import orchestration with dry-run support, dedup, and optional workspace write
- database support for import dedup in both PostgreSQL and libSQL
- onboarding integration for conversation import infrastructure
- setup spec and feature parity updates

This PR is intentionally the parent infrastructure only. Source-specific parsers are left for follow-up PRs:
- #150 Claude
- #151 OpenAI / ChatGPT
- #152 Gemini

## Scope

Included:
- generic import plumbing in `src/cli/import.rs`
- CLI wiring in `src/cli/mod.rs`
- DB dedup API in both backends
- onboarding import step
- workspace write path for imported conversations
- setup spec and parity updates

Not included:
- Claude parser implementation
- ChatGPT / Codex parser implementation
- Gemini parser implementation

## Fidelity Improvements

This PR also tightens the underlying history model so source-specific importers can plug into a correct storage path:

- preserve imported conversation timestamps in real conversation rows
- preserve imported message timestamps
- store explicit message ordering via `sequence_num`
- use stable history pagination cursors
- add migration-forward regression coverage for the new ordering column
- avoid workspace filename collisions for duplicate conversation titles

## Onboarding Behavior

Because this is the infra-only parent PR, onboarding only surfaces sources whose parsers are implemented in the current build.

That keeps the parent PR honest as a standalone merge while preserving the shared import surface for follow-up parser PRs.

