### PR TITLE
fix: publish ironclaw_safety 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3496,7 +3496,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw_safety"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aho-corasick",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,7 +104,7 @@ cron = "0.13"
 ironclaw_common = { path = "crates/ironclaw_common", version = "0.1.0" }
 
 # Safety/sanitization
-ironclaw_safety = { path = "crates/ironclaw_safety", version = "0.1.0" }
+ironclaw_safety = { path = "crates/ironclaw_safety", version = "0.2.0" }
 regex = "1"
 aho-corasick = "1"
 

--- a/crates/ironclaw_safety/Cargo.toml
+++ b/crates/ironclaw_safety/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ironclaw_safety"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Prompt injection defense, input validation, secret leak detection, and safety policy enforcement"
@@ -8,7 +8,6 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
-publish = false
 
 [package.metadata.dist]
 dist = false

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,7 +1,2 @@
 [workspace]
 git_release_enable = false
-
-[[package]]
-name = "ironclaw_safety"
-publish = false
-release = false


### PR DESCRIPTION
## Summary
- bump ironclaw_safety from 0.1.0 to 0.2.0
- remove publish = false so release-plz can publish ironclaw_safety
- stop excluding ironclaw_safety from release-plz
- update ironclaw to depend on ironclaw_safety 0.2.0

## Why
After #1657, release-plz gets past ironclaw_common but still fails while verifying ironclaw because the packaged crate resolves ironclaw_safety from crates.io. The published 0.1.0 API does not match the current workspace API, so the release flow needs a new published ironclaw_safety version.

## Verification
- cargo test -p ironclaw_safety
- cargo check -p ironclaw
- cargo publish --dry-run --allow-dirty --manifest-path crates/ironclaw_safety/Cargo.toml
