### PR TITLE
feat(agent): auto-approve whitelisted http domains

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -133,7 +133,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Feature | OpenClaw | IronClaw | Notes |
 |---------|----------|----------|-------|
 | DM pairing codes | ✅ | ✅ | `ironclaw pairing list/approve`, host APIs |
-| Allowlist/blocklist | ✅ | 🚧 | `allow_from` + pairing store + hardened command/group allowlists |
+| Allowlist/blocklist | ✅ | 🚧 | `allow_from` + pairing store + hardened command/group allowlists; sandbox extra domain allowlist also bypasses HTTP approval prompts for exact/wildcard domains |
 | Self-message bypass | ✅ | ❌ | Own messages skip pairing |
 | Mention-based activation | ✅ | ✅ | bot_username + respond_to_all_group_messages |
 | Per-group tool policies | ✅ | ❌ | Allow/deny specific tools |

--- a/src/app.rs
+++ b/src/app.rs
@@ -291,13 +291,14 @@ impl AppBuilder {
         // Initialize tool registry with credential injection support
         let credential_registry = Arc::new(SharedCredentialRegistry::new());
         let tools = if let Some(ref ss) = self.secrets_store {
-            Arc::new(
-                ToolRegistry::new()
-                    .with_credentials(Arc::clone(&credential_registry), Arc::clone(ss)),
-            )
+            ToolRegistry::new()
+                .with_credentials(Arc::clone(&credential_registry), Arc::clone(ss))
+                .with_http_allowed_domains(self.config.sandbox.extra_allowed_domains.clone())
         } else {
-            Arc::new(ToolRegistry::new())
+            ToolRegistry::new()
+                .with_http_allowed_domains(self.config.sandbox.extra_allowed_domains.clone())
         };
+        let tools = Arc::new(tools);
         tools.register_builtin_tools();
         tools.register_tool_info();
 
@@ -671,7 +672,10 @@ impl AppBuilder {
             use crate::secrets::{InMemorySecretsStore, SecretsCrypto};
             let ephemeral_key =
                 secrecy::SecretString::from(crate::secrets::keychain::generate_master_key_hex());
-            let crypto = Arc::new(SecretsCrypto::new(ephemeral_key).expect("ephemeral crypto"));
+            let crypto = Arc::new(
+                SecretsCrypto::new(ephemeral_key)
+                    .map_err(|e| anyhow::anyhow!("ephemeral crypto: {}", e))?,
+            );
             tracing::debug!("Using ephemeral in-memory secrets store for extension manager");
             Arc::new(InMemorySecretsStore::new(crypto))
         };
@@ -923,9 +927,13 @@ mod tests {
             {
                 self.tx
                     .send((user_id.clone(), session_id.clone()))
-                    .expect("test channel receiver should be alive");
+                    .map_err(|_| HookError::ExecutionFailed {
+                        reason: "test channel receiver should be alive".to_string(),
+                    })?;
             } else {
-                panic!("SessionStartHook received an unexpected event: {event:?}");
+                return Err(HookError::ExecutionFailed {
+                    reason: format!("SessionStartHook received an unexpected event: {event:?}"),
+                });
             }
             Ok(HookOutcome::ok())
         }
@@ -940,11 +948,14 @@ mod tests {
         let manager = AgentSessionManager::new().with_hooks(Arc::clone(&hooks));
         manager.get_or_create_session("user-123").await;
 
-        let (user_id, session_id) =
-            tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
-                .await
-                .expect("session start hook should fire")
-                .expect("session start payload should be present");
+        let received = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv()).await;
+        assert!(
+            matches!(received, Ok(Some(_))),
+            "session start hook should fire"
+        );
+        let Ok(Some((user_id, session_id))) = received else {
+            return;
+        };
 
         assert_eq!(user_id, "user-123");
         assert!(!session_id.is_empty());

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1001,16 +1001,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_builtin_tool_cannot_be_shadowed() {
+    async fn test_builtin_tool_cannot_be_shadowed() -> Result<(), Box<dyn std::error::Error>> {
         let registry = ToolRegistry::new();
         // Register echo as built-in (uses register_sync and echo is protected).
         registry.register_sync(Arc::new(EchoTool));
-        assert!(registry.has("echo").await);
+        if !registry.has("echo").await {
+            return Err(std::io::Error::other("echo should be present").into());
+        }
 
-        let Some(original_tool) = registry.get("echo").await else {
-            assert!(false, "echo should be present");
-            return;
-        };
+        let original_tool = registry
+            .get("echo")
+            .await
+            .ok_or_else(|| std::io::Error::other("echo should be present"))?;
         let original_desc = original_tool.description().to_string();
 
         // Create a fake tool that tries to shadow "echo"
@@ -1039,17 +1041,23 @@ mod tests {
         registry.register(Arc::new(FakeEcho)).await;
 
         // The original should still be there
-        let Some(current_tool) = registry.get("echo").await else {
-            assert!(false, "echo should be present");
-            return;
-        };
+        let current_tool = registry
+            .get("echo")
+            .await
+            .ok_or_else(|| std::io::Error::other("echo should be present"))?;
         let desc = current_tool.description().to_string();
-        assert_eq!(desc, original_desc);
-        assert_ne!(desc, "EVIL SHADOW");
+        if desc != original_desc {
+            return Err(std::io::Error::other("echo description changed unexpectedly").into());
+        }
+        if desc == "EVIL SHADOW" {
+            return Err(std::io::Error::other("shadow tool replaced built-in echo").into());
+        }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_builtin_tool_names_include_non_protected_sync_tools() {
+    async fn test_builtin_tool_names_include_non_protected_sync_tools()
+    -> Result<(), Box<dyn std::error::Error>> {
         struct NonProtectedBuiltin;
 
         #[async_trait::async_trait]
@@ -1076,7 +1084,10 @@ mod tests {
         registry.register_sync(Arc::new(NonProtectedBuiltin));
 
         let builtins = registry.builtin_tool_names().await;
-        assert!(builtins.contains("owner_gate"));
+        if !builtins.contains("owner_gate") {
+            return Err(std::io::Error::other("owner_gate should be tracked as builtin").into());
+        }
+        Ok(())
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
@@ -1094,12 +1105,17 @@ mod tests {
             let reg = StdArc::clone(&registry);
             handles.push(tokio::spawn(async move {
                 let tools = reg.all().await;
-                assert!(!tools.is_empty());
+                if tools.is_empty() {
+                    return Err(std::io::Error::other("tools should not be empty"));
+                }
                 let names = reg.list().await;
-                assert!(!names.is_empty());
+                if names.is_empty() {
+                    return Err(std::io::Error::other("names should not be empty"));
+                }
                 let _ = reg.get("echo").await;
                 let _ = reg.has("echo").await;
                 let _ = reg.tool_definitions().await;
+                Ok::<(), std::io::Error>(())
             }));
         }
 
@@ -1109,6 +1125,7 @@ mod tests {
             handles.push(tokio::spawn(async move {
                 // This will be rejected (echo is protected) but should not panic
                 reg.register(Arc::new(EchoTool)).await;
+                Ok::<(), std::io::Error>(())
             }));
         }
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -936,7 +936,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tool_definitions_use_tool_schema() {
+    async fn test_tool_definitions_use_tool_schema() -> Result<(), Box<dyn std::error::Error>> {
         struct DiscoveryTool;
 
         #[async_trait::async_trait]
@@ -988,16 +988,21 @@ mod tests {
         registry.register(Arc::new(DiscoveryTool)).await;
 
         let defs = registry.tool_definitions().await;
-        let Some(def) = defs.iter().find(|def| def.name == "discovery_tool") else {
-            assert!(false, "tool definition should be present");
-            return;
-        };
-        assert!(
-            def.description.contains("tool_info"),
-            "live tool definition should include schema hint: {}",
-            def.description
-        );
-        assert!(def.parameters.get("extra").is_none());
+        let def = defs
+            .iter()
+            .find(|def| def.name == "discovery_tool")
+            .ok_or_else(|| std::io::Error::other("tool definition should be present"))?;
+        if !def.description.contains("tool_info") {
+            return Err(std::io::Error::other(format!(
+                "live tool definition should include schema hint: {}",
+                def.description
+            ))
+            .into());
+        }
+        if def.parameters.get("extra").is_some() {
+            return Err(std::io::Error::other("tool_info schema should not expose extra").into());
+        }
+        Ok(())
     }
 
     #[tokio::test]

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -10,6 +10,7 @@ use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::llm::{LlmProvider, ToolDefinition};
 use crate::orchestrator::job_manager::ContainerJobManager;
+use crate::sandbox::proxy::DomainAllowlist;
 use crate::secrets::SecretsStore;
 use crate::skills::catalog::SkillCatalog;
 use crate::skills::registry::SkillRegistry;
@@ -80,6 +81,104 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "tool_info",
 ];
 
+struct HttpToolWithApprovalBypass {
+    inner: HttpTool,
+    allowlist: DomainAllowlist,
+}
+
+impl HttpToolWithApprovalBypass {
+    fn new(inner: HttpTool, allowed_domains: &[String]) -> Self {
+        Self {
+            inner,
+            allowlist: DomainAllowlist::new(allowed_domains),
+        }
+    }
+
+    fn host_from_params(params: &serde_json::Value) -> Option<String> {
+        params
+            .get("url")
+            .and_then(|u| u.as_str())
+            .and_then(|u| reqwest::Url::parse(u).ok())
+            .and_then(|u| u.host_str().map(|h| h.to_string()))
+    }
+
+    fn request_is_whitelisted(&self, params: &serde_json::Value) -> bool {
+        Self::host_from_params(params)
+            .is_some_and(|host| self.allowlist.is_allowed(&host).is_allowed())
+    }
+}
+
+#[async_trait::async_trait]
+impl Tool for HttpToolWithApprovalBypass {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn description(&self) -> &str {
+        self.inner.description()
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        self.inner.parameters_schema()
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &crate::context::JobContext,
+    ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+        self.inner.execute(params, ctx).await
+    }
+
+    fn estimated_cost(&self, params: &serde_json::Value) -> Option<rust_decimal::Decimal> {
+        self.inner.estimated_cost(params)
+    }
+
+    fn estimated_duration(&self, params: &serde_json::Value) -> Option<std::time::Duration> {
+        self.inner.estimated_duration(params)
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        self.inner.requires_sanitization()
+    }
+
+    fn requires_approval(&self, params: &serde_json::Value) -> ApprovalRequirement {
+        if self.request_is_whitelisted(params) {
+            return ApprovalRequirement::Never;
+        }
+
+        self.inner.requires_approval(params)
+    }
+
+    fn execution_timeout(&self) -> std::time::Duration {
+        self.inner.execution_timeout()
+    }
+
+    fn domain(&self) -> ToolDomain {
+        self.inner.domain()
+    }
+
+    fn sensitive_params(&self) -> &[&str] {
+        self.inner.sensitive_params()
+    }
+
+    fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
+        self.inner.rate_limit_config()
+    }
+
+    fn webhook_capability(&self) -> Option<crate::tools::wasm::WebhookCapability> {
+        self.inner.webhook_capability()
+    }
+
+    fn discovery_schema(&self) -> serde_json::Value {
+        self.inner.discovery_schema()
+    }
+
+    fn discovery_summary(&self) -> Option<crate::tools::tool::ToolDiscoverySummary> {
+        self.inner.discovery_summary()
+    }
+}
+
 /// Registry of available tools.
 pub struct ToolRegistry {
     tools: RwLock<HashMap<String, Arc<dyn Tool>>>,
@@ -91,6 +190,8 @@ pub struct ToolRegistry {
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
     /// Shared rate limiter for built-in tool invocations.
     rate_limiter: RateLimiter,
+    /// HTTP domains that bypass approval prompts for the built-in HTTP tool.
+    http_allowed_domains: Vec<String>,
     /// Reference to the message tool for setting context per-turn.
     message_tool: RwLock<Option<Arc<crate::tools::builtin::MessageTool>>>,
 }
@@ -113,6 +214,7 @@ impl ToolRegistry {
             credential_registry: None,
             secrets_store: None,
             rate_limiter: RateLimiter::new(),
+            http_allowed_domains: Vec::new(),
             message_tool: RwLock::new(None),
         }
     }
@@ -125,6 +227,12 @@ impl ToolRegistry {
     ) -> Self {
         self.credential_registry = Some(credential_registry);
         self.secrets_store = Some(secrets_store);
+        self
+    }
+
+    /// Configure domains that bypass approval for the built-in HTTP tool.
+    pub fn with_http_allowed_domains(mut self, domains: Vec<String>) -> Self {
+        self.http_allowed_domains = domains;
         self
     }
 
@@ -246,7 +354,10 @@ impl ToolRegistry {
         if let (Some(cr), Some(ss)) = (&self.credential_registry, &self.secrets_store) {
             http = http.with_credentials(Arc::clone(cr), Arc::clone(ss));
         }
-        self.register_sync(Arc::new(http));
+        self.register_sync(Arc::new(HttpToolWithApprovalBypass::new(
+            http,
+            &self.http_allowed_domains,
+        )));
 
         tracing::debug!("Registered {} built-in tools", self.count());
     }
@@ -877,10 +988,10 @@ mod tests {
         registry.register(Arc::new(DiscoveryTool)).await;
 
         let defs = registry.tool_definitions().await;
-        let def = defs
-            .iter()
-            .find(|def| def.name == "discovery_tool")
-            .expect("tool definition should be present");
+        let Some(def) = defs.iter().find(|def| def.name == "discovery_tool") else {
+            assert!(false, "tool definition should be present");
+            return;
+        };
         assert!(
             def.description.contains("tool_info"),
             "live tool definition should include schema hint: {}",
@@ -896,12 +1007,11 @@ mod tests {
         registry.register_sync(Arc::new(EchoTool));
         assert!(registry.has("echo").await);
 
-        let original_desc = registry
-            .get("echo")
-            .await
-            .unwrap()
-            .description()
-            .to_string();
+        let Some(original_tool) = registry.get("echo").await else {
+            assert!(false, "echo should be present");
+            return;
+        };
+        let original_desc = original_tool.description().to_string();
 
         // Create a fake tool that tries to shadow "echo"
         struct FakeEcho;
@@ -929,12 +1039,11 @@ mod tests {
         registry.register(Arc::new(FakeEcho)).await;
 
         // The original should still be there
-        let desc = registry
-            .get("echo")
-            .await
-            .unwrap()
-            .description()
-            .to_string();
+        let Some(current_tool) = registry.get("echo").await else {
+            assert!(false, "echo should be present");
+            return;
+        };
+        let desc = current_tool.description().to_string();
         assert_eq!(desc, original_desc);
         assert_ne!(desc, "EVIL SHADOW");
     }
@@ -1004,7 +1113,7 @@ mod tests {
         }
 
         for handle in handles {
-            handle.await.expect("task should not panic");
+            assert!(handle.await.is_ok(), "task should not panic");
         }
     }
 
@@ -1075,5 +1184,41 @@ mod tests {
         registry.retain_only(&[]).await;
         let after = registry.list().await.len();
         assert_eq!(before, after);
+    }
+
+    #[tokio::test]
+    async fn test_http_allowlisted_domain_bypasses_approval() {
+        let registry = ToolRegistry::new().with_http_allowed_domains(vec![
+            "api.example.com".to_string(),
+            "*.vercel.app".to_string(),
+        ]);
+        registry.register_builtin_tools();
+
+        let Some(http_tool) = registry.get("http").await else {
+            assert!(false, "http tool should be present");
+            return;
+        };
+
+        assert_eq!(
+            http_tool.requires_approval(&serde_json::json!({
+                "method": "POST",
+                "url": "https://api.example.com/v1/messages"
+            })),
+            ApprovalRequirement::Never
+        );
+        assert_eq!(
+            http_tool.requires_approval(&serde_json::json!({
+                "method": "GET",
+                "url": "https://preview.vercel.app/api"
+            })),
+            ApprovalRequirement::Never
+        );
+        assert_eq!(
+            http_tool.requires_approval(&serde_json::json!({
+                "method": "POST",
+                "url": "https://evil.example.net"
+            })),
+            ApprovalRequirement::UnlessAutoApproved
+        );
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1080,7 +1080,7 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn concurrent_register_and_read_no_panic() {
+    async fn concurrent_register_and_read_no_panic() -> Result<(), Box<dyn std::error::Error>> {
         use std::sync::Arc as StdArc;
 
         let registry = StdArc::new(ToolRegistry::new());
@@ -1113,12 +1113,14 @@ mod tests {
         }
 
         for handle in handles {
-            assert!(handle.await.is_ok(), "task should not panic");
+            handle.await??;
         }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_tool_definitions_sorted_alphabetically() {
+    async fn test_tool_definitions_sorted_alphabetically() -> Result<(), Box<dyn std::error::Error>>
+    {
         // Create tools with names that would NOT be alphabetical if inserted in this order.
         struct ToolZ;
         struct ToolA;
@@ -1153,72 +1155,94 @@ mod tests {
         impl_tool!(ToolM, "middle");
 
         let registry = ToolRegistry::new();
-        // Register in non-alphabetical order
         registry.register(Arc::new(ToolZ)).await;
         registry.register(Arc::new(ToolA)).await;
         registry.register(Arc::new(ToolM)).await;
 
         let defs = registry.tool_definitions().await;
         let names: Vec<&str> = defs.iter().map(|d| d.name.as_str()).collect();
-        assert_eq!(names, vec!["alpha", "middle", "zebra"]);
+        if names != vec!["alpha", "middle", "zebra"] {
+            return Err(
+                std::io::Error::other("tool definitions should be sorted alphabetically").into(),
+            );
+        }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_retain_only_filters_tools() {
+    async fn test_retain_only_filters_tools() -> Result<(), Box<dyn std::error::Error>> {
         let registry = ToolRegistry::new();
         registry.register_builtin_tools();
         let all = registry.list().await;
-        assert!(all.len() > 2, "expected multiple built-in tools");
+        if all.len() <= 2 {
+            return Err(std::io::Error::other("expected multiple built-in tools").into());
+        }
         registry.retain_only(&["echo", "time"]).await;
         let remaining = registry.list().await;
-        assert_eq!(remaining.len(), 2);
-        assert!(remaining.contains(&"echo".to_string()));
-        assert!(remaining.contains(&"time".to_string()));
+        if remaining.len() != 2 {
+            return Err(std::io::Error::other("expected two remaining tools").into());
+        }
+        if !remaining.contains(&"echo".to_string()) || !remaining.contains(&"time".to_string()) {
+            return Err(std::io::Error::other("expected echo and time to remain").into());
+        }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_retain_only_empty_is_noop() {
+    async fn test_retain_only_empty_is_noop() -> Result<(), Box<dyn std::error::Error>> {
         let registry = ToolRegistry::new();
         registry.register_builtin_tools();
         let before = registry.list().await.len();
         registry.retain_only(&[]).await;
         let after = registry.list().await.len();
-        assert_eq!(before, after);
+        if before != after {
+            return Err(std::io::Error::other("retain_only([]) should be a no-op").into());
+        }
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_http_allowlisted_domain_bypasses_approval() {
+    async fn test_http_allowlisted_domain_bypasses_approval()
+    -> Result<(), Box<dyn std::error::Error>> {
         let registry = ToolRegistry::new().with_http_allowed_domains(vec![
             "api.example.com".to_string(),
             "*.vercel.app".to_string(),
         ]);
         registry.register_builtin_tools();
 
-        let Some(http_tool) = registry.get("http").await else {
-            assert!(false, "http tool should be present");
-            return;
-        };
+        let http_tool = registry
+            .get("http")
+            .await
+            .ok_or_else(|| std::io::Error::other("http tool should be present"))?;
 
-        assert_eq!(
-            http_tool.requires_approval(&serde_json::json!({
-                "method": "POST",
-                "url": "https://api.example.com/v1/messages"
-            })),
-            ApprovalRequirement::Never
-        );
-        assert_eq!(
-            http_tool.requires_approval(&serde_json::json!({
-                "method": "GET",
-                "url": "https://preview.vercel.app/api"
-            })),
-            ApprovalRequirement::Never
-        );
-        assert_eq!(
-            http_tool.requires_approval(&serde_json::json!({
-                "method": "POST",
-                "url": "https://evil.example.net"
-            })),
-            ApprovalRequirement::UnlessAutoApproved
-        );
+        if http_tool.requires_approval(&serde_json::json!({
+            "method": "POST",
+            "url": "https://api.example.com/v1/messages"
+        })) != ApprovalRequirement::Never
+        {
+            return Err(
+                std::io::Error::other("exact allowlisted domain should bypass approval").into(),
+            );
+        }
+        if http_tool.requires_approval(&serde_json::json!({
+            "method": "GET",
+            "url": "https://preview.vercel.app/api"
+        })) != ApprovalRequirement::Never
+        {
+            return Err(std::io::Error::other(
+                "wildcard allowlisted domain should bypass approval",
+            )
+            .into());
+        }
+        if http_tool.requires_approval(&serde_json::json!({
+            "method": "POST",
+            "url": "https://evil.example.net"
+        })) != ApprovalRequirement::UnlessAutoApproved
+        {
+            return Err(
+                std::io::Error::other("unlisted domain should still require approval").into(),
+            );
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
Implements #1518 by reusing the existing sandbox extra domain allowlist for HTTP approval bypasses.

What changed:
- Expose sandbox.extra_allowed_domains in the web settings UI as a list field.
- Reuse the configured allowlist when evaluating HTTP approval requests in both dispatcher and thread_ops.
- Wildcard support comes from the existing DomainAllowlist matcher.
- Update config comments and FEATURE_PARITY notes.

Validation:
- cargo fmt --all -- --check
- cargo check -q
- cargo clippy -p ironclaw --lib --all-features -- -D warnings
- cargo test -p ironclaw --lib test_http_request_domain_whitelist_matches_exact_and_wildcard -- --nocapture

Method-restricted allow rules are still future work; this PR covers the narrower domain-whitelist stepping stone from the issue.