### PR TITLE
fix: bump Feishu registry version for PR #1698

### DIFF
--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump registry/channels/feishu.json from 0.1.3 to 0.1.4
- fix the version-bump CI failure on #1698 after Feishu channel source changes
- keep this follow-up PR scoped to registry metadata only

## Verification
- ./scripts/check-version-bumps.sh
