### PR TITLE
fix(mcp): handle empty 202 notification acknowledgements

### DIFF
--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -528,16 +528,16 @@ mod tests {
         let app = Router::new().route("/", post(accepted));
         let listener = TcpListener::bind("127.0.0.1:0")
             .await
-            .expect("bind test accepted server");
+            .expect("Failed to bind to an ephemeral port");
         let addr = listener
             .local_addr()
-            .expect("resolve accepted server address");
+            .expect("Failed to get listener's local address");
         let url = format!("http://127.0.0.1:{}", addr.port());
 
         let handle = tokio::spawn(async move {
             axum::serve(listener, app)
                 .await
-                .expect("serve accepted test server");
+                .expect("Test server failed to run");
         });
 
         (url, handle)


### PR DESCRIPTION
Fixes #1436.\n\nMCP Streamable HTTP notifications may legitimately return 202 Accepted with an empty body. The HTTP transport now treats that as an empty JSON-RPC acknowledgement instead of trying to parse JSON, which unblocks session initialization against servers such as kubernetes-mcp-server.\n\nValidation:\n- cargo test -p ironclaw --lib http_transport::tests::test_accepted_notification_returns_empty_response -- --nocapture\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings