### PR TITLE
feat: add per-thread delete functionality with full-stack implementation

### DIFF
--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -458,6 +458,10 @@ pub async fn start_server(
         .route("/api/chat/history", get(chat_history_handler))
         .route("/api/chat/threads", get(chat_threads_handler))
         .route("/api/chat/thread/new", post(chat_new_thread_handler))
+        .route(
+            "/api/chat/thread/{id}",
+            axum::routing::delete(chat_delete_thread_handler),
+        )
         // Memory
         .route("/api/memory/tree", get(memory_tree_handler))
         .route("/api/memory/list", get(memory_list_handler))
@@ -2103,6 +2107,68 @@ async fn chat_new_thread_handler(
     }
 
     Ok(Json(info))
+}
+
+async fn chat_delete_thread_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    // Rate-limit delete requests using the shared chat rate limiter
+    if !state.chat_rate_limiter.check(&user.user_id) {
+        return Err((
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many requests".to_string(),
+        ));
+    }
+
+    let thread_id = Uuid::parse_str(&id)
+        .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid thread ID".to_string()))?;
+
+    let store = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+
+    // Prevent deletion of assistant threads across all channels
+    let metadata = store.get_conversation_metadata(thread_id).await.map_err(|e| {
+        tracing::error!("Failed to fetch metadata for thread {}: {}", thread_id, e);
+        (StatusCode::INTERNAL_SERVER_ERROR, "Internal error".to_string())
+    })?;
+    if let Some(meta) = metadata {
+        if meta.get("thread_type").and_then(|v| v.as_str()) == Some("assistant") {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "Cannot delete the assistant thread".to_string(),
+            ));
+        }
+    }
+
+    let deleted = store
+        .delete_conversation(thread_id, &user.user_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete conversation {}: {}", thread_id, e);
+            (StatusCode::INTERNAL_SERVER_ERROR, "Delete failed".to_string())
+        })?;
+
+    if !deleted {
+        return Err((StatusCode::NOT_FOUND, "Thread not found".to_string()));
+    }
+
+    // Also remove from in-memory session if present
+    if let Some(ref sm) = state.session_manager {
+        let session = sm.get_or_create_session(&user.user_id).await;
+        let mut sess = session.lock().await;
+        sess.threads.remove(&thread_id);
+        // If the deleted thread was the active one, clear it.
+        // Frontend will fall back to assistant thread when available.
+        if sess.active_thread == Some(thread_id) {
+            sess.active_thread = None;
+        }
+    }
+
+    Ok(Json(serde_json::json!({"ok": true})))
 }
 
 // Job handlers moved to handlers/jobs.rs

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -2039,6 +2039,18 @@ function loadThreads() {
         item.appendChild(dot);
       }
 
+      // Delete button
+      const delBtn = document.createElement('button');
+      delBtn.className = 'thread-delete-btn';
+      delBtn.title = (typeof I18n !== 'undefined') ? I18n.t('chat.deleteThread') : 'Delete';
+      delBtn.setAttribute('aria-label', (typeof I18n !== 'undefined') ? I18n.t('chat.deleteThread') : 'Delete');
+      delBtn.textContent = '\u00D7';
+      delBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        deleteThread(thread.id, threadTitle(thread));
+      });
+      item.appendChild(delBtn);
+
       item.addEventListener('click', () => switchThread(thread.id));
       list.appendChild(item);
     }
@@ -2113,6 +2125,32 @@ function createNewThread() {
     loadThreads();
   }).catch((err) => {
     showToast('Failed to create thread: ' + err.message, 'error');
+  });
+}
+
+function deleteThread(threadId, title) {
+  const displayTitle = title || threadId;
+  const confirmMessage = (typeof I18n !== 'undefined')
+    ? I18n.t('chat.confirmDeleteThread', { title: displayTitle })
+    : ('Delete "' + displayTitle + '"?');
+  if (!confirm(confirmMessage)) return;
+
+  apiFetch('/api/chat/thread/' + threadId, { method: 'DELETE' }).then(() => {
+    showToast((typeof I18n !== 'undefined') ? I18n.t('chat.threadDeleted') : 'Thread deleted', 'success');
+    if (currentThreadId === threadId) {
+      currentThreadId = assistantThreadId || null;
+      if (currentThreadId) {
+        loadHistory();
+      } else {
+        document.getElementById('chat-messages').innerHTML = '';
+      }
+    }
+    loadThreads();
+  }).catch((err) => {
+    const message = (typeof I18n !== 'undefined')
+      ? I18n.t('chat.deleteThreadFailed', { message: err.message })
+      : ('Delete failed: ' + err.message);
+    showToast(message, 'error');
   });
 }
 

--- a/src/channels/web/static/i18n/en.js
+++ b/src/channels/web/static/i18n/en.js
@@ -106,6 +106,10 @@ I18n.register('en', {
   
   // Chat Tab
   'chat.newThread': 'New Thread',
+  'chat.deleteThread': 'Delete Thread',
+  'chat.confirmDeleteThread': 'Delete "{title}"?',
+  'chat.threadDeleted': 'Thread deleted',
+  'chat.deleteThreadFailed': 'Delete failed: {message}',
   'chat.toggleSidebar': 'Toggle Sidebar',
   'chat.assistant': 'Assistant',
   'chat.conversations': 'Conversations',

--- a/src/channels/web/static/i18n/zh-CN.js
+++ b/src/channels/web/static/i18n/zh-CN.js
@@ -106,6 +106,10 @@ I18n.register('zh-CN', {
   
   // 聊天标签页
   'chat.newThread': '新对话',
+  'chat.deleteThread': '删除对话',
+  'chat.confirmDeleteThread': '确认删除“{title}”？',
+  'chat.threadDeleted': '对话已删除',
+  'chat.deleteThreadFailed': '删除失败：{message}',
   'chat.toggleSidebar': '切换侧边栏',
   'chat.assistant': '助手',
   'chat.conversations': '对话列表',

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -3860,6 +3860,35 @@ mark {
   border-left: 2px solid var(--accent);
 }
 
+.thread-delete-btn {
+  display: inline-flex;
+  visibility: hidden;
+  background: none;
+  border: none;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  padding: 0 2px;
+  margin-left: 4px;
+  border-radius: 3px;
+  flex-shrink: 0;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+}
+
+.thread-item:hover .thread-delete-btn {
+  visibility: visible;
+  opacity: 0.5;
+  pointer-events: auto;
+}
+
+.thread-delete-btn:hover {
+  opacity: 1;
+  color: var(--error);
+}
+
 .thread-label {
   font-family: var(--font-mono);
   font-size: 12px;

--- a/src/channels/web/tests/multi_tenant.rs
+++ b/src/channels/web/tests/multi_tenant.rs
@@ -17,10 +17,11 @@ use tower::ServiceExt;
 use uuid::Uuid;
 
 use crate::channels::web::auth::{
-    AuthenticatedUser, MultiAuthState, UserIdentity, auth_middleware,
+    AuthenticatedUser, CombinedAuthState, MultiAuthState, UserIdentity, auth_middleware,
 };
 use crate::channels::web::server::{
-    ActiveConfigSnapshot, GatewayState, PerUserRateLimiter, PromptQueue, RateLimiter, WorkspacePool,
+    ActiveConfigSnapshot, GatewayState, PerUserRateLimiter, PromptQueue, RateLimiter,
+    WorkspacePool, start_server,
 };
 use crate::channels::web::sse::SseManager;
 
@@ -948,5 +949,229 @@ mod db_auth_cache {
             // Cache must be bounded at capacity, not grown to 10.
             assert_eq!(c.len(), 4, "cache should be bounded to capacity"); // safety: test assertion
         }
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════
+// Chat Thread Delete API Tests
+// ═══════════════════════════════════════════════════════════════════════
+
+#[cfg(feature = "libsql")]
+mod chat_thread_delete {
+    use super::*;
+    use reqwest::Client;
+
+    async fn start_chat_server(
+        state: Arc<GatewayState>,
+        auth: MultiAuthState,
+    ) -> (std::net::SocketAddr, Client) {
+        let addr = start_server(
+            "127.0.0.1:0".parse().expect("valid localhost addr"),
+            Arc::clone(&state),
+            CombinedAuthState::from(auth),
+        )
+        .await
+        .expect("failed to start web server");
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("failed to build reqwest client");
+
+        (addr, client)
+    }
+
+    async fn shutdown_server(state: &Arc<GatewayState>) {
+        if let Some(tx) = state.shutdown_tx.write().await.take() {
+            let _ = tx.send(());
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_thread_successfully_removes_thread() {
+        let (db, _dir) = test_db().await;
+        let state = build_state(Some(Arc::clone(&db)), None);
+        let auth = two_user_auth();
+
+        let thread_id = Uuid::new_v4();
+        db.ensure_conversation(thread_id, "gateway", "alice", None, Some("gateway"))
+            .await
+            .expect("seed thread");
+
+        let (addr, client) = start_chat_server(Arc::clone(&state), auth).await;
+
+        let resp = client
+            .delete(format!("http://{addr}/api/chat/thread/{thread_id}"))
+            .bearer_auth("tok-alice")
+            .send()
+            .await
+            .expect("delete request failed");
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body: serde_json::Value = resp.json().await.expect("delete response json");
+        assert_eq!(body["ok"], serde_json::Value::Bool(true));
+
+        let still_belongs = db
+            .conversation_belongs_to_user(thread_id, "alice")
+            .await
+            .expect("conversation lookup failed");
+        assert!(
+            !still_belongs,
+            "thread should be removed after successful delete"
+        );
+
+        shutdown_server(&state).await;
+    }
+
+    #[tokio::test]
+    async fn delete_nonexistent_thread_returns_not_found() {
+        let (db, _dir) = test_db().await;
+        let state = build_state(Some(db), None);
+        let auth = two_user_auth();
+
+        let missing_id = Uuid::new_v4();
+        let (addr, client) = start_chat_server(Arc::clone(&state), auth).await;
+
+        let resp = client
+            .delete(format!("http://{addr}/api/chat/thread/{missing_id}"))
+            .bearer_auth("tok-alice")
+            .send()
+            .await
+            .expect("delete request failed");
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = resp.text().await.expect("response body");
+        assert!(
+            body.contains("Thread not found"),
+            "expected not found message, got: {body}"
+        );
+
+        shutdown_server(&state).await;
+    }
+
+    #[tokio::test]
+    async fn delete_foreign_user_thread_returns_not_found() {
+        let (db, _dir) = test_db().await;
+        let state = build_state(Some(Arc::clone(&db)), None);
+        let auth = two_user_auth();
+
+        let alice_thread_id = Uuid::new_v4();
+        db.ensure_conversation(alice_thread_id, "gateway", "alice", None, Some("gateway"))
+            .await
+            .expect("seed alice thread");
+
+        let (addr, client) = start_chat_server(Arc::clone(&state), auth).await;
+
+        let resp = client
+            .delete(format!("http://{addr}/api/chat/thread/{alice_thread_id}"))
+            .bearer_auth("tok-bob")
+            .send()
+            .await
+            .expect("delete request failed");
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+
+        let still_exists_for_alice = db
+            .conversation_belongs_to_user(alice_thread_id, "alice")
+            .await
+            .expect("conversation lookup failed");
+        assert!(
+            still_exists_for_alice,
+            "foreign delete attempt must not remove alice thread"
+        );
+
+        shutdown_server(&state).await;
+    }
+
+    #[tokio::test]
+    async fn delete_assistant_thread_returns_forbidden() {
+        let (db, _dir) = test_db().await;
+        let state = build_state(Some(Arc::clone(&db)), None);
+        let auth = two_user_auth();
+
+        let assistant_id = db
+            .get_or_create_assistant_conversation("alice", "gateway")
+            .await
+            .expect("create assistant thread");
+
+        let (addr, client) = start_chat_server(Arc::clone(&state), auth).await;
+
+        let resp = client
+            .delete(format!("http://{addr}/api/chat/thread/{assistant_id}"))
+            .bearer_auth("tok-alice")
+            .send()
+            .await
+            .expect("delete request failed");
+
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = resp.text().await.expect("response body");
+        assert!(
+            body.contains("Cannot delete the assistant thread"),
+            "expected assistant-thread protection error, got: {body}"
+        );
+
+        let still_exists = db
+            .conversation_belongs_to_user(assistant_id, "alice")
+            .await
+            .expect("assistant lookup failed");
+        assert!(still_exists, "assistant thread must remain intact");
+
+        shutdown_server(&state).await;
+    }
+
+    #[tokio::test]
+    async fn delete_thread_rate_limited_returns_429() {
+        let (db, _dir) = test_db().await;
+        let mut state = build_state(Some(Arc::clone(&db)), None);
+
+        // Tight limit so second delete attempt is throttled.
+        Arc::get_mut(&mut state)
+            .expect("state must be uniquely owned during setup")
+            .chat_rate_limiter = PerUserRateLimiter::new(1, 60);
+
+        let auth = two_user_auth();
+        let thread_ok = Uuid::new_v4();
+        let thread_blocked = Uuid::new_v4();
+        db.ensure_conversation(thread_ok, "gateway", "alice", None, Some("gateway"))
+            .await
+            .expect("seed first thread");
+        db.ensure_conversation(thread_blocked, "gateway", "alice", None, Some("gateway"))
+            .await
+            .expect("seed second thread");
+
+        let (addr, client) = start_chat_server(Arc::clone(&state), auth).await;
+
+        let first = client
+            .delete(format!("http://{addr}/api/chat/thread/{thread_ok}"))
+            .bearer_auth("tok-alice")
+            .send()
+            .await
+            .expect("first delete failed");
+        assert_eq!(first.status(), StatusCode::OK);
+
+        let second = client
+            .delete(format!("http://{addr}/api/chat/thread/{thread_blocked}"))
+            .bearer_auth("tok-alice")
+            .send()
+            .await
+            .expect("second delete failed");
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        let second_body = second.text().await.expect("429 response body");
+        assert!(
+            second_body.contains("Too many requests"),
+            "expected rate-limit message, got: {second_body}"
+        );
+
+        let blocked_still_exists = db
+            .conversation_belongs_to_user(thread_blocked, "alice")
+            .await
+            .expect("blocked thread lookup failed");
+        assert!(
+            blocked_still_exists,
+            "rate-limited delete should not remove the target thread"
+        );
+
+        shutdown_server(&state).await;
     }
 }

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -623,6 +623,71 @@ impl ConversationStore for LibSqlBackend {
             None => Ok(None),
         }
     }
+
+    async fn delete_conversation(
+        &self,
+        conversation_id: Uuid,
+        user_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let conn = self.connect().await?;
+        let cid = conversation_id.to_string();
+
+        conn.execute("BEGIN IMMEDIATE", params![])
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let result: Result<bool, DatabaseError> = async {
+            // Verify ownership first
+            let mut rows = conn
+                .query(
+                    "SELECT 1 FROM conversations WHERE id = ?1 AND user_id = ?2",
+                    params![cid.clone(), user_id],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            let found = rows
+                .next()
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            if found.is_none() {
+                return Ok(false);
+            }
+
+            // Delete messages first (foreign key child)
+            conn.execute(
+                "DELETE FROM conversation_messages WHERE conversation_id = ?1",
+                params![cid.clone()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+            // Delete the conversation itself
+            let affected = conn
+                .execute(
+                    "DELETE FROM conversations WHERE id = ?1 AND user_id = ?2",
+                    params![cid, user_id],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+            Ok(affected > 0)
+        }
+        .await;
+
+        match &result {
+            Ok(true) => {
+                conn.execute("COMMIT", params![])
+                    .await
+                    .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            }
+            _ => {
+                // Rollback on error or when no rows were affected (Ok(false))
+                let _ = conn.execute("ROLLBACK", params![]).await;
+            }
+        }
+
+        result
+    }
 }
 
 #[cfg(test)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -444,6 +444,14 @@ pub trait ConversationStore: Send + Sync {
         &self,
         conversation_id: Uuid,
     ) -> Result<Option<String>, DatabaseError>;
+
+    /// Delete a conversation and all its messages. Returns true if the
+    /// conversation existed and was deleted.
+    async fn delete_conversation(
+        &self,
+        conversation_id: Uuid,
+        user_id: &str,
+    ) -> Result<bool, DatabaseError>;
 }
 
 #[async_trait]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -232,6 +232,16 @@ impl ConversationStore for PgBackend {
             .get_conversation_source_channel(conversation_id)
             .await
     }
+
+    async fn delete_conversation(
+        &self,
+        conversation_id: Uuid,
+        user_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        self.store
+            .delete_conversation(conversation_id, user_id)
+            .await
+    }
 }
 
 // ==================== JobStore ====================

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1933,6 +1933,47 @@ impl Store {
         Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
     }
 
+    /// Delete a conversation and all its messages. Returns true if the
+    /// conversation existed and was deleted.
+    pub async fn delete_conversation(
+        &self,
+        conversation_id: Uuid,
+        user_id: &str,
+    ) -> Result<bool, DatabaseError> {
+        let mut conn = self.conn().await?;
+        let tx = conn.transaction().await?;
+
+        // Verify ownership
+        let row = tx
+            .query_opt(
+                "SELECT 1 FROM conversations WHERE id = $1 AND user_id = $2",
+                &[&conversation_id, &user_id],
+            )
+            .await?;
+        if row.is_none() {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        // Delete messages first
+        tx.execute(
+            "DELETE FROM conversation_messages WHERE conversation_id = $1",
+            &[&conversation_id],
+        )
+        .await?;
+
+        // Delete the conversation
+        let affected = tx
+            .execute(
+                "DELETE FROM conversations WHERE id = $1 AND user_id = $2",
+                &[&conversation_id, &user_id],
+            )
+            .await?;
+
+        tx.commit().await?;
+        Ok(affected > 0)
+    }
+
     /// Load messages for a conversation with cursor-based pagination.
     ///
     /// Returns `(messages_oldest_first, has_more)`.


### PR DESCRIPTION
Add DELETE /api/chat/thread/{id} endpoint allowing users to remove individual chat threads from the sidebar, with comprehensive backend, frontend, and test coverage.

## Backend
- Add delete_conversation to ConversationStore trait (libsql + postgres)
- Wrap delete operations in transactions (BEGIN IMMEDIATE for libsql)
- Protect assistant thread from deletion (return 403 Forbidden)
- Apply shared chat_rate_limiter to delete endpoint
- Sanitize error responses: log details server-side, return generic messages

## Frontend
- Add per-thread delete button in chat sidebar with hover reveal
- Localize delete button title/confirm/success/failure messages (en, zh-CN)
- Add aria-label for accessibility
- Use visibility/opacity instead of display toggle to prevent layout jump
- Clear active thread on delete and fallback to assistant thread

## Tests
- Add 5 integration tests for delete-thread API:
  - Successful deletion removes thread
  - Deleting nonexistent thread returns 404
  - Cross-user deletion attempt returns   - Cross-user deletion attempt returns   - Cross-user deletion attempt retung  - Cross-user deletion attempt returns   - Cross-user deletion attempt retu,   - Cros,zh  - Crossmulti_tenant.rs, libsql/conversations.rs, postgres.rs, mod.rs, store.rs

## Summary

<!-- 2-5 bullet points: what changed and why -->

-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
