### PR TITLE
fix(web): open Google auth links in a new tab

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -1388,19 +1388,23 @@ function showAuthCard(data) {
   links.className = 'auth-links';
 
   if (data.auth_url) {
-    const oauthBtn = document.createElement('button');
-    oauthBtn.className = 'auth-oauth';
-    oauthBtn.textContent = I18n.t('authRequired.authenticateWith', {name: data.extension_name});
-    oauthBtn.addEventListener('click', () => {
-      openOAuthUrl(data.auth_url);
-    });
-    links.appendChild(oauthBtn);
+    const href = getValidatedOAuthUrl(data.auth_url);
+    if (href) {
+      const oauthLink = document.createElement('a');
+      oauthLink.className = 'auth-oauth';
+      oauthLink.href = href;
+      oauthLink.target = '_blank';
+      oauthLink.rel = 'noopener noreferrer';
+      oauthLink.textContent = I18n.t('authRequired.authenticateWith', {name: data.extension_name});
+      links.appendChild(oauthLink);
+    }
   }
 
   if (data.setup_url) {
     const setupLink = document.createElement('a');
     setupLink.href = data.setup_url;
     setupLink.target = '_blank';
+    setupLink.rel = 'noopener noreferrer';
     setupLink.textContent = I18n.t('authRequired.getToken');
     links.appendChild(setupLink);
   }
@@ -3111,7 +3115,7 @@ function closeConfigureModal(extensionName) {
 // Rejects javascript:, data:, and other non-HTTPS schemes to prevent URL-injection.
 // Uses the URL constructor to safely parse and validate the scheme, which also
 // handles non-string values (objects, null, etc.) that would throw on .startsWith().
-function openOAuthUrl(url) {
+function getValidatedOAuthUrl(url) {
   let parsed;
   try {
     parsed = new URL(url);
@@ -3121,9 +3125,15 @@ function openOAuthUrl(url) {
   } catch (e) {
     console.warn('Blocked invalid/non-HTTPS OAuth URL:', url, e.message);
     showToast('Invalid OAuth URL returned by server', 'error');
-    return;
+    return null;
   }
-  window.open(parsed.href, '_blank', 'width=600,height=700');
+  return parsed.href;
+}
+
+function openOAuthUrl(url) {
+  const href = getValidatedOAuthUrl(url);
+  if (!href) return;
+  window.open(href, '_blank', 'width=600,height=700');
 }
 
 // --- Pairing ---

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -1380,7 +1380,7 @@ body {
   border-color: var(--border);
 }
 
-.auth-card .auth-actions button.auth-oauth {
+.auth-card .auth-actions .auth-oauth {
   background: var(--success);
   border-color: var(--success);
   color: var(--text-on-accent);

--- a/tests/e2e/scenarios/test_extensions.py
+++ b/tests/e2e/scenarios/test_extensions.py
@@ -750,7 +750,7 @@ async def test_auth_card_with_oauth(page):
     assert await oauth_link.evaluate("(node) => node.tagName") == "A"
     assert await oauth_link.get_attribute("target") == "_blank"
     rel = await oauth_link.get_attribute("rel")
-    assert rel and "noopener" in rel
+    assert rel and "noopener" in rel and "noreferrer" in rel
     assert "slack" in await oauth_link.text_content()
 
 

--- a/tests/e2e/scenarios/test_extensions.py
+++ b/tests/e2e/scenarios/test_extensions.py
@@ -741,13 +741,17 @@ async def test_auth_card_token_only(page):
 
 
 async def test_auth_card_with_oauth(page):
-    """Auth card with auth_url shows the OAuth button."""
+    """Auth card with auth_url shows a new-tab OAuth link."""
     await _show_auth_card(page, extension_name="slack", auth_url="https://slack.com/oauth/authorize")
 
     card = page.locator(SEL["auth_card"])
-    oauth_btn = card.locator(SEL["auth_oauth_btn"])
-    assert await oauth_btn.count() == 1
-    assert "slack" in await oauth_btn.text_content()
+    oauth_link = card.locator(SEL["auth_oauth_btn"])
+    assert await oauth_link.count() == 1
+    assert await oauth_link.evaluate("(node) => node.tagName") == "A"
+    assert await oauth_link.get_attribute("target") == "_blank"
+    rel = await oauth_link.get_attribute("rel")
+    assert rel and "noopener" in rel
+    assert "slack" in await oauth_link.text_content()
 
 
 async def test_auth_card_with_setup_url(page):


### PR DESCRIPTION
Closes #1502.

This changes the auth-card OAuth CTA from a popup-style button to a real target=_blank link, with noopener/noreferrer for safety. Existing automatic OAuth flows still use the popup path.