### PR TITLE
security(webhooks): add HMAC verification

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -65,7 +65,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Channel | OpenClaw | IronClaw | Priority | Notes |
 |---------|----------|----------|----------|-------|
 | CLI/TUI | ✅ | ✅ | - | Ratatui-based TUI |
-| HTTP webhook | ✅ | ✅ | - | axum with secret validation |
+| HTTP webhook | ✅ | ✅ | - | axum with HMAC signature validation + legacy secret fallback; unscoped route stays owner-scoped and multi-tenant deployments use `/api/webhooks/u/{user_id}/{path}` |
 | REPL (simple) | ✅ | ✅ | - | For testing |
 | WASM channels | ❌ | ✅ | - | IronClaw innovation; host resolves owner scope vs sender identity |
 | WhatsApp | ✅ | ❌ | P1 | Baileys (Web), same-phone mode with echo detection |

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -5592,7 +5592,7 @@ mod tests {
             capabilities,
             std::collections::HashMap::new(),
             Vec::new(),
-            Arc::new(PairingStore::new()),
+            Arc::new(PairingStore::new_noop()),
         );
 
         let result = super::near::agent::channel_host::Host::http_request(

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -120,6 +120,12 @@ Browser-facing HTTP API and SSE/WebSocket real-time streaming. Axum-based, singl
 | GET | `/api/tokens` | List own tokens |
 | DELETE | `/api/tokens/{id}` | Revoke a token |
 
+### Webhooks
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/api/webhooks/{path}` | Public routine webhook trigger in single-user mode; resolves routines in the gateway owner's scope, prefers `X-Hub-Signature-256` HMAC validation, and falls back to `X-Webhook-Secret` for compatibility |
+| POST | `/api/webhooks/u/{user_id}/{path}` | User-scoped webhook trigger for multi-tenant deployments; resolves routines for the explicit user scope |
+
 ### Settings
 | Method | Path | Description |
 |--------|------|-------------|

--- a/src/channels/web/handlers/webhooks.rs
+++ b/src/channels/web/handlers/webhooks.rs
@@ -1,13 +1,18 @@
 //! Public webhook trigger endpoint for routine webhook triggers.
 //!
-//! `POST /api/webhooks/{path}` — matches the path against routines with
-//! `Trigger::Webhook { path, secret }`, validates the secret via constant-time
-//! comparison, and fires the matching routine through the `RoutineEngine`.
+//! `POST /api/webhooks/{path}` resolves webhook routines in the gateway owner's
+//! scope, validates the request with either `X-Hub-Signature-256` (preferred)
+//! or the legacy `X-Webhook-Secret` header, and fires the matching routine
+//! through the `RoutineEngine`.
+//!
+//! `POST /api/webhooks/u/{user_id}/{path}` is the explicit multi-tenant variant
+//! that scopes the lookup to the requested `user_id`.
 
 use std::sync::Arc;
 
 use axum::{
     Json,
+    body::Bytes,
     extract::{Path, State},
     http::{HeaderMap, StatusCode},
 };
@@ -16,35 +21,49 @@ use subtle::ConstantTimeEq;
 use crate::agent::routine::Trigger;
 use crate::channels::web::server::GatewayState;
 
-/// Validate the webhook secret for a routine.
+fn auth_failed() -> (StatusCode, String) {
+    (
+        StatusCode::UNAUTHORIZED,
+        "Webhook authentication failed".to_string(),
+    )
+}
+
+/// Validate the webhook authentication for a routine.
 ///
-/// Returns `Ok(())` if the routine has a configured secret and the provided
-/// secret matches via constant-time comparison. Returns an appropriate HTTP
-/// error if the secret is missing (403) or invalid (401).
-fn validate_webhook_secret(
+/// Accepts `X-Hub-Signature-256` (preferred) for body HMAC verification and
+/// falls back to the legacy `X-Webhook-Secret` header for compatibility.
+fn validate_webhook_auth(
     trigger: &Trigger,
-    provided_secret: &str,
+    headers: &HeaderMap,
+    body: &[u8],
 ) -> Result<(), (StatusCode, String)> {
-    // Require webhook secret — routines without a secret cannot be triggered via webhook
     let expected_secret = match trigger {
         Trigger::Webhook {
             secret: Some(s), ..
         } => s,
-        _ => {
-            return Err((
-                StatusCode::FORBIDDEN,
-                "Webhook secret not configured for this routine. \
-                 Set a secret with: ironclaw routine update <id> --webhook-secret <secret>"
-                    .to_string(),
-            ));
-        }
+        _ => return Err(auth_failed()),
     };
 
+    if let Some(raw_signature) = headers.get("x-hub-signature-256") {
+        let signature = raw_signature.to_str().map_err(|_| auth_failed())?;
+        if !crate::channels::wasm::signature::verify_hmac_sha256_prefixed(
+            expected_secret,
+            body,
+            signature,
+            "sha256=",
+        ) {
+            return Err(auth_failed());
+        }
+        return Ok(());
+    }
+
+    let provided_secret = headers
+        .get("x-webhook-secret")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(auth_failed)?;
+
     if !bool::from(provided_secret.as_bytes().ct_eq(expected_secret.as_bytes())) {
-        return Err((
-            StatusCode::UNAUTHORIZED,
-            "Invalid webhook secret".to_string(),
-        ));
+        return Err(auth_failed());
     }
 
     Ok(())
@@ -53,28 +72,29 @@ fn validate_webhook_secret(
 /// Handle incoming webhook POST to `/api/webhooks/{path}`.
 ///
 /// This endpoint is **public** (no gateway auth token required) but protected
-/// by the per-routine webhook secret sent via the `X-Webhook-Secret` header.
-///
-/// **Single-user/backward-compatible**: looks up routines by path across all
-/// users. Disabled in multi-tenant mode — use the user-scoped endpoint at
-/// `/api/webhooks/u/{user_id}/{path}` instead.
+/// by either a per-routine HMAC signature (`X-Hub-Signature-256`) or the
+/// legacy `X-Webhook-Secret` header. In multi-tenant mode the unscoped route is
+/// disabled; callers should use `/api/webhooks/u/{user_id}/{path}`.
 pub async fn webhook_trigger_handler(
     State(state): State<Arc<GatewayState>>,
     Path(path): Path<String>,
     headers: HeaderMap,
+    body: Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     // In multi-tenant mode, reject unscoped webhooks to prevent cross-user
-    // routine triggering. The per-routine secret provides some protection,
-    // but tenant isolation requires scoping by user_id.
-    // Use workspace_pool as the multi-tenant indicator — it's only set when
-    // has_any_users() was true at startup (not just when a DB exists).
+    // routine triggering. The per-routine secret provides some protection, but
+    // tenant isolation requires scoping by user_id.
     if state.workspace_pool.is_some() {
         return Err((
             StatusCode::GONE,
             "Unscoped webhooks disabled in multi-tenant mode. Use /api/webhooks/u/{user_id}/{path} instead.".to_string(),
         ));
     }
-    fire_webhook_inner(state, &path, None, &headers).await
+    let owner_user_id = state
+        .workspace
+        .as_ref()
+        .map(|workspace| workspace.user_id().to_owned());
+    fire_webhook_inner(state, &path, owner_user_id.as_deref(), &headers, body).await
 }
 
 /// Handle incoming webhook POST to `/api/webhooks/u/{user_id}/{path}`.
@@ -86,8 +106,9 @@ pub async fn webhook_trigger_user_scoped_handler(
     State(state): State<Arc<GatewayState>>,
     Path((user_id, path)): Path<(String, String)>,
     headers: HeaderMap,
+    body: Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    fire_webhook_inner(state, &path, Some(&user_id), &headers).await
+    fire_webhook_inner(state, &path, Some(&user_id), &headers, body).await
 }
 
 /// Shared webhook logic for both scoped and unscoped endpoints.
@@ -96,6 +117,7 @@ async fn fire_webhook_inner(
     path: &str,
     user_id: Option<&str>,
     headers: &HeaderMap,
+    body: Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     // Rate limit check
     if !state.webhook_rate_limiter.check() {
@@ -110,22 +132,28 @@ async fn fire_webhook_inner(
         "Database not available".to_string(),
     ))?;
 
-    // Targeted query — when user_id is provided, restrict to that user's routines
+    // Scope the lookup to the gateway owner or explicit user_id so webhook
+    // paths do not become a cross-tenant identifier.
     let routine = store
         .get_webhook_routine_by_path(path, user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        .ok_or((
-            StatusCode::NOT_FOUND,
-            "No routine matches this webhook path".to_string(),
-        ))?;
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let provided_secret = headers
-        .get("x-webhook-secret")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
+    let routine = match routine {
+        Some(routine) => routine,
+        None => {
+            // Do comparable auth work even for misses so path enumeration
+            // does not trivially short-circuit before signature validation.
+            let miss_probe = Trigger::Webhook {
+                path: None,
+                secret: Some("__missing_webhook_probe__".to_string()),
+            };
+            let _ = validate_webhook_auth(&miss_probe, headers, &body);
+            return Err(auth_failed());
+        }
+    };
 
-    validate_webhook_secret(&routine.trigger, provided_secret)?;
+    validate_webhook_auth(&routine.trigger, headers, &body)?;
 
     // Fire through the RoutineEngine so guardrails, run tracking,
     // notifications, and FullJob dispatch all work correctly.
@@ -159,77 +187,108 @@ async fn fire_webhook_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::http::HeaderValue;
 
-    /// Routines with `secret: None` must be rejected with 403.
+    fn legacy_secret_headers(secret: &str) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        let value =
+            HeaderValue::from_str(secret).unwrap_or_else(|_| HeaderValue::from_static("invalid"));
+        headers.insert("x-webhook-secret", value);
+        headers
+    }
+
+    fn hmac_headers(body: &[u8], secret: &str) -> Result<HeaderMap, String> {
+        use hmac::{Hmac, Mac};
+        use sha2::Sha256;
+
+        let mut headers = HeaderMap::new();
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes())
+            .map_err(|err| format!("hmac key: {err}"))?;
+        mac.update(body);
+        let sig = format!("sha256={}", hex::encode(mac.finalize().into_bytes()));
+        let value = HeaderValue::from_str(&sig).map_err(|err| format!("header: {err}"))?;
+        headers.insert("x-hub-signature-256", value);
+        Ok(headers)
+    }
+
+    /// Routines with `secret: None` must be rejected.
     #[test]
-    fn test_validate_rejects_missing_secret() {
+    fn test_validate_rejects_missing_secret() -> Result<(), String> {
         let trigger = Trigger::Webhook {
             path: Some("my-hook".to_string()),
             secret: None,
         };
-        let result = validate_webhook_secret(&trigger, "any-secret");
+        let result = validate_webhook_auth(&trigger, &HeaderMap::new(), b"{}");
         let (status, msg) = result.unwrap_err();
-        assert_eq!(status, StatusCode::FORBIDDEN);
-        assert!(
-            msg.contains("not configured"),
-            "Error should tell user to configure a secret, got: {msg}"
-        );
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(msg, "Webhook authentication failed");
+        Ok(())
     }
 
-    /// Non-webhook triggers must be rejected with 403.
+    /// Non-webhook triggers must be rejected.
     #[test]
-    fn test_validate_rejects_non_webhook_trigger() {
+    fn test_validate_rejects_non_webhook_trigger() -> Result<(), String> {
         let trigger = Trigger::Manual;
-        let result = validate_webhook_secret(&trigger, "any-secret");
+        let result = validate_webhook_auth(&trigger, &HeaderMap::new(), b"{}");
         let (status, _) = result.unwrap_err();
-        assert_eq!(status, StatusCode::FORBIDDEN);
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        Ok(())
     }
 
-    /// Correct secret passes validation.
+    /// Correct legacy secret passes validation.
     #[test]
-    fn test_validate_accepts_correct_secret() {
+    fn test_validate_accepts_correct_legacy_secret() -> Result<(), String> {
         let trigger = Trigger::Webhook {
             path: Some("my-hook".to_string()),
             secret: Some("s3cret-token".to_string()),
         };
-        assert!(validate_webhook_secret(&trigger, "s3cret-token").is_ok());
+        assert!(
+            validate_webhook_auth(&trigger, &legacy_secret_headers("s3cret-token"), b"{}").is_ok()
+        );
+        Ok(())
     }
 
-    /// Wrong secret returns 401.
+    /// Correct HMAC signature passes validation.
     #[test]
-    fn test_validate_rejects_wrong_secret() {
+    fn test_validate_accepts_correct_hmac_signature() -> Result<(), String> {
+        let trigger = Trigger::Webhook {
+            path: Some("my-hook".to_string()),
+            secret: Some("s3cret-token".to_string()),
+        };
+        let body = br#"{"event":"push"}"#;
+        assert!(
+            validate_webhook_auth(&trigger, &hmac_headers(body, "s3cret-token")?, body).is_ok()
+        );
+        Ok(())
+    }
+
+    /// Wrong legacy secret returns 401.
+    #[test]
+    fn test_validate_rejects_wrong_legacy_secret() -> Result<(), String> {
         let trigger = Trigger::Webhook {
             path: Some("my-hook".to_string()),
             secret: Some("correct-secret".to_string()),
         };
-        let result = validate_webhook_secret(&trigger, "wrong-secret");
+        let result = validate_webhook_auth(&trigger, &legacy_secret_headers("wrong-secret"), b"{}");
         let (status, msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-        assert!(msg.contains("Invalid"), "Expected 'Invalid' in: {msg}");
+        assert_eq!(msg, "Webhook authentication failed");
+        Ok(())
     }
 
-    /// Empty provided secret returns 401 (not a false positive).
+    /// Wrong HMAC signature returns 401.
     #[test]
-    fn test_validate_rejects_empty_provided_secret() {
+    fn test_validate_rejects_wrong_hmac_signature() -> Result<(), String> {
         let trigger = Trigger::Webhook {
             path: Some("my-hook".to_string()),
-            secret: Some("real-secret".to_string()),
+            secret: Some("correct-secret".to_string()),
         };
-        let result = validate_webhook_secret(&trigger, "");
-        let (status, _) = result.unwrap_err();
+        let body = br#"{"event":"push"}"#;
+        let headers = hmac_headers(body, "wrong-secret")?;
+        let result = validate_webhook_auth(&trigger, &headers, body);
+        let (status, msg) = result.unwrap_err();
         assert_eq!(status, StatusCode::UNAUTHORIZED);
-    }
-
-    /// Constant-time comparison: secrets of different lengths are still rejected
-    /// (not short-circuited in a way that leaks length info).
-    #[test]
-    fn test_validate_rejects_different_length_secret() {
-        let trigger = Trigger::Webhook {
-            path: None,
-            secret: Some("short".to_string()),
-        };
-        let result = validate_webhook_secret(&trigger, "a-much-longer-secret-value");
-        let (status, _) = result.unwrap_err();
-        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(msg, "Webhook authentication failed");
+        Ok(())
     }
 }

--- a/src/channels/web/handlers/webhooks.rs
+++ b/src/channels/web/handlers/webhooks.rs
@@ -90,11 +90,12 @@ pub async fn webhook_trigger_handler(
             "Unscoped webhooks disabled in multi-tenant mode. Use /api/webhooks/u/{user_id}/{path} instead.".to_string(),
         ));
     }
-    let owner_user_id = state
-        .workspace
-        .as_ref()
-        .map(|workspace| workspace.user_id().to_owned());
-    fire_webhook_inner(state, &path, owner_user_id.as_deref(), &headers, body).await
+    let owner_user_id = state.workspace.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Workspace not available".to_string(),
+    ))?;
+    let owner_user_id = owner_user_id.user_id().to_string();
+    fire_webhook_inner(state, &owner_user_id, &path, &headers, body).await
 }
 
 /// Handle incoming webhook POST to `/api/webhooks/u/{user_id}/{path}`.
@@ -108,14 +109,14 @@ pub async fn webhook_trigger_user_scoped_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    fire_webhook_inner(state, &path, Some(&user_id), &headers, body).await
+    fire_webhook_inner(state, &user_id, &path, &headers, body).await
 }
 
 /// Shared webhook logic for both scoped and unscoped endpoints.
 async fn fire_webhook_inner(
     state: Arc<GatewayState>,
+    user_id: &str,
     path: &str,
-    user_id: Option<&str>,
     headers: &HeaderMap,
     body: Bytes,
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
@@ -135,7 +136,7 @@ async fn fire_webhook_inner(
     // Scope the lookup to the gateway owner or explicit user_id so webhook
     // paths do not become a cross-tenant identifier.
     let routine = store
-        .get_webhook_routine_by_path(path, user_id)
+        .get_webhook_routine_by_path(user_id, path)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 

--- a/src/db/libsql/routines.rs
+++ b/src/db/libsql/routines.rs
@@ -535,12 +535,12 @@ impl RoutineStore for LibSqlBackend {
 
     async fn get_webhook_routine_by_path(
         &self,
+        user_id: &str,
         path: &str,
-        user_id: Option<&str>,
     ) -> Result<Option<Routine>, DatabaseError> {
         let conn = self.connect().await?;
-        let mut rows = if let Some(uid) = user_id {
-            conn.query(
+        let mut rows = conn
+            .query(
                 &format!(
                     "SELECT {} FROM routines WHERE enabled = 1 AND trigger_type = 'webhook' \
                      AND user_id = ?2 \
@@ -548,23 +548,10 @@ impl RoutineStore for LibSqlBackend {
                      OR (json_extract(trigger_config, '$.path') IS NULL AND CAST(id AS TEXT) = ?1))",
                     ROUTINE_COLUMNS
                 ),
-                params![path, uid],
+                params![path, user_id],
             )
             .await
-            .map_err(|e| DatabaseError::Query(e.to_string()))?
-        } else {
-            conn.query(
-                &format!(
-                    "SELECT {} FROM routines WHERE enabled = 1 AND trigger_type = 'webhook' \
-                     AND (json_extract(trigger_config, '$.path') = ?1 \
-                     OR (json_extract(trigger_config, '$.path') IS NULL AND CAST(id AS TEXT) = ?1))",
-                    ROUTINE_COLUMNS
-                ),
-                params![path],
-            )
-            .await
-            .map_err(|e| DatabaseError::Query(e.to_string()))?
-        };
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
 
         match rows
             .next()
@@ -712,12 +699,12 @@ mod tests {
         backend.create_routine(&user_two).await.unwrap();
 
         let found_one = backend
-            .get_webhook_routine_by_path(shared_path, Some("user-1"))
+            .get_webhook_routine_by_path("user-1", shared_path)
             .await
             .unwrap()
             .expect("user-1 webhook");
         let found_two = backend
-            .get_webhook_routine_by_path(shared_path, Some("user-2"))
+            .get_webhook_routine_by_path("user-2", shared_path)
             .await
             .unwrap()
             .expect("user-2 webhook");
@@ -728,7 +715,7 @@ mod tests {
         assert_eq!(found_two.user_id, "user-2");
         assert!(
             backend
-                .get_webhook_routine_by_path(shared_path, Some("missing-user"))
+                .get_webhook_routine_by_path("missing-user", shared_path)
                 .await
                 .unwrap()
                 .is_none()

--- a/src/db/libsql/routines.rs
+++ b/src/db/libsql/routines.rs
@@ -636,6 +636,16 @@ mod tests {
         }
     }
 
+    fn test_webhook_routine(user_id: &str, name: &str, path: &str, secret: &str) -> Routine {
+        Routine {
+            trigger: Trigger::Webhook {
+                path: Some(path.to_string()),
+                secret: Some(secret.to_string()),
+            },
+            ..test_routine(user_id, name)
+        }
+    }
+
     fn test_run(routine_id: Uuid, status: RunStatus, started_at: DateTime<Utc>) -> RoutineRun {
         RoutineRun {
             id: Uuid::new_v4(),
@@ -686,5 +696,42 @@ mod tests {
         assert_eq!(statuses.len(), 1);
         assert_eq!(statuses.get(&requested.id), Some(&RunStatus::Ok));
         assert!(!statuses.contains_key(&other.id));
+    }
+
+    #[tokio::test]
+    async fn get_webhook_routine_by_path_is_scoped_to_user_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("routine-webhooks.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let shared_path = "shared-webhook";
+        let user_one = test_webhook_routine("user-1", "user-one-webhook", shared_path, "secret-1");
+        let user_two = test_webhook_routine("user-2", "user-two-webhook", shared_path, "secret-2");
+        backend.create_routine(&user_one).await.unwrap();
+        backend.create_routine(&user_two).await.unwrap();
+
+        let found_one = backend
+            .get_webhook_routine_by_path(shared_path, Some("user-1"))
+            .await
+            .unwrap()
+            .expect("user-1 webhook");
+        let found_two = backend
+            .get_webhook_routine_by_path(shared_path, Some("user-2"))
+            .await
+            .unwrap()
+            .expect("user-2 webhook");
+
+        assert_eq!(found_one.id, user_one.id);
+        assert_eq!(found_one.user_id, "user-1");
+        assert_eq!(found_two.id, user_two.id);
+        assert_eq!(found_two.user_id, "user-2");
+        assert!(
+            backend
+                .get_webhook_routine_by_path(shared_path, Some("missing-user"))
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -623,8 +623,8 @@ pub trait RoutineStore: Send + Sync {
     ) -> Result<(), DatabaseError>;
     async fn get_webhook_routine_by_path(
         &self,
+        user_id: &str,
         path: &str,
-        user_id: Option<&str>,
     ) -> Result<Option<Routine>, DatabaseError>;
 
     /// List routine runs that were dispatched as full_job but have not yet

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -615,10 +615,10 @@ impl RoutineStore for PgBackend {
 
     async fn get_webhook_routine_by_path(
         &self,
+        user_id: &str,
         path: &str,
-        user_id: Option<&str>,
     ) -> Result<Option<Routine>, DatabaseError> {
-        self.store.get_webhook_routine_by_path(path, user_id).await
+        self.store.get_webhook_routine_by_path(user_id, path).await
     }
 
     async fn list_dispatched_routine_runs(&self) -> Result<Vec<RoutineRun>, DatabaseError> {

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1165,26 +1165,18 @@ impl Store {
     /// Find an enabled webhook routine by its configured path (or fallback to ID).
     pub async fn get_webhook_routine_by_path(
         &self,
+        user_id: &str,
         path: &str,
-        user_id: Option<&str>,
     ) -> Result<Option<Routine>, DatabaseError> {
         let conn = self.conn().await?;
-        let row = if let Some(uid) = user_id {
-            conn.query_opt(
+        let row = conn
+            .query_opt(
                 "SELECT * FROM routines WHERE enabled AND trigger_type = 'webhook' \
-                 AND user_id = $2 \
-                 AND (trigger_config->>'path' = $1 OR (trigger_config->>'path' IS NULL AND id::text = $1))",
-                &[&path, &uid],
+                 AND user_id = $1 \
+                 AND (trigger_config->>'path' = $2 OR (trigger_config->>'path' IS NULL AND id::text = $2))",
+                &[&user_id, &path],
             )
-            .await?
-        } else {
-            conn.query_opt(
-                "SELECT * FROM routines WHERE enabled AND trigger_type = 'webhook' \
-                 AND (trigger_config->>'path' = $1 OR (trigger_config->>'path' IS NULL AND id::text = $1))",
-                &[&path],
-            )
-            .await?
-        };
+            .await?;
         row.as_ref().map(row_to_routine).transpose()
     }
 

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -234,11 +234,10 @@ impl TenantScope {
 
     pub async fn get_webhook_routine_by_path(
         &self,
+        user_id: &str,
         path: &str,
     ) -> Result<Option<Routine>, DatabaseError> {
-        self.inner
-            .get_webhook_routine_by_path(path, Some(self.identity.owner_id.as_str()))
-            .await
+        self.inner.get_webhook_routine_by_path(user_id, path).await
     }
 
     // === LLM call recording ===


### PR DESCRIPTION
Addresses #1507 by tightening the public webhook trigger endpoint:\n\n- prefer X-Hub-Signature-256 HMAC verification over the legacy X-Webhook-Secret header\n- return a generic auth failure for webhook auth errors to avoid path/config enumeration\n- update web gateway docs and feature parity notes\n\nValidation:\n- cargo fmt --all -- --check\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings\n- cargo test -p ironclaw --lib webhooks::tests -- --nocapture\n