### PR TITLE
fix: bump registry versions for staging promotion 1451

### DIFF
--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "GitHub integration for issues, PRs, repos, and code search",
   "keywords": [

--- a/registry/tools/gmail.json
+++ b/registry/tools/gmail.json
@@ -2,7 +2,7 @@
   "name": "gmail",
   "display_name": "Gmail",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Read, send, and manage Gmail messages and threads",
   "keywords": [

--- a/registry/tools/google-calendar.json
+++ b/registry/tools/google-calendar.json
@@ -2,7 +2,7 @@
   "name": "google-calendar",
   "display_name": "Google Calendar",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Create, read, update, and delete Google Calendar events",
   "keywords": [

--- a/registry/tools/google-docs.json
+++ b/registry/tools/google-docs.json
@@ -2,7 +2,7 @@
   "name": "google-docs",
   "display_name": "Google Docs",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Create and edit Google Docs documents",
   "keywords": [

--- a/registry/tools/google-drive.json
+++ b/registry/tools/google-drive.json
@@ -2,7 +2,7 @@
   "name": "google-drive",
   "display_name": "Google Drive",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Upload, download, search, and manage Google Drive files and folders",
   "keywords": [

--- a/registry/tools/google-sheets.json
+++ b/registry/tools/google-sheets.json
@@ -2,7 +2,7 @@
   "name": "google-sheets",
   "display_name": "Google Sheets",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Read and write Google Sheets spreadsheet data",
   "keywords": [

--- a/registry/tools/google-slides.json
+++ b/registry/tools/google-slides.json
@@ -2,7 +2,7 @@
   "name": "google-slides",
   "display_name": "Google Slides",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Create and edit Google Slides presentations",
   "keywords": [

--- a/registry/tools/llm-context.json
+++ b/registry/tools/llm-context.json
@@ -2,7 +2,7 @@
   "name": "llm-context",
   "display_name": "LLM Context",
   "kind": "tool",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "wit_version": "0.3.0",
   "description": "Fetch pre-extracted web content from Brave Search for grounding LLM answers (RAG, fact-checking)",
   "keywords": [

--- a/registry/tools/slack.json
+++ b/registry/tools/slack.json
@@ -2,7 +2,7 @@
   "name": "slack-tool",
   "display_name": "Slack Tool",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Your agent uses Slack to post and read messages in your workspace",
   "keywords": [

--- a/registry/tools/telegram.json
+++ b/registry/tools/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram-mtproto",
   "display_name": "Telegram Tool",
   "kind": "tool",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Your agent uses your Telegram account to read and send messages",
   "keywords": [

--- a/registry/tools/web-search.json
+++ b/registry/tools/web-search.json
@@ -2,7 +2,7 @@
   "name": "web-search",
   "display_name": "Web Search",
   "kind": "tool",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Search the web using Brave Search API",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump the 11 changed tool registry versions required by the version-bump gate on staging promotion PR #1451
- bump the changed Feishu channel registry version to 0.1.3 because main is already at 0.1.2
- keep the fix scoped to registry metadata only so merging this PR updates the existing promotion branch cleanly

## Testing
- GITHUB_BASE_REF=main ./scripts/check-version-bumps.sh