### PR TITLE
fix(auth): make shared Google tool status scope-aware

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -3839,26 +3839,39 @@ impl ExtensionManager {
         // authoritative signal — setup secrets (client_id/secret) are
         // intermediate and may be auto-resolved via builtins.
         if let Some(ref auth) = cap_file.auth {
-            let has_token = self
+            let token_is_managed = self
                 .secrets
                 .exists(user_id, &auth.secret_name)
                 .await
-                .unwrap_or(false)
-                || auth
-                    .env_var
-                    .as_ref()
-                    .is_some_and(|v| std::env::var(v).is_ok());
-            if has_token {
+                .unwrap_or(false);
+            let has_env_token = auth
+                .env_var
+                .as_ref()
+                .is_some_and(|v| std::env::var(v).is_ok());
+
+            if token_is_managed {
+                // Token lives in the secrets store — check whether the merged
+                // scope set of all tools sharing this secret is satisfied.
                 if let Some(ref oauth) = auth.oauth {
                     let merged = self
-                        .collect_shared_scopes(&auth.secret_name, &oauth.scopes)
+                        .collect_shared_scopes(&auth.secret_name, &oauth.scopes, user_id)
                         .await;
-                    if self.needs_scope_expansion(&auth.secret_name, &merged).await {
+                    if self
+                        .needs_scope_expansion(&auth.secret_name, &merged, user_id)
+                        .await
+                    {
                         return ToolAuthState::NeedsAuth;
                     }
                 }
                 return ToolAuthState::Ready;
             }
+
+            if has_env_token {
+                // Externally-managed token (env var) — skip scope checks;
+                // the user is responsible for granting adequate scopes.
+                return ToolAuthState::Ready;
+            }
+
             return if auth.oauth.is_some() {
                 ToolAuthState::NeedsAuth
             } else {
@@ -9091,7 +9104,7 @@ mod tests {
             .map_err(|err| format!("store scopes: {err}"))?;
 
         assert_eq!(
-            mgr.check_tool_auth_status("google-docs").await,
+            mgr.check_tool_auth_status("google-docs", "test").await,
             ToolAuthState::Ready
         );
 
@@ -9124,14 +9137,165 @@ mod tests {
         .map_err(|err| format!("write google-slides.capabilities.json: {err}"))?;
 
         assert_eq!(
-            mgr.check_tool_auth_status("google-docs").await,
+            mgr.check_tool_auth_status("google-docs", "test").await,
             ToolAuthState::NeedsAuth,
             "adding the second shared-auth Google tool should require reauth for the existing tool"
         );
         assert_eq!(
-            mgr.check_tool_auth_status("google-slides").await,
+            mgr.check_tool_auth_status("google-slides", "test").await,
             ToolAuthState::NeedsAuth,
             "second Google tool should require scope expansion when the shared token lacks its scope",
+        );
+
+        Ok(())
+    }
+
+    /// Env-var-provided tokens must always return Ready — the user manages
+    /// scopes externally, so the scope-expansion check must not apply.
+    /// Uses `HOME` as env_var since it always exists, avoiding `set_var`
+    /// which is unsafe in multi-threaded test runs.
+    #[tokio::test]
+    async fn test_env_var_token_skips_scope_expansion() -> Result<(), String> {
+        let dir = tempfile::tempdir().map_err(|err| format!("temp dir: {err}"))?;
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).map_err(|err| format!("tools dir: {err}"))?;
+
+        let caps = serde_json::json!({
+            "auth": {
+                "secret_name": "google_oauth_token",
+                "display_name": "Google",
+                "oauth": {
+                    "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                    "token_url": "https://oauth2.googleapis.com/token",
+                    "client_id_env": "GOOGLE_OAUTH_CLIENT_ID",
+                    "client_secret_env": "GOOGLE_OAUTH_CLIENT_SECRET",
+                    "scopes": ["https://www.googleapis.com/auth/documents"],
+                    "use_pkce": false,
+                    "extra_params": {
+                        "access_type": "offline",
+                        "prompt": "consent"
+                    }
+                },
+                "env_var": "HOME"
+            }
+        });
+        std::fs::write(tools_dir.join("google-docs.wasm"), b"\0asm")
+            .map_err(|err| format!("write wasm: {err}"))?;
+        std::fs::write(
+            tools_dir.join("google-docs.capabilities.json"),
+            serde_json::to_vec(&caps).map_err(|err| format!("serialize: {err}"))?,
+        )
+        .map_err(|err| format!("write caps: {err}"))?;
+
+        // No managed token in secrets store — only the env var (HOME) is present.
+        let mgr = make_test_manager(None, tools_dir);
+
+        assert_eq!(
+            mgr.check_tool_auth_status("google-docs", "test").await,
+            ToolAuthState::Ready,
+            "env-var token should be Ready without scope expansion check"
+        );
+
+        Ok(())
+    }
+
+    /// When both a managed token AND an env-var token exist, the managed
+    /// path (with scope expansion checks) must take priority.
+    #[tokio::test]
+    async fn test_managed_token_takes_priority_over_env_var() -> Result<(), String> {
+        let dir = tempfile::tempdir().map_err(|err| format!("temp dir: {err}"))?;
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).map_err(|err| format!("tools dir: {err}"))?;
+
+        // Both tools point env_var at HOME (always set) so the env-var path
+        // would return Ready — but the managed token path should win.
+        let caps = serde_json::json!({
+            "auth": {
+                "secret_name": "google_oauth_token",
+                "display_name": "Google",
+                "oauth": {
+                    "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                    "token_url": "https://oauth2.googleapis.com/token",
+                    "client_id_env": "GOOGLE_OAUTH_CLIENT_ID",
+                    "client_secret_env": "GOOGLE_OAUTH_CLIENT_SECRET",
+                    "scopes": ["https://www.googleapis.com/auth/documents"],
+                    "use_pkce": false,
+                    "extra_params": {
+                        "access_type": "offline",
+                        "prompt": "consent"
+                    }
+                },
+                "env_var": "HOME"
+            }
+        });
+        std::fs::write(tools_dir.join("google-docs.wasm"), b"\0asm")
+            .map_err(|err| format!("write wasm: {err}"))?;
+        std::fs::write(
+            tools_dir.join("google-docs.capabilities.json"),
+            serde_json::to_vec(&caps).map_err(|err| format!("serialize: {err}"))?,
+        )
+        .map_err(|err| format!("write caps: {err}"))?;
+
+        // Second tool requires an additional scope.
+        let slides_caps = serde_json::json!({
+            "auth": {
+                "secret_name": "google_oauth_token",
+                "display_name": "Google",
+                "oauth": {
+                    "authorization_url": "https://accounts.google.com/o/oauth2/v2/auth",
+                    "token_url": "https://oauth2.googleapis.com/token",
+                    "client_id_env": "GOOGLE_OAUTH_CLIENT_ID",
+                    "client_secret_env": "GOOGLE_OAUTH_CLIENT_SECRET",
+                    "scopes": ["https://www.googleapis.com/auth/presentations"],
+                    "use_pkce": false,
+                    "extra_params": {
+                        "access_type": "offline",
+                        "prompt": "consent"
+                    }
+                },
+                "env_var": "HOME"
+            }
+        });
+        std::fs::write(tools_dir.join("google-slides.wasm"), b"\0asm")
+            .map_err(|err| format!("write wasm: {err}"))?;
+        std::fs::write(
+            tools_dir.join("google-slides.capabilities.json"),
+            serde_json::to_vec(&slides_caps).map_err(|err| format!("serialize: {err}"))?,
+        )
+        .map_err(|err| format!("write caps: {err}"))?;
+
+        let mgr = make_test_manager(None, tools_dir);
+
+        // Store a managed token with only the docs scope.
+        mgr.secrets
+            .create(
+                "test",
+                crate::secrets::CreateSecretParams::new("google_oauth_token", "managed-token")
+                    .with_provider("google-docs"),
+            )
+            .await
+            .map_err(|err| format!("store token: {err}"))?;
+        mgr.secrets
+            .create(
+                "test",
+                crate::secrets::CreateSecretParams::new(
+                    "google_oauth_token_scopes",
+                    "https://www.googleapis.com/auth/documents",
+                )
+                .with_provider("google-docs"),
+            )
+            .await
+            .map_err(|err| format!("store scopes: {err}"))?;
+
+        assert_eq!(
+            mgr.check_tool_auth_status("google-docs", "test").await,
+            ToolAuthState::NeedsAuth,
+            "managed token path must win: merged scopes unsatisfied despite env var being set"
+        );
+        assert_eq!(
+            mgr.check_tool_auth_status("google-slides", "test").await,
+            ToolAuthState::NeedsAuth,
+            "slides scope missing from managed token even though env var is set"
         );
 
         Ok(())


### PR DESCRIPTION
Fixes #1500 by making WASM tool auth status scope-aware for shared Google OAuth tokens.

When a second Google tool is installed with the same shared token secret, the existing token no longer marks it as ready unless the merged scope set is already satisfied. This keeps the UI and auth flow aligned with the actual OAuth coverage.

Validation:
- cargo fmt --all -- --check
- cargo check -q
- cargo clippy -p ironclaw --lib --all-features -- -D warnings
- cargo test -p ironclaw --lib manager::tests::test_shared_google_oauth_status_requires_scope_expansion_for_second_tool -- --nocapture --test-threads=1