### PR TITLE
fix(agent): prevent cross-channel approval hijacking

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -10,7 +10,6 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
-use uuid::Uuid;
 
 use crate::agent::context_monitor::ContextMonitor;
 use crate::agent::heartbeat::spawn_heartbeat;
@@ -1015,59 +1014,18 @@ impl Agent {
             }
         }
 
-        // Resolve session and thread. Approval submissions are allowed to
-        // target an already-loaded owned thread by UUID across channels so the
-        // web approval UI can approve work that originated from HTTP/other
-        // owner-scoped channels.
-        let approval_thread_uuid = if matches!(
-            submission,
-            Submission::ExecApproval { .. } | Submission::ApprovalResponse { .. }
-        ) {
-            message
-                .conversation_scope()
-                .and_then(|thread_id| Uuid::parse_str(thread_id).ok())
-        } else {
-            None
-        };
-
-        let (session, thread_id) = if let Some(target_thread_id) = approval_thread_uuid {
-            let session = self
-                .session_manager
-                .get_or_create_session(&message.user_id)
-                .await;
-            let mut sess = session.lock().await;
-            if sess.threads.contains_key(&target_thread_id) {
-                sess.active_thread = Some(target_thread_id);
-                sess.last_active_at = chrono::Utc::now();
-                drop(sess);
-                self.session_manager
-                    .register_thread(
-                        &message.user_id,
-                        &message.channel,
-                        target_thread_id,
-                        Arc::clone(&session),
-                    )
-                    .await;
-                (session, target_thread_id)
-            } else {
-                drop(sess);
-                self.session_manager
-                    .resolve_thread(
-                        &message.user_id,
-                        &message.channel,
-                        message.conversation_scope(),
-                    )
-                    .await
-            }
-        } else {
-            self.session_manager
-                .resolve_thread(
-                    &message.user_id,
-                    &message.channel,
-                    message.conversation_scope(),
-                )
-                .await
-        };
+        // Resolve session and thread using the normal channel-scoped mapping.
+        // Approval submissions must follow the same ownership rules as other
+        // inputs so a UUID from a different channel cannot be adopted into the
+        // current channel's session.
+        let (session, thread_id) = self
+            .session_manager
+            .resolve_thread(
+                &message.user_id,
+                &message.channel,
+                message.conversation_scope(),
+            )
+            .await;
         tracing::debug!(
             message_id = %message.id,
             thread_id = %thread_id,


### PR DESCRIPTION
Fixes #1485.

Removes the approval-only cross-channel UUID adoption path in Agent::run so approval submissions follow normal channel-scoped thread resolution. This prevents a message on a different channel from hijacking a thread that belongs elsewhere in the session.

Validation:
- cargo fmt --all -- --check
- cargo check -q
- targeted session_manager cross-channel tests