### PR TITLE
feat(tool_info): add curated summaries for selected built-in tools

### DIFF
--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -981,7 +981,7 @@ mod tests {
         assert!(alice_stats.last_active_at.is_some());
 
         // Bob has no LLM calls so doesn't appear in summary stats
-        assert!(stats.iter().find(|s| s.user_id == "bob").is_none());
+        assert!(!stats.iter().any(|s| s.user_id == "bob"));
 
         // Filter to single user
         let alice_only = db.user_summary_stats(Some("alice")).await.unwrap();

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -12,7 +12,9 @@ use reqwest::Client;
 use crate::context::JobContext;
 use crate::safety::LeakDetector;
 use crate::secrets::SecretsStore;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use crate::tools::tool::{
+    ApprovalRequirement, Tool, ToolDiscoverySummary, ToolError, ToolOutput, require_str,
+};
 use crate::tools::wasm::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
 
 #[cfg(feature = "html-to-markdown")]
@@ -46,6 +48,31 @@ const USER_AGENT: &str = concat!(
     env!("CARGO_PKG_VERSION"),
     " (https://github.com/nearai/ironclaw)"
 );
+
+fn http_tool_summary() -> ToolDiscoverySummary {
+    ToolDiscoverySummary {
+        always_required: vec!["url".into()],
+        conditional_requirements: vec![
+            "'body' is typical for POST, PUT, and PATCH requests.".into(),
+            "'save_to' must be a path under /tmp/ (for binary downloads).".into(),
+        ],
+        notes: vec![
+            "HTTPS only — http:// URLs are rejected.".into(),
+            "localhost, private IPs, and cloud metadata endpoints are blocked (SSRF protection).".into(),
+            "Headers accept either object {\"Name\": \"Value\"} or array [{\"name\": \"N\", \"value\": \"V\"}] format.".into(),
+            "timeout_secs defaults to 30, maximum 300.".into(),
+            "Response body capped at 5 MB (text) or 50 MB (save_to file downloads).".into(),
+            "Credentials in headers (Authorization, X-API-Key, etc.) or URL query params trigger approval.".into(),
+            "GET with no credentials or custom headers does not require approval.".into(),
+            "Redirects are followed only for simple GETs (max 3 hops); non-GET redirects are blocked.".into(),
+        ],
+        examples: vec![
+            serde_json::json!({"method": "GET", "url": "https://api.example.com/data"}),
+            serde_json::json!({"method": "POST", "url": "https://api.example.com/items", "body": {"name": "test"}, "headers": {"Authorization": "Bearer token"}}),
+            serde_json::json!({"method": "GET", "url": "https://example.com/photo.jpg", "save_to": "/tmp/photo.jpg"}),
+        ],
+    }
+}
 
 /// Tool for making HTTP requests.
 ///
@@ -829,6 +856,10 @@ impl Tool for HttpTool {
         true // External data always needs sanitization
     }
 
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(http_tool_summary())
+    }
+
     fn requires_approval(&self, params: &serde_json::Value) -> ApprovalRequirement {
         let has_credentials = crate::safety::params_contain_manual_credentials(params)
             || (self.credential_registry.as_ref().is_some_and(|registry| {
@@ -1482,5 +1513,16 @@ mod tests {
     fn test_save_to_rejects_bare_tmp() {
         let err = validate_save_to_path("/tmp").unwrap_err();
         assert!(err.to_string().contains("must be under /tmp/"));
+    }
+
+    #[test]
+    fn http_discovery_summary_explains_policies_and_constraints() {
+        let summary = http_tool_summary();
+        assert_eq!(summary.always_required, vec!["url".to_string()]);
+        assert!(summary.notes.iter().any(|n| n.contains("HTTPS only")));
+        assert!(summary.notes.iter().any(|n| n.contains("SSRF")));
+        assert!(summary.notes.iter().any(|n| n.contains("save_to")));
+        assert!(summary.notes.iter().any(|n| n.contains("approval")));
+        assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -64,7 +64,7 @@ fn http_tool_summary() -> ToolDiscoverySummary {
             "Response body capped at 5 MB (text) or 50 MB (save_to file downloads).".into(),
             "Credentials in headers (Authorization, X-API-Key, etc.) or URL query params trigger approval.".into(),
             "GET with no credentials or custom headers does not require approval.".into(),
-            "Redirects are followed only for simple GETs (max 3 hops); non-GET redirects are blocked.".into(),
+            "Redirects are followed only for GETs with no custom headers and no body (max 3 hops); non-GET redirects are blocked.".into(),
         ],
         examples: vec![
             serde_json::json!({"method": "GET", "url": "https://api.example.com/data"}),

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -2298,9 +2298,22 @@ mod tests {
     #[test]
     fn create_job_discovery_summary_explains_modes_and_credentials() {
         let summary = create_job_tool_summary();
-        assert_eq!(summary.always_required, vec!["title".to_string(), "description".to_string()]);
-        assert!(summary.conditional_requirements.iter().any(|r| r.contains("claude_code")));
-        assert!(summary.conditional_requirements.iter().any(|r| r.contains("credentials")));
+        assert_eq!(
+            summary.always_required,
+            vec!["title".to_string(), "description".to_string()]
+        );
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("claude_code"))
+        );
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("credentials"))
+        );
         assert!(summary.notes.iter().any(|n| n.contains("wait")));
         assert!(summary.notes.iter().any(|n| n.contains("uppercase")));
         assert_eq!(summary.examples.len(), 3);

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -79,17 +79,16 @@ fn create_job_tool_summary() -> ToolDiscoverySummary {
     ToolDiscoverySummary {
         always_required: vec!["title".into(), "description".into()],
         conditional_requirements: vec![
-            "mode='claude_code' uses Claude Code CLI for complex software engineering tasks.".into(),
             "credentials requires each secret to already exist in the secrets store (via 'ironclaw tool auth' or web UI).".into(),
-            "project_dir must be an existing directory under ~/.ironclaw/projects/. Auto-created if omitted.".into(),
         ],
         notes: vec![
             "wait defaults to true (blocks up to 10 minutes for completion).".into(),
             "Set wait=false to start the job and return immediately; poll with job_status or job_events.".into(),
-            "mode defaults to 'worker' (IronClaw sub-agent with shell, file, and patch tools).".into(),
+            "mode defaults to 'worker' (IronClaw sub-agent with shell, file, and patch tools). Use 'claude_code' for complex software engineering tasks.".into(),
+            "project_dir must be under ~/.ironclaw/projects/. Auto-created if omitted.".into(),
             "Credential env var names must be uppercase: [A-Z_][A-Z0-9_]* (e.g. GITHUB_TOKEN). Max 20 grants per job.".into(),
             "Certain env var names are denied (PATH, HOME, LD_PRELOAD, etc.) to prevent process hijacking.".into(),
-            "Rate limit: 5 job creations per 30-second window.".into(),
+            "Rate limit: 5 per minute, 30 per hour.".into(),
         ],
         examples: vec![
             serde_json::json!({"title": "Build landing page", "description": "Create a responsive landing page using React and Tailwind CSS"}),
@@ -2306,16 +2305,19 @@ mod tests {
             summary
                 .conditional_requirements
                 .iter()
-                .any(|r| r.contains("claude_code"))
+                .any(|r| r.contains("credentials")),
+            "should explain credential requirement",
         );
         assert!(
-            summary
-                .conditional_requirements
-                .iter()
-                .any(|r| r.contains("credentials"))
+            summary.notes.iter().any(|n| n.contains("claude_code")),
+            "should explain claude_code mode",
         );
         assert!(summary.notes.iter().any(|n| n.contains("wait")));
         assert!(summary.notes.iter().any(|n| n.contains("uppercase")));
+        assert!(
+            summary.notes.iter().any(|n| n.contains("5 per minute")),
+            "should state correct rate limit",
+        );
         assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -23,7 +23,9 @@ use crate::history::SandboxJobRecord;
 use crate::orchestrator::auth::CredentialGrant;
 use crate::orchestrator::job_manager::{ContainerJobManager, JobMode};
 use crate::secrets::SecretsStore;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use crate::tools::tool::{
+    ApprovalRequirement, Tool, ToolDiscoverySummary, ToolError, ToolOutput, require_str,
+};
 use ironclaw_common::AppEvent;
 
 /// Lazy scheduler reference, filled after Agent::new creates the Scheduler.
@@ -70,6 +72,30 @@ async fn resolve_job_id(input: &str, context_manager: &ContextManager) -> Result
             "ambiguous prefix '{}' matches {} jobs, provide more characters",
             input, n
         ))),
+    }
+}
+
+fn create_job_tool_summary() -> ToolDiscoverySummary {
+    ToolDiscoverySummary {
+        always_required: vec!["title".into(), "description".into()],
+        conditional_requirements: vec![
+            "mode='claude_code' uses Claude Code CLI for complex software engineering tasks.".into(),
+            "credentials requires each secret to already exist in the secrets store (via 'ironclaw tool auth' or web UI).".into(),
+            "project_dir must be an existing directory under ~/.ironclaw/projects/. Auto-created if omitted.".into(),
+        ],
+        notes: vec![
+            "wait defaults to true (blocks up to 10 minutes for completion).".into(),
+            "Set wait=false to start the job and return immediately; poll with job_status or job_events.".into(),
+            "mode defaults to 'worker' (IronClaw sub-agent with shell, file, and patch tools).".into(),
+            "Credential env var names must be uppercase: [A-Z_][A-Z0-9_]* (e.g. GITHUB_TOKEN). Max 20 grants per job.".into(),
+            "Certain env var names are denied (PATH, HOME, LD_PRELOAD, etc.) to prevent process hijacking.".into(),
+            "Rate limit: 5 job creations per 30-second window.".into(),
+        ],
+        examples: vec![
+            serde_json::json!({"title": "Build landing page", "description": "Create a responsive landing page using React and Tailwind CSS"}),
+            serde_json::json!({"title": "Refactor auth module", "description": "Extract auth logic into a separate service", "mode": "claude_code"}),
+            serde_json::json!({"title": "Deploy to staging", "description": "Run the deploy script and verify health checks", "wait": false, "credentials": {"github_token": "GITHUB_TOKEN"}}),
+        ],
     }
 }
 
@@ -920,6 +946,10 @@ impl Tool for CreateJobTool {
 
     fn requires_sanitization(&self) -> bool {
         false
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(create_job_tool_summary())
     }
 }
 
@@ -2263,5 +2293,16 @@ mod tests {
         let cm = ContextManager::new(5);
         let result = resolve_job_id("not-hex-at-all!", &cm).await;
         assert!(result.is_err()); // safety: test
+    }
+
+    #[test]
+    fn create_job_discovery_summary_explains_modes_and_credentials() {
+        let summary = create_job_tool_summary();
+        assert_eq!(summary.always_required, vec!["title".to_string(), "description".to_string()]);
+        assert!(summary.conditional_requirements.iter().any(|r| r.contains("claude_code")));
+        assert!(summary.conditional_requirements.iter().any(|r| r.contains("credentials")));
+        assert!(summary.notes.iter().any(|n| n.contains("wait")));
+        assert!(summary.notes.iter().any(|n| n.contains("uppercase")));
+        assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -22,14 +22,17 @@ fn message_tool_summary() -> ToolDiscoverySummary {
         conditional_requirements: vec![
             "Omitting 'channel' defaults to the current conversation's channel.".into(),
             "Omitting 'target' defaults to the current sender/group.".into(),
-            "Attachments must be files under ~/.ironclaw or /tmp/ (download with http tool first).".into(),
+            "Attachments must be files under ~/.ironclaw or /tmp/ (download with http tool first)."
+                .into(),
         ],
         notes: vec![
             "Signal targets: E.164 phone number (+1234567890) or group ID.".into(),
             "Telegram targets: username (@alice), bare username, or chat ID (numeric).".into(),
             "Slack targets: channel name (#general) or user ID (U1234567890).".into(),
-            "For interactive chat, omit channel and target to reply in the current conversation.".into(),
-            "Images are sent as photos on Telegram; other file types pass through as attachments.".into(),
+            "For interactive chat, omit channel and target to reply in the current conversation."
+                .into(),
+            "Images are sent as photos on Telegram; other file types pass through as attachments."
+                .into(),
             "Rate limit: 10/min, 100/hour.".into(),
         ],
         examples: vec![
@@ -1101,7 +1104,12 @@ mod tests {
         assert!(summary.notes.iter().any(|n| n.contains("Signal")));
         assert!(summary.notes.iter().any(|n| n.contains("Telegram")));
         assert!(summary.notes.iter().any(|n| n.contains("Slack")));
-        assert!(summary.conditional_requirements.iter().any(|r| r.contains("channel")));
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("channel"))
+        );
         assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -12,8 +12,33 @@ use crate::channels::{ChannelManager, OutgoingResponse};
 use crate::context::JobContext;
 use crate::extensions::ExtensionManager;
 use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolError, ToolOutput, ToolRateLimitConfig, require_str,
+    ApprovalRequirement, Tool, ToolDiscoverySummary, ToolError, ToolOutput, ToolRateLimitConfig,
+    require_str,
 };
+
+fn message_tool_summary() -> ToolDiscoverySummary {
+    ToolDiscoverySummary {
+        always_required: vec!["content".into()],
+        conditional_requirements: vec![
+            "Omitting 'channel' defaults to the current conversation's channel.".into(),
+            "Omitting 'target' defaults to the current sender/group.".into(),
+            "Attachments must be files under ~/.ironclaw or /tmp/ (download with http tool first).".into(),
+        ],
+        notes: vec![
+            "Signal targets: E.164 phone number (+1234567890) or group ID.".into(),
+            "Telegram targets: username (@alice), bare username, or chat ID (numeric).".into(),
+            "Slack targets: channel name (#general) or user ID (U1234567890).".into(),
+            "For interactive chat, omit channel and target to reply in the current conversation.".into(),
+            "Images are sent as photos on Telegram; other file types pass through as attachments.".into(),
+            "Rate limit: 10/min, 100/hour.".into(),
+        ],
+        examples: vec![
+            serde_json::json!({"content": "Hello!"}),
+            serde_json::json!({"content": "Check this out", "channel": "telegram", "target": "@alice"}),
+            serde_json::json!({"content": "Here's the report", "attachments": ["/tmp/report.pdf"]}),
+        ],
+    }
+}
 
 /// Tool for sending messages to channels.
 pub struct MessageTool {
@@ -432,6 +457,10 @@ impl Tool for MessageTool {
 
     fn requires_sanitization(&self) -> bool {
         false
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(message_tool_summary())
     }
 }
 
@@ -1063,5 +1092,16 @@ mod tests {
         assert_eq!(gateway.len(), 1);
         assert_eq!(gateway[0].0, "owner-scope");
         assert_eq!(gateway[0].1.thread_id.as_deref(), Some("thread-123"));
+    }
+
+    #[test]
+    fn message_discovery_summary_explains_routing_and_formats() {
+        let summary = message_tool_summary();
+        assert_eq!(summary.always_required, vec!["content".to_string()]);
+        assert!(summary.notes.iter().any(|n| n.contains("Signal")));
+        assert!(summary.notes.iter().any(|n| n.contains("Telegram")));
+        assert!(summary.notes.iter().any(|n| n.contains("Slack")));
+        assert!(summary.conditional_requirements.iter().any(|r| r.contains("channel")));
+        assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -20,17 +20,17 @@ fn message_tool_summary() -> ToolDiscoverySummary {
     ToolDiscoverySummary {
         always_required: vec!["content".into()],
         conditional_requirements: vec![
-            "Omitting 'channel' defaults to the current conversation's channel.".into(),
-            "Omitting 'target' defaults to the current sender/group.".into(),
             "Attachments must be files under ~/.ironclaw or /tmp/ (download with http tool first)."
                 .into(),
         ],
         notes: vec![
+            "Omitting 'channel' defaults to the current conversation's channel.".into(),
+            "Omitting 'target' defaults to the current sender/group.".into(),
+            "For interactive chat, omit channel and target to reply in the current conversation."
+                .into(),
             "Signal targets: E.164 phone number (+1234567890) or group ID.".into(),
             "Telegram targets: username (@alice), bare username, or chat ID (numeric).".into(),
             "Slack targets: channel name (#general) or user ID (U1234567890).".into(),
-            "For interactive chat, omit channel and target to reply in the current conversation."
-                .into(),
             "Images are sent as photos on Telegram; other file types pass through as attachments."
                 .into(),
             "Rate limit: 10/min, 100/hour.".into(),
@@ -1101,15 +1101,20 @@ mod tests {
     fn message_discovery_summary_explains_routing_and_formats() {
         let summary = message_tool_summary();
         assert_eq!(summary.always_required, vec!["content".to_string()]);
-        assert!(summary.notes.iter().any(|n| n.contains("Signal")));
-        assert!(summary.notes.iter().any(|n| n.contains("Telegram")));
-        assert!(summary.notes.iter().any(|n| n.contains("Slack")));
         assert!(
             summary
                 .conditional_requirements
                 .iter()
-                .any(|r| r.contains("channel"))
+                .any(|r| r.contains("Attachments")),
+            "should explain attachment path constraint",
         );
+        assert!(
+            summary.notes.iter().any(|n| n.contains("channel")),
+            "should explain default channel behavior",
+        );
+        assert!(summary.notes.iter().any(|n| n.contains("Signal")));
+        assert!(summary.notes.iter().any(|n| n.contains("Telegram")));
+        assert!(summary.notes.iter().any(|n| n.contains("Slack")));
         assert_eq!(summary.examples.len(), 3);
     }
 }

--- a/src/tools/builtin/time.rs
+++ b/src/tools/builtin/time.rs
@@ -623,8 +623,18 @@ mod tests {
     fn time_discovery_summary_explains_operations_and_requirements() {
         let summary = time_tool_summary();
         assert_eq!(summary.always_required, vec!["operation".to_string()]);
-        assert!(summary.conditional_requirements.iter().any(|r| r.contains("to_timezone")));
-        assert!(summary.conditional_requirements.iter().any(|r| r.contains("timestamp2")));
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("to_timezone"))
+        );
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("timestamp2"))
+        );
         assert!(summary.notes.iter().any(|n| n.contains("IANA")));
         assert_eq!(summary.examples.len(), 5);
     }

--- a/src/tools/builtin/time.rs
+++ b/src/tools/builtin/time.rs
@@ -9,13 +9,14 @@ use crate::tools::tool::{Tool, ToolDiscoverySummary, ToolError, ToolOutput};
 
 fn time_tool_summary() -> ToolDiscoverySummary {
     ToolDiscoverySummary {
-        always_required: vec!["operation".into()],
+        always_required: vec![],
         conditional_requirements: vec![
             "parse/convert/format/diff require 'input' (or legacy alias 'timestamp').".into(),
             "convert requires 'to_timezone'.".into(),
             "diff requires 'timestamp2'.".into(),
         ],
         notes: vec![
+            "'operation' defaults to 'now' if omitted. Valid values: now, parse, convert, format, diff.".into(),
             "'input' and 'timestamp' are aliases; prefer 'input'.".into(),
             "Timezones use IANA names (e.g. 'America/New_York', 'Europe/London').".into(),
             "Naive timestamps (no UTC offset) require 'timezone' or 'from_timezone' to interpret.".into(),
@@ -622,18 +623,25 @@ mod tests {
     #[test]
     fn time_discovery_summary_explains_operations_and_requirements() {
         let summary = time_tool_summary();
-        assert_eq!(summary.always_required, vec!["operation".to_string()]);
         assert!(
-            summary
-                .conditional_requirements
-                .iter()
-                .any(|r| r.contains("to_timezone"))
+            summary.always_required.is_empty(),
+            "operation defaults to 'now', so nothing is always required",
+        );
+        assert!(
+            summary.notes.iter().any(|n| n.contains("defaults to 'now'")),
+            "should explain operation defaults to now",
         );
         assert!(
             summary
                 .conditional_requirements
                 .iter()
-                .any(|r| r.contains("timestamp2"))
+                .any(|r| r.contains("to_timezone")),
+        );
+        assert!(
+            summary
+                .conditional_requirements
+                .iter()
+                .any(|r| r.contains("timestamp2")),
         );
         assert!(summary.notes.iter().any(|n| n.contains("IANA")));
         assert_eq!(summary.examples.len(), 5);

--- a/src/tools/builtin/time.rs
+++ b/src/tools/builtin/time.rs
@@ -5,7 +5,32 @@ use chrono::{DateTime, LocalResult, NaiveDate, NaiveDateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 
 use crate::context::JobContext;
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use crate::tools::tool::{Tool, ToolDiscoverySummary, ToolError, ToolOutput};
+
+fn time_tool_summary() -> ToolDiscoverySummary {
+    ToolDiscoverySummary {
+        always_required: vec!["operation".into()],
+        conditional_requirements: vec![
+            "parse/convert/format/diff require 'input' (or legacy alias 'timestamp').".into(),
+            "convert requires 'to_timezone'.".into(),
+            "diff requires 'timestamp2'.".into(),
+        ],
+        notes: vec![
+            "'input' and 'timestamp' are aliases; prefer 'input'.".into(),
+            "Timezones use IANA names (e.g. 'America/New_York', 'Europe/London').".into(),
+            "Naive timestamps (no UTC offset) require 'timezone' or 'from_timezone' to interpret.".into(),
+            "'format' and 'format_string' are aliases for the strftime pattern; prefer 'format_string'.".into(),
+            "The user's timezone is auto-detected from context when available.".into(),
+        ],
+        examples: vec![
+            serde_json::json!({"operation": "now", "timezone": "America/New_York"}),
+            serde_json::json!({"operation": "parse", "input": "2026-03-08 03:30:00", "from_timezone": "America/New_York"}),
+            serde_json::json!({"operation": "convert", "input": "2026-03-08T07:30:00Z", "to_timezone": "Europe/London"}),
+            serde_json::json!({"operation": "format", "input": "2026-03-08T07:30:00Z", "timezone": "America/New_York", "format_string": "%Y-%m-%d %H:%M:%S %Z"}),
+            serde_json::json!({"operation": "diff", "input": "2026-03-01T00:00:00Z", "timestamp2": "2026-03-08T00:00:00Z"}),
+        ],
+    }
+}
 
 /// Tool for getting current time and date operations.
 pub struct TimeTool;
@@ -97,6 +122,10 @@ impl Tool for TimeTool {
 
     fn requires_sanitization(&self) -> bool {
         false // Internal tool, no external data
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(time_tool_summary())
     }
 }
 
@@ -588,5 +617,15 @@ mod tests {
             .expect("empty from_timezone string should not error");
 
         assert!(output.result.get("output").is_some(), "should have output");
+    }
+
+    #[test]
+    fn time_discovery_summary_explains_operations_and_requirements() {
+        let summary = time_tool_summary();
+        assert_eq!(summary.always_required, vec!["operation".to_string()]);
+        assert!(summary.conditional_requirements.iter().any(|r| r.contains("to_timezone")));
+        assert!(summary.conditional_requirements.iter().any(|r| r.contains("timestamp2")));
+        assert!(summary.notes.iter().any(|n| n.contains("IANA")));
+        assert_eq!(summary.examples.len(), 5);
     }
 }

--- a/src/tools/builtin/tool_info.rs
+++ b/src/tools/builtin/tool_info.rs
@@ -2,7 +2,8 @@
 //!
 //! Three levels of detail:
 //! - Default: name, description, parameter names (compact ~150 bytes)
-//! - `detail: "summary"`: adds curated rules, notes, and examples
+//! - `detail: "summary"`: adds curated rules/notes/examples when a tool provides
+//!   them, otherwise falls back to schema-derived required fields only
 //! - `detail: "schema"` / `include_schema: true`: adds the full typed JSON Schema
 //!
 //! Keeps the tools array compact (WASM tools use permissive schemas)
@@ -21,6 +22,21 @@ enum ToolInfoDetail {
     Names,
     Summary,
     Schema,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SummarySource {
+    Curated,
+    SchemaFallback,
+}
+
+impl SummarySource {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Curated => "curated",
+            Self::SchemaFallback => "schema_fallback",
+        }
+    }
 }
 
 impl ToolInfoDetail {
@@ -97,7 +113,7 @@ impl Tool for ToolInfoTool {
     }
 
     fn description(&self) -> &str {
-        "Get info about any tool: description, parameter names, curated summary guidance, or full discovery schema."
+        "Get info about any tool: description, parameter names, curated summary guidance for selected tools, or the full discovery schema."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -111,7 +127,7 @@ impl Tool for ToolInfoTool {
                 "detail": {
                     "type": "string",
                     "enum": ["names", "summary", "schema"],
-                    "description": "Response detail level. 'names' returns parameter names only. 'summary' adds curated rules/examples. 'schema' returns the full discovery schema.",
+                    "description": "Response detail level. 'names' returns parameter names only. 'summary' adds curated rules/examples when available, otherwise basic schema-derived requirements. 'schema' returns the full discovery schema.",
                     "default": "names"
                 },
                 "include_schema": {
@@ -155,9 +171,12 @@ impl Tool for ToolInfoTool {
         match detail {
             ToolInfoDetail::Names => {}
             ToolInfoDetail::Summary => {
-                let summary = tool
-                    .discovery_summary()
-                    .unwrap_or_else(|| fallback_summary(&schema));
+                let (summary_source, summary) = match tool.discovery_summary() {
+                    Some(summary) => (SummarySource::Curated, summary),
+                    None => (SummarySource::SchemaFallback, fallback_summary(&schema)),
+                };
+                info["summary_source"] =
+                    serde_json::Value::String(summary_source.as_str().to_string());
                 info["summary"] = serde_json::to_value(summary).map_err(|err| {
                     ToolError::ExecutionFailed(format!(
                         "failed to serialize discovery summary: {err}"
@@ -210,7 +229,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_tool_info_with_summary() {
+    async fn test_tool_info_with_summary_fallback() {
         let registry = Arc::new(ToolRegistry::new());
         registry.register(Arc::new(EchoTool)).await;
 
@@ -226,10 +245,74 @@ mod tests {
 
         let info = &result.result;
         assert_eq!(info["name"], "echo");
+        assert_eq!(info["summary_source"], "schema_fallback");
         assert!(info["summary"].is_object());
         assert_eq!(
             info["summary"]["always_required"],
             serde_json::json!(["message"])
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_info_with_curated_summary() {
+        #[derive(Debug)]
+        struct SummaryTool;
+
+        #[async_trait::async_trait]
+        impl Tool for SummaryTool {
+            fn name(&self) -> &str {
+                "summary_tool"
+            }
+
+            fn description(&self) -> &str {
+                "Summary-capable test tool"
+            }
+
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "input": { "type": "string" }
+                    },
+                    "required": ["input"]
+                })
+            }
+
+            fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+                Some(ToolDiscoverySummary {
+                    notes: vec!["curated note".into()],
+                    ..ToolDiscoverySummary::default()
+                })
+            }
+
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                unreachable!()
+            }
+        }
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(SummaryTool)).await;
+
+        let tool = ToolInfoTool::new(Arc::downgrade(&registry));
+        let ctx = JobContext::default();
+        let result = tool
+            .execute(
+                serde_json::json!({"name": "summary_tool", "detail": "summary"}),
+                &ctx,
+            )
+            .await
+            .unwrap();
+
+        let info = &result.result;
+        assert_eq!(info["name"], "summary_tool");
+        assert_eq!(info["summary_source"], "curated");
+        assert_eq!(
+            info["summary"]["notes"],
+            serde_json::json!(["curated note"])
         );
     }
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -904,8 +904,76 @@ mod tests {
             .find(|def| def.name == "discovery_tool")
             .expect("tool definition should be present");
         assert!(
-            def.description.contains("tool_info"),
-            "live tool definition should include schema hint: {}",
+            def.description.contains("detail: \"summary\""),
+            "live tool definition should advertise curated summaries when present: {}",
+            def.description
+        );
+        assert!(
+            def.description.contains("detail: \"schema\""),
+            "live tool definition should advertise full discovery schema when present: {}",
+            def.description
+        );
+        assert!(def.parameters.get("extra").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_tool_definition_schema_hint_omits_summary_when_not_curated() {
+        struct SchemaOnlyTool;
+
+        #[async_trait::async_trait]
+        impl Tool for SchemaOnlyTool {
+            fn name(&self) -> &str {
+                "schema_only_tool"
+            }
+
+            fn description(&self) -> &str {
+                "Schema-only discovery test tool"
+            }
+
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" }
+                    }
+                })
+            }
+
+            fn discovery_schema(&self) -> serde_json::Value {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "extra": { "type": "string" }
+                    }
+                })
+            }
+
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+
+        let registry = ToolRegistry::new();
+        registry.register(Arc::new(SchemaOnlyTool)).await;
+
+        let defs = registry.tool_definitions().await;
+        let def = defs
+            .iter()
+            .find(|def| def.name == "schema_only_tool")
+            .expect("tool definition should be present");
+        assert!(
+            def.description.contains("detail: \"schema\""),
+            "schema-only tool should still advertise full discovery schema: {}",
+            def.description
+        );
+        assert!(
+            !def.description.contains("detail: \"summary\""),
+            "schema-only tool should not advertise curated summaries it does not have: {}",
             def.description
         );
         assert!(def.parameters.get("extra").is_none());

--- a/src/tools/tool.rs
+++ b/src/tools/tool.rs
@@ -263,7 +263,11 @@ impl ToolSchema {
     }
 }
 
-/// Curated discovery guidance surfaced by `tool_info(detail: "summary")`.
+/// Curated discovery guidance surfaced by `tool_info(detail: "summary")` for
+/// tools that opt in.
+///
+/// Tools without a curated summary fall back to schema-derived required fields
+/// only, so callers should not assume summary coverage is universal.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct ToolDiscoverySummary {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -407,7 +411,7 @@ pub trait Tool: Send + Sync {
     /// Curated discovery guidance used by `tool_info(detail: "summary")`.
     ///
     /// Default: no custom summary; callers may derive a minimal fallback from
-    /// `discovery_schema()`.
+    /// `discovery_schema()`. At the moment only a subset of tools override this.
     fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
         None
     }
@@ -415,16 +419,25 @@ pub trait Tool: Send + Sync {
     /// Get the tool schema for LLM function calling.
     fn schema(&self) -> ToolSchema {
         let parameters = self.parameters_schema();
-        let has_discovery_hint =
-            self.discovery_summary().is_some() || self.discovery_schema() != parameters;
-        let description = if has_discovery_hint {
-            format!(
-                "{} (call tool_info(name: \"{}\", detail: \"summary\") for rules/examples or detail: \"schema\" for the full discovery schema)",
+        let has_curated_summary = self.discovery_summary().is_some();
+        let has_extended_discovery_schema = self.discovery_schema() != parameters;
+        let description = match (has_curated_summary, has_extended_discovery_schema) {
+            (true, true) => format!(
+                "{} (call tool_info(name: \"{}\", detail: \"summary\") for curated rules/examples or detail: \"schema\" for the full discovery schema)",
                 self.description(),
                 self.name()
-            )
-        } else {
-            self.description().to_string()
+            ),
+            (true, false) => format!(
+                "{} (call tool_info(name: \"{}\", detail: \"summary\") for curated rules/examples)",
+                self.description(),
+                self.name()
+            ),
+            (false, true) => format!(
+                "{} (call tool_info(name: \"{}\", detail: \"schema\") for the full discovery schema)",
+                self.description(),
+                self.name()
+            ),
+            (false, false) => self.description().to_string(),
         };
         ToolSchema {
             name: self.name().to_string(),

--- a/tests/e2e_builtin_tool_coverage.rs
+++ b/tests/e2e_builtin_tool_coverage.rs
@@ -1095,6 +1095,11 @@ mod tests {
             "detail: summary should include summary field: {:?}",
             routine_json
         );
+        assert_eq!(
+            routine_json["summary_source"], "curated",
+            "routine_create should report curated summary coverage: {:?}",
+            routine_json
+        );
         assert!(
             routine_json["summary"]["conditional_requirements"]
                 .as_array()


### PR DESCRIPTION
## Summary

- Adds curated `discovery_summary()` guidance for four selected built-in tools: `time`, `http`, `message`, and `create_job`
- Explicitly scopes the rollout: `tool_info(detail: "summary")` is curated for selected tools today, and falls back to schema-derived required fields for the rest
- Makes `tool_info` report `summary_source` (`curated` vs `schema_fallback`) so callers can tell which kind of summary they received
- Only advertises `detail: "summary"` in tool descriptions when curated guidance actually exists; schema-only tools now point to `detail: "schema"`

## Change Type

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #1332, #1334, #1330, #1331

## Validation

- [x] `cargo fmt`
- [ ] `cargo clippy --all --benches --tests --examples --all-features`
- [x] Relevant tests pass:
  - `cargo test --lib tool_info`
  - `cargo test --lib schema_hint`
  - `cargo test --test e2e_builtin_tool_coverage tool_info_discovery`
- [x] Manual testing: deployed branch summary coverage remains limited to the selected tools listed above

## Security Impact

None

## Database Impact

None

## Blast Radius

- Curated summaries added in: `src/tools/builtin/http.rs`, `src/tools/builtin/job.rs`, `src/tools/builtin/message.rs`, `src/tools/builtin/time.rs`
- Scope clarification and summary-source reporting in: `src/tools/builtin/tool_info.rs`, `src/tools/tool.rs`, `src/tools/registry.rs`
- Test coverage in: `tests/e2e_builtin_tool_coverage.rs`

## Rollback Plan

- Revert the selected-tool summary additions independently if needed
- Revert the scope-clarification commit separately if we later broaden curated coverage across more tools

---

**Review track**: B
