### PR TITLE
Feat session guard timer

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -11,6 +11,7 @@ use uuid::Uuid;
 
 use crate::agent::Agent;
 use crate::agent::session::{PendingApproval, Session, ThreadState};
+use crate::agent::session_manager::SessionGuardTimer;
 use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
 use crate::error::Error;
@@ -263,7 +264,7 @@ struct ChatDelegate<'a> {
 #[async_trait]
 impl<'a> LoopDelegate for ChatDelegate<'a> {
     async fn check_signals(&self) -> LoopSignal {
-        let sess = self.session.lock().await;
+        let sess = SessionGuardTimer::new(self.session.lock().await, "check_signals");
         if let Some(thread) = sess.threads.get(&self.thread_id)
             && thread.state == ThreadState::Interrupted
         {
@@ -562,7 +563,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 };
                 redacted_args.push(safe);
             }
-            let mut sess = self.session.lock().await;
+            let mut sess = SessionGuardTimer::new(self.session.lock().await, "record_tool_calls");
             if let Some(thread) = sess.threads.get_mut(&self.thread_id)
                 && let Some(turn) = thread.last_turn_mut()
             {
@@ -671,7 +672,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 let needs_approval = match requirement {
                     ApprovalRequirement::Never => false,
                     ApprovalRequirement::UnlessAutoApproved => {
-                        let sess = self.session.lock().await;
+                        let sess = SessionGuardTimer::new(
+                            self.session.lock().await,
+                            "check_auto_approval",
+                        );
                         !sess.is_tool_auto_approved(&tc.name)
                     }
                     ApprovalRequirement::Always => true,
@@ -850,7 +854,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                         &error_msg,
                     );
                     {
-                        let mut sess = self.session.lock().await;
+                        let mut sess = SessionGuardTimer::new(
+                            self.session.lock().await,
+                            "record_preflight_error",
+                        );
                         if let Some(thread) = sess.threads.get_mut(&self.thread_id)
                             && let Some(turn) = thread.last_turn_mut()
                         {
@@ -934,7 +941,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     {
                         let auth_data = parse_auth_result(&tool_result);
                         {
-                            let mut sess = self.session.lock().await;
+                            let mut sess = SessionGuardTimer::new(
+                                self.session.lock().await,
+                                "enter_auth_mode",
+                            );
                             if let Some(thread) = sess.threads.get_mut(&self.thread_id) {
                                 thread.enter_auth_mode(ext_name.clone());
                             }
@@ -975,7 +985,8 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
                     // Record sanitized result in thread (identity-based matching).
                     {
-                        let mut sess = self.session.lock().await;
+                        let mut sess =
+                            SessionGuardTimer::new(self.session.lock().await, "record_tool_result");
                         if let Some(thread) = sess.threads.get_mut(&self.thread_id)
                             && let Some(turn) = thread.last_turn_mut()
                         {

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -46,7 +46,7 @@ pub use routine_engine::{RoutineEngine, SandboxReadiness};
 pub use scheduler::{Scheduler, SchedulerDeps};
 pub use self_repair::{BrokenTool, RepairResult, RepairTask, SelfRepair, StuckJob};
 pub use session::{PendingApproval, PendingAuth, Session, Thread, ThreadState, Turn, TurnState};
-pub use session_manager::SessionManager;
+pub use session_manager::{SessionGuardTimer, SessionManager};
 pub use submission::{Submission, SubmissionParser, SubmissionResult};
 pub use task::{Task, TaskContext, TaskHandler, TaskOutput};
 pub use undo::{Checkpoint, UndoManager};

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -13,6 +13,53 @@ use crate::agent::session::Session;
 use crate::agent::undo::UndoManager;
 use crate::hooks::HookRegistry;
 
+pub struct SessionGuardTimer<'a> {
+    guard: tokio::sync::MutexGuard<'a, Session>,
+    #[cfg(debug_assertions)]
+    acquired_at: std::time::Instant,
+    #[cfg(debug_assertions)]
+    context: &'static str,
+}
+
+impl<'a> SessionGuardTimer<'a> {
+    pub fn new(guard: tokio::sync::MutexGuard<'a, Session>, context: &'static str) -> Self {
+        Self {
+            guard,
+            #[cfg(debug_assertions)]
+            acquired_at: std::time::Instant::now(),
+            #[cfg(debug_assertions)]
+            context,
+        }
+    }
+}
+
+impl<'a> std::ops::Deref for SessionGuardTimer<'a> {
+    type Target = Session;
+    fn deref(&self) -> &Session {
+        &self.guard
+    }
+}
+
+impl<'a> std::ops::DerefMut for SessionGuardTimer<'a> {
+    fn deref_mut(&mut self) -> &mut Session {
+        &mut self.guard
+    }
+}
+
+#[cfg(debug_assertions)]
+impl<'a> Drop for SessionGuardTimer<'a> {
+    fn drop(&mut self) {
+        let held_for = self.acquired_at.elapsed();
+        if held_for > std::time::Duration::from_secs(5) {
+            tracing::warn!(
+                held_ms = held_for.as_millis(),
+                context = self.context,
+                "Session lock held for >5s — possible lock-across-await violation"
+            );
+        }
+    }
+}
+
 /// Warn when session count exceeds this threshold.
 const SESSION_COUNT_WARNING_THRESHOLD: usize = 1000;
 
@@ -155,7 +202,7 @@ impl SessionManager {
 
             // Fast path: exact key match
             if let Some(&thread_id) = thread_map.get(&key) {
-                let sess = session.lock().await;
+                let sess = SessionGuardTimer::new(session.lock().await, "resolve_thread_lookup");
                 if sess.threads.contains_key(&thread_id) {
                     return (Arc::clone(&session), thread_id);
                 }
@@ -176,7 +223,7 @@ impl SessionManager {
 
         // If we found an adoptable UUID, verify it exists in session and acquire write lock
         if let Some(ext_uuid) = adoptable_uuid {
-            let sess = session.lock().await;
+            let sess = SessionGuardTimer::new(session.lock().await, "resolve_thread_adopt");
             if sess.threads.contains_key(&ext_uuid) {
                 drop(sess);
 
@@ -199,7 +246,7 @@ impl SessionManager {
 
         // Create new thread (always create a new one for a new key)
         let thread_id = {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "resolve_thread_create");
             let thread = sess.create_thread(Some(channel));
             thread.id
         };

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -15,6 +15,7 @@ use crate::agent::dispatcher::{
     AgenticLoopResult, check_auth_required, execute_chat_tool_standalone, parse_auth_result,
 };
 use crate::agent::session::{MAX_PENDING_MESSAGES, PendingApproval, Session, ThreadState};
+use crate::agent::session_manager::SessionGuardTimer;
 use crate::agent::submission::SubmissionResult;
 use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
@@ -58,7 +59,7 @@ impl Agent {
             .get_or_create_session(&message.user_id)
             .await;
         {
-            let sess = session.lock().await;
+            let sess = SessionGuardTimer::new(session.lock().await, "hydrate_check_exists");
             if sess.threads.contains_key(&thread_uuid) {
                 return None;
             }
@@ -172,7 +173,7 @@ impl Agent {
         let effective_source_channel = db_source_channel.as_deref();
 
         let session_id = {
-            let sess = session.lock().await;
+            let sess = SessionGuardTimer::new(session.lock().await, "hydrate_get_session_id");
             sess.id
         };
 
@@ -187,7 +188,7 @@ impl Agent {
 
         // Insert into session and register with session manager
         {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "hydrate_insert_thread");
             sess.threads.insert(thread_uuid, thread);
             sess.active_thread = Some(thread_uuid);
             sess.last_active_at = chrono::Utc::now();
@@ -228,7 +229,7 @@ impl Agent {
 
         // First check thread state without holding lock during I/O
         let (thread_state, approval_context) = {
-            let sess = session.lock().await;
+            let sess = SessionGuardTimer::new(session.lock().await, "check_thread_state");
             let thread = sess
                 .threads
                 .get(&thread_id)
@@ -251,7 +252,8 @@ impl Agent {
         // Check thread state
         match thread_state {
             ThreadState::Processing => {
-                let mut sess = session.lock().await;
+                let mut sess =
+                    SessionGuardTimer::new(session.lock().await, "queue_pending_message");
                 if let Some(thread) = sess.threads.get_mut(&thread_id) {
                     // Re-check state under lock — the turn may have completed
                     // between the snapshot read and this mutable lock acquisition.
@@ -398,31 +400,30 @@ impl Agent {
         // Job tools (create_job, list_jobs, etc.) are in the tool registry
 
         // Auto-compact if needed BEFORE adding new turn
-        {
-            let mut sess = session.lock().await;
+        let compact_needed = {
+            let sess = SessionGuardTimer::new(session.lock().await, "auto_compact_check");
             let thread = sess
                 .threads
-                .get_mut(&thread_id)
+                .get(&thread_id)
                 .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
-
             let messages = thread.messages();
-            if let Some(strategy) = self.context_monitor.suggest_compaction(&messages) {
-                let pct = self.context_monitor.usage_percent(&messages);
-                tracing::info!("Context at {:.1}% capacity, auto-compacting", pct);
+            self.context_monitor
+                .suggest_compaction(&messages)
+                .map(|strategy| (strategy, self.context_monitor.usage_percent(&messages)))
+        };
+        if let Some((strategy, pct)) = compact_needed {
+            tracing::info!("Context at {:.1}% capacity, auto-compacting", pct);
+            let _ = self
+                .channels
+                .send_status(
+                    &message.channel,
+                    StatusUpdate::Status(format!("Context at {:.0}% capacity, compacting...", pct)),
+                    &message.metadata,
+                )
+                .await;
 
-                // Notify the user that compaction is happening
-                let _ = self
-                    .channels
-                    .send_status(
-                        &message.channel,
-                        StatusUpdate::Status(format!(
-                            "Context at {:.0}% capacity, compacting...",
-                            pct
-                        )),
-                        &message.metadata,
-                    )
-                    .await;
-
+            let mut sess = SessionGuardTimer::new(session.lock().await, "auto_compact_execute");
+            if let Some(thread) = sess.threads.get_mut(&thread_id) {
                 let compactor = ContextCompactor::new(self.llm().clone());
                 if let Err(e) = compactor
                     .compact(thread, strategy, self.workspace().map(|w| w.as_ref()))
@@ -435,18 +436,20 @@ impl Agent {
 
         // Create checkpoint before turn
         let undo_mgr = self.session_manager.get_undo_manager(thread_id).await;
-        {
-            let sess = session.lock().await;
+        let (turn_number, messages) = {
+            let sess = SessionGuardTimer::new(session.lock().await, "checkpoint_read");
             let thread = sess
                 .threads
                 .get(&thread_id)
                 .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
-
+            (thread.turn_number(), thread.messages())
+        };
+        {
             let mut mgr = undo_mgr.lock().await;
             mgr.checkpoint(
-                thread.turn_number(),
-                thread.messages(),
-                format!("Before turn {}", thread.turn_number()),
+                turn_number,
+                messages,
+                format!("Before turn {}", turn_number),
             );
         }
 
@@ -460,7 +463,7 @@ impl Agent {
 
         // Start the turn and get messages
         let turn_messages = {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "start_turn");
             let thread = sess
                 .threads
                 .get_mut(&thread_id)
@@ -506,7 +509,7 @@ impl Agent {
             .await;
 
         // Re-acquire lock and check if interrupted
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "complete_turn");
         let thread = sess
             .threads
             .get_mut(&thread_id)
@@ -869,7 +872,7 @@ impl Agent {
             return Ok(SubmissionResult::ok_with_message("Nothing to undo."));
         }
 
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "process_undo");
         let thread = sess
             .threads
             .get_mut(&thread_id)
@@ -907,7 +910,7 @@ impl Agent {
             return Ok(SubmissionResult::ok_with_message("Nothing to redo."));
         }
 
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "process_redo");
         let thread = sess
             .threads
             .get_mut(&thread_id)
@@ -932,7 +935,7 @@ impl Agent {
         session: Arc<Mutex<Session>>,
         thread_id: Uuid,
     ) -> Result<SubmissionResult, Error> {
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "process_interrupt");
         let thread = sess
             .threads
             .get_mut(&thread_id)
@@ -952,20 +955,28 @@ impl Agent {
         session: Arc<Mutex<Session>>,
         thread_id: Uuid,
     ) -> Result<SubmissionResult, Error> {
-        let mut sess = session.lock().await;
+        let (strategy, usage) = {
+            let sess = SessionGuardTimer::new(session.lock().await, "compact_check");
+            let thread = sess
+                .threads
+                .get(&thread_id)
+                .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
+            let messages = thread.messages();
+            let usage = self.context_monitor.usage_percent(&messages);
+            let strategy = self
+                .context_monitor
+                .suggest_compaction(&messages)
+                .unwrap_or(
+                    crate::agent::context_monitor::CompactionStrategy::Summarize { keep_recent: 5 },
+                );
+            (strategy, usage)
+        };
+
+        let mut sess = SessionGuardTimer::new(session.lock().await, "compact_execute");
         let thread = sess
             .threads
             .get_mut(&thread_id)
             .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
-
-        let messages = thread.messages();
-        let usage = self.context_monitor.usage_percent(&messages);
-        let strategy = self
-            .context_monitor
-            .suggest_compaction(&messages)
-            .unwrap_or(
-                crate::agent::context_monitor::CompactionStrategy::Summarize { keep_recent: 5 },
-            );
 
         let compactor = ContextCompactor::new(self.llm().clone());
         match compactor
@@ -991,16 +1002,17 @@ impl Agent {
         session: Arc<Mutex<Session>>,
         thread_id: Uuid,
     ) -> Result<SubmissionResult, Error> {
-        let mut sess = session.lock().await;
-        let thread = sess
-            .threads
-            .get_mut(&thread_id)
-            .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
-        thread.turns.clear();
-        thread.pending_messages.clear();
-        thread.state = ThreadState::Idle;
+        {
+            let mut sess = SessionGuardTimer::new(session.lock().await, "process_clear");
+            let thread = sess
+                .threads
+                .get_mut(&thread_id)
+                .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
+            thread.turns.clear();
+            thread.pending_messages.clear();
+            thread.state = ThreadState::Idle;
+        }
 
-        // Clear undo history too
         let undo_mgr = self.session_manager.get_undo_manager(thread_id).await;
         undo_mgr.lock().await.clear();
 
@@ -1019,7 +1031,7 @@ impl Agent {
     ) -> Result<SubmissionResult, Error> {
         // Get pending approval for this thread
         let pending = {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "take_pending_approval");
             let thread = sess
                 .threads
                 .get_mut(&thread_id)
@@ -1054,7 +1066,7 @@ impl Agent {
             && req_id != pending.request_id
         {
             // Put it back and return error
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "restore_pending_approval");
             if let Some(thread) = sess.threads.get_mut(&thread_id) {
                 thread.await_approval(pending);
             }
@@ -1066,7 +1078,7 @@ impl Agent {
         if approved {
             // If always, add to auto-approved set
             if always {
-                let mut sess = session.lock().await;
+                let mut sess = SessionGuardTimer::new(session.lock().await, "auto_approve_tool");
                 sess.auto_approve_tool(&pending.tool_name);
                 tracing::info!(
                     "Auto-approved tool '{}' for session {}",
@@ -1077,7 +1089,7 @@ impl Agent {
 
             // Reset thread state to processing
             {
-                let mut sess = session.lock().await;
+                let mut sess = SessionGuardTimer::new(session.lock().await, "resume_processing");
                 if let Some(thread) = sess.threads.get_mut(&thread_id) {
                     thread.state = ThreadState::Processing;
                 }
@@ -1162,7 +1174,8 @@ impl Agent {
 
             // Record sanitized result in thread
             {
-                let mut sess = session.lock().await;
+                let mut sess =
+                    SessionGuardTimer::new(session.lock().await, "record_approval_result");
                 if let Some(thread) = sess.threads.get_mut(&thread_id)
                     && let Some(turn) = thread.last_turn_mut()
                 {
@@ -1240,7 +1253,10 @@ impl Agent {
                         let needs = match requirement {
                             ApprovalRequirement::Never => false,
                             ApprovalRequirement::UnlessAutoApproved => {
-                                let sess = session.lock().await;
+                                let sess = SessionGuardTimer::new(
+                                    session.lock().await,
+                                    "check_deferred_approval",
+                                );
                                 !sess.is_tool_auto_approved(&tc.name)
                             }
                             ApprovalRequirement::Always => true,
@@ -1419,7 +1435,8 @@ impl Agent {
 
                 // Record sanitized result in thread
                 {
-                    let mut sess = session.lock().await;
+                    let mut sess =
+                        SessionGuardTimer::new(session.lock().await, "record_deferred_result");
                     if let Some(thread) = sess.threads.get_mut(&thread_id)
                         && let Some(turn) = thread.last_turn_mut()
                     {
@@ -1481,7 +1498,8 @@ impl Agent {
                 let parameters = new_pending.display_parameters.clone();
 
                 {
-                    let mut sess = session.lock().await;
+                    let mut sess =
+                        SessionGuardTimer::new(session.lock().await, "await_deferred_approval");
                     if let Some(thread) = sess.threads.get_mut(&thread_id) {
                         thread.await_approval(new_pending);
                     }
@@ -1523,7 +1541,8 @@ impl Agent {
                 .await;
 
             // Handle the result
-            let mut sess = session.lock().await;
+            let mut sess =
+                SessionGuardTimer::new(session.lock().await, "handle_approval_loop_result");
             let thread = sess
                 .threads
                 .get_mut(&thread_id)
@@ -1620,20 +1639,24 @@ impl Agent {
                  You can continue the conversation or try a different approach.",
                 pending.tool_name
             );
-            {
-                let mut sess = session.lock().await;
+            let should_persist = {
+                let mut sess = SessionGuardTimer::new(session.lock().await, "process_rejection");
                 if let Some(thread) = sess.threads.get_mut(&thread_id) {
                     thread.clear_pending_approval();
                     thread.complete_turn(&rejection);
-                    // User message already persisted at turn start; save rejection response
-                    self.persist_assistant_response(
-                        thread_id,
-                        &message.channel,
-                        &message.user_id,
-                        &rejection,
-                    )
-                    .await;
+                    true
+                } else {
+                    false
                 }
+            };
+            if should_persist {
+                self.persist_assistant_response(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    &rejection,
+                )
+                .await;
             }
 
             let _ = self
@@ -1664,20 +1687,24 @@ impl Agent {
         instructions: String,
     ) {
         let auth_data = parse_auth_result(tool_result);
-        {
-            let mut sess = session.lock().await;
+        let should_persist = {
+            let mut sess = SessionGuardTimer::new(session.lock().await, "enter_auth_mode");
             if let Some(thread) = sess.threads.get_mut(&thread_id) {
                 thread.enter_auth_mode(ext_name.clone());
                 thread.complete_turn(&instructions);
-                // User message already persisted at turn start; save auth instructions
-                self.persist_assistant_response(
-                    thread_id,
-                    &message.channel,
-                    &message.user_id,
-                    &instructions,
-                )
-                .await;
+                true
+            } else {
+                false
             }
+        };
+        if should_persist {
+            self.persist_assistant_response(
+                thread_id,
+                &message.channel,
+                &message.user_id,
+                &instructions,
+            )
+            .await;
         }
         let _ = self
             .channels
@@ -1710,7 +1737,7 @@ impl Agent {
 
         // Clear auth mode regardless of outcome
         {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "clear_auth_mode");
             if let Some(thread) = sess.threads.get_mut(&thread_id) {
                 thread.pending_auth = None;
             }
@@ -1748,7 +1775,8 @@ impl Agent {
             }
             Ok(result) => {
                 {
-                    let mut sess = session.lock().await;
+                    let mut sess =
+                        SessionGuardTimer::new(session.lock().await, "re_enter_auth_mode");
                     if let Some(thread) = sess.threads.get_mut(&thread_id) {
                         thread.enter_auth_mode(pending.extension_name.clone());
                     }
@@ -1773,7 +1801,8 @@ impl Agent {
                 // Token validation errors: re-enter auth mode and re-prompt
                 if matches!(e, crate::extensions::ExtensionError::ValidationFailed(_)) {
                     {
-                        let mut sess = session.lock().await;
+                        let mut sess =
+                            SessionGuardTimer::new(session.lock().await, "auth_validation_retry");
                         if let Some(thread) = sess.threads.get_mut(&thread_id) {
                             thread.enter_auth_mode(pending.extension_name.clone());
                         }
@@ -1819,7 +1848,7 @@ impl Agent {
             .session_manager
             .get_or_create_session(&message.user_id)
             .await;
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "new_thread");
         let thread = sess.create_thread(Some(&message.channel));
         let thread_id = thread.id;
         Ok(SubmissionResult::ok_with_message(format!(
@@ -1837,7 +1866,7 @@ impl Agent {
             .session_manager
             .get_or_create_session(&message.user_id)
             .await;
-        let mut sess = session.lock().await;
+        let mut sess = SessionGuardTimer::new(session.lock().await, "switch_thread");
 
         if sess.switch_thread(target_thread_id) {
             Ok(SubmissionResult::ok_with_message(format!(
@@ -1859,7 +1888,7 @@ impl Agent {
         let mut mgr = undo_mgr.lock().await;
 
         if let Some(checkpoint) = mgr.restore(checkpoint_id) {
-            let mut sess = session.lock().await;
+            let mut sess = SessionGuardTimer::new(session.lock().await, "process_resume");
             let thread = sess
                 .threads
                 .get_mut(&thread_id)


### PR DESCRIPTION
## Summary

- SessionGuardTimer wraps session lock acquisitions and warns in debug builds if held >5s. Release builds pay nothing (#[cfg(debug_assertions)]).
- Wrapped 40 production lock sites in session_manager.rs, dispatcher.rs, and thread_ops.rs. Each site gets a context string so the warning tells you where.
- Found and fixed 4 lock-across-await violations in thread_ops.rs while wrapping (session lock held during persist_assistant_response, get_undo_manager, send_status, etc.)
- 2 compact sites still hold the lock across compact().await because it needs &mut Thread. Splitting compact() into prepare/apply is a separate refactor.

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #1219

## Validation

- [x] cargo fmt
- [x] cargo clippy --all --benches --tests --examples --all-features
- [x] Relevant tests pass: cargo test --lib agent:: (416 passed)
- [x] Manual testing: deployed to running ironclaw instance, ran basic chat, tool calls, rapid messages, undo/redo, /compact, /new, and a 24-turn conversation. Zero session guard warnings fired, no false positives.

## Security Impact

None

## Database Impact

None

## Blast Radius

4 files in src/agent/. session_manager.rs gets the new type + 3 wrapped sites, dispatcher.rs gets 6, thread_ops.rs gets 31 plus the 4 violation fixes, mod.rs adds the re-export. Every change wraps an existing lock().await call, no behavior change.

## Rollback Plan

Single commit revert. SessionGuardTimer is transparent (Deref/DerefMut to Session), so removing it just goes back to raw lock().await. The 4 violation fixes are restructurings that don't change runtime behavior.

---

**Review track**: C