### PR TITLE
feat(cli): show credential auth status in tool info

### DIFF
--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -1327,7 +1327,7 @@ mod tests {
                     "credentials": {
                         "github": {
                             "secret_name": "gh_token",
-                            "location": "AuthorizationBearer",
+                            "location": { "type": "bearer" },
                             "host_patterns": ["api.github.com"]
                         }
                     }


### PR DESCRIPTION
## Summary
- `ironclaw tool info <name>` now checks the secrets store and shows whether each required credential is configured or missing
- Consolidates credentials from `http.credentials`, `auth`, and `setup.required_secrets` into a single deduplicated **Auth** section with `✓ configured` / `✗ missing` status
- Secrets already shown in Auth are filtered from the Secrets section to avoid redundancy

### Before
```
  Credentials:
    github_token: github_token -> Bearer
  Secrets (existence check only):
    github_token
    github_*
  Auth: GitHub [github_token]
  Required secrets:
    github_token: GitHub Personal Access Token (...)
```

### After
```
  Secrets (existence check only):
    github_*
  Auth:
    github_token (GitHub) -> AuthorizationBearer  ✗ missing
```

## Test plan
- [x] Run `ironclaw tool info <tool_with_auth>` — verify single Auth section with status
- [x] Run `ironclaw tool info <tool_without_auth>` — verify no Auth section appears
- [x] Store a credential via `ironclaw tool auth`, re-run `tool info` — verify `✓ configured`
- [x] Verify secrets section only shows entries not already in Auth (e.g. wildcards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)