### PR TITLE
fix(agent): return errors when approval thread disappears

### DIFF
--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -2183,7 +2183,10 @@ mod tests {
                 None => Err("Internal error: thread no longer exists"),
             };
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err(), "Internal error: thread no longer exists");
+            assert_eq!(
+                result.unwrap_err(),
+                "Internal error: thread no longer exists"
+            );
         }
 
         // Scenario 2: Thread existed then was removed (simulates disappearance
@@ -2210,7 +2213,10 @@ mod tests {
                 None => Err("Internal error: thread no longer exists"),
             };
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err(), "Internal error: thread no longer exists");
+            assert_eq!(
+                result.unwrap_err(),
+                "Internal error: thread no longer exists"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

- Replace 6 silent `if let Some(thread)` patterns in `process_approval()` with explicit `match` arms
- Critical paths (set state to Processing, rejection, deferred approval setup) now return `SubmissionResult::error` when thread is missing
- Non-critical paths (recording tool results) log errors but continue since the tool already executed
- Users are now notified when their approval/rejection cannot be processed due to a missing thread

## Test plan

- [x] Added regression test `test_approval_on_missing_thread_should_error`
- [x] All 63 approval-related tests pass
- [x] Clippy clean with zero warnings

Closes #1487