### PR TITLE
fix(llm): prevent UTF-8 panic in is_recoverable_tool_call_segment

### DIFF
--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1384,10 +1384,7 @@ fn line_bounds(text: &str, pos: usize) -> (usize, usize) {
     let pos = pos.min(text.len());
     // Walk backward to a valid char boundary to avoid slicing inside a
     // multi-byte UTF-8 sequence.
-    let mut safe_pos = pos;
-    while safe_pos > 0 && !text.is_char_boundary(safe_pos) {
-        safe_pos -= 1;
-    }
+    let safe_pos = (0..=pos).rev().find(|&i| text.is_char_boundary(i)).unwrap_or(0);
     let start = text[..safe_pos].rfind('\n').map_or(0, |idx| idx + 1);
     let end = text[safe_pos..].find('\n').map_or(text.len(), |idx| safe_pos + idx);
     (start, end)


### PR DESCRIPTION
## Summary

- Fix UTF-8 panic in `line_bounds()` when `end.saturating_sub(1)` lands inside a multi-byte character (e.g. emoji like 🔥 right before `\n<tool_call>`)
- `line_bounds()` now adjusts `pos` backward to the nearest char boundary using `is_char_boundary()` before slicing
- Added 4 regression tests covering multi-byte characters, valid positions, out-of-bounds pos, and the original crash scenario

Closes #1669

## Test plan

- [x] `test_line_bounds_at_multibyte_char_boundary` — verifies no panic when pos is inside a 4-byte emoji
- [x] `test_line_bounds_at_valid_positions` — verifies correct behavior at normal positions
- [x] `test_line_bounds_pos_beyond_len` — verifies clamping when pos exceeds text length
- [x] `test_is_recoverable_with_emoji_before_tool_call` — reproduces the exact crash scenario from #1669

🤖 Generated with [Claude Code](https://claude.com/claude-code)