### PR TITLE
fix(security): sanitize internal error details in API responses

### DIFF
--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -16,7 +16,7 @@ use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::channels::web::util::{
-    build_turns_from_db_messages, tool_error_for_display, truncate_preview,
+    build_turns_from_db_messages, sanitized_db_error, tool_error_for_display, truncate_preview,
 };
 
 pub async fn chat_send_handler(
@@ -355,7 +355,7 @@ pub async fn chat_history_handler(
         let (messages, has_more) = store
             .list_conversation_messages_paginated(thread_id, before_cursor, limit as i64)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| sanitized_db_error(e, "list paginated conversation messages"))?;
 
         let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
         let turns = build_turns_from_db_messages(&messages);
@@ -432,7 +432,7 @@ pub async fn chat_history_handler(
         let (messages, has_more) = store
             .list_conversation_messages_paginated(thread_id, None, limit as i64)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| sanitized_db_error(e, "list conversation messages"))?;
 
         if !messages.is_empty() {
             let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
@@ -476,7 +476,7 @@ pub async fn chat_threads_handler(
         let assistant_id = store
             .get_or_create_assistant_conversation(&identity.user_id, "gateway")
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| sanitized_db_error(e, "get assistant conversation"))?;
 
         if let Ok(summaries) = store
             .list_conversations_all_channels(&identity.user_id, 50)

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -11,6 +11,7 @@ use axum::{
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
+use crate::channels::web::util::{sanitized_action_failure, sanitized_internal_error_response};
 
 pub(crate) fn derive_activation_status(
     ext: &crate::extensions::InstalledExtension,
@@ -55,7 +56,7 @@ pub async fn extensions_list_handler(
     let installed = ext_mgr
         .list(None, false, &user.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_internal_error_response(e, "list installed extensions"))?;
 
     let pairing_store = crate::pairing::PairingStore::new();
     let mut owner_bound_channels = std::collections::HashSet::new();
@@ -139,7 +140,11 @@ pub async fn extensions_install_handler(
         .await
     {
         Ok(result) => Ok(Json(ActionResponse::ok(result.message))),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "install extension",
+            "Extension installation failed",
+        ))),
     }
 }
 
@@ -155,7 +160,11 @@ pub async fn extensions_remove_handler(
 
     match ext_mgr.remove(&name, &user.user_id).await {
         Ok(message) => Ok(Json(ActionResponse::ok(message))),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "remove extension",
+            "Extension removal failed",
+        ))),
     }
 }
 

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -817,12 +817,13 @@ pub async fn job_files_read_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::channels::web::util::sanitized_db_error;
 
     #[test]
     fn test_db_error_does_not_leak_details() {
-        let (status, body) = db_error("test_context", "relation \"jobs\" does not exist");
+        let (status, body) = sanitized_db_error("relation \"jobs\" does not exist", "test_context");
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
-        assert_eq!(body, "Internal database error");
+        assert_eq!(body, "Database error");
         assert!(!body.contains("relation"));
         assert!(!body.contains("does not exist"));
     }

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -14,14 +14,7 @@ use uuid::Uuid;
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
-
-fn db_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
-    tracing::error!(%e, context, "Database error in jobs handler");
-    (
-        StatusCode::INTERNAL_SERVER_ERROR,
-        "Internal database error".to_string(),
-    )
-}
+use crate::channels::web::util::{sanitized_db_error, sanitized_internal_error_response};
 
 pub async fn jobs_list_handler(
     State(state): State<Arc<GatewayState>>,
@@ -221,7 +214,7 @@ pub async fn jobs_detail_handler(
         }
         Ok(None) => {}
         Err(e) => {
-            return Err(db_error("jobs_handler", e));
+            return Err(sanitized_db_error(e, "get sandbox job detail"));
         }
     }
 
@@ -274,7 +267,7 @@ pub async fn jobs_detail_handler(
             }))
         }
         Ok(None) => Err((StatusCode::NOT_FOUND, "Job not found".to_string())),
-        Err(e) => Err(db_error("jobs_handler", e)),
+        Err(e) => Err(sanitized_db_error(e, "get agent job detail")),
     }
 }
 
@@ -309,7 +302,7 @@ pub async fn jobs_cancel_handler(
                             Some(chrono::Utc::now()),
                         )
                         .await
-                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                        .map_err(|e| sanitized_db_error(e, "persist sandbox job cancellation"))?;
                 }
                 return Ok(Json(serde_json::json!({
                     "status": "cancelled",
@@ -318,7 +311,7 @@ pub async fn jobs_cancel_handler(
             }
             Ok(None) => {}
             Err(e) => {
-                return Err(db_error("jobs_handler", e));
+                return Err(sanitized_db_error(e, "get sandbox job for cancellation"));
             }
         }
     }
@@ -352,7 +345,7 @@ pub async fn jobs_cancel_handler(
                             Some("Cancelled by user"),
                         )
                         .await
-                        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                        .map_err(|e| sanitized_db_error(e, "persist agent job cancellation"))?;
                 }
                 return Ok(Json(serde_json::json!({
                     "status": "cancelled",
@@ -361,7 +354,7 @@ pub async fn jobs_cancel_handler(
             }
             Ok(None) => {}
             Err(e) => {
-                return Err(db_error("jobs_handler", e));
+                return Err(sanitized_db_error(e, "get agent job for cancellation"));
             }
         }
     }
@@ -429,7 +422,7 @@ pub async fn jobs_restart_handler(
             store
                 .save_sandbox_job(&record)
                 .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                .map_err(|e| sanitized_db_error(e, "persist restarted sandbox job"))?;
 
             let mode = match store.get_sandbox_job_mode(old_job_id).await {
                 Ok(Some(m)) if m == "claude_code" => {
@@ -460,16 +453,13 @@ pub async fn jobs_restart_handler(
                 )
                 .await
                 .map_err(|e| {
-                    (
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to create container: {}", e),
-                    )
+                    sanitized_internal_error_response(e, "create restarted sandbox container")
                 })?;
 
             store
                 .update_sandbox_job_status(new_job_id, "running", None, None, Some(now), None)
                 .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                .map_err(|e| sanitized_db_error(e, "mark restarted sandbox job running"))?;
 
             return Ok(Json(serde_json::json!({
                 "status": "restarted",
@@ -479,7 +469,7 @@ pub async fn jobs_restart_handler(
         }
         Ok(None) => {}
         Err(e) => {
-            return Err(db_error("jobs_handler", e));
+            return Err(sanitized_db_error(e, "get sandbox job for restart"));
         }
     }
 
@@ -526,7 +516,9 @@ pub async fn jobs_restart_handler(
             let new_job_id = scheduler
                 .dispatch_job(&old_job.user_id, &title, &old_job.description, None)
                 .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                .map_err(|e| {
+                    sanitized_internal_error_response(e, "dispatch restarted agent job")
+                })?;
 
             Ok(Json(serde_json::json!({
                 "status": "restarted",
@@ -535,7 +527,7 @@ pub async fn jobs_restart_handler(
             })))
         }
         Ok(None) => Err((StatusCode::NOT_FOUND, "Job not found".to_string())),
-        Err(e) => Err(db_error("jobs_handler", e)),
+        Err(e) => Err(sanitized_db_error(e, "get agent job for restart")),
     }
 }
 
@@ -611,7 +603,7 @@ pub async fn jobs_prompt_handler(
                 return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
             }
             Err(e) => {
-                return Err(db_error("jobs_handler", e));
+                return Err(sanitized_db_error(e, "get agent job for prompt"));
             }
         }
     }
@@ -624,10 +616,9 @@ pub async fn jobs_prompt_handler(
     if let Some(ref scheduler) = *scheduler_guard
         && scheduler.is_running(job_id).await
     {
-        scheduler
-            .send_message(job_id, content)
-            .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        scheduler.send_message(job_id, content).await.map_err(|e| {
+            sanitized_internal_error_response(e, "send prompt to running agent job")
+        })?;
         return Ok(Json(serde_json::json!({
             "status": "sent",
             "job_id": job_id.to_string(),
@@ -666,7 +657,7 @@ pub async fn jobs_events_handler(
             }
         }
         Err(e) => {
-            return Err(db_error("jobs_events_handler", e));
+            return Err(sanitized_db_error(e, "get sandbox job events"));
         }
     };
     if !is_owner {
@@ -676,7 +667,7 @@ pub async fn jobs_events_handler(
     let events = store
         .list_job_events(job_id, None)
         .await
-        .map_err(|e| db_error("jobs_events_handler", e))?;
+        .map_err(|e| sanitized_db_error(e, "list job events"))?;
 
     let events_json: Vec<serde_json::Value> = events
         .into_iter()
@@ -720,7 +711,7 @@ pub async fn job_files_list_handler(
     let job = store
         .get_sandbox_job(job_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get sandbox job file list"))?
         .ok_or((StatusCode::NOT_FOUND, "Job not found".to_string()))?;
 
     if job.user_id != user.user_id {
@@ -788,7 +779,7 @@ pub async fn job_files_read_handler(
     let job = store
         .get_sandbox_job(job_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get sandbox job file read"))?
         .ok_or((StatusCode::NOT_FOUND, "Job not found".to_string()))?;
 
     if job.user_id != user.user_id {

--- a/src/channels/web/handlers/memory.rs
+++ b/src/channels/web/handlers/memory.rs
@@ -12,6 +12,7 @@ use serde::Deserialize;
 use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
+use crate::channels::web::util::sanitized_workspace_error;
 use crate::workspace::Workspace;
 
 /// Resolve the workspace for the authenticated user.
@@ -48,7 +49,7 @@ pub async fn memory_tree_handler(
     let all_paths = workspace
         .list_all()
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_workspace_error(e, "list workspace tree"))?;
 
     // Collect unique directories and files
     let mut entries: Vec<TreeEntry> = Vec::new();
@@ -94,7 +95,7 @@ pub async fn memory_list_handler(
     let entries = workspace
         .list(path)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_workspace_error(e, "list workspace directory"))?;
 
     let list_entries: Vec<ListEntry> = entries
         .iter()
@@ -127,7 +128,7 @@ pub async fn memory_read_handler(
     let doc = workspace
         .read(&query.path)
         .await
-        .map_err(|e| (StatusCode::NOT_FOUND, e.to_string()))?;
+        .map_err(|e| sanitized_workspace_error(e, "read workspace document"))?;
 
     Ok(Json(MemoryReadResponse {
         path: query.path,
@@ -160,16 +161,7 @@ pub async fn memory_write_handler(
                 .write_to_layer(layer_name, &req.path, &req.content, req.force)
                 .await
         }
-        .map_err(|e| {
-            use crate::error::WorkspaceError;
-            let status = match &e {
-                WorkspaceError::LayerNotFound { .. } => StatusCode::BAD_REQUEST,
-                WorkspaceError::LayerReadOnly { .. } => StatusCode::FORBIDDEN,
-                WorkspaceError::PrivacyRedirectFailed => StatusCode::UNPROCESSABLE_ENTITY,
-                _ => StatusCode::INTERNAL_SERVER_ERROR,
-            };
-            (status, e.to_string())
-        })?;
+        .map_err(|e| sanitized_workspace_error(e, "write workspace layer"))?;
         return Ok(Json(MemoryWriteResponse {
             path: req.path,
             status: "written",
@@ -183,12 +175,12 @@ pub async fn memory_write_handler(
         workspace
             .append(&req.path, &req.content)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| sanitized_workspace_error(e, "append workspace document"))?;
     } else {
         workspace
             .write(&req.path, &req.content)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| sanitized_workspace_error(e, "write workspace document"))?;
     }
 
     Ok(Json(MemoryWriteResponse {
@@ -210,7 +202,7 @@ pub async fn memory_search_handler(
     let results = workspace
         .search(&req.query, limit)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_workspace_error(e, "search workspace"))?;
 
     let hits: Vec<SearchHit> = results
         .iter()

--- a/src/channels/web/handlers/routines.rs
+++ b/src/channels/web/handlers/routines.rs
@@ -14,6 +14,7 @@ use crate::agent::routine::{Trigger, next_cron_fire};
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
+use crate::channels::web::util::sanitized_db_error;
 use crate::error::RoutineError;
 
 pub async fn routines_list_handler(
@@ -28,7 +29,7 @@ pub async fn routines_list_handler(
     let routines = store
         .list_routines(&user.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "list routines"))?;
 
     let items: Vec<RoutineInfo> = routines.iter().map(RoutineInfo::from_routine).collect();
 
@@ -47,7 +48,7 @@ pub async fn routines_summary_handler(
     let routines = store
         .list_routines(&user.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "list routines summary"))?;
 
     let total = routines.len() as u64;
     let enabled = routines.iter().filter(|r| r.enabled).count() as u64;
@@ -95,7 +96,7 @@ pub async fn routines_detail_handler(
     let routine = store
         .get_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get routine detail"))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
     if routine.user_id != user.user_id {
@@ -105,7 +106,7 @@ pub async fn routines_detail_handler(
     let runs = store
         .list_routine_runs(routine_id, 20)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "list routine detail runs"))?;
 
     let recent_runs: Vec<RoutineRunInfo> = runs
         .iter()
@@ -205,7 +206,7 @@ pub async fn routines_toggle_handler(
     let mut routine = store
         .get_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get routine for toggle"))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
     if routine.user_id != user.user_id {
@@ -239,7 +240,7 @@ pub async fn routines_toggle_handler(
     store
         .update_routine(&routine)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "update routine toggle state"))?;
 
     // Refresh the in-memory event trigger cache so event/system_event
     // routines reflect the new enabled state immediately (issue #1076).
@@ -272,7 +273,7 @@ pub async fn routines_delete_handler(
     let routine = store
         .get_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get routine for delete"))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
     if routine.user_id != user.user_id {
@@ -282,7 +283,7 @@ pub async fn routines_delete_handler(
     let deleted = store
         .delete_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "delete routine"))?;
 
     if deleted {
         // Refresh the in-memory event trigger cache so deleted event/system_event
@@ -320,7 +321,7 @@ pub async fn routines_runs_handler(
     let routine = store
         .get_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get routine runs"))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
     if routine.user_id != user.user_id {
@@ -330,7 +331,7 @@ pub async fn routines_runs_handler(
     let runs = store
         .list_routine_runs(routine_id, 50)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_db_error(e, "list routine runs"))?;
 
     let run_infos: Vec<RoutineRunInfo> = runs
         .iter()

--- a/src/channels/web/handlers/routines.rs
+++ b/src/channels/web/handlers/routines.rs
@@ -14,8 +14,7 @@ use crate::agent::routine::{Trigger, next_cron_fire};
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
-use crate::channels::web::util::sanitized_db_error;
-use crate::error::RoutineError;
+use crate::channels::web::util::{sanitized_db_error, sanitized_routine_error};
 
 pub async fn routines_list_handler(
     State(state): State<Arc<GatewayState>>,
@@ -175,7 +174,7 @@ pub async fn routines_trigger_handler(
     let run_id = engine
         .fire_manual(routine_id, Some(&user.user_id))
         .await
-        .map_err(|e| (routine_error_status(&e), e.to_string()))?;
+        .map_err(|e| sanitized_routine_error(e, "trigger routine manually"))?;
 
     Ok(Json(serde_json::json!({
         "status": "triggered",
@@ -351,16 +350,4 @@ pub async fn routines_runs_handler(
         "routine_id": routine_id,
         "runs": run_infos,
     })))
-}
-
-/// Map `RoutineError` variants to appropriate HTTP status codes.
-fn routine_error_status(err: &RoutineError) -> StatusCode {
-    match err {
-        RoutineError::NotFound { .. } => StatusCode::NOT_FOUND,
-        RoutineError::NotAuthorized { .. } => StatusCode::FORBIDDEN,
-        RoutineError::Disabled { .. }
-        | RoutineError::Cooldown { .. }
-        | RoutineError::MaxConcurrent { .. } => StatusCode::CONFLICT,
-        _ => StatusCode::INTERNAL_SERVER_ERROR,
-    }
 }

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -11,6 +11,10 @@ use axum::{
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
+use crate::channels::web::util::{
+    sanitized_action_failure, sanitized_bad_gateway, sanitized_bad_request,
+    sanitized_internal_error_response,
+};
 
 pub async fn skills_list_handler(
     State(state): State<Arc<GatewayState>>,
@@ -21,12 +25,9 @@ pub async fn skills_list_handler(
         "Skills system not enabled".to_string(),
     ))?;
 
-    let guard = registry.read().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Skill registry lock poisoned: {}", e),
-        )
-    })?;
+    let guard = registry
+        .read()
+        .map_err(|e| sanitized_internal_error_response(e, "read skill registry"))?;
 
     let skills: Vec<SkillInfo> = guard
         .skills()
@@ -88,12 +89,9 @@ pub async fn skills_search_handler(
     // Search local skills
     let query_lower = req.query.to_lowercase();
     let installed: Vec<SkillInfo> = {
-        let guard = registry.read().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Skill registry lock poisoned: {}", e),
-            )
-        })?;
+        let guard = registry
+            .read()
+            .map_err(|e| sanitized_internal_error_response(e, "read skill registry"))?;
         guard
             .skills()
             .iter()
@@ -152,7 +150,9 @@ pub async fn skills_install_handler(
         // Fetch from explicit URL (with SSRF protection)
         crate::tools::builtin::skill_tools::fetch_skill_content(url)
             .await
-            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
+            .map_err(|e| {
+                sanitized_bad_request(e, "fetch skill from explicit URL", "Invalid skill source")
+            })?
     } else if let Some(ref catalog) = state.skill_catalog {
         // Prefer slug (e.g. "owner/skill-name") over display name for the
         // download URL, since the registry endpoint expects a slug.
@@ -164,7 +164,9 @@ pub async fn skills_install_handler(
         let url = crate::skills::catalog::skill_download_url(catalog.registry_url(), download_key);
         crate::tools::builtin::skill_tools::fetch_skill_content(&url)
             .await
-            .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?
+            .map_err(|e| {
+                sanitized_bad_gateway(e, "download skill from catalog", "Failed to download skill")
+            })?
     } else {
         return Ok(Json(ActionResponse::fail(
             "Provide 'content' or 'url' to install a skill".to_string(),
@@ -173,16 +175,14 @@ pub async fn skills_install_handler(
 
     // Parse, check duplicates, and get install_dir under a brief read lock.
     let (user_dir, skill_name_from_parse) = {
-        let guard = registry.read().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Skill registry lock poisoned: {}", e),
-            )
-        })?;
+        let guard = registry
+            .read()
+            .map_err(|e| sanitized_internal_error_response(e, "read skill registry"))?;
 
         let normalized = crate::skills::normalize_line_endings(&content);
-        let parsed = crate::skills::parser::parse_skill_md(&normalized)
-            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+        let parsed = crate::skills::parser::parse_skill_md(&normalized).map_err(|e| {
+            sanitized_bad_request(e, "parse skill definition", "Invalid skill definition")
+        })?;
         let skill_name = parsed.manifest.name.clone();
 
         if guard.has(&skill_name) {
@@ -204,22 +204,23 @@ pub async fn skills_install_handler(
             &normalized,
         )
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_internal_error_response(e, "prepare skill install"))?;
 
     // Commit: brief write lock for in-memory addition
-    let mut guard = registry.write().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Skill registry lock poisoned: {}", e),
-        )
-    })?;
+    let mut guard = registry
+        .write()
+        .map_err(|e| sanitized_internal_error_response(e, "write skill registry"))?;
 
     match guard.commit_install(&skill_name, loaded_skill) {
         Ok(()) => Ok(Json(ActionResponse::ok(format!(
             "Skill '{}' installed",
             skill_name
         )))),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "commit skill install",
+            "Skill installation failed",
+        ))),
     }
 }
 
@@ -250,35 +251,33 @@ pub async fn skills_remove_handler(
 
     // Validate removal under a brief read lock
     let skill_path = {
-        let guard = registry.read().map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Skill registry lock poisoned: {}", e),
-            )
-        })?;
-        guard
-            .validate_remove(&name)
-            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?
+        let guard = registry
+            .read()
+            .map_err(|e| sanitized_internal_error_response(e, "read skill registry"))?;
+        guard.validate_remove(&name).map_err(|e| {
+            sanitized_bad_request(e, "validate skill removal", "Invalid skill removal request")
+        })?
     };
 
     // Delete files from disk (async I/O, no lock held)
     crate::skills::registry::SkillRegistry::delete_skill_files(&skill_path)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| sanitized_internal_error_response(e, "delete skill files"))?;
 
     // Remove from in-memory registry under a brief write lock
-    let mut guard = registry.write().map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            format!("Skill registry lock poisoned: {}", e),
-        )
-    })?;
+    let mut guard = registry
+        .write()
+        .map_err(|e| sanitized_internal_error_response(e, "write skill registry"))?;
 
     match guard.commit_remove(&name) {
         Ok(()) => Ok(Json(ActionResponse::ok(format!(
             "Skill '{}' removed",
             name
         )))),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "commit skill removal",
+            "Skill removal failed",
+        ))),
     }
 }

--- a/src/channels/web/handlers/webhooks.rs
+++ b/src/channels/web/handlers/webhooks.rs
@@ -15,6 +15,7 @@ use subtle::ConstantTimeEq;
 
 use crate::agent::routine::Trigger;
 use crate::channels::web::server::GatewayState;
+use crate::channels::web::util::{sanitized_db_error, sanitized_routine_error};
 
 /// Validate the webhook secret for a routine.
 ///
@@ -114,7 +115,7 @@ async fn fire_webhook_inner(
     let routine = store
         .get_webhook_routine_by_path(path, user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| sanitized_db_error(e, "get webhook routine by path"))?
         .ok_or((
             StatusCode::NOT_FOUND,
             "No routine matches this webhook path".to_string(),
@@ -137,16 +138,10 @@ async fn fire_webhook_inner(
         ))?
     };
 
-    let run_id = engine.fire_webhook(routine.id, path).await.map_err(|e| {
-        let status = match &e {
-            crate::error::RoutineError::NotFound { .. } => StatusCode::NOT_FOUND,
-            crate::error::RoutineError::Disabled { .. }
-            | crate::error::RoutineError::Cooldown { .. }
-            | crate::error::RoutineError::MaxConcurrent { .. } => StatusCode::CONFLICT,
-            _ => StatusCode::INTERNAL_SERVER_ERROR,
-        };
-        (status, e.to_string())
-    })?;
+    let run_id = engine
+        .fire_webhook(routine.id, path)
+        .await
+        .map_err(|e| sanitized_routine_error(e, "trigger routine from webhook"))?;
 
     Ok(Json(serde_json::json!({
         "status": "triggered",

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -1821,7 +1821,13 @@ async fn chat_history_handler(
         let (messages, has_more) = store
             .list_conversation_messages_paginated(thread_id, before_cursor, limit as i64)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = %e, "DB error listing paginated messages");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
+            })?;
 
         let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
         let turns = build_turns_from_db_messages(&messages);
@@ -1894,7 +1900,13 @@ async fn chat_history_handler(
         let (messages, has_more) = store
             .list_conversation_messages_paginated(thread_id, None, limit as i64)
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = %e, "DB error listing messages");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
+            })?;
 
         if !messages.is_empty() {
             let oldest_timestamp = messages.first().map(|m| m.created_at.to_rfc3339());
@@ -1937,7 +1949,13 @@ async fn chat_threads_handler(
         let assistant_id = store
             .get_or_create_assistant_conversation(&user.user_id, "gateway")
             .await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+            .map_err(|e| {
+                tracing::error!(error = %e, "DB error getting assistant conversation");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Database error".to_string(),
+                )
+            })?;
 
         match store
             .list_conversations_all_channels(&user.user_id, 50)
@@ -2159,7 +2177,13 @@ async fn extensions_list_handler(
     let installed = ext_mgr
         .list(None, false, &user.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "Error listing extensions");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal error".to_string(),
+            )
+        })?;
 
     let pairing_store = crate::pairing::PairingStore::new();
     let mut owner_bound_channels = std::collections::HashSet::new();
@@ -2574,7 +2598,13 @@ async fn extensions_setup_handler(
     let setup = ext_mgr
         .get_setup_schema(&name, &user.user_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+        .map_err(|e| {
+            tracing::error!(error = %e, "Error getting extension setup schema");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal error".to_string(),
+            )
+        })?;
 
     let kind = ext_mgr
         .list(None, false, &user.user_id)
@@ -2648,9 +2678,13 @@ async fn pairing_list_handler(
     Path(channel): Path<String>,
 ) -> Result<Json<PairingListResponse>, (StatusCode, String)> {
     let store = crate::pairing::PairingStore::new();
-    let requests = store
-        .list_pending(&channel)
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let requests = store.list_pending(&channel).map_err(|e| {
+        tracing::error!(error = %e, "Error listing pairing requests");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Internal error".to_string(),
+        )
+    })?;
 
     let infos = requests
         .into_iter()
@@ -2706,17 +2740,26 @@ async fn routines_runs_handler(
     let routine = store
         .get_routine(routine_id)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .map_err(|e| {
+            tracing::error!(error = %e, "DB error getting routine");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Database error".to_string(),
+            )
+        })?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
     if routine.user_id != user.user_id {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 
-    let runs = store
-        .list_routine_runs(routine_id, 50)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    let runs = store.list_routine_runs(routine_id, 50).await.map_err(|e| {
+        tracing::error!(error = %e, "DB error listing routine runs");
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Database error".to_string(),
+        )
+    })?;
 
     let run_infos: Vec<RoutineRunInfo> = runs
         .iter()

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -59,7 +59,9 @@ use crate::channels::web::handlers::skills::{
 use crate::channels::web::log_layer::LogBroadcaster;
 use crate::channels::web::sse::SseManager;
 use crate::channels::web::types::*;
-use crate::channels::web::util::{build_turns_from_db_messages, truncate_preview};
+use crate::channels::web::util::{
+    build_turns_from_db_messages, sanitized_action_failure, truncate_preview,
+};
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::orchestrator::job_manager::ContainerJobManager;
@@ -2314,7 +2316,11 @@ async fn extensions_install_handler(
 
             Ok(Json(resp))
         }
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "install extension from gateway",
+            "Extension installation failed",
+        ))),
     }
 }
 
@@ -2365,7 +2371,11 @@ async fn extensions_activate_handler(
             );
 
             if !needs_auth {
-                return Ok(Json(ActionResponse::fail(activate_err.to_string())));
+                return Ok(Json(sanitized_action_failure(
+                    activate_err,
+                    "activate extension from gateway",
+                    "Extension activation failed",
+                )));
             }
 
             // Activation failed due to auth; try authenticating first.
@@ -2384,7 +2394,11 @@ async fn extensions_activate_handler(
                                 error = %e,
                                 "extensions_activate_handler: retry after auth still failed"
                             );
-                            Ok(Json(ActionResponse::fail(e.to_string())))
+                            Ok(Json(sanitized_action_failure(
+                                e,
+                                "retry extension activation after auth",
+                                "Extension activation failed",
+                            )))
                         }
                     }
                 }
@@ -2401,10 +2415,11 @@ async fn extensions_activate_handler(
                     resp.instructions = auth_result.instructions().map(String::from);
                     Ok(Json(resp))
                 }
-                Err(auth_err) => Ok(Json(ActionResponse::fail(format!(
-                    "Authentication failed: {}",
-                    auth_err
-                )))),
+                Err(auth_err) => Ok(Json(sanitized_action_failure(
+                    auth_err,
+                    "authenticate extension during activation",
+                    "Authentication failed",
+                ))),
             }
         }
     }
@@ -2517,7 +2532,11 @@ async fn extensions_remove_handler(
 
     match ext_mgr.remove(&name, &user.user_id).await {
         Ok(message) => Ok(Json(ActionResponse::ok(message))),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "remove extension from gateway",
+            "Extension removal failed",
+        ))),
     }
 }
 
@@ -2668,7 +2687,11 @@ async fn extensions_setup_submit_handler(
             }
             Ok(Json(resp))
         }
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "submit extension setup",
+            "Extension setup failed",
+        ))),
     }
 }
 
@@ -2719,7 +2742,11 @@ async fn pairing_approve_handler(
             StatusCode::TOO_MANY_REQUESTS,
             "Too many failed approve attempts; try again later".to_string(),
         )),
-        Err(e) => Ok(Json(ActionResponse::fail(e.to_string()))),
+        Err(e) => Ok(Json(sanitized_action_failure(
+            e,
+            "approve pairing request",
+            "Pairing approval failed",
+        ))),
     }
 }
 
@@ -3354,6 +3381,7 @@ mod tests {
             .expect("request");
         req.extensions_mut().insert(UserIdentity {
             user_id: "test".to_string(),
+            role: "admin".to_string(),
             workspace_read_scopes: Vec::new(),
         });
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3063,6 +3063,55 @@ mod tests {
         })
     }
 
+    fn test_gateway_state_with_store(
+        store: Arc<dyn crate::db::Database>,
+        ext_mgr: Option<Arc<ExtensionManager>>,
+    ) -> Arc<GatewayState> {
+        Arc::new(GatewayState {
+            msg_tx: tokio::sync::RwLock::new(None),
+            sse: Arc::new(SseManager::new()),
+            workspace: None,
+            workspace_pool: None,
+            session_manager: None,
+            log_broadcaster: None,
+            log_level_handle: None,
+            extension_manager: ext_mgr,
+            tool_registry: None,
+            store: Some(store),
+            job_manager: None,
+            prompt_queue: None,
+            owner_id: "test".to_string(),
+            default_sender_id: "test".to_string(),
+            shutdown_tx: tokio::sync::RwLock::new(None),
+            ws_tracker: None,
+            llm_provider: None,
+            skill_registry: None,
+            skill_catalog: None,
+            scheduler: None,
+            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+            oauth_rate_limiter: RateLimiter::new(10, 60),
+            webhook_rate_limiter: RateLimiter::new(10, 60),
+            registry_entries: vec![],
+            cost_guard: None,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            startup_time: std::time::Instant::now(),
+            active_config: ActiveConfigSnapshot::default(),
+        })
+    }
+
+    #[cfg(feature = "libsql")]
+    async fn create_unmigrated_test_db() -> (Arc<dyn crate::db::Database>, tempfile::TempDir) {
+        use crate::db::libsql::LibSqlBackend;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("test.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        let db: Arc<dyn crate::db::Database> = Arc::new(backend);
+        (db, temp_dir)
+    }
+
     /// Build a test router with just the OAuth callback route.
     fn test_oauth_router(state: Arc<GatewayState>) -> Router {
         Router::new()
@@ -3302,6 +3351,47 @@ mod tests {
                 .contains("Activation failed"),
             "expected activation failure in message: {:?}",
             parsed
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_routines_list_sanitizes_database_errors() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let (db, _tmp) = create_unmigrated_test_db().await;
+        let state = test_gateway_state_with_store(db, None);
+        let app = Router::new()
+            .route(
+                "/api/routines",
+                get(crate::channels::web::handlers::routines::routines_list_handler),
+            )
+            .with_state(state);
+
+        let mut req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/routines")
+            .body(Body::empty())
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let text = String::from_utf8(body.to_vec()).expect("utf8 body");
+        assert_eq!(text, "Database error");
+        assert!(
+            !text.contains("no such table"),
+            "client response should not leak backend error details"
         );
     }
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3028,8 +3028,10 @@ mod tests {
 
     // --- OAuth callback handler tests ---
 
-    /// Build a minimal `GatewayState` for testing the OAuth callback handler.
-    fn test_gateway_state(ext_mgr: Option<Arc<ExtensionManager>>) -> Arc<GatewayState> {
+    fn test_gateway_state_inner(
+        ext_mgr: Option<Arc<ExtensionManager>>,
+        store: Option<Arc<dyn crate::db::Database>>,
+    ) -> Arc<GatewayState> {
         Arc::new(GatewayState {
             msg_tx: tokio::sync::RwLock::new(None),
             sse: Arc::new(SseManager::new()),
@@ -3040,7 +3042,7 @@ mod tests {
             log_level_handle: None,
             extension_manager: ext_mgr,
             tool_registry: None,
-            store: None,
+            store,
             job_manager: None,
             prompt_queue: None,
             owner_id: "test".to_string(),
@@ -3063,40 +3065,16 @@ mod tests {
         })
     }
 
+    /// Build a minimal `GatewayState` for testing the OAuth callback handler.
+    fn test_gateway_state(ext_mgr: Option<Arc<ExtensionManager>>) -> Arc<GatewayState> {
+        test_gateway_state_inner(ext_mgr, None)
+    }
+
     fn test_gateway_state_with_store(
         store: Arc<dyn crate::db::Database>,
         ext_mgr: Option<Arc<ExtensionManager>>,
     ) -> Arc<GatewayState> {
-        Arc::new(GatewayState {
-            msg_tx: tokio::sync::RwLock::new(None),
-            sse: Arc::new(SseManager::new()),
-            workspace: None,
-            workspace_pool: None,
-            session_manager: None,
-            log_broadcaster: None,
-            log_level_handle: None,
-            extension_manager: ext_mgr,
-            tool_registry: None,
-            store: Some(store),
-            job_manager: None,
-            prompt_queue: None,
-            owner_id: "test".to_string(),
-            default_sender_id: "test".to_string(),
-            shutdown_tx: tokio::sync::RwLock::new(None),
-            ws_tracker: None,
-            llm_provider: None,
-            skill_registry: None,
-            skill_catalog: None,
-            scheduler: None,
-            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: RateLimiter::new(10, 60),
-            webhook_rate_limiter: RateLimiter::new(10, 60),
-            registry_entries: vec![],
-            cost_guard: None,
-            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
-            startup_time: std::time::Instant::now(),
-            active_config: ActiveConfigSnapshot::default(),
-        })
+        test_gateway_state_inner(ext_mgr, Some(store))
     }
 
     #[cfg(feature = "libsql")]

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -4,7 +4,7 @@ use std::fmt::Display;
 
 use axum::http::StatusCode;
 
-use crate::channels::web::types::{ToolCallInfo, TurnInfo};
+use crate::channels::web::types::{ActionResponse, ToolCallInfo, TurnInfo};
 
 pub use ironclaw_common::truncate_preview;
 
@@ -13,15 +13,26 @@ pub fn tool_error_for_display(error: &str) -> String {
     ironclaw_safety::SafetyLayer::unwrap_tool_output(error).unwrap_or_else(|| error.to_string())
 }
 
-fn sanitized_internal_error<E: Display>(
+fn sanitized_status_error<E: Display>(
+    status: StatusCode,
     error: E,
     context: &str,
     client_message: &str,
 ) -> (StatusCode, String) {
     tracing::error!(error = %error, context, "Web gateway request failed");
-    (
+    (status, client_message.to_string())
+}
+
+fn sanitized_internal_error<E: Display>(
+    error: E,
+    context: &str,
+    client_message: &str,
+) -> (StatusCode, String) {
+    sanitized_status_error(
         StatusCode::INTERNAL_SERVER_ERROR,
-        client_message.to_string(),
+        error,
+        context,
+        client_message,
     )
 }
 
@@ -38,6 +49,83 @@ pub fn sanitized_internal_error_response<E: Display>(
     sanitized_internal_error(error, context, "Internal error")
 }
 
+/// Log a detailed validation error while returning a safe 400 response.
+pub fn sanitized_bad_request<E: Display>(
+    error: E,
+    context: &str,
+    client_message: &str,
+) -> (StatusCode, String) {
+    sanitized_status_error(StatusCode::BAD_REQUEST, error, context, client_message)
+}
+
+/// Log a detailed upstream failure while returning a safe 502 response.
+pub fn sanitized_bad_gateway<E: Display>(
+    error: E,
+    context: &str,
+    client_message: &str,
+) -> (StatusCode, String) {
+    sanitized_status_error(StatusCode::BAD_GATEWAY, error, context, client_message)
+}
+
+/// Log a detailed backend error while returning a generic failed action payload.
+pub fn sanitized_action_failure<E: Display>(
+    error: E,
+    context: &str,
+    client_message: &str,
+) -> ActionResponse {
+    tracing::error!(error = %error, context, "Web gateway action failed");
+    ActionResponse::fail(client_message)
+}
+
+/// Return safe client responses for `WorkspaceError` values.
+pub fn sanitized_workspace_error(
+    error: crate::error::WorkspaceError,
+    context: &str,
+) -> (StatusCode, String) {
+    use crate::error::WorkspaceError;
+
+    match error {
+        err @ WorkspaceError::DocumentNotFound { .. } => {
+            sanitized_status_error(StatusCode::NOT_FOUND, err, context, "Path not found")
+        }
+        err @ WorkspaceError::InvalidDocType { .. } => {
+            sanitized_bad_request(err, context, "Invalid workspace document type")
+        }
+        err @ WorkspaceError::LayerNotFound { .. } => {
+            sanitized_bad_request(err, context, "Workspace layer not found")
+        }
+        err @ WorkspaceError::LayerReadOnly { .. } => sanitized_status_error(
+            StatusCode::FORBIDDEN,
+            err,
+            context,
+            "Workspace layer is read-only",
+        ),
+        err @ WorkspaceError::PrivacyRedirectFailed => sanitized_status_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            err,
+            context,
+            "Sensitive content requires a private workspace layer",
+        ),
+        err @ WorkspaceError::InjectionRejected { .. } => sanitized_status_error(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            err,
+            context,
+            "Write rejected: prompt injection detected",
+        ),
+        err @ WorkspaceError::NotInitialized { .. } => sanitized_status_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            err,
+            context,
+            "Workspace not available",
+        ),
+        err @ WorkspaceError::SearchFailed { .. }
+        | err @ WorkspaceError::EmbeddingFailed { .. }
+        | err @ WorkspaceError::ChunkingFailed { .. }
+        | err @ WorkspaceError::HeartbeatError { .. }
+        | err @ WorkspaceError::IoError { .. } => sanitized_internal_error_response(err, context),
+    }
+}
+
 /// Return safe client responses for `RoutineError` while preserving user-actionable variants.
 pub fn sanitized_routine_error(
     error: crate::error::RoutineError,
@@ -46,11 +134,18 @@ pub fn sanitized_routine_error(
     use crate::error::RoutineError;
 
     match error {
-        err @ RoutineError::NotFound { .. } => (StatusCode::NOT_FOUND, err.to_string()),
-        err @ RoutineError::NotAuthorized { .. } => (StatusCode::FORBIDDEN, err.to_string()),
-        err @ RoutineError::Disabled { .. }
-        | err @ RoutineError::Cooldown { .. }
-        | err @ RoutineError::MaxConcurrent { .. } => (StatusCode::CONFLICT, err.to_string()),
+        RoutineError::NotFound { .. } | RoutineError::NotAuthorized { .. } => {
+            (StatusCode::NOT_FOUND, "Routine not found".to_string())
+        }
+        RoutineError::Disabled { .. } => (StatusCode::CONFLICT, "Routine is disabled".to_string()),
+        RoutineError::Cooldown { .. } => (
+            StatusCode::CONFLICT,
+            "Routine is in cooldown period".to_string(),
+        ),
+        RoutineError::MaxConcurrent { .. } => (
+            StatusCode::CONFLICT,
+            "Routine has reached the maximum concurrent runs".to_string(),
+        ),
         err @ RoutineError::Database { .. } => sanitized_db_error(err, context),
         err @ RoutineError::LlmFailed { .. }
         | err @ RoutineError::JobDispatchFailed { .. }
@@ -193,8 +288,9 @@ mod tests {
 
     #[test]
     fn test_sanitized_internal_error_hides_internal_details() {
-        let (_, body) =
+        let (status, body) =
             sanitized_internal_error_response("container launch failed: timeout", "restart job");
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
         assert_eq!(body, "Internal error");
     }
 
@@ -207,6 +303,68 @@ mod tests {
             "trigger routine",
         );
         assert_eq!(body, "Database error");
+    }
+
+    #[test]
+    fn test_sanitized_routine_not_found_hides_routine_id() {
+        let (status, body) = sanitized_routine_error(
+            crate::error::RoutineError::NotFound { id: Uuid::new_v4() },
+            "trigger routine",
+        );
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "Routine not found");
+    }
+
+    #[test]
+    fn test_sanitized_routine_not_authorized_matches_not_found() {
+        let (status, body) = sanitized_routine_error(
+            crate::error::RoutineError::NotAuthorized { id: Uuid::new_v4() },
+            "trigger routine",
+        );
+        assert_eq!(status, StatusCode::NOT_FOUND);
+        assert_eq!(body, "Routine not found");
+    }
+
+    #[test]
+    fn test_sanitized_routine_conflict_variants_hide_routine_name() {
+        let disabled = sanitized_routine_error(
+            crate::error::RoutineError::Disabled {
+                name: "prod-db-secret-rotation".to_string(),
+            },
+            "trigger routine",
+        );
+        assert_eq!(
+            disabled,
+            (StatusCode::CONFLICT, "Routine is disabled".to_string())
+        );
+
+        let cooldown = sanitized_routine_error(
+            crate::error::RoutineError::Cooldown {
+                name: "prod-db-secret-rotation".to_string(),
+            },
+            "trigger routine",
+        );
+        assert_eq!(
+            cooldown,
+            (
+                StatusCode::CONFLICT,
+                "Routine is in cooldown period".to_string(),
+            )
+        );
+
+        let max_concurrent = sanitized_routine_error(
+            crate::error::RoutineError::MaxConcurrent {
+                name: "prod-db-secret-rotation".to_string(),
+            },
+            "trigger routine",
+        );
+        assert_eq!(
+            max_concurrent,
+            (
+                StatusCode::CONFLICT,
+                "Routine has reached the maximum concurrent runs".to_string(),
+            )
+        );
     }
 
     // ---- build_turns_from_db_messages tests ----

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -38,6 +38,34 @@ pub fn sanitized_internal_error_response<E: Display>(
     sanitized_internal_error(error, context, "Internal error")
 }
 
+/// Return safe client responses for `RoutineError` while preserving user-actionable variants.
+pub fn sanitized_routine_error(
+    error: crate::error::RoutineError,
+    context: &str,
+) -> (StatusCode, String) {
+    use crate::error::RoutineError;
+
+    match error {
+        err @ RoutineError::NotFound { .. } => (StatusCode::NOT_FOUND, err.to_string()),
+        err @ RoutineError::NotAuthorized { .. } => (StatusCode::FORBIDDEN, err.to_string()),
+        err @ RoutineError::Disabled { .. }
+        | err @ RoutineError::Cooldown { .. }
+        | err @ RoutineError::MaxConcurrent { .. } => (StatusCode::CONFLICT, err.to_string()),
+        err @ RoutineError::Database { .. } => sanitized_db_error(err, context),
+        err @ RoutineError::LlmFailed { .. }
+        | err @ RoutineError::JobDispatchFailed { .. }
+        | err @ RoutineError::EmptyResponse
+        | err @ RoutineError::TruncatedResponse
+        | err @ RoutineError::UnknownTriggerType { .. }
+        | err @ RoutineError::UnknownActionType { .. }
+        | err @ RoutineError::MissingField { .. }
+        | err @ RoutineError::InvalidCron { .. }
+        | err @ RoutineError::UnknownRunStatus { .. } => {
+            sanitized_internal_error_response(err, context)
+        }
+    }
+}
+
 /// Parse tool call summary JSON objects into `ToolCallInfo` structs.
 fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
     calls
@@ -168,6 +196,17 @@ mod tests {
         let (_, body) =
             sanitized_internal_error_response("container launch failed: timeout", "restart job");
         assert_eq!(body, "Internal error");
+    }
+
+    #[test]
+    fn test_sanitized_routine_error_hides_database_details() {
+        let (_, body) = sanitized_routine_error(
+            crate::error::RoutineError::Database {
+                reason: "sqlite: no such table: routine_runs".to_string(),
+            },
+            "trigger routine",
+        );
+        assert_eq!(body, "Database error");
     }
 
     // ---- build_turns_from_db_messages tests ----

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -1,5 +1,9 @@
 //! Shared utility functions for the web gateway.
 
+use std::fmt::Display;
+
+use axum::http::StatusCode;
+
 use crate::channels::web::types::{ToolCallInfo, TurnInfo};
 
 pub use ironclaw_common::truncate_preview;
@@ -7,6 +11,31 @@ pub use ironclaw_common::truncate_preview;
 /// Convert stored tool errors into plain text suitable for UI display.
 pub fn tool_error_for_display(error: &str) -> String {
     ironclaw_safety::SafetyLayer::unwrap_tool_output(error).unwrap_or_else(|| error.to_string())
+}
+
+fn sanitized_internal_error<E: Display>(
+    error: E,
+    context: &str,
+    client_message: &str,
+) -> (StatusCode, String) {
+    tracing::error!(error = %error, context, "Web gateway request failed");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        client_message.to_string(),
+    )
+}
+
+/// Log a detailed backend error while returning a generic DB message to the client.
+pub fn sanitized_db_error<E: Display>(error: E, context: &str) -> (StatusCode, String) {
+    sanitized_internal_error(error, context, "Database error")
+}
+
+/// Log a detailed backend error while returning a generic internal message to the client.
+pub fn sanitized_internal_error_response<E: Display>(
+    error: E,
+    context: &str,
+) -> (StatusCode, String) {
+    sanitized_internal_error(error, context, "Internal error")
 }
 
 /// Parse tool call summary JSON objects into `ToolCallInfo` structs.
@@ -127,6 +156,19 @@ pub fn build_turns_from_db_messages(
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[test]
+    fn test_sanitized_db_error_hides_internal_details() {
+        let (_, body) = sanitized_db_error("sqlite: no such table: routines", "list routines");
+        assert_eq!(body, "Database error");
+    }
+
+    #[test]
+    fn test_sanitized_internal_error_hides_internal_details() {
+        let (_, body) =
+            sanitized_internal_error_response("container launch failed: timeout", "restart job");
+        assert_eq!(body, "Internal error");
+    }
 
     // ---- build_turns_from_db_messages tests ----
 


### PR DESCRIPTION
## Summary

- add shared web-gateway sanitization helpers that log backend failures while returning generic `500` bodies to clients
- extend the sanitization pass across the inline `server.rs` handlers in this PR and the live jobs, routines, and webhook-trigger paths wired into the current router
- add regression coverage for the sanitized contract with helper unit tests and a libSQL-backed route test that verifies `/api/routines` returns `Database error` instead of leaking backend text

This hardens the leak paths touched in this branch. Other gateway handlers still have raw `e.to_string()` responses and should be handled in follow-up work rather than being implied as covered here.

## Test plan

- [x] `cargo fmt`
- [x] `cargo test test_sanitized_db_error_hides_internal_details -- --nocapture`
- [x] `cargo test test_sanitized_routine_error_hides_database_details -- --nocapture`
- [x] `cargo test --features libsql test_routines_list_sanitizes_database_errors -- --nocapture`
- [x] `cargo clippy --all-features --all-targets -- -D warnings`

Addresses #1702
