### PR TITLE
fix(llm): filter XML tool-call recovery by context

### DIFF
--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1319,16 +1319,21 @@ fn is_recoverable_tool_call_segment(
     }
 
     let (first_line_start, first_line_end) = line_bounds(text, start);
+    let first_line = &text[first_line_start..first_line_end];
+
+    if first_line.trim_start().starts_with('>') {
+        return false;
+    }
+
     let (_, last_line_end) = line_bounds(text, end.saturating_sub(1));
     let first_line_prefix = &text[first_line_start..start];
     let last_line_suffix = &text[end..last_line_end];
-    let first_line = &text[first_line_start..first_line_end];
 
     if !first_line_prefix.trim().is_empty() || !last_line_suffix.trim().is_empty() {
         return false;
     }
 
-    !first_line.trim_start().starts_with('>')
+    true
 }
 
 /// Clean up LLM response by stripping model-internal tags and reasoning patterns.


### PR DESCRIPTION
## Summary

- prevent `recover_tool_calls_from_content` from converting XML tool-call examples inside fenced code blocks, inline code, or markdown blockquotes into real tool calls
- keep XML recovery working for legitimate standalone tool-call payloads emitted by models that use text-based tool calling
- add regression tests covering ignored quoted/code contexts and a preserved multiline positive case

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

- None

## Validation

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [x] Relevant tests pass: `cargo test test_recover_ --lib`, `cargo test llm::reasoning --lib`
- [ ] Manual testing: None

## Security Impact

- Hardens text-based tool-call recovery so quoted or code-formatted attacker-controlled XML is not reinterpreted as executable tool calls. This only affects the LLM tool recovery path in `src/llm/reasoning.rs`.

## Database Impact

- None

## Blast Radius

- `src/llm/reasoning.rs` XML tool-call recovery and its unit tests.
- Could affect local-model compatibility only if a model emits XML tool calls inline with other prose on the same line rather than as isolated tool-call blocks. Existing standalone recovery behavior remains covered by tests.

## Rollback Plan

- Revert commit `8724178` to restore the previous recovery behavior.

---

**Review track**: C (security/runtime/DB/CI)