### PR TITLE
fix: include Completed and Submitted in JobState::is_terminal()

### DIFF
--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -74,7 +74,14 @@ impl JobState {
 
     /// Check if this is a terminal state.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
+        matches!(
+            self,
+            Self::Completed
+                | Self::Submitted
+                | Self::Accepted
+                | Self::Failed
+                | Self::Cancelled
+        )
     }
 
     /// Check if the job is active (not terminal).


### PR DESCRIPTION
## Summary

`JobState::is_terminal()` only included `Accepted`, `Failed`, and `Cancelled` — but not `Completed` or `Submitted`. This caused `FullJobWatcher::wait_for_completion()` to poll indefinitely for completed jobs, since `is_active()` (`!is_terminal()`) returned `true` for `Completed` jobs.

**Impact:** `routine_runs` stayed in `running` status forever after the underlying `agent_job` had already completed, blocking future routine scheduling due to `max_concurrent` guards. In practice, all cron routines eventually stopped firing after a daemon restart because zombie "running" records accumulated.

## Root Cause

In `src/context/state.rs`:
```rust
// Before (bug):
pub fn is_terminal(&self) -> bool {
    matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
}

// After (fix):
pub fn is_terminal(&self) -> bool {
    matches!(
        self,
        Self::Completed | Self::Submitted | Self::Accepted | Self::Failed | Self::Cancelled
    )
}
```

`FullJobWatcher` (in `routine_engine.rs`) calls `job_ctx.state.is_active()` in a polling loop. Since `Completed` was not terminal, the watcher never broke out of the loop and the routine run was never finalized.

## Test plan

- [x] All 11 existing `context::state::tests` pass
- [x] Verified in production: routine_runs now correctly transition from `running` to `ok`/`failed` when the linked agent_job completes
- [x] No zombie `running` records after daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)