### PR TITLE
test(e2e): align WASM reinstall expectation with uninstall cleanup

### DIFF
--- a/tests/e2e/scenarios/test_wasm_lifecycle.py
+++ b/tests/e2e/scenarios/test_wasm_lifecycle.py
@@ -99,7 +99,7 @@ async def web_search_removed(ironclaw_server, web_search_configured):
 
 @pytest.fixture(scope="module")
 async def web_search_reinstalled(ironclaw_server, web_search_removed):
-    """Reinstall web-search after removal to verify saved-secret recovery."""
+    """Reinstall web-search after removal to verify it returns unconfigured."""
     await _ensure_removed(ironclaw_server, "web-search")
     data = await _install_extension(ironclaw_server, "web-search")
     return {"name": "web-search", "install": data}


### PR DESCRIPTION
## Summary
- update the WASM reinstall lifecycle E2E to match staging uninstall semantics
- expect reinstall to require setup again instead of reusing deleted secrets
- keep the stale activation error assertion intact

## Testing
- cargo build --no-default-features --features libsql
- pytest tests/e2e/scenarios/test_wasm_lifecycle.py -k test_reinstall_after_remove -vv
- pytest tests/e2e/scenarios/test_extension_uninstall_cleanup.py -vv