### PR TITLE
feat(security): add outbound trust policy for wasm and mcp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -168,7 +168,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2136,7 +2136,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2323,7 +2323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3150,7 +3150,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -3439,6 +3439,7 @@ dependencies = [
  "postgres-types",
  "pretty_assertions",
  "rand 0.8.5",
+ "rcgen",
  "readabilityrs",
  "refinery",
  "regex",
@@ -3466,6 +3467,7 @@ dependencies = [
  "tokio",
  "tokio-postgres",
  "tokio-postgres-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-stream",
  "tokio-test",
  "tokio-tungstenite 0.26.2",
@@ -3514,7 +3516,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4134,7 +4136,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4429,6 +4431,16 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
+
+[[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -4920,7 +4932,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4957,9 +4969,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5082,6 +5094,19 @@ checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -5472,7 +5497,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5518,6 +5543,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6154,7 +6180,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6379,7 +6405,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7179,7 +7205,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8029,7 +8055,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8551,6 +8577,15 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
+]
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -199,6 +199,8 @@ pretty_assertions = "1"
 tempfile = "3"
 insta = "1.46.3"
 criterion = "0.5"
+rcgen = "0.13"
+tokio-rustls = "0.26"
 
 [[bench]]
 name = "safety_check"

--- a/src/NETWORK_SECURITY.md
+++ b/src/NETWORK_SECURITY.md
@@ -2,7 +2,7 @@
 
 This document catalogs every network-facing surface in IronClaw, its authentication mechanism, bind address, security controls, and known findings. Use this as the authoritative reference during code reviews that touch network-facing code.
 
-**Last updated:** 2026-02-18
+**Last updated:** 2026-03-24
 
 ---
 
@@ -425,11 +425,18 @@ The `http` tool (`src/tools/builtin/http.rs`) has its own SSRF protections:
 
 ### MCP Client
 
-MCP servers are external processes accessed via HTTP. The MCP client (`src/tools/mcp/client.rs`) uses `reqwest` with a 30-second timeout but has **no SSRF protections** — it connects to whatever URL is configured for the MCP server.
+MCP HTTP transports and MCP OAuth/discovery flows now share the same outbound URL safety model:
 
-This is by design: MCP server URLs come from **operator-controlled configuration** (config files, environment variables, or the CLI `tool install` command), not from user input or LLM output. A compromised config file is outside IronClaw's threat model — it would imply the operator's machine is already compromised.
+- remote MCP servers must still use HTTPS
+- plain `http://` remains limited to localhost / loopback development targets
+- private/internal IPs and hostnames resolving to private IPs are rejected by default
+- invalid TLS certificates remain rejected by default
+- operator-managed outbound trust policies may grant narrowly scoped exceptions for
+  configured MCP servers that explicitly opt in via `outbound_trust.allowed_policy_ids`
 
-**Reference:** `src/tools/mcp/client.rs` — `reqwest::Client` builder
+This preserves the existing operator-configured server model while avoiding a global "trust any internal HTTPS" bypass. Stdio and Unix socket MCP transports are unchanged; the outbound trust policy applies only to MCP HTTP requests and MCP OAuth/discovery HTTP requests.
+
+**Reference:** `src/tools/mcp/http_transport.rs`, `src/tools/mcp/auth.rs`, `src/security/outbound_trust.rs`
 
 ### Sandbox Domain Allowlists
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -479,6 +479,8 @@ impl AppBuilder {
 
                 if let Some(ref runtime) = wasm_tool_runtime {
                     let mut loader = WasmToolLoader::new(Arc::clone(runtime), Arc::clone(&tools));
+                    loader = loader
+                        .with_outbound_trust_config(self.config.security.outbound_trust.clone());
                     if let Some(ref secrets) = secrets_store {
                         loader = loader.with_secrets_store(Arc::clone(secrets));
                     }
@@ -555,6 +557,7 @@ impl AppBuilder {
                             let tools = Arc::clone(&tools);
                             let pm = Arc::clone(&pm);
                             let owner_id = owner_id.clone();
+                            let outbound_trust_config = self.config.security.outbound_trust.clone();
 
                             join_set.spawn(async move {
                                 let server_name = server.name.clone();
@@ -565,6 +568,7 @@ impl AppBuilder {
                                     &pm,
                                     secrets,
                                     &owner_id,
+                                    &outbound_trust_config,
                                 )
                                 .await
                                 {
@@ -715,20 +719,23 @@ impl AppBuilder {
             Arc::new(InMemorySecretsStore::new(crypto))
         };
         let extension_manager = {
-            let manager = Arc::new(ExtensionManager::new(
-                Arc::clone(&mcp_session_manager),
-                Arc::clone(&mcp_process_manager),
-                ext_secrets,
-                Arc::clone(tools),
-                Some(Arc::clone(hooks)),
-                wasm_tool_runtime.clone(),
-                self.config.wasm.tools_dir.clone(),
-                self.config.channels.wasm_channels_dir.clone(),
-                self.config.tunnel.public_url.clone(),
-                self.config.owner_id.clone(),
-                self.db.clone(),
-                catalog_entries.clone(),
-            ));
+            let manager = Arc::new(
+                ExtensionManager::new(
+                    Arc::clone(&mcp_session_manager),
+                    Arc::clone(&mcp_process_manager),
+                    ext_secrets,
+                    Arc::clone(tools),
+                    Some(Arc::clone(hooks)),
+                    wasm_tool_runtime.clone(),
+                    self.config.wasm.tools_dir.clone(),
+                    self.config.channels.wasm_channels_dir.clone(),
+                    self.config.tunnel.public_url.clone(),
+                    self.config.owner_id.clone(),
+                    self.db.clone(),
+                    catalog_entries.clone(),
+                )
+                .with_outbound_trust_config(self.config.security.outbound_trust.clone()),
+            );
             tools.register_extension_tools(Arc::clone(&manager));
             tracing::debug!("Extension manager initialized with in-chat discovery tools");
 

--- a/src/channels/wasm/capabilities.rs
+++ b/src/channels/wasm/capabilities.rs
@@ -155,6 +155,11 @@ impl ChannelCapabilities {
         // Prefix with channel namespace
         Ok(self.prefix_workspace_path(path))
     }
+
+    /// Get the declared outbound trust policy IDs for this channel.
+    pub fn declared_outbound_trust_policy_ids(&self) -> &[String] {
+        self.tool_capabilities.declared_outbound_trust_policy_ids()
+    }
 }
 
 /// Configuration for an HTTP endpoint the channel wants to register.

--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -20,6 +20,7 @@ use crate::channels::wasm::wrapper::WasmChannel;
 use crate::db::SettingsStore;
 use crate::pairing::PairingStore;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::OutboundTrustConfig;
 
 /// Loads WASM channels from the filesystem.
 pub struct WasmChannelLoader {
@@ -27,6 +28,7 @@ pub struct WasmChannelLoader {
     pairing_store: Arc<PairingStore>,
     settings_store: Option<Arc<dyn SettingsStore>>,
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+    outbound_trust_config: OutboundTrustConfig,
     owner_scope_id: String,
 }
 
@@ -43,6 +45,7 @@ impl WasmChannelLoader {
             pairing_store,
             settings_store,
             secrets_store: None,
+            outbound_trust_config: OutboundTrustConfig::default(),
             owner_scope_id: owner_scope_id.into(),
         }
     }
@@ -50,6 +53,12 @@ impl WasmChannelLoader {
     /// Set the secrets store for host-based credential injection in WASM channels.
     pub fn with_secrets_store(mut self, store: Arc<dyn SecretsStore + Send + Sync>) -> Self {
         self.secrets_store = Some(store);
+        self
+    }
+
+    /// Set the outbound trust policy config for WASM channel execution.
+    pub fn with_outbound_trust_config(mut self, config: OutboundTrustConfig) -> Self {
+        self.outbound_trust_config = config;
         self
     }
 
@@ -160,6 +169,7 @@ impl WasmChannelLoader {
         if let Some(ref secrets) = self.secrets_store {
             channel = channel.with_secrets_store(Arc::clone(secrets));
         }
+        channel = channel.with_outbound_trust_config(self.outbound_trust_config.clone());
 
         tracing::info!(
             name = name,

--- a/src/channels/wasm/schema.rs
+++ b/src/channels/wasm/schema.rs
@@ -514,6 +514,41 @@ mod tests {
     }
 
     #[test]
+    fn test_channel_capabilities_parse_outbound_trust_allowed_policy_ids() {
+        let json = r#"{
+            "name": "internal-webhook",
+            "capabilities": {
+                "outbound_trust": {
+                    "allowed_policy_ids": ["corp-slack-internal"]
+                },
+                "channel": {
+                    "allowed_paths": ["/webhook/internal"]
+                }
+            }
+        }"#;
+
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        let caps = file.to_capabilities();
+
+        assert_eq!(
+            caps.declared_outbound_trust_policy_ids(),
+            ["corp-slack-internal"]
+        );
+    }
+
+    #[test]
+    fn test_channel_capabilities_outbound_trust_defaults_to_empty() {
+        let json = r#"{
+            "name": "internal-webhook"
+        }"#;
+
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        let caps = file.to_capabilities();
+
+        assert!(caps.declared_outbound_trust_policy_ids().is_empty());
+    }
+
+    #[test]
     fn test_parse_with_polling() {
         let json = r#"{
             "name": "telegram",

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -51,7 +51,8 @@ pub async fn setup_wasm_channels(
         Arc::clone(&pairing_store),
         settings_store.clone(),
         config.owner_id.clone(),
-    );
+    )
+    .with_outbound_trust_config(config.security.outbound_trust.clone());
     if let Some(secrets) = secrets_store {
         loader = loader.with_secrets_store(Arc::clone(secrets));
     }

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -55,7 +55,7 @@ use crate::safety::LeakDetector;
 use crate::secrets::SecretsStore;
 use crate::security::outbound_trust::{
     OutboundTrustConfig, OutboundTrustDecision, OutboundTrustRequestContext, OutboundTrustResolver,
-    OutboundTrustSurface,
+    OutboundTrustSurface, is_dangerous_ip,
 };
 use crate::tools::wasm::LogLevel;
 use crate::tools::wasm::WasmResourceLimiter;
@@ -3242,6 +3242,7 @@ fn should_skip_response_leak_scan(url: &str) -> bool {
 }
 
 /// Resolve the URL's hostname and reject connections to private/internal IPs.
+/// Performs blocking DNS resolution and must only run on a blocking thread.
 fn reject_private_ip(url: &str) -> Result<(), String> {
     let parsed = url::Url::parse(url).map_err(|e| format!("Failed to parse URL: {e}"))?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -3261,7 +3262,7 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
         .ok_or_else(|| "Failed to parse host from URL".to_string())?;
 
     if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return if is_private_ip(ip) {
+        return if is_dangerous_ip(ip) {
             Err(format!(
                 "HTTP request to private/internal IP {} is not allowed",
                 ip
@@ -3282,7 +3283,7 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
     }
 
     for addr in &addrs {
-        if is_private_ip(addr.ip()) {
+        if is_dangerous_ip(addr.ip()) {
             return Err(format!(
                 "DNS rebinding detected: {} resolved to private IP {}",
                 host,
@@ -3292,24 +3293,6 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-fn is_private_ip(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_unspecified()
-                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
-        }
-        std::net::IpAddr::V6(v6) => {
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || (v6.segments()[0] & 0xFE00) == 0xFC00
-                || (v6.segments()[0] & 0xFFC0) == 0xFE80
-        }
-    }
 }
 
 /// Pre-resolve host credentials for all HTTP capability mappings.

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -53,6 +53,10 @@ use crate::error::ChannelError;
 use crate::pairing::PairingStore;
 use crate::safety::LeakDetector;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::{
+    OutboundTrustConfig, OutboundTrustDecision, OutboundTrustRequestContext, OutboundTrustResolver,
+    OutboundTrustSurface,
+};
 use crate::tools::wasm::LogLevel;
 use crate::tools::wasm::WasmResourceLimiter;
 use crate::tools::wasm::credential_injector::{
@@ -92,6 +96,7 @@ struct ResolvedHostCredential {
 struct ChannelStoreData {
     limiter: WasmResourceLimiter,
     host_state: ChannelHostState,
+    outbound_trust_resolver: Arc<OutboundTrustResolver>,
     wasi: WasiCtx,
     table: ResourceTable,
     /// Injected credentials for URL substitution (e.g., bot tokens).
@@ -112,6 +117,7 @@ impl ChannelStoreData {
         memory_limit: u64,
         channel_name: &str,
         capabilities: ChannelCapabilities,
+        outbound_trust_resolver: Arc<OutboundTrustResolver>,
         credentials: HashMap<String, String>,
         host_credentials: Vec<ResolvedHostCredential>,
         pairing_store: Arc<PairingStore>,
@@ -122,6 +128,7 @@ impl ChannelStoreData {
         Self {
             limiter: WasmResourceLimiter::new(memory_limit),
             host_state: ChannelHostState::new(channel_name, capabilities),
+            outbound_trust_resolver,
             wasi,
             table: ResourceTable::new(),
             credentials,
@@ -385,6 +392,15 @@ impl near::agent::channel_host::Host for ChannelStoreData {
             .map(|h| h.max_response_bytes)
             .unwrap_or(10 * 1024 * 1024);
 
+        let outbound_trust = resolve_channel_http_outbound_trust_decision(
+            &self.outbound_trust_resolver,
+            self.host_state.capabilities(),
+            self.host_state.channel_name(),
+            &url,
+        );
+
+        enforce_channel_private_network_policy(&url, outbound_trust.allow_private_network)?;
+
         // Make the HTTP request using a dedicated single-threaded runtime.
         // We're inside spawn_blocking, so we can't rely on the main runtime's
         // I/O driver (it may be busy with WASM compilation or other startup work).
@@ -400,10 +416,7 @@ impl near::agent::channel_host::Host for ChannelStoreData {
         }
         let rt = self.http_runtime.as_ref().expect("just initialized");
         let result = rt.block_on(async {
-            let client = reqwest::Client::builder()
-                .connect_timeout(std::time::Duration::from_secs(10))
-                .build()
-                .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+            let client = build_channel_http_client(outbound_trust.allow_invalid_tls)?;
 
             let mut request = match method.to_uppercase().as_str() {
                 "GET" => client.get(&url),
@@ -726,6 +739,9 @@ pub struct WasmChannel {
     /// Secrets store for host-based credential injection.
     /// Used to pre-resolve credentials before each WASM callback.
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+
+    /// Shared outbound trust policy resolver for this channel surface.
+    outbound_trust_resolver: Arc<OutboundTrustResolver>,
 }
 
 /// Update broadcast metadata in memory and persist to the settings store when
@@ -849,6 +865,7 @@ impl WasmChannel {
             owner_scope_id: owner_scope_id.into(),
             owner_actor_id: None,
             secrets_store: None,
+            outbound_trust_resolver: Arc::new(OutboundTrustResolver::default()),
         }
     }
 
@@ -865,6 +882,12 @@ impl WasmChannel {
     /// Bind this channel to the external actor that maps to the configured owner.
     pub fn with_owner_actor_id(mut self, owner_actor_id: Option<String>) -> Self {
         self.owner_actor_id = owner_actor_id;
+        self
+    }
+
+    /// Set the outbound trust policy config for this channel surface.
+    pub fn with_outbound_trust_config(mut self, config: OutboundTrustConfig) -> Self {
+        self.outbound_trust_resolver = Arc::new(OutboundTrustResolver::new(config));
         self
     }
 
@@ -1075,6 +1098,7 @@ impl WasmChannel {
         runtime: &WasmChannelRuntime,
         prepared: &PreparedChannelModule,
         capabilities: &ChannelCapabilities,
+        outbound_trust_resolver: Arc<OutboundTrustResolver>,
         credentials: HashMap<String, String>,
         host_credentials: Vec<ResolvedHostCredential>,
         pairing_store: Arc<PairingStore>,
@@ -1087,6 +1111,7 @@ impl WasmChannel {
             limits.memory_bytes,
             &prepared.name,
             capabilities.clone(),
+            outbound_trust_resolver,
             credentials,
             host_credentials,
             pairing_store,
@@ -1215,6 +1240,7 @@ impl WasmChannel {
         .await;
         let pairing_store = self.pairing_store.clone();
         let workspace_store = self.workspace_store.clone();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         tokio::time::timeout(timeout, async move {
             tokio::task::spawn_blocking(move || {
@@ -1222,6 +1248,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1367,6 +1394,7 @@ impl WasmChannel {
         let body = body.to_vec();
 
         let channel_name = self.name.clone();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         // Execute in blocking task with timeout
         let result = tokio::time::timeout(timeout, async move {
@@ -1375,6 +1403,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1464,6 +1493,7 @@ impl WasmChannel {
         .await;
         let pairing_store = self.pairing_store.clone();
         let workspace_store = self.workspace_store.clone();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         // Execute in blocking task with timeout
         let result = tokio::time::timeout(timeout, async move {
@@ -1472,6 +1502,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1580,6 +1611,7 @@ impl WasmChannel {
         let thread_id = thread_id.map(|s| s.to_string());
         let metadata_json = metadata_json.to_string();
         let attachments = attachments.to_vec();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         // Execute in blocking task with timeout
         tracing::info!(channel = %channel_name, "Starting on_respond WASM execution");
@@ -1599,6 +1631,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1722,6 +1755,7 @@ impl WasmChannel {
         let content = content.to_string();
         let thread_id = thread_id.map(|s| s.to_string());
         let attachments = attachments.to_vec();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         let result = tokio::time::timeout(timeout, async move {
             tokio::task::spawn_blocking(move || {
@@ -1737,6 +1771,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1828,6 +1863,7 @@ impl WasmChannel {
         let Some(wit_update) = status_to_wit(status, metadata) else {
             return Ok(());
         };
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         let result = tokio::time::timeout(timeout, async move {
             tokio::task::spawn_blocking(move || {
@@ -1835,6 +1871,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    outbound_trust_resolver,
                     credentials,
                     host_credentials,
                     pairing_store,
@@ -1882,6 +1919,7 @@ impl WasmChannel {
         runtime: &Arc<WasmChannelRuntime>,
         prepared: &Arc<PreparedChannelModule>,
         capabilities: &ChannelCapabilities,
+        outbound_trust_resolver: Arc<OutboundTrustResolver>,
         credentials: &RwLock<HashMap<String, String>>,
         host_credentials: Vec<ResolvedHostCredential>,
         pairing_store: Arc<PairingStore>,
@@ -1904,6 +1942,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    Arc::clone(&outbound_trust_resolver),
                     credentials_snapshot,
                     host_credentials,
                     pairing_store,
@@ -1997,6 +2036,7 @@ impl WasmChannel {
                 .await;
                 let pairing_store = self.pairing_store.clone();
                 let callback_timeout = self.runtime.config().callback_timeout;
+                let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
                 let Some(wit_update) = status_to_wit(&status, metadata) else {
                     return Ok(());
                 };
@@ -2017,6 +2057,7 @@ impl WasmChannel {
                             &runtime,
                             &prepared,
                             &capabilities,
+                            Arc::clone(&outbound_trust_resolver),
                             &credentials,
                             hc,
                             pairing_store.clone(),
@@ -2290,6 +2331,7 @@ impl WasmChannel {
         let poll_secrets_store = self.secrets_store.clone();
         let owner_scope_id = self.owner_scope_id.clone();
         let owner_actor_id = self.owner_actor_id.clone();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         tokio::spawn(async move {
             let mut interval_timer = tokio::time::interval(interval);
@@ -2317,6 +2359,7 @@ impl WasmChannel {
                             &runtime,
                             &prepared,
                             &capabilities,
+                            Arc::clone(&outbound_trust_resolver),
                             &credentials,
                             host_credentials,
                             pairing_store.clone(),
@@ -2379,6 +2422,7 @@ impl WasmChannel {
         runtime: &Arc<WasmChannelRuntime>,
         prepared: &Arc<PreparedChannelModule>,
         capabilities: &ChannelCapabilities,
+        outbound_trust_resolver: Arc<OutboundTrustResolver>,
         credentials: &RwLock<HashMap<String, String>>,
         host_credentials: Vec<ResolvedHostCredential>,
         pairing_store: Arc<PairingStore>,
@@ -2408,6 +2452,7 @@ impl WasmChannel {
                     &runtime,
                     &prepared,
                     &capabilities,
+                    Arc::clone(&outbound_trust_resolver),
                     credentials_snapshot,
                     host_credentials,
                     pairing_store,
@@ -3144,6 +3189,45 @@ fn extract_host_from_url(url: &str) -> Option<String> {
     })
 }
 
+fn resolve_channel_http_outbound_trust_decision(
+    resolver: &OutboundTrustResolver,
+    capabilities: &ChannelCapabilities,
+    channel_name: &str,
+    url: &str,
+) -> OutboundTrustDecision {
+    resolver.resolve(&OutboundTrustRequestContext {
+        surface: OutboundTrustSurface::WasmChannel,
+        extension_name: channel_name,
+        url,
+        declared_policy_ids: capabilities.declared_outbound_trust_policy_ids(),
+    })
+}
+
+fn enforce_channel_private_network_policy(
+    url: &str,
+    allow_private_network: bool,
+) -> Result<(), String> {
+    if allow_private_network {
+        Ok(())
+    } else {
+        reject_private_ip(url)
+    }
+}
+
+fn build_channel_http_client(allow_invalid_tls: bool) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none());
+
+    if allow_invalid_tls {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))
+}
+
 fn should_skip_response_leak_scan(url: &str) -> bool {
     url::Url::parse(url).is_ok_and(|parsed| {
         matches!(parsed.scheme(), "http" | "https")
@@ -3155,6 +3239,77 @@ fn should_skip_response_leak_scan(url: &str) -> bool {
                 .and_then(|segments| segments.rev().find(|segment| !segment.is_empty()))
                 .is_some_and(|segment| segment == "getUpdates")
     })
+}
+
+/// Resolve the URL's hostname and reject connections to private/internal IPs.
+fn reject_private_ip(url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(url).map_err(|e| format!("Failed to parse URL: {e}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(format!("Unsupported URL scheme: {}", parsed.scheme()));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("URL contains userinfo (@) which is not allowed".to_string());
+    }
+
+    let host = parsed
+        .host_str()
+        .map(|h| {
+            h.strip_prefix('[')
+                .and_then(|v| v.strip_suffix(']'))
+                .unwrap_or(h)
+        })
+        .ok_or_else(|| "Failed to parse host from URL".to_string())?;
+
+    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
+        return if is_private_ip(ip) {
+            Err(format!(
+                "HTTP request to private/internal IP {} is not allowed",
+                ip
+            ))
+        } else {
+            Ok(())
+        };
+    }
+
+    use std::net::ToSocketAddrs;
+    let addrs: Vec<_> = format!("{}:0", host)
+        .to_socket_addrs()
+        .map_err(|e| format!("DNS resolution failed for {}: {}", host, e))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("DNS resolution returned no addresses for {}", host));
+    }
+
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            return Err(format!(
+                "DNS rebinding detected: {} resolved to private IP {}",
+                host,
+                addr.ip()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+fn is_private_ip(ip: std::net::IpAddr) -> bool {
+    match ip {
+        std::net::IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
+        }
+        std::net::IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xFE00) == 0xFC00
+                || (v6.segments()[0] & 0xFFC0) == 0xFE80
+        }
+    }
 }
 
 /// Pre-resolve host credentials for all HTTP capability mappings.
@@ -3384,6 +3539,208 @@ mod tests {
         assert_eq!(response.body, b"Bad request");
     }
 
+    #[test]
+    fn test_resolve_channel_http_outbound_trust_default_denies_exceptions() {
+        use crate::security::outbound_trust::OutboundTrustResolver;
+
+        let decision = super::resolve_channel_http_outbound_trust_decision(
+            &OutboundTrustResolver::default(),
+            &ChannelCapabilities::for_channel("test"),
+            "test",
+            "https://10.42.0.15/api/status",
+        );
+
+        assert_eq!(decision.matched_policy_id, None);
+        assert!(!decision.allow_invalid_tls);
+        assert!(!decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_resolve_channel_http_outbound_trust_policy_can_enable_private_network() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+        use crate::tools::wasm::Capabilities as ToolCapabilities;
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-channel".to_string(),
+                display_name: "corp-channel".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmChannel],
+                allowed_risks: vec![OutboundTrustRisk::AllowPrivateNetwork],
+                targets: vec![OutboundTrustTarget {
+                    host: "10.42.0.15".to_string(),
+                    port: Some(443),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+        let capabilities = ChannelCapabilities::for_channel("test").with_tool_capabilities(
+            ToolCapabilities::default()
+                .with_outbound_trust_policy_ids(vec!["corp-channel".to_string()]),
+        );
+
+        let decision = super::resolve_channel_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "test",
+            "https://10.42.0.15/api/status",
+        );
+
+        assert_eq!(decision.matched_policy_id.as_deref(), Some("corp-channel"));
+        assert!(!decision.allow_invalid_tls);
+        assert!(decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_resolve_channel_http_outbound_trust_policy_can_enable_invalid_tls() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+        use crate::tools::wasm::Capabilities as ToolCapabilities;
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-channel".to_string(),
+                display_name: "corp-channel".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmChannel],
+                allowed_risks: vec![OutboundTrustRisk::AllowInvalidTls],
+                targets: vec![OutboundTrustTarget {
+                    host: "internal.example".to_string(),
+                    port: Some(443),
+                    path_prefix: Some("/hooks".to_string()),
+                }],
+            }],
+        });
+        let capabilities = ChannelCapabilities::for_channel("test").with_tool_capabilities(
+            ToolCapabilities::default()
+                .with_outbound_trust_policy_ids(vec!["corp-channel".to_string()]),
+        );
+
+        let decision = super::resolve_channel_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "test",
+            "https://internal.example/hooks/poll",
+        );
+
+        assert_eq!(decision.matched_policy_id.as_deref(), Some("corp-channel"));
+        assert!(decision.allow_invalid_tls);
+        assert!(!decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_channel_private_network_policy_respects_outbound_trust() {
+        let denied =
+            super::enforce_channel_private_network_policy("https://127.0.0.1:8443/api", false);
+        assert!(denied.is_err());
+
+        let allowed =
+            super::enforce_channel_private_network_policy("https://127.0.0.1:8443/api", true);
+        assert!(allowed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_outbound_trust_allows_private_self_signed_https_for_wasm_channels() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+        use crate::testing::tls::SelfSignedHttpsServer;
+        use crate::tools::wasm::Capabilities as ToolCapabilities;
+
+        let server = SelfSignedHttpsServer::start(r#"{"ok":true}"#).await;
+        let url = server.url("/api/status");
+
+        let tls_err = super::build_channel_http_client(false)
+            .expect("client")
+            .get(&url)
+            .send()
+            .await
+            .expect_err("self-signed endpoint should fail without invalid-tls trust");
+        assert!(
+            tls_err.is_request() || tls_err.is_connect() || tls_err.is_body(),
+            "expected request failure for untrusted TLS, got: {tls_err}"
+        );
+
+        let denied = super::enforce_channel_private_network_policy(&url, false);
+        assert!(denied.is_err(), "expected private-network denial");
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-channel".to_string(),
+                display_name: "corp-channel".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmChannel],
+                allowed_risks: vec![
+                    OutboundTrustRisk::AllowInvalidTls,
+                    OutboundTrustRisk::AllowPrivateNetwork,
+                ],
+                targets: vec![OutboundTrustTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: Some(server.port()),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+        let capabilities = ChannelCapabilities::default().with_tool_capabilities(
+            ToolCapabilities::default()
+                .with_outbound_trust_policy_ids(vec!["corp-channel".to_string()]),
+        );
+
+        let decision = super::resolve_channel_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "test-channel",
+            &url,
+        );
+        assert!(decision.allow_invalid_tls);
+        assert!(decision.allow_private_network);
+
+        super::enforce_channel_private_network_policy(&url, decision.allow_private_network)
+            .expect("private-network trust should allow request");
+
+        let response = super::build_channel_http_client(decision.allow_invalid_tls)
+            .expect("trusted client")
+            .get(&url)
+            .send()
+            .await
+            .expect("trusted request should succeed");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+
+    #[test]
+    fn test_channel_outbound_trust_does_not_expand_http_allowlist() {
+        use crate::channels::wasm::host::ChannelHostState;
+        use crate::tools::wasm::{
+            Capabilities as ToolCapabilities, EndpointPattern, HttpCapability,
+        };
+
+        let capabilities =
+            ChannelCapabilities::for_channel("test").with_tool_capabilities(ToolCapabilities {
+                http: Some(HttpCapability {
+                    allowlist: vec![EndpointPattern::host("api.example.com")],
+                    ..Default::default()
+                }),
+                outbound_trust_policy_ids: vec!["corp-channel".to_string()],
+                ..Default::default()
+            });
+        let host_state = ChannelHostState::new("test", capabilities);
+
+        let result = host_state.check_http_allowed("https://10.42.0.15/api/status", "GET");
+        assert!(result.is_err());
+    }
+
     #[tokio::test]
     async fn test_channel_start_and_shutdown() {
         let channel = create_test_channel();
@@ -3437,6 +3794,7 @@ mod tests {
             &runtime,
             &prepared,
             &capabilities,
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             &credentials,
             Vec::new(), // no host credentials in test
             Arc::new(PairingStore::new()),
@@ -4328,6 +4686,7 @@ mod tests {
             1024 * 1024,
             "test",
             ChannelCapabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             creds,
             Vec::new(),
             Arc::new(PairingStore::new()),
@@ -4362,6 +4721,7 @@ mod tests {
             1024 * 1024,
             "test",
             ChannelCapabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             std::collections::HashMap::new(),
             Vec::new(),
             Arc::new(PairingStore::new()),
@@ -4393,6 +4753,7 @@ mod tests {
             1024 * 1024,
             "test",
             ChannelCapabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             creds,
             host_creds,
             Arc::new(PairingStore::new()),
@@ -4426,6 +4787,7 @@ mod tests {
             1024 * 1024,
             "test",
             ChannelCapabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             creds,
             Vec::new(),
             Arc::new(PairingStore::new()),

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -11,6 +11,7 @@ use clap::{Args, Subcommand};
 use crate::config::Config;
 use crate::db::Database;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::OutboundTrustConfig;
 use crate::tools::mcp::{
     McpClient, McpProcessManager, McpServerConfig, McpSessionManager, OAuthConfig,
     auth::{authorize_mcp_server, is_authenticated},
@@ -440,7 +441,9 @@ async fn auth_server(name: String, user_id: String) -> anyhow::Result<()> {
     println!();
 
     // Perform OAuth flow (supports both pre-configured OAuth and DCR)
-    match authorize_mcp_server(&server, &secrets, &user_id).await {
+    let outbound_trust_config = load_outbound_trust_config().await;
+
+    match authorize_mcp_server(&server, &secrets, &user_id, &outbound_trust_config).await {
         Ok(_token) => {
             println!();
             println!("  ✓ Successfully authenticated with '{}'!", name);
@@ -488,6 +491,7 @@ async fn test_server(name: String, user_id: String) -> anyhow::Result<()> {
 
     // Create client
     let session_manager = Arc::new(McpSessionManager::new());
+    let outbound_trust_config = load_outbound_trust_config().await;
 
     // Always check for stored tokens (from either pre-configured OAuth or DCR)
     let secrets = get_secrets_store().await?;
@@ -495,7 +499,13 @@ async fn test_server(name: String, user_id: String) -> anyhow::Result<()> {
 
     let client = if has_tokens {
         // We have stored tokens, use authenticated client
-        McpClient::new_authenticated(server.clone(), session_manager.clone(), secrets, user_id)
+        McpClient::new_authenticated(
+            server.clone(),
+            session_manager.clone(),
+            secrets,
+            user_id,
+            outbound_trust_config.clone(),
+        )
     } else if server.requires_auth() {
         // OAuth configured but no tokens - need to authenticate
         println!();
@@ -514,6 +524,7 @@ async fn test_server(name: String, user_id: String) -> anyhow::Result<()> {
             &process_manager,
             None,
             "default",
+            &outbound_trust_config,
         )
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))?
@@ -613,6 +624,13 @@ const DEFAULT_USER_ID: &str = "default";
 async fn connect_db() -> Option<Arc<dyn Database>> {
     let config = Config::from_env().await.ok()?;
     crate::db::connect_from_config(&config.database).await.ok()
+}
+
+async fn load_outbound_trust_config() -> OutboundTrustConfig {
+    Config::from_env()
+        .await
+        .map(|config| config.security.outbound_trust)
+        .unwrap_or_default()
 }
 
 /// Load MCP servers (DB if available, else disk).

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -20,6 +20,7 @@ mod safety;
 mod sandbox;
 mod search;
 mod secrets;
+mod security;
 mod skills;
 mod transcription;
 mod tunnel;
@@ -50,6 +51,8 @@ use self::safety::resolve_safety_config;
 pub use self::sandbox::{ClaudeCodeConfig, SandboxModeConfig};
 pub use self::search::WorkspaceSearchConfig;
 pub use self::secrets::SecretsConfig;
+pub use self::security::SecurityConfig;
+use self::security::resolve_security_config;
 pub use self::skills::SkillsConfig;
 pub use self::transcription::TranscriptionConfig;
 pub use self::tunnel::TunnelConfig;
@@ -89,6 +92,7 @@ pub struct Config {
     pub channels: ChannelsConfig,
     pub agent: AgentConfig,
     pub safety: SafetyConfig,
+    pub security: SecurityConfig,
     pub wasm: WasmConfig,
     pub secrets: SecretsConfig,
     pub builder: BuilderModeConfig,
@@ -150,6 +154,7 @@ impl Config {
                 max_output_length: 100_000,
                 injection_check_enabled: false,
             },
+            security: SecurityConfig::default(),
             wasm: WasmConfig {
                 enabled: false,
                 ..WasmConfig::default()
@@ -329,6 +334,7 @@ impl Config {
             channels,
             agent: AgentConfig::resolve(settings)?,
             safety: resolve_safety_config(settings)?,
+            security: resolve_security_config(settings)?,
             wasm: WasmConfig::resolve(settings)?,
             secrets: SecretsConfig::resolve().await?,
             builder: BuilderModeConfig::resolve(settings)?,

--- a/src/config/security.rs
+++ b/src/config/security.rs
@@ -1,0 +1,47 @@
+use crate::error::ConfigError;
+use crate::security::outbound_trust::OutboundTrustConfig;
+
+/// Security runtime config resolved from persisted settings.
+#[derive(Debug, Clone, Default)]
+pub struct SecurityConfig {
+    pub outbound_trust: OutboundTrustConfig,
+}
+
+pub(crate) fn resolve_security_config(
+    settings: &crate::settings::Settings,
+) -> Result<SecurityConfig, ConfigError> {
+    Ok(SecurityConfig {
+        outbound_trust: settings.security.outbound_trust.to_runtime_config(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::config::security::resolve_security_config;
+    use crate::security::outbound_trust::{OutboundTrustRisk, OutboundTrustSurface};
+    use crate::settings::{OutboundTrustPolicySettings, OutboundTrustTargetSettings, Settings};
+
+    #[test]
+    fn resolve_uses_settings_outbound_trust() {
+        let mut settings = Settings::default();
+        settings.security.outbound_trust.enabled = true;
+        settings.security.outbound_trust.policies = vec![OutboundTrustPolicySettings {
+            id: "corp-internal-api".to_string(),
+            display_name: "corp-internal-api".to_string(),
+            description: Some("internal API".to_string()),
+            enabled: true,
+            allowed_surfaces: vec![OutboundTrustSurface::WasmTool],
+            allowed_risks: vec![OutboundTrustRisk::AllowInvalidTls],
+            targets: vec![OutboundTrustTargetSettings {
+                host: "internal-api.example.test".to_string(),
+                port: Some(443),
+                path_prefix: Some("/api".to_string()),
+            }],
+        }];
+
+        let cfg = resolve_security_config(&settings).expect("resolve");
+        assert!(cfg.outbound_trust.enabled);
+        assert_eq!(cfg.outbound_trust.policies.len(), 1);
+        assert_eq!(cfg.outbound_trust.policies[0].id, "corp-internal-api");
+    }
+}

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -25,6 +25,7 @@ use crate::extensions::{
 use crate::hooks::HookRegistry;
 use crate::pairing::PairingStore;
 use crate::secrets::{CreateSecretParams, SecretsStore};
+use crate::security::outbound_trust::OutboundTrustConfig;
 use crate::tools::ToolRegistry;
 use crate::tools::mcp::McpClient;
 use crate::tools::mcp::auth::{
@@ -399,6 +400,7 @@ pub struct ExtensionManager {
     secrets: Arc<dyn SecretsStore + Send + Sync>,
     tool_registry: Arc<ToolRegistry>,
     hooks: Option<Arc<HookRegistry>>,
+    outbound_trust_config: OutboundTrustConfig,
     pending_auth: RwLock<HashMap<String, PendingAuth>>,
     /// Tunnel URL for webhook configuration and remote OAuth callbacks.
     tunnel_url: Option<String>,
@@ -542,6 +544,7 @@ impl ExtensionManager {
             secrets,
             tool_registry,
             hooks,
+            outbound_trust_config: OutboundTrustConfig::default(),
             pending_auth: RwLock::new(HashMap::new()),
             tunnel_url,
             user_id,
@@ -563,6 +566,12 @@ impl ExtensionManager {
             #[cfg(test)]
             test_telegram_binding_resolver: RwLock::new(None),
         }
+    }
+
+    /// Set the global outbound trust config used for extension activation flows.
+    pub fn with_outbound_trust_config(mut self, config: OutboundTrustConfig) -> Self {
+        self.outbound_trust_config = config;
+        self
     }
 
     #[cfg(test)]
@@ -2545,7 +2554,9 @@ impl ExtensionManager {
         }
 
         // CLI/local mode: run the full blocking OAuth flow (opens browser, waits for callback)
-        match authorize_mcp_server(&server, &self.secrets, user_id).await {
+        match authorize_mcp_server(&server, &self.secrets, user_id, &self.outbound_trust_config)
+            .await
+        {
             Ok(_token) => {
                 tracing::info!("MCP server '{}' authenticated via OAuth", name);
                 Ok(AuthResult::authenticated(name, ExtensionKind::McpServer))
@@ -2595,7 +2606,7 @@ impl ExtensionManager {
         user_id: &str,
     ) -> Result<AuthResult, ExtensionError> {
         // Try to discover OAuth metadata and build a URL the user can open manually
-        let metadata = discover_full_oauth_metadata(&server.url)
+        let metadata = discover_full_oauth_metadata(server, &self.outbound_trust_config)
             .await
             .map_err(|e| match e {
                 crate::tools::mcp::auth::AuthError::NotSupported => {
@@ -2624,9 +2635,14 @@ impl ExtensionManager {
         let (client_id, client_secret) = if let Some(ref oauth) = server.oauth {
             (oauth.client_id.clone(), None)
         } else if let Some(ref reg_endpoint) = metadata.registration_endpoint {
-            let registration = register_client(reg_endpoint, &redirect_uri)
-                .await
-                .map_err(|e| ExtensionError::AuthFailed(e.to_string()))?;
+            let registration = register_client(
+                server,
+                &self.outbound_trust_config,
+                reg_endpoint,
+                &redirect_uri,
+            )
+            .await
+            .map_err(|e| ExtensionError::AuthFailed(e.to_string()))?;
 
             (registration.client_id, None)
         } else {
@@ -3573,6 +3589,7 @@ impl ExtensionManager {
             &self.mcp_process_manager,
             Some(Arc::clone(&self.secrets)),
             user_id,
+            &self.outbound_trust_config,
         )
         .await
         .map_err(|e| ExtensionError::ActivationFailed(e.to_string()))?;
@@ -3679,6 +3696,7 @@ impl ExtensionManager {
         };
 
         let loader = WasmToolLoader::new(Arc::clone(runtime), Arc::clone(&self.tool_registry))
+            .with_outbound_trust_config(self.outbound_trust_config.clone())
             .with_secrets_store(Arc::clone(&self.secrets));
         loader
             .load_from_files(name, &wasm_path, cap_path_option)
@@ -3797,6 +3815,7 @@ impl ExtensionManager {
                 settings_store,
                 self.user_id.clone(),
             )
+            .with_outbound_trust_config(self.outbound_trust_config.clone())
             .with_secrets_store(Arc::clone(&self.secrets));
             loader
                 .load_from_files(name, &wasm_path, cap_path_option)
@@ -3814,6 +3833,7 @@ impl ExtensionManager {
                 settings_store,
                 self.user_id.clone(),
             )
+            .with_outbound_trust_config(self.outbound_trust_config.clone())
             .with_secrets_store(Arc::clone(&self.secrets));
             loader
                 .load_from_files(name, &wasm_path, cap_path_option)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,7 @@ pub mod registry;
 pub mod safety;
 pub mod sandbox;
 pub mod secrets;
+pub mod security;
 pub mod service;
 pub mod settings;
 pub mod setup;

--- a/src/security/mod.rs
+++ b/src/security/mod.rs
@@ -1,0 +1,1 @@
+pub mod outbound_trust;

--- a/src/security/outbound_trust.rs
+++ b/src/security/outbound_trust.rs
@@ -1,0 +1,436 @@
+use serde::{Deserialize, Serialize};
+
+/// Runtime configuration for outbound trust policy evaluation.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutboundTrustConfig {
+    /// Global kill switch for all outbound trust decisions.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Configured operator-managed trust policies.
+    #[serde(default)]
+    pub policies: Vec<OutboundTrustPolicy>,
+}
+
+/// Execution surface that wants to consume an outbound trust policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutboundTrustSurface {
+    WasmTool,
+    WasmChannel,
+    McpServer,
+}
+
+/// Explicit risk bit granted by a policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OutboundTrustRisk {
+    AllowInvalidTls,
+    AllowPrivateNetwork,
+}
+
+/// Operator-managed outbound trust policy entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundTrustPolicy {
+    /// Stable policy identifier referenced by extensions.
+    pub id: String,
+
+    /// Human-friendly policy name.
+    pub display_name: String,
+
+    /// Optional operator note.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Whether this policy is active.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Surfaces this policy may be used from.
+    #[serde(default)]
+    pub allowed_surfaces: Vec<OutboundTrustSurface>,
+
+    /// Explicit risk flags granted by this policy.
+    #[serde(default)]
+    pub allowed_risks: Vec<OutboundTrustRisk>,
+
+    /// Target tuples the request URL must match.
+    #[serde(default)]
+    pub targets: Vec<OutboundTrustTarget>,
+}
+
+/// Host/port/path tuple matched against a request URL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundTrustTarget {
+    /// Exact hostname or IP literal.
+    pub host: String,
+
+    /// Optional port restriction.
+    #[serde(default)]
+    pub port: Option<u16>,
+
+    /// Optional path prefix restriction.
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+}
+
+/// Shared request-scoped decision context for outbound trust resolution.
+#[derive(Debug, Clone, Copy)]
+pub struct OutboundTrustRequestContext<'a> {
+    pub surface: OutboundTrustSurface,
+    pub extension_name: &'a str,
+    pub url: &'a str,
+    pub declared_policy_ids: &'a [String],
+}
+
+/// Decision returned to runtime consumers.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OutboundTrustDecision {
+    pub matched_policy_id: Option<String>,
+    pub allow_invalid_tls: bool,
+    pub allow_private_network: bool,
+}
+
+/// Shared resolver for operator-managed outbound trust policies.
+#[derive(Debug, Clone)]
+pub struct OutboundTrustResolver {
+    config: OutboundTrustConfig,
+}
+
+impl Default for OutboundTrustResolver {
+    fn default() -> Self {
+        Self::new(OutboundTrustConfig::default())
+    }
+}
+
+impl OutboundTrustResolver {
+    pub fn new(config: OutboundTrustConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn resolve(&self, ctx: &OutboundTrustRequestContext<'_>) -> OutboundTrustDecision {
+        if !self.config.enabled {
+            return OutboundTrustDecision::default();
+        }
+
+        let target = match NormalizedRequestTarget::parse(ctx.url) {
+            Some(target) => target,
+            None => return OutboundTrustDecision::default(),
+        };
+
+        let mut decision = OutboundTrustDecision::default();
+
+        for policy in &self.config.policies {
+            if !policy.enabled
+                || !ctx
+                    .declared_policy_ids
+                    .iter()
+                    .any(|declared| declared == &policy.id)
+                || !policy.allowed_surfaces.contains(&ctx.surface)
+                || !policy
+                    .targets
+                    .iter()
+                    .any(|candidate| target.matches(candidate))
+            {
+                continue;
+            }
+
+            if decision.matched_policy_id.is_none() {
+                decision.matched_policy_id = Some(policy.id.clone());
+            }
+
+            for risk in &policy.allowed_risks {
+                match risk {
+                    OutboundTrustRisk::AllowInvalidTls => decision.allow_invalid_tls = true,
+                    OutboundTrustRisk::AllowPrivateNetwork => {
+                        decision.allow_private_network = true;
+                    }
+                }
+            }
+        }
+
+        decision
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct NormalizedRequestTarget {
+    host: String,
+    port: Option<u16>,
+    path: String,
+}
+
+impl NormalizedRequestTarget {
+    fn parse(url: &str) -> Option<Self> {
+        let parsed = url::Url::parse(url).ok()?;
+        if !matches!(parsed.scheme(), "http" | "https") {
+            return None;
+        }
+
+        let host = parsed.host_str()?.to_ascii_lowercase();
+        Some(Self {
+            host,
+            port: parsed.port_or_known_default(),
+            path: parsed.path().to_string(),
+        })
+    }
+
+    fn matches(&self, target: &OutboundTrustTarget) -> bool {
+        if self.host != target.host.to_ascii_lowercase() {
+            return false;
+        }
+
+        if let Some(expected_port) = target.port
+            && self.port != Some(expected_port)
+        {
+            return false;
+        }
+
+        if let Some(path_prefix) = &target.path_prefix
+            && !self.path.starts_with(path_prefix)
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustRequestContext,
+        OutboundTrustResolver, OutboundTrustRisk, OutboundTrustSurface, OutboundTrustTarget,
+    };
+
+    fn policy(
+        id: &str,
+        surfaces: Vec<OutboundTrustSurface>,
+        risks: Vec<OutboundTrustRisk>,
+        targets: Vec<OutboundTrustTarget>,
+    ) -> OutboundTrustPolicy {
+        OutboundTrustPolicy {
+            id: id.to_string(),
+            display_name: id.to_string(),
+            description: None,
+            enabled: true,
+            allowed_surfaces: surfaces,
+            allowed_risks: risks,
+            targets,
+        }
+    }
+
+    fn target(host: &str) -> OutboundTrustTarget {
+        OutboundTrustTarget {
+            host: host.to_string(),
+            port: None,
+            path_prefix: None,
+        }
+    }
+
+    fn resolve(
+        resolver: &OutboundTrustResolver,
+        surface: OutboundTrustSurface,
+        url: &str,
+        declared_policy_ids: &[String],
+    ) -> super::OutboundTrustDecision {
+        resolver.resolve(&OutboundTrustRequestContext {
+            surface,
+            extension_name: "test-extension",
+            url,
+            declared_policy_ids,
+        })
+    }
+
+    #[test]
+    fn matches_exact_host() {
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![policy(
+                "corp-internal-api",
+                vec![OutboundTrustSurface::WasmTool],
+                vec![OutboundTrustRisk::AllowInvalidTls],
+                vec![target("internal-api.example.test")],
+            )],
+        });
+
+        let result = resolve(
+            &resolver,
+            OutboundTrustSurface::WasmTool,
+            "https://internal-api.example.test/api/status",
+            &["corp-internal-api".to_string()],
+        );
+
+        assert_eq!(
+            result.matched_policy_id.as_deref(),
+            Some("corp-internal-api")
+        );
+        assert!(result.allow_invalid_tls);
+        assert!(!result.allow_private_network);
+    }
+
+    #[test]
+    fn respects_port_and_path_prefix() {
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-gateway".to_string(),
+                display_name: "corp-gateway".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::McpServer],
+                allowed_risks: vec![OutboundTrustRisk::AllowPrivateNetwork],
+                targets: vec![OutboundTrustTarget {
+                    host: "10.0.0.25".to_string(),
+                    port: Some(8443),
+                    path_prefix: Some("/rpc".to_string()),
+                }],
+            }],
+        });
+
+        let allowed = resolve(
+            &resolver,
+            OutboundTrustSurface::McpServer,
+            "https://10.0.0.25:8443/rpc/tools/list",
+            &["corp-gateway".to_string()],
+        );
+        assert!(allowed.allow_private_network);
+
+        let wrong_port = resolve(
+            &resolver,
+            OutboundTrustSurface::McpServer,
+            "https://10.0.0.25:443/rpc/tools/list",
+            &["corp-gateway".to_string()],
+        );
+        assert_eq!(wrong_port.matched_policy_id, None);
+
+        let wrong_path = resolve(
+            &resolver,
+            OutboundTrustSurface::McpServer,
+            "https://10.0.0.25:8443/other",
+            &["corp-gateway".to_string()],
+        );
+        assert_eq!(wrong_path.matched_policy_id, None);
+    }
+
+    #[test]
+    fn requires_declared_policy_id() {
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![policy(
+                "corp-internal-api",
+                vec![OutboundTrustSurface::WasmTool],
+                vec![OutboundTrustRisk::AllowInvalidTls],
+                vec![target("internal-api.example.test")],
+            )],
+        });
+
+        let result = resolve(
+            &resolver,
+            OutboundTrustSurface::WasmTool,
+            "https://internal-api.example.test/api/status",
+            &[],
+        );
+
+        assert_eq!(result.matched_policy_id, None);
+        assert!(!result.allow_invalid_tls);
+        assert!(!result.allow_private_network);
+    }
+
+    #[test]
+    fn rejects_surface_mismatch() {
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![policy(
+                "corp-channel",
+                vec![OutboundTrustSurface::WasmChannel],
+                vec![OutboundTrustRisk::AllowInvalidTls],
+                vec![target("hooks.internal.example")],
+            )],
+        });
+
+        let result = resolve(
+            &resolver,
+            OutboundTrustSurface::WasmTool,
+            "https://hooks.internal.example/webhook",
+            &["corp-channel".to_string()],
+        );
+
+        assert_eq!(result.matched_policy_id, None);
+    }
+
+    #[test]
+    fn disabled_config_or_policy_grants_nothing() {
+        let disabled_globally = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: false,
+            policies: vec![policy(
+                "corp-internal-api",
+                vec![OutboundTrustSurface::WasmTool],
+                vec![
+                    OutboundTrustRisk::AllowInvalidTls,
+                    OutboundTrustRisk::AllowPrivateNetwork,
+                ],
+                vec![target("10.42.0.15")],
+            )],
+        });
+        let global_result = resolve(
+            &disabled_globally,
+            OutboundTrustSurface::WasmTool,
+            "https://10.42.0.15/api/status",
+            &["corp-internal-api".to_string()],
+        );
+        assert_eq!(global_result.matched_policy_id, None);
+
+        let disabled_policy = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                enabled: false,
+                ..policy(
+                    "corp-internal-api",
+                    vec![OutboundTrustSurface::WasmTool],
+                    vec![OutboundTrustRisk::AllowPrivateNetwork],
+                    vec![target("10.42.0.15")],
+                )
+            }],
+        });
+        let policy_result = resolve(
+            &disabled_policy,
+            OutboundTrustSurface::WasmTool,
+            "https://10.42.0.15/api/status",
+            &["corp-internal-api".to_string()],
+        );
+        assert_eq!(policy_result.matched_policy_id, None);
+    }
+
+    #[test]
+    fn unions_risks_across_matching_policies() {
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![
+                policy(
+                    "tls",
+                    vec![OutboundTrustSurface::WasmTool],
+                    vec![OutboundTrustRisk::AllowInvalidTls],
+                    vec![target("internal-api.example.test")],
+                ),
+                policy(
+                    "private",
+                    vec![OutboundTrustSurface::WasmTool],
+                    vec![OutboundTrustRisk::AllowPrivateNetwork],
+                    vec![target("internal-api.example.test")],
+                ),
+            ],
+        });
+
+        let result = resolve(
+            &resolver,
+            OutboundTrustSurface::WasmTool,
+            "https://internal-api.example.test/api/status",
+            &["tls".to_string(), "private".to_string()],
+        );
+
+        assert_eq!(result.matched_policy_id.as_deref(), Some("tls"));
+        assert!(result.allow_invalid_tls);
+        assert!(result.allow_private_network);
+    }
+}

--- a/src/security/outbound_trust.rs
+++ b/src/security/outbound_trust.rs
@@ -1,3 +1,5 @@
+use std::net::IpAddr;
+
 use serde::{Deserialize, Serialize};
 
 /// Runtime configuration for outbound trust policy evaluation.
@@ -153,6 +155,32 @@ impl OutboundTrustResolver {
     }
 }
 
+pub(crate) fn is_dangerous_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || (v4.octets()[0] == 169 && v4.octets()[1] == 254)
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+        }
+        IpAddr::V6(v6) => {
+            let segs = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (segs[0] & 0xffc0) == 0xfe80
+                || (segs[0] & 0xffc0) == 0xfec0
+                || (segs[0] & 0xfe00) == 0xfc00
+                || (segs[0] == 0x2001 && segs[1] == 0x0db8)
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| is_dangerous_ip(IpAddr::V4(v4)))
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct NormalizedRequestTarget {
     host: String,
@@ -198,6 +226,8 @@ impl NormalizedRequestTarget {
 
 #[cfg(test)]
 mod tests {
+    use std::net::IpAddr;
+
     use super::{
         OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustRequestContext,
         OutboundTrustResolver, OutboundTrustRisk, OutboundTrustSurface, OutboundTrustTarget,
@@ -240,6 +270,18 @@ mod tests {
             url,
             declared_policy_ids,
         })
+    }
+
+    #[test]
+    fn dangerous_ip_blocks_ipv4_mapped_private_ipv6() {
+        let ip: IpAddr = "::ffff:10.0.0.1".parse().unwrap();
+        assert!(super::is_dangerous_ip(ip));
+    }
+
+    #[test]
+    fn dangerous_ip_allows_public_ipv6() {
+        let ip: IpAddr = "2606:4700::1111".parse().unwrap();
+        assert!(!super::is_dangerous_ip(ip));
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -8,6 +8,10 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 use crate::bootstrap::ironclaw_base_dir;
+use crate::security::outbound_trust::{
+    OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustRisk, OutboundTrustSurface,
+    OutboundTrustTarget,
+};
 
 /// User settings persisted to disk.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -130,6 +134,10 @@ pub struct Settings {
     /// Safety configuration.
     #[serde(default)]
     pub safety: SafetySettings,
+
+    /// Security configuration.
+    #[serde(default)]
+    pub security: SecuritySettings,
 
     /// Builder configuration.
     #[serde(default)]
@@ -682,6 +690,113 @@ impl Default for SafetySettings {
         Self {
             max_output_length: default_max_output_length(),
             injection_check_enabled: true,
+        }
+    }
+}
+
+/// Security configuration.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct SecuritySettings {
+    /// Operator-managed outbound trust policy configuration.
+    #[serde(default)]
+    pub outbound_trust: OutboundTrustSettings,
+}
+
+/// Outbound trust policy settings.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct OutboundTrustSettings {
+    /// Global kill switch for outbound trust policy evaluation.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Configured outbound trust policies.
+    #[serde(default)]
+    pub policies: Vec<OutboundTrustPolicySettings>,
+}
+
+impl OutboundTrustSettings {
+    /// Convert persisted settings into runtime resolver config.
+    pub fn to_runtime_config(&self) -> OutboundTrustConfig {
+        OutboundTrustConfig {
+            enabled: self.enabled,
+            policies: self
+                .policies
+                .iter()
+                .map(OutboundTrustPolicySettings::to_runtime_policy)
+                .collect(),
+        }
+    }
+}
+
+/// Persisted operator-managed outbound trust policy.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundTrustPolicySettings {
+    /// Stable policy identifier referenced by extensions.
+    pub id: String,
+
+    /// Human-friendly name for review and admin UX.
+    pub display_name: String,
+
+    /// Optional operator note describing the trust exception.
+    #[serde(default)]
+    pub description: Option<String>,
+
+    /// Whether this policy is active.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Surfaces allowed to consume this policy.
+    #[serde(default)]
+    pub allowed_surfaces: Vec<OutboundTrustSurface>,
+
+    /// Explicit risk exceptions granted by this policy.
+    #[serde(default)]
+    pub allowed_risks: Vec<OutboundTrustRisk>,
+
+    /// Target tuples the policy may match.
+    #[serde(default)]
+    pub targets: Vec<OutboundTrustTargetSettings>,
+}
+
+impl OutboundTrustPolicySettings {
+    fn to_runtime_policy(&self) -> OutboundTrustPolicy {
+        OutboundTrustPolicy {
+            id: self.id.clone(),
+            display_name: self.display_name.clone(),
+            description: self.description.clone(),
+            enabled: self.enabled,
+            allowed_surfaces: self.allowed_surfaces.clone(),
+            allowed_risks: self.allowed_risks.clone(),
+            targets: self
+                .targets
+                .iter()
+                .map(OutboundTrustTargetSettings::to_runtime_target)
+                .collect(),
+        }
+    }
+}
+
+/// Persisted outbound trust target tuple.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundTrustTargetSettings {
+    /// Exact hostname or IP literal.
+    pub host: String,
+
+    /// Optional port restriction.
+    #[serde(default)]
+    pub port: Option<u16>,
+
+    /// Optional path prefix restriction.
+    #[serde(default)]
+    pub path_prefix: Option<String>,
+}
+
+impl OutboundTrustTargetSettings {
+    fn to_runtime_target(&self) -> OutboundTrustTarget {
+        OutboundTrustTarget {
+            host: self.host.clone(),
+            port: self.port,
+            path_prefix: self.path_prefix.clone(),
         }
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -20,6 +20,7 @@
 
 pub mod credentials;
 pub mod fault_injection;
+pub mod tls;
 
 use std::sync::Arc;
 use std::sync::Mutex;

--- a/src/testing/tls.rs
+++ b/src/testing/tls.rs
@@ -21,10 +21,10 @@ impl SelfSignedHttpsServer {
         let body = Arc::<str>::from(body.into());
         let listener = TcpListener::bind(("127.0.0.1", 0))
             .await
-            .expect("bind self-signed HTTPS test listener");
+            .expect("bind self-signed HTTPS test listener"); // safety: test-only setup helper
         let addr = listener
             .local_addr()
-            .expect("read local addr for self-signed HTTPS test listener");
+            .expect("read local addr for self-signed HTTPS test listener"); // safety: test-only setup helper
         let acceptor = TlsAcceptor::from(Arc::new(server_config()));
         let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
 
@@ -89,17 +89,17 @@ fn server_config() -> ServerConfig {
     CRYPTO_PROVIDER.get_or_init(|| {
         tokio_rustls::rustls::crypto::ring::default_provider()
             .install_default()
-            .expect("install rustls crypto provider for test HTTPS server");
+            .expect("install rustls crypto provider for test HTTPS server"); // safety: test-only setup helper
     });
 
     let rcgen::CertifiedKey { cert, key_pair } =
         generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
-            .expect("generate self-signed cert for test HTTPS server");
+            .expect("generate self-signed cert for test HTTPS server"); // safety: test-only setup helper
 
     let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
 
     ServerConfig::builder()
         .with_no_client_auth()
         .with_single_cert(vec![cert.der().clone()], key_der)
-        .expect("build rustls server config for test HTTPS server")
+        .expect("build rustls server config for test HTTPS server") // safety: test-only setup helper
 }

--- a/src/testing/tls.rs
+++ b/src/testing/tls.rs
@@ -1,0 +1,105 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::OnceLock;
+
+use rcgen::generate_simple_self_signed;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio_rustls::TlsAcceptor;
+use tokio_rustls::rustls::ServerConfig;
+use tokio_rustls::rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer};
+
+/// Minimal local HTTPS server for tests that need a self-signed certificate.
+pub struct SelfSignedHttpsServer {
+    addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+}
+
+impl SelfSignedHttpsServer {
+    pub async fn start(body: impl Into<String>) -> Self {
+        let body = Arc::<str>::from(body.into());
+        let listener = TcpListener::bind(("127.0.0.1", 0))
+            .await
+            .expect("bind self-signed HTTPS test listener");
+        let addr = listener
+            .local_addr()
+            .expect("read local addr for self-signed HTTPS test listener");
+        let acceptor = TlsAcceptor::from(Arc::new(server_config()));
+        let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_rx => break,
+                    accept_result = listener.accept() => {
+                        let (stream, _) = match accept_result {
+                            Ok(pair) => pair,
+                            Err(_) => continue,
+                        };
+                        let acceptor = acceptor.clone();
+                        let body = Arc::clone(&body);
+                        tokio::spawn(async move {
+                            let mut tls_stream = match acceptor.accept(stream).await {
+                                Ok(stream) => stream,
+                                Err(_) => return,
+                            };
+
+                            let mut request_buf = [0_u8; 2048];
+                            let _ = tls_stream.read(&mut request_buf).await;
+
+                            let response = format!(
+                                "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+                                body.len(),
+                                body,
+                            );
+                            let _ = tls_stream.write_all(response.as_bytes()).await;
+                            let _ = tls_stream.shutdown().await;
+                        });
+                    }
+                }
+            }
+        });
+
+        Self {
+            addr,
+            shutdown_tx: Some(shutdown_tx),
+        }
+    }
+
+    pub fn port(&self) -> u16 {
+        self.addr.port()
+    }
+
+    pub fn url(&self, path: &str) -> String {
+        format!("https://127.0.0.1:{}{}", self.addr.port(), path)
+    }
+}
+
+impl Drop for SelfSignedHttpsServer {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+    }
+}
+
+fn server_config() -> ServerConfig {
+    static CRYPTO_PROVIDER: OnceLock<()> = OnceLock::new();
+    CRYPTO_PROVIDER.get_or_init(|| {
+        tokio_rustls::rustls::crypto::ring::default_provider()
+            .install_default()
+            .expect("install rustls crypto provider for test HTTPS server");
+    });
+
+    let rcgen::CertifiedKey { cert, key_pair } =
+        generate_simple_self_signed(vec!["localhost".to_string(), "127.0.0.1".to_string()])
+            .expect("generate self-signed cert for test HTTPS server");
+
+    let key_der = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(key_pair.serialize_der()));
+
+    ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.der().clone()], key_der)
+        .expect("build rustls server config for test HTTPS server")
+}

--- a/src/tools/README.md
+++ b/src/tools/README.md
@@ -120,6 +120,7 @@ Both are first-class in the extension system (`ironclaw tool install` handles bo
 - Growing ecosystem of pre-built servers (GitHub, Notion, Postgres, etc.)
 - Any language (TypeScript/Python most common)
 - Can do websockets, streaming, background polling
+- HTTP-based MCP servers still honor IronClaw network policy; private-network and invalid-TLS exceptions require operator-managed `outbound_trust` policy plus per-server opt-in
 - Cost: external process with full system access (no sandbox), manages own credentials, IronClaw can't prevent leaks
 
 **Decision guide:**

--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -4,7 +4,6 @@
 //! See: https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/authorization/
 
 use std::collections::HashMap;
-use std::net::IpAddr;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,26 +15,14 @@ use tokio::net::TcpListener;
 
 use crate::cli::oauth_defaults::{self, OAUTH_CALLBACK_PORT};
 use crate::secrets::{CreateSecretParams, SecretsStore};
+use crate::security::outbound_trust::{OutboundTrustConfig, OutboundTrustResolver};
 use crate::tools::mcp::config::McpServerConfig;
+use crate::tools::mcp::network::{
+    build_mcp_http_client, resolve_mcp_outbound_trust_decision, validate_mcp_url,
+};
 
-/// Shared HTTP client for all OAuth/discovery requests.
-///
-/// Redirects are disabled for security (prevents redirect-based SSRF).
-/// Per-request timeouts can override the default via `.timeout()` on
-/// the request builder.
-fn oauth_http_client() -> Result<&'static reqwest::Client, AuthError> {
-    static CLIENT: std::sync::OnceLock<Result<reqwest::Client, AuthError>> =
-        std::sync::OnceLock::new();
-    CLIENT
-        .get_or_init(|| {
-            reqwest::Client::builder()
-                .timeout(Duration::from_secs(30))
-                .redirect(reqwest::redirect::Policy::none())
-                .build()
-                .map_err(|e| AuthError::Http(e.to_string()))
-        })
-        .as_ref()
-        .map_err(Clone::clone)
+fn oauth_http_client(allow_invalid_tls: bool) -> Result<reqwest::Client, AuthError> {
+    build_mcp_http_client(allow_invalid_tls).map_err(AuthError::Http)
 }
 
 /// Log a debug message when a discovery/auth response is a redirect.
@@ -201,6 +188,14 @@ pub struct AccessToken {
     pub scope: Option<String>,
 }
 
+struct AuthorizationCodeExchange<'a> {
+    client_id: &'a str,
+    code: &'a str,
+    redirect_uri: &'a str,
+    pkce: Option<&'a PkceChallenge>,
+    resource: Option<&'a str>,
+}
+
 /// Token response from the authorization server.
 #[derive(Debug, Deserialize)]
 struct TokenResponse {
@@ -276,109 +271,13 @@ pub fn canonical_resource_uri(server_url: &str) -> String {
 }
 
 // ---------------------------------------------------------------------------
-// SSRF protection
+// Shared outbound HTTP validation
 // ---------------------------------------------------------------------------
 
-/// Check if an IP address is dangerous (loopback, link-local, private, etc.)
-fn is_dangerous_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_broadcast()
-                || v4.is_unspecified()
-                || (v4.octets()[0] == 169 && v4.octets()[1] == 254) // link-local
-                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64) // CGNAT 100.64/10
-        }
-        IpAddr::V6(v6) => {
-            let segs = v6.segments();
-            v6.is_loopback()
-                || v6.is_unspecified()
-                // Link-local (fe80::/10)
-                || (segs[0] & 0xffc0) == 0xfe80
-                // Site-local / deprecated (fec0::/10)
-                || (segs[0] & 0xffc0) == 0xfec0
-                // Unique local (fc00::/7)
-                || (segs[0] & 0xfe00) == 0xfc00
-                // Documentation (2001:db8::/32)
-                || (segs[0] == 0x2001 && segs[1] == 0x0db8)
-                // Check for IPv4-mapped IPv6 (::ffff:x.x.x.x)
-                || v6
-                    .to_ipv4_mapped()
-                    .is_some_and(|v4| is_dangerous_ip(IpAddr::V4(v4)))
-        }
-    }
-}
-
-/// Validate that a URL is safe for server-side requests (SSRF protection).
-async fn validate_url_safe(url: &str) -> Result<(), AuthError> {
-    let parsed = reqwest::Url::parse(url)
-        .map_err(|e| AuthError::DiscoveryFailed(format!("Invalid URL: {}", e)))?;
-
-    // Must be HTTPS. HTTP is only allowed for localhost/loopback (dev scenarios).
-    let scheme = parsed.scheme();
-    if scheme != "https" && scheme != "http" {
-        return Err(AuthError::DiscoveryFailed(format!(
-            "Unsupported scheme: {}",
-            scheme
-        )));
-    }
-    if scheme == "http" {
-        if !crate::tools::mcp::config::is_localhost_url(url) {
-            let host = parsed.host_str().unwrap_or("");
-            return Err(AuthError::DiscoveryFailed(format!(
-                "HTTP is only allowed for localhost; use HTTPS for '{}'",
-                host
-            )));
-        }
-        // Localhost HTTP is allowed for dev — skip SSRF checks since we've
-        // already validated the host is localhost/loopback.
-        return Ok(());
-    }
-
-    let host = parsed
-        .host_str()
-        .ok_or_else(|| AuthError::DiscoveryFailed("URL has no host".to_string()))?;
-
-    // For IP literals, parse directly and check.
-    if let Ok(ip) = host.parse::<IpAddr>()
-        && is_dangerous_ip(ip)
-    {
-        return Err(AuthError::DiscoveryFailed(format!(
-            "URL points to a restricted IP address: {}",
-            host
-        )));
-    }
-
-    // For hostnames, resolve DNS and check each resolved address.
-    // This prevents DNS-based SSRF where a hostname resolves to an internal IP
-    // (e.g., 169.254.169.254 for cloud metadata endpoints).
-    if host.parse::<IpAddr>().is_err() {
-        let addr = format!("{}:{}", host, parsed.port_or_known_default().unwrap_or(443));
-        match tokio::net::lookup_host(&addr).await {
-            Ok(addrs) => {
-                for socket_addr in addrs {
-                    if is_dangerous_ip(socket_addr.ip()) {
-                        return Err(AuthError::DiscoveryFailed(format!(
-                            "URL hostname '{}' resolves to restricted IP address: {}",
-                            host,
-                            socket_addr.ip()
-                        )));
-                    }
-                }
-            }
-            Err(e) => {
-                // DNS failure = fail closed (do not allow the request)
-                return Err(AuthError::DiscoveryFailed(format!(
-                    "DNS resolution failed for '{}': {}",
-                    host, e
-                )));
-            }
-        }
-    }
-
-    Ok(())
+async fn validate_url_safe(url: &str, allow_private_network: bool) -> Result<(), AuthError> {
+    validate_mcp_url(url, allow_private_network)
+        .await
+        .map_err(AuthError::DiscoveryFailed)
 }
 
 // ---------------------------------------------------------------------------
@@ -415,10 +314,15 @@ fn parse_resource_metadata_url(www_authenticate: &str) -> Option<String> {
 }
 
 /// Fetch protected resource metadata from a URL.
-async fn fetch_resource_metadata(url: &str) -> Result<ProtectedResourceMetadata, AuthError> {
-    validate_url_safe(url).await?;
+async fn fetch_resource_metadata(
+    resolver: &OutboundTrustResolver,
+    server_config: &McpServerConfig,
+    url: &str,
+) -> Result<ProtectedResourceMetadata, AuthError> {
+    let outbound_trust = resolve_mcp_outbound_trust_decision(resolver, server_config, url);
+    validate_url_safe(url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     let response = client
         .get(url)
@@ -448,13 +352,18 @@ async fn fetch_resource_metadata(url: &str) -> Result<ProtectedResourceMetadata,
 /// unauthenticated requests.  In practice the 400 path rarely yields a
 /// `WWW-Authenticate` header (GitHub's MCP does not), so discovery
 /// typically falls through to strategy 2 (RFC 9728) or 3 (direct).
-async fn discover_via_401(server_url: &str) -> Result<AuthorizationServerMetadata, AuthError> {
-    validate_url_safe(server_url).await?;
+async fn discover_via_401(
+    resolver: &OutboundTrustResolver,
+    server_config: &McpServerConfig,
+) -> Result<AuthorizationServerMetadata, AuthError> {
+    let outbound_trust =
+        resolve_mcp_outbound_trust_decision(resolver, server_config, &server_config.url);
+    validate_url_safe(&server_config.url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     let response = client
-        .post(server_url)
+        .post(&server_config.url)
         .timeout(Duration::from_secs(10))
         .header("Content-Type", "application/json")
         .body("{}")
@@ -462,7 +371,7 @@ async fn discover_via_401(server_url: &str) -> Result<AuthorizationServerMetadat
         .await
         .map_err(|e| AuthError::DiscoveryFailed(e.to_string()))?;
 
-    log_redirect_if_applicable(server_url, &response);
+    log_redirect_if_applicable(&server_config.url, &response);
 
     let status = response.status().as_u16();
 
@@ -489,12 +398,15 @@ async fn discover_via_401(server_url: &str) -> Result<AuthorizationServerMetadat
         )
     })?;
 
-    let resource_meta = fetch_resource_metadata(&resource_metadata_url).await?;
-    try_discover_from_auth_servers(&resource_meta).await
+    let resource_meta =
+        fetch_resource_metadata(resolver, server_config, &resource_metadata_url).await?;
+    try_discover_from_auth_servers(resolver, server_config, &resource_meta).await
 }
 
 /// Try to discover auth server metadata from resource metadata's authorization_servers list.
 async fn try_discover_from_auth_servers(
+    resolver: &OutboundTrustResolver,
+    server_config: &McpServerConfig,
     resource_meta: &ProtectedResourceMetadata,
 ) -> Result<AuthorizationServerMetadata, AuthError> {
     let auth_server_url = resource_meta
@@ -502,7 +414,7 @@ async fn try_discover_from_auth_servers(
         .first()
         .ok_or_else(|| AuthError::DiscoveryFailed("No authorization servers listed".to_string()))?;
 
-    discover_authorization_server(auth_server_url).await
+    discover_authorization_server(server_config, resolver, auth_server_url).await
 }
 
 // ---------------------------------------------------------------------------
@@ -511,13 +423,17 @@ async fn try_discover_from_auth_servers(
 
 /// Discover protected resource metadata from an MCP server.
 pub async fn discover_protected_resource(
-    server_url: &str,
+    server_config: &McpServerConfig,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<ProtectedResourceMetadata, AuthError> {
-    validate_url_safe(server_url).await?;
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+    let outbound_trust =
+        resolve_mcp_outbound_trust_decision(&resolver, server_config, &server_config.url);
+    validate_url_safe(&server_config.url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
-    let well_known_url = build_well_known_uri(server_url, "oauth-protected-resource")?;
+    let well_known_url = build_well_known_uri(&server_config.url, "oauth-protected-resource")?;
 
     let response = client
         .get(&well_known_url)
@@ -540,11 +456,15 @@ pub async fn discover_protected_resource(
 
 /// Discover authorization server metadata.
 pub async fn discover_authorization_server(
+    server_config: &McpServerConfig,
+    resolver: &OutboundTrustResolver,
     auth_server_url: &str,
 ) -> Result<AuthorizationServerMetadata, AuthError> {
-    validate_url_safe(auth_server_url).await?;
+    let outbound_trust =
+        resolve_mcp_outbound_trust_decision(resolver, server_config, auth_server_url);
+    validate_url_safe(auth_server_url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     let well_known_url = build_well_known_uri(auth_server_url, "oauth-authorization-server")?;
 
@@ -575,7 +495,9 @@ pub async fn discover_authorization_server(
 /// First checks if endpoints are explicitly configured, then falls back to discovery.
 pub async fn discover_oauth_endpoints(
     server_config: &McpServerConfig,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<(String, String), AuthError> {
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
     let oauth = server_config
         .oauth
         .as_ref()
@@ -587,7 +509,7 @@ pub async fn discover_oauth_endpoints(
     }
 
     // Try to discover from the server
-    let resource_meta = discover_protected_resource(&server_config.url).await?;
+    let resource_meta = discover_protected_resource(server_config, outbound_trust_config).await?;
 
     // Get the first authorization server
     let auth_server_url = resource_meta
@@ -596,7 +518,8 @@ pub async fn discover_oauth_endpoints(
         .ok_or_else(|| AuthError::DiscoveryFailed("No authorization servers listed".to_string()))?;
 
     // Discover the authorization server metadata
-    let auth_meta = discover_authorization_server(auth_server_url).await?;
+    let auth_meta =
+        discover_authorization_server(server_config, &resolver, auth_server_url).await?;
 
     Ok((auth_meta.authorization_endpoint, auth_meta.token_endpoint))
 }
@@ -609,34 +532,44 @@ pub async fn discover_oauth_endpoints(
 /// 2. **RFC 9728**: Discover protected resource metadata, then authorization server from it
 /// 3. **Direct**: Treat MCP server as its own auth server
 pub async fn discover_full_oauth_metadata(
-    server_url: &str,
+    server_config: &McpServerConfig,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<AuthorizationServerMetadata, AuthError> {
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+
     // Strategy 1: 401-based discovery
-    if let Ok(meta) = discover_via_401(server_url).await {
+    if let Ok(meta) = discover_via_401(&resolver, server_config).await {
         return Ok(meta);
     }
 
     // Strategy 2: RFC 9728 protected resource discovery
-    if let Ok(resource_meta) = discover_protected_resource(server_url).await
-        && let Ok(meta) = try_discover_from_auth_servers(&resource_meta).await
+    if let Ok(resource_meta) =
+        discover_protected_resource(server_config, outbound_trust_config).await
+        && let Ok(meta) =
+            try_discover_from_auth_servers(&resolver, server_config, &resource_meta).await
     {
         return Ok(meta);
     }
 
     // Strategy 3: Direct - treat MCP server as its own auth server
-    discover_authorization_server(server_url).await
+    discover_authorization_server(server_config, &resolver, &server_config.url).await
 }
 
 /// Perform Dynamic Client Registration with an authorization server.
 ///
 /// This allows clients to register themselves at runtime without pre-configured credentials.
 pub async fn register_client(
+    server_config: &McpServerConfig,
+    outbound_trust_config: &OutboundTrustConfig,
     registration_endpoint: &str,
     redirect_uri: &str,
 ) -> Result<ClientRegistrationResponse, AuthError> {
-    validate_url_safe(registration_endpoint).await?;
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+    let outbound_trust =
+        resolve_mcp_outbound_trust_decision(&resolver, server_config, registration_endpoint);
+    validate_url_safe(registration_endpoint, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     let request = ClientRegistrationRequest {
         client_name: "IronClaw".to_string(),
@@ -689,6 +622,7 @@ pub async fn authorize_mcp_server(
     server_config: &McpServerConfig,
     secrets: &Arc<dyn SecretsStore + Send + Sync>,
     user_id: &str,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<AccessToken, AuthError> {
     // Find an available port for the callback first (needed for DCR)
     let (listener, port) = find_available_port().await?;
@@ -709,7 +643,8 @@ pub async fn authorize_mcp_server(
     let (client_id, authorization_url, token_url, use_pkce, scopes, mut extra_params) =
         if let Some(oauth) = &server_config.oauth {
             // Pre-configured OAuth
-            let (auth_url, tok_url) = discover_oauth_endpoints(server_config).await?;
+            let (auth_url, tok_url) =
+                discover_oauth_endpoints(server_config, outbound_trust_config).await?;
             (
                 oauth.client_id.clone(),
                 auth_url,
@@ -721,14 +656,21 @@ pub async fn authorize_mcp_server(
         } else {
             // Try Dynamic Client Registration
             println!("  Discovering OAuth endpoints...");
-            let auth_meta = discover_full_oauth_metadata(&server_config.url).await?;
+            let auth_meta =
+                discover_full_oauth_metadata(server_config, outbound_trust_config).await?;
 
             let registration_endpoint = auth_meta
                 .registration_endpoint
                 .ok_or(AuthError::NotSupported)?;
 
             println!("  Registering client dynamically...");
-            let registration = register_client(&registration_endpoint, &redirect_uri).await?;
+            let registration = register_client(
+                server_config,
+                outbound_trust_config,
+                &registration_endpoint,
+                &redirect_uri,
+            )
+            .await?;
             println!("  Client registered: {}", registration.client_id);
 
             (
@@ -758,11 +700,18 @@ pub async fn authorize_mcp_server(
     // Compute canonical resource URI for RFC 8707
     let resource = canonical_resource_uri(&server_config.url);
 
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+    let auth_outbound_trust =
+        resolve_mcp_outbound_trust_decision(&resolver, server_config, &authorization_url);
+
     // Validate the discovered authorization URL to prevent a malicious MCP server
     // from redirecting the user to a phishing page or non-HTTPS endpoint.
-    validate_url_safe(&authorization_url)
-        .await
-        .map_err(|e| AuthError::DiscoveryFailed(format!("Unsafe authorization endpoint: {}", e)))?;
+    validate_url_safe(
+        &authorization_url,
+        auth_outbound_trust.allow_private_network,
+    )
+    .await
+    .map_err(|e| AuthError::DiscoveryFailed(format!("Unsafe authorization endpoint: {}", e)))?;
 
     // Build authorization URL
     let auth_url = build_authorization_url(
@@ -795,12 +744,16 @@ pub async fn authorize_mcp_server(
 
     // Exchange code for token
     let token = exchange_code_for_token(
+        server_config,
+        outbound_trust_config,
         &token_url,
-        &client_id,
-        &code,
-        &redirect_uri,
-        pkce.as_ref(),
-        Some(&resource),
+        AuthorizationCodeExchange {
+            client_id: &client_id,
+            code: &code,
+            redirect_uri: &redirect_uri,
+            pkce: pkce.as_ref(),
+            resource: Some(&resource),
+        },
     )
     .await?;
 
@@ -890,30 +843,30 @@ pub async fn wait_for_authorization_callback(
 }
 
 /// Exchange the authorization code for an access token.
-pub async fn exchange_code_for_token(
+async fn exchange_code_for_token(
+    server_config: &McpServerConfig,
+    outbound_trust_config: &OutboundTrustConfig,
     token_url: &str,
-    client_id: &str,
-    code: &str,
-    redirect_uri: &str,
-    pkce: Option<&PkceChallenge>,
-    resource: Option<&str>,
+    exchange: AuthorizationCodeExchange<'_>,
 ) -> Result<AccessToken, AuthError> {
-    validate_url_safe(token_url).await?;
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+    let outbound_trust = resolve_mcp_outbound_trust_decision(&resolver, server_config, token_url);
+    validate_url_safe(token_url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     let mut params = vec![
         ("grant_type", "authorization_code".to_string()),
-        ("code", code.to_string()),
-        ("redirect_uri", redirect_uri.to_string()),
-        ("client_id", client_id.to_string()),
+        ("code", exchange.code.to_string()),
+        ("redirect_uri", exchange.redirect_uri.to_string()),
+        ("client_id", exchange.client_id.to_string()),
     ];
 
-    if let Some(pkce) = pkce {
+    if let Some(pkce) = exchange.pkce {
         params.push(("code_verifier", pkce.verifier.clone()));
     }
 
-    if let Some(resource) = resource {
+    if let Some(resource) = exchange.resource {
         params.push(("resource", resource.to_string()));
     }
 
@@ -1060,6 +1013,7 @@ pub async fn refresh_access_token(
     server_config: &McpServerConfig,
     secrets: &Arc<dyn SecretsStore + Send + Sync>,
     user_id: &str,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<AccessToken, AuthError> {
     // Get client_id (from config or stored DCR)
     let client_id = get_client_id(server_config, secrets, user_id).await?;
@@ -1076,18 +1030,21 @@ pub async fn refresh_access_token(
             url.clone()
         } else {
             // Discover from server
-            let auth_meta = discover_full_oauth_metadata(&server_config.url).await?;
+            let auth_meta =
+                discover_full_oauth_metadata(server_config, outbound_trust_config).await?;
             auth_meta.token_endpoint
         }
     } else {
         // DCR - always discover
-        let auth_meta = discover_full_oauth_metadata(&server_config.url).await?;
+        let auth_meta = discover_full_oauth_metadata(server_config, outbound_trust_config).await?;
         auth_meta.token_endpoint
     };
 
-    validate_url_safe(&token_url).await?;
+    let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+    let outbound_trust = resolve_mcp_outbound_trust_decision(&resolver, server_config, &token_url);
+    validate_url_safe(&token_url, outbound_trust.allow_private_network).await?;
 
-    let client = oauth_http_client()?;
+    let client = oauth_http_client(outbound_trust.allow_invalid_tls)?;
 
     // Compute canonical resource URI for RFC 8707
     let resource = canonical_resource_uri(&server_config.url);
@@ -1137,6 +1094,7 @@ pub async fn refresh_access_token(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::IpAddr;
 
     #[test]
     fn test_pkce_challenge_generation() {
@@ -1603,70 +1561,104 @@ mod tests {
 
     #[test]
     fn test_is_dangerous_ip_loopback_v4() {
-        assert!(is_dangerous_ip("127.0.0.1".parse().unwrap()));
-        assert!(is_dangerous_ip("127.0.0.2".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "127.0.0.1".parse().unwrap()
+        ));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "127.0.0.2".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_private_v4() {
-        assert!(is_dangerous_ip("10.0.0.1".parse().unwrap()));
-        assert!(is_dangerous_ip("172.16.0.1".parse().unwrap()));
-        assert!(is_dangerous_ip("192.168.1.1".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "10.0.0.1".parse().unwrap()
+        ));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "172.16.0.1".parse().unwrap()
+        ));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "192.168.1.1".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_link_local_v4() {
-        assert!(is_dangerous_ip("169.254.169.254".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "169.254.169.254".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_cgnat() {
-        assert!(is_dangerous_ip("100.64.0.1".parse().unwrap()));
-        assert!(is_dangerous_ip("100.127.255.254".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "100.64.0.1".parse().unwrap()
+        ));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "100.127.255.254".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_safe_v4() {
-        assert!(!is_dangerous_ip("8.8.8.8".parse().unwrap()));
-        assert!(!is_dangerous_ip("1.1.1.1".parse().unwrap()));
+        assert!(!crate::tools::mcp::network::is_dangerous_ip(
+            "8.8.8.8".parse().unwrap()
+        ));
+        assert!(!crate::tools::mcp::network::is_dangerous_ip(
+            "1.1.1.1".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_ipv4_mapped_v6_loopback() {
         // ::ffff:127.0.0.1 must be blocked
         let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
-        assert!(is_dangerous_ip(ip));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(ip));
     }
 
     #[test]
     fn test_is_dangerous_ip_ipv4_mapped_v6_link_local() {
         // ::ffff:169.254.169.254 must be blocked
         let ip: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
-        assert!(is_dangerous_ip(ip));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(ip));
     }
 
     #[test]
     fn test_is_dangerous_ip_unspecified() {
-        assert!(is_dangerous_ip("0.0.0.0".parse().unwrap()));
-        assert!(is_dangerous_ip("::".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "0.0.0.0".parse().unwrap()
+        ));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "::".parse().unwrap()
+        ));
     }
 
     #[test]
     fn test_is_dangerous_ip_v6_loopback() {
-        assert!(is_dangerous_ip("::1".parse().unwrap()));
+        assert!(crate::tools::mcp::network::is_dangerous_ip(
+            "::1".parse().unwrap()
+        ));
     }
 
     #[tokio::test]
     async fn test_validate_url_safe_https() {
-        assert!(validate_url_safe("https://example.com/path").await.is_ok());
+        assert!(
+            validate_url_safe("https://example.com/path", false)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
     async fn test_validate_url_safe_http_localhost_allowed() {
         // HTTP is only allowed for localhost dev scenarios
-        assert!(validate_url_safe("http://localhost/path").await.is_ok());
         assert!(
-            validate_url_safe("http://localhost:8080/path")
+            validate_url_safe("http://localhost/path", false)
+                .await
+                .is_ok()
+        );
+        assert!(
+            validate_url_safe("http://localhost:8080/path", false)
                 .await
                 .is_ok()
         );
@@ -1675,33 +1667,75 @@ mod tests {
     #[tokio::test]
     async fn test_validate_url_safe_http_non_localhost_rejected() {
         // HTTP to non-localhost hosts must be rejected (plaintext credential risk)
-        assert!(validate_url_safe("http://example.com/path").await.is_err());
+        assert!(
+            validate_url_safe("http://example.com/path", false)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn test_validate_url_safe_bad_scheme() {
-        assert!(validate_url_safe("ftp://example.com/path").await.is_err());
-        assert!(validate_url_safe("file:///etc/passwd").await.is_err());
+        assert!(
+            validate_url_safe("ftp://example.com/path", false)
+                .await
+                .is_err()
+        );
+        assert!(
+            validate_url_safe("file:///etc/passwd", false)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn test_validate_url_safe_private_ip() {
         // 127.0.0.1 over HTTP is allowed (localhost dev scenario)
-        assert!(validate_url_safe("http://127.0.0.1/path").await.is_ok());
-        // Private/link-local IPs over HTTPS are blocked (SSRF protection)
-        assert!(validate_url_safe("https://10.0.0.1/path").await.is_err());
         assert!(
-            validate_url_safe("https://169.254.169.254/latest/meta-data")
+            validate_url_safe("http://127.0.0.1/path", false)
+                .await
+                .is_ok()
+        );
+        // Private/link-local IPs over HTTPS are blocked (SSRF protection)
+        assert!(
+            validate_url_safe("https://10.0.0.1/path", false)
+                .await
+                .is_err()
+        );
+        assert!(
+            validate_url_safe("https://169.254.169.254/latest/meta-data", false)
                 .await
                 .is_err()
         );
         // Private IPs over HTTP (non-localhost) are blocked
-        assert!(validate_url_safe("http://10.0.0.1/path").await.is_err());
+        assert!(
+            validate_url_safe("http://10.0.0.1/path", false)
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
     async fn test_validate_url_safe_public_ip() {
-        assert!(validate_url_safe("https://8.8.8.8/dns").await.is_ok());
+        assert!(
+            validate_url_safe("https://8.8.8.8/dns", false)
+                .await
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_url_safe_private_ip_allowed_by_policy() {
+        assert!(
+            validate_url_safe("https://10.0.0.1/path", true)
+                .await
+                .is_ok()
+        );
+        assert!(
+            validate_url_safe("https://192.168.1.1/path", true)
+                .await
+                .is_ok()
+        );
     }
 
     // --- New tests for parse_resource_metadata_url ---

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -12,9 +12,11 @@ use tokio::sync::RwLock;
 
 use crate::context::JobContext;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::{OutboundTrustConfig, OutboundTrustResolver};
 use crate::tools::mcp::auth::refresh_access_token;
 use crate::tools::mcp::config::McpServerConfig;
 use crate::tools::mcp::http_transport::HttpMcpTransport;
+use crate::tools::mcp::network::resolve_mcp_outbound_trust_decision;
 use crate::tools::mcp::protocol::{
     CallToolResult, InitializeResult, ListToolsResult, McpRequest, McpResponse, McpTool,
 };
@@ -58,6 +60,9 @@ pub struct McpClient {
     /// Custom headers to include in every request.
     custom_headers: HashMap<String, String>,
 
+    /// Global outbound trust policy config used for token refresh / OAuth retries.
+    outbound_trust_config: OutboundTrustConfig,
+
     /// Ensures the MCP initialize handshake runs exactly once.
     /// Uses `OnceCell` to serialize concurrent callers so only one
     /// actually sends the request; subsequent calls return immediately.
@@ -84,6 +89,7 @@ impl McpClient {
             user_id: "default".to_string(),
             server_config: None,
             custom_headers: HashMap::new(),
+            outbound_trust_config: OutboundTrustConfig::default(),
             initialized: tokio::sync::OnceCell::new(),
         }
     }
@@ -107,6 +113,7 @@ impl McpClient {
             user_id: "default".to_string(),
             server_config: None,
             custom_headers: HashMap::new(),
+            outbound_trust_config: OutboundTrustConfig::default(),
             initialized: tokio::sync::OnceCell::new(),
         }
     }
@@ -117,7 +124,10 @@ impl McpClient {
     /// The config must use HTTP transport (the default); for stdio/UDS use `new_with_transport`.
     ///
     /// Returns an error if the config uses a non-HTTP transport.
-    pub fn new_with_config(config: McpServerConfig) -> Result<Self, ToolError> {
+    pub fn new_with_config(
+        config: McpServerConfig,
+        outbound_trust_config: OutboundTrustConfig,
+    ) -> Result<Self, ToolError> {
         if !matches!(
             config.effective_transport(),
             crate::tools::mcp::config::EffectiveTransport::Http
@@ -127,9 +137,13 @@ impl McpClient {
                     .to_string(),
             ));
         }
-        let transport = Arc::new(HttpMcpTransport::new(
+        let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+        let outbound_trust = resolve_mcp_outbound_trust_decision(&resolver, &config, &config.url);
+        let transport = Arc::new(HttpMcpTransport::new_with_network_policy(
             config.url.clone(),
             config.name.clone(),
+            outbound_trust.allow_invalid_tls,
+            outbound_trust.allow_private_network,
         ));
 
         Ok(Self {
@@ -142,6 +156,7 @@ impl McpClient {
             secrets: None,
             user_id: "default".to_string(),
             custom_headers: config.headers.clone(),
+            outbound_trust_config,
             initialized: tokio::sync::OnceCell::new(),
             server_config: Some(config),
         })
@@ -155,10 +170,18 @@ impl McpClient {
         session_manager: Arc<McpSessionManager>,
         secrets: Arc<dyn SecretsStore + Send + Sync>,
         user_id: impl Into<String>,
+        outbound_trust_config: OutboundTrustConfig,
     ) -> Self {
+        let resolver = OutboundTrustResolver::new(outbound_trust_config.clone());
+        let outbound_trust = resolve_mcp_outbound_trust_decision(&resolver, &config, &config.url);
         let transport = Arc::new(
-            HttpMcpTransport::new(config.url.clone(), config.name.clone())
-                .with_session_manager(session_manager.clone()),
+            HttpMcpTransport::new_with_network_policy(
+                config.url.clone(),
+                config.name.clone(),
+                outbound_trust.allow_invalid_tls,
+                outbound_trust.allow_private_network,
+            )
+            .with_session_manager(session_manager.clone()),
         );
 
         let custom_headers = config.headers.clone();
@@ -174,6 +197,7 @@ impl McpClient {
             user_id: user_id.into(),
             server_config: Some(config),
             custom_headers,
+            outbound_trust_config,
             initialized: tokio::sync::OnceCell::new(),
         }
     }
@@ -210,6 +234,7 @@ impl McpClient {
             user_id: user_id.into(),
             server_config,
             custom_headers,
+            outbound_trust_config: OutboundTrustConfig::default(),
             initialized: tokio::sync::OnceCell::new(),
         }
     }
@@ -398,7 +423,14 @@ impl McpClient {
                             "MCP token expired, attempting refresh for '{}'",
                             self.server_name
                         );
-                        match refresh_access_token(config, secrets, &self.user_id).await {
+                        match refresh_access_token(
+                            config,
+                            secrets,
+                            &self.user_id,
+                            &self.outbound_trust_config,
+                        )
+                        .await
+                        {
                             Ok(_) => {
                                 tracing::info!("MCP token refreshed for '{}'", self.server_name);
                                 continue;
@@ -551,6 +583,7 @@ impl Clone for McpClient {
             user_id: self.user_id.clone(),
             server_config: self.server_config.clone(),
             custom_headers: self.custom_headers.clone(),
+            outbound_trust_config: self.outbound_trust_config.clone(),
             initialized: tokio::sync::OnceCell::new(),
         }
     }
@@ -774,7 +807,8 @@ mod tests {
         headers.insert("X-Custom".to_string(), "value".to_string());
 
         let config = McpServerConfig::new("test", "http://localhost:8080").with_headers(headers);
-        let client = McpClient::new_with_config(config.clone()).expect("HTTP config should work");
+        let client = McpClient::new_with_config(config.clone(), OutboundTrustConfig::default())
+            .expect("HTTP config should work");
 
         assert_eq!(client.server_name(), "test");
         assert_eq!(client.server_url(), "http://localhost:8080");
@@ -786,7 +820,8 @@ mod tests {
     #[test]
     fn test_new_with_config_no_headers() {
         let config = McpServerConfig::new("bare", "http://localhost:9090");
-        let client = McpClient::new_with_config(config).expect("HTTP config should work");
+        let client = McpClient::new_with_config(config, OutboundTrustConfig::default())
+            .expect("HTTP config should work");
 
         assert_eq!(client.server_name(), "bare");
         assert!(client.custom_headers.is_empty());
@@ -1174,7 +1209,7 @@ mod tests {
             vec!["hello".to_string()],
             HashMap::new(),
         );
-        let result = McpClient::new_with_config(config);
+        let result = McpClient::new_with_config(config, OutboundTrustConfig::default());
         let err = result
             .err()
             .expect("stdio config must be rejected")
@@ -1341,7 +1376,13 @@ mod tests {
         let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
             Arc::new(EmptyTokenStore);
 
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client = McpClient::new_authenticated(
+            config,
+            session_manager,
+            secrets,
+            "test-user",
+            OutboundTrustConfig::default(),
+        );
 
         let headers = client.build_request_headers().await.unwrap(); // safety: test
         assert!(
@@ -1406,7 +1447,13 @@ mod tests {
         let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
             Arc::new(PaddedTokenStore);
 
-        let client = McpClient::new_authenticated(config, session_manager, secrets, "test-user");
+        let client = McpClient::new_authenticated(
+            config,
+            session_manager,
+            secrets,
+            "test-user",
+            OutboundTrustConfig::default(),
+        );
 
         let headers = client.build_request_headers().await.unwrap(); // safety: test
         assert_eq!(

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -51,6 +51,10 @@ pub struct McpServerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub oauth: Option<OAuthConfig>,
 
+    /// Optional outbound trust policy opt-in for this MCP server.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub outbound_trust: Option<McpOutboundTrustConfig>,
+
     /// Whether this server is enabled.
     #[serde(default = "default_true")]
     pub enabled: bool,
@@ -64,6 +68,13 @@ fn default_true() -> bool {
     true
 }
 
+/// MCP server declaration of allowed operator-managed outbound trust policies.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpOutboundTrustConfig {
+    #[serde(default)]
+    pub allowed_policy_ids: Vec<String>,
+}
+
 impl McpServerConfig {
     /// Create a new MCP server configuration.
     pub fn new(name: impl Into<String>, url: impl Into<String>) -> Self {
@@ -73,6 +84,7 @@ impl McpServerConfig {
             transport: None,
             headers: HashMap::new(),
             oauth: None,
+            outbound_trust: None,
             enabled: true,
             description: None,
         }
@@ -95,6 +107,7 @@ impl McpServerConfig {
             }),
             headers: HashMap::new(),
             oauth: None,
+            outbound_trust: None,
             enabled: true,
             description: None,
         }
@@ -110,6 +123,7 @@ impl McpServerConfig {
             }),
             headers: HashMap::new(),
             oauth: None,
+            outbound_trust: None,
             enabled: true,
             description: None,
         }
@@ -130,6 +144,12 @@ impl McpServerConfig {
     /// Set custom headers.
     pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
         self.headers = headers;
+        self
+    }
+
+    /// Declare which operator-managed outbound trust policies this server may use.
+    pub fn with_outbound_trust_policy_ids(mut self, allowed_policy_ids: Vec<String>) -> Self {
+        self.outbound_trust = Some(McpOutboundTrustConfig { allowed_policy_ids });
         self
     }
 
@@ -220,6 +240,14 @@ impl McpServerConfig {
         self.headers
             .keys()
             .any(|k| k.eq_ignore_ascii_case("authorization"))
+    }
+
+    /// Declared operator-managed outbound trust policy IDs for this server.
+    pub fn declared_outbound_trust_policy_ids(&self) -> &[String] {
+        self.outbound_trust
+            .as_ref()
+            .map(|config| config.allowed_policy_ids.as_slice())
+            .unwrap_or(&[])
     }
 
     /// Check if this server requires authentication.
@@ -1127,6 +1155,28 @@ mod tests {
         assert_eq!(parsed.name, "http-server");
         assert!(parsed.transport.is_none());
         assert_eq!(parsed.headers.get("X-Custom").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_config_roundtrip_with_outbound_trust() {
+        let mut config = McpServerConfig::new("corp-mcp", "https://mcp.internal.example/api");
+        config.outbound_trust = Some(McpOutboundTrustConfig {
+            allowed_policy_ids: vec!["corp-mcp".to_string(), "corp-auth".to_string()],
+        });
+
+        let json = serde_json::to_string_pretty(&config).unwrap();
+        let parsed: McpServerConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            parsed.declared_outbound_trust_policy_ids(),
+            &["corp-mcp".to_string(), "corp-auth".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_config_defaults_without_outbound_trust() {
+        let config = McpServerConfig::new("notion", "https://mcp.notion.com");
+        assert!(config.declared_outbound_trust_policy_ids().is_empty());
     }
 
     // --- Issue 3 regression: is_localhost_url rejects attacker subdomains ---

--- a/src/tools/mcp/factory.rs
+++ b/src/tools/mcp/factory.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::OutboundTrustConfig;
 use crate::tools::mcp::config::{EffectiveTransport, McpServerConfig};
 use crate::tools::mcp::{McpClient, McpProcessManager, McpSessionManager, McpTransport};
 
@@ -30,6 +31,7 @@ pub async fn create_client_from_config(
     process_manager: &Arc<McpProcessManager>,
     secrets: Option<Arc<dyn SecretsStore + Send + Sync>>,
     user_id: &str,
+    outbound_trust_config: &OutboundTrustConfig,
 ) -> Result<McpClient, McpFactoryError> {
     let server_name = server.name.clone();
 
@@ -88,22 +90,27 @@ pub async fn create_client_from_config(
                         Arc::clone(session_manager),
                         Arc::clone(secrets),
                         user_id,
+                        outbound_trust_config.clone(),
                     ))
                 } else {
-                    Ok(McpClient::new_with_config(server)
-                        .map_err(|e| McpFactoryError::InvalidConfig {
-                            name: server_name.clone(),
-                            reason: e.to_string(),
-                        })?
-                        .with_session_manager(Arc::clone(session_manager)))
+                    Ok(
+                        McpClient::new_with_config(server, outbound_trust_config.clone())
+                            .map_err(|e| McpFactoryError::InvalidConfig {
+                                name: server_name.clone(),
+                                reason: e.to_string(),
+                            })?
+                            .with_session_manager(Arc::clone(session_manager)),
+                    )
                 }
             } else {
-                Ok(McpClient::new_with_config(server)
-                    .map_err(|e| McpFactoryError::InvalidConfig {
-                        name: server_name,
-                        reason: e.to_string(),
-                    })?
-                    .with_session_manager(Arc::clone(session_manager)))
+                Ok(
+                    McpClient::new_with_config(server, outbound_trust_config.clone())
+                        .map_err(|e| McpFactoryError::InvalidConfig {
+                            name: server_name,
+                            reason: e.to_string(),
+                        })?
+                        .with_session_manager(Arc::clone(session_manager)),
+                )
             }
         }
     }
@@ -125,6 +132,7 @@ mod tests {
             &process_manager,
             None,
             "test-user",
+            &OutboundTrustConfig::default(),
         )
         .await
         .expect("factory should succeed for HTTP config");

--- a/src/tools/mcp/http_transport.rs
+++ b/src/tools/mcp/http_transport.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 
+use crate::tools::mcp::network::{build_mcp_http_client, validate_mcp_url};
 use crate::tools::mcp::protocol::{McpRequest, McpResponse};
 use crate::tools::mcp::session::McpSessionManager;
 use crate::tools::mcp::transport::McpTransport;
@@ -22,6 +23,9 @@ pub struct HttpMcpTransport {
     server_url: String,
     server_name: String,
     http_client: reqwest::Client,
+    #[cfg(test)]
+    allow_invalid_tls: bool,
+    allow_private_network: bool,
     session_manager: Option<Arc<McpSessionManager>>,
     custom_headers: HashMap<String, String>,
 }
@@ -29,17 +33,24 @@ pub struct HttpMcpTransport {
 impl HttpMcpTransport {
     /// Create a new HTTP transport for the given server URL.
     pub fn new(server_url: impl Into<String>, server_name: impl Into<String>) -> Self {
+        Self::new_with_network_policy(server_url, server_name, false, false)
+    }
+
+    /// Create a new HTTP transport with explicit outbound network policy flags.
+    pub fn new_with_network_policy(
+        server_url: impl Into<String>,
+        server_name: impl Into<String>,
+        allow_invalid_tls: bool,
+        allow_private_network: bool,
+    ) -> Self {
         Self {
             server_url: server_url.into(),
             server_name: server_name.into(),
-            // reqwest::Client::builder().build() only fails if the TLS backend
-            // cannot initialize, which does not happen with the default rustls
-            // feature set. Panic is acceptable here (same as reqwest's own
-            // `Client::new()`).
-            http_client: reqwest::Client::builder()
-                .timeout(std::time::Duration::from_secs(30))
-                .build()
-                .expect("Failed to create HTTP client"), // safety: TLS init with default rustls cannot fail
+            http_client: build_mcp_http_client(allow_invalid_tls)
+                .unwrap_or_else(|e| panic!("Failed to create HTTP client: {e}")),
+            #[cfg(test)]
+            allow_invalid_tls,
+            allow_private_network,
             session_manager: None,
             custom_headers: HashMap::new(),
         }
@@ -69,6 +80,16 @@ impl HttpMcpTransport {
     pub(crate) fn session_manager(&self) -> Option<&Arc<McpSessionManager>> {
         self.session_manager.as_ref()
     }
+
+    #[cfg(test)]
+    pub(crate) fn allow_invalid_tls(&self) -> bool {
+        self.allow_invalid_tls
+    }
+
+    #[cfg(test)]
+    pub(crate) fn allow_private_network(&self) -> bool {
+        self.allow_private_network
+    }
 }
 
 #[async_trait]
@@ -78,6 +99,10 @@ impl McpTransport for HttpMcpTransport {
         request: &McpRequest,
         headers: &HashMap<String, String>,
     ) -> Result<McpResponse, ToolError> {
+        validate_mcp_url(&self.server_url, self.allow_private_network)
+            .await
+            .map_err(|e| ToolError::ExternalService(format!("[{}] {}", self.server_name, e)))?;
+
         // Build the HTTP request.
         let mut req_builder = self
             .http_client
@@ -398,6 +423,18 @@ mod tests {
         let transport =
             HttpMcpTransport::new("http://localhost:8080", "test").with_custom_headers(headers);
         assert_eq!(transport.custom_headers.get("X-Custom").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_new_with_network_policy_records_flags() {
+        let transport = HttpMcpTransport::new_with_network_policy(
+            "https://mcp.internal.example",
+            "test",
+            true,
+            true,
+        );
+        assert!(transport.allow_invalid_tls());
+        assert!(transport.allow_private_network());
     }
 
     // -- Wire-level echo server tests -----------------------------------------

--- a/src/tools/mcp/mod.rs
+++ b/src/tools/mcp/mod.rs
@@ -19,6 +19,7 @@
 //!     session_manager,
 //!     secrets,
 //!     "user_id",
+//!     Default::default(),
 //! );
 //!
 //! // List and register tools
@@ -33,6 +34,7 @@ mod client;
 pub mod config;
 pub mod factory;
 pub(crate) mod http_transport;
+pub(crate) mod network;
 pub(crate) mod process;
 mod protocol;
 pub mod session;
@@ -43,7 +45,7 @@ pub(crate) mod unix_transport;
 
 pub use auth::{is_authenticated, refresh_access_token};
 pub use client::McpClient;
-pub use config::{McpServerConfig, McpServersFile, OAuthConfig};
+pub use config::{McpOutboundTrustConfig, McpServerConfig, McpServersFile, OAuthConfig};
 pub use factory::{McpFactoryError, create_client_from_config};
 pub use process::McpProcessManager;
 pub use protocol::{InitializeResult, McpRequest, McpResponse, McpTool};

--- a/src/tools/mcp/network.rs
+++ b/src/tools/mcp/network.rs
@@ -6,6 +6,8 @@ use crate::security::outbound_trust::{
 };
 use crate::tools::mcp::config::{McpServerConfig, is_localhost_url};
 
+pub(crate) use crate::security::outbound_trust::is_dangerous_ip;
+
 pub(crate) fn resolve_mcp_outbound_trust_decision(
     resolver: &OutboundTrustResolver,
     server_config: &McpServerConfig,
@@ -87,32 +89,6 @@ pub(crate) async fn validate_mcp_url(url: &str, allow_private_network: bool) -> 
     }
 
     Ok(())
-}
-
-pub(crate) fn is_dangerous_ip(ip: IpAddr) -> bool {
-    match ip {
-        IpAddr::V4(v4) => {
-            v4.is_loopback()
-                || v4.is_private()
-                || v4.is_link_local()
-                || v4.is_broadcast()
-                || v4.is_unspecified()
-                || (v4.octets()[0] == 169 && v4.octets()[1] == 254)
-                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
-        }
-        IpAddr::V6(v6) => {
-            let segs = v6.segments();
-            v6.is_loopback()
-                || v6.is_unspecified()
-                || (segs[0] & 0xffc0) == 0xfe80
-                || (segs[0] & 0xffc0) == 0xfec0
-                || (segs[0] & 0xfe00) == 0xfc00
-                || (segs[0] == 0x2001 && segs[1] == 0x0db8)
-                || v6
-                    .to_ipv4_mapped()
-                    .is_some_and(|v4| is_dangerous_ip(IpAddr::V4(v4)))
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/tools/mcp/network.rs
+++ b/src/tools/mcp/network.rs
@@ -1,0 +1,185 @@
+use std::net::IpAddr;
+use std::time::Duration;
+
+use crate::security::outbound_trust::{
+    OutboundTrustDecision, OutboundTrustRequestContext, OutboundTrustResolver, OutboundTrustSurface,
+};
+use crate::tools::mcp::config::{McpServerConfig, is_localhost_url};
+
+pub(crate) fn resolve_mcp_outbound_trust_decision(
+    resolver: &OutboundTrustResolver,
+    server_config: &McpServerConfig,
+    url: &str,
+) -> OutboundTrustDecision {
+    resolver.resolve(&OutboundTrustRequestContext {
+        surface: OutboundTrustSurface::McpServer,
+        extension_name: &server_config.name,
+        url,
+        declared_policy_ids: server_config.declared_outbound_trust_policy_ids(),
+    })
+}
+
+pub(crate) fn build_mcp_http_client(allow_invalid_tls: bool) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .redirect(reqwest::redirect::Policy::none());
+
+    if allow_invalid_tls {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to create MCP HTTP client: {e}"))
+}
+
+pub(crate) async fn validate_mcp_url(url: &str, allow_private_network: bool) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url).map_err(|e| format!("Invalid URL: {e}"))?;
+
+    let scheme = parsed.scheme();
+    if scheme != "https" && scheme != "http" {
+        return Err(format!("Unsupported scheme: {scheme}"));
+    }
+
+    if scheme == "http" {
+        if !is_localhost_url(url) {
+            let host = parsed.host_str().unwrap_or("");
+            return Err(format!(
+                "HTTP is only allowed for localhost; use HTTPS for '{host}'"
+            ));
+        }
+
+        return Ok(());
+    }
+
+    if allow_private_network {
+        return Ok(());
+    }
+
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| "URL has no host".to_string())?;
+
+    if let Ok(ip) = host.parse::<IpAddr>()
+        && is_dangerous_ip(ip)
+    {
+        return Err(format!("URL points to a restricted IP address: {host}"));
+    }
+
+    if host.parse::<IpAddr>().is_err() {
+        let addr = format!("{}:{}", host, parsed.port_or_known_default().unwrap_or(443));
+        match tokio::net::lookup_host(&addr).await {
+            Ok(addrs) => {
+                for socket_addr in addrs {
+                    if is_dangerous_ip(socket_addr.ip()) {
+                        return Err(format!(
+                            "URL hostname '{}' resolves to restricted IP address: {}",
+                            host,
+                            socket_addr.ip()
+                        ));
+                    }
+                }
+            }
+            Err(e) => {
+                return Err(format!("DNS resolution failed for '{host}': {e}"));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn is_dangerous_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || (v4.octets()[0] == 169 && v4.octets()[1] == 254)
+                || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64)
+        }
+        IpAddr::V6(v6) => {
+            let segs = v6.segments();
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (segs[0] & 0xffc0) == 0xfe80
+                || (segs[0] & 0xffc0) == 0xfec0
+                || (segs[0] & 0xfe00) == 0xfc00
+                || (segs[0] == 0x2001 && segs[1] == 0x0db8)
+                || v6
+                    .to_ipv4_mapped()
+                    .is_some_and(|v4| is_dangerous_ip(IpAddr::V4(v4)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::security::outbound_trust::{
+        OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+        OutboundTrustSurface, OutboundTrustTarget,
+    };
+    use crate::testing::tls::SelfSignedHttpsServer;
+    use crate::tools::mcp::config::McpServerConfig;
+
+    #[tokio::test]
+    async fn test_outbound_trust_allows_private_self_signed_https_for_mcp_servers() {
+        let server = SelfSignedHttpsServer::start(r#"{"ok":true}"#).await;
+        let url = server.url("/api/status");
+
+        let config = McpServerConfig::new("test-mcp", &url)
+            .with_outbound_trust_policy_ids(vec!["corp-mcp".to_string()]);
+
+        let tls_err = super::build_mcp_http_client(false)
+            .expect("client")
+            .get(&url)
+            .send()
+            .await
+            .expect_err("self-signed endpoint should fail without invalid-tls trust");
+        assert!(
+            tls_err.is_request() || tls_err.is_connect() || tls_err.is_body(),
+            "expected request failure for untrusted TLS, got: {tls_err}"
+        );
+
+        let denied = super::validate_mcp_url(&url, false).await;
+        assert!(denied.is_err(), "expected private-network denial");
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-mcp".to_string(),
+                display_name: "corp-mcp".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::McpServer],
+                allowed_risks: vec![
+                    OutboundTrustRisk::AllowInvalidTls,
+                    OutboundTrustRisk::AllowPrivateNetwork,
+                ],
+                targets: vec![OutboundTrustTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: Some(server.port()),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+
+        let decision = super::resolve_mcp_outbound_trust_decision(&resolver, &config, &url);
+        assert!(decision.allow_invalid_tls);
+        assert!(decision.allow_private_network);
+
+        super::validate_mcp_url(&url, decision.allow_private_network)
+            .await
+            .expect("private-network trust should allow MCP URL");
+
+        let response = super::build_mcp_http_client(decision.allow_invalid_tls)
+            .expect("trusted client")
+            .get(&url)
+            .send()
+            .await
+            .expect("trusted request should succeed");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -11,6 +11,7 @@ use crate::extensions::ExtensionManager;
 use crate::llm::{LlmProvider, ToolDefinition};
 use crate::orchestrator::job_manager::ContainerJobManager;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::OutboundTrustConfig;
 use crate::skills::catalog::SkillCatalog;
 use crate::skills::registry::SkillRegistry;
 use crate::tools::builder::{
@@ -684,6 +685,7 @@ impl ToolRegistry {
         if let Some(oauth) = reg.oauth_refresh {
             wrapper = wrapper.with_oauth_refresh(oauth);
         }
+        wrapper = wrapper.with_outbound_trust_config(reg.outbound_trust_config);
 
         // Register the tool
         self.register(Arc::new(wrapper)).await;
@@ -728,6 +730,7 @@ impl ToolRegistry {
         runtime: &Arc<WasmToolRuntime>,
         user_id: &str,
         name: &str,
+        outbound_trust_config: OutboundTrustConfig,
     ) -> Result<(), WasmRegistrationError> {
         // Load tool with integrity verification
         let tool_with_binary = store
@@ -754,6 +757,7 @@ impl ToolRegistry {
             schema: Some(tool_with_binary.tool.parameters_schema.clone()),
             secrets_store: self.secrets_store.clone(),
             oauth_refresh: None,
+            outbound_trust_config,
         })
         .await
         .map_err(WasmRegistrationError::Wasm)?;
@@ -799,6 +803,8 @@ pub struct WasmToolRegistration<'a> {
     pub secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
     /// OAuth refresh configuration for auto-refreshing expired tokens.
     pub oauth_refresh: Option<OAuthRefreshConfig>,
+    /// Global outbound trust policy config for the wasm_tool surface.
+    pub outbound_trust_config: OutboundTrustConfig,
 }
 
 impl Default for ToolRegistry {

--- a/src/tools/wasm/capabilities.rs
+++ b/src/tools/wasm/capabilities.rs
@@ -34,6 +34,8 @@ pub struct Capabilities {
     pub secrets: Option<SecretsCapability>,
     /// Webhook authentication and signature verification.
     pub webhook: Option<WebhookCapability>,
+    /// Operator-managed outbound trust policy IDs this extension may request.
+    pub outbound_trust_policy_ids: Vec<String>,
 }
 
 impl Capabilities {
@@ -72,6 +74,17 @@ impl Capabilities {
             allowed_names: allowed,
         });
         self
+    }
+
+    /// Declare outbound trust policy IDs this tool is allowed to reference.
+    pub fn with_outbound_trust_policy_ids(mut self, policy_ids: Vec<String>) -> Self {
+        self.outbound_trust_policy_ids = policy_ids;
+        self
+    }
+
+    /// Get the declared outbound trust policy IDs for this extension.
+    pub fn declared_outbound_trust_policy_ids(&self) -> &[String] {
+        &self.outbound_trust_policy_ids
     }
 }
 

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -75,6 +75,10 @@ pub struct CapabilitiesFile {
     #[serde(default)]
     pub webhook: Option<WebhookCapabilitySchema>,
 
+    /// Outbound trust policy opt-in declaration.
+    #[serde(default)]
+    pub outbound_trust: Option<OutboundTrustCapabilitySchema>,
+
     /// Authentication setup instructions.
     /// Used by `ironclaw config` to guide users through auth setup.
     #[serde(default)]
@@ -155,6 +159,7 @@ impl CapabilitiesFile {
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);
             self.workspace = self.workspace.or(inner.workspace);
             self.webhook = self.webhook.or(inner.webhook);
+            self.outbound_trust = self.outbound_trust.or(inner.outbound_trust);
             self.auth = self.auth.or(inner.auth);
             self.setup = self.setup.or(inner.setup);
         }
@@ -250,8 +255,20 @@ impl CapabilitiesFile {
             caps.webhook = Some(webhook.to_webhook_capability());
         }
 
+        if let Some(outbound_trust) = &self.outbound_trust {
+            caps.outbound_trust_policy_ids = outbound_trust.allowed_policy_ids.clone();
+        }
+
         caps
     }
+}
+
+/// Outbound trust policy opt-in schema.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OutboundTrustCapabilitySchema {
+    /// Operator-managed policy IDs this extension may reference.
+    #[serde(default)]
+    pub allowed_policy_ids: Vec<String>,
 }
 
 /// HTTP capability schema.
@@ -774,6 +791,23 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_outbound_trust_allowed_policy_ids() {
+        let json = r#"{
+            "outbound_trust": {
+                "allowed_policy_ids": ["corp-internal-api", "corp-shared-gateway"]
+            }
+        }"#;
+
+        let file = CapabilitiesFile::from_json(json).unwrap();
+        let caps = file.to_capabilities();
+
+        assert_eq!(
+            caps.declared_outbound_trust_policy_ids(),
+            ["corp-internal-api", "corp-shared-gateway"]
+        );
+    }
+
+    #[test]
     fn test_parse_credentials() {
         let json = r#"{
             "http": {
@@ -949,6 +983,14 @@ mod tests {
         assert!(caps.secrets.is_some());
         let secrets = caps.secrets.unwrap();
         assert!(secrets.is_allowed("slack_token"));
+    }
+
+    #[test]
+    fn test_outbound_trust_defaults_to_empty_policy_ids() {
+        let file = CapabilitiesFile::from_json("{}").unwrap();
+        let caps = file.to_capabilities();
+
+        assert!(caps.declared_outbound_trust_policy_ids().is_empty());
     }
 
     #[test]

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -40,6 +40,7 @@ use std::sync::Arc;
 use tokio::fs;
 
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::OutboundTrustConfig;
 use crate::tools::registry::{ToolRegistry, WasmRegistrationError, WasmToolRegistration};
 use crate::tools::wasm::capabilities_schema::CapabilitiesFile;
 use crate::tools::wasm::{
@@ -82,6 +83,7 @@ pub struct WasmToolLoader {
     runtime: Arc<WasmToolRuntime>,
     registry: Arc<ToolRegistry>,
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
+    outbound_trust_config: OutboundTrustConfig,
 }
 
 impl WasmToolLoader {
@@ -91,12 +93,19 @@ impl WasmToolLoader {
             runtime,
             registry,
             secrets_store: None,
+            outbound_trust_config: OutboundTrustConfig::default(),
         }
     }
 
     /// Set the secrets store for credential injection in WASM tools.
     pub fn with_secrets_store(mut self, store: Arc<dyn SecretsStore + Send + Sync>) -> Self {
         self.secrets_store = Some(store);
+        self
+    }
+
+    /// Set the outbound trust policy config for WASM tool execution.
+    pub fn with_outbound_trust_config(mut self, config: OutboundTrustConfig) -> Self {
+        self.outbound_trust_config = config;
         self
     }
 
@@ -181,6 +190,7 @@ impl WasmToolLoader {
                 schema: None,
                 secrets_store: self.secrets_store.clone(),
                 oauth_refresh,
+                outbound_trust_config: self.outbound_trust_config.clone(),
             })
             .await?;
 
@@ -304,7 +314,13 @@ impl WasmToolLoader {
         tool_name: &str,
     ) -> Result<(), WasmLoadError> {
         self.registry
-            .register_wasm_from_storage(store, &self.runtime, user_id, tool_name)
+            .register_wasm_from_storage(
+                store,
+                &self.runtime,
+                user_id,
+                tool_name,
+                self.outbound_trust_config.clone(),
+            )
             .await?;
 
         tracing::info!(

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -20,6 +20,10 @@ use crate::context::JobContext;
 use crate::llm::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 use crate::safety::LeakDetector;
 use crate::secrets::SecretsStore;
+use crate::security::outbound_trust::{
+    OutboundTrustConfig, OutboundTrustDecision, OutboundTrustRequestContext, OutboundTrustResolver,
+    OutboundTrustSurface,
+};
 use crate::tools::tool::{Tool, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
 use crate::tools::wasm::credential_injector::{
@@ -89,6 +93,8 @@ struct ResolvedHostCredential {
 struct StoreData {
     limiter: WasmResourceLimiter,
     host_state: HostState,
+    extension_name: String,
+    outbound_trust_resolver: Arc<OutboundTrustResolver>,
     wasi: WasiCtx,
     table: ResourceTable,
     /// Injected credentials for URL/header placeholder substitution.
@@ -108,7 +114,9 @@ struct StoreData {
 impl StoreData {
     fn new(
         memory_limit: u64,
+        extension_name: impl Into<String>,
         capabilities: Capabilities,
+        outbound_trust_resolver: Arc<OutboundTrustResolver>,
         credentials: HashMap<String, String>,
         host_credentials: Vec<ResolvedHostCredential>,
     ) -> Self {
@@ -118,6 +126,8 @@ impl StoreData {
         Self {
             limiter: WasmResourceLimiter::new(memory_limit),
             host_state: HostState::new(capabilities),
+            extension_name: extension_name.into(),
+            outbound_trust_resolver,
             wasi,
             table: ResourceTable::new(),
             credentials,
@@ -332,8 +342,16 @@ impl near::agent::host::Host for StoreData {
             .map(|h| h.max_response_bytes)
             .unwrap_or(10 * 1024 * 1024);
 
-        // Resolve hostname and reject private/internal IPs to prevent DNS rebinding.
-        reject_private_ip(&url)?;
+        let outbound_trust = resolve_http_outbound_trust_decision(
+            &self.outbound_trust_resolver,
+            self.host_state.capabilities(),
+            &self.extension_name,
+            &url,
+        );
+
+        // Resolve hostname and reject private/internal IPs unless a matching
+        // outbound trust policy explicitly allows private network access.
+        enforce_private_network_policy(&url, outbound_trust.allow_private_network)?;
 
         // Make HTTP request using a dedicated single-threaded runtime.
         // We're inside spawn_blocking, so we can't rely on the main runtime's
@@ -403,11 +421,7 @@ impl near::agent::host::Host for StoreData {
         });
 
         let result = rt.block_on(async {
-            let client = reqwest::Client::builder()
-                .connect_timeout(Duration::from_secs(10))
-                .redirect(reqwest::redirect::Policy::none())
-                .build()
-                .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+            let client = build_wasm_http_client(outbound_trust.allow_invalid_tls)?;
 
             let mut request = match method.to_uppercase().as_str() {
                 "GET" => client.get(&url),
@@ -579,6 +593,8 @@ pub struct WasmToolWrapper {
     secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
     /// OAuth refresh configuration for auto-refreshing expired tokens.
     oauth_refresh: Option<OAuthRefreshConfig>,
+    /// Shared outbound trust policy resolver for this tool surface.
+    outbound_trust_resolver: Arc<OutboundTrustResolver>,
     /// Optional HTTP interceptor for testing — returns canned responses
     /// instead of making real requests when set.
     http_interceptor: Option<Arc<dyn HttpInterceptor>>,
@@ -811,6 +827,7 @@ impl WasmToolWrapper {
             credentials: HashMap::new(),
             secrets_store: None,
             oauth_refresh: None,
+            outbound_trust_resolver: Arc::new(OutboundTrustResolver::default()),
             http_interceptor: None,
         }
     }
@@ -876,6 +893,12 @@ impl WasmToolWrapper {
         self
     }
 
+    /// Set the outbound trust policy config for this tool surface.
+    pub fn with_outbound_trust_config(mut self, config: OutboundTrustConfig) -> Self {
+        self.outbound_trust_resolver = Arc::new(OutboundTrustResolver::new(config));
+        self
+    }
+
     /// Get the resource limits for this tool.
     pub fn limits(&self) -> &ResourceLimits {
         &self.prepared.limits
@@ -911,7 +934,9 @@ impl WasmToolWrapper {
         // Create store with fresh state (NEAR pattern: fresh instance per call)
         let mut store_data = StoreData::new(
             limits.memory_bytes,
+            self.prepared.name.clone(),
             self.capabilities.clone(),
+            Arc::clone(&self.outbound_trust_resolver),
             self.credentials.clone(),
             host_credentials,
         );
@@ -1010,7 +1035,9 @@ pub(super) fn extract_wasm_metadata(
 ) -> Result<(String, serde_json::Value), WasmError> {
     let store_data = StoreData::new(
         limits.memory_bytes,
+        "metadata_extract",
         Capabilities::default(),
+        Arc::new(OutboundTrustResolver::default()),
         HashMap::new(),
         vec![],
     );
@@ -1119,6 +1146,7 @@ impl Tool for WasmToolWrapper {
         let description = self.description.clone();
         let schemas = self.schemas.clone();
         let credentials = self.credentials.clone();
+        let outbound_trust_resolver = Arc::clone(&self.outbound_trust_resolver);
 
         // Execute in blocking task with timeout
         let result = tokio::time::timeout(timeout, async move {
@@ -1131,6 +1159,7 @@ impl Tool for WasmToolWrapper {
                 credentials,
                 secrets_store: None, // Not needed in blocking task
                 oauth_refresh: None, // Already used above for pre-refresh
+                outbound_trust_resolver,
                 http_interceptor: self.http_interceptor.clone(),
             };
 
@@ -1497,6 +1526,42 @@ fn extract_host_from_url(url: &str) -> Option<String> {
             .unwrap_or(h)
             .to_lowercase()
     })
+}
+
+fn resolve_http_outbound_trust_decision(
+    resolver: &OutboundTrustResolver,
+    capabilities: &Capabilities,
+    extension_name: &str,
+    url: &str,
+) -> OutboundTrustDecision {
+    resolver.resolve(&OutboundTrustRequestContext {
+        surface: OutboundTrustSurface::WasmTool,
+        extension_name,
+        url,
+        declared_policy_ids: capabilities.declared_outbound_trust_policy_ids(),
+    })
+}
+
+fn enforce_private_network_policy(url: &str, allow_private_network: bool) -> Result<(), String> {
+    if allow_private_network {
+        Ok(())
+    } else {
+        reject_private_ip(url)
+    }
+}
+
+fn build_wasm_http_client(allow_invalid_tls: bool) -> Result<reqwest::Client, String> {
+    let mut builder = reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .redirect(reqwest::redirect::Policy::none());
+
+    if allow_invalid_tls {
+        builder = builder.danger_accept_invalid_certs(true);
+    }
+
+    builder
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))
 }
 
 /// Resolve the URL's hostname and reject connections to private/internal IP addresses.
@@ -1996,7 +2061,9 @@ mod tests {
 
         let store_data = StoreData::new(
             1024 * 1024,
+            "test-tool",
             Capabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             HashMap::new(),
             host_credentials,
         );
@@ -2035,7 +2102,9 @@ mod tests {
 
         let store_data = StoreData::new(
             1024 * 1024,
+            "test-tool",
             Capabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             HashMap::new(),
             host_credentials,
         );
@@ -2061,7 +2130,9 @@ mod tests {
 
         let store_data = StoreData::new(
             1024 * 1024,
+            "test-tool",
             Capabilities::default(),
+            Arc::new(crate::security::outbound_trust::OutboundTrustResolver::default()),
             HashMap::new(),
             host_credentials,
         );
@@ -2492,6 +2563,201 @@ mod tests {
         // 8.8.8.8 (Google DNS) is public
         let result = super::reject_private_ip("https://8.8.8.8/dns-query");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_resolve_http_outbound_trust_default_denies_exceptions() {
+        use crate::security::outbound_trust::OutboundTrustResolver;
+
+        let decision = super::resolve_http_outbound_trust_decision(
+            &OutboundTrustResolver::default(),
+            &Capabilities::default(),
+            "internal_tool",
+            "https://10.42.0.15/api/status",
+        );
+
+        assert_eq!(decision.matched_policy_id, None);
+        assert!(!decision.allow_invalid_tls);
+        assert!(!decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_resolve_http_outbound_trust_policy_can_enable_private_network() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-internal-api".to_string(),
+                display_name: "corp-internal-api".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmTool],
+                allowed_risks: vec![OutboundTrustRisk::AllowPrivateNetwork],
+                targets: vec![OutboundTrustTarget {
+                    host: "10.42.0.15".to_string(),
+                    port: Some(443),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+        let capabilities = Capabilities::default()
+            .with_outbound_trust_policy_ids(vec!["corp-internal-api".to_string()]);
+
+        let decision = super::resolve_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "internal_tool",
+            "https://10.42.0.15/api/status",
+        );
+
+        assert_eq!(
+            decision.matched_policy_id.as_deref(),
+            Some("corp-internal-api")
+        );
+        assert!(!decision.allow_invalid_tls);
+        assert!(decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_resolve_http_outbound_trust_policy_can_enable_invalid_tls() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-internal-api".to_string(),
+                display_name: "corp-internal-api".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmTool],
+                allowed_risks: vec![OutboundTrustRisk::AllowInvalidTls],
+                targets: vec![OutboundTrustTarget {
+                    host: "internal-api.example.test".to_string(),
+                    port: Some(443),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+        let capabilities = Capabilities::default()
+            .with_outbound_trust_policy_ids(vec!["corp-internal-api".to_string()]);
+
+        let decision = super::resolve_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "internal_tool",
+            "https://internal-api.example.test/api/status",
+        );
+
+        assert_eq!(
+            decision.matched_policy_id.as_deref(),
+            Some("corp-internal-api")
+        );
+        assert!(decision.allow_invalid_tls);
+        assert!(!decision.allow_private_network);
+    }
+
+    #[test]
+    fn test_enforce_private_network_policy_respects_outbound_trust() {
+        let denied = super::enforce_private_network_policy("https://127.0.0.1:8443/api", false);
+        assert!(denied.is_err());
+
+        let allowed = super::enforce_private_network_policy("https://127.0.0.1:8443/api", true);
+        assert!(allowed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_outbound_trust_allows_private_self_signed_https_for_wasm_tools() {
+        use crate::security::outbound_trust::{
+            OutboundTrustConfig, OutboundTrustPolicy, OutboundTrustResolver, OutboundTrustRisk,
+            OutboundTrustSurface, OutboundTrustTarget,
+        };
+        use crate::testing::tls::SelfSignedHttpsServer;
+
+        let server = SelfSignedHttpsServer::start(r#"{"ok":true}"#).await;
+        let url = server.url("/api/status");
+
+        let tls_err = super::build_wasm_http_client(false)
+            .expect("client")
+            .get(&url)
+            .send()
+            .await
+            .expect_err("self-signed endpoint should fail without invalid-tls trust");
+        assert!(
+            tls_err.is_request() || tls_err.is_connect() || tls_err.is_body(),
+            "expected request failure for untrusted TLS, got: {tls_err}"
+        );
+
+        let denied = super::enforce_private_network_policy(&url, false);
+        assert!(denied.is_err(), "expected private-network denial");
+
+        let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+            enabled: true,
+            policies: vec![OutboundTrustPolicy {
+                id: "corp-lab".to_string(),
+                display_name: "corp-lab".to_string(),
+                description: None,
+                enabled: true,
+                allowed_surfaces: vec![OutboundTrustSurface::WasmTool],
+                allowed_risks: vec![
+                    OutboundTrustRisk::AllowInvalidTls,
+                    OutboundTrustRisk::AllowPrivateNetwork,
+                ],
+                targets: vec![OutboundTrustTarget {
+                    host: "127.0.0.1".to_string(),
+                    port: Some(server.port()),
+                    path_prefix: Some("/api".to_string()),
+                }],
+            }],
+        });
+        let capabilities =
+            Capabilities::default().with_outbound_trust_policy_ids(vec!["corp-lab".to_string()]);
+
+        let decision = super::resolve_http_outbound_trust_decision(
+            &resolver,
+            &capabilities,
+            "test-tool",
+            &url,
+        );
+        assert!(decision.allow_invalid_tls);
+        assert!(decision.allow_private_network);
+
+        super::enforce_private_network_policy(&url, decision.allow_private_network)
+            .expect("private-network trust should allow request");
+
+        let response = super::build_wasm_http_client(decision.allow_invalid_tls)
+            .expect("trusted client")
+            .get(&url)
+            .send()
+            .await
+            .expect("trusted request should succeed");
+        assert_eq!(response.status(), reqwest::StatusCode::OK);
+    }
+
+    #[test]
+    fn test_outbound_trust_does_not_expand_http_allowlist() {
+        use crate::tools::wasm::EndpointPattern;
+        use crate::tools::wasm::HostState;
+        use crate::tools::wasm::HttpCapability;
+
+        let caps = Capabilities {
+            http: Some(HttpCapability {
+                allowlist: vec![EndpointPattern::host("api.example.com")],
+                ..Default::default()
+            }),
+            outbound_trust_policy_ids: vec!["corp-internal-api".to_string()],
+            ..Default::default()
+        };
+        let host_state = HostState::new(caps);
+
+        let result = host_state.check_http_allowed("https://10.42.0.15/api/status", "GET");
+        assert!(result.is_err());
     }
 
     #[tokio::test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -22,7 +22,7 @@ use crate::safety::LeakDetector;
 use crate::secrets::SecretsStore;
 use crate::security::outbound_trust::{
     OutboundTrustConfig, OutboundTrustDecision, OutboundTrustRequestContext, OutboundTrustResolver,
-    OutboundTrustSurface,
+    OutboundTrustSurface, is_dangerous_ip,
 };
 use crate::tools::tool::{Tool, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
@@ -1567,6 +1567,7 @@ fn build_wasm_http_client(allow_invalid_tls: bool) -> Result<reqwest::Client, St
 /// Resolve the URL's hostname and reject connections to private/internal IP addresses.
 /// This prevents DNS rebinding attacks where an attacker's domain resolves to an
 /// internal IP after passing the allowlist check.
+/// Performs blocking DNS resolution and must only run on a blocking thread.
 fn reject_private_ip(url: &str) -> Result<(), String> {
     let parsed = url::Url::parse(url).map_err(|e| format!("Failed to parse URL: {e}"))?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -1587,7 +1588,7 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
 
     // If the host is already an IP, check it directly
     if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return if is_private_ip(ip) {
+        return if is_dangerous_ip(ip) {
             Err(format!(
                 "HTTP request to private/internal IP {} is not allowed",
                 ip
@@ -1611,7 +1612,7 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
     }
 
     for addr in &addrs {
-        if is_private_ip(addr.ip()) {
+        if is_dangerous_ip(addr.ip()) {
             return Err(format!(
                 "DNS rebinding detected: {} resolved to private IP {}",
                 host,
@@ -1621,27 +1622,6 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
     }
 
     Ok(())
-}
-
-/// Check if an IP address belongs to a private/internal range.
-fn is_private_ip(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            v4.is_loopback()           // 127.0.0.0/8
-            || v4.is_private()         // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-            || v4.is_link_local()      // 169.254.0.0/16
-            || v4.is_unspecified()     // 0.0.0.0
-            || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
-        }
-        std::net::IpAddr::V6(v6) => {
-            v6.is_loopback()           // ::1
-            || v6.is_unspecified()     // ::
-            // fc00::/7 (unique local)
-            || (v6.segments()[0] & 0xFE00) == 0xFC00
-            // fe80::/10 (link-local)
-            || (v6.segments()[0] & 0xFFC0) == 0xFE80
-        }
-    }
 }
 
 fn schema_contains_container_properties(schema: &serde_json::Value) -> bool {
@@ -2503,44 +2483,55 @@ mod tests {
     }
 
     #[test]
-    fn test_is_private_ip_v4() {
+    fn test_is_dangerous_ip_v4() {
         use std::net::IpAddr;
         // Private ranges
-        assert!(super::is_private_ip("127.0.0.1".parse::<IpAddr>().unwrap()));
-        assert!(super::is_private_ip("10.0.0.1".parse::<IpAddr>().unwrap()));
-        assert!(super::is_private_ip(
+        assert!(super::is_dangerous_ip(
+            "127.0.0.1".parse::<IpAddr>().unwrap()
+        ));
+        assert!(super::is_dangerous_ip(
+            "10.0.0.1".parse::<IpAddr>().unwrap()
+        ));
+        assert!(super::is_dangerous_ip(
             "172.16.0.1".parse::<IpAddr>().unwrap()
         ));
-        assert!(super::is_private_ip(
+        assert!(super::is_dangerous_ip(
             "192.168.1.1".parse::<IpAddr>().unwrap()
         ));
-        assert!(super::is_private_ip(
+        assert!(super::is_dangerous_ip(
             "169.254.1.1".parse::<IpAddr>().unwrap()
         ));
-        assert!(super::is_private_ip("0.0.0.0".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip("0.0.0.0".parse::<IpAddr>().unwrap()));
         // CGNAT
-        assert!(super::is_private_ip(
+        assert!(super::is_dangerous_ip(
             "100.64.0.1".parse::<IpAddr>().unwrap()
         ));
 
         // Public IPs
-        assert!(!super::is_private_ip("8.8.8.8".parse::<IpAddr>().unwrap()));
-        assert!(!super::is_private_ip("1.1.1.1".parse::<IpAddr>().unwrap()));
-        assert!(!super::is_private_ip(
+        assert!(!super::is_dangerous_ip(
+            "8.8.8.8".parse::<IpAddr>().unwrap()
+        ));
+        assert!(!super::is_dangerous_ip(
+            "1.1.1.1".parse::<IpAddr>().unwrap()
+        ));
+        assert!(!super::is_dangerous_ip(
             "93.184.216.34".parse::<IpAddr>().unwrap()
         ));
     }
 
     #[test]
-    fn test_is_private_ip_v6() {
+    fn test_is_dangerous_ip_v6() {
         use std::net::IpAddr;
-        assert!(super::is_private_ip("::1".parse::<IpAddr>().unwrap()));
-        assert!(super::is_private_ip("::".parse::<IpAddr>().unwrap()));
-        assert!(super::is_private_ip("fc00::1".parse::<IpAddr>().unwrap()));
-        assert!(super::is_private_ip("fe80::1".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip("::1".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip("::".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip("fc00::1".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip("fe80::1".parse::<IpAddr>().unwrap()));
+        assert!(super::is_dangerous_ip(
+            "::ffff:10.0.0.1".parse::<IpAddr>().unwrap()
+        ));
 
         // Public
-        assert!(!super::is_private_ip(
+        assert!(!super::is_dangerous_ip(
             "2606:4700::1111".parse::<IpAddr>().unwrap()
         ));
     }
@@ -2555,6 +2546,12 @@ mod tests {
     #[test]
     fn test_reject_private_ip_internal() {
         let result = super::reject_private_ip("https://192.168.1.1/admin");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_reject_private_ip_ipv4_mapped_v6_internal() {
+        let result = super::reject_private_ip("https://[::ffff:10.0.0.1]/admin");
         assert!(result.is_err());
     }
 

--- a/tests/outbound_trust_resolver.rs
+++ b/tests/outbound_trust_resolver.rs
@@ -1,0 +1,200 @@
+use ironclaw::security::outbound_trust::{
+    OutboundTrustConfig, OutboundTrustDecision, OutboundTrustPolicy, OutboundTrustRequestContext,
+    OutboundTrustResolver, OutboundTrustRisk, OutboundTrustSurface, OutboundTrustTarget,
+};
+
+fn decision(
+    resolver: &OutboundTrustResolver,
+    surface: OutboundTrustSurface,
+    extension_name: &str,
+    url: &str,
+    declared_policy_ids: &[String],
+) -> OutboundTrustDecision {
+    resolver.resolve(&OutboundTrustRequestContext {
+        surface,
+        extension_name,
+        url,
+        declared_policy_ids,
+    })
+}
+
+fn policy(
+    id: &str,
+    surfaces: Vec<OutboundTrustSurface>,
+    risks: Vec<OutboundTrustRisk>,
+    targets: Vec<OutboundTrustTarget>,
+) -> OutboundTrustPolicy {
+    OutboundTrustPolicy {
+        id: id.to_string(),
+        display_name: "test".to_string(),
+        description: Some("test policy".to_string()),
+        enabled: true,
+        allowed_surfaces: surfaces,
+        allowed_risks: risks,
+        targets,
+    }
+}
+
+fn target(host: &str) -> OutboundTrustTarget {
+    OutboundTrustTarget {
+        host: host.to_string(),
+        port: None,
+        path_prefix: None,
+    }
+}
+
+#[test]
+fn matches_exact_host_and_declared_policy() {
+    let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+        enabled: true,
+        policies: vec![policy(
+            "corp-internal-api",
+            vec![OutboundTrustSurface::WasmTool],
+            vec![OutboundTrustRisk::AllowInvalidTls],
+            vec![target("internal-api.example.test")],
+        )],
+    });
+
+    let result = decision(
+        &resolver,
+        OutboundTrustSurface::WasmTool,
+        "internal_tool",
+        "https://internal-api.example.test/api/status",
+        &["corp-internal-api".to_string()],
+    );
+
+    assert_eq!(
+        result.matched_policy_id.as_deref(),
+        Some("corp-internal-api")
+    );
+    assert!(result.allow_invalid_tls);
+    assert!(!result.allow_private_network);
+}
+
+#[test]
+fn requires_declared_policy_id_even_when_target_matches() {
+    let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+        enabled: true,
+        policies: vec![policy(
+            "corp-internal-api",
+            vec![OutboundTrustSurface::WasmTool],
+            vec![OutboundTrustRisk::AllowInvalidTls],
+            vec![target("internal-api.example.test")],
+        )],
+    });
+
+    let result = decision(
+        &resolver,
+        OutboundTrustSurface::WasmTool,
+        "internal_tool",
+        "https://internal-api.example.test/api/status",
+        &[],
+    );
+
+    assert_eq!(result.matched_policy_id, None);
+    assert!(!result.allow_invalid_tls);
+    assert!(!result.allow_private_network);
+}
+
+#[test]
+fn respects_surface_target_port_and_path_prefix() {
+    let resolver = OutboundTrustResolver::new(OutboundTrustConfig {
+        enabled: true,
+        policies: vec![OutboundTrustPolicy {
+            id: "corp-mcp".to_string(),
+            display_name: "corp-mcp".to_string(),
+            description: None,
+            enabled: true,
+            allowed_surfaces: vec![OutboundTrustSurface::McpServer],
+            allowed_risks: vec![OutboundTrustRisk::AllowPrivateNetwork],
+            targets: vec![OutboundTrustTarget {
+                host: "10.0.0.25".to_string(),
+                port: Some(8443),
+                path_prefix: Some("/rpc".to_string()),
+            }],
+        }],
+    });
+
+    let allowed = decision(
+        &resolver,
+        OutboundTrustSurface::McpServer,
+        "corp-gateway",
+        "https://10.0.0.25:8443/rpc/tools/list",
+        &["corp-mcp".to_string()],
+    );
+    assert_eq!(allowed.matched_policy_id.as_deref(), Some("corp-mcp"));
+    assert!(!allowed.allow_invalid_tls);
+    assert!(allowed.allow_private_network);
+
+    let wrong_surface = decision(
+        &resolver,
+        OutboundTrustSurface::WasmChannel,
+        "corp-gateway",
+        "https://10.0.0.25:8443/rpc/tools/list",
+        &["corp-mcp".to_string()],
+    );
+    assert_eq!(wrong_surface.matched_policy_id, None);
+
+    let wrong_port = decision(
+        &resolver,
+        OutboundTrustSurface::McpServer,
+        "corp-gateway",
+        "https://10.0.0.25:443/rpc/tools/list",
+        &["corp-mcp".to_string()],
+    );
+    assert_eq!(wrong_port.matched_policy_id, None);
+
+    let wrong_path = decision(
+        &resolver,
+        OutboundTrustSurface::McpServer,
+        "corp-gateway",
+        "https://10.0.0.25:8443/other",
+        &["corp-mcp".to_string()],
+    );
+    assert_eq!(wrong_path.matched_policy_id, None);
+}
+
+#[test]
+fn disabled_config_or_policy_grants_no_exceptions() {
+    let disabled_globally = OutboundTrustResolver::new(OutboundTrustConfig {
+        enabled: false,
+        policies: vec![policy(
+            "corp-internal-api",
+            vec![OutboundTrustSurface::WasmTool],
+            vec![
+                OutboundTrustRisk::AllowInvalidTls,
+                OutboundTrustRisk::AllowPrivateNetwork,
+            ],
+            vec![target("10.42.0.15")],
+        )],
+    });
+    let global_result = decision(
+        &disabled_globally,
+        OutboundTrustSurface::WasmTool,
+        "internal_tool",
+        "https://10.42.0.15/api/status",
+        &["corp-internal-api".to_string()],
+    );
+    assert_eq!(global_result.matched_policy_id, None);
+
+    let disabled_policy = OutboundTrustResolver::new(OutboundTrustConfig {
+        enabled: true,
+        policies: vec![OutboundTrustPolicy {
+            enabled: false,
+            ..policy(
+                "corp-internal-api",
+                vec![OutboundTrustSurface::WasmTool],
+                vec![OutboundTrustRisk::AllowPrivateNetwork],
+                vec![target("10.42.0.15")],
+            )
+        }],
+    });
+    let policy_result = decision(
+        &disabled_policy,
+        OutboundTrustSurface::WasmTool,
+        "internal_tool",
+        "https://10.42.0.15/api/status",
+        &["corp-internal-api".to_string()],
+    );
+    assert_eq!(policy_result.matched_policy_id, None);
+}


### PR DESCRIPTION
## Summary

Adds an operator-managed outbound trust policy system for narrowly scoped HTTPS exceptions on extension-style outbound surfaces.

This change:
- adds a shared `outbound_trust` policy model under `settings.security`
- requires dual opt-in before any exception is granted:
  - operator config must define a matching policy
  - the consuming WASM tool, WASM channel, or MCP server must explicitly declare the allowed policy id
- supports two explicit risk flags:
  - `allow_invalid_tls`
  - `allow_private_network`
- wires the shared resolver into:
  - WASM tool HTTP
  - WASM channel HTTP
  - MCP HTTP transport and MCP OAuth/discovery HTTP flows
- keeps existing defaults unchanged:
  - HTTPS remains required for remote MCP
  - plain HTTP remains limited to localhost development targets
  - private/internal network targets remain blocked by default
  - invalid TLS certificates remain rejected by default
- adds focused tests, including self-signed HTTPS integration coverage for WASM tools, WASM channels, and MCP servers

## Why

IronClaw already has strong outbound network defaults, but operators still need a manageable way to allow a small set of internal HTTPS integrations that use private network targets or private CA / self-signed certificates.

This PR adds that capability without introducing a global bypass. Exceptions remain:
- operator-managed
- surface-scoped
- target-scoped
- risk-scoped
- extension/server-declared

## Design Notes

Policies are matched by exact host, optional port, and optional path prefix.

A request only gets an exception when all of the following are true:
- outbound trust is globally enabled
- a matching policy exists
- the policy is enabled
- the policy allows the current surface
- the request target matches the policy target tuple
- the extension/server declared that policy id in its own capabilities/config

This keeps policy ownership with the operator while preventing arbitrary extension code from inheriting broad trust exceptions.

## Test Plan

- [x] `cargo fmt --all --check`
- [x] `cargo test outbound_trust --lib -- --nocapture`
- [x] `cargo test --test outbound_trust_resolver -- --nocapture`
- [x] `cargo clippy --all --tests --all-features -- -D warnings`
