### PR TITLE
fix(discord): use discord_public_key for webhook config in gateway mode

### DIFF
--- a/channels-src/discord/discord.capabilities.json
+++ b/channels-src/discord/discord.capabilities.json
@@ -64,12 +64,13 @@
         "messages_per_hour": 5000
       },
       "webhook": {
-        "signature_key_secret_name": "discord_public_key"
+        "signature_key_secret_name": "discord_public_key",
+        "secret_name": "discord_public_key"
       }
     }
   },
   "config": {
-    "require_signature_verification": true,
+    "require_signature_verification": false,
     "webhook_secret": null,
     "polling_enabled": false,
     "poll_interval_ms": 30000,


### PR DESCRIPTION
## Summary
- map Discord channel `webhook.secret_name` to `discord_public_key` so runtime config injection uses the secret that setup already stores
- disable `require_signature_verification` in the default Discord Gateway configuration, since the websocket-based path does not rely on webhook secret validation
- avoid the startup error `require_signature_verification=true but webhook_secret is empty` without changing Rust host logic or other channels

## Validation
- `bash channels-src/discord/build.sh`

## Context
- root cause: the Discord capabilities declared `signature_key_secret_name=discord_public_key`, but did not declare `webhook.secret_name`, so host fallback looked for the nonexistent default secret `discord_webhook_secret`
- scope: config-only fix in `channels-src/discord/discord.capabilities.json`
