### PR TITLE
feat: add AWS Bedrock embeddings provider

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -350,6 +350,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | MMR re-ranking | ✅ | ❌ | Maximal marginal relevance for result diversity |
 | LLM-based query expansion | ✅ | ❌ | Expand FTS queries via LLM |
 | OpenAI embeddings | ✅ | ✅ | |
+| Bedrock embeddings | ❌ | ✅ | Reuses Bedrock region/profile auth for Titan Text Embeddings V2 |
 | Gemini embeddings | ✅ | ❌ | |
 | Local embeddings | ✅ | ❌ | |
 | SQLite-vec backend | ✅ | ❌ | IronClaw uses PostgreSQL |

--- a/src/app.rs
+++ b/src/app.rs
@@ -345,7 +345,12 @@ impl AppBuilder {
         let embeddings = self
             .config
             .embeddings
-            .create_provider(&self.config.llm.nearai.base_url, self.session.clone());
+            .create_provider(
+                &self.config.llm.nearai.base_url,
+                self.session.clone(),
+                self.config.llm.bedrock.as_ref(),
+            )
+            .await;
 
         // Register memory tools if database is available
         let workspace_user_id = self.config.owner_id.as_str();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -397,7 +397,12 @@ pub async fn run_memory_command(mem_cmd: &MemoryCommand) -> anyhow::Result<()> {
 
     let embeddings = config
         .embeddings
-        .create_provider(&config.llm.nearai.base_url, session);
+        .create_provider(
+            &config.llm.nearai.base_url,
+            session,
+            config.llm.bedrock.as_ref(),
+        )
+        .await;
 
     let db: Arc<dyn crate::db::Database> = crate::db::connect_from_config(&config.database)
         .await

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -84,13 +84,16 @@ impl EmbeddingsConfig {
             "EMBEDDING_PROVIDER",
         )?;
 
-        let model = optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| {
-            if provider == "bedrock" {
-                "amazon.titan-embed-text-v2:0".to_string()
-            } else {
-                settings.embeddings.model.clone()
-            }
-        });
+        let model = if provider == "bedrock" {
+            optional_env("EMBEDDING_MODEL")?
+                .unwrap_or_else(|| "amazon.titan-embed-text-v2:0".to_string())
+        } else {
+            db_first_or_default(
+                &settings.embeddings.model,
+                &defaults.model,
+                "EMBEDDING_MODEL",
+            )?
+        };
 
         // ollama_base_url lives on the top-level Settings, not the embeddings
         // sub-struct. Use a manual DB > env > default chain.
@@ -468,7 +471,7 @@ mod tests {
     #[cfg(feature = "bedrock")]
     #[test]
     fn bedrock_provider_defaults_to_titan_v2() {
-        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = lock_env();
         clear_embedding_env();
         // SAFETY: Under ENV_MUTEX.
         unsafe {
@@ -492,7 +495,7 @@ mod tests {
     #[cfg(feature = "bedrock")]
     #[test]
     fn bedrock_dimension_validation_rejects_unsupported_values() {
-        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        let _guard = lock_env();
         clear_embedding_env();
         // SAFETY: Under ENV_MUTEX.
         unsafe {

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -6,7 +6,7 @@ use crate::config::helpers::{
     db_first_bool, db_first_or_default, optional_env, parse_optional_env, validate_base_url,
 };
 use crate::error::ConfigError;
-use crate::llm::SessionManager;
+use crate::llm::{BedrockConfig, SessionManager};
 use crate::settings::Settings;
 use crate::workspace::EmbeddingProvider;
 
@@ -18,7 +18,7 @@ pub const DEFAULT_EMBEDDING_CACHE_SIZE: usize = 10_000;
 pub struct EmbeddingsConfig {
     /// Whether embeddings are enabled.
     pub enabled: bool,
-    /// Provider to use: "openai", "nearai", or "ollama"
+    /// Provider to use: "openai", "nearai", "ollama", or "bedrock"
     pub provider: String,
     /// OpenAI API key (for OpenAI provider).
     pub openai_api_key: Option<SecretString>,
@@ -64,6 +64,7 @@ pub(crate) fn default_dimension_for_model(model: &str) -> usize {
         "text-embedding-3-small" => 1536,
         "text-embedding-3-large" => 3072,
         "text-embedding-ada-002" => 1536,
+        "amazon.titan-embed-text-v2:0" => 1024,
         "nomic-embed-text" => 768,
         "mxbai-embed-large" => 1024,
         "all-minilm" => 384,
@@ -83,11 +84,12 @@ impl EmbeddingsConfig {
             "EMBEDDING_PROVIDER",
         )?;
 
-        let model = db_first_or_default(
-            &settings.embeddings.model,
-            &defaults.model,
-            "EMBEDDING_MODEL",
-        )?;
+        let model = if provider == "bedrock" {
+            optional_env("EMBEDDING_MODEL")?
+                .unwrap_or_else(|| "amazon.titan-embed-text-v2:0".to_string())
+        } else {
+            optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| settings.embeddings.model.clone())
+        };
 
         // ollama_base_url lives on the top-level Settings, not the embeddings
         // sub-struct. Use a manual DB > env > default chain.
@@ -105,6 +107,13 @@ impl EmbeddingsConfig {
         // Dimension depends on the resolved model, not on a DB setting — env-only.
         let dimension =
             parse_optional_env("EMBEDDING_DIMENSION", default_dimension_for_model(&model))?;
+        if provider == "bedrock" && !matches!(dimension, 256 | 512 | 1024) {
+            return Err(ConfigError::InvalidValue {
+                key: "EMBEDDING_DIMENSION".to_string(),
+                message: "Bedrock Titan v2 embeddings support only 256, 512, or 1024 dimensions"
+                    .to_string(),
+            });
+        }
 
         let enabled = db_first_bool(
             settings.embeddings.enabled,
@@ -151,10 +160,11 @@ impl EmbeddingsConfig {
     /// Returns `None` if embeddings are disabled or the required credentials
     /// are missing. The `nearai_base_url` and `session` are needed only for
     /// the NEAR AI provider but must be passed unconditionally.
-    pub fn create_provider(
+    pub async fn create_provider(
         &self,
         nearai_base_url: &str,
         session: Arc<SessionManager>,
+        bedrock_config: Option<&BedrockConfig>,
     ) -> Option<Arc<dyn EmbeddingProvider>> {
         if !self.enabled {
             tracing::debug!("Embeddings disabled (set EMBEDDING_ENABLED=true to enable)");
@@ -172,6 +182,44 @@ impl EmbeddingsConfig {
                     crate::workspace::NearAiEmbeddings::new(nearai_base_url, session)
                         .with_model(&self.model, self.dimension),
                 ))
+            }
+            "bedrock" => {
+                #[cfg(feature = "bedrock")]
+                {
+                    let Some(bedrock) = bedrock_config else {
+                        tracing::warn!(
+                            "Embeddings configured for Bedrock but no Bedrock config is available"
+                        );
+                        return None;
+                    };
+                    tracing::debug!(
+                        "Embeddings enabled via Bedrock (model: {}, region: {}, dim: {})",
+                        self.model,
+                        bedrock.region,
+                        self.dimension,
+                    );
+                    match crate::workspace::BedrockEmbeddings::new(
+                        bedrock,
+                        &self.model,
+                        self.dimension,
+                    )
+                    .await
+                    {
+                        Ok(provider) => Some(Arc::new(provider) as Arc<dyn EmbeddingProvider>),
+                        Err(e) => {
+                            tracing::warn!("Failed to initialize Bedrock embeddings provider: {e}");
+                            None
+                        }
+                    }
+                }
+                #[cfg(not(feature = "bedrock"))]
+                {
+                    let _ = bedrock_config;
+                    tracing::warn!(
+                        "Embeddings configured for Bedrock but the `bedrock` feature is disabled"
+                    );
+                    None
+                }
             }
             "ollama" => {
                 tracing::debug!(
@@ -413,6 +461,62 @@ mod tests {
         // SAFETY: Under ENV_MUTEX.
         unsafe {
             std::env::remove_var("EMBEDDING_CACHE_SIZE");
+        }
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[test]
+    fn bedrock_provider_defaults_to_titan_v2() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_PROVIDER", "bedrock");
+        }
+
+        let settings = Settings::default();
+        let config = EmbeddingsConfig::resolve(&settings).expect("resolve should succeed");
+        assert_eq!(config.provider, "bedrock");
+        assert_eq!(config.model, "amazon.titan-embed-text-v2:0");
+        assert_eq!(config.dimension, 1024);
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+        }
+    }
+
+    #[cfg(feature = "bedrock")]
+    #[test]
+    fn bedrock_dimension_validation_rejects_unsupported_values() {
+        let _guard = ENV_MUTEX.lock().expect("env mutex poisoned");
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_PROVIDER", "bedrock");
+            std::env::set_var("EMBEDDING_DIMENSION", "1536");
+        }
+
+        let settings = Settings::default();
+        let result = EmbeddingsConfig::resolve(&settings);
+        assert!(
+            result.is_err(),
+            "unsupported bedrock dimensions should fail"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("256, 512, or 1024"),
+            "error should mention valid dimensions: {err}"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_DIMENSION");
         }
     }
 }

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -84,12 +84,13 @@ impl EmbeddingsConfig {
             "EMBEDDING_PROVIDER",
         )?;
 
-        let model = if provider == "bedrock" {
-            optional_env("EMBEDDING_MODEL")?
-                .unwrap_or_else(|| "amazon.titan-embed-text-v2:0".to_string())
-        } else {
-            optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| settings.embeddings.model.clone())
-        };
+        let model = optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| {
+            if provider == "bedrock" {
+                "amazon.titan-embed-text-v2:0".to_string()
+            } else {
+                settings.embeddings.model.clone()
+            }
+        });
 
         // ollama_base_url lives on the top-level Settings, not the embeddings
         // sub-struct. Use a manual DB > env > default chain.

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -302,12 +302,13 @@ key first, then falls back to the standard env var.
 1. Ask "Enable semantic search?" (default: yes)
 2. Detect available providers:
    - NEAR AI: if backend is `nearai` OR valid session exists
+   - AWS Bedrock: if backend is `bedrock`
    - OpenAI: if `OPENAI_API_KEY` in env OR (backend is `openai` AND cached key)
 3. If both available → let user choose
 4. If only one → use it
 5. If neither → disable embeddings
 
-**Default model:** `text-embedding-3-small` (for both providers)
+**Default model:** `text-embedding-3-small` for NEAR AI/OpenAI, `amazon.titan-embed-text-v2:0` for AWS Bedrock
 
 ---
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -2350,25 +2350,22 @@ impl SetupWizard {
             return Ok(());
         }
 
-        let mut options = Vec::new();
+        let mut provider_options = Vec::new();
         if has_nearai {
-            options.push("NEAR AI (uses same auth, no extra cost)");
+            provider_options.push(("nearai", "NEAR AI (uses same auth, no extra cost)"));
         }
         if has_bedrock {
-            options.push("AWS Bedrock (uses AWS auth and region)");
+            provider_options.push(("bedrock", "AWS Bedrock (uses AWS auth and region)"));
         }
-        options.push("OpenAI (requires API key)");
+        provider_options.push(("openai", "OpenAI (requires API key)"));
 
-        let choice = select_one("Select embeddings provider:", &options).map_err(SetupError::Io)?;
-
-        // Map choice back to provider name
-        let provider = if has_nearai && choice == 0 {
-            "nearai"
-        } else if has_bedrock && ((has_nearai && choice == 1) || (!has_nearai && choice == 0)) {
-            "bedrock"
-        } else {
-            "openai"
-        };
+        let display_options: Vec<&str> = provider_options
+            .iter()
+            .map(|(_, display)| *display)
+            .collect();
+        let choice =
+            select_one("Select embeddings provider:", &display_options).map_err(SetupError::Io)?;
+        let provider = provider_options[choice].0;
 
         match provider {
             "nearai" => {

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -2323,6 +2323,7 @@ impl SetupWizard {
         let has_openai_key = std::env::var("OPENAI_API_KEY").is_ok()
             || (backend == "openai" && self.llm_api_key.is_some());
         let has_nearai = backend == "nearai" || self.session_manager.is_some();
+        let has_bedrock = backend == "bedrock";
 
         // If the LLM backend is OpenAI and we already have a key, default to OpenAI embeddings
         if backend == "openai" && has_openai_key {
@@ -2333,8 +2334,16 @@ impl SetupWizard {
             return Ok(());
         }
 
-        // If no NEAR AI session and no OpenAI key, only OpenAI is viable
-        if !has_nearai && !has_openai_key {
+        if backend == "bedrock" {
+            self.settings.embeddings.enabled = true;
+            self.settings.embeddings.provider = "bedrock".to_string();
+            self.settings.embeddings.model = "amazon.titan-embed-text-v2:0".to_string();
+            print_success("Embeddings enabled via AWS Bedrock");
+            return Ok(());
+        }
+
+        // If no NEAR AI session, Bedrock config, or OpenAI key, embeddings aren't available.
+        if !has_nearai && !has_bedrock && !has_openai_key {
             print_info("No NEAR AI session or OpenAI key found for embeddings.");
             print_info("Set OPENAI_API_KEY in your environment to enable embeddings.");
             self.settings.embeddings.enabled = false;
@@ -2345,6 +2354,9 @@ impl SetupWizard {
         if has_nearai {
             options.push("NEAR AI (uses same auth, no extra cost)");
         }
+        if has_bedrock {
+            options.push("AWS Bedrock (uses AWS auth and region)");
+        }
         options.push("OpenAI (requires API key)");
 
         let choice = select_one("Select embeddings provider:", &options).map_err(SetupError::Io)?;
@@ -2352,6 +2364,8 @@ impl SetupWizard {
         // Map choice back to provider name
         let provider = if has_nearai && choice == 0 {
             "nearai"
+        } else if has_bedrock && ((has_nearai && choice == 1) || (!has_nearai && choice == 0)) {
+            "bedrock"
         } else {
             "openai"
         };
@@ -2362,6 +2376,12 @@ impl SetupWizard {
                 self.settings.embeddings.provider = "nearai".to_string();
                 self.settings.embeddings.model = "text-embedding-3-small".to_string();
                 print_success("Embeddings enabled via NEAR AI");
+            }
+            "bedrock" => {
+                self.settings.embeddings.enabled = true;
+                self.settings.embeddings.provider = "bedrock".to_string();
+                self.settings.embeddings.model = "amazon.titan-embed-text-v2:0".to_string();
+                print_success("Embeddings enabled via AWS Bedrock");
             }
             _ => {
                 if !has_openai_key {

--- a/src/workspace/README.md
+++ b/src/workspace/README.md
@@ -112,6 +112,12 @@ When a workspace has additional read scopes (via `with_additional_read_scopes`),
 
 **Design rule:** If you want shared identity across users, seed the same content into each user's scope at setup time. Don't rely on multi-scope fallback for identity files.
 
+**Embeddings providers:**
+- **NEAR AI** - reuses the session auth path
+- **OpenAI** - uses `OPENAI_API_KEY`
+- **Ollama** - local embedding server
+- **AWS Bedrock** - Titan Text Embeddings V2 with Bedrock region/profile auth
+
 ## Heartbeat System
 
 Proactive periodic execution (default: 30 minutes):

--- a/src/workspace/embeddings.rs
+++ b/src/workspace/embeddings.rs
@@ -433,6 +433,39 @@ struct BedrockTitanEmbeddingResponse {
 }
 
 #[cfg(feature = "bedrock")]
+fn map_bedrock_invoke_model_error<R: std::fmt::Debug>(
+    error: &aws_sdk_bedrockruntime::error::SdkError<
+        aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError,
+        R,
+    >,
+) -> EmbeddingError {
+    use aws_sdk_bedrockruntime::error::SdkError;
+    use aws_sdk_bedrockruntime::operation::invoke_model::InvokeModelError;
+
+    match error {
+        SdkError::ServiceError(service_err) => match service_err.err() {
+            InvokeModelError::ThrottlingException(_) => {
+                EmbeddingError::RateLimited { retry_after: None }
+            }
+            InvokeModelError::AccessDeniedException(_) => EmbeddingError::AuthFailed,
+            InvokeModelError::ValidationException(e) => EmbeddingError::InvalidResponse(format!(
+                "Bedrock validation error: {}",
+                e.message().unwrap_or("unknown")
+            )),
+            InvokeModelError::ModelNotReadyException(e) => EmbeddingError::HttpError(format!(
+                "Bedrock model not ready: {}",
+                e.message().unwrap_or("unknown")
+            )),
+            other => EmbeddingError::HttpError(format!("Bedrock service error: {other:?}")),
+        },
+        SdkError::TimeoutError(_) => {
+            EmbeddingError::HttpError("Bedrock request timed out".to_string())
+        }
+        other => EmbeddingError::HttpError(format!("Bedrock request failed: {other:?}")),
+    }
+}
+
+#[cfg(feature = "bedrock")]
 #[async_trait]
 impl EmbeddingProvider for BedrockEmbeddings {
     fn dimension(&self) -> usize {
@@ -474,7 +507,7 @@ impl EmbeddingProvider for BedrockEmbeddings {
             .body(aws_smithy_types::Blob::new(body))
             .send()
             .await
-            .map_err(|e| EmbeddingError::HttpError(e.to_string()))?;
+            .map_err(|e| map_bedrock_invoke_model_error(&e))?;
 
         let result: BedrockTitanEmbeddingResponse = serde_json::from_slice(response.body.as_ref())
             .map_err(|e| {

--- a/src/workspace/embeddings.rs
+++ b/src/workspace/embeddings.rs
@@ -514,6 +514,14 @@ impl EmbeddingProvider for BedrockEmbeddings {
                 EmbeddingError::InvalidResponse(format!("Failed to parse response: {}", e))
             })?;
 
+        if result.embedding.len() != self.dimension {
+            return Err(EmbeddingError::InvalidResponse(format!(
+                "Bedrock returned embedding of dimension {}, expected {}",
+                result.embedding.len(),
+                self.dimension,
+            )));
+        }
+
         Ok(result.embedding)
     }
 }

--- a/src/workspace/embeddings.rs
+++ b/src/workspace/embeddings.rs
@@ -386,6 +386,105 @@ impl EmbeddingProvider for NearAiEmbeddings {
     }
 }
 
+/// AWS Bedrock embedding provider using Titan Text Embeddings V2.
+#[cfg(feature = "bedrock")]
+pub struct BedrockEmbeddings {
+    client: aws_sdk_bedrockruntime::Client,
+    model: String,
+    dimension: usize,
+}
+
+#[cfg(feature = "bedrock")]
+impl BedrockEmbeddings {
+    /// Create a new Bedrock embedding provider.
+    pub async fn new(
+        config: &crate::llm::BedrockConfig,
+        model: impl Into<String>,
+        dimension: usize,
+    ) -> Result<Self, EmbeddingError> {
+        let mut builder = aws_config::defaults(aws_config::BehaviorVersion::latest())
+            .region(aws_config::Region::new(config.region.clone()));
+        if let Some(ref profile) = config.profile {
+            builder = builder.profile_name(profile);
+        }
+
+        let sdk_config = builder.load().await;
+        Ok(Self {
+            client: aws_sdk_bedrockruntime::Client::new(&sdk_config),
+            model: model.into(),
+            dimension,
+        })
+    }
+}
+
+#[cfg(feature = "bedrock")]
+#[derive(Debug, Serialize)]
+struct BedrockTitanEmbeddingRequest<'a> {
+    #[serde(rename = "inputText")]
+    input_text: &'a str,
+    dimensions: usize,
+    normalize: bool,
+}
+
+#[cfg(feature = "bedrock")]
+#[derive(Debug, Deserialize)]
+struct BedrockTitanEmbeddingResponse {
+    embedding: Vec<f32>,
+}
+
+#[cfg(feature = "bedrock")]
+#[async_trait]
+impl EmbeddingProvider for BedrockEmbeddings {
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    fn model_name(&self) -> &str {
+        &self.model
+    }
+
+    fn max_input_length(&self) -> usize {
+        32_000
+    }
+
+    async fn embed(&self, text: &str) -> Result<Vec<f32>, EmbeddingError> {
+        if text.len() > self.max_input_length() {
+            return Err(EmbeddingError::TextTooLong {
+                length: text.len(),
+                max: self.max_input_length(),
+            });
+        }
+
+        let request = BedrockTitanEmbeddingRequest {
+            input_text: text,
+            dimensions: self.dimension,
+            normalize: true,
+        };
+
+        let body = serde_json::to_vec(&request).map_err(|e| {
+            EmbeddingError::InvalidResponse(format!("Failed to serialize request: {}", e))
+        })?;
+
+        let response = self
+            .client
+            .invoke_model()
+            .model_id(&self.model)
+            .content_type("application/json")
+            .accept("application/json")
+            .body(aws_smithy_types::Blob::new(body))
+            .send()
+            .await
+            .map_err(|e| EmbeddingError::HttpError(e.to_string()))?;
+
+        let result: BedrockTitanEmbeddingResponse = serde_json::from_slice(response.body.as_ref())
+            .map_err(|e| {
+                EmbeddingError::InvalidResponse(format!("Failed to parse response: {}", e))
+            })?;
+
+        Ok(result.embedding)
+    }
+}
+
 /// Ollama embedding provider using a local Ollama instance.
 ///
 /// Ollama serves embedding models (e.g. `nomic-embed-text`, `mxbai-embed-large`)

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -58,6 +58,8 @@ pub use document::{
     is_config_path, is_identity_path, merge_workspace_entries, paths,
 };
 pub use embedding_cache::{CachedEmbeddingProvider, EmbeddingCacheConfig};
+#[cfg(feature = "bedrock")]
+pub use embeddings::BedrockEmbeddings;
 pub use embeddings::{
     EmbeddingProvider, MockEmbeddings, NearAiEmbeddings, OllamaEmbeddings, OpenAiEmbeddings,
 };


### PR DESCRIPTION
Implements issue #1501 by adding a Bedrock-backed embeddings provider using Titan Text Embeddings V2, wiring it through config/setup/docs, and updating feature parity.\n\nValidation:\n- cargo fmt --all -- --check\n- cargo check -q\n- cargo clippy -p ironclaw --lib --all-features -- -D warnings\n- cargo test -p ironclaw --features bedrock --lib bedrock_ -- --nocapture\n- IC_BASE_REF=origin/staging /Users/nigecoleman/.codex/skills/rust-pr-preflight/scripts/preflight.sh (baseline boundary warnings only)