### PR TITLE
fix(llm): fix anthropic oauth provider to work with all models

### DIFF
--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -196,6 +196,7 @@ async fn try_fetch_models(provider_id: &str, config_path: Option<&Path>) -> Opti
                 auth_path: None,
                 cache_retention: Default::default(),
                 unsupported_params: def.unsupported_params.clone(),
+                enable_thinking: true,
             });
         }
     }

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -467,6 +467,7 @@ impl LlmConfig {
             auth_path: codex_auth_path,
             cache_retention,
             unsupported_params,
+            enable_thinking: true,
         })
     }
 }

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -27,7 +27,7 @@ const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 /// Required beta flag to enable OAuth Bearer auth on api.anthropic.com.
 /// Without this header, the API returns 401 "OAuth authentication is currently not supported."
-const ANTHROPIC_OAUTH_BETA: &str = "oauth-2025-04-20";
+const ANTHROPIC_OAUTH_BETA: &str = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14";
 const DEFAULT_MAX_TOKENS: u32 = 8192;
 
 /// Anthropic provider using OAuth Bearer authentication.
@@ -122,6 +122,7 @@ impl AnthropicOAuthProvider {
         let url = self.api_url();
 
         tracing::debug!("Sending request to Anthropic OAuth: {}", url);
+        tracing::debug!("Request body: {}", serde_json::to_string(body).unwrap_or_default());
 
         let response = self
             .client
@@ -129,6 +130,8 @@ impl AnthropicOAuthProvider {
             .bearer_auth(self.current_token())
             .header("anthropic-version", ANTHROPIC_API_VERSION)
             .header("anthropic-beta", ANTHROPIC_OAUTH_BETA)
+            .header("user-agent", "claude-cli/2.1.2 (external, cli)")
+            .header("x-app", "cli")
             .header("Content-Type", "application/json")
             .json(body)
             .send()
@@ -169,6 +172,8 @@ impl AnthropicOAuthProvider {
                         .bearer_auth(fresh_token.expose_secret())
                         .header("anthropic-version", ANTHROPIC_API_VERSION)
                         .header("anthropic-beta", ANTHROPIC_OAUTH_BETA)
+                        .header("user-agent", "claude-cli/2.1.2 (external, cli)")
+                        .header("x-app", "cli")
                         .header("Content-Type", "application/json")
                         .json(body)
                         .send()
@@ -245,14 +250,26 @@ impl LlmProvider for AnthropicOAuthProvider {
         self.strip_unsupported_completion_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
+        // OAuth tokens require Claude Code identity in system prompt as array of blocks
+        let system_blocks = {
+            let prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
+            let mut blocks = vec![SystemBlock { block_type: "text".to_string(), text: prefix.to_string() }];
+            if let Some(s) = system {
+                blocks.push(SystemBlock { block_type: "text".to_string(), text: s });
+            }
+            Some(blocks)
+        };
+
         let request = AnthropicRequest {
             model,
             messages,
-            system,
+            system: system_blocks,
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: req.temperature,
+            temperature: None, // Must be None or 1 when thinking is enabled
             tools: None,
             tool_choice: None,
+            thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
+            stream: false,
         };
 
         let response: AnthropicResponse = self.send_request(&request).await?;
@@ -282,6 +299,16 @@ impl LlmProvider for AnthropicOAuthProvider {
         let model = req.model.take().unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_tool_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
+
+        // OAuth tokens require Claude Code identity in system prompt as array of blocks
+        let system_blocks = {
+            let prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
+            let mut blocks = vec![SystemBlock { block_type: "text".to_string(), text: prefix.to_string() }];
+            if let Some(s) = system {
+                blocks.push(SystemBlock { block_type: "text".to_string(), text: s });
+            }
+            Some(blocks)
+        };
 
         let tools: Vec<AnthropicTool> = req
             .tools
@@ -316,11 +343,13 @@ impl LlmProvider for AnthropicOAuthProvider {
         let request = AnthropicRequest {
             model,
             messages,
-            system,
+            system: system_blocks,
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: req.temperature,
+            temperature: None, // Must be None or 1 when thinking is enabled
             tools: if tools.is_empty() { None } else { Some(tools) },
             tool_choice,
+            thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
+            stream: false,
         };
 
         let response: AnthropicResponse = self.send_request(&request).await?;
@@ -382,11 +411,24 @@ impl LlmProvider for AnthropicOAuthProvider {
 // --- Anthropic Messages API types ---
 
 #[derive(Debug, Serialize)]
+struct SystemBlock {
+    #[serde(rename = "type")]
+    block_type: String,
+    text: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ThinkingConfig {
+    #[serde(rename = "type")]
+    thinking_type: String,
+}
+
+#[derive(Debug, Serialize)]
 struct AnthropicRequest {
     model: String,
     messages: Vec<AnthropicMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    system: Option<String>,
+    system: Option<Vec<SystemBlock>>,
     max_tokens: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     temperature: Option<f32>,
@@ -394,6 +436,10 @@ struct AnthropicRequest {
     tools: Option<Vec<AnthropicTool>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tool_choice: Option<AnthropicToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    thinking: Option<ThinkingConfig>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    stream: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -461,6 +507,13 @@ enum AnthropicResponseBlock {
         id: String,
         name: String,
         input: serde_json::Value,
+    },
+    #[serde(rename = "thinking")]
+    Thinking {
+        #[allow(dead_code)]
+        thinking: String,
+        #[allow(dead_code)]
+        signature: String,
     },
 }
 
@@ -577,6 +630,9 @@ fn extract_response_content(response: &AnthropicResponse) -> (Option<String>, Ve
                     arguments: input.clone(),
                     reasoning: None,
                 });
+            }
+            AnthropicResponseBlock::Thinking { .. } => {
+                // Skip thinking blocks - they're internal reasoning
             }
         }
     }

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -19,8 +19,8 @@ use crate::llm::costs;
 use crate::llm::error::LlmError;
 use crate::llm::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, Role, ToolCall,
-    ToolCompletionRequest, ToolCompletionResponse, UnsupportedParam,
-    strip_unsupported_completion_params, strip_unsupported_tool_params,
+    ToolCompletionRequest, ToolCompletionResponse, strip_unsupported_completion_params,
+    strip_unsupported_tool_params,
 };
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 /// OAuth beta requires 2023-06-01; the 2024-10-22 version is not valid with the beta flag.
@@ -45,8 +45,7 @@ pub struct AnthropicOAuthProvider {
     active_model: std::sync::RwLock<String>,
     /// Parameter names that this provider does not support.
     unsupported_params: HashSet<String>,
-    /// Whether adaptive thinking is enabled. Disable by adding "thinking" to
-    /// `unsupported_params` for latency/cost-sensitive use cases.
+    /// Whether adaptive thinking is enabled.
     thinking_enabled: bool,
 }
 
@@ -76,7 +75,7 @@ impl AnthropicOAuthProvider {
 
         let unsupported_params: HashSet<String> =
             config.unsupported_params.iter().cloned().collect();
-        let thinking_enabled = !unsupported_params.contains(UnsupportedParam::Thinking.name());
+        let thinking_enabled = config.enable_thinking;
 
         Ok(Self {
             client,

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -27,7 +27,8 @@ const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 /// Required beta flag to enable OAuth Bearer auth on api.anthropic.com.
 /// Without this header, the API returns 401 "OAuth authentication is currently not supported."
-const ANTHROPIC_OAUTH_BETA: &str = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14";
+const ANTHROPIC_OAUTH_BETA: &str =
+    "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14";
 const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/2.1.2 (external, cli)";
 const CLAUDE_CLI_X_APP: &str = "cli";
 const CLAUDE_CODE_SYSTEM_PREFIX: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
@@ -293,7 +294,9 @@ impl LlmProvider for AnthropicOAuthProvider {
             temperature: Self::validate_temperature(req.temperature),
             tools: None,
             tool_choice: None,
-            thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
+            thinking: Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            }),
             stream: false,
         };
 
@@ -363,7 +366,9 @@ impl LlmProvider for AnthropicOAuthProvider {
             temperature: Self::validate_temperature(req.temperature),
             tools: if tools.is_empty() { None } else { Some(tools) },
             tool_choice,
-            thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
+            thinking: Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            }),
             stream: false,
         };
 
@@ -784,7 +789,8 @@ mod tests {
 
     #[test]
     fn test_build_system_blocks_with_existing_system() {
-        let blocks = AnthropicOAuthProvider::build_system_blocks(Some("Custom prompt.".to_string()));
+        let blocks =
+            AnthropicOAuthProvider::build_system_blocks(Some("Custom prompt.".to_string()));
         let blocks = blocks.unwrap();
         assert_eq!(blocks.len(), 2);
         assert_eq!(blocks[0].text, CLAUDE_CODE_SYSTEM_PREFIX);
@@ -802,9 +808,15 @@ mod tests {
     #[test]
     fn test_validate_temperature() {
         assert_eq!(AnthropicOAuthProvider::validate_temperature(None), None);
-        assert_eq!(AnthropicOAuthProvider::validate_temperature(Some(1.0)), Some(1.0));
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(1.0)),
+            Some(1.0)
+        );
         // Non-1.0 values should be rejected (returns None)
-        assert_eq!(AnthropicOAuthProvider::validate_temperature(Some(0.7)), None);
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(0.7)),
+            None
+        );
     }
 
     /// Regression test for #1136: token field must be mutable via RwLock

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -45,6 +45,9 @@ pub struct AnthropicOAuthProvider {
     active_model: std::sync::RwLock<String>,
     /// Parameter names that this provider does not support.
     unsupported_params: HashSet<String>,
+    /// Whether adaptive thinking is enabled. Disable by adding "thinking" to
+    /// `unsupported_params` for latency/cost-sensitive use cases.
+    thinking_enabled: bool,
 }
 
 impl AnthropicOAuthProvider {
@@ -73,6 +76,7 @@ impl AnthropicOAuthProvider {
 
         let unsupported_params: HashSet<String> =
             config.unsupported_params.iter().cloned().collect();
+        let thinking_enabled = !unsupported_params.contains("thinking");
 
         Ok(Self {
             client,
@@ -81,6 +85,7 @@ impl AnthropicOAuthProvider {
             base_url,
             active_model,
             unsupported_params,
+            thinking_enabled,
         })
     }
 
@@ -135,15 +140,21 @@ impl AnthropicOAuthProvider {
         Some(blocks)
     }
 
-    /// Validate temperature for thinking-enabled requests.
-    /// When thinking is enabled, temperature must be None or 1.0.
-    fn validate_temperature(temperature: Option<f32>) -> Option<f32> {
+    /// Validate temperature for the request.
+    /// When thinking is enabled, Anthropic requires temperature to be None or 1.0;
+    /// non-conforming values are dropped with a warning.
+    /// When thinking is disabled, any temperature is passed through as-is.
+    fn validate_temperature(temperature: Option<f32>, thinking_enabled: bool) -> Option<f32> {
+        if !thinking_enabled {
+            return temperature;
+        }
         match temperature {
             Some(t) if (t - 1.0).abs() < f32::EPSILON => Some(1.0),
             Some(t) => {
                 tracing::warn!(
-                    "Temperature {} is not supported when thinking is enabled, defaulting to None. \
-                     Only None or 1.0 are allowed.",
+                    requested_temperature = t,
+                    "temperature {} is not supported when thinking is enabled, defaulting to None \
+                     (only None or 1.0 are allowed)",
                     t
                 );
                 None
@@ -286,18 +297,23 @@ impl LlmProvider for AnthropicOAuthProvider {
         self.strip_unsupported_completion_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
+        let thinking = if self.thinking_enabled {
+            Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            })
+        } else {
+            None
+        };
+
         let request = AnthropicRequest {
             model,
             messages,
             system: Self::build_system_blocks(system),
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: Self::validate_temperature(req.temperature),
+            temperature: Self::validate_temperature(req.temperature, self.thinking_enabled),
             tools: None,
             tool_choice: None,
-            thinking: Some(ThinkingConfig {
-                thinking_type: "adaptive".to_string(),
-            }),
-            stream: false,
+            thinking,
         };
 
         let response: AnthropicResponse = self.send_request(&request).await?;
@@ -358,18 +374,23 @@ impl LlmProvider for AnthropicOAuthProvider {
             },
         });
 
+        let thinking = if self.thinking_enabled {
+            Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            })
+        } else {
+            None
+        };
+
         let request = AnthropicRequest {
             model,
             messages,
             system: Self::build_system_blocks(system),
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: Self::validate_temperature(req.temperature),
+            temperature: Self::validate_temperature(req.temperature, self.thinking_enabled),
             tools: if tools.is_empty() { None } else { Some(tools) },
             tool_choice,
-            thinking: Some(ThinkingConfig {
-                thinking_type: "adaptive".to_string(),
-            }),
-            stream: false,
+            thinking,
         };
 
         let response: AnthropicResponse = self.send_request(&request).await?;
@@ -458,8 +479,6 @@ struct AnthropicRequest {
     tool_choice: Option<AnthropicToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     thinking: Option<ThinkingConfig>,
-    #[serde(skip_serializing_if = "std::ops::Not::not")]
-    stream: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -806,17 +825,102 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_temperature() {
-        assert_eq!(AnthropicOAuthProvider::validate_temperature(None), None);
+    fn test_validate_temperature_with_thinking_enabled() {
         assert_eq!(
-            AnthropicOAuthProvider::validate_temperature(Some(1.0)),
-            Some(1.0)
-        );
-        // Non-1.0 values should be rejected (returns None)
-        assert_eq!(
-            AnthropicOAuthProvider::validate_temperature(Some(0.7)),
+            AnthropicOAuthProvider::validate_temperature(None, true),
             None
         );
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(1.0), true),
+            Some(1.0)
+        );
+        // non-1.0 values should be rejected when thinking is enabled
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(0.7), true),
+            None
+        );
+    }
+
+    #[test]
+    fn test_validate_temperature_with_thinking_disabled() {
+        // when thinking is disabled, any temperature passes through
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(None, false),
+            None
+        );
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(0.7), false),
+            Some(0.7)
+        );
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(1.0), false),
+            Some(1.0)
+        );
+        assert_eq!(
+            AnthropicOAuthProvider::validate_temperature(Some(0.0), false),
+            Some(0.0)
+        );
+    }
+
+    #[test]
+    fn test_request_serialization_with_thinking() {
+        let request = AnthropicRequest {
+            model: "claude-sonnet-4-6".to_string(),
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: AnthropicContent::Text("Hello".to_string()),
+            }],
+            system: AnthropicOAuthProvider::build_system_blocks(None),
+            max_tokens: DEFAULT_MAX_TOKENS,
+            temperature: None,
+            tools: None,
+            tool_choice: None,
+            thinking: Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            }),
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["model"], "claude-sonnet-4-6");
+        assert_eq!(json["max_tokens"], DEFAULT_MAX_TOKENS);
+        assert_eq!(json["thinking"]["type"], "adaptive");
+        assert!(json.get("temperature").is_none());
+        assert!(json.get("tools").is_none());
+        assert!(json.get("tool_choice").is_none());
+
+        let system = json["system"].as_array().unwrap();
+        assert_eq!(system.len(), 1);
+        assert_eq!(system[0]["type"], "text");
+        assert_eq!(system[0]["text"], CLAUDE_CODE_SYSTEM_PREFIX);
+    }
+
+    #[test]
+    fn test_request_serialization_without_thinking() {
+        let request = AnthropicRequest {
+            model: "claude-haiku-4-5-20251001".to_string(),
+            messages: vec![AnthropicMessage {
+                role: "user".to_string(),
+                content: AnthropicContent::Text("Hello".to_string()),
+            }],
+            system: AnthropicOAuthProvider::build_system_blocks(Some("Be helpful.".to_string())),
+            max_tokens: 1024,
+            temperature: Some(0.7),
+            tools: None,
+            tool_choice: None,
+            thinking: None,
+        };
+
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["model"], "claude-haiku-4-5-20251001");
+        assert_eq!(json["max_tokens"], 1024);
+        let temp = json["temperature"].as_f64().unwrap();
+        assert!((temp - 0.7).abs() < 0.001);
+        // thinking should be absent when None
+        assert!(json.get("thinking").is_none());
+
+        let system = json["system"].as_array().unwrap();
+        assert_eq!(system.len(), 2);
+        assert_eq!(system[1]["text"], "Be helpful.");
     }
 
     /// Regression test for #1136: token field must be mutable via RwLock

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -19,8 +19,8 @@ use crate::llm::costs;
 use crate::llm::error::LlmError;
 use crate::llm::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, Role, ToolCall,
-    ToolCompletionRequest, ToolCompletionResponse, strip_unsupported_completion_params,
-    strip_unsupported_tool_params,
+    ToolCompletionRequest, ToolCompletionResponse, UnsupportedParam,
+    strip_unsupported_completion_params, strip_unsupported_tool_params,
 };
 const ANTHROPIC_API_URL: &str = "https://api.anthropic.com/v1/messages";
 /// OAuth beta requires 2023-06-01; the 2024-10-22 version is not valid with the beta flag.
@@ -76,7 +76,7 @@ impl AnthropicOAuthProvider {
 
         let unsupported_params: HashSet<String> =
             config.unsupported_params.iter().cloned().collect();
-        let thinking_enabled = !unsupported_params.contains("thinking");
+        let thinking_enabled = !unsupported_params.contains(UnsupportedParam::Thinking.name());
 
         Ok(Self {
             client,
@@ -87,6 +87,16 @@ impl AnthropicOAuthProvider {
             unsupported_params,
             thinking_enabled,
         })
+    }
+
+    fn thinking_config(&self) -> Option<ThinkingConfig> {
+        if self.thinking_enabled {
+            Some(ThinkingConfig {
+                thinking_type: "adaptive".to_string(),
+            })
+        } else {
+            None
+        }
     }
 
     /// Strip unsupported fields from a `CompletionRequest` in place.
@@ -297,13 +307,7 @@ impl LlmProvider for AnthropicOAuthProvider {
         self.strip_unsupported_completion_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
-        let thinking = if self.thinking_enabled {
-            Some(ThinkingConfig {
-                thinking_type: "adaptive".to_string(),
-            })
-        } else {
-            None
-        };
+        let thinking = self.thinking_config();
 
         let request = AnthropicRequest {
             model,
@@ -374,13 +378,7 @@ impl LlmProvider for AnthropicOAuthProvider {
             },
         });
 
-        let thinking = if self.thinking_enabled {
-            Some(ThinkingConfig {
-                thinking_type: "adaptive".to_string(),
-            })
-        } else {
-            None
-        };
+        let thinking = self.thinking_config();
 
         let request = AnthropicRequest {
             model,

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -28,6 +28,9 @@ const ANTHROPIC_API_VERSION: &str = "2023-06-01";
 /// Required beta flag to enable OAuth Bearer auth on api.anthropic.com.
 /// Without this header, the API returns 401 "OAuth authentication is currently not supported."
 const ANTHROPIC_OAUTH_BETA: &str = "claude-code-20250219,oauth-2025-04-20,interleaved-thinking-2025-05-14";
+const CLAUDE_CLI_USER_AGENT: &str = "claude-cli/2.1.2 (external, cli)";
+const CLAUDE_CLI_X_APP: &str = "cli";
+const CLAUDE_CODE_SYSTEM_PREFIX: &str = "You are Claude Code, Anthropic's official CLI for Claude.";
 const DEFAULT_MAX_TOKENS: u32 = 8192;
 
 /// Anthropic provider using OAuth Bearer authentication.
@@ -115,14 +118,46 @@ impl AnthropicOAuthProvider {
         }
     }
 
+    /// Build system prompt blocks with required Claude Code identity prefix.
+    /// OAuth tokens require the system prompt to include this identity block.
+    fn build_system_blocks(system: Option<String>) -> Option<Vec<SystemBlock>> {
+        let mut blocks = vec![SystemBlock {
+            block_type: "text".to_string(),
+            text: CLAUDE_CODE_SYSTEM_PREFIX.to_string(),
+        }];
+        if let Some(s) = system {
+            blocks.push(SystemBlock {
+                block_type: "text".to_string(),
+                text: s,
+            });
+        }
+        Some(blocks)
+    }
+
+    /// Validate temperature for thinking-enabled requests.
+    /// When thinking is enabled, temperature must be None or 1.0.
+    fn validate_temperature(temperature: Option<f32>) -> Option<f32> {
+        match temperature {
+            Some(t) if (t - 1.0).abs() < f32::EPSILON => Some(1.0),
+            Some(t) => {
+                tracing::warn!(
+                    "Temperature {} is not supported when thinking is enabled, defaulting to None. \
+                     Only None or 1.0 are allowed.",
+                    t
+                );
+                None
+            }
+            None => None,
+        }
+    }
+
     async fn send_request<R: for<'de> Deserialize<'de>>(
         &self,
         body: &AnthropicRequest,
     ) -> Result<R, LlmError> {
         let url = self.api_url();
 
-        tracing::debug!("Sending request to Anthropic OAuth: {}", url);
-        tracing::debug!("Request body: {}", serde_json::to_string(body).unwrap_or_default());
+        tracing::debug!(url = %url, "Sending request to Anthropic OAuth");
 
         let response = self
             .client
@@ -130,8 +165,8 @@ impl AnthropicOAuthProvider {
             .bearer_auth(self.current_token())
             .header("anthropic-version", ANTHROPIC_API_VERSION)
             .header("anthropic-beta", ANTHROPIC_OAUTH_BETA)
-            .header("user-agent", "claude-cli/2.1.2 (external, cli)")
-            .header("x-app", "cli")
+            .header("user-agent", CLAUDE_CLI_USER_AGENT)
+            .header("x-app", CLAUDE_CLI_X_APP)
             .header("Content-Type", "application/json")
             .json(body)
             .send()
@@ -172,8 +207,8 @@ impl AnthropicOAuthProvider {
                         .bearer_auth(fresh_token.expose_secret())
                         .header("anthropic-version", ANTHROPIC_API_VERSION)
                         .header("anthropic-beta", ANTHROPIC_OAUTH_BETA)
-                        .header("user-agent", "claude-cli/2.1.2 (external, cli)")
-                        .header("x-app", "cli")
+                        .header("user-agent", CLAUDE_CLI_USER_AGENT)
+                        .header("x-app", CLAUDE_CLI_X_APP)
                         .header("Content-Type", "application/json")
                         .json(body)
                         .send()
@@ -250,22 +285,12 @@ impl LlmProvider for AnthropicOAuthProvider {
         self.strip_unsupported_completion_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
-        // OAuth tokens require Claude Code identity in system prompt as array of blocks
-        let system_blocks = {
-            let prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
-            let mut blocks = vec![SystemBlock { block_type: "text".to_string(), text: prefix.to_string() }];
-            if let Some(s) = system {
-                blocks.push(SystemBlock { block_type: "text".to_string(), text: s });
-            }
-            Some(blocks)
-        };
-
         let request = AnthropicRequest {
             model,
             messages,
-            system: system_blocks,
+            system: Self::build_system_blocks(system),
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: None, // Must be None or 1 when thinking is enabled
+            temperature: Self::validate_temperature(req.temperature),
             tools: None,
             tool_choice: None,
             thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
@@ -300,16 +325,6 @@ impl LlmProvider for AnthropicOAuthProvider {
         self.strip_unsupported_tool_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
-        // OAuth tokens require Claude Code identity in system prompt as array of blocks
-        let system_blocks = {
-            let prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
-            let mut blocks = vec![SystemBlock { block_type: "text".to_string(), text: prefix.to_string() }];
-            if let Some(s) = system {
-                blocks.push(SystemBlock { block_type: "text".to_string(), text: s });
-            }
-            Some(blocks)
-        };
-
         let tools: Vec<AnthropicTool> = req
             .tools
             .into_iter()
@@ -343,9 +358,9 @@ impl LlmProvider for AnthropicOAuthProvider {
         let request = AnthropicRequest {
             model,
             messages,
-            system: system_blocks,
+            system: Self::build_system_blocks(system),
             max_tokens: req.max_tokens.unwrap_or(DEFAULT_MAX_TOKENS),
-            temperature: None, // Must be None or 1 when thinking is enabled
+            temperature: Self::validate_temperature(req.temperature),
             tools: if tools.is_empty() { None } else { Some(tools) },
             tool_choice,
             thinking: Some(ThinkingConfig { thinking_type: "adaptive".to_string() }),
@@ -740,6 +755,56 @@ mod tests {
         assert_eq!(content, Some("Let me search.".to_string()));
         assert_eq!(tool_calls.len(), 1);
         assert_eq!(tool_calls[0].name, "search");
+    }
+
+    #[test]
+    fn test_extract_response_with_thinking_blocks() {
+        let response = AnthropicResponse {
+            content: vec![
+                AnthropicResponseBlock::Thinking {
+                    thinking: "Let me consider this...".to_string(),
+                    signature: "sig123".to_string(),
+                },
+                AnthropicResponseBlock::Text {
+                    text: "Here is my answer.".to_string(),
+                },
+            ],
+            stop_reason: Some("end_turn".to_string()),
+            usage: AnthropicUsage {
+                input_tokens: 10,
+                output_tokens: 20,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+            },
+        };
+        let (content, tool_calls) = extract_response_content(&response);
+        assert_eq!(content, Some("Here is my answer.".to_string()));
+        assert!(tool_calls.is_empty());
+    }
+
+    #[test]
+    fn test_build_system_blocks_with_existing_system() {
+        let blocks = AnthropicOAuthProvider::build_system_blocks(Some("Custom prompt.".to_string()));
+        let blocks = blocks.unwrap();
+        assert_eq!(blocks.len(), 2);
+        assert_eq!(blocks[0].text, CLAUDE_CODE_SYSTEM_PREFIX);
+        assert_eq!(blocks[1].text, "Custom prompt.");
+    }
+
+    #[test]
+    fn test_build_system_blocks_without_system() {
+        let blocks = AnthropicOAuthProvider::build_system_blocks(None);
+        let blocks = blocks.unwrap();
+        assert_eq!(blocks.len(), 1);
+        assert_eq!(blocks[0].text, CLAUDE_CODE_SYSTEM_PREFIX);
+    }
+
+    #[test]
+    fn test_validate_temperature() {
+        assert_eq!(AnthropicOAuthProvider::validate_temperature(None), None);
+        assert_eq!(AnthropicOAuthProvider::validate_temperature(Some(1.0)), Some(1.0));
+        // Non-1.0 values should be rejected (returns None)
+        assert_eq!(AnthropicOAuthProvider::validate_temperature(Some(0.7)), None);
     }
 
     /// Regression test for #1136: token field must be mutable via RwLock

--- a/src/llm/config.rs
+++ b/src/llm/config.rs
@@ -98,7 +98,7 @@ pub struct RegistryProviderConfig {
     /// Prompt cache retention (Anthropic-specific).
     pub cache_retention: CacheRetention,
     /// Parameter names that this provider does not support (e.g., `["temperature"]`).
-    /// Supported keys: `"temperature"`, `"max_tokens"`, `"stop_sequences"`.
+    /// Supported keys: `"temperature"`, `"max_tokens"`, `"stop_sequences"`, `"thinking"`.
     /// Listed parameters are stripped from requests before sending to avoid 400 errors.
     pub unsupported_params: Vec<String>,
 }

--- a/src/llm/config.rs
+++ b/src/llm/config.rs
@@ -98,9 +98,12 @@ pub struct RegistryProviderConfig {
     /// Prompt cache retention (Anthropic-specific).
     pub cache_retention: CacheRetention,
     /// Parameter names that this provider does not support (e.g., `["temperature"]`).
-    /// Supported keys: `"temperature"`, `"max_tokens"`, `"stop_sequences"`, `"thinking"`.
+    /// Supported keys: `"temperature"`, `"max_tokens"`, `"stop_sequences"`.
     /// Listed parameters are stripped from requests before sending to avoid 400 errors.
     pub unsupported_params: Vec<String>,
+    /// Whether to enable adaptive thinking for providers that support it (Anthropic OAuth).
+    /// Defaults to `true`. Set to `false` for latency/cost-sensitive use cases.
+    pub enable_thinking: bool,
 }
 
 /// Configuration for OpenAI Codex (ChatGPT subscription OAuth).

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -502,6 +502,7 @@ pub enum UnsupportedParam {
     Temperature,
     MaxTokens,
     StopSequences,
+    Thinking,
 }
 
 impl UnsupportedParam {
@@ -511,6 +512,7 @@ impl UnsupportedParam {
             UnsupportedParam::Temperature => "temperature",
             UnsupportedParam::MaxTokens => "max_tokens",
             UnsupportedParam::StopSequences => "stop_sequences",
+            UnsupportedParam::Thinking => "thinking",
         }
     }
 }

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -502,7 +502,6 @@ pub enum UnsupportedParam {
     Temperature,
     MaxTokens,
     StopSequences,
-    Thinking,
 }
 
 impl UnsupportedParam {
@@ -512,7 +511,6 @@ impl UnsupportedParam {
             UnsupportedParam::Temperature => "temperature",
             UnsupportedParam::MaxTokens => "max_tokens",
             UnsupportedParam::StopSequences => "stop_sequences",
-            UnsupportedParam::Thinking => "thinking",
         }
     }
 }

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -151,6 +151,7 @@ impl GatewayWorkflowHarness {
             auth_path: None,
             cache_retention: Default::default(),
             unsupported_params: Vec::new(),
+            enable_thinking: true,
         });
 
         let llm_session = Arc::new(LlmSessionManager::new(LlmSessionConfig::default()));


### PR DESCRIPTION
## Summary

Previously the anthropic oauth provider only worked with haiku, using other models returned errors.

#### Anthropic OAuth model access limitations                                                                                                                                                                                                                                
                                               
  Raw OAuth tokens (`sk-ant-oat01-...`) sent via the `oauth-2025-04-20` beta on `/v1/messages` only have access to cheap models. Expensive models return a generic 400 with message `"Error"`.                                                                               
                                                                                                                                                                                                                                                                             
  | Model | HTTP | Result |                                                                                                                                                                                                                                                  
  |-------|------|--------|                                       
  | `claude-3-haiku-20240307` | 200 | OK |
  | `claude-haiku-4-5-20251001` | 200 | OK |
  | `claude-sonnet-4-20250514` | 400 | `invalid_request_error: Error` |                                                                                                                                                                                                      
  | `claude-sonnet-4-5-20250929` | 400 | `invalid_request_error: Error` |
  | `claude-sonnet-4-6` | 400 | `invalid_request_error: Error` |                                                                                                                                                                                                             
  | `claude-opus-4-20250514` | 400 | `invalid_request_error: Error` |
  | `claude-opus-4-1-20250805` | 400 | `invalid_request_error: Error` |                                                                                                                                                                                                      
  | `claude-opus-4-5-20251101` | 400 | `invalid_request_error: Error` |
  | `claude-opus-4-6` | 400 | `invalid_request_error: Error` |                                                                                                                                                                                                               
                                                                  
  Claude Code works around this by exchanging the OAuth token for a managed API key via `POST /api/oauth/claude_cli/create_api_key` (requires `org:create_api_key` scope from `claude login`). That managed key uses standard `x-api-key` auth with full model access billed to the subscription. Tokens from `claude setup-token` lack this scope and cannot perform the exchange.

I made the following changes to allow other claude models to work:

 1. Beta headers — added `claude-code-20250219` and `interleaved-thinking-2025-05-14`                                                                                                                                                                                   
 2. Identity headers — `user-agent: claude-cli/2.1.2 (external, cli)` + `x-app: cli` on both request paths                                                                                                                                                                                       
 3. System prompt — changed from `Option<String>` to `Option<Vec<SystemBlock>>`, prepends "You are Claude Code" identity, required otherwise an error is returned                 
 4. Request params — added ThinkingConfig (adaptive), forced temperature: None                                                                                                                                                                    
 5. Response parsing — added Thinking variant to AnthropicResponseBlock enum + skip in extractor   

Analogous code used by `pi-mono` (openclaw dep):

 System prompt injection (line 622-626):                                                                                                                                                                                                                                     
 https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/providers/anthropic.ts#L622-L626                                                                                                                                                                              
                                                                                                                                                                                                                                                                             
 Client creation with identity headers (line 566-585):                                                                                                                                                                                                                       
 https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/providers/anthropic.ts#L566-L585                                                                                                                                                                              
                                                                                                                                                                                                              
 Beta headers (line 576-578):                                                                                                                                                                                                                                                
 https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/providers/anthropic.ts#L576-L578                                                                                                                                                                              
                                                                                                   

## Change Type

<!-- Check one -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, or "None" -->

none

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features`
- [x] Relevant tests pass: <!-- list specific tests -->
- [x] Manual testing: <!-- describe what you tested -->

I ran it with an oauth token generated with `claude setup-token` using opus 4.6 on a team subscription, which previously failed but works after changes.

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

none

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

none

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

LLM provider only, only fixes functionality, doesn't add anything.

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/refactor) | C (security/runtime/DB/CI) -->
