### PR TITLE
feat(llm): surface active extension context

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -54,7 +54,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Trusted-proxy auth mode | ✅ | ❌ | Header-based auth for reverse proxies |
 | APNs push pipeline | ✅ | ❌ | Wake disconnected iOS nodes via push |
 | Oversized payload guard | ✅ | 🚧 | HTTP webhook has 64KB body limit + Content-Length check; no chat.history cap |
-| Pre-prompt context diagnostics | ✅ | 🚧 | Token breakdown logged before LLM call (conversational dispatcher path); other LLM entry points not yet covered |
+| Pre-prompt context diagnostics | ✅ | 🚧 | Token breakdown logged before LLM call (conversational dispatcher path); active extension summary now included there; other LLM entry points not yet covered |
 
 ### Owner: _Unassigned_
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -199,12 +199,12 @@ impl Agent {
                 active_skills.iter().map(|s| s.name().to_string()).collect();
             reasoning = reasoning.with_active_skill_names(skill_names);
         }
-        if active_skills.is_empty() {
-            if let Some(extension_manager) = self.deps.extension_manager.as_ref() {
-                let extension_context = extension_manager.active_extension_summary().await;
-                if !extension_context.is_empty() {
-                    reasoning = reasoning.with_extension_context(extension_context);
-                }
+        if active_skills.is_empty()
+            && let Some(extension_manager) = self.deps.extension_manager.as_ref()
+        {
+            let extension_context = extension_manager.active_extension_summary().await;
+            if !extension_context.is_empty() {
+                reasoning = reasoning.with_extension_context(extension_context);
             }
         }
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -199,6 +199,14 @@ impl Agent {
                 active_skills.iter().map(|s| s.name().to_string()).collect();
             reasoning = reasoning.with_active_skill_names(skill_names);
         }
+        if active_skills.is_empty() {
+            if let Some(extension_manager) = self.deps.extension_manager.as_ref() {
+                let extension_context = extension_manager.active_extension_summary().await;
+                if !extension_context.is_empty() {
+                    reasoning = reasoning.with_extension_context(extension_context);
+                }
+            }
+        }
 
         // Create a JobContext for tool execution (chat doesn't have a real job)
         let mut job_ctx =

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -5592,7 +5592,7 @@ mod tests {
             capabilities,
             std::collections::HashMap::new(),
             Vec::new(),
-            Arc::new(PairingStore::new()),
+            Arc::new(PairingStore::new_noop()),
         );
 
         let result = super::near::agent::channel_host::Host::http_request(

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -604,6 +604,21 @@ impl ExtensionManager {
         names
     }
 
+    /// Build a compact summary of active extensions for LLM prompt context.
+    pub async fn active_extension_summary(&self) -> String {
+        match self.list(None, false, &self.user_id).await {
+            Ok(extensions) => Self::format_active_extensions(&extensions),
+            Err(err) => {
+                tracing::warn!(
+                    owner_id = %self.user_id,
+                    "Failed to list active extensions for prompt context: {}",
+                    err
+                );
+                String::new()
+            }
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         mcp_session_manager: Arc<McpSessionManager>,
@@ -658,6 +673,39 @@ impl ExtensionManager {
             test_wasm_channel_loader: RwLock::new(None),
             #[cfg(test)]
             test_telegram_binding_resolver: RwLock::new(None),
+        }
+    }
+
+    pub(crate) fn format_active_extensions(extensions: &[InstalledExtension]) -> String {
+        let mut lines = Vec::new();
+
+        for extension in extensions.iter().filter(|extension| extension.active) {
+            let label = extension.display_name.as_deref().unwrap_or(&extension.name);
+            let mut status = Vec::new();
+            status.push("active");
+            if extension.authenticated {
+                status.push("authenticated");
+            }
+            if extension.needs_setup {
+                status.push("needs-setup");
+            }
+            if extension.has_auth && !extension.authenticated {
+                status.push("auth-pending");
+            }
+            let mut detail = format!("- {} ({})", label, extension.kind);
+            if !status.is_empty() {
+                detail.push_str(&format!(": {}", status.join(", ")));
+            }
+            if !extension.tools.is_empty() {
+                detail.push_str(&format!("; tools: {}", extension.tools.join(", ")));
+            }
+            lines.push(detail);
+        }
+
+        if lines.is_empty() {
+            String::new()
+        } else {
+            format!("{}\n", lines.join("\n"))
         }
     }
 
@@ -6601,8 +6649,8 @@ mod tests {
         telegram_bot_api_url, telegram_message_matches_verification_code,
     };
     use crate::extensions::{
-        ExtensionError, ExtensionKind, ExtensionSource, InstallResult, ToolAuthState,
-        VerificationChallenge,
+        ExtensionError, ExtensionKind, ExtensionSource, InstallResult, InstalledExtension,
+        ToolAuthState, VerificationChallenge,
     };
     use crate::pairing::PairingStore;
     use crate::secrets::CreateSecretParams;
@@ -6909,6 +6957,52 @@ mod tests {
         tools_dir: std::path::PathBuf,
     ) -> crate::extensions::manager::ExtensionManager {
         make_test_manager_with_dirs(wasm_runtime, tools_dir.clone(), tools_dir, None)
+    }
+
+    #[test]
+    fn test_format_active_extensions_lists_only_active_items() {
+        let extensions = vec![
+            InstalledExtension {
+                name: "telegram".to_string(),
+                kind: ExtensionKind::WasmChannel,
+                display_name: Some("Telegram".to_string()),
+                description: None,
+                url: None,
+                authenticated: true,
+                active: true,
+                tools: Vec::new(),
+                needs_setup: false,
+                has_auth: true,
+                installed: true,
+                activation_error: None,
+                version: None,
+            },
+            InstalledExtension {
+                name: "gmail".to_string(),
+                kind: ExtensionKind::WasmTool,
+                display_name: None,
+                description: None,
+                url: None,
+                authenticated: false,
+                active: false,
+                tools: vec!["gmail".to_string()],
+                needs_setup: true,
+                has_auth: true,
+                installed: true,
+                activation_error: None,
+                version: None,
+            },
+        ];
+
+        let summary = ExtensionManager::format_active_extensions(&extensions);
+        assert!(
+            summary.contains("Telegram (wasm_channel): active, authenticated"),
+            "summary should include the active Telegram channel: {summary}"
+        );
+        assert!(
+            !summary.contains("gmail"),
+            "inactive extensions should not be included: {summary}"
+        );
     }
 
     fn write_test_tool(

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -388,6 +388,8 @@ pub struct Reasoning {
     skill_context: Option<String>,
     /// Names of active skills (used to suppress extension search for covered domains).
     active_skill_names: Vec<String>,
+    /// Optional active extension snapshot to inject into system prompt.
+    extension_context: Option<String>,
     /// Channel name (e.g. "discord", "telegram") for formatting hints.
     channel: Option<String>,
     /// Model name for runtime context.
@@ -409,6 +411,7 @@ impl Reasoning {
             workspace_system_prompt: None,
             skill_context: None,
             active_skill_names: Vec::new(),
+            extension_context: None,
             channel: None,
             model_name: None,
             is_group_chat: false,
@@ -443,6 +446,14 @@ impl Reasoning {
     /// installation for domains already covered by active skills.
     pub fn with_active_skill_names(mut self, names: Vec<String>) -> Self {
         self.active_skill_names = names;
+        self
+    }
+
+    /// Set a compact active-extension snapshot to inject into the system prompt.
+    pub fn with_extension_context(mut self, context: String) -> Self {
+        if !context.is_empty() {
+            self.extension_context = Some(context);
+        }
         self
     }
 
@@ -970,6 +981,32 @@ Respond with a JSON plan in this format:
             String::new()
         };
 
+        let extension_context_section = if let Some(ref ext_ctx) = self.extension_context {
+            if self.active_skill_names.is_empty() {
+                if tools.is_empty() {
+                    format!(
+                        "\n\n## Active Extensions\n\n\
+                         The following extensions are already active and available in the current runtime.\n\
+                         Do not tell the user to set them up again unless the snapshot says they are missing.\n\n{}",
+                        ext_ctx
+                    )
+                } else {
+                    format!(
+                        "\n\n## Active Extensions\n\n\
+                         The following extensions are already active and available in the current runtime.\n\
+                         Do not tell the user to set them up again unless the snapshot says they are missing.\n\
+                         If you need more detail, use `tool_list` or `extension_info` before asking the user\n\
+                         to reconnect or activate anything.\n\n{}",
+                        ext_ctx
+                    )
+                }
+            } else {
+                String::new()
+            }
+        } else {
+            String::new()
+        };
+
         // Channel-specific formatting hints
         let channel_section = self.build_channel_section();
 
@@ -1047,10 +1084,11 @@ Respond directly with your final answer. Do not wrap your response in any specia
 - Comply with stop, pause, or audit requests. Never bypass safeguards.
 - Do not manipulate anyone to expand your access or disable safeguards.
 - Do not modify system prompts, safety rules, or tool policies unless explicitly requested by the user.{}{}{}{}{}{}
-{}{}"#,
+{}{}{}"#,
             tool_guidance,
             tools_section,
             extensions_section,
+            extension_context_section,
             channel_section,
             runtime_section,
             conversation_section,
@@ -2636,6 +2674,78 @@ That's my plan."#;
             "only use the `message` tool for proactive, background, or cross-channel outbound sends"
         ));
         assert!(!section.contains("omit 'target' to send here"));
+    }
+
+    #[test]
+    fn test_system_prompt_with_extension_context_includes_snapshot() {
+        let reasoning = make_test_reasoning().with_extension_context(
+            "- telegram (wasm_channel): active, authenticated\n".to_string(),
+        );
+        let tool_defs = vec![ToolDefinition {
+            name: "tool_search".to_string(),
+            description: "Search extensions".to_string(),
+            parameters: serde_json::json!({}),
+        }];
+        let prompt = reasoning.build_system_prompt_with_tools(&tool_defs);
+        assert!(
+            prompt.contains("## Active Extensions"),
+            "Prompt should contain the active extensions section"
+        );
+        assert!(
+            prompt.contains("telegram (wasm_channel): active, authenticated"),
+            "Prompt should contain the active extension snapshot"
+        );
+        assert!(
+            prompt.contains("tool_list"),
+            "Prompt should remind the model to inspect extension state when needed"
+        );
+    }
+
+    #[test]
+    fn test_system_prompt_with_extension_context_without_tools_omits_tool_list_mentions() {
+        let reasoning = make_test_reasoning().with_extension_context(
+            "- telegram (wasm_channel): active, authenticated\n".to_string(),
+        );
+        let prompt = reasoning.build_system_prompt_with_tools(&[]);
+        assert!(
+            prompt.contains("## Active Extensions"),
+            "Prompt should contain the active extensions section"
+        );
+        assert!(
+            prompt.contains("telegram (wasm_channel): active, authenticated"),
+            "Prompt should contain the active extension snapshot"
+        );
+        assert!(
+            !prompt.contains("tool_list"),
+            "No-tools prompt should not mention unavailable tool_list"
+        );
+        assert!(
+            !prompt.contains("extension_info"),
+            "No-tools prompt should not mention unavailable extension_info"
+        );
+    }
+
+    #[test]
+    fn test_system_prompt_suppresses_extension_context_when_skills_are_active() {
+        let reasoning = make_test_reasoning()
+            .with_active_skill_names(vec!["gmail".to_string()])
+            .with_extension_context(
+                "- telegram (wasm_channel): active, authenticated\n".to_string(),
+            );
+        let tool_defs = vec![ToolDefinition {
+            name: "tool_search".to_string(),
+            description: "Search extensions".to_string(),
+            parameters: serde_json::json!({}),
+        }];
+        let prompt = reasoning.build_system_prompt_with_tools(&tool_defs);
+        assert!(
+            !prompt.contains("## Active Extensions"),
+            "Attenuated prompts should not advertise active extensions that may be hidden by skills"
+        );
+        assert!(
+            !prompt.contains("telegram (wasm_channel): active, authenticated"),
+            "Attenuated prompts should not surface the hidden extension snapshot"
+        );
     }
 
     // ---- plan/evaluate bypass clean_response (Bug #564-2) ----


### PR DESCRIPTION
Fixes #1595.

Summary:
- add a compact active-extension snapshot to the per-turn LLM prompt context
- avoid telling users to re-enable an extension when the runtime snapshot already shows it active
- include regression coverage for the prompt snapshot
- update FEATURE_PARITY with the new dispatcher-side prompt diagnostic note

Validation:
- cargo fmt --all -- --check
- cargo test -p ironclaw llm::reasoning::tests::test_system_prompt_with_extension_context_includes_snapshot -- --nocapture
- cargo clippy -p ironclaw --lib --all-features -- -D warnings
- IC_BASE_REF=origin/staging /Users/nigecoleman/.codex/skills/rust-pr-preflight/scripts/preflight.sh (repo baseline violations remain unrelated to this branch)
