### PR TITLE
perf(agent): reduce lock contention in thread resolution

### DIFF
--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -929,9 +929,13 @@ mod tests {
         let manager = SessionManager::new();
 
         // Case 1: Normal resolution creates thread and maps it
-        let (session1, tid1) = manager.resolve_thread("user1", "chan1", Some("ext-1")).await;
+        let (session1, tid1) = manager
+            .resolve_thread("user1", "chan1", Some("ext-1"))
+            .await;
         // Resolving again with same key should return same thread (fast path)
-        let (_, tid1_again) = manager.resolve_thread("user1", "chan1", Some("ext-1")).await;
+        let (_, tid1_again) = manager
+            .resolve_thread("user1", "chan1", Some("ext-1"))
+            .await;
         assert_eq!(tid1, tid1_again);
 
         // Case 2: UUID adoption - insert a thread directly into session


### PR DESCRIPTION
## Summary

- Consolidate two separate `thread_map.read().await` acquisitions into a single one in `resolve_thread()`
- Previously: read lock #1 for key lookup, drop, read lock #2 for UUID adoption check
- Now: both checks happen under one read lock, reducing contention under concurrent approval load
- Write-lock upgrade still uses double-checked locking (unavoidable)

## Test plan

- [x] Added regression test `test_resolve_thread_consolidates_read_path` covering all 3 paths (fast path, UUID adoption, new thread)
- [x] All 34 session_manager tests pass
- [x] Clippy clean with zero warnings

Closes #1489