### PR TITLE
fix(wasm): inject Content-Length: 0 for bodyless mutating HTTP requests

### DIFF
--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1766,10 +1766,10 @@ fn build_tool_usage_hint(tool_name: &str, schema: &serde_json::Value) -> String 
 /// sent — some APIs (e.g. Gmail) return 411 without it. Returns `true` when
 /// the host should inject a `Content-Length: 0` header.
 fn needs_content_length_zero(method: &str, headers: &HashMap<String, String>) -> bool {
-    let mutating = matches!(
-        method.to_uppercase().as_str(),
-        "POST" | "PUT" | "PATCH" | "DELETE"
-    );
+    let mutating = method.eq_ignore_ascii_case("POST")
+        || method.eq_ignore_ascii_case("PUT")
+        || method.eq_ignore_ascii_case("PATCH")
+        || method.eq_ignore_ascii_case("DELETE");
     mutating
         && !headers
             .iter()


### PR DESCRIPTION
## Summary
- The WASM host `http_request` now auto-injects `Content-Length: 0` for POST/PUT/PATCH/DELETE requests with no body, fixing Gmail 411 errors and proactively covering all current and future WASM tools.

## Problem
Gmail's `trash_message` (`POST /messages/{id}/trash`) sends a POST with no body. The Gmail API requires `Content-Length` on POST and returns HTTP 411 without it. The same class of issue could affect any WASM tool making bodyless mutating requests (e.g. Google Calendar DELETE, Google Drive DELETE).

## Fix
Moved the fix from the gmail tool into the WASM host runtime (`src/tools/wasm/wrapper.rs`). The host now:
1. Detects mutating methods (POST/PUT/PATCH/DELETE) with no body
2. Checks the tool hasn't already set a `Content-Length` header (case-insensitive)
3. Injects `Content-Length: 0` automatically

Extracted `needs_content_length_zero()` as a testable helper with 8 regression tests.

## Test plan
- [x] 8 unit tests for `needs_content_length_zero()` covering all HTTP methods, case-insensitive detection, and explicit header passthrough
- [ ] Call `trash_message` with a valid message ID and verify it succeeds (HTTP 200)
- [ ] Verify POST-with-body actions (send, draft, reply) still include `Content-Type: application/json` and no extra `Content-Length`

🤖 Generated with [Claude Code](https://claude.com/claude-code)