### PR TITLE
feat(workspace): add document metadata helpers

### DIFF
--- a/migrations/V1__initial.sql
+++ b/migrations/V1__initial.sql
@@ -184,6 +184,7 @@ CREATE INDEX idx_memory_documents_user ON memory_documents(user_id);
 CREATE INDEX idx_memory_documents_path ON memory_documents(user_id, path);
 CREATE INDEX idx_memory_documents_path_prefix ON memory_documents(user_id, path text_pattern_ops);
 CREATE INDEX idx_memory_documents_updated ON memory_documents(updated_at DESC);
+CREATE INDEX idx_memory_documents_metadata ON memory_documents USING GIN(metadata);
 
 -- ==================== Workspace: Memory Chunks ====================
 -- Documents are chunked for hybrid search (FTS + vector)

--- a/src/db/libsql/workspace.rs
+++ b/src/db/libsql/workspace.rs
@@ -376,6 +376,30 @@ impl WorkspaceStore for LibSqlBackend {
         Ok(())
     }
 
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let now = fmt_ts(&Utc::now());
+        let metadata = metadata.to_string();
+        conn.execute(
+            "UPDATE memory_documents SET metadata = ?2, updated_at = ?3 WHERE id = ?1",
+            params![id.to_string(), metadata, now],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Metadata update failed: {}", e),
+        })?;
+        Ok(())
+    }
+
     async fn delete_document_by_path(
         &self,
         user_id: &str,
@@ -569,6 +593,50 @@ impl WorkspaceStore for LibSqlBackend {
             .await
             .map_err(|e| WorkspaceError::SearchFailed {
                 reason: format!("Query failed: {}", e),
+            })?;
+
+        let mut docs = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Query failed: {}", e),
+            })?
+        {
+            docs.push(row_to_memory_document(&row));
+        }
+        Ok(docs)
+    }
+
+    async fn list_documents_by_metadata(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+        key: &str,
+        value: &str,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let agent_id_str = agent_id.map(|id| id.to_string());
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, agent_id, path, content,
+                       created_at, updated_at, metadata
+                FROM memory_documents
+                WHERE user_id = ?1 AND agent_id IS ?2
+                  AND json_extract(metadata, '$.' || ?3) = ?4
+                ORDER BY updated_at DESC
+                "#,
+                params![user_id, agent_id_str.as_deref(), key, value],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Metadata query failed: {}", e),
             })?;
 
         let mut docs = Vec::new();

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -595,6 +595,11 @@ pub trait WorkspaceStore: Send + Sync {
         path: &str,
     ) -> Result<MemoryDocument, WorkspaceError>;
     async fn update_document(&self, id: Uuid, content: &str) -> Result<(), WorkspaceError>;
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError>;
     async fn delete_document_by_path(
         &self,
         user_id: &str,
@@ -616,6 +621,13 @@ pub trait WorkspaceStore: Send + Sync {
         &self,
         user_id: &str,
         agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError>;
+    async fn list_documents_by_metadata(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+        key: &str,
+        value: &str,
     ) -> Result<Vec<MemoryDocument>, WorkspaceError>;
     async fn delete_chunks(&self, document_id: Uuid) -> Result<(), WorkspaceError>;
     async fn insert_chunk(

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -634,6 +634,14 @@ impl WorkspaceStore for PgBackend {
         self.repo.update_document(id, content).await
     }
 
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        self.repo.update_document_metadata(id, metadata).await
+    }
+
     async fn delete_document_by_path(
         &self,
         user_id: &str,
@@ -668,6 +676,18 @@ impl WorkspaceStore for PgBackend {
         agent_id: Option<Uuid>,
     ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
         self.repo.list_documents(user_id, agent_id).await
+    }
+
+    async fn list_documents_by_metadata(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+        key: &str,
+        value: &str,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        self.repo
+            .list_documents_by_metadata(user_id, agent_id, key, value)
+            .await
     }
 
     async fn delete_chunks(&self, document_id: Uuid) -> Result<(), WorkspaceError> {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -203,6 +203,18 @@ impl WorkspaceStorage {
         }
     }
 
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.update_document_metadata(id, metadata).await,
+            Self::Db(db) => db.update_document_metadata(id, metadata).await,
+        }
+    }
+
     async fn delete_document_by_path(
         &self,
         user_id: &str,
@@ -238,6 +250,26 @@ impl WorkspaceStorage {
             #[cfg(feature = "postgres")]
             Self::Repo(repo) => repo.list_all_paths(user_id, agent_id).await,
             Self::Db(db) => db.list_all_paths(user_id, agent_id).await,
+        }
+    }
+
+    async fn list_documents_by_metadata(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+        key: &str,
+        value: &str,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => {
+                repo.list_documents_by_metadata(user_id, agent_id, key, value)
+                    .await
+            }
+            Self::Db(db) => {
+                db.list_documents_by_metadata(user_id, agent_id, key, value)
+                    .await
+            }
         }
     }
 
@@ -550,6 +582,31 @@ impl Workspace {
         self.storage.get_document_by_id(doc.id).await
     }
 
+    /// Write or update a file and attach metadata in one step.
+    pub async fn write_with_metadata(
+        &self,
+        path: &str,
+        content: &str,
+        metadata: serde_json::Value,
+    ) -> Result<MemoryDocument, WorkspaceError> {
+        let doc = self.write(path, content).await?;
+        self.storage
+            .update_document_metadata(doc.id, &metadata)
+            .await?;
+        self.storage.get_document_by_id(doc.id).await
+    }
+
+    /// Update metadata for an existing document.
+    pub async fn update_metadata(
+        &self,
+        document_id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        self.storage
+            .update_document_metadata(document_id, metadata)
+            .await
+    }
+
     /// Append content to a file.
     ///
     /// Creates the file if it doesn't exist.
@@ -752,6 +809,17 @@ impl Workspace {
     pub async fn list_all(&self) -> Result<Vec<String>, WorkspaceError> {
         self.storage
             .list_all_paths(&self.user_id, self.agent_id)
+            .await
+    }
+
+    /// List documents matching a metadata key/value pair.
+    pub async fn list_by_metadata(
+        &self,
+        key: &str,
+        value: &str,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        self.storage
+            .list_documents_by_metadata(&self.user_id, self.agent_id, key, value)
             .await
     }
 
@@ -1530,6 +1598,8 @@ fn normalize_directory(path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "libsql")]
+    use crate::db::Database;
 
     #[test]
     fn test_normalize_path() {
@@ -1694,6 +1764,62 @@ mod tests {
         // Injection content targeting a non-system-prompt file should not
         // be checked (the guard is in write/append, not reject_if_injected).
         assert!(!is_system_prompt_file("notes/foo.md"));
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_workspace_metadata_round_trip_and_filtering() {
+        use crate::db::libsql::LibSqlBackend;
+        use std::sync::Arc;
+
+        let tempdir = tempfile::tempdir().expect("tempdir");
+        let db_path = tempdir.path().join("workspace_metadata.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("new local db");
+        backend.run_migrations().await.expect("run migrations");
+        let db: Arc<dyn Database> = Arc::new(backend);
+        let workspace = Workspace::new_with_db("user1", db);
+
+        let doc = workspace
+            .write_with_metadata(
+                "skills/deploy/SKILL.md",
+                "---\nname: deploy\n---\n\nDeploy prompt.",
+                serde_json::json!({
+                    "context_type": "skill",
+                    "trust_level": "trusted",
+                }),
+            )
+            .await
+            .expect("write with metadata");
+
+        assert_eq!(doc.path, "skills/deploy/SKILL.md");
+        assert_eq!(doc.metadata["context_type"], "skill");
+        assert_eq!(doc.metadata["trust_level"], "trusted");
+
+        let filtered = workspace
+            .list_by_metadata("context_type", "skill")
+            .await
+            .expect("list by metadata");
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].path, "skills/deploy/SKILL.md");
+
+        workspace
+            .update_metadata(
+                doc.id,
+                &serde_json::json!({
+                    "context_type": "skill",
+                    "trust_level": "installed",
+                }),
+            )
+            .await
+            .expect("update metadata");
+
+        let updated = workspace
+            .read("skills/deploy/SKILL.md")
+            .await
+            .expect("read doc");
+        assert_eq!(updated.metadata["trust_level"], "installed");
     }
 }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -589,10 +589,19 @@ impl Workspace {
         content: &str,
         metadata: serde_json::Value,
     ) -> Result<MemoryDocument, WorkspaceError> {
-        let doc = self.write(path, content).await?;
+        let path = normalize_path(path);
+        if is_system_prompt_file(&path) && !content.is_empty() {
+            reject_if_injected(&path, content)?;
+        }
+        let doc = self
+            .storage
+            .get_or_create_document_by_path(&self.user_id, self.agent_id, &path)
+            .await?;
+        self.storage.update_document(doc.id, content).await?;
         self.storage
             .update_document_metadata(doc.id, &metadata)
             .await?;
+        self.reindex_document(doc.id).await?;
         self.storage.get_document_by_id(doc.id).await
     }
 

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -150,6 +150,26 @@ impl Repository {
         Ok(())
     }
 
+    /// Update a document's metadata.
+    pub async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        let conn = self.conn().await?;
+
+        conn.execute(
+            "UPDATE memory_documents SET metadata = $2, updated_at = NOW() WHERE id = $1",
+            &[&id, metadata],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Metadata update failed: {}", e),
+        })?;
+
+        Ok(())
+    }
+
     /// Delete a document by its path.
     pub async fn delete_document_by_path(
         &self,
@@ -262,6 +282,37 @@ impl Repository {
             .await
             .map_err(|e| WorkspaceError::SearchFailed {
                 reason: format!("Query failed: {}", e),
+            })?;
+
+        Ok(rows.iter().map(|r| self.row_to_document(r)).collect())
+    }
+
+    /// List documents matching a metadata key/value pair.
+    pub async fn list_documents_by_metadata(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+        key: &str,
+        value: &str,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        let conn = self.conn().await?;
+
+        let rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, agent_id, path, content,
+                       created_at, updated_at, metadata
+                FROM memory_documents
+                WHERE user_id = $1
+                  AND agent_id IS NOT DISTINCT FROM $2
+                  AND metadata ->> $3 = $4
+                ORDER BY updated_at DESC
+                "#,
+                &[&user_id, &agent_id, &key, &value],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Metadata query failed: {}", e),
             })?;
 
         Ok(rows.iter().map(|r| self.row_to_document(r)).collect())

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -296,6 +296,12 @@ impl Repository {
         value: &str,
     ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
         let conn = self.conn().await?;
+        let mut filter = serde_json::Map::new();
+        filter.insert(
+            key.to_string(),
+            serde_json::Value::String(value.to_string()),
+        );
+        let filter = serde_json::Value::Object(filter);
 
         let rows = conn
             .query(
@@ -305,10 +311,10 @@ impl Repository {
                 FROM memory_documents
                 WHERE user_id = $1
                   AND agent_id IS NOT DISTINCT FROM $2
-                  AND metadata ->> $3 = $4
+                  AND metadata @> $3::jsonb
                 ORDER BY updated_at DESC
                 "#,
-                &[&user_id, &agent_id, &key, &value],
+                &[&user_id, &agent_id, &filter],
             )
             .await
             .map_err(|e| WorkspaceError::SearchFailed {


### PR DESCRIPTION
Partial foundation for #1504.\n\nThis PR adds workspace-level document metadata helpers and a regression test for round-tripping and filtering metadata. It does not rewrite the skill registry yet; that remains a follow-up slice once the workspace API is in place.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo check -q\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings\n- cargo test -p ironclaw workspace::tests::test_workspace_metadata_round_trip_and_filtering -- --nocapture