### PR TITLE
fix(agent): reduce approval thread lock contention

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1040,14 +1040,20 @@ impl Agent {
                 sess.active_thread = Some(target_thread_id);
                 sess.last_active_at = chrono::Utc::now();
                 drop(sess);
-                self.session_manager
-                    .register_thread(
-                        &message.user_id,
-                        &message.channel,
-                        target_thread_id,
-                        Arc::clone(&session),
-                    )
-                    .await;
+                if !self
+                    .session_manager
+                    .is_thread_registered(&message.user_id, &message.channel, target_thread_id)
+                    .await
+                {
+                    self.session_manager
+                        .register_thread(
+                            &message.user_id,
+                            &message.channel,
+                            target_thread_id,
+                            Arc::clone(&session),
+                        )
+                        .await;
+                }
                 (session, target_thread_id)
             } else {
                 drop(sess);

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1019,16 +1019,16 @@ impl Agent {
         // target an already-loaded owned thread by UUID across channels so the
         // web approval UI can approve work that originated from HTTP/other
         // owner-scoped channels.
-        let approval_thread_uuid = if matches!(
+        let approval_thread_scope = if matches!(
             submission,
             Submission::ExecApproval { .. } | Submission::ApprovalResponse { .. }
         ) {
-            message
-                .conversation_scope()
-                .and_then(|thread_id| Uuid::parse_str(thread_id).ok())
+            message.conversation_scope()
         } else {
             None
         };
+        let approval_thread_uuid =
+            approval_thread_scope.and_then(|thread_id| Uuid::parse_str(thread_id).ok());
 
         let (session, thread_id) = if let Some(target_thread_id) = approval_thread_uuid {
             let session = self
@@ -1040,11 +1040,26 @@ impl Agent {
                 sess.active_thread = Some(target_thread_id);
                 sess.last_active_at = chrono::Utc::now();
                 drop(sess);
-                if !self
-                    .session_manager
-                    .is_thread_registered(&message.user_id, &message.channel, target_thread_id)
-                    .await
-                {
+                if let Some(approval_thread_scope) = approval_thread_scope {
+                    if !self
+                        .session_manager
+                        .is_thread_registered(
+                            &message.user_id,
+                            &message.channel,
+                            approval_thread_scope,
+                        )
+                        .await
+                    {
+                        self.session_manager
+                            .register_thread(
+                                &message.user_id,
+                                &message.channel,
+                                target_thread_id,
+                                Arc::clone(&session),
+                            )
+                            .await;
+                    }
+                } else {
                     self.session_manager
                         .register_thread(
                             &message.user_id,

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -221,6 +221,29 @@ impl SessionManager {
         }
     }
 
+    /// Check whether a thread is already registered for the given user/channel.
+    ///
+    /// This is a cheap read-only lookup used by approval routing to avoid
+    /// taking the session write lock on the common path where the approval
+    /// thread is already mapped.
+    pub async fn is_thread_registered(
+        &self,
+        user_id: &str,
+        channel: &str,
+        thread_id: Uuid,
+    ) -> bool {
+        let key = ThreadKey {
+            user_id: user_id.to_string(),
+            channel: channel.to_string(),
+            external_thread_id: Some(thread_id.to_string()),
+        };
+
+        let thread_map = self.thread_map.read().await;
+        thread_map
+            .get(&key)
+            .is_some_and(|mapped| *mapped == thread_id)
+    }
+
     /// Get undo manager for a thread.
     pub async fn get_undo_manager(&self, thread_id: Uuid) -> Arc<Mutex<UndoManager>> {
         // Fast path
@@ -666,6 +689,37 @@ mod tests {
             let sessions = manager.sessions.read().await;
             assert!(sessions.contains_key("user-new"));
         }
+    }
+
+    #[tokio::test]
+    async fn test_is_thread_registered() {
+        use crate::agent::session::{Session, Thread};
+
+        let manager = SessionManager::new();
+        let tid = Uuid::new_v4();
+        let session = Arc::new(Mutex::new(Session::new("user-reg")));
+
+        {
+            let mut sess = session.lock().await;
+            let thread = Thread::with_id(tid, sess.id);
+            sess.threads.insert(tid, thread);
+        }
+
+        assert!(
+            !manager
+                .is_thread_registered("user-reg", "gateway", tid)
+                .await
+        );
+
+        manager
+            .register_thread("user-reg", "gateway", tid, Arc::clone(&session))
+            .await;
+
+        assert!(
+            manager
+                .is_thread_registered("user-reg", "gateway", tid)
+                .await
+        );
     }
 
     #[tokio::test]

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -230,18 +230,14 @@ impl SessionManager {
         &self,
         user_id: &str,
         channel: &str,
-        thread_id: Uuid,
+        external_thread_id: &str,
     ) -> bool {
-        let key = ThreadKey {
-            user_id: user_id.to_string(),
-            channel: channel.to_string(),
-            external_thread_id: Some(thread_id.to_string()),
-        };
-
         let thread_map = self.thread_map.read().await;
-        thread_map
-            .get(&key)
-            .is_some_and(|mapped| *mapped == thread_id)
+        thread_map.iter().any(|(key, _)| {
+            key.user_id == user_id
+                && key.channel == channel
+                && key.external_thread_id.as_deref() == Some(external_thread_id)
+        })
     }
 
     /// Get undo manager for a thread.
@@ -707,7 +703,7 @@ mod tests {
 
         assert!(
             !manager
-                .is_thread_registered("user-reg", "gateway", tid)
+                .is_thread_registered("user-reg", "gateway", &tid.to_string())
                 .await
         );
 
@@ -717,7 +713,7 @@ mod tests {
 
         assert!(
             manager
-                .is_thread_registered("user-reg", "gateway", tid)
+                .is_thread_registered("user-reg", "gateway", &tid.to_string())
                 .await
         );
     }
@@ -856,7 +852,7 @@ mod tests {
     // === QA Plan P3 - 4.2: Concurrent session stress tests ===
 
     #[tokio::test]
-    async fn concurrent_get_or_create_same_user_returns_same_session() {
+    async fn concurrent_get_or_create_same_user_returns_same_session() -> anyhow::Result<()> {
         let manager = Arc::new(SessionManager::new());
 
         let handles: Vec<_> = (0..30)
@@ -868,17 +864,19 @@ mod tests {
 
         let mut sessions = Vec::new();
         for handle in handles {
-            sessions.push(handle.await.expect("task should not panic"));
+            sessions.push(handle.await?);
         }
 
         // All 30 must return the *same* Arc (double-checked locking guarantee).
         for s in &sessions {
             assert!(Arc::ptr_eq(&sessions[0], s));
         }
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn concurrent_resolve_thread_distinct_users_no_cross_talk() {
+    async fn concurrent_resolve_thread_distinct_users_no_cross_talk() -> anyhow::Result<()> {
         let manager = Arc::new(SessionManager::new());
 
         let handles: Vec<_> = (0..20)
@@ -894,7 +892,7 @@ mod tests {
 
         let mut results = Vec::new();
         for handle in handles {
-            results.push(handle.await.expect("task should not panic"));
+            results.push(handle.await?);
         }
 
         // All thread IDs must be unique.
@@ -907,10 +905,12 @@ mod tests {
             assert!(sess.threads.contains_key(tid));
             assert_eq!(sess.threads.len(), 1);
         }
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn concurrent_resolve_thread_same_user_different_channels() {
+    async fn concurrent_resolve_thread_same_user_different_channels() -> anyhow::Result<()> {
         let manager = Arc::new(SessionManager::new());
         let channels = ["gateway", "telegram", "slack", "cli", "repl"];
 
@@ -928,7 +928,7 @@ mod tests {
 
         let mut results = Vec::new();
         for handle in handles {
-            results.push(handle.await.expect("task should not panic"));
+            results.push(handle.await?);
         }
 
         // All 5 threads must be unique (different channels = different keys).
@@ -938,10 +938,12 @@ mod tests {
         // All threads should live in the same session.
         let sess = results[0].1.lock().await;
         assert_eq!(sess.threads.len(), 5);
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn concurrent_get_undo_manager_same_thread_returns_same_arc() {
+    async fn concurrent_get_undo_manager_same_thread_returns_same_arc() -> anyhow::Result<()> {
         let manager = Arc::new(SessionManager::new());
         let (_, tid) = manager.resolve_thread("undo-user", "gateway", None).await;
 
@@ -954,13 +956,15 @@ mod tests {
 
         let mut managers = Vec::new();
         for handle in handles {
-            managers.push(handle.await.expect("task should not panic"));
+            managers.push(handle.await?);
         }
 
         // All 20 must point to the same UndoManager.
         for m in &managers {
             assert!(Arc::ptr_eq(&managers[0], m));
         }
+
+        Ok(())
     }
 
     #[tokio::test]


### PR DESCRIPTION
Addresses #1489 by skipping the redundant session write-lock path when an approval thread is already registered, reducing lock contention in approval thread resolution.

Validation:
- cargo fmt --all -- --check
- cargo clippy -p ironclaw --lib --all-features -- -D warnings
- cargo test -p ironclaw test_is_thread_registered -- --nocapture