### PR TITLE
feat(skills): add CLAWHUB_ENABLED flag to disable ClawHub registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -219,7 +219,8 @@ HEARTBEAT_NOTIFY_USER=default
 
 # Skills / ClawHub Registry
 # CLAWHUB_ENABLED=true              # Set to false to disable the public ClawHub skill registry
-#                                    # (local skill management and URL/content installs still work)
+#                                    # and all remote skill fetching (catalog + URL installs).
+#                                    # Local skill management and inline content installs still work.
 
 # Safety settings
 SAFETY_MAX_OUTPUT_LENGTH=100000

--- a/.env.example
+++ b/.env.example
@@ -217,6 +217,10 @@ HEARTBEAT_NOTIFY_USER=default
 # ACP_TIMEOUT_SECS=1800                  # Maximum session timeout
 # Configure agents via CLI: ironclaw acp add goose --command goose --arg "--stdio"
 
+# Skills / ClawHub Registry
+# CLAWHUB_ENABLED=true              # Set to false to disable the public ClawHub skill registry
+#                                    # (local skill management and URL/content installs still work)
+
 # Safety settings
 SAFETY_MAX_OUTPUT_LENGTH=100000
 SAFETY_INJECTION_CHECK_ENABLED=true

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -6330,6 +6330,11 @@ function fetchGatewayStatus() {
     restartEnabled = data.restart_enabled || false;
     updateRestartButtonVisibility();
 
+    var clawHubEl = document.querySelector('.skill-search-section');
+    if (clawHubEl) {
+      clawHubEl.style.display = data.clawhub_enabled === false ? 'none' : '';
+    }
+
     var popover = document.getElementById('gateway-popover');
     var html = '';
 

--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -487,7 +487,7 @@
           </div>
           <div class="settings-subpanel" id="settings-skills">
             <div class="extensions-container">
-              <div class="extensions-section">
+              <div class="extensions-section skill-search-section">
                 <h3 data-i18n="skills.searchClawHub">Search ClawHub</h3>
                 <div class="skill-search-box">
                   <input type="text" id="skill-search-input" data-i18n-placeholder="skills.searchPlaceholder" placeholder="Search for skills...">

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -839,9 +839,12 @@ Agent:
                 } else if args.is_empty() {
                     self.handle_skills_list().await
                 } else {
-                    Ok(SubmissionResult::error(
-                        "Usage: /skills or /skills search <query>",
-                    ))
+                    let hint = if self.skill_catalog().is_some() {
+                        "Usage: /skills or /skills search <query>"
+                    } else {
+                        "Usage: /skills"
+                    };
+                    Ok(SubmissionResult::error(hint))
                 }
             }
 

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -690,51 +690,55 @@ impl Agent {
         tenant: &crate::tenant::TenantCtx,
     ) -> Result<SubmissionResult, Error> {
         match command {
-            "help" => Ok(SubmissionResult::response(concat!(
-                "System:\n",
-                "  /help             Show this help\n",
-                "  /model [name]     Show or switch the active model\n",
-                "  /version          Show version info\n",
-                "  /tools            List available tools\n",
-                "  /debug            Toggle debug mode\n",
-                "  /reasoning [N|all] Show agent reasoning for turns\n",
-                "  /ping             Connectivity check\n",
-                "\n",
-                "Jobs:\n",
-                "  /job <desc>       Create a new job\n",
-                "  /status [id]      Check job status\n",
-                "  /cancel <id>      Cancel a job\n",
-                "  /list             List all jobs\n",
-                "\n",
-                "Plans:\n",
-                "  /plan <desc>      Create an execution plan\n",
-                "  /plan approve [ref] Approve and start execution\n",
-                "  /plan status [ref]  Check plan progress\n",
-                "  /plan revise [ref]  Revise with feedback\n",
-                "  /plan list        List all plans\n",
-                "\n",
-                "Session:\n",
-                "  /undo             Undo last turn\n",
-                "  /redo             Redo undone turn\n",
-                "  /compact          Compress context window\n",
-                "  /clear            Clear current thread\n",
-                "  /interrupt        Stop current operation\n",
-                "  /new              New conversation thread\n",
-                "  /thread <id>      Switch to thread\n",
-                "  /resume           Resume a previous conversation\n",
-                "\n",
-                "Skills:\n",
-                "  /skills             List installed skills\n",
-                "  /skills search <q>  Search ClawHub registry\n",
-                "\n",
-                "Agent:\n",
-                "  /heartbeat        Run heartbeat check\n",
-                "  /summarize        Summarize current thread\n",
-                "  /suggest          Suggest next steps\n",
-                "  /restart          Gracefully restart the process\n",
-                "\n",
-                "  /quit             Exit",
-            ))),
+            "help" => {
+                let mut skills_section =
+                    String::from("Skills:\n  /skills             List installed skills\n");
+                if self.skill_catalog().is_some() {
+                    skills_section.push_str("  /skills search <q>  Search ClawHub registry\n");
+                }
+                Ok(SubmissionResult::response(format!(
+                    "System:\n\
+                     \x20 /help             Show this help\n\
+                     \x20 /model [name]     Show or switch the active model\n\
+                     \x20 /version          Show version info\n\
+                     \x20 /tools            List available tools\n\
+                     \x20 /debug            Toggle debug mode\n\
+                     \x20 /reasoning [N|all] Show agent reasoning for turns\n\
+                     \x20 /ping             Connectivity check\n\
+                     \n\
+                     Jobs:\n\
+                     \x20 /job <desc>       Create a new job\n\
+                     \x20 /status [id]      Check job status\n\
+                     \x20 /cancel <id>      Cancel a job\n\
+                     \x20 /list             List all jobs\n\
+                     \n\
+                     Plans:\n\
+                     \x20 /plan <desc>      Create an execution plan\n\
+                     \x20 /plan approve [ref] Approve and start execution\n\
+                     \x20 /plan status [ref]  Check plan progress\n\
+                     \x20 /plan revise [ref]  Revise with feedback\n\
+                     \x20 /plan list        List all plans\n\
+                     \n\
+                     Session:\n\
+                     \x20 /undo             Undo last turn\n\
+                     \x20 /redo             Redo undone turn\n\
+                     \x20 /compact          Compress context window\n\
+                     \x20 /clear            Clear current thread\n\
+                     \x20 /interrupt        Stop current operation\n\
+                     \x20 /new              New conversation thread\n\
+                     \x20 /thread <id>      Switch to thread\n\
+                     \x20 /resume           Resume a previous conversation\n\
+                     \n\
+                     {skills_section}\n\
+                     Agent:\n\
+                     \x20 /heartbeat        Run heartbeat check\n\
+                     \x20 /summarize        Summarize current thread\n\
+                     \x20 /suggest          Suggest next steps\n\
+                     \x20 /restart          Gracefully restart the process\n\
+                     \n\
+                     \x20 /quit             Exit"
+                )))
+            }
 
             "ping" => Ok(SubmissionResult::response("pong!")),
 
@@ -942,10 +946,15 @@ impl Agent {
         };
 
         let skills = guard.skills();
+        let has_catalog = self.skill_catalog().is_some();
+
         if skills.is_empty() {
-            return Ok(SubmissionResult::response(
-                "No skills installed.\n\nUse /skills search <query> to find skills on ClawHub.",
-            ));
+            let msg = if has_catalog {
+                "No skills installed.\n\nUse /skills search <query> to find skills on ClawHub."
+            } else {
+                "No skills installed."
+            };
+            return Ok(SubmissionResult::response(msg));
         }
 
         let mut out = String::from("Installed skills:\n\n");
@@ -961,7 +970,9 @@ impl Agent {
                 s.manifest.name, s.manifest.version, s.trust, desc,
             ));
         }
-        out.push_str("\nUse /skills search <query> to find more on ClawHub.");
+        if has_catalog {
+            out.push_str("\nUse /skills search <query> to find more on ClawHub.");
+        }
 
         Ok(SubmissionResult::response(out))
     }

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -691,52 +691,55 @@ impl Agent {
     ) -> Result<SubmissionResult, Error> {
         match command {
             "help" => {
-                let mut skills_section =
-                    String::from("Skills:\n  /skills             List installed skills\n");
-                if self.skill_catalog().is_some() {
-                    skills_section.push_str("  /skills search <q>  Search ClawHub registry\n");
-                }
+                let skills_search = if self.skill_catalog().is_some() {
+                    "  /skills search <q>  Search ClawHub registry\n"
+                } else {
+                    ""
+                };
                 Ok(SubmissionResult::response(format!(
-                    "System:\n\
-                     \x20 /help             Show this help\n\
-                     \x20 /model [name]     Show or switch the active model\n\
-                     \x20 /version          Show version info\n\
-                     \x20 /tools            List available tools\n\
-                     \x20 /debug            Toggle debug mode\n\
-                     \x20 /reasoning [N|all] Show agent reasoning for turns\n\
-                     \x20 /ping             Connectivity check\n\
-                     \n\
-                     Jobs:\n\
-                     \x20 /job <desc>       Create a new job\n\
-                     \x20 /status [id]      Check job status\n\
-                     \x20 /cancel <id>      Cancel a job\n\
-                     \x20 /list             List all jobs\n\
-                     \n\
-                     Plans:\n\
-                     \x20 /plan <desc>      Create an execution plan\n\
-                     \x20 /plan approve [ref] Approve and start execution\n\
-                     \x20 /plan status [ref]  Check plan progress\n\
-                     \x20 /plan revise [ref]  Revise with feedback\n\
-                     \x20 /plan list        List all plans\n\
-                     \n\
-                     Session:\n\
-                     \x20 /undo             Undo last turn\n\
-                     \x20 /redo             Redo undone turn\n\
-                     \x20 /compact          Compress context window\n\
-                     \x20 /clear            Clear current thread\n\
-                     \x20 /interrupt        Stop current operation\n\
-                     \x20 /new              New conversation thread\n\
-                     \x20 /thread <id>      Switch to thread\n\
-                     \x20 /resume           Resume a previous conversation\n\
-                     \n\
-                     {skills_section}\n\
-                     Agent:\n\
-                     \x20 /heartbeat        Run heartbeat check\n\
-                     \x20 /summarize        Summarize current thread\n\
-                     \x20 /suggest          Suggest next steps\n\
-                     \x20 /restart          Gracefully restart the process\n\
-                     \n\
-                     \x20 /quit             Exit"
+                    "\
+System:
+  /help             Show this help
+  /model [name]     Show or switch the active model
+  /version          Show version info
+  /tools            List available tools
+  /debug            Toggle debug mode
+  /reasoning [N|all] Show agent reasoning for turns
+  /ping             Connectivity check
+
+Jobs:
+  /job <desc>       Create a new job
+  /status [id]      Check job status
+  /cancel <id>      Cancel a job
+  /list             List all jobs
+
+Plans:
+  /plan <desc>      Create an execution plan
+  /plan approve [ref] Approve and start execution
+  /plan status [ref]  Check plan progress
+  /plan revise [ref]  Revise with feedback
+  /plan list        List all plans
+
+Session:
+  /undo             Undo last turn
+  /redo             Redo undone turn
+  /compact          Compress context window
+  /clear            Clear current thread
+  /interrupt        Stop current operation
+  /new              New conversation thread
+  /thread <id>      Switch to thread
+  /resume           Resume a previous conversation
+
+Skills:
+  /skills             List installed skills
+{skills_search}\
+Agent:
+  /heartbeat        Run heartbeat check
+  /summarize        Summarize current thread
+  /suggest          Suggest next steps
+  /restart          Gracefully restart the process
+
+  /quit             Exit"
                 )))
             }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1062,9 +1062,14 @@ impl AppBuilder {
             }
 
             let registry = Arc::new(std::sync::RwLock::new(registry));
-            let catalog = ironclaw_skills::catalog::shared_catalog();
-            tools.register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
-            (Some(registry), Some(catalog))
+            let catalog = if self.config.skills.clawhub_enabled {
+                Some(ironclaw_skills::catalog::shared_catalog())
+            } else {
+                tracing::debug!("ClawHub registry disabled (CLAWHUB_ENABLED=false)");
+                None
+            };
+            tools.register_skill_tools(Arc::clone(&registry), catalog.clone());
+            (Some(registry), catalog)
         } else {
             (None, None)
         };

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -174,6 +174,7 @@ pub async fn skills_install_handler(
     ))?;
 
     let mut resolved_download_key = None;
+    let name = req.name.as_deref().unwrap_or("");
     let content = if let Some(ref raw) = req.content {
         raw.clone()
     } else if let Some(url) = req.url.as_deref().filter(|s| !s.is_empty()) {
@@ -194,17 +195,13 @@ pub async fn skills_install_handler(
             .await
             .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
     } else if let Some(ref catalog) = state.skill_catalog {
-        let name = req.name.as_deref().unwrap_or("");
         let download_key = if let Some(slug) = req.slug.as_deref().filter(|s| !s.is_empty()) {
             slug.to_string()
         } else if name.contains('/') {
             name.to_string()
         } else if !name.is_empty() {
             let outcome = catalog.search(name).await;
-            match ironclaw_skills::catalog::resolve_catalog_slug_for_name(
-                name,
-                &outcome.results,
-            ) {
+            match ironclaw_skills::catalog::resolve_catalog_slug_for_name(name, &outcome.results) {
                 Ok(Some(resolved)) => resolved,
                 Ok(None) => {
                     let reason = outcome
@@ -239,12 +236,8 @@ pub async fn skills_install_handler(
     };
 
     let normalized = ironclaw_skills::normalize_line_endings(&content);
-    let name_ref = req.name.as_deref().unwrap_or("");
-    let requested_identifier = install_requested_identifier(
-        name_ref,
-        req.slug.as_deref(),
-        resolved_download_key.as_deref(),
-    );
+    let requested_identifier =
+        install_requested_identifier(name, req.slug.as_deref(), resolved_download_key.as_deref());
 
     // Parse, check duplicates, and get install_dir under a brief read lock.
     let (user_dir, skill_name_from_parse, install_content) = {

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -161,7 +161,12 @@ pub async fn skills_install_handler(
         ));
     }
 
-    tracing::info!(user_id = %user.user_id, skill = %req.name, "skill install requested");
+    let skill_label = req
+        .name
+        .as_deref()
+        .or(req.slug.as_deref())
+        .unwrap_or("<url/content>");
+    tracing::info!(user_id = %user.user_id, skill = %skill_label, "skill install requested");
 
     let registry = state.skill_registry.as_ref().ok_or((
         StatusCode::NOT_IMPLEMENTED,
@@ -171,20 +176,33 @@ pub async fn skills_install_handler(
     let mut resolved_download_key = None;
     let content = if let Some(ref raw) = req.content {
         raw.clone()
-    } else if let Some(ref url) = req.url {
+    } else if let Some(url) = req.url.as_deref().filter(|s| !s.is_empty()) {
+        // Block URL installs when ClawHub is disabled. We cannot reliably
+        // distinguish a direct URL from a ClawHub mirror or proxy, so
+        // disabling ClawHub must also disable all URL-based fetches to
+        // enforce the operator's intent.
+        if state.skill_catalog.is_none() {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "URL-based skill installs are disabled when ClawHub is disabled \
+                 (CLAWHUB_ENABLED=false). Provide 'content' directly."
+                    .to_string(),
+            ));
+        }
         // Fetch from explicit URL (with SSRF protection)
         crate::tools::builtin::skill_tools::fetch_skill_content(url)
             .await
             .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
     } else if let Some(ref catalog) = state.skill_catalog {
+        let name = req.name.as_deref().unwrap_or("");
         let download_key = if let Some(slug) = req.slug.as_deref().filter(|s| !s.is_empty()) {
             slug.to_string()
-        } else if req.name.contains('/') {
-            req.name.clone()
-        } else {
-            let outcome = catalog.search(&req.name).await;
+        } else if name.contains('/') {
+            name.to_string()
+        } else if !name.is_empty() {
+            let outcome = catalog.search(name).await;
             match ironclaw_skills::catalog::resolve_catalog_slug_for_name(
-                &req.name,
+                name,
                 &outcome.results,
             ) {
                 Ok(Some(resolved)) => resolved,
@@ -196,12 +214,17 @@ pub async fn skills_install_handler(
                         StatusCode::BAD_REQUEST,
                         format!(
                             "Could not resolve skill name '{}' to a catalog slug: {}",
-                            req.name, reason
+                            name, reason
                         ),
                     ));
                 }
                 Err(e) => return Err((StatusCode::BAD_REQUEST, e.to_string())),
             }
+        } else {
+            return Ok(Json(ActionResponse::fail(
+                "Provide 'name' (for catalog lookup), 'url', or 'content' to install a skill."
+                    .to_string(),
+            )));
         };
         let url =
             ironclaw_skills::catalog::skill_download_url(catalog.registry_url(), &download_key);
@@ -211,13 +234,14 @@ pub async fn skills_install_handler(
             .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?
     } else {
         return Ok(Json(ActionResponse::fail(
-            "Provide 'content' or 'url' to install a skill".to_string(),
+            "ClawHub registry is disabled. Provide 'content' to install a skill.".to_string(),
         )));
     };
 
     let normalized = ironclaw_skills::normalize_line_endings(&content);
+    let name_ref = req.name.as_deref().unwrap_or("");
     let requested_identifier = install_requested_identifier(
-        &req.name,
+        name_ref,
         req.slug.as_deref(),
         resolved_download_key.as_deref(),
     );

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3782,6 +3782,8 @@ async fn gateway_status_handler(
         .map(|v| v.to_lowercase() == "true")
         .unwrap_or(false);
 
+    let clawhub_enabled = state.skill_catalog.is_some();
+
     Json(GatewayStatusResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
         sse_connections,
@@ -3795,6 +3797,7 @@ async fn gateway_status_handler(
         llm_backend: state.active_config.llm_backend.clone(),
         llm_model: state.active_config.llm_model.clone(),
         enabled_channels: state.active_config.enabled_channels.clone(),
+        clawhub_enabled,
     })
 }
 
@@ -3823,6 +3826,7 @@ struct GatewayStatusResponse {
     llm_backend: String,
     llm_model: String,
     enabled_channels: Vec<String>,
+    clawhub_enabled: bool,
 }
 
 #[cfg(test)]
@@ -6564,5 +6568,33 @@ mod tests {
     fn test_is_local_origin_rejects_garbage() {
         assert!(!is_local_origin("not-a-url"));
         assert!(!is_local_origin(""));
+    }
+
+    #[test]
+    fn gateway_status_response_serializes_clawhub_enabled() {
+        let resp = GatewayStatusResponse {
+            version: "0.0.0".to_string(),
+            sse_connections: 0,
+            ws_connections: 0,
+            total_connections: 0,
+            uptime_secs: 0,
+            restart_enabled: false,
+            daily_cost: None,
+            actions_this_hour: None,
+            model_usage: None,
+            llm_backend: "test".to_string(),
+            llm_model: "test".to_string(),
+            enabled_channels: vec![],
+            clawhub_enabled: false,
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["clawhub_enabled"], false);
+
+        let resp_enabled = GatewayStatusResponse {
+            clawhub_enabled: true,
+            ..resp
+        };
+        let json = serde_json::to_value(&resp_enabled).unwrap();
+        assert_eq!(json["clawhub_enabled"], true);
     }
 }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4017,14 +4017,12 @@ mod tests {
 
     // --- OAuth callback handler tests ---
 
-    /// Build a minimal `GatewayState` for handler tests.
-    fn test_gateway_state_with_dependencies(
-        ext_mgr: Option<Arc<ExtensionManager>>,
-        store: Option<Arc<dyn Database>>,
-        db_auth: Option<Arc<crate::channels::web::auth::DbAuthenticator>>,
-        pairing_store: Option<Arc<crate::pairing::PairingStore>>,
-    ) -> Arc<GatewayState> {
-        Arc::new(GatewayState {
+    /// Build a minimal `GatewayState` with all optional fields set to `None`.
+    ///
+    /// Returns the raw struct so callers can override fields before wrapping
+    /// in `Arc`. Use `test_gateway_state()` for the common Arc-wrapped case.
+    fn test_gateway_state_base() -> GatewayState {
+        GatewayState {
             msg_tx: tokio::sync::RwLock::new(None),
             sse: Arc::new(SseManager::new()),
             workspace: None,
@@ -4032,9 +4030,9 @@ mod tests {
             session_manager: None,
             log_broadcaster: None,
             log_level_handle: None,
-            extension_manager: ext_mgr,
+            extension_manager: None,
             tool_registry: None,
-            store,
+            store: None,
             job_manager: None,
             prompt_queue: None,
             owner_id: "test".to_string(),
@@ -4054,8 +4052,8 @@ mod tests {
             startup_time: std::time::Instant::now(),
             active_config: ActiveConfigSnapshot::default(),
             secrets_store: None,
-            db_auth,
-            pairing_store,
+            db_auth: None,
+            pairing_store: None,
             oauth_providers: None,
             oauth_state_store: None,
             oauth_base_url: None,
@@ -4069,6 +4067,22 @@ mod tests {
         })
     }
 
+    /// Build a minimal `GatewayState` for handler tests with specific dependencies.
+    fn test_gateway_state_with_dependencies(
+        ext_mgr: Option<Arc<ExtensionManager>>,
+        store: Option<Arc<dyn Database>>,
+        db_auth: Option<Arc<crate::channels::web::auth::DbAuthenticator>>,
+        pairing_store: Option<Arc<crate::pairing::PairingStore>>,
+    ) -> Arc<GatewayState> {
+        let mut state = test_gateway_state_base();
+        state.extension_manager = ext_mgr;
+        state.store = store;
+        state.db_auth = db_auth;
+        state.pairing_store = pairing_store;
+        Arc::new(state)
+    }
+
+    /// Build a minimal `GatewayState` for testing the OAuth callback handler.
     fn test_gateway_state(ext_mgr: Option<Arc<ExtensionManager>>) -> Arc<GatewayState> {
         test_gateway_state_with_dependencies(ext_mgr, None, None, None)
     }
@@ -6596,5 +6610,39 @@ mod tests {
         };
         let json = serde_json::to_value(&resp_enabled).unwrap();
         assert_eq!(json["clawhub_enabled"], true);
+    }
+
+    #[tokio::test]
+    async fn skills_search_returns_501_when_catalog_disabled() {
+        use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
+        use crate::channels::web::handlers::skills::skills_search_handler;
+
+        let dir = tempfile::tempdir().unwrap();
+        let registry = Arc::new(std::sync::RwLock::new(
+            ironclaw_skills::SkillRegistry::new(dir.path().join("skills"))
+                .with_installed_dir(dir.path().join("installed")),
+        ));
+
+        // Skills enabled (registry present) but ClawHub disabled (catalog None).
+        let mut state = test_gateway_state_base();
+        state.skill_registry = Some(registry);
+        let state = Arc::new(state);
+
+        let result = skills_search_handler(
+            axum::extract::State(state),
+            AuthenticatedUser(UserIdentity {
+                user_id: "test".into(),
+                role: "admin".into(),
+                workspace_read_scopes: vec![],
+            }),
+            axum::Json(crate::channels::web::types::SkillSearchRequest {
+                query: "test".into(),
+            }),
+        )
+        .await;
+
+        let err = result.expect_err("should fail with 501 when catalog is None");
+        assert_eq!(err.0, axum::http::StatusCode::NOT_IMPLEMENTED);
+        assert!(err.1.contains("catalog"));
     }
 }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4064,7 +4064,7 @@ mod tests {
             oauth_sweep_shutdown: None,
             frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
             tool_dispatcher: None,
-        })
+        }
     }
 
     /// Build a minimal `GatewayState` for handler tests with specific dependencies.

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -647,7 +647,9 @@ pub struct SkillSearchResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct SkillInstallRequest {
-    pub name: String,
+    /// Skill name or slug. Required for catalog installs; optional when `url`
+    /// or `content` is provided (the name is parsed from the SKILL.md content).
+    pub name: Option<String>,
     /// Registry slug (e.g. "owner/skill-name"). Preferred over `name` for
     /// constructing the download URL when fetching from ClawHub.
     pub slug: Option<String>,

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -53,16 +53,30 @@ pub async fn run_skills_command(
     let full_config = crate::config::Config::from_env_with_toml(config_path)
         .await
         .map_err(|e| anyhow::anyhow!("{e:#}"))?;
-    let config = full_config.skills;
+    dispatch_skills_command(cmd, &full_config.skills).await
+}
 
+/// Dispatch a skills subcommand with the given config.
+///
+/// Extracted from [`run_skills_command`] so it can be tested without
+/// loading the full application configuration.
+async fn dispatch_skills_command(cmd: SkillsCommand, config: &SkillsConfig) -> anyhow::Result<()> {
     if !config.enabled {
         anyhow::bail!("Skills system is disabled (SKILLS_ENABLED=false)");
     }
 
     match cmd {
-        SkillsCommand::List { verbose, json } => cmd_list(&config, verbose, json).await,
-        SkillsCommand::Search { query, json } => cmd_search(&query, json).await,
-        SkillsCommand::Info { name, json } => cmd_info(&config, &name, json).await,
+        SkillsCommand::List { verbose, json } => cmd_list(config, verbose, json).await,
+        SkillsCommand::Search { query, json } => {
+            if !config.clawhub_enabled {
+                anyhow::bail!(
+                    "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
+                     Use 'ironclaw skills install --url <url>' for direct installs."
+                );
+            }
+            cmd_search(&query, json).await
+        }
+        SkillsCommand::Info { name, json } => cmd_info(config, &name, json).await,
     }
 }
 
@@ -123,7 +137,9 @@ async fn cmd_list(config: &SkillsConfig, verbose: bool, json: bool) -> anyhow::R
         println!("  User:      {}", config.local_dir.display());
         println!("  Installed: {}", config.installed_dir.display());
         println!();
-        println!("Use 'ironclaw skills search <query>' to find skills on ClawHub.");
+        if config.clawhub_enabled {
+            println!("Use 'ironclaw skills search <query>' to find skills on ClawHub.");
+        }
         return Ok(());
     }
 
@@ -341,6 +357,27 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn search_rejected_when_clawhub_disabled() {
+        let config = SkillsConfig {
+            clawhub_enabled: false,
+            ..SkillsConfig::default()
+        };
+        let result = dispatch_skills_command(
+            SkillsCommand::Search {
+                query: "test".into(),
+                json: false,
+            },
+            &config,
+        )
+        .await;
+        let err = result.expect_err("should reject search when ClawHub is disabled");
+        assert!(
+            err.to_string().contains("disabled"),
+            "error should mention disabled: {err}"
+        );
+    }
 
     #[test]
     fn truncate_short_string() {

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -71,7 +71,7 @@ async fn dispatch_skills_command(cmd: SkillsCommand, config: &SkillsConfig) -> a
             if !config.clawhub_enabled {
                 anyhow::bail!(
                     "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
-                     Use 'ironclaw skills install --url <url>' for direct installs."
+                     Local skill management (list, info) is still available."
                 );
             }
             cmd_search(&query, json).await

--- a/src/config/skills.rs
+++ b/src/config/skills.rs
@@ -12,6 +12,8 @@ use crate::settings::Settings;
 pub struct SkillsConfig {
     /// Whether the skills system is enabled.
     pub enabled: bool,
+    /// Whether the public ClawHub registry is accessible.
+    pub clawhub_enabled: bool,
     /// Directory containing user-placed skills (default: ~/.ironclaw/skills/).
     /// Skills here are loaded with `Trusted` trust level.
     pub local_dir: PathBuf,
@@ -31,6 +33,7 @@ impl Default for SkillsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            clawhub_enabled: true,
             local_dir: default_skills_dir(),
             installed_dir: default_installed_skills_dir(),
             max_active_skills: 3,
@@ -57,6 +60,11 @@ impl SkillsConfig {
 
         Ok(Self {
             enabled: db_first_bool(ss.enabled, defaults.enabled, "SKILLS_ENABLED")?,
+            clawhub_enabled: db_first_bool(
+                ss.clawhub_enabled,
+                defaults.clawhub_enabled,
+                "CLAWHUB_ENABLED",
+            )?,
             // local_dir and installed_dir are env-only (filesystem paths, no settings counterpart)
             local_dir: optional_env("SKILLS_DIR")?
                 .map(PathBuf::from)
@@ -76,5 +84,48 @@ impl SkillsConfig {
             )?,
             max_scan_depth: parse_optional_env("SKILLS_MAX_SCAN_DEPTH", 3)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::Settings;
+
+    #[test]
+    fn clawhub_enabled_defaults_true() {
+        let _guard = lock_env();
+        unsafe {
+            std::env::remove_var("CLAWHUB_ENABLED");
+        }
+        let config = SkillsConfig::resolve(&Settings::default()).unwrap();
+        assert!(config.clawhub_enabled);
+    }
+
+    #[test]
+    fn clawhub_enabled_false_from_env() {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("CLAWHUB_ENABLED", "false");
+        }
+        let config = SkillsConfig::resolve(&Settings::default()).unwrap();
+        assert!(!config.clawhub_enabled);
+        unsafe {
+            std::env::remove_var("CLAWHUB_ENABLED");
+        }
+    }
+
+    #[test]
+    fn clawhub_enabled_rejects_invalid() {
+        let _guard = lock_env();
+        unsafe {
+            std::env::set_var("CLAWHUB_ENABLED", "maybe");
+        }
+        let result = SkillsConfig::resolve(&Settings::default());
+        assert!(result.is_err());
+        unsafe {
+            std::env::remove_var("CLAWHUB_ENABLED");
+        }
     }
 }

--- a/src/config/skills.rs
+++ b/src/config/skills.rs
@@ -12,7 +12,10 @@ use crate::settings::Settings;
 pub struct SkillsConfig {
     /// Whether the skills system is enabled.
     pub enabled: bool,
-    /// Whether the public ClawHub registry is accessible.
+    /// Whether the public ClawHub registry is accessible. When `false`, both
+    /// catalog lookups and URL-based skill installs are blocked (we cannot
+    /// distinguish a direct URL from a ClawHub mirror), leaving only inline
+    /// `content` installs available.
     pub clawhub_enabled: bool,
     /// Directory containing user-placed skills (default: ~/.ironclaw/skills/).
     /// Skills here are loaded with `Trusted` trust level.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -905,6 +905,10 @@ pub struct SkillsSettings {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
+    /// Whether the public ClawHub registry is accessible.
+    #[serde(default = "default_true")]
+    pub clawhub_enabled: bool,
+
     /// Maximum number of skills that can be active simultaneously.
     #[serde(default = "default_skills_max_active")]
     pub max_active_skills: usize,
@@ -926,6 +930,7 @@ impl Default for SkillsSettings {
     fn default() -> Self {
         Self {
             enabled: true,
+            clawhub_enabled: true,
             max_active_skills: default_skills_max_active(),
             max_context_tokens: default_skills_max_context_tokens(),
         }

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -622,37 +622,54 @@ impl Tool for SkillInstallTool {
     }
 
     fn description(&self) -> &str {
-        "Install a skill from SKILL.md content, a URL, or by name from the ClawHub catalog."
+        if self.catalog.is_some() {
+            "Install a skill from SKILL.md content, a URL, or by name from the ClawHub catalog."
+        } else {
+            "Install a skill from SKILL.md content."
+        }
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Skill name or slug (from search results)"
-                },
-                "slug": {
-                    "type": "string",
-                    "description": "Registry slug from catalog search results; preferred when installing from ClawHub"
-                },
-                "url": {
-                    "type": "string",
-                    "description": "Direct URL to a SKILL.md file"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Raw SKILL.md content to install directly"
-                },
-                "install_dependencies": {
-                    "type": "boolean",
-                    "description": "When true, also install companion skills declared in requires.skills. Defaults to false so dependency installs stay explicit in the approved tool call.",
-                    "default": false
+        if self.catalog.is_some() {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Skill name or slug (from search results)"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Registry slug from catalog search results; preferred when installing from ClawHub"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Direct URL to a SKILL.md file"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Raw SKILL.md content to install directly"
+                    },
+                    "install_dependencies": {
+                        "type": "boolean",
+                        "description": "When true, also install companion skills declared in requires.skills. Defaults to false so dependency installs stay explicit in the approved tool call.",
+                        "default": false
+                    }
                 }
-            },
-            "required": ["name"]
-        })
+            })
+        } else {
+            // Disabled mode: only content installs allowed
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "Raw SKILL.md content to install directly"
+                    }
+                },
+                "required": ["content"]
+            })
+        }
     }
 
     async fn execute(
@@ -661,7 +678,10 @@ impl Tool for SkillInstallTool {
         _ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
-        let name = require_str(&params, "name")?;
+        let name = params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
         let install_dependencies = params
             .get("install_dependencies")
             .and_then(|v| v.as_bool())
@@ -678,7 +698,7 @@ impl Tool for SkillInstallTool {
         // shortcut, an agent that mis-interprets an active persona bundle
         // as "needs to be installed" will trigger a 404 against the
         // ClawHub registry for skills that exist only locally.
-        {
+        if let Some(name) = name {
             let guard = self
                 .registry
                 .read()
@@ -710,6 +730,12 @@ impl Tool for SkillInstallTool {
             fetch_skill_content(url).await.map_err(ToolError::from)?
         } else if let Some(ref catalog) = self.catalog {
             // Look up in catalog and fetch
+            let name = name.ok_or_else(|| {
+                ToolError::ExecutionFailed(
+                    "Provide 'name' (for catalog lookup), 'url', or 'content' to install a skill."
+                        .into(),
+                )
+            })?;
             let download_key = resolve_catalog_download_key(
                 catalog.as_ref(),
                 name,
@@ -725,8 +751,14 @@ impl Tool for SkillInstallTool {
                 .await
                 .map_err(ToolError::from)?
         } else {
+            // ClawHub disabled: only content installs are allowed. URL fetches
+            // are also blocked because we cannot distinguish a direct URL from
+            // a ClawHub mirror or proxy — disabling ClawHub must disable all
+            // remote skill fetching to honour the operator's intent.
             return Err(ToolError::ExecutionFailed(
-                "ClawHub registry is disabled. Provide a 'url' or 'content' parameter.".into(),
+                "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
+                 Only 'content' installs are available."
+                    .into(),
             ));
         };
 
@@ -1356,6 +1388,11 @@ mod tests {
         assert!(schema["properties"].get("slug").is_some());
         assert!(schema["properties"].get("url").is_some());
         assert!(schema["properties"].get("content").is_some());
+        // name should not be required (it is optional for URL/content installs)
+        assert!(
+            schema.get("required").is_none(),
+            "skill_install should have no required parameters"
+        );
     }
 
     #[test]
@@ -1431,7 +1468,74 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_skill_install_without_catalog_rejects_name_only() {
+    async fn test_skill_install_rejects_empty_params() {
+        let tool = SkillInstallTool::new(test_registry(), Some(test_catalog()));
+        let ctx = crate::context::JobContext::default();
+        let result = tool.execute(serde_json::json!({}), &ctx).await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("Provide") || err.contains("name"),
+            "Expected helpful error when no params given, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_skill_install_schema_disabled_only_content() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let schema = tool.parameters_schema();
+        assert!(
+            schema["properties"].get("content").is_some(),
+            "disabled schema should include content"
+        );
+        assert!(
+            schema["properties"].get("url").is_none(),
+            "disabled schema should not include url"
+        );
+        assert!(
+            schema["properties"].get("name").is_none(),
+            "disabled schema should not include name"
+        );
+        assert_eq!(
+            schema["required"],
+            serde_json::json!(["content"]),
+            "content should be required when disabled"
+        );
+    }
+
+    #[test]
+    fn test_skill_install_description_disabled() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        assert!(
+            !tool.description().contains("URL"),
+            "disabled description should not mention URL"
+        );
+        assert!(
+            !tool.description().contains("ClawHub"),
+            "disabled description should not mention ClawHub"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skill_install_blocks_url_when_clawhub_disabled() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let ctx = crate::context::JobContext::default();
+        let result = tool
+            .execute(
+                serde_json::json!({"url": "https://example.com/SKILL.md"}),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("disabled"),
+            "Expected disabled error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skill_install_blocks_name_when_clawhub_disabled() {
         let tool = SkillInstallTool::new(test_registry(), None);
         let ctx = crate::context::JobContext::default();
         let result = tool
@@ -1440,8 +1544,8 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("ClawHub") || err.contains("disabled"),
-            "Expected ClawHub disabled error, got: {err}"
+            err.contains("disabled"),
+            "Expected disabled error, got: {err}"
         );
     }
 

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -574,13 +574,13 @@ impl Tool for SkillSearchTool {
 
 pub struct SkillInstallTool {
     registry: Arc<std::sync::RwLock<SkillRegistry>>,
-    catalog: Arc<SkillCatalog>,
+    catalog: Option<Arc<SkillCatalog>>,
 }
 
 impl SkillInstallTool {
     pub fn new(
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
-        catalog: Arc<SkillCatalog>,
+        catalog: Option<Arc<SkillCatalog>>,
     ) -> Self {
         Self { registry, catalog }
     }
@@ -700,7 +700,6 @@ impl Tool for SkillInstallTool {
         }
 
         let content = if let Some(raw) = params.get("content").and_then(|v| v.as_str()) {
-            // Direct content provided
             raw.to_string()
         } else if let Some(url) = params
             .get("url")
@@ -709,22 +708,26 @@ impl Tool for SkillInstallTool {
         {
             // Fetch from explicit URL
             fetch_skill_content(url).await.map_err(ToolError::from)?
-        } else {
+        } else if let Some(ref catalog) = self.catalog {
             // Look up in catalog and fetch
             let download_key = resolve_catalog_download_key(
-                self.catalog.as_ref(),
+                catalog.as_ref(),
                 name,
                 requested_identifier.as_deref(),
             )
             .await?;
             requested_identifier = Some(download_key.clone());
             let download_url = ironclaw_skills::catalog::skill_download_url(
-                self.catalog.registry_url(),
+                catalog.registry_url(),
                 &download_key,
             );
             fetch_skill_content(&download_url)
                 .await
                 .map_err(ToolError::from)?
+        } else {
+            return Err(ToolError::ExecutionFailed(
+                "ClawHub registry is disabled. Provide a 'url' or 'content' parameter.".into(),
+            ));
         };
 
         let normalized = ironclaw_skills::normalize_line_endings(&content);
@@ -1342,7 +1345,7 @@ mod tests {
     #[test]
     fn test_skill_install_schema() {
         use crate::tools::tool::ApprovalRequirement;
-        let tool = SkillInstallTool::new(test_registry(), test_catalog());
+        let tool = SkillInstallTool::new(test_registry(), Some(test_catalog()));
         assert_eq!(tool.name(), "skill_install");
         assert_eq!(
             tool.requires_approval(&serde_json::json!({})),
@@ -1414,6 +1417,32 @@ mod tests {
         ];
 
         assert!(resolve_catalog_slug_for_name("Mortgage Calculator", &entries).is_err());
+    }
+
+    #[test]
+    fn test_skill_install_schema_without_catalog() {
+        use crate::tools::tool::ApprovalRequirement;
+        let tool = SkillInstallTool::new(test_registry(), None);
+        assert_eq!(tool.name(), "skill_install");
+        assert_eq!(
+            tool.requires_approval(&serde_json::json!({})),
+            ApprovalRequirement::UnlessAutoApproved
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skill_install_without_catalog_rejects_name_only() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let ctx = crate::context::JobContext::default();
+        let result = tool
+            .execute(serde_json::json!({"name": "some-skill"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("ClawHub") || err.contains("disabled"),
+            "Expected ClawHub disabled error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -726,7 +726,13 @@ impl Tool for SkillInstallTool {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
         {
-            // Fetch from explicit URL
+            if self.catalog.is_none() {
+                return Err(ToolError::ExecutionFailed(
+                    "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
+                     Only 'content' installs are available."
+                        .into(),
+                ));
+            }
             fetch_skill_content(url).await.map_err(ToolError::from)?
         } else if let Some(ref catalog) = self.catalog {
             // Look up in catalog and fetch
@@ -743,10 +749,8 @@ impl Tool for SkillInstallTool {
             )
             .await?;
             requested_identifier = Some(download_key.clone());
-            let download_url = ironclaw_skills::catalog::skill_download_url(
-                catalog.registry_url(),
-                &download_key,
-            );
+            let download_url =
+                ironclaw_skills::catalog::skill_download_url(catalog.registry_url(), &download_key);
             fetch_skill_content(&download_url)
                 .await
                 .map_err(ToolError::from)?
@@ -857,8 +861,19 @@ impl Tool for SkillInstallTool {
 
         let chain_report = if required_skills.is_empty() {
             ChainInstallReport::default()
-        } else if !install_dependencies {
-            let missing_required_skills = {
+        } else if let Some(catalog) = self.catalog.as_ref().filter(|_| install_dependencies) {
+            install_missing_skill_dependencies(
+                &self.registry,
+                catalog.registry_url(),
+                required_skills,
+                |url| async move { fetch_skill_content(&url).await },
+            )
+            .await?
+        } else {
+            // Either install_dependencies is false (user must install deps
+            // explicitly) or ClawHub is disabled (cannot fetch from registry).
+            // In both cases: report missing deps without fetching them.
+            let missing = {
                 let guard = self
                     .registry
                     .read()
@@ -868,19 +883,10 @@ impl Tool for SkillInstallTool {
                     .filter(|skill| !guard.has(skill))
                     .collect::<Vec<_>>()
             };
-
             ChainInstallReport {
-                pending_explicit_install: missing_required_skills,
+                pending_explicit_install: missing,
                 ..Default::default()
             }
-        } else {
-            install_missing_skill_dependencies(
-                &self.registry,
-                self.catalog.registry_url(),
-                required_skills,
-                |url| async move { fetch_skill_content(&url).await },
-            )
-            .await?
         };
 
         let output = build_skill_install_output(&installed_name, &chain_report);

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -311,6 +311,21 @@ impl ToolRegistry {
         tools.remove(&key)
     }
 
+    /// Unregister a tool (sync version for startup/registration paths).
+    pub fn unregister_sync(&self, name: &str) {
+        match self.tools.try_write() {
+            Ok(mut tools) => {
+                tools.remove(name);
+            }
+            Err(_) => {
+                tracing::debug!(
+                    tool = name,
+                    "unregister_sync: lock contested, skipping removal"
+                );
+            }
+        }
+    }
+
     /// Get a tool by name.
     ///
     /// Falls back to a hyphen→underscore alias when the exact name is not
@@ -743,7 +758,7 @@ impl ToolRegistry {
     ///
     /// These allow the LLM to manage prompt-level skills through conversation.
     /// When `catalog` is `None` (ClawHub disabled), `skill_search` is omitted
-    /// and `skill_install` only accepts direct URL or content.
+    /// and `skill_install` only accepts content installs.
     pub fn register_skill_tools(
         &self,
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
@@ -765,6 +780,10 @@ impl ToolRegistry {
                 Arc::clone(catalog),
             )));
             count += 1;
+        } else {
+            // Ensure skill_search is removed if previously registered (e.g. when
+            // re-registering with catalog disabled after an initial registration).
+            self.unregister_sync("skill_search");
         }
 
         tracing::debug!(
@@ -1770,6 +1789,30 @@ mod tests {
         assert!(
             !registry.has("skill_search").await,
             "skill_search should not be registered without catalog"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_register_skill_tools_without_catalog_removes_prior_search() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = ToolRegistry::new();
+        let sr = Arc::new(std::sync::RwLock::new(ironclaw_skills::SkillRegistry::new(
+            dir.path().to_path_buf(),
+        )));
+        let catalog = Arc::new(ironclaw_skills::catalog::SkillCatalog::with_url(
+            "http://127.0.0.1:1",
+        ));
+        // First register with catalog (installs skill_search)
+        registry.register_skill_tools(Arc::clone(&sr), Some(catalog));
+        assert!(
+            registry.has("skill_search").await,
+            "skill_search should be registered with catalog"
+        );
+        // Re-register without catalog (should remove skill_search)
+        registry.register_skill_tools(sr, None);
+        assert!(
+            !registry.has("skill_search").await,
+            "skill_search should be removed when re-registering without catalog"
         );
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -315,10 +315,12 @@ impl ToolRegistry {
     pub fn unregister_sync(&self, name: &str) {
         match self.tools.try_write() {
             Ok(mut tools) => {
-                tools.remove(name);
+                if let Some(key) = Self::resolve_key(&tools, name) {
+                    tools.remove(&key);
+                }
             }
             Err(_) => {
-                tracing::debug!(
+                tracing::warn!(
                     tool = name,
                     "unregister_sync: lock contested, skipping removal"
                 );

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -751,18 +751,25 @@ impl ToolRegistry {
     ) {
         self.register_sync(Arc::new(SkillListTool::new(Arc::clone(&registry))));
         self.register_sync(Arc::new(SkillRemoveTool::new(Arc::clone(&registry))));
+        self.register_sync(Arc::new(SkillInstallTool::new(
+            Arc::clone(&registry),
+            catalog.clone(),
+        )));
+
+        // Base tools: list, remove, install
+        let mut count = 3;
 
         if let Some(ref catalog) = catalog {
             self.register_sync(Arc::new(SkillSearchTool::new(
-                Arc::clone(&registry),
+                registry,
                 Arc::clone(catalog),
             )));
+            count += 1;
         }
 
-        self.register_sync(Arc::new(SkillInstallTool::new(registry, catalog.clone())));
-
         tracing::debug!(
-            "Registered skill management tools (clawhub={})",
+            "Registered {} skill management tools (clawhub={})",
+            count,
             catalog.is_some()
         );
     }
@@ -1753,7 +1760,7 @@ mod tests {
     async fn test_register_skill_tools_without_catalog() {
         let dir = tempfile::tempdir().unwrap();
         let registry = ToolRegistry::new();
-        let sr = Arc::new(std::sync::RwLock::new(crate::skills::SkillRegistry::new(
+        let sr = Arc::new(std::sync::RwLock::new(ironclaw_skills::SkillRegistry::new(
             dir.path().to_path_buf(),
         )));
         registry.register_skill_tools(sr, None);

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -742,22 +742,29 @@ impl ToolRegistry {
     /// Register skill management tools (list, search, install, remove).
     ///
     /// These allow the LLM to manage prompt-level skills through conversation.
+    /// When `catalog` is `None` (ClawHub disabled), `skill_search` is omitted
+    /// and `skill_install` only accepts direct URL or content.
     pub fn register_skill_tools(
         &self,
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
-        catalog: Arc<SkillCatalog>,
+        catalog: Option<Arc<SkillCatalog>>,
     ) {
         self.register_sync(Arc::new(SkillListTool::new(Arc::clone(&registry))));
-        self.register_sync(Arc::new(SkillSearchTool::new(
-            Arc::clone(&registry),
-            Arc::clone(&catalog),
-        )));
-        self.register_sync(Arc::new(SkillInstallTool::new(
-            Arc::clone(&registry),
-            Arc::clone(&catalog),
-        )));
-        self.register_sync(Arc::new(SkillRemoveTool::new(registry)));
-        tracing::debug!("Registered 4 skill management tools");
+        self.register_sync(Arc::new(SkillRemoveTool::new(Arc::clone(&registry))));
+
+        if let Some(ref catalog) = catalog {
+            self.register_sync(Arc::new(SkillSearchTool::new(
+                Arc::clone(&registry),
+                Arc::clone(catalog),
+            )));
+        }
+
+        self.register_sync(Arc::new(SkillInstallTool::new(registry, catalog.clone())));
+
+        tracing::debug!(
+            "Registered skill management tools (clawhub={})",
+            catalog.is_some()
+        );
     }
 
     /// Register routine management tools.
@@ -1741,5 +1748,21 @@ mod tests {
         let removed = registry.unregister("my-mcp-search").await;
         assert!(removed.is_some(), "unregister must resolve hyphen alias");
         assert!(!registry.has("my_mcp_search").await, "tool should be gone");
+    }
+    #[tokio::test]
+    async fn test_register_skill_tools_without_catalog() {
+        let dir = tempfile::tempdir().unwrap();
+        let registry = ToolRegistry::new();
+        let sr = Arc::new(std::sync::RwLock::new(crate::skills::SkillRegistry::new(
+            dir.path().to_path_buf(),
+        )));
+        registry.register_skill_tools(sr, None);
+        assert!(registry.has("skill_list").await);
+        assert!(registry.has("skill_remove").await);
+        assert!(registry.has("skill_install").await);
+        assert!(
+            !registry.has("skill_search").await,
+            "skill_search should not be registered without catalog"
+        );
     }
 }

--- a/src/tools/schema_validator.rs
+++ b/src/tools/schema_validator.rs
@@ -522,7 +522,7 @@ mod tests {
             )),
             Box::new(SkillInstallTool::new(
                 Arc::clone(&registry),
-                Arc::clone(&catalog),
+                Some(Arc::clone(&catalog)),
             )),
             Box::new(SkillRemoveTool::new(Arc::clone(&registry))),
         ];

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1096,6 +1096,105 @@ async def http_channel_server_without_secret(
 
 
 @pytest.fixture(scope="session")
+async def clawhub_disabled_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an ironclaw instance with CLAWHUB_ENABLED=false for disabled-mode tests."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-clawhub-disabled-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-clawhub-disabled-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        db_path = os.path.join(db_tmpdir.name, "clawhub-disabled.db")
+        home_dir = home_tmpdir.name
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_dir,
+            "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "openai_compatible",
+            "LLM_BASE_URL": mock_llm_server,
+            "LLM_MODEL": "mock-model",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": db_path,
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "CLAWHUB_ENABLED": "false",
+            "ROUTINES_ENABLED": "false",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"clawhub-disabled server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
 async def browser(ironclaw_server):
     """Session-scoped Playwright browser instance.
 

--- a/tests/e2e/scenarios/test_clawhub_disabled.py
+++ b/tests/e2e/scenarios/test_clawhub_disabled.py
@@ -1,0 +1,68 @@
+"""Scenario: ClawHub disabled mode (CLAWHUB_ENABLED=false).
+
+Verifies that when ClawHub is disabled:
+- Gateway status reports clawhub_enabled=false
+- Skill search API returns 501
+- URL-based skill installs are blocked (403)
+- Content-based skill installs still work
+- Skill listing still works
+"""
+
+from helpers import api_get, api_post, auth_headers
+
+
+async def test_gateway_status_shows_clawhub_disabled(clawhub_disabled_server):
+    """GET /api/gateway/status should report clawhub_enabled: false."""
+    r = await api_get(clawhub_disabled_server, "/api/gateway/status")
+    assert r.status_code == 200
+    assert r.json()["clawhub_enabled"] is False
+
+
+async def test_skills_search_api_returns_501(clawhub_disabled_server):
+    """POST /api/skills/search should return 501 when ClawHub is disabled."""
+    r = await api_post(clawhub_disabled_server, "/api/skills/search", json={"query": "test"})
+    assert r.status_code == 501
+
+
+async def test_skills_install_url_blocked(clawhub_disabled_server):
+    """POST /api/skills/install with a URL should be rejected when ClawHub is disabled."""
+    r = await api_post(
+        clawhub_disabled_server,
+        "/api/skills/install",
+        headers={**auth_headers(), "X-Confirm-Action": "true"},
+        json={"url": "https://example.com/SKILL.md"},
+    )
+    assert r.status_code == 403, f"Expected 403 for URL install, got {r.status_code}: {r.text}"
+    assert "disabled" in r.text.lower()
+
+
+async def test_skills_install_content_allowed(clawhub_disabled_server):
+    """POST /api/skills/install with inline content should succeed when ClawHub is disabled."""
+    skill_content = (
+        "---\n"
+        "name: e2e-test-skill\n"
+        "version: 0.1.0\n"
+        "description: A test skill for E2E\n"
+        "activation:\n"
+        "  keywords: [e2e-test]\n"
+        "---\n"
+        "# E2E Test Skill\n"
+        "This is a test skill installed via content.\n"
+    )
+    r = await api_post(
+        clawhub_disabled_server,
+        "/api/skills/install",
+        headers={**auth_headers(), "X-Confirm-Action": "true"},
+        json={"content": skill_content},
+    )
+    assert r.status_code == 200, f"Expected 200 for content install, got {r.status_code}: {r.text}"
+    assert r.json().get("success") is True, f"Expected success, got: {r.json()}"
+
+
+async def test_skills_list_api_still_works(clawhub_disabled_server):
+    """GET /api/skills should return 200 regardless of ClawHub status."""
+    r = await api_get(clawhub_disabled_server, "/api/skills")
+    assert r.status_code == 200
+    data = r.json()
+    assert "skills" in data
+    assert isinstance(data["skills"], list)

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -588,6 +588,7 @@ pub struct TestRigBuilder {
     injection_check: bool,
     auto_approve_tools: Option<bool>,
     enable_skills: bool,
+    clawhub_disabled: bool,
     enable_routines: bool,
     http_exchanges: Vec<HttpExchange>,
     http_interceptor_override: Option<Arc<dyn HttpInterceptor>>,
@@ -610,6 +611,7 @@ impl TestRigBuilder {
             injection_check: false,
             auto_approve_tools: Some(true),
             enable_skills: false,
+            clawhub_disabled: false,
             enable_routines: false,
             http_exchanges: Vec::new(),
             http_interceptor_override: None,
@@ -742,6 +744,13 @@ impl TestRigBuilder {
         self
     }
 
+    /// Disable ClawHub catalog while keeping local skill management.
+    /// Must be combined with `.with_skills()` to have any effect.
+    pub fn with_clawhub_disabled(mut self) -> Self {
+        self.clawhub_disabled = true;
+        self
+    }
+
     /// Enable the routines system so the scheduler is wired with a `RoutineEngine`,
     /// allowing routine jobs to actually execute. Routine tools are always registered
     /// but require the engine to dispatch jobs.
@@ -802,6 +811,7 @@ impl TestRigBuilder {
             injection_check,
             auto_approve_tools,
             enable_skills,
+            clawhub_disabled,
             enable_routines,
             http_exchanges: explicit_http_exchanges,
             http_interceptor_override,
@@ -1049,12 +1059,17 @@ impl TestRigBuilder {
                     ironclaw_skills::SkillRegistry::new(temp_dir.path().join("skills"))
                         .with_installed_dir(temp_dir.path().join("installed_skills")),
                 ));
-                let catalog = ironclaw_skills::catalog::shared_catalog();
+                let catalog = if clawhub_disabled {
+                    None
+                } else {
+                    Some(ironclaw_skills::catalog::shared_catalog())
+                };
                 components
                     .tools
-                    .register_skill_tools(Arc::clone(&registry), Some(Arc::clone(&catalog)));
+                    .register_skill_tools(Arc::clone(&registry), catalog.clone());
                 components.skill_registry = Some(registry);
-                components.skill_catalog = Some(catalog);
+                components.skill_catalog = catalog;
+                components.config.skills.clawhub_enabled = !clawhub_disabled;
             }
 
             // Register any extra test-specific tools.

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -1052,7 +1052,7 @@ impl TestRigBuilder {
                 let catalog = ironclaw_skills::catalog::shared_catalog();
                 components
                     .tools
-                    .register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
+                    .register_skill_tools(Arc::clone(&registry), Some(Arc::clone(&catalog)));
                 components.skill_registry = Some(registry);
                 components.skill_catalog = Some(catalog);
             }

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -873,6 +873,7 @@ impl TestRigBuilder {
         config.agent.max_tool_iterations = max_tool_iterations;
         config.safety.injection_check_enabled = injection_check;
         config.skills.enabled = enable_skills;
+        config.skills.clawhub_enabled = !clawhub_disabled;
         if let Some(v) = auto_approve_tools {
             config.agent.auto_approve_tools = v;
         }
@@ -1069,7 +1070,6 @@ impl TestRigBuilder {
                     .register_skill_tools(Arc::clone(&registry), catalog.clone());
                 components.skill_registry = Some(registry);
                 components.skill_catalog = catalog;
-                components.config.skills.clawhub_enabled = !clawhub_disabled;
             }
 
             // Register any extra test-specific tools.


### PR DESCRIPTION
## Summary

Closes #1570.

- Adds `CLAWHUB_ENABLED` environment variable (default `true`) to control access to the public ClawHub skill registry
- When `false`: skips `SkillCatalog` instantiation, excludes `skill_search` from LLM tools, returns `clawhub_enabled: false` in gateway status, hides "Search ClawHub" UI, returns 501 for `/api/skills/search`
- Blocks URL-based skill installs when disabled (cannot distinguish direct URLs from ClawHub mirrors/proxies) — only inline `content` installs remain available
- Preserves local skill management (`skill_list`, `skill_remove`) and content-based `skill_install`
- Dynamic tool schema: `skill_install` hides `url`/`name` params and requires `content` when catalog is disabled
- Makes `SkillInstallRequest.name` optional (content installs derive name from SKILL.md)

## Test plan

- [x] `cargo fmt` — no changes
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 4301 passed, 0 failed
- [x] 17 new/updated tests: config parsing (3), tool registry (2), skill tool behavior (7), gateway status serialization (1), web handler 501 (1), CLI rejection (1), schema validator (1), test rig builder (1)
- [x] New E2E test suite (`test_clawhub_disabled.py`): gateway status, search 501, URL install 403, content install 200, skill list 200
- [x] Manual: set `CLAWHUB_ENABLED=false`, verified gateway UI hides "Search ClawHub" section
- [x] Manual: `/api/gateway/status` returns `clawhub_enabled: false`

### Commit breakdown

1. **299619b4** `feat(skills): add CLAWHUB_ENABLED flag` — core config, app wiring, tool registry, web gateway status, frontend JS gating
2. **2c83edaf** `fix: address PR review feedback` — test_gateway_state_base refactor, 501 integration test, TestRigBuilder.with_clawhub_disabled()
3. **98c83a5c** `fix: enforce in CLI and hide hints` — gate `ironclaw skills search`, conditional /help, hide ClawHub hints
4. **5c12c2e9** `fix: harden disabled mode` — block URL installs (mirror ambiguity), dynamic tool schema/description, Optional name, unregister_sync, E2E tests, simplification pass