### PR TITLE
fix(agent): eliminate TOCTOU race in approval thread resolution

### DIFF
--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -915,18 +915,12 @@ impl Agent {
             if approved && always {
                 let tool_name = pending.tool_name.clone();
                 sess.auto_approve_tool(&tool_name);
-                tracing::info!(
-                    "Auto-approved tool '{}' for session {}",
-                    tool_name,
-                    sess.id
-                );
+                tracing::info!("Auto-approved tool '{}' for session {}", tool_name, sess.id);
             }
 
             // Set thread state to Processing for approved requests.
             // Re-borrow the thread since the previous borrow was dropped.
-            if approved
-                && let Some(thread) = sess.threads.get_mut(&thread_id)
-            {
+            if approved && let Some(thread) = sess.threads.get_mut(&thread_id) {
                 thread.state = ThreadState::Processing;
             }
 
@@ -2133,10 +2127,7 @@ mod tests {
 
         // Verify both mutations happened atomically
         assert!(session.is_tool_auto_approved("web_fetch"));
-        assert_eq!(
-            session.threads[&thread_id].state,
-            ThreadState::Processing
-        );
+        assert_eq!(session.threads[&thread_id].state, ThreadState::Processing);
         // Pending approval should be consumed (not restored)
         assert!(session.threads[&thread_id].pending_approval.is_none());
     }


### PR DESCRIPTION
## Summary
- Combines 4 separate lock acquisitions in `process_approval()` into a single atomic scope: check thread state, take pending approval, verify request_id, set auto-approve, and transition to Processing all happen under one lock
- Eliminates the race window where concurrent operations could modify session state between check and mutation
- Fixes rejection path to warn when thread disappears instead of silently succeeding

Closes #1486

## Test plan
- [x] 2 regression tests: request_id mismatch preserves pending state, approval with always sets auto-approve + Processing atomically
- [x] All 358 agent tests pass
- [x] Clippy clean with `--all-features`
- [x] Both default and libsql features compile