### PR TITLE
feat(routines): surface notifications in chat context

### DIFF
--- a/migrations/V14__conversation_notifications.sql
+++ b/migrations/V14__conversation_notifications.sql
@@ -1,0 +1,18 @@
+-- Persist routine notifications so the next user reply can see them as context.
+
+CREATE TABLE conversation_notifications (
+    id UUID PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    conversation_scope_id TEXT,
+    source_kind TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    consumed_at TIMESTAMPTZ,
+    expires_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_conversation_notifications_lookup
+    ON conversation_notifications(user_id, channel, conversation_scope_id, consumed_at, created_at);

--- a/src/agent/CLAUDE.md
+++ b/src/agent/CLAUDE.md
@@ -42,6 +42,7 @@ Session (per user)
 
 - A session has one **active thread** at a time; threads can be switched.
 - Turns are append-only. Undo rolls back by restoring a prior checkpoint (message list, not a full thread snapshot).
+- Routine notifications are stored separately from turns and injected into the next user turn as a transient system message, so they can influence LLM context without becoming fake user/assistant turns.
 - `UndoManager` is per-thread, stored in `SessionManager`, not on `Session` itself. Max 20 checkpoints (oldest dropped when exceeded).
 - Group chat detection: if `metadata.chat_type` is `group`/`channel`/`supergroup`, `MEMORY.md` is excluded from the system prompt to prevent leaking personal context.
 - **Auth mode**: if a thread has `pending_auth` set (e.g. from `tool_auth` returning `awaiting_token`), the next user message is intercepted before any turn creation, logging, or safety validation and sent directly to the credential store. Any control submission (undo, interrupt, etc.) cancels auth mode.

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -136,6 +136,52 @@ fn should_fallback_routine_notification(error: &ChannelError) -> bool {
     !matches!(error, ChannelError::MissingRoutingTarget { .. })
 }
 
+async fn persist_routine_notification(
+    store: Option<Arc<dyn Database>>,
+    channel: &str,
+    user_id: &str,
+    response: &OutgoingResponse,
+) {
+    let Some(store) = store else {
+        return;
+    };
+
+    let source_id = response
+        .metadata
+        .get("routine_id")
+        .and_then(|value| value.as_str())
+        .or_else(|| {
+            response
+                .metadata
+                .get("routine_name")
+                .and_then(|value| value.as_str())
+        })
+        .unwrap_or("routine");
+    let expires_at = Some(chrono::Utc::now() + chrono::TimeDelta::seconds(7 * 24 * 60 * 60));
+    let metadata = response.metadata.clone();
+
+    if let Err(e) = store
+        .add_conversation_notification(
+            user_id,
+            channel,
+            None,
+            "routine",
+            source_id,
+            &response.content,
+            &metadata,
+            expires_at,
+        )
+        .await
+    {
+        tracing::warn!(
+            channel = %channel,
+            user = %user_id,
+            error = %e,
+            "Failed to persist routine notification context"
+        );
+    }
+}
+
 /// Core dependencies for the agent.
 ///
 /// Bundles the shared components to reduce argument count.
@@ -620,6 +666,7 @@ impl Agent {
 
                     // Spawn notification forwarder (mirrors heartbeat pattern)
                     let channels = self.channels.clone();
+                    let store = self.store().cloned();
                     let extension_manager = self.deps.extension_manager.clone();
                     tokio::spawn(async move {
                         while let Some(response) = notify_rx.recv().await {
@@ -674,7 +721,9 @@ impl Agent {
                             };
 
                             if !targeted_ok && let Some(user) = fallback_user {
-                                let results = channels.broadcast_all(&user, response).await;
+                                let fallback_response = response.clone();
+                                let results =
+                                    channels.broadcast_all(&user, fallback_response).await;
                                 for (ch, result) in results {
                                     if let Err(e) = result {
                                         tracing::warn!(
@@ -682,8 +731,24 @@ impl Agent {
                                             ch,
                                             e
                                         );
+                                    } else {
+                                        persist_routine_notification(
+                                            store.clone(),
+                                            &ch,
+                                            &user,
+                                            &response,
+                                        )
+                                        .await;
                                     }
                                 }
+                            } else if targeted_ok {
+                                persist_routine_notification(
+                                    store.clone(),
+                                    notify_channel.as_deref().unwrap_or(""),
+                                    &user,
+                                    &response,
+                                )
+                                .await;
                             }
                         }
                     });

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -157,7 +157,7 @@ async fn persist_routine_notification(
                 .and_then(|value| value.as_str())
         })
         .unwrap_or("routine");
-    let expires_at = Some(chrono::Utc::now() + chrono::TimeDelta::seconds(7 * 24 * 60 * 60));
+    let expires_at = Some(chrono::Utc::now() + chrono::TimeDelta::days(7));
     let metadata = response.metadata.clone();
 
     if let Err(e) = store
@@ -742,13 +742,23 @@ impl Agent {
                                     }
                                 }
                             } else if targeted_ok {
-                                persist_routine_notification(
-                                    store.clone(),
-                                    notify_channel.as_deref().unwrap_or(""),
-                                    &user,
-                                    &response,
-                                )
-                                .await;
+                                if let Some(channel) = notify_channel
+                                    .as_deref()
+                                    .filter(|channel| !channel.is_empty())
+                                {
+                                    persist_routine_notification(
+                                        store.clone(),
+                                        channel,
+                                        &user,
+                                        &response,
+                                    )
+                                    .await;
+                                } else {
+                                    tracing::warn!(
+                                        user = %user,
+                                        "Skipping routine notification persistence: missing notify channel"
+                                    );
+                                }
                             }
                         }
                     });

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -627,6 +627,7 @@ impl RoutineEngine {
             &self.notify_tx,
             &routine.notify,
             &routine.user_id,
+            routine.id,
             &routine.name,
             status,
             Some(summary),
@@ -1103,6 +1104,7 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
         &ctx.notify_tx,
         &routine.notify,
         &routine.user_id,
+        routine.id,
         &routine.name,
         status,
         summary.as_deref(),
@@ -1706,10 +1708,12 @@ async fn execute_routine_tool(
 }
 
 /// Send a notification based on the routine's notify config and run status.
+#[allow(clippy::too_many_arguments)]
 async fn send_notification(
     tx: &mpsc::Sender<OutgoingResponse>,
     notify: &NotifyConfig,
     owner_id: &str,
+    routine_id: Uuid,
     routine_name: &str,
     status: RunStatus,
     summary: Option<&str>,
@@ -1744,11 +1748,13 @@ async fn send_notification(
         attachments: Vec::new(),
         metadata: serde_json::json!({
             "source": "routine",
+            "routine_id": routine_id,
             "routine_name": routine_name,
             "status": status.to_string(),
             "owner_id": owner_id,
             "notify_user": notify.user,
             "notify_channel": notify.channel,
+            "notify_thread_id": thread_id,
         }),
     };
 

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1899,7 +1899,8 @@ mod tests {
     }
 
     #[test]
-    fn test_rebuild_chat_messages_with_enriched_tool_calls() {
+    fn test_rebuild_chat_messages_with_enriched_tool_calls()
+    -> Result<(), Box<dyn std::error::Error>> {
         let tool_json = serde_json::json!([
             {
                 "name": "memory_search",
@@ -1931,7 +1932,9 @@ mod tests {
         // assistant with tool_calls
         assert_eq!(result[1].role, crate::llm::Role::Assistant);
         assert!(result[1].tool_calls.is_some());
-        let tcs = result[1].tool_calls.as_ref().unwrap();
+        let tcs = result[1].tool_calls.as_ref().ok_or_else(|| {
+            std::io::Error::other("expected assistant tool calls in rebuilt messages")
+        })?;
         assert_eq!(tcs.len(), 2);
         assert_eq!(tcs[0].name, "memory_search");
         assert_eq!(tcs[0].id, "call_0");
@@ -1949,6 +1952,7 @@ mod tests {
         // final assistant
         assert_eq!(result[4].role, crate::llm::Role::Assistant);
         assert_eq!(result[4].content, "I found some results.");
+        Ok(())
     }
 
     #[test]
@@ -2032,7 +2036,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_awaiting_approval_rejection_includes_tool_context() {
+    async fn test_awaiting_approval_rejection_includes_tool_context()
+    -> Result<(), Box<dyn std::error::Error>> {
         // Test that when a thread is in AwaitingApproval state and receives a new message,
         // process_user_input rejects it with a non-error status that includes tool context.
         use crate::agent::session::{PendingApproval, Session, Thread, ThreadState};
@@ -2099,8 +2104,11 @@ mod tests {
                     msg
                 );
             }
-            _ => panic!("Expected approval rejection message"),
+            _ => {
+                return Err(std::io::Error::other("expected approval rejection message").into());
+            }
         }
+        Ok(())
     }
 
     // Helper function to extract the approval message without needing a full Agent instance

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -20,15 +20,96 @@ use crate::channels::web::util::truncate_preview;
 use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
 use crate::error::Error;
+use crate::history::ConversationNotification;
 use crate::llm::{ChatMessage, ToolCall};
 use crate::tools::redact_params;
 
 const FORGED_THREAD_ID_ERROR: &str = "Invalid or unauthorized thread ID.";
+const ROUTINE_NOTIFICATION_CONTEXT_LIMIT: i64 = 5;
+const ROUTINE_NOTIFICATION_PREVIEW_CHARS: usize = 400;
 
 fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     // Gateway-style channels send server-issued conversation UUIDs.
     // Unknown UUIDs should be rejected instead of silently creating a new thread.
     matches!(channel, "gateway" | "test")
+}
+
+fn routine_notification_title(notification: &ConversationNotification) -> String {
+    notification
+        .metadata
+        .get("routine_name")
+        .and_then(|value| value.as_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| notification.source_id.clone())
+}
+
+fn routine_notification_digest(notifications: &[ConversationNotification]) -> String {
+    let mut lines = Vec::with_capacity(notifications.len() + 2);
+    lines.push("Recent routine notifications for this conversation:".to_string());
+    for notification in notifications {
+        let title = routine_notification_title(notification);
+        let preview = truncate_preview(&notification.content, ROUTINE_NOTIFICATION_PREVIEW_CHARS);
+        lines.push(format!("- {title}: {preview}"));
+    }
+    lines.push("Use this context when answering the user's next message.".to_string());
+    lines.join("\n")
+}
+
+async fn load_routine_notification_context(
+    agent: &Agent,
+    message: &IncomingMessage,
+) -> (Vec<Uuid>, Option<ChatMessage>) {
+    let Some(store) = agent.store() else {
+        return (Vec::new(), None);
+    };
+
+    let scope = message.conversation_scope();
+    match store
+        .list_unread_conversation_notifications(
+            &message.user_id,
+            &message.channel,
+            scope,
+            ROUTINE_NOTIFICATION_CONTEXT_LIMIT,
+        )
+        .await
+    {
+        Ok(notifications) if !notifications.is_empty() => {
+            let notification_ids = notifications.iter().map(|n| n.id).collect();
+            let digest = routine_notification_digest(&notifications);
+            (notification_ids, Some(ChatMessage::system(digest)))
+        }
+        Ok(_) => (Vec::new(), None),
+        Err(e) => {
+            tracing::warn!(
+                user = %message.user_id,
+                channel = %message.channel,
+                error = %e,
+                "Failed to load routine notification context"
+            );
+            (Vec::new(), None)
+        }
+    }
+}
+
+async fn consume_routine_notification_context(agent: &Agent, notification_ids: &[Uuid]) {
+    if notification_ids.is_empty() {
+        return;
+    }
+
+    let Some(store) = agent.store() else {
+        return;
+    };
+
+    if let Err(e) = store
+        .mark_conversation_notifications_consumed(notification_ids)
+        .await
+    {
+        tracing::warn!(
+            notification_count = notification_ids.len(),
+            error = %e,
+            "Failed to mark routine notifications consumed"
+        );
+    }
 }
 
 impl Agent {
@@ -361,7 +442,7 @@ impl Agent {
         };
 
         // Start the turn and get messages
-        let turn_messages = {
+        let mut turn_messages = {
             let mut sess = session.lock().await;
             let thread = sess
                 .threads
@@ -371,6 +452,12 @@ impl Agent {
             turn.image_content_parts = image_parts;
             thread.messages()
         };
+
+        let (notification_ids, notification_context) =
+            load_routine_notification_context(self, message).await;
+        if let Some(notification_message) = notification_context {
+            turn_messages.insert(0, notification_message);
+        }
 
         // Persist user message to DB immediately so it survives crashes
         tracing::debug!(
@@ -415,6 +502,7 @@ impl Agent {
             .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
 
         if thread.state == ThreadState::Interrupted {
+            consume_routine_notification_context(self, &notification_ids).await;
             let _ = self
                 .channels
                 .send_status(
@@ -498,6 +586,7 @@ impl Agent {
                         .await;
                 }
 
+                consume_routine_notification_context(self, &notification_ids).await;
                 Ok(SubmissionResult::response(response))
             }
             Ok(AgenticLoopResult::NeedApproval { pending }) => {
@@ -522,6 +611,7 @@ impl Agent {
                         &message.metadata,
                     )
                     .await;
+                consume_routine_notification_context(self, &notification_ids).await;
                 Ok(SubmissionResult::NeedApproval {
                     request_id,
                     tool_name,
@@ -533,6 +623,7 @@ impl Agent {
             Err(e) => {
                 thread.fail_turn(e.to_string());
                 // User message already persisted at turn start; nothing else to save
+                consume_routine_notification_context(self, &notification_ids).await;
                 Ok(SubmissionResult::error(e.to_string()))
             }
         }

--- a/src/db/CLAUDE.md
+++ b/src/db/CLAUDE.md
@@ -37,7 +37,7 @@ cargo check --all-features                            # both
 | `libsql_migrations.rs` | Consolidated libSQL schema (CREATE IF NOT EXISTS, no ALTER TABLE) |
 | `tls.rs` | TLS connector factory for PostgreSQL (`rustls` + system root certs) |
 
-PostgreSQL schema: `migrations/V1__initial.sql` through `V9__flexible_embedding_dimension.sql` (managed by `refinery`). V1 is the base schema; later migrations add tables, columns, and rename `claude_code_events` → `job_events`.
+PostgreSQL schema: `migrations/V1__initial.sql` through `V14__conversation_notifications.sql` (managed by `refinery`). V1 is the base schema; later migrations add tables, columns, and rename `claude_code_events` → `job_events`.
 
 ## Trait Structure
 
@@ -45,7 +45,7 @@ The `Database` supertrait is composed of seven sub-traits. Leaf consumers can de
 
 | Sub-trait | Methods | Covers |
 |-----------|---------|--------|
-| `ConversationStore` | 12 | Conversations, messages |
+| `ConversationStore` | 18 | Conversations, messages, routine notifications |
 | `JobStore` | 13 | Agent jobs, actions, LLM calls, estimation |
 | `SandboxStore` | 13 | Sandbox jobs, job events |
 | `RoutineStore` | 15 | Routines, routine runs |
@@ -99,6 +99,7 @@ The `Database` supertrait is composed of seven sub-traits. Leaf consumers can de
 **Core:**
 - `conversations` — multi-channel conversation tracking
 - `conversation_messages` — individual messages within a conversation
+- `conversation_notifications` — unread routine notification records injected into the next user turn
 - `agent_jobs` — job metadata and status
 - `job_actions` — event-sourced tool executions
 - `job_events` — sandbox job streaming events (renamed from `claude_code_events` in V7)

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -2,7 +2,7 @@
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
-use libsql::params;
+use libsql::{params, params_from_iter};
 use uuid::Uuid;
 
 use super::{LibSqlBackend, fmt_ts, get_i64, get_json, get_opt_text, get_text, get_ts, opt_text};
@@ -678,18 +678,25 @@ impl ConversationStore for LibSqlBackend {
 
         let conn = self.connect().await?;
         let now = fmt_ts(&Utc::now());
-        for notification_id in notification_ids {
-            conn.execute(
-                r#"
-                UPDATE conversation_notifications
-                SET consumed_at = ?2
-                WHERE id = ?1 AND consumed_at IS NULL
-                "#,
-                params![notification_id.to_string(), now.clone()],
-            )
+        let placeholders: Vec<String> = (1..=notification_ids.len())
+            .map(|idx| format!("?{}", idx))
+            .collect();
+        let sql = format!(
+            "UPDATE conversation_notifications
+             SET consumed_at = ?{}
+             WHERE id IN ({}) AND consumed_at IS NULL",
+            notification_ids.len() + 1,
+            placeholders.join(", ")
+        );
+        let mut values: Vec<libsql::Value> = notification_ids
+            .iter()
+            .map(|id| libsql::Value::Text(id.to_string()))
+            .collect();
+        values.push(libsql::Value::Text(now));
+        let params = params_from_iter(values);
+        conn.execute(sql.as_str(), params)
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
-        }
         Ok(())
     }
 
@@ -718,13 +725,14 @@ impl ConversationStore for LibSqlBackend {
 mod tests {
     use super::*;
     use crate::db::Database;
+    use std::error::Error;
 
     #[tokio::test]
-    async fn test_get_or_create_routine_conversation_is_idempotent() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_get_or_create_routine_conversation_is_idempotent() -> Result<(), Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("test_routine_conv.db");
-        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
-        backend.run_migrations().await.unwrap();
+        let backend = LibSqlBackend::new_local(&db_path).await?;
+        backend.run_migrations().await?;
 
         let routine_id = Uuid::new_v4();
         let user_id = "test_user";
@@ -732,22 +740,19 @@ mod tests {
         // First call — creates the conversation
         let id1 = backend
             .get_or_create_routine_conversation(routine_id, "my-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         // Second call — should return the SAME conversation
         let id2 = backend
             .get_or_create_routine_conversation(routine_id, "my-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(id1, id2, "Expected same conversation ID on repeated calls");
 
         // Third call — still the same
         let id3 = backend
             .get_or_create_routine_conversation(routine_id, "my-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(id1, id3);
 
@@ -755,21 +760,21 @@ mod tests {
         let other_routine_id = Uuid::new_v4();
         let id4 = backend
             .get_or_create_routine_conversation(other_routine_id, "other-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         assert_ne!(
             id1, id4,
             "Different routines should get different conversations"
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_routine_conversation_persists_across_messages() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_routine_conversation_persists_across_messages() -> Result<(), Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("test_routine_persist.db");
-        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
-        backend.run_migrations().await.unwrap();
+        let backend = LibSqlBackend::new_local(&db_path).await?;
+        backend.run_migrations().await?;
 
         let routine_id = Uuid::new_v4();
         let user_id = "test_user";
@@ -777,32 +782,25 @@ mod tests {
         // First invocation: create conversation and add a message
         let id1 = backend
             .get_or_create_routine_conversation(routine_id, "my-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         backend
             .add_conversation_message(id1, "assistant", "[cron] Completed: all good")
-            .await
-            .unwrap();
+            .await?;
 
         // Second invocation: should find existing conversation
         let id2 = backend
             .get_or_create_routine_conversation(routine_id, "my-routine", user_id)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(id1, id2, "Second invocation should reuse same conversation");
 
         backend
             .add_conversation_message(id2, "assistant", "[cron] Completed: still good")
-            .await
-            .unwrap();
+            .await?;
 
         // Verify only one routine conversation exists (not two)
-        let convs = backend
-            .list_conversations_all_channels(user_id, 50)
-            .await
-            .unwrap();
+        let convs = backend.list_conversations_all_channels(user_id, 50).await?;
 
         let routine_convs: Vec<_> = convs.iter().filter(|c| c.channel == "routine").collect();
         assert_eq!(
@@ -811,39 +809,40 @@ mod tests {
             "Should have exactly 1 routine conversation, found {}",
             routine_convs.len()
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_or_create_heartbeat_conversation_is_idempotent() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_get_or_create_heartbeat_conversation_is_idempotent() -> Result<(), Box<dyn Error>>
+    {
+        let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("test_heartbeat_conv.db");
-        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
-        backend.run_migrations().await.unwrap();
+        let backend = LibSqlBackend::new_local(&db_path).await?;
+        backend.run_migrations().await?;
 
         let user_id = "test_user";
 
         let id1 = backend
             .get_or_create_heartbeat_conversation(user_id)
-            .await
-            .unwrap();
+            .await?;
 
         let id2 = backend
             .get_or_create_heartbeat_conversation(user_id)
-            .await
-            .unwrap();
+            .await?;
 
         assert_eq!(
             id1, id2,
             "Expected same heartbeat conversation on repeated calls"
         );
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_conversation_notifications_scope_and_consumption() {
-        let dir = tempfile::tempdir().unwrap();
+    async fn test_conversation_notifications_scope_and_consumption() -> Result<(), Box<dyn Error>> {
+        let dir = tempfile::tempdir()?;
         let db_path = dir.path().join("test_notifications.db");
-        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
-        backend.run_migrations().await.unwrap();
+        let backend = LibSqlBackend::new_local(&db_path).await?;
+        backend.run_migrations().await?;
 
         let user_id = "test_user";
         let channel = "gateway";
@@ -860,8 +859,7 @@ mod tests {
                 &serde_json::json!({"routine_name": "Scoped"}),
                 None,
             )
-            .await
-            .unwrap();
+            .await?;
         let global_id = backend
             .add_conversation_notification(
                 user_id,
@@ -873,34 +871,30 @@ mod tests {
                 &serde_json::json!({"routine_name": "Global"}),
                 None,
             )
-            .await
-            .unwrap();
+            .await?;
 
         let scoped_notifications = backend
             .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
-            .await
-            .unwrap();
+            .await?;
         assert_eq!(scoped_notifications.len(), 2);
         assert_eq!(scoped_notifications[0].id, scoped_id);
         assert_eq!(scoped_notifications[1].id, global_id);
 
         let global_notifications = backend
             .list_unread_conversation_notifications(user_id, channel, None, 10)
-            .await
-            .unwrap();
+            .await?;
         assert_eq!(global_notifications.len(), 1);
         assert_eq!(global_notifications[0].id, global_id);
 
         backend
             .mark_conversation_notifications_consumed(&[scoped_id])
-            .await
-            .unwrap();
+            .await?;
 
         let scoped_notifications = backend
             .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
-            .await
-            .unwrap();
+            .await?;
         assert_eq!(scoped_notifications.len(), 1);
         assert_eq!(scoped_notifications[0].id, global_id);
+        Ok(())
     }
 }

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 use super::{LibSqlBackend, fmt_ts, get_i64, get_json, get_opt_text, get_text, get_ts, opt_text};
 use crate::db::ConversationStore;
 use crate::error::DatabaseError;
-use crate::history::{ConversationMessage, ConversationSummary};
+use crate::history::{ConversationMessage, ConversationNotification, ConversationSummary};
 
 #[async_trait]
 impl ConversationStore for LibSqlBackend {
@@ -58,6 +58,48 @@ impl ConversationStore for LibSqlBackend {
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
         self.touch_conversation(conversation_id).await?;
+        Ok(id)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_conversation_notification(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        source_kind: &str,
+        source_id: &str,
+        content: &str,
+        metadata: &serde_json::Value,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Uuid, DatabaseError> {
+        let conn = self.connect().await?;
+        let id = Uuid::new_v4();
+        let now = fmt_ts(&Utc::now());
+        conn.execute(
+            r#"
+            INSERT INTO conversation_notifications (
+                id, user_id, channel, conversation_scope_id,
+                source_kind, source_id, content, metadata,
+                created_at, expires_at
+            )
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            "#,
+            params![
+                id.to_string(),
+                user_id,
+                channel,
+                opt_text(conversation_scope_id),
+                source_kind,
+                source_id,
+                content,
+                metadata.to_string(),
+                now,
+                expires_at.as_ref().map(fmt_ts)
+            ],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(id)
     }
 
@@ -546,6 +588,111 @@ impl ConversationStore for LibSqlBackend {
         Ok(messages)
     }
 
+    async fn list_unread_conversation_notifications(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<ConversationNotification>, DatabaseError> {
+        let conn = self.connect().await?;
+        let now = fmt_ts(&Utc::now());
+        let mut rows = if let Some(scope) = conversation_scope_id {
+            conn.query(
+                r#"
+                SELECT id, user_id, channel, conversation_scope_id,
+                       source_kind, source_id, content, metadata,
+                       created_at, consumed_at, expires_at
+                FROM conversation_notifications
+                WHERE user_id = ?1
+                  AND channel = ?2
+                  AND consumed_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > ?3)
+                  AND (conversation_scope_id IS NULL OR conversation_scope_id = ?4)
+                ORDER BY datetime(created_at) ASC, rowid ASC
+                LIMIT ?5
+                "#,
+                params![user_id, channel, now, scope, limit],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        } else {
+            conn.query(
+                r#"
+                SELECT id, user_id, channel, conversation_scope_id,
+                       source_kind, source_id, content, metadata,
+                       created_at, consumed_at, expires_at
+                FROM conversation_notifications
+                WHERE user_id = ?1
+                  AND channel = ?2
+                  AND conversation_scope_id IS NULL
+                  AND consumed_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > ?3)
+                ORDER BY datetime(created_at) ASC, rowid ASC
+                LIMIT ?4
+                "#,
+                params![user_id, channel, now, limit],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        };
+
+        let mut notifications = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            notifications.push(ConversationNotification {
+                id: get_text(&row, 0).parse().unwrap_or_default(),
+                user_id: get_text(&row, 1),
+                channel: get_text(&row, 2),
+                conversation_scope_id: get_opt_text(&row, 3),
+                source_kind: get_text(&row, 4),
+                source_id: get_text(&row, 5),
+                content: get_text(&row, 6),
+                metadata: get_json(&row, 7),
+                created_at: get_ts(&row, 8),
+                consumed_at: get_opt_text(&row, 9).and_then(|ts| {
+                    chrono::DateTime::parse_from_rfc3339(&ts)
+                        .ok()
+                        .map(|dt| dt.with_timezone(&Utc))
+                }),
+                expires_at: get_opt_text(&row, 10).and_then(|ts| {
+                    chrono::DateTime::parse_from_rfc3339(&ts)
+                        .ok()
+                        .map(|dt| dt.with_timezone(&Utc))
+                }),
+            });
+        }
+        Ok(notifications)
+    }
+
+    async fn mark_conversation_notifications_consumed(
+        &self,
+        notification_ids: &[Uuid],
+    ) -> Result<(), DatabaseError> {
+        if notification_ids.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.connect().await?;
+        let now = fmt_ts(&Utc::now());
+        for notification_id in notification_ids {
+            conn.execute(
+                r#"
+                UPDATE conversation_notifications
+                SET consumed_at = ?2
+                WHERE id = ?1 AND consumed_at IS NULL
+                "#,
+                params![notification_id.to_string(), now.clone()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     async fn conversation_belongs_to_user(
         &self,
         conversation_id: Uuid,
@@ -689,5 +836,71 @@ mod tests {
             id1, id2,
             "Expected same heartbeat conversation on repeated calls"
         );
+    }
+
+    #[tokio::test]
+    async fn test_conversation_notifications_scope_and_consumption() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_notifications.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let user_id = "test_user";
+        let channel = "gateway";
+        let scoped = "thread-123";
+
+        let scoped_id = backend
+            .add_conversation_notification(
+                user_id,
+                channel,
+                Some(scoped),
+                "routine",
+                "routine-1",
+                "Scoped notification",
+                &serde_json::json!({"routine_name": "Scoped"}),
+                None,
+            )
+            .await
+            .unwrap();
+        let global_id = backend
+            .add_conversation_notification(
+                user_id,
+                channel,
+                None,
+                "routine",
+                "routine-2",
+                "Global notification",
+                &serde_json::json!({"routine_name": "Global"}),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let scoped_notifications = backend
+            .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
+            .await
+            .unwrap();
+        assert_eq!(scoped_notifications.len(), 2);
+        assert_eq!(scoped_notifications[0].id, scoped_id);
+        assert_eq!(scoped_notifications[1].id, global_id);
+
+        let global_notifications = backend
+            .list_unread_conversation_notifications(user_id, channel, None, 10)
+            .await
+            .unwrap();
+        assert_eq!(global_notifications.len(), 1);
+        assert_eq!(global_notifications[0].id, global_id);
+
+        backend
+            .mark_conversation_notifications_consumed(&[scoped_id])
+            .await
+            .unwrap();
+
+        let scoped_notifications = backend
+            .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
+            .await
+            .unwrap();
+        assert_eq!(scoped_notifications.len(), 1);
+        assert_eq!(scoped_notifications[0].id, global_id);
     }
 }

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -65,6 +65,23 @@ CREATE TABLE IF NOT EXISTS conversation_messages (
 CREATE INDEX IF NOT EXISTS idx_conversation_messages_conversation
     ON conversation_messages(conversation_id);
 
+CREATE TABLE IF NOT EXISTS conversation_notifications (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    conversation_scope_id TEXT,
+    source_kind TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    consumed_at TEXT,
+    expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_notifications_lookup
+    ON conversation_notifications(user_id, channel, conversation_scope_id, consumed_at, created_at);
+
 -- ==================== Agent Jobs ====================
 
 CREATE TABLE IF NOT EXISTS agent_jobs (
@@ -723,6 +740,28 @@ CREATE INDEX IF NOT EXISTS idx_routines_event_triggers
     WHERE enabled = 1 AND trigger_type IN ('event', 'system_event');
 
 PRAGMA foreign_keys=ON;
+"#,
+    ),
+    (
+        14,
+        "conversation_notifications",
+        r#"
+CREATE TABLE IF NOT EXISTS conversation_notifications (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL,
+    channel TEXT NOT NULL,
+    conversation_scope_id TEXT,
+    source_kind TEXT NOT NULL,
+    source_id TEXT NOT NULL,
+    content TEXT NOT NULL,
+    metadata TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    consumed_at TEXT,
+    expires_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_conversation_notifications_lookup
+    ON conversation_notifications(user_id, channel, conversation_scope_id, consumed_at, created_at);
 "#,
     ),
 ];

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -700,10 +700,10 @@ mod tests {
     /// chose postgres when both features were enabled (PR #209).
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn test_create_secrets_store_libsql_backend() {
+    async fn test_create_secrets_store_libsql_backend() -> Result<(), Box<dyn std::error::Error>> {
         use secrecy::SecretString;
 
-        let tmp = tempfile::tempdir().unwrap();
+        let tmp = tempfile::tempdir()?;
         let db_path = tmp.path().join("test.db");
 
         let config = crate::config::DatabaseConfig {
@@ -717,18 +717,13 @@ mod tests {
         };
 
         let master_key = SecretString::from("a]".repeat(16));
-        let crypto = Arc::new(crate::secrets::SecretsCrypto::new(master_key).unwrap());
+        let crypto = Arc::new(crate::secrets::SecretsCrypto::new(master_key)?);
 
-        let store = create_secrets_store(&config, crypto).await;
-        assert!(
-            store.is_ok(),
-            "create_secrets_store should succeed for libsql backend"
-        );
+        let store = create_secrets_store(&config, crypto).await?;
 
         // Verify basic operation works
-        let store = store.unwrap();
-        let exists = store.exists("test_user", "nonexistent_secret").await;
-        assert!(exists.is_ok());
-        assert!(!exists.unwrap());
+        let exists = store.exists("test_user", "nonexistent_secret").await?;
+        assert!(!exists);
+        Ok(())
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -35,8 +35,9 @@ use crate::context::{ActionRecord, JobContext, JobState};
 use crate::error::DatabaseError;
 use crate::error::WorkspaceError;
 use crate::history::{
-    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationSummary, JobEventRecord,
-    LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow,
+    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationNotification,
+    ConversationSummary, JobEventRecord, LlmCallRecord, SandboxJobRecord, SandboxJobSummary,
+    SettingRow,
 };
 use crate::workspace::{MemoryChunk, MemoryDocument, WorkspaceEntry};
 use crate::workspace::{SearchConfig, SearchResult};
@@ -330,6 +331,18 @@ pub trait ConversationStore: Send + Sync {
         role: &str,
         content: &str,
     ) -> Result<Uuid, DatabaseError>;
+    #[allow(clippy::too_many_arguments)]
+    async fn add_conversation_notification(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        source_kind: &str,
+        source_id: &str,
+        content: &str,
+        metadata: &serde_json::Value,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Uuid, DatabaseError>;
     async fn ensure_conversation(
         &self,
         id: Uuid,
@@ -389,6 +402,17 @@ pub trait ConversationStore: Send + Sync {
         &self,
         conversation_id: Uuid,
     ) -> Result<Vec<ConversationMessage>, DatabaseError>;
+    async fn list_unread_conversation_notifications(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<ConversationNotification>, DatabaseError>;
+    async fn mark_conversation_notifications_consumed(
+        &self,
+        notification_ids: &[Uuid],
+    ) -> Result<(), DatabaseError>;
     async fn conversation_belongs_to_user(
         &self,
         conversation_id: Uuid,

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -21,8 +21,9 @@ use crate::db::{
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
-    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationSummary, JobEventRecord,
-    LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow, Store,
+    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationNotification,
+    ConversationSummary, JobEventRecord, LlmCallRecord, SandboxJobRecord, SandboxJobSummary,
+    SettingRow, Store,
 };
 use crate::workspace::{
     MemoryChunk, MemoryDocument, Repository, SearchConfig, SearchResult, WorkspaceEntry,
@@ -90,6 +91,32 @@ impl ConversationStore for PgBackend {
     ) -> Result<Uuid, DatabaseError> {
         self.store
             .add_conversation_message(conversation_id, role, content)
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn add_conversation_notification(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        source_kind: &str,
+        source_id: &str,
+        content: &str,
+        metadata: &serde_json::Value,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Uuid, DatabaseError> {
+        self.store
+            .add_conversation_notification(
+                user_id,
+                channel,
+                conversation_scope_id,
+                source_kind,
+                source_id,
+                content,
+                metadata,
+                expires_at,
+            )
             .await
     }
 
@@ -201,6 +228,27 @@ impl ConversationStore for PgBackend {
         conversation_id: Uuid,
     ) -> Result<Vec<ConversationMessage>, DatabaseError> {
         self.store.list_conversation_messages(conversation_id).await
+    }
+
+    async fn list_unread_conversation_notifications(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<ConversationNotification>, DatabaseError> {
+        self.store
+            .list_unread_conversation_notifications(user_id, channel, conversation_scope_id, limit)
+            .await
+    }
+
+    async fn mark_conversation_notifications_consumed(
+        &self,
+        notification_ids: &[Uuid],
+    ) -> Result<(), DatabaseError> {
+        self.store
+            .mark_conversation_notifications_consumed(notification_ids)
+            .await
     }
 
     async fn conversation_belongs_to_user(

--- a/src/history/mod.rs
+++ b/src/history/mod.rs
@@ -14,6 +14,7 @@ pub use analytics::{JobStats, ToolStats};
 #[cfg(feature = "postgres")]
 pub use store::Store;
 pub use store::{
-    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationSummary, JobEventRecord,
-    LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow,
+    AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationNotification,
+    ConversationSummary, JobEventRecord, LlmCallRecord, SandboxJobRecord, SandboxJobSummary,
+    SettingRow,
 };

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -29,6 +29,22 @@ pub struct LlmCallRecord<'a> {
     pub purpose: Option<&'a str>,
 }
 
+/// A routine notification that can be injected into the user's next turn.
+#[derive(Debug, Clone)]
+pub struct ConversationNotification {
+    pub id: Uuid,
+    pub user_id: String,
+    pub channel: String,
+    pub conversation_scope_id: Option<String>,
+    pub source_kind: String,
+    pub source_id: String,
+    pub content: String,
+    pub metadata: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub consumed_at: Option<DateTime<Utc>>,
+    pub expires_at: Option<DateTime<Utc>>,
+}
+
 /// Database store for the agent.
 #[cfg(feature = "postgres")]
 pub struct Store {
@@ -136,6 +152,49 @@ impl Store {
         // Update conversation activity
         self.touch_conversation(conversation_id).await?;
 
+        Ok(id)
+    }
+
+    /// Persist a routine notification for later injection into the user's next turn.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn add_conversation_notification(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        source_kind: &str,
+        source_id: &str,
+        content: &str,
+        metadata: &serde_json::Value,
+        expires_at: Option<DateTime<Utc>>,
+    ) -> Result<Uuid, DatabaseError> {
+        let conn = self.conn().await?;
+        let id = Uuid::new_v4();
+        let created_at = Utc::now();
+
+        conn.execute(
+            r#"
+            INSERT INTO conversation_notifications (
+                id, user_id, channel, conversation_scope_id,
+                source_kind, source_id, content, metadata,
+                created_at, expires_at
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            "#,
+            &[
+                &id,
+                &user_id,
+                &channel,
+                &conversation_scope_id,
+                &source_kind,
+                &source_id,
+                &content,
+                metadata,
+                &created_at,
+                &expires_at,
+            ],
+        )
+        .await?;
         Ok(id)
     }
 
@@ -1909,6 +1968,98 @@ impl Store {
                 created_at: r.get("created_at"),
             })
             .collect())
+    }
+
+    /// Load unread routine notifications for a channel and conversation scope.
+    pub async fn list_unread_conversation_notifications(
+        &self,
+        user_id: &str,
+        channel: &str,
+        conversation_scope_id: Option<&str>,
+        limit: i64,
+    ) -> Result<Vec<ConversationNotification>, DatabaseError> {
+        let conn = self.conn().await?;
+        let now = Utc::now();
+
+        let rows = if let Some(scope) = conversation_scope_id {
+            conn.query(
+                r#"
+                SELECT id, user_id, channel, conversation_scope_id,
+                       source_kind, source_id, content, metadata,
+                       created_at, consumed_at, expires_at
+                FROM conversation_notifications
+                WHERE user_id = $1
+                  AND channel = $2
+                  AND consumed_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > $3)
+                  AND (conversation_scope_id IS NULL OR conversation_scope_id = $4)
+                ORDER BY created_at ASC, id ASC
+                LIMIT $5
+                "#,
+                &[&user_id, &channel, &now, &scope, &limit],
+            )
+            .await?
+        } else {
+            conn.query(
+                r#"
+                SELECT id, user_id, channel, conversation_scope_id,
+                       source_kind, source_id, content, metadata,
+                       created_at, consumed_at, expires_at
+                FROM conversation_notifications
+                WHERE user_id = $1
+                  AND channel = $2
+                  AND conversation_scope_id IS NULL
+                  AND consumed_at IS NULL
+                  AND (expires_at IS NULL OR expires_at > $3)
+                ORDER BY created_at ASC, id ASC
+                LIMIT $4
+                "#,
+                &[&user_id, &channel, &now, &limit],
+            )
+            .await?
+        };
+
+        Ok(rows
+            .iter()
+            .map(|r| ConversationNotification {
+                id: r.get("id"),
+                user_id: r.get("user_id"),
+                channel: r.get("channel"),
+                conversation_scope_id: r.get("conversation_scope_id"),
+                source_kind: r.get("source_kind"),
+                source_id: r.get("source_id"),
+                content: r.get("content"),
+                metadata: r.get("metadata"),
+                created_at: r.get("created_at"),
+                consumed_at: r.get("consumed_at"),
+                expires_at: r.get("expires_at"),
+            })
+            .collect())
+    }
+
+    /// Mark notifications as consumed.
+    pub async fn mark_conversation_notifications_consumed(
+        &self,
+        notification_ids: &[Uuid],
+    ) -> Result<(), DatabaseError> {
+        if notification_ids.is_empty() {
+            return Ok(());
+        }
+
+        let conn = self.conn().await?;
+        let consumed_at = Utc::now();
+        for notification_id in notification_ids {
+            conn.execute(
+                r#"
+                UPDATE conversation_notifications
+                SET consumed_at = $2
+                WHERE id = $1 AND consumed_at IS NULL
+                "#,
+                &[notification_id, &consumed_at],
+            )
+            .await?;
+        }
+        Ok(())
     }
 }
 

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -2048,17 +2048,15 @@ impl Store {
 
         let conn = self.conn().await?;
         let consumed_at = Utc::now();
-        for notification_id in notification_ids {
-            conn.execute(
-                r#"
-                UPDATE conversation_notifications
-                SET consumed_at = $2
-                WHERE id = $1 AND consumed_at IS NULL
-                "#,
-                &[notification_id, &consumed_at],
-            )
-            .await?;
-        }
+        conn.execute(
+            r#"
+            UPDATE conversation_notifications
+            SET consumed_at = $2
+            WHERE id = ANY($1) AND consumed_at IS NULL
+            "#,
+            &[&notification_ids, &consumed_at],
+        )
+        .await?;
         Ok(())
     }
 }
@@ -2374,30 +2372,28 @@ mod tests {
     #[cfg(feature = "postgres")]
     #[tokio::test]
     #[ignore]
-    async fn test_save_job_persists_user_id() {
+    async fn test_save_job_persists_user_id() -> Result<(), Box<dyn std::error::Error>> {
         use crate::config::Config;
         use crate::context::JobContext;
 
         let _ = dotenvy::dotenv();
-        let config = Config::from_env().await.expect("Failed to load config");
-        let store = Store::new(&config.database)
-            .await
-            .expect("Failed to connect to database");
-        store
-            .run_migrations()
-            .await
-            .expect("Failed to run migrations");
+        let config = Config::from_env().await?;
+        let store = Store::new(&config.database).await?;
+        store.run_migrations().await?;
 
         let ctx = JobContext::with_user("test-user-42", "PG user_id test", "regression test");
-        store.save_job(&ctx).await.unwrap();
+        store.save_job(&ctx).await?;
 
-        let loaded = store.get_job(ctx.job_id).await.unwrap().unwrap();
+        let loaded = store
+            .get_job(ctx.job_id)
+            .await?
+            .ok_or_else(|| std::io::Error::other("expected saved job to load"))?;
         assert_eq!(loaded.user_id, "test-user-42");
 
         // Clean up
-        let conn = store.conn().await.unwrap();
+        let conn = store.conn().await?;
         conn.execute("DELETE FROM agent_jobs WHERE id = $1", &[&ctx.job_id])
-            .await
-            .unwrap();
+            .await?;
+        Ok(())
     }
 }

--- a/tests/routine_notifications.rs
+++ b/tests/routine_notifications.rs
@@ -1,0 +1,66 @@
+#![cfg(feature = "libsql")]
+
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::db::{ConversationStore, Database};
+
+#[tokio::test]
+async fn notification_scope_and_consumption_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = tempfile::tempdir()?;
+    let db_path = dir.path().join("routine_notifications.db");
+    let backend = LibSqlBackend::new_local(&db_path).await?;
+    backend.run_migrations().await?;
+
+    let user_id = "test_user";
+    let channel = "gateway";
+    let scoped = "thread-123";
+
+    let scoped_id = backend
+        .add_conversation_notification(
+            user_id,
+            channel,
+            Some(scoped),
+            "routine",
+            "routine-1",
+            "Scoped notification",
+            &serde_json::json!({"routine_name": "Scoped"}),
+            None,
+        )
+        .await?;
+    let global_id = backend
+        .add_conversation_notification(
+            user_id,
+            channel,
+            None,
+            "routine",
+            "routine-2",
+            "Global notification",
+            &serde_json::json!({"routine_name": "Global"}),
+            None,
+        )
+        .await?;
+
+    let scoped_notifications = backend
+        .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
+        .await?;
+    assert_eq!(scoped_notifications.len(), 2);
+    assert_eq!(scoped_notifications[0].id, scoped_id);
+    assert_eq!(scoped_notifications[1].id, global_id);
+
+    let global_notifications = backend
+        .list_unread_conversation_notifications(user_id, channel, None, 10)
+        .await?;
+    assert_eq!(global_notifications.len(), 1);
+    assert_eq!(global_notifications[0].id, global_id);
+
+    backend
+        .mark_conversation_notifications_consumed(&[scoped_id])
+        .await?;
+
+    let scoped_notifications = backend
+        .list_unread_conversation_notifications(user_id, channel, Some(scoped), 10)
+        .await?;
+    assert_eq!(scoped_notifications.len(), 1);
+    assert_eq!(scoped_notifications[0].id, global_id);
+
+    Ok(())
+}


### PR DESCRIPTION
Persist routine notifications as channel-scoped records and inject unread ones into the next user turn as a transient system message. This keeps them out of fake turns while making them available to the LLM when the user replies.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo check -q\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings\n- cargo test -p ironclaw test_conversation_notifications_scope_and_consumption -- --nocapture