### PR TITLE
fix: allow publishing ironclaw_common

### DIFF
--- a/crates/ironclaw_common/Cargo.toml
+++ b/crates/ironclaw_common/Cargo.toml
@@ -8,7 +8,6 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
-publish = false
 
 [package.metadata.dist]
 dist = false


### PR DESCRIPTION
## Summary
- remove publish = false from crates/ironclaw_common/Cargo.toml
- make ironclaw_common publishable so release-plz can publish it before ironclaw
- keep the fix scoped to the release blocker without refactoring the crate layout

## Why
The Release-plz release job is failing because ironclaw depends on ironclaw_common, but Cargo cannot resolve ironclaw_common from crates.io while it is marked publish = false.

## Verification
- cargo publish --dry-run --allow-dirty --manifest-path crates/ironclaw_common/Cargo.toml
