### PR TITLE
fix(wasm): fall back to default scope for secret injection

### DIFF
--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -15,7 +15,7 @@ use crate::config::Config;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::pairing::PairingStore;
-use crate::secrets::SecretsStore;
+use crate::secrets::{SecretsStore, get_decrypted_with_default};
 
 /// Result of WASM channel setup.
 pub struct WasmChannelSetup {
@@ -129,8 +129,7 @@ async fn register_channel(
     let hmac_secret_name = loaded.hmac_secret_name();
 
     let webhook_secret = if let Some(secrets) = secrets_store {
-        secrets
-            .get_decrypted(&config.owner_id, &secret_name)
+        get_decrypted_with_default(secrets.as_ref(), &config.owner_id, &secret_name)
             .await
             .ok()
             .map(|s| s.expose().to_string())
@@ -222,7 +221,8 @@ async fn register_channel(
     // Register Ed25519 signature key if declared in capabilities.
     if let Some(ref sig_key_name) = sig_key_secret_name
         && let Some(secrets) = secrets_store
-        && let Ok(key_secret) = secrets.get_decrypted(&config.owner_id, sig_key_name).await
+        && let Ok(key_secret) =
+            get_decrypted_with_default(secrets.as_ref(), &config.owner_id, sig_key_name).await
     {
         match wasm_router
             .register_signature_key(&channel_name, key_secret.expose())
@@ -240,9 +240,8 @@ async fn register_channel(
     // Register HMAC signing secret if declared in capabilities.
     if let Some(ref hmac_secret_name) = hmac_secret_name
         && let Some(secrets) = secrets_store
-        && let Ok(secret) = secrets
-            .get_decrypted(&config.owner_id, hmac_secret_name)
-            .await
+        && let Ok(secret) =
+            get_decrypted_with_default(secrets.as_ref(), &config.owner_id, hmac_secret_name).await
     {
         wasm_router
             .register_hmac_secret(&channel_name, secret.expose())
@@ -305,8 +304,8 @@ pub async fn inject_channel_credentials(
     let mut injected_placeholders = HashSet::new();
 
     // 1. Try injecting from persistent secrets store if available
-    if let Some(secrets) = secrets {
-        let all_secrets = secrets
+    if let Some(secrets_store) = secrets {
+        let all_secrets = secrets_store
             .list(owner_id)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to list secrets: {}", e))?;
@@ -318,7 +317,13 @@ pub async fn inject_channel_credentials(
                 continue;
             }
 
-            let decrypted = match secrets.get_decrypted(owner_id, &secret_meta.name).await {
+            let decrypted = match get_decrypted_with_default(
+                secrets_store,
+                owner_id,
+                &secret_meta.name,
+            )
+            .await
+            {
                 Ok(d) => d,
                 Err(e) => {
                     tracing::warn!(

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -52,7 +52,7 @@ use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse,
 use crate::error::ChannelError;
 use crate::pairing::PairingStore;
 use crate::safety::LeakDetector;
-use crate::secrets::SecretsStore;
+use crate::secrets::{SecretsStore, get_decrypted_with_default};
 use crate::tools::wasm::LogLevel;
 use crate::tools::wasm::WasmResourceLimiter;
 use crate::tools::wasm::credential_injector::{
@@ -3196,20 +3196,18 @@ async fn resolve_channel_host_credentials(
             continue;
         }
 
-        let secret = match store
-            .get_decrypted(owner_scope_id, &mapping.secret_name)
-            .await
-        {
-            Ok(s) => s,
-            Err(e) => {
-                tracing::debug!(
-                    secret_name = %mapping.secret_name,
-                    error = %e,
-                    "Could not resolve credential for WASM channel (auth may not be configured)"
-                );
-                continue;
-            }
-        };
+        let secret =
+            match get_decrypted_with_default(store, owner_scope_id, &mapping.secret_name).await {
+                Ok(secret) => secret,
+                Err(e) => {
+                    tracing::debug!(
+                        secret_name = %mapping.secret_name,
+                        error = %e,
+                        "Could not resolve credential for WASM channel (auth may not be configured)"
+                    );
+                    continue;
+                }
+            };
 
         let mut injected = InjectedCredentials::empty();
         inject_credential(&mut injected, &mapping.location, &secret);
@@ -4667,6 +4665,38 @@ mod tests {
         assert_eq!(msg.sender_id, "guest-42"); // safety: test-only assertion
         assert_eq!(msg.conversation_scope(), Some("999")); // safety: test-only assertion
         assert!(last_broadcast_metadata.read().await.is_none()); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_resolve_channel_host_credentials_falls_back_to_default_scope() {
+        use super::resolve_channel_host_credentials;
+        use crate::secrets::{CreateSecretParams, CredentialMapping, SecretsStore};
+        use crate::tools::wasm::{Capabilities, HttpCapability};
+
+        let store = crate::testing::credentials::test_secrets_store();
+        store
+            .create(
+                "default",
+                CreateSecretParams::new("matrix_access_token", "fallback-token"),
+            )
+            .await
+            .expect("seed default secret");
+
+        let mut http = HttpCapability::default();
+        http.credentials.insert(
+            "matrix_access_token".to_string(),
+            CredentialMapping::bearer("matrix_access_token", "matrix.org"),
+        );
+        let capabilities = ChannelCapabilities::for_channel("matrix")
+            .with_tool_capabilities(Capabilities::default().with_http(http));
+
+        let result = resolve_channel_host_credentials(&capabilities, Some(&store), "agent3").await;
+
+        assert_eq!(result.len(), 1); // safety: test-only assertion
+        assert_eq!(
+            result[0].headers.get("Authorization"),
+            Some(&"Bearer fallback-token".to_string())
+        ); // safety: test-only assertion
     }
 
     #[tokio::test]

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -110,6 +110,36 @@ pub fn create_secrets_store(
     store
 }
 
+/// Resolve a decrypted secret for a user, falling back to the `default`
+/// scope when the primary lookup fails.
+///
+/// This keeps hosted deployments usable when secrets are configured once via
+/// the default CLI scope but runtime execution happens under a different
+/// owner/user ID.
+pub async fn get_decrypted_with_default(
+    store: &(dyn SecretsStore + Send + Sync),
+    user_id: &str,
+    name: &str,
+) -> Result<DecryptedSecret, SecretError> {
+    match store.get_decrypted(user_id, name).await {
+        Ok(secret) => Ok(secret),
+        Err(primary_err) if user_id != "default" => {
+            match store.get_decrypted("default", name).await {
+                Ok(secret) => {
+                    tracing::debug!(
+                        user_id = %user_id,
+                        secret_name = %name,
+                        "Resolved secret from default scope fallback"
+                    );
+                    Ok(secret)
+                }
+                Err(_) => Err(primary_err),
+            }
+        }
+        Err(err) => Err(err),
+    }
+}
+
 /// Try to resolve an existing master key from env var or OS keychain.
 ///
 /// Resolution order:
@@ -150,6 +180,7 @@ pub fn crypto_from_hex(hex: &str) -> Result<std::sync::Arc<SecretsCrypto>, Secre
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::testing::credentials::test_secrets_store;
 
     #[test]
     fn test_crypto_from_hex_valid() {
@@ -163,5 +194,48 @@ mod tests {
     fn test_crypto_from_hex_invalid() {
         let result = crypto_from_hex("too_short");
         assert!(result.is_err()); // safety: test assertion
+    }
+
+    #[tokio::test]
+    async fn test_get_decrypted_with_default_falls_back_to_default_scope() {
+        let store = test_secrets_store();
+        store
+            .create(
+                "default",
+                CreateSecretParams::new("matrix_access_token", "fallback-token"),
+            )
+            .await
+            .expect("seed default secret");
+
+        let secret = get_decrypted_with_default(&store, "agent3", "matrix_access_token")
+            .await
+            .expect("resolve via default scope");
+
+        assert_eq!(secret.expose(), "fallback-token"); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_get_decrypted_with_default_uses_primary_scope_first() {
+        let store = test_secrets_store();
+        store
+            .create(
+                "agent3",
+                CreateSecretParams::new("matrix_access_token", "primary-token"),
+            )
+            .await
+            .expect("seed primary secret");
+        store
+            .create(
+                "default",
+                CreateSecretParams::new("matrix_access_token", "fallback-token"),
+            )
+            .await
+            .expect("seed default secret");
+
+        let secret = get_decrypted_with_default(&store, "agent3", "matrix_access_token")
+            .await
+            .expect("resolve via primary scope");
+
+        assert_eq!(secret.expose(), "primary-token"); // safety: test-only assertion
     }
 }

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -19,7 +19,7 @@ use wasmtime_wasi::{ResourceTable, WasiCtx, WasiCtxBuilder, WasiView};
 use crate::context::JobContext;
 use crate::llm::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 use crate::safety::LeakDetector;
-use crate::secrets::SecretsStore;
+use crate::secrets::{SecretsStore, get_decrypted_with_default};
 use crate::tools::tool::{Tool, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
 use crate::tools::wasm::credential_injector::{
@@ -1300,43 +1300,13 @@ async fn resolve_host_credentials(
             continue;
         }
 
-        // Try to get credential under the provided user_id first.
-        // If not found and user_id != "default", fallback to "default" (global credentials).
-        // This handles OAuth tokens stored globally under "default" but accessed from routine contexts.
-        let secret = match store.get_decrypted(user_id, &mapping.secret_name).await {
-            Ok(s) => Some(s),
+        let secret = match get_decrypted_with_default(store, user_id, &mapping.secret_name).await {
+            Ok(secret) => secret,
             Err(e) => {
-                tracing::trace!(
-                    user_id = %user_id,
-                    secret_name = %mapping.secret_name,
-                    error = %e,
-                    "No matching host credential resolved for WASM tool in the requested scope"
-                );
-
-                // If lookup fails and we're not already looking up "default", try "default" as fallback
-                if user_id != "default" {
-                    tracing::debug!(
-                        secret_name = %mapping.secret_name,
-                        user_id = %user_id,
-                        error = %e,
-                        "Credential not found for user, trying default global credentials"
-                    );
-                    store
-                        .get_decrypted("default", &mapping.secret_name)
-                        .await
-                        .ok()
-                } else {
-                    None
-                }
-            }
-        };
-
-        let secret = match secret {
-            Some(s) => s,
-            None => {
                 tracing::warn!(
                     secret_name = %mapping.secret_name,
                     user_id = %user_id,
+                    error = %e,
                     "Could not resolve credential for WASM tool (not found in user context or default)"
                 );
                 continue;


### PR DESCRIPTION
Fixes the hosted TEE credential-injection gap reported in #1537 by resolving WASM tool/channel secrets from the default scope when the active owner scope misses.\n\nChanges:\n- add shared default-scope secret resolution helper\n- use it for WASM tool host credentials\n- use it for WASM channel webhook/config credential lookup\n- add regression coverage for the default fallback path\n\nValidation:\n- cargo fmt --all -- --check\n- cargo test -p ironclaw get_decrypted_with_default -- --nocapture\n- cargo test -p ironclaw test_resolve_host_credentials_owner_scope_bearer -- --nocapture\n- cargo test -p ironclaw test_resolve_channel_host_credentials_falls_back_to_default_scope -- --nocapture\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings