### PR TITLE
test(e2e): add agent loop recovery coverage

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
           - group: features
             files: "tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"
           - group: extensions
-            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
+            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
           - group: routines
             files: "tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"
     steps:

--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -981,7 +981,7 @@ mod tests {
         assert!(alice_stats.last_active_at.is_some());
 
         // Bob has no LLM calls so doesn't appear in summary stats
-        assert!(stats.iter().find(|s| s.user_id == "bob").is_none());
+        assert!(!stats.iter().any(|s| s.user_id == "bob"));
 
         // Filter to single user
         let alice_only = db.user_summary_stats(Some("alice")).await.unwrap();

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -444,6 +444,200 @@ async def hosted_oauth_refresh_server(
 
 
 @pytest.fixture(scope="session")
+async def loop_limited_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance with a low tool-iteration limit."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "openai_compatible",
+            "LLM_BASE_URL": mock_llm_server,
+            "LLM_MODEL": "mock-model",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "loop-limited.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+            "AGENT_MAX_TOOL_ITERATIONS": "2",
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"loop-limited ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
+async def length_preserving_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance using the NearAI provider path."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "nearai",
+            "NEARAI_BASE_URL": mock_llm_server,
+            "NEARAI_MODEL": "mock-model",
+            "NEARAI_API_KEY": "mock-nearai-key",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "length-preserving.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"length-preserving ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
 async def extension_cleanup_server(
     ironclaw_binary,
     mock_llm_server,
@@ -672,6 +866,28 @@ async def page(ironclaw_server, browser):
     pg = await context.new_page()
     await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
     # Wait for the app to initialize (auth screen hidden, SSE connected)
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def loop_limited_page(loop_limited_server, browser):
+    """Fresh Playwright page bound to the low-iteration gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{loop_limited_server}/?token={AUTH_TOKEN}")
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def length_preserving_page(length_preserving_server, browser):
+    """Fresh Playwright page bound to the length-preserving gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{length_preserving_server}/?token={AUTH_TOKEN}")
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     yield pg
     await context.close()

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -26,6 +26,7 @@ SEL = {
     "chat_messages": "#chat-messages",
     "message_user": "#chat-messages .message.user",
     "message_assistant": "#chat-messages .message.assistant",
+    "message_system": "#chat-messages .message.system",
     # Skills
     "skill_search_input": "#skill-search-input",
     "skill_search_results": "#skill-search-results",
@@ -180,6 +181,75 @@ async def api_post(base_url: str, path: str, **kwargs) -> httpx.Response:
             timeout=kwargs.pop("timeout", 10),
             **kwargs,
         )
+
+
+async def send_chat_and_wait_for_terminal_message(
+    page,
+    message: str,
+    *,
+    timeout: int = 30000,
+) -> dict[str, str]:
+    """Send a chat message and wait for the next terminal visible outcome.
+
+    Returns a dict with:
+    - ``role``: ``assistant`` or ``system``
+    - ``text``: rendered text of the newest terminal message
+    """
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    assistant_sel = SEL["message_assistant"]
+    system_sel = SEL["message_system"]
+    before_assistant = await page.locator(assistant_sel).count()
+    before_system = await page.locator(system_sel).count()
+
+    await chat_input.fill(message)
+    await chat_input.press("Enter")
+
+    handle = await page.wait_for_function(
+        """({
+            assistantSelector,
+            systemSelector,
+            chatInputSelector,
+            assistantCount,
+            systemCount,
+        }) => {
+            const input = document.querySelector(chatInputSelector);
+            const systems = document.querySelectorAll(systemSelector);
+            if (systems.length > systemCount) {
+                const last = systems[systems.length - 1];
+                const content = last.querySelector('.message-content');
+                return {
+                    role: 'system',
+                    text: ((content && content.innerText) || last.innerText || '').trim(),
+                };
+            }
+
+            const assistants = document.querySelectorAll(assistantSelector);
+            if (assistants.length > assistantCount && input && !input.disabled) {
+                const last = assistants[assistants.length - 1];
+                const content = last.querySelector('.message-content');
+                const text = ((content && content.innerText) || last.innerText || '').trim();
+                if (text.length > 0 && !last.hasAttribute('data-streaming')) {
+                    return {
+                        role: 'assistant',
+                        text,
+                    };
+                }
+            }
+
+            return null;
+        }""",
+        arg={
+            "assistantSelector": assistant_sel,
+            "systemSelector": system_sel,
+            "chatInputSelector": SEL["chat_input"],
+            "assistantCount": before_assistant,
+            "systemCount": before_system,
+        },
+        timeout=timeout,
+    )
+    return await handle.json_value()
 
 
 def signed_http_webhook_headers(body: bytes) -> dict[str, str]:

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -23,6 +23,14 @@ CANNED_RESPONSES = [
 ]
 DEFAULT_RESPONSE = "I understand your request."
 
+TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
+TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
+    r"issue 1780 truncated tool call",
+    re.IGNORECASE,
+)
+EMPTY_REPLY_TRIGGER = re.compile(r"issue 1780 empty reply", re.IGNORECASE)
+LOOP_FOREVER_TRIGGER = re.compile(r"issue 1780 loop forever", re.IGNORECASE)
+
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
     (
@@ -109,16 +117,27 @@ def _new_oauth_state() -> dict:
     }
 
 
+def _message_text(msg: dict) -> str:
+    content = msg.get("content", "")
+    if isinstance(content, list):
+        content = " ".join(
+            p.get("text", "") for p in content if p.get("type") == "text"
+        )
+    return content
+
+
 def _last_user_content(messages: list[dict]) -> str:
     for msg in reversed(messages):
         if msg.get("role") == "user":
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                content = " ".join(
-                    p.get("text", "") for p in content if p.get("type") == "text"
-                )
-            return content
+            return _message_text(msg)
     return ""
+
+
+def _conversation_has_user_trigger(messages: list[dict], pattern: re.Pattern[str]) -> bool:
+    for msg in messages:
+        if msg.get("role") == "user" and pattern.search(_message_text(msg)):
+            return True
+    return False
 
 
 def _is_job_mode(messages: list[dict]) -> bool:
@@ -254,6 +273,82 @@ async def _send_sse(resp: web.StreamResponse, data: dict):
     await resp.write(f"data: {json.dumps(data)}\n\n".encode())
 
 
+def match_special_response(messages: list[dict], has_tools: bool) -> dict | None:
+    """Deterministic issue-specific responses for agent-loop recovery tests."""
+    last_user = _last_user_content(messages)
+
+    if _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        if has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "echo",
+                    "arguments": {"message": "loop-iteration"},
+                },
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after hitting the tool iteration limit.",
+        }
+
+    if _conversation_has_user_trigger(messages, TRUNCATED_TOOL_CALL_TRIGGER):
+        if TRUNCATED_TOOL_CALL_TRIGGER.search(last_user) and has_tools:
+            return {
+                "type": "truncated_tool_call",
+                "tool_call": {
+                    "tool_name": "time",
+                    "arguments": {},
+                },
+                "content": "Attempting a tool call but the response was truncated.",
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after discarding a truncated tool call.",
+        }
+
+    if TOOL_FAILURE_TRIGGER.search(last_user) and has_tools:
+        return {
+            "type": "tool_call",
+            "tool_call": {
+                "tool_name": "time",
+                "arguments": {"operation": "broken-operation"},
+            },
+        }
+
+    if EMPTY_REPLY_TRIGGER.search(last_user):
+        return {"type": "empty_text"}
+
+    return None
+
+
+async def _dispatch_special_response(
+    request: web.Request,
+    cid: str,
+    stream: bool,
+    special: dict,
+) -> web.StreamResponse | web.Response:
+    if special["type"] == "tool_call":
+        tc = special["tool_call"]
+        if not stream:
+            return _tool_call_response(cid, tc)
+        return await _stream_tool_call(request, cid, tc)
+    if special["type"] == "truncated_tool_call":
+        tc = special["tool_call"]
+        content = special["content"]
+        if not stream:
+            return _truncated_tool_call_response(cid, tc, content)
+        return await _stream_truncated_tool_call(request, cid, tc, content)
+    if special["type"] == "empty_text":
+        if not stream:
+            return _text_response(cid, "")
+        return await _stream_text(request, cid, "")
+
+    text = special["text"]
+    if not stream:
+        return _text_response(cid, text)
+    return await _stream_text(request, cid, text)
+
+
 async def chat_completions(request: web.Request) -> web.StreamResponse:
     """Handle POST /v1/chat/completions and /chat/completions."""
     body = await request.json()
@@ -275,6 +370,12 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
 
+    # Special chat-loop recovery cases that intentionally override the normal
+    # tool-result summary path (for example, the looping case).
+    special = match_special_response(messages, has_tools)
+    if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        return await _dispatch_special_response(request, cid, stream, special)
+
     # Tool result in messages -> text summary
     tr = _find_tool_result(messages)
     if tr:
@@ -282,6 +383,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if not stream:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
+
+    if special:
+        return await _dispatch_special_response(request, cid, stream, special)
 
     # Tool-call pattern match
     tc = match_tool_call(messages, has_tools)
@@ -317,6 +421,28 @@ def _tool_call_response(cid: str, tc: dict) -> web.Response:
                             "function": {"name": tc["tool_name"],
                                          "arguments": json.dumps(tc["arguments"])}}],
         }, "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    })
+
+
+def _truncated_tool_call_response(cid: str, tc: dict, content: str) -> web.Response:
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+    return web.json_response({
+        "id": cid,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "mock-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": f"{content}\n<tool_call>{tool_tag}</tool_call>",
+            },
+            "finish_reason": "length",
+        }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     })
 
@@ -359,6 +485,39 @@ async def _stream_tool_call(request: web.Request, cid: str, tc: dict) -> web.Str
     # Final chunk: finish reason
     chunk["choices"][0]["delta"] = {}
     chunk["choices"][0]["finish_reason"] = "tool_calls"
+    await _send_sse(resp, chunk)
+    await resp.write(b"data: [DONE]\n\n")
+    return resp
+
+
+async def _stream_truncated_tool_call(
+    request: web.Request,
+    cid: str,
+    tc: dict,
+    content: str,
+) -> web.StreamResponse:
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type": "text/event-stream", "Cache-Control": "no-cache"})
+    await resp.prepare(request)
+    base = _make_base(cid)
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+
+    chunk = {**base, "choices": [{"index": 0, "delta": {
+        "role": "assistant",
+        "content": content,
+    }, "finish_reason": None}]}
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {
+        "content": f"\n<tool_call>{tool_tag}</tool_call>",
+    }
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {}
+    chunk["choices"][0]["finish_reason"] = "length"
     await _send_sse(resp, chunk)
     await resp.write(b"data: [DONE]\n\n")
     return resp

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -118,10 +118,10 @@ def _new_oauth_state() -> dict:
 
 
 def _message_text(msg: dict) -> str:
-    content = msg.get("content", "")
+    content = msg.get("content") or ""
     if isinstance(content, list):
         content = " ".join(
-            p.get("text", "") for p in content if p.get("type") == "text"
+            p.get("text") or "" for p in content if p.get("type") == "text"
         )
     return content
 

--- a/tests/e2e/scenarios/test_agent_loop_recovery.py
+++ b/tests/e2e/scenarios/test_agent_loop_recovery.py
@@ -1,0 +1,77 @@
+"""Agent-loop recovery regressions for issue #1780."""
+
+from helpers import SEL, send_chat_and_wait_for_terminal_message
+
+
+async def _create_new_thread(page) -> None:
+    previous_thread = await page.evaluate("() => currentThreadId")
+    await page.evaluate("createNewThread()")
+    await page.wait_for_function(
+        """(prevThread) => {
+            return !!currentThreadId
+                && currentThreadId !== prevThread
+                && document.querySelectorAll('#chat-messages .message').length === 0;
+        }""",
+        arg=previous_thread,
+        timeout=10000,
+    )
+
+
+async def test_tool_failure_recovery_shows_final_response(page):
+    """A failed tool call should surface a final assistant response and not hang."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 tool failure",
+    )
+
+    assert result["role"] == "assistant", result
+    text = result["text"].lower()
+    assert "time tool returned" in text, result
+    assert (
+        "unknown operation" in text
+        or "broken-operation" in text
+        or "error" in text
+    ), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_truncated_tool_call_is_discarded_gracefully(length_preserving_page):
+    """A length-truncated tool call should be ignored and the turn should recover."""
+    await _create_new_thread(length_preserving_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        length_preserving_page,
+        "issue 1780 truncated tool call",
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after discarding a truncated tool call" in result["text"].lower(), result
+    assert await length_preserving_page.locator(SEL["approval_card"]).count() == 0
+    assert await length_preserving_page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_empty_reply_uses_chat_fallback(page):
+    """An empty LLM reply should terminate visibly instead of hanging."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 empty reply",
+    )
+
+    assert "error:" in result["text"].lower(), result
+    assert "empty" in result["text"].lower(), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_looping_tool_calls_terminate_under_low_iteration_limit(loop_limited_page):
+    """A looping tool-call pattern should terminate once force-text kicks in."""
+    await _create_new_thread(loop_limited_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        loop_limited_page,
+        "issue 1780 loop forever",
+        timeout=20000,
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after hitting the tool iteration limit" in result["text"].lower(), result
+    assert await loop_limited_page.locator(SEL["chat_input"]).is_enabled()


### PR DESCRIPTION
## Summary
- add browser E2E coverage for agent loop recovery paths from #1780
- extend the mock LLM and E2E fixtures for truncated tool calls, empty replies, and low-iteration loop termination
- include the new scenario file in the regular E2E CI workflow

## Testing
- cargo fmt --all --check
- cargo clippy --no-default-features --features libsql --tests -- -D warnings
- cd tests/e2e && .venv/bin/pytest scenarios/test_agent_loop_recovery.py -v
- cd tests/e2e && .venv/bin/pytest scenarios/test_tool_execution.py -v