### PR TITLE
fix: downgrade excessive debug logging in hot path

### DIFF
--- a/src/channels/relay/client.rs
+++ b/src/channels/relay/client.rs
@@ -123,7 +123,7 @@ impl RelayClient {
     /// for validating the callback — no URLs.
     pub async fn initiate_oauth(&self, state_nonce: Option<&str>) -> Result<String, RelayError> {
         let url = format!("{}/oauth/slack/auth", self.base_url);
-        tracing::debug!(relay_url = %url, "RelayClient::initiate_oauth: sending request");
+        tracing::trace!(relay_url = %url, "RelayClient::initiate_oauth: sending request");
         let mut query: Vec<(&str, &str)> = vec![];
         if let Some(nonce) = state_nonce {
             query.push(("state_nonce", nonce));
@@ -143,7 +143,7 @@ impl RelayClient {
                 );
                 RelayError::Network(e.to_string())
             })?;
-        tracing::debug!(
+        tracing::trace!(
             relay_url = %url,
             status = %resp.status(),
             "RelayClient::initiate_oauth: received response"
@@ -239,7 +239,7 @@ impl RelayClient {
         body: serde_json::Value,
     ) -> Result<serde_json::Value, RelayError> {
         let url = format!("{}/proxy/{}/{}", self.base_url, provider, method);
-        tracing::debug!(
+        tracing::trace!(
             relay_url = %url,
             provider = %provider,
             method = %method,
@@ -289,7 +289,7 @@ impl RelayClient {
     /// extension manager so subsequent calls to `relay_signing_secret()` use it.
     pub async fn get_signing_secret(&self, team_id: &str) -> Result<Vec<u8>, RelayError> {
         let url = format!("{}/relay/signing-secret", self.base_url);
-        tracing::debug!(
+        tracing::trace!(
             relay_url = %url,
             "RelayClient::get_signing_secret: fetching signing secret"
         );
@@ -323,7 +323,7 @@ impl RelayClient {
                 message: body,
             });
         }
-        tracing::debug!(
+        tracing::trace!(
             relay_url = %url,
             "RelayClient::get_signing_secret: received successful response"
         );

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2201,7 +2201,7 @@ async fn extensions_activate_handler(
     AuthenticatedUser(user): AuthenticatedUser,
     Path(name): Path<String>,
 ) -> Result<Json<ActionResponse>, (StatusCode, String)> {
-    tracing::debug!(
+    tracing::trace!(
         extension = %name,
         user_id = %user.user_id,
         "extensions_activate_handler: received activate request"
@@ -2235,7 +2235,7 @@ async fn extensions_activate_handler(
                 crate::extensions::ExtensionError::AuthRequired
             );
 
-            tracing::debug!(
+            tracing::trace!(
                 extension = %name,
                 error = %activate_err,
                 needs_auth = needs_auth,
@@ -2249,7 +2249,7 @@ async fn extensions_activate_handler(
             // Activation failed due to auth; try authenticating first.
             match ext_mgr.auth(&name, &user.user_id).await {
                 Ok(auth_result) if auth_result.is_authenticated() => {
-                    tracing::debug!(
+                    tracing::trace!(
                         extension = %name,
                         "extensions_activate_handler: auth reports authenticated, retrying activate"
                     );

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -690,7 +690,7 @@ impl ExtensionManager {
                                 && parsed.username().is_empty()
                                 && parsed.password().is_none() =>
                         {
-                            tracing::debug!(
+                            tracing::trace!(
                                 extension = %name,
                                 relay_url_host = %parsed.host_str().unwrap_or("unknown"),
                                 "effective_relay_url: using per-extension override from settings"
@@ -968,7 +968,7 @@ impl ExtensionManager {
             match store.get_setting(&self.user_id, &key).await {
                 Ok(Some(v)) => {
                     let has_id = v.as_str().is_some_and(|s| !s.is_empty());
-                    tracing::debug!(
+                    tracing::trace!(
                         extension = %name,
                         has_team_id = has_id,
                         "has_stored_team_id: checked store"
@@ -976,7 +976,7 @@ impl ExtensionManager {
                     return has_id;
                 }
                 Ok(None) => {
-                    tracing::debug!(
+                    tracing::trace!(
                         extension = %name,
                         "has_stored_team_id: no team_id setting found"
                     );
@@ -4292,7 +4292,7 @@ impl ExtensionManager {
         name: &str,
         user_id: &str,
     ) -> Result<AuthResult, ExtensionError> {
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             user_id = %user_id,
             "auth_channel_relay: starting"
@@ -4306,14 +4306,14 @@ impl ExtensionManager {
         // to "authenticated" even when no team_id exists, preventing the OAuth
         // flow from being offered to the user.
         if self.has_stored_team_id(name, user_id).await {
-            tracing::debug!(
+            tracing::trace!(
                 extension = %name,
                 "auth_channel_relay: already authenticated (team_id in store)"
             );
             return Ok(AuthResult::authenticated(name, ExtensionKind::ChannelRelay));
         }
 
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             "auth_channel_relay: no stored team_id, initiating OAuth"
         );
@@ -4335,7 +4335,7 @@ impl ExtensionManager {
             .await
             .unwrap_or_else(|| relay_config.url.clone());
 
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             relay_url = %effective_url,
             "auth_channel_relay: creating relay client for OAuth"
@@ -4377,7 +4377,7 @@ impl ExtensionManager {
 
         // Channel-relay derives all URLs from trusted instance_url in chat-api.
         // We only pass the nonce for CSRF validation on the callback.
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             relay_url = %effective_url,
             "auth_channel_relay: calling initiate_oauth on channel-relay"
@@ -4413,7 +4413,7 @@ impl ExtensionManager {
         name: &str,
         user_id: &str,
     ) -> Result<ActivateResult, ExtensionError> {
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             user_id = %user_id,
             "activate_channel_relay: starting"
@@ -4426,7 +4426,7 @@ impl ExtensionManager {
             match store.get_setting(user_id, &team_id_key).await {
                 Ok(Some(v)) => {
                     let id = v.as_str().map(|s| s.to_string()).unwrap_or_default();
-                    tracing::debug!(
+                    tracing::trace!(
                         extension = %name,
                         team_id_empty = id.is_empty(),
                         "activate_channel_relay: loaded team_id from store"
@@ -4434,7 +4434,7 @@ impl ExtensionManager {
                     id
                 }
                 Ok(None) => {
-                    tracing::debug!(
+                    tracing::trace!(
                         extension = %name,
                         setting_key = %team_id_key,
                         "activate_channel_relay: no team_id in settings store"
@@ -4451,7 +4451,7 @@ impl ExtensionManager {
                 }
             }
         } else {
-            tracing::debug!(
+            tracing::trace!(
                 extension = %name,
                 "activate_channel_relay: no settings store available"
             );
@@ -4459,7 +4459,7 @@ impl ExtensionManager {
         };
 
         if team_id.is_empty() {
-            tracing::debug!(
+            tracing::trace!(
                 extension = %name,
                 "activate_channel_relay: team_id is empty, returning AuthRequired"
             );
@@ -4482,7 +4482,7 @@ impl ExtensionManager {
             .await
             .unwrap_or_else(|| relay_config.url.clone());
 
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             relay_url = %effective_url,
             "activate_channel_relay: relay config loaded"
@@ -4507,7 +4507,7 @@ impl ExtensionManager {
 
         // Fetch the per-instance signing secret from channel-relay.
         // This must succeed — there is no fallback.
-        tracing::debug!(
+        tracing::trace!(
             extension = %name,
             relay_url = %effective_url,
             "activate_channel_relay: fetching signing secret from channel-relay"


### PR DESCRIPTION
## Summary

- Downgrade 23 `tracing::debug!` statements introduced by PR #1681 to `tracing::trace!` across three files:
  - `src/channels/relay/client.rs` (5 sites): HTTP request/response logging in `initiate_oauth`, `proxy_provider`, `get_signing_secret`
  - `src/channels/web/server.rs` (3 sites): handler entry/retry logging in `extensions_activate_handler`
  - `src/extensions/manager.rs` (15 sites): step-by-step logging in `has_stored_team_id` (called per-extension in list loop), `effective_relay_url`, `auth_channel_relay`, `activate_channel_relay`
- All `warn!` and `info!` level logs are preserved for actionable diagnostics
- Zero clippy warnings confirmed

Closes #1686

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all --tests` passes with zero warnings
- [ ] Manual: run with `RUST_LOG=ironclaw=debug` and verify relay activation no longer floods logs
- [ ] Manual: run with `RUST_LOG=ironclaw=trace` and verify all downgraded messages still appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)