### PR TITLE
fix: remove stale stream_token gate from channel-relay activation

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1631,15 +1631,25 @@ impl ExtensionManager {
                 self.persist_active_channels(user_id).await;
                 self.activation_errors.write().await.remove(name);
 
-                // Remove stored team_id setting and clean up OAuth state
-                if let Some(ref store) = self.store {
-                    let _ = store
+                // Remove stored team_id setting and clean up secrets
+                if let Some(ref store) = self.store
+                    && let Err(e) = store
                         .delete_setting(user_id, &format!("relay:{}:team_id", name))
-                        .await;
+                        .await
+                {
+                    tracing::warn!(error = %e, name, "Failed to delete relay team_id setting on removal");
                 }
-                let _ = self
+                if let Err(e) = self
                     .secrets
                     .delete(user_id, &format!("relay:{}:oauth_state", name))
+                    .await
+                {
+                    tracing::warn!(error = %e, name, "Failed to delete relay oauth_state secret on removal");
+                }
+                // Clean up legacy stream_token secret from pre-webhook installs
+                let _ = self
+                    .secrets
+                    .delete(user_id, &format!("relay:{}:stream_token", name))
                     .await;
 
                 // Stop webhook traffic before removing the channel from the managers.

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -429,6 +429,9 @@ mod tests {
             port: 3000,
             auth_token: None,
             user_id: "test".to_string(),
+            workspace_read_scopes: Vec::new(),
+            memory_layers: Vec::new(),
+            user_tokens: None,
         });
         c
     }
@@ -440,6 +443,9 @@ mod tests {
             port,
             auth_token: None,
             user_id: "test".to_string(),
+            workspace_read_scopes: Vec::new(),
+            memory_layers: Vec::new(),
+            user_tokens: None,
         });
         c
     }


### PR DESCRIPTION
## Summary

- Removes the dead `relay:<name>:stream_token` secret gate that blocked channel-relay activation since the webhook callback migration (#1254). Uses the `team_id` setting (already written by the OAuth callback) as the "auth completed" marker instead.
- Fixes a bug where `list()` hardcoded `activation_error: None` for relay channels, silently hiding activation failures from the UI.
- Cleans up stale comments/naming referencing the old streaming model.

## Changes

All in `src/extensions/manager.rs`:

| Function | Change |
|---|---|
| `is_relay_channel()` | Check `team_id` setting instead of `stream_token` secret |
| `activate_channel_relay()` | Gate on `team_id` emptiness, not `stream_token` existence |
| `list()` | Read `activation_errors` for relay channels (was hardcoded `None`) |
| Removal flow | Delete `team_id` setting + `oauth_state` secret instead of `stream_token` |
| `configure()` | Return empty allowed-secrets set (relay is OAuth-only) |
| `configure_token()` | Return `AuthRequired` (no manual token entry for relay) |
| Test | Updated to match OAuth-only model |

## Test plan

- [ ] `cargo check` passes
- [ ] `cargo clippy --all --all-features` passes with zero warnings
- [ ] Activate a Slack relay via OAuth flow: team_id stored, relay connects
- [ ] Remove relay: team_id setting deleted, oauth_state secret cleaned up
- [ ] Failed activation: error visible in `list()` response (no longer silently hidden)
- [ ] `configure_token()` for relay returns AuthRequired (not a stream_token write)


Made with [Cursor](https://cursor.com)