### PR TITLE
fix(wasm): avoid persisting dedup before message delivery succeeds

### DIFF
--- a/src/channels/wasm/error.rs
+++ b/src/channels/wasm/error.rs
@@ -83,6 +83,16 @@ pub enum WasmChannelError {
 
     #[error("WIT version mismatch: {0}")]
     IncompatibleWitVersion(String),
+
+    #[error("Channel {name} failed to send message to agent queue (timeout={timeout_secs}s, emitted={emitted_count})")]
+    SendTimeout {
+        name: String,
+        timeout_secs: u64,
+        emitted_count: usize,
+    },
+
+    #[error("Channel {name} agent message channel is closed (permanent)")]
+    ChannelClosed { name: String },
 }
 
 impl From<crate::tools::wasm::WasmError> for WasmChannelError {

--- a/src/channels/wasm/host.rs
+++ b/src/channels/wasm/host.rs
@@ -6,7 +6,7 @@
 //! - Rate limiting for message emission
 
 use std::collections::HashMap;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use crate::channels::wasm::capabilities::{ChannelCapabilities, EmitRateLimitConfig};
 use crate::channels::wasm::error::WasmChannelError;
@@ -502,6 +502,43 @@ impl ChannelHostState {
     }
 }
 
+/// Path infix that identifies dedup workspace keys.
+///
+/// WASM channels write event dedup keys under `state/dedup/<event_id>`.
+/// After the channel namespace prefix is applied the full path looks like
+/// `channels/<name>/state/dedup/<event_id>`.  We detect dedup writes by
+/// scanning for this infix so the dedup lifecycle can be tracked separately
+/// from ordinary workspace KV state.
+pub const DEDUP_PATH_INFIX: &str = "/state/dedup/";
+
+/// A Pending dedup entry expires after this many seconds if delivery never
+/// completes (e.g. process crash after commit but before promote).  Once
+/// expired the same event_id is allowed to be re-processed.
+const DEDUP_PENDING_TTL: Duration = Duration::from_secs(60);
+
+/// A Delivered dedup entry is kept for this long as the idempotency window.
+/// Webhook retries typically occur within ~30 minutes; 24 h is a safe margin.
+const DEDUP_DELIVERED_TTL: Duration = Duration::from_secs(24 * 3600);
+
+/// Lifecycle stage of a dedup entry.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum DedupStatus {
+    /// WASM callback committed the key but message delivery has not yet been
+    /// confirmed.  Treated as duplicate by concurrent requests to prevent
+    /// double-processing.  Expires after `DEDUP_PENDING_TTL` so a crash does
+    /// not permanently block future retries.
+    Pending,
+    /// Message was successfully delivered to the agent queue.  Treated as
+    /// duplicate for the full `DEDUP_DELIVERED_TTL` idempotency window.
+    Delivered,
+}
+
+#[derive(Debug, Clone)]
+struct DedupEntry {
+    status: DedupStatus,
+    created_at: Instant,
+}
+
 /// In-memory workspace store for WASM channels.
 ///
 /// Persists workspace writes across callback invocations within a single
@@ -511,8 +548,17 @@ impl ChannelHostState {
 ///
 /// Uses `std::sync::RwLock` (not tokio) because WASM execution runs
 /// inside `spawn_blocking`.
+///
+/// # Dedup sub-store
+///
+/// Writes to paths matching `*/state/dedup/*` are diverted from the plain
+/// KV `data` map into a separate `dedup` map that tracks a two-stage
+/// lifecycle: **Pending → Delivered**.  Reads for the same paths consult the
+/// dedup map with TTL logic so stale Pending entries do not permanently block
+/// retries after a crash.
 pub struct ChannelWorkspaceStore {
     data: std::sync::RwLock<std::collections::HashMap<String, String>>,
+    dedup: std::sync::RwLock<std::collections::HashMap<String, DedupEntry>>,
 }
 
 impl ChannelWorkspaceStore {
@@ -520,22 +566,61 @@ impl ChannelWorkspaceStore {
     pub fn new() -> Self {
         Self {
             data: std::sync::RwLock::new(std::collections::HashMap::new()),
+            dedup: std::sync::RwLock::new(std::collections::HashMap::new()),
         }
     }
 
+    /// Returns true if `path` is a dedup key (contains the dedup infix).
+    fn is_dedup_path(path: &str) -> bool {
+        path.contains(DEDUP_PATH_INFIX)
+    }
+
     /// Commit pending writes from a callback execution into the store.
+    ///
+    /// Writes whose path contains the dedup infix are stored as **Pending**
+    /// entries in the dedup sub-store rather than in the plain KV map.
+    /// Call [`promote_pending_to_delivered`] immediately after this to advance
+    /// them to **Delivered** once you have confirmed successful message
+    /// delivery.
+    ///
+    /// Also opportunistically evicts expired dedup entries.
     pub fn commit_writes(&self, writes: &[PendingWorkspaceWrite]) {
         if writes.is_empty() {
             return;
         }
+
+        self.cleanup_expired_dedup();
+
+        // Acquire locks separately so a poisoned dedup lock never silently
+        // drops ordinary KV writes that have nothing to do with dedup.
         if let Ok(mut data) = self.data.write() {
             for write in writes {
-                tracing::debug!(
-                    path = %write.path,
-                    content_len = write.content.len(),
-                    "Committing workspace write to channel store"
-                );
-                data.insert(write.path.clone(), write.content.clone());
+                if !Self::is_dedup_path(&write.path) {
+                    tracing::debug!(
+                        path = %write.path,
+                        content_len = write.content.len(),
+                        "Committing workspace write to channel store"
+                    );
+                    data.insert(write.path.clone(), write.content.clone());
+                }
+            }
+        }
+
+        if let Ok(mut dedup) = self.dedup.write() {
+            for write in writes {
+                if Self::is_dedup_path(&write.path) {
+                    tracing::debug!(
+                        path = %write.path,
+                        "Registering dedup key as Pending"
+                    );
+                    // Only insert if not already Delivered — a second webhook
+                    // arriving after a successful delivery must not downgrade
+                    // the status.
+                    dedup.entry(write.path.clone()).or_insert_with(|| DedupEntry {
+                        status: DedupStatus::Pending,
+                        created_at: Instant::now(),
+                    });
+                }
             }
         }
     }
@@ -598,10 +683,72 @@ impl ChannelWorkspaceStore {
         data.insert(dest_path.to_string(), raw_queue);
         Ok(true)
     }
+
+    /// Promote any dedup entries found in `writes` from **Pending** to
+    /// **Delivered**.
+    ///
+    /// Call this immediately after [`commit_writes`] once message delivery to
+    /// the agent queue has been confirmed.  Only keys whose current status is
+    /// `Pending` are updated; already-Delivered keys are left unchanged.
+    pub fn promote_pending_to_delivered(&self, writes: &[PendingWorkspaceWrite]) {
+        if writes.is_empty() {
+            return;
+        }
+        if let Ok(mut dedup) = self.dedup.write() {
+            for write in writes {
+                if Self::is_dedup_path(&write.path) {
+                    if let Some(entry) = dedup.get_mut(&write.path) {
+                        if entry.status == DedupStatus::Pending {
+                            tracing::debug!(
+                                path = %write.path,
+                                "Promoting dedup key from Pending to Delivered"
+                            );
+                            entry.status = DedupStatus::Delivered;
+                            entry.created_at = Instant::now();
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// Remove expired dedup entries.
+    ///
+    /// - `Pending` entries older than `DEDUP_PENDING_TTL` are dropped so a
+    ///   crashed delivery attempt does not permanently block future retries.
+    /// - `Delivered` entries older than `DEDUP_DELIVERED_TTL` are dropped to
+    ///   bound memory usage.
+    pub fn cleanup_expired_dedup(&self) {
+        let now = Instant::now();
+        if let Ok(mut dedup) = self.dedup.write() {
+            dedup.retain(|_, entry| {
+                let ttl = match entry.status {
+                    DedupStatus::Pending => DEDUP_PENDING_TTL,
+                    DedupStatus::Delivered => DEDUP_DELIVERED_TTL,
+                };
+                now.duration_since(entry.created_at) < ttl
+            });
+        }
+    }
 }
 
 impl crate::tools::wasm::WorkspaceReader for ChannelWorkspaceStore {
     fn read(&self, path: &str) -> Option<String> {
+        if Self::is_dedup_path(path) {
+            // For dedup paths, return "1" only if a non-expired entry exists.
+            // This allows WASM guests to use workspace_read to check dedup status
+            // while the dedup lifecycle is managed separately.
+            let dedup = self.dedup.read().ok()?;
+            let entry = dedup.get(path)?;
+            let ttl = match entry.status {
+                DedupStatus::Pending => DEDUP_PENDING_TTL,
+                DedupStatus::Delivered => DEDUP_DELIVERED_TTL,
+            };
+            if Instant::now().duration_since(entry.created_at) < ttl {
+                return Some("1".to_string());
+            }
+            return None;
+        }
         self.data.read().ok()?.get(path).cloned()
     }
 }
@@ -1215,5 +1362,135 @@ mod tests {
 
         let messages = state.take_emitted_messages();
         assert_eq!(messages[0].attachments.len(), 2);
+    }
+
+    // --- ChannelWorkspaceStore dedup lifecycle tests ---
+
+    use std::time::{Duration, Instant};
+    use crate::tools::wasm::WorkspaceReader;
+    use super::{
+        ChannelWorkspaceStore, DedupEntry, DedupStatus, PendingWorkspaceWrite,
+        DEDUP_PENDING_TTL,
+    };
+
+    fn dedup_write(path: &str) -> PendingWorkspaceWrite {
+        PendingWorkspaceWrite { path: path.to_string(), content: "1".to_string() }
+    }
+
+    fn kv_write(path: &str, content: &str) -> PendingWorkspaceWrite {
+        PendingWorkspaceWrite { path: path.to_string(), content: content.to_string() }
+    }
+
+    #[test]
+    fn test_is_dedup_path() {
+        assert!(ChannelWorkspaceStore::is_dedup_path("channels/foo/state/dedup/evt1"));
+        assert!(ChannelWorkspaceStore::is_dedup_path("/state/dedup/anything"));
+        assert!(!ChannelWorkspaceStore::is_dedup_path("channels/foo/state/config"));
+        assert!(!ChannelWorkspaceStore::is_dedup_path(""));
+    }
+
+    #[test]
+    fn test_commit_writes_dedup_goes_to_pending() {
+        let store = ChannelWorkspaceStore::new();
+        let writes = vec![dedup_write("channels/foo/state/dedup/evt1")];
+        store.commit_writes(&writes);
+
+        // Dedup path must be readable while Pending (within TTL)
+        assert_eq!(
+            store.read("channels/foo/state/dedup/evt1"),
+            Some("1".to_string())
+        );
+
+        // Must not appear in the plain KV data map
+        assert!(store.data.read().unwrap().get("channels/foo/state/dedup/evt1").is_none());
+    }
+
+    #[test]
+    fn test_promote_pending_to_delivered() {
+        let store = ChannelWorkspaceStore::new();
+        let writes = vec![dedup_write("channels/foo/state/dedup/evt1")];
+        store.commit_writes(&writes);
+        store.promote_pending_to_delivered(&writes);
+
+        // Still readable after promotion
+        assert_eq!(
+            store.read("channels/foo/state/dedup/evt1"),
+            Some("1".to_string())
+        );
+
+        // Internal status must be Delivered
+        let dedup = store.dedup.read().unwrap();
+        let entry = dedup.get("channels/foo/state/dedup/evt1").unwrap();
+        assert_eq!(entry.status, DedupStatus::Delivered, "status should be Delivered");
+    }
+
+    #[test]
+    fn test_dedup_pending_ttl_expiry() {
+        let store = ChannelWorkspaceStore::new();
+        // Inject an already-expired Pending entry directly
+        {
+            let mut dedup = store.dedup.write().unwrap();
+            dedup.insert(
+                "channels/foo/state/dedup/old_evt".to_string(),
+                DedupEntry {
+                    status: DedupStatus::Pending,
+                    created_at: Instant::now()
+                        .checked_sub(DEDUP_PENDING_TTL + Duration::from_secs(1))
+                        .unwrap_or_else(Instant::now),
+                },
+            );
+        }
+
+        // Expired Pending entry must not be visible
+        assert_eq!(store.read("channels/foo/state/dedup/old_evt"), None);
+    }
+
+    #[test]
+    fn test_non_dedup_paths_unaffected() {
+        let store = ChannelWorkspaceStore::new();
+        let writes = vec![kv_write("channels/foo/state/config", "hello")];
+        store.commit_writes(&writes);
+
+        // Ordinary KV write must be readable
+        assert_eq!(store.read("channels/foo/state/config"), Some("hello".to_string()));
+
+        // Dedup map must stay empty
+        assert!(store.dedup.read().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_delivered_not_downgraded_to_pending() {
+        let store = ChannelWorkspaceStore::new();
+        let writes = vec![dedup_write("channels/foo/state/dedup/evt1")];
+
+        // First webhook: Pending → Delivered
+        store.commit_writes(&writes);
+        store.promote_pending_to_delivered(&writes);
+
+        // Second webhook for the same event — must not downgrade status
+        store.commit_writes(&writes);
+
+        let dedup = store.dedup.read().unwrap();
+        let entry = dedup.get("channels/foo/state/dedup/evt1").unwrap();
+        assert_eq!(entry.status, DedupStatus::Delivered, "must not downgrade Delivered to Pending");
+    }
+
+    #[test]
+    fn test_poisoned_dedup_lock_does_not_drop_kv_writes() {
+        // Simulate a poisoned dedup lock by panicking inside a write guard,
+        // then verify that subsequent commit_writes still persists plain KV.
+        let store = std::sync::Arc::new(ChannelWorkspaceStore::new());
+        let store2 = store.clone();
+
+        // Poison the dedup lock
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = store2.dedup.write().unwrap();
+            panic!("intentional poison");
+        });
+
+        // dedup lock is now poisoned; plain KV writes must still succeed
+        let kv = vec![kv_write("channels/foo/state/counter", "42")];
+        store.commit_writes(&kv);
+        assert_eq!((*store).read("channels/foo/state/counter"), Some("42".to_string()));
     }
 }

--- a/src/channels/wasm/mod.rs
+++ b/src/channels/wasm/mod.rs
@@ -97,7 +97,10 @@ mod wrapper;
 pub use bundled::{available_channel_names, bundled_channel_names, install_bundled_channel};
 pub use capabilities::{ChannelCapabilities, EmitRateLimitConfig, HttpEndpointConfig, PollConfig};
 pub use error::WasmChannelError;
-pub use host::{ChannelEmitRateLimiter, ChannelHostState, EmittedMessage};
+pub use host::{
+    ChannelEmitRateLimiter, ChannelHostState, ChannelWorkspaceStore, EmittedMessage,
+    PendingWorkspaceWrite, DEDUP_PATH_INFIX,
+};
 pub use loader::{
     DiscoveredChannel, LoadResults, LoadedChannel, WasmChannelLoader, default_channels_dir,
     discover_channels,

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -46,6 +46,7 @@ use crate::channels::wasm::capabilities::ChannelCapabilities;
 use crate::channels::wasm::error::WasmChannelError;
 use crate::channels::wasm::host::{
     ChannelEmitRateLimiter, ChannelHostState, ChannelWorkspaceStore, EmittedMessage,
+    PendingWorkspaceWrite,
 };
 use crate::channels::wasm::router::RegisteredEndpoint;
 use crate::channels::wasm::runtime::{PreparedChannelModule, WasmChannelRuntime};
@@ -64,6 +65,7 @@ use crate::tools::wasm::credential_injector::{
 const WEBSOCKET_EVENT_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue";
 const WEBSOCKET_EVENT_PROCESSING_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue_processing";
 const WEBSOCKET_EVENT_QUEUE_MAX_ITEMS: usize = 100;
+const SEND_TIMEOUT_SECS: u64 = 10;
 
 // Generate component model bindings from the WIT file
 wasmtime::component::bindgen!({
@@ -1593,7 +1595,6 @@ impl WasmChannel {
         )
         .await;
         let pairing_store = self.pairing_store.clone();
-        let workspace_store = self.workspace_store.clone();
 
         // Prepare request data
         let method = method.to_string();
@@ -1637,11 +1638,13 @@ impl WasmChannel {
                 let mut host_state =
                     Self::extract_host_state(&mut store, &prepared.name, &capabilities);
 
-                // Commit pending workspace writes to the persistent store
+                // Defer workspace commit until after successful message delivery.
+                // This prevents dedup keys from being committed before messages
+                // reach the agent queue — the root cause of message loss when the
+                // queue is temporarily full and the upstream platform retries.
                 let pending_writes = host_state.take_pending_writes();
-                workspace_store.commit_writes(&pending_writes);
 
-                Ok((response, host_state))
+                Ok((response, host_state, pending_writes))
             })
             .await
             .map_err(|e| WasmChannelError::ExecutionPanicked {
@@ -1653,10 +1656,19 @@ impl WasmChannel {
 
         let channel_name = self.name.clone();
         match result {
-            Ok(Ok((response, mut host_state))) => {
-                // Process emitted messages
+            Ok(Ok((response, mut host_state, pending_writes))) => {
+                // Process emitted messages BEFORE committing workspace writes.
+                // If delivery fails, workspace (including dedup keys) stays
+                // uncommitted so the upstream platform can retry successfully.
+                // NOTE: This assumes each webhook/poll produces at most 1 emitted
+                // message. If multiple messages per event are needed in the future,
+                // a per-message ack or outbox mechanism must be added to avoid
+                // partial-success replay issues.
                 let emitted = host_state.take_emitted_messages();
                 self.process_emitted_messages(emitted).await?;
+
+                self.workspace_store.commit_writes(&pending_writes);
+                self.workspace_store.promote_pending_to_delivered(&pending_writes);
 
                 tracing::debug!(
                     channel = %channel_name,
@@ -1699,7 +1711,6 @@ impl WasmChannel {
         )
         .await;
         let pairing_store = self.pairing_store.clone();
-        let workspace_store = self.workspace_store.clone();
 
         // Execute in blocking task with timeout
         let result = tokio::time::timeout(timeout, async move {
@@ -1723,11 +1734,12 @@ impl WasmChannel {
                 let mut host_state =
                     Self::extract_host_state(&mut store, &prepared.name, &capabilities);
 
-                // Commit pending workspace writes to the persistent store
+                // Defer workspace commit until after successful message delivery.
+                // For poll-based channels, failure recovery relies on the next
+                // poll tick re-running the WASM callback (no external retry).
                 let pending_writes = host_state.take_pending_writes();
-                workspace_store.commit_writes(&pending_writes);
 
-                Ok(((), host_state))
+                Ok(((), host_state, pending_writes))
             })
             .await
             .map_err(|e| WasmChannelError::ExecutionPanicked {
@@ -1739,12 +1751,17 @@ impl WasmChannel {
 
         let channel_name = self.name.clone();
         match result {
-            Ok(Ok(((), mut host_state))) => {
+            Ok(Ok(((), mut host_state, pending_writes))) => {
                 let _ = drain_guest_logs(&channel_name, "on_poll", &mut host_state);
 
-                // Process emitted messages
+                // Deliver messages before committing workspace writes.
+                // For poll-based channels, failure recovery relies on the next
+                // poll tick re-running the WASM callback (no external retry).
                 let emitted = host_state.take_emitted_messages();
                 self.process_emitted_messages(emitted).await?;
+
+                self.workspace_store.commit_writes(&pending_writes);
+                self.workspace_store.promote_pending_to_delivered(&pending_writes);
 
                 tracing::debug!(
                     channel = %channel_name,
@@ -2393,9 +2410,10 @@ impl WasmChannel {
         &self,
         messages: Vec<EmittedMessage>,
     ) -> Result<(), WasmChannelError> {
+        let emitted_count = messages.len();
         tracing::info!(
             channel = %self.name,
-            message_count = messages.len(),
+            message_count = emitted_count,
             "Processing emitted messages from WASM callback"
         );
 
@@ -2410,7 +2428,7 @@ impl WasmChannel {
             let Some(tx) = tx_guard.as_ref() else {
                 tracing::error!(
                     channel = %self.name,
-                    count = messages.len(),
+                    count = emitted_count,
                     "Messages emitted but no sender available - channel may not be started!"
                 );
                 return Ok(());
@@ -2480,7 +2498,10 @@ impl WasmChannel {
                 self.update_broadcast_metadata(&emitted.metadata_json).await;
             }
 
-            // Send to stream — no locks held across this await
+            // Send to stream with timeout to prevent indefinite blocking when
+            // the agent queue is full. A blocked send would hold up the WASM
+            // callback, delay commit_writes, and cause dedup keys to never be
+            // persisted — making webhook retries look like new events.
             tracing::info!(
                 channel = %self.name,
                 user_id = %emitted.user_id,
@@ -2489,18 +2510,42 @@ impl WasmChannel {
                 "Sending emitted message to agent"
             );
 
-            if tx.send(msg).await.is_err() {
-                tracing::error!(
-                    channel = %self.name,
-                    "Failed to send emitted message, channel closed"
-                );
-                break;
+            match tokio::time::timeout(
+                Duration::from_secs(SEND_TIMEOUT_SECS),
+                tx.send(msg),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
+                    tracing::info!(
+                        channel = %self.name,
+                        "Message successfully sent to agent queue"
+                    );
+                }
+                Ok(Err(_)) => {
+                    tracing::error!(
+                        channel = %self.name,
+                        emitted_count,
+                        "Agent message channel closed (permanent)"
+                    );
+                    return Err(WasmChannelError::ChannelClosed {
+                        name: self.name.clone(),
+                    });
+                }
+                Err(_) => {
+                    tracing::error!(
+                        channel = %self.name,
+                        emitted_count,
+                        timeout_secs = SEND_TIMEOUT_SECS,
+                        "Send to agent queue timed out — agent may be blocked"
+                    );
+                    return Err(WasmChannelError::SendTimeout {
+                        name: self.name.clone(),
+                        timeout_secs: SEND_TIMEOUT_SECS,
+                        emitted_count,
+                    });
+                }
             }
-
-            tracing::info!(
-                channel = %self.name,
-                "Message successfully sent to agent queue"
-            );
         }
 
         Ok(())
@@ -2563,10 +2608,12 @@ impl WasmChannel {
                         ).await;
 
                         match result {
-                            Ok(emitted_messages) => {
-                                // Process any emitted messages
-                                if !emitted_messages.is_empty()
-                                    && let Err(e) = Self::dispatch_emitted_messages(
+                            Ok((emitted_messages, pending_writes)) => {
+                                // Dispatch messages BEFORE committing workspace.
+                                // On failure, dedup keys stay uncommitted so the
+                                // next poll tick can re-try.
+                                let dispatch_ok = if !emitted_messages.is_empty() {
+                                    match Self::dispatch_emitted_messages(
                                         EmitDispatchContext {
                                             channel_name: &channel_name,
                                             owner_scope_id: &owner_scope_id,
@@ -2578,12 +2625,24 @@ impl WasmChannel {
                                         },
                                         emitted_messages,
                                     ).await {
-                                        tracing::warn!(
-                                            channel = %channel_name,
-                                            error = %e,
-                                            "Failed to dispatch emitted messages from poll"
-                                        );
+                                        Ok(()) => true,
+                                        Err(e) => {
+                                            tracing::warn!(
+                                                channel = %channel_name,
+                                                error = %e,
+                                                "Failed to dispatch emitted messages from poll"
+                                            );
+                                            false
+                                        }
                                     }
+                                } else {
+                                    true
+                                };
+
+                                if dispatch_ok {
+                                    workspace_store.commit_writes(&pending_writes);
+                                    workspace_store.promote_pending_to_delivered(&pending_writes);
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!(
@@ -2622,14 +2681,14 @@ impl WasmChannel {
         pairing_store: Arc<PairingStore>,
         timeout: Duration,
         workspace_store: &Arc<ChannelWorkspaceStore>,
-    ) -> Result<Vec<EmittedMessage>, WasmChannelError> {
+    ) -> Result<(Vec<EmittedMessage>, Vec<PendingWorkspaceWrite>), WasmChannelError> {
         // Skip if no WASM bytes (testing mode)
         if prepared.component().is_none() {
             tracing::debug!(
                 channel = %channel_name,
                 "WASM channel on_poll called (no WASM module)"
             );
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         }
 
         let runtime = Arc::clone(runtime);
@@ -2637,7 +2696,6 @@ impl WasmChannel {
         let capabilities = Self::inject_workspace_reader(capabilities, workspace_store);
         let credentials_snapshot = credentials.read().await.clone();
         let channel_name_owned = channel_name.to_string();
-        let workspace_store = Arc::clone(workspace_store);
 
         // Execute in blocking task with timeout
         let result = tokio::time::timeout(timeout, async move {
@@ -2661,11 +2719,11 @@ impl WasmChannel {
                 let mut host_state =
                     Self::extract_host_state(&mut store, &prepared.name, &capabilities);
 
-                // Commit pending workspace writes to the persistent store
+                // Return pending writes without committing — the caller commits
+                // only after successful message delivery.
                 let pending_writes = host_state.take_pending_writes();
-                workspace_store.commit_writes(&pending_writes);
 
-                Ok(host_state)
+                Ok((host_state, pending_writes))
             })
             .await
             .map_err(|e| WasmChannelError::ExecutionPanicked {
@@ -2676,7 +2734,7 @@ impl WasmChannel {
         .await;
 
         match result {
-            Ok(Ok(mut host_state)) => {
+            Ok(Ok((mut host_state, pending_writes))) => {
                 let _ = drain_guest_logs(channel_name, "on_poll", &mut host_state);
                 let emitted = host_state.take_emitted_messages();
                 tracing::debug!(
@@ -2684,7 +2742,7 @@ impl WasmChannel {
                     emitted_count = emitted.len(),
                     "WASM channel on_poll completed"
                 );
-                Ok(emitted)
+                Ok((emitted, pending_writes))
             }
             Ok(Err(e)) => Err(e),
             Err(_) => Err(WasmChannelError::Timeout {
@@ -2702,9 +2760,10 @@ impl WasmChannel {
         dispatch: EmitDispatchContext<'_>,
         messages: Vec<EmittedMessage>,
     ) -> Result<(), WasmChannelError> {
+        let emitted_count = messages.len();
         tracing::info!(
             channel = %dispatch.channel_name,
-            message_count = messages.len(),
+            message_count = emitted_count,
             "Processing emitted messages from polling callback"
         );
 
@@ -2714,7 +2773,7 @@ impl WasmChannel {
             let Some(tx) = tx_guard.as_ref() else {
                 tracing::error!(
                     channel = %dispatch.channel_name,
-                    count = messages.len(),
+                    count = emitted_count,
                     "Messages emitted but no sender available - channel may not be started!"
                 );
                 return Ok(());
@@ -2791,7 +2850,6 @@ impl WasmChannel {
                 .await;
             }
 
-            // Send to stream — no locks held across this await
             tracing::info!(
                 channel = %dispatch.channel_name,
                 user_id = %emitted.user_id,
@@ -2800,18 +2858,42 @@ impl WasmChannel {
                 "Sending polled message to agent"
             );
 
-            if tx.send(msg).await.is_err() {
-                tracing::error!(
-                    channel = %dispatch.channel_name,
-                    "Failed to send polled message, channel closed"
-                );
-                break;
+            match tokio::time::timeout(
+                Duration::from_secs(SEND_TIMEOUT_SECS),
+                tx.send(msg),
+            )
+            .await
+            {
+                Ok(Ok(())) => {
+                    tracing::info!(
+                        channel = %dispatch.channel_name,
+                        "Message successfully sent to agent queue"
+                    );
+                }
+                Ok(Err(_)) => {
+                    tracing::error!(
+                        channel = %dispatch.channel_name,
+                        emitted_count,
+                        "Agent message channel closed (permanent)"
+                    );
+                    return Err(WasmChannelError::ChannelClosed {
+                        name: dispatch.channel_name.to_string(),
+                    });
+                }
+                Err(_) => {
+                    tracing::error!(
+                        channel = %dispatch.channel_name,
+                        emitted_count,
+                        timeout_secs = SEND_TIMEOUT_SECS,
+                        "Send to agent queue timed out — agent may be blocked"
+                    );
+                    return Err(WasmChannelError::SendTimeout {
+                        name: dispatch.channel_name.to_string(),
+                        timeout_secs: SEND_TIMEOUT_SECS,
+                        emitted_count,
+                    });
+                }
             }
-
-            tracing::info!(
-                channel = %dispatch.channel_name,
-                "Message successfully sent to agent queue"
-            );
         }
 
         Ok(())
@@ -3367,9 +3449,12 @@ fn spawn_websocket_poll(poll_guard: tokio::sync::OwnedMutexGuard<()>, ctx: Webso
             )
             .await
             {
-                Ok(emitted_messages) => {
-                    if !emitted_messages.is_empty()
-                        && let Err(error) = WasmChannel::dispatch_emitted_messages(
+                Ok((emitted_messages, pending_writes)) => {
+                    // Dispatch messages BEFORE committing workspace writes.
+                    // On failure, dedup keys stay uncommitted so the next poll
+                    // tick can retry.
+                    let dispatch_ok = if !emitted_messages.is_empty() {
+                        match WasmChannel::dispatch_emitted_messages(
                             EmitDispatchContext {
                                 channel_name: &ctx.channel_name,
                                 owner_scope_id: &ctx.owner_scope_id,
@@ -3382,8 +3467,20 @@ fn spawn_websocket_poll(poll_guard: tokio::sync::OwnedMutexGuard<()>, ctx: Webso
                             emitted_messages,
                         )
                         .await
-                    {
-                        tracing::warn!(channel = %ctx.channel_name, error = %error, "Failed to dispatch emitted websocket poll messages");
+                        {
+                            Ok(()) => true,
+                            Err(error) => {
+                                tracing::warn!(channel = %ctx.channel_name, error = %error, "Failed to dispatch emitted websocket poll messages");
+                                false
+                            }
+                        }
+                    } else {
+                        true
+                    };
+
+                    if dispatch_ok {
+                        ctx.workspace_store.commit_writes(&pending_writes);
+                        ctx.workspace_store.promote_pending_to_delivered(&pending_writes);
                     }
                 }
                 Err(error) => {
@@ -4492,7 +4589,7 @@ mod tests {
         .await;
 
         assert!(result.is_ok()); // safety: test-only assertion
-        assert!(result.unwrap().is_empty());
+        assert!(result.unwrap().0.is_empty());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

WASM channels that write a dedup key (`workspace_write("state/dedup/<event_id>")`)
before emitting a message can permanently lose that message.

In `call_on_http_request` and `call_on_poll`, `commit_writes` runs inside
`spawn_blocking` — before `process_emitted_messages`. If the agent queue is
full and `tx.send().await` blocks or fails, the dedup key is already
persisted. The next platform retry sees the key, treats the event as a
duplicate, and drops it. The user never receives a reply.

A secondary issue: `tx.send().await` has no timeout, so a stalled receiver
can silently block the WASM callback with no error surfaced.

## Fix

**Primary:** move `commit_writes` out of `spawn_blocking` and call it only
after `process_emitted_messages` succeeds. On failure the error propagates
as-is (HTTP 500 for webhooks, skipped tick for polling), the dedup key stays
uncommitted, and the platform retry is handled correctly.

The same reorder is applied to `execute_poll` and the polling dispatch loop
for consistency.

**Supporting safeguard:** add a two-stage Pending → Delivered lifecycle to
`ChannelWorkspaceStore` for dedup paths. `commit_writes` marks them Pending;
`promote_pending_to_delivered` (called after a successful send) marks them
Delivered. TTLs prevent a crashed Pending entry from permanently blocking
future retries (60 s) while keeping the delivered idempotency window long
enough for platform retry windows (24 h). The plain KV behavior for all
other workspace paths is unchanged.

`tx.send` now uses a 10-second timeout. A stalled send returns
`WasmChannelError::SendTimeout` instead of blocking indefinitely.

## Behavior

This change preserves current channel behavior, which assumes at most one
emitted message per webhook or poll tick. Channels that do not write dedup
keys are unaffected.