### PR TITLE
fix: bump Discord and Slack registry versions for PR #1698

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -2,7 +2,7 @@
   "name": "discord",
   "display_name": "Discord Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Discord",
   "keywords": [

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -2,7 +2,7 @@
   "name": "slack",
   "display_name": "Slack Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Slack",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump registry/channels/discord.json from 0.2.1 to 0.2.2
- bump registry/channels/slack.json from 0.2.1 to 0.2.2
- fix the remaining version-bump CI failures on #1698

## Verification
- ./scripts/check-version-bumps.sh
