### PR TITLE
test: add routine coverage for issue 1781

### DIFF
--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -805,6 +805,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -890,6 +891,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -944,6 +946,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         // Record the run in DB, then spawn execution
@@ -1082,6 +1085,7 @@ struct EngineContext {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     sandbox_readiness: SandboxReadiness,
+    event_cache: Arc<RwLock<Vec<EventMatcher>>>,
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
@@ -1176,6 +1180,15 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
         tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
     }
 
+    update_cached_event_runtime(
+        &ctx.event_cache,
+        routine.id,
+        now,
+        routine.run_count + 1,
+        new_failures,
+    )
+    .await;
+
     // Persist routine result to its dedicated conversation thread
     let thread_id = match ctx
         .store
@@ -1220,6 +1233,26 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
         thread_id.as_deref(),
     )
     .await;
+}
+
+async fn update_cached_event_runtime(
+    event_cache: &Arc<RwLock<Vec<EventMatcher>>>,
+    routine_id: Uuid,
+    last_run_at: chrono::DateTime<Utc>,
+    run_count: u64,
+    consecutive_failures: u32,
+) {
+    let mut cache = event_cache.write().await;
+    for matcher in cache.iter_mut() {
+        let routine = match matcher {
+            EventMatcher::Message { routine, .. } | EventMatcher::System { routine } => routine,
+        };
+        if routine.id == routine_id {
+            routine.last_run_at = Some(last_run_at);
+            routine.run_count = run_count;
+            routine.consecutive_failures = consecutive_failures;
+        }
+    }
 }
 
 /// Sanitize a routine name for use in workspace paths.

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -96,6 +96,10 @@ pub(crate) fn routine_matches_message(routine: &Routine, message: &IncomingMessa
     true
 }
 
+fn trigger_uses_event_cache(trigger: &Trigger) -> bool {
+    matches!(trigger, Trigger::Event { .. } | Trigger::SystemEvent { .. })
+}
+
 /// The routine execution engine.
 pub struct RoutineEngine {
     config: RoutineConfig,
@@ -659,7 +663,7 @@ impl RoutineEngine {
             None
         };
 
-        if let Err(e) = self
+        let runtime_updated = match self
             .store
             .update_routine_runtime(
                 routine.id,
@@ -671,10 +675,25 @@ impl RoutineEngine {
             )
             .await
         {
-            tracing::error!(
-                routine = %routine.name,
-                "Failed to update routine runtime after dispatched run: {}", e
-            );
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    routine = %routine.name,
+                    "Failed to update routine runtime after dispatched run: {}", e
+                );
+                false
+            }
+        };
+
+        if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+            update_cached_event_runtime(
+                self.event_cache.as_ref(),
+                routine.id,
+                now,
+                routine.run_count + 1,
+                new_failures,
+            )
+            .await;
         }
 
         // Persist result to the routine's conversation thread
@@ -1165,7 +1184,7 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
         0
     };
 
-    if let Err(e) = ctx
+    let runtime_updated = match ctx
         .store
         .update_routine_runtime(
             routine.id,
@@ -1177,17 +1196,23 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
         )
         .await
     {
-        tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
-    }
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+            false
+        }
+    };
 
-    update_cached_event_runtime(
-        &ctx.event_cache,
-        routine.id,
-        now,
-        routine.run_count + 1,
-        new_failures,
-    )
-    .await;
+    if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+        update_cached_event_runtime(
+            ctx.event_cache.as_ref(),
+            routine.id,
+            now,
+            routine.run_count + 1,
+            new_failures,
+        )
+        .await;
+    }
 
     // Persist routine result to its dedicated conversation thread
     let thread_id = match ctx
@@ -1236,7 +1261,7 @@ async fn execute_routine(ctx: EngineContext, routine: Routine, run: RoutineRun) 
 }
 
 async fn update_cached_event_runtime(
-    event_cache: &Arc<RwLock<Vec<EventMatcher>>>,
+    event_cache: &RwLock<Vec<EventMatcher>>,
     routine_id: Uuid,
     last_run_at: chrono::DateTime<Utc>,
     run_count: u64,
@@ -1251,6 +1276,7 @@ async fn update_cached_event_runtime(
             routine.last_run_at = Some(last_run_at);
             routine.run_count = run_count;
             routine.consecutive_failures = consecutive_failures;
+            break;
         }
     }
 }

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -14,6 +14,7 @@ import uuid
 from aiohttp import web
 
 CANNED_RESPONSES = [
+    (re.compile(r"empty routine response", re.IGNORECASE), ""),
     (re.compile(r"hello|hi|hey", re.IGNORECASE), "Hello! How can I help you today?"),
     (re.compile(r"2\s*\+\s*2|two plus two", re.IGNORECASE), "The answer is 4."),
     (re.compile(r"skill|install", re.IGNORECASE), "I can help you with skills management."),
@@ -25,6 +26,11 @@ DEFAULT_RESPONSE = "I understand your request."
 
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
+    (
+        re.compile(r"loop until cap", re.IGNORECASE),
+        "echo",
+        lambda _: {"message": "loop-until-cap"},
+    ),
     (
         re.compile(r"make approval post (?P<label>[a-z0-9_-]+)", re.IGNORECASE),
         "http",
@@ -61,6 +67,21 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create failing lightweight owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Failing lightweight routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Empty routine response for {m.group('name')}.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
             re.IGNORECASE,
         ),
@@ -75,8 +96,41 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create looping full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Looping full-job routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Loop until cap for {m.group('name')}.",
+            "action_type": "full_job",
+            "max_iterations": 1,
+        },
+    ),
+    (
+        re.compile(
+            r"create cron owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Cron routine {m.group('name')}",
+            "trigger_type": "cron",
+            "schedule": "0 */5 * * * *",
+            "timezone": "UTC",
+            "prompt": f"Confirm that cron routine {m.group('name')} executed.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create event routine (?P<name>[a-z0-9][a-z0-9_-]*) "
-            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)",
+            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)"
+            r"(?: cooldown (?P<cooldown>\d+))?",
             re.IGNORECASE,
         ),
         "routine_create",
@@ -89,7 +143,7 @@ TOOL_CALL_PATTERNS = [
             "prompt": f"Acknowledge that {m.group('name')} fired.",
             "action_type": "lightweight",
             "use_tools": False,
-            "cooldown_secs": 0,
+            "cooldown_secs": int(m.group("cooldown") or 0),
         },
     ),
     (
@@ -121,6 +175,21 @@ def _last_user_content(messages: list[dict]) -> str:
     return ""
 
 
+def _job_contains_marker(messages: list[dict], marker: str) -> bool:
+    marker_lower = marker.lower()
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                p.get("text", "") for p in content if p.get("type") == "text"
+            )
+        if marker_lower in str(content).lower():
+            return True
+    return False
+
+
 def _is_job_mode(messages: list[dict]) -> bool:
     """Detect if this conversation is a background job (not chat)."""
     for msg in messages:
@@ -147,6 +216,25 @@ def match_job_response(messages: list[dict], has_tools: bool) -> dict | None:
 
     last_user = _last_user_content(messages)
     tool_result_count = _count_tool_results(messages)
+    loop_until_cap = _job_contains_marker(messages, "loop until cap")
+
+    if loop_until_cap and "create a plan" in last_user.lower():
+        return {"text": json.dumps({
+            "goal": "Keep iterating until the worker hits the iteration cap",
+            "actions": [],
+            "estimated_cost": 0.001,
+            "estimated_time_secs": 5,
+            "confidence": 0.8,
+        })}
+
+    if loop_until_cap and "all planned actions have been executed" in last_user.lower():
+        return {"text": "loop until cap still requires more work"}
+
+    if loop_until_cap and has_tools:
+        return {"tool_call": {
+            "tool_name": "echo",
+            "arguments": {"message": "loop-until-cap"},
+        }}
 
     # Planning call (no tools available = complete() not complete_with_tools())
     if "create a plan" in last_user.lower():

--- a/tests/e2e/scenarios/test_routine_event_batch.py
+++ b/tests/e2e/scenarios/test_routine_event_batch.py
@@ -7,7 +7,7 @@ import uuid
 import httpx
 import pytest
 
-from helpers import AUTH_TOKEN, SEL, signed_http_webhook_headers
+from helpers import AUTH_TOKEN, SEL, api_post, signed_http_webhook_headers
 
 
 async def _send_chat_message(page, message: str) -> None:
@@ -39,11 +39,15 @@ async def _create_event_routine(
     name: str,
     pattern: str,
     channel: str = "http",
+    cooldown_secs: int | None = None,
 ) -> dict:
     """Create an event routine through chat and return its API record."""
+    message = f"create event routine {name} channel {channel} pattern {pattern}"
+    if cooldown_secs is not None:
+        message += f" cooldown {cooldown_secs}"
     await _send_chat_message(
         page,
-        f"create event routine {name} channel {channel} pattern {pattern}",
+        message,
     )
     return await _wait_for_routine(base_url, name)
 
@@ -54,13 +58,14 @@ async def _post_http_message(
     content: str,
     sender_id: str | None = None,
     thread_id: str | None = None,
+    wait_for_response: bool = True,
 ) -> dict:
     """Send a signed HTTP-channel message and return the JSON body."""
     payload = {
         "user_id": sender_id or f"sender-{uuid.uuid4().hex[:8]}",
         "thread_id": thread_id or f"thread-{uuid.uuid4().hex[:8]}",
         "content": content,
-        "wait_for_response": True,
+        "wait_for_response": wait_for_response,
     }
     body = json.dumps(payload).encode("utf-8")
 
@@ -75,7 +80,10 @@ async def _post_http_message(
     assert response.status_code == 200, (
         f"HTTP webhook failed: {response.status_code} {response.text[:400]}"
     )
-    return response.json()
+    data = response.json()
+    if wait_for_response:
+        assert data.get("response"), f"Expected synchronous response body, got: {data}"
+    return data
 
 
 async def _wait_for_routine(base_url: str, name: str, timeout: float = 20.0) -> dict:
@@ -138,6 +146,17 @@ async def _wait_for_completed_run(
             return runs[0]
         await asyncio.sleep(0.5)
     raise AssertionError(f"Routine '{routine_id}' did not complete within {timeout}s")
+
+
+async def _toggle_routine(base_url: str, routine_id: str, enabled: bool) -> dict:
+    """Toggle a routine through the routines API."""
+    response = await api_post(
+        base_url,
+        f"/api/routines/{routine_id}/toggle",
+        json={"enabled": enabled},
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 @pytest.mark.asyncio
@@ -314,4 +333,85 @@ async def test_routine_execution_history_is_available(
 
     assert completed_run["id"]
     assert completed_run["started_at"]
+    assert completed_run["status"].lower() == "attention"
+
+
+@pytest.mark.asyncio
+async def test_event_trigger_respects_cooldown(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Rapid matching events should not re-fire a routine within cooldown."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="alert",
+        cooldown_secs=30,
+    )
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: primary incident",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    first_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert first_run["status"].lower() == "attention"
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: follow-up incident",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+
+    runs = await _get_routine_runs(ironclaw_server, routine["id"])
+    assert len(runs) == 1, f"Cooldown should suppress duplicate fire, got runs={runs}"
+
+
+@pytest.mark.asyncio
+async def test_event_routine_can_be_paused_and_resumed(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Disabled routines should not fire until they are re-enabled."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="resume",
+    )
+
+    disabled = await _toggle_routine(ironclaw_server, routine["id"], False)
+    assert disabled["status"] == "disabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+    assert await _get_routine_runs(ironclaw_server, routine["id"]) == []
+
+    enabled = await _toggle_routine(ironclaw_server, routine["id"], True)
+    assert enabled["status"] == "enabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
     assert completed_run["status"].lower() == "attention"

--- a/tests/e2e/scenarios/test_routine_full_job.py
+++ b/tests/e2e/scenarios/test_routine_full_job.py
@@ -10,8 +10,6 @@ Requires Playwright (browser-based tests).
 import asyncio
 import uuid
 
-from playwright.async_api import TimeoutError as PlaywrightTimeoutError
-
 from helpers import SEL, api_get, api_post
 
 
@@ -31,18 +29,8 @@ async def _send_chat_message(page, message: str) -> None:
         "selector": SEL["message_assistant"],
         "expectedCount": before_count + 1,
     }
-    try:
-        await page.wait_for_function(
-            """({ selector, expectedCount }) => {
-                return document.querySelectorAll(selector).length >= expectedCount;
-            }""",
-            arg=wait_args,
-            timeout=5000,
-        )
-    except PlaywrightTimeoutError:
-        approval_card = page.locator(SEL["approval_card"]).last
-        await approval_card.wait_for(state="visible", timeout=10000)
-        await approval_card.locator("button.approve").click()
+
+    async def _wait_for_assistant() -> None:
         await page.wait_for_function(
             """({ selector, expectedCount }) => {
                 return document.querySelectorAll(selector).length >= expectedCount;
@@ -50,6 +38,39 @@ async def _send_chat_message(page, message: str) -> None:
             arg=wait_args,
             timeout=30000,
         )
+
+    async def _wait_for_approval():
+        approval_card = page.locator(SEL["approval_card"]).last
+        await approval_card.wait_for(
+            state="visible",
+            timeout=30000,
+        )
+        return approval_card
+
+    assistant_task = asyncio.create_task(_wait_for_assistant())
+    approval_task = asyncio.create_task(_wait_for_approval())
+
+    done, pending = await asyncio.wait(
+        {assistant_task, approval_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    if assistant_task in done and assistant_task.exception() is None:
+        await assistant_task
+        return
+
+    if approval_task not in done or approval_task.exception() is not None:
+        await assistant_task
+        return
+
+    approval_card = await approval_task
+    await approval_card.locator("button.approve").click()
+    await _wait_for_assistant()
 
 
 async def _open_tab(page, tab: str) -> None:

--- a/tests/e2e/scenarios/test_routine_full_job.py
+++ b/tests/e2e/scenarios/test_routine_full_job.py
@@ -10,6 +10,8 @@ Requires Playwright (browser-based tests).
 import asyncio
 import uuid
 
+from playwright.async_api import TimeoutError as PlaywrightTimeoutError
+
 from helpers import SEL, api_get, api_post
 
 
@@ -25,15 +27,38 @@ async def _send_chat_message(page, message: str) -> None:
     await chat_input.fill(message)
     await chat_input.press("Enter")
 
-    await page.wait_for_function(
-        """({ selector, expectedCount }) => {
-            return document.querySelectorAll(selector).length >= expectedCount;
-        }""",
-        arg={
-            "selector": SEL["message_assistant"],
-            "expectedCount": before_count + 1,
-        },
-        timeout=30000,
+    wait_args = {
+        "selector": SEL["message_assistant"],
+        "expectedCount": before_count + 1,
+    }
+    try:
+        await page.wait_for_function(
+            """({ selector, expectedCount }) => {
+                return document.querySelectorAll(selector).length >= expectedCount;
+            }""",
+            arg=wait_args,
+            timeout=5000,
+        )
+    except PlaywrightTimeoutError:
+        approval_card = page.locator(SEL["approval_card"]).last
+        await approval_card.wait_for(state="visible", timeout=10000)
+        await approval_card.locator("button.approve").click()
+        await page.wait_for_function(
+            """({ selector, expectedCount }) => {
+                return document.querySelectorAll(selector).length >= expectedCount;
+            }""",
+            arg=wait_args,
+            timeout=30000,
+        )
+
+
+async def _open_tab(page, tab: str) -> None:
+    """Switch to a visible top-level tab."""
+    button = page.locator(SEL["tab_button"].format(tab=tab))
+    await button.click()
+    await page.locator(SEL["tab_panel"].format(tab=tab)).wait_for(
+        state="visible",
+        timeout=5000,
     )
 
 
@@ -131,3 +156,65 @@ async def test_full_job_routine_completes_with_tools(page, ironclaw_server):
         assert job["state"].lower() in success_states, (
             f"Expected job state in {success_states}, got '{job['state']}'"
         )
+
+
+async def test_cron_routine_appears_and_can_be_manually_triggered(page, ironclaw_server):
+    """Cron routines should expose schedule metadata and support manual trigger."""
+    name = f"cron-{uuid.uuid4().hex[:8]}"
+
+    await _send_chat_message(page, f"create cron owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    assert routine["trigger_type"] == "cron"
+    assert routine["trigger_raw"] == "0 */5 * * * * *"
+    assert routine["next_fire_at"], f"Expected next_fire_at on cron routine: {routine}"
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    trigger_cell_text = await row.locator("td").nth(1).inner_text()
+    assert trigger_cell_text.strip() == routine["trigger_summary"]
+
+    resp = await api_post(ironclaw_server, f"/api/routines/{routine['id']}/trigger")
+    resp.raise_for_status()
+    assert resp.json()["status"] == "triggered"
+
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert completed_run["trigger_type"] == "manual"
+    assert completed_run["status"].lower() == "attention"
+
+
+async def test_failed_routine_is_visible_in_ui(page, ironclaw_server):
+    """A failed routine should surface failed state and error text in the UI."""
+    name = f"fail-{uuid.uuid4().hex[:8]}"
+    failure_reason = "Response contained no message or tool call"
+
+    await _send_chat_message(page, f"create failing lightweight owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    trigger_response = await api_post(
+        ironclaw_server,
+        f"/api/routines/{routine['id']}/trigger",
+    )
+    trigger_response.raise_for_status()
+    assert trigger_response.json()["status"] == "triggered"
+
+    failed_run = await _wait_for_completed_run(ironclaw_server, routine["id"], timeout=60)
+    assert failed_run["status"].lower() == "failed", failed_run
+    assert failure_reason in failed_run["result_summary"]
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    await row.click()
+
+    detail = page.locator("#routine-detail")
+    await detail.wait_for(state="visible", timeout=10000)
+    await detail.locator(".badge.failed").first.wait_for(state="visible", timeout=10000)
+    assert "failing" in (await detail.locator(".badge.failed").first.inner_text()).lower()
+
+    recent_run_row = detail.locator("table.routines-table tbody tr").first
+    await recent_run_row.wait_for(state="visible", timeout=10000)
+    recent_run_text = await recent_run_row.inner_text()
+    assert "failed" in recent_run_text.lower()
+    assert failure_reason in recent_run_text

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -11,18 +11,48 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use chrono::Utc;
     use ironclaw::agent::routine::{
         NotifyConfig, Routine, RoutineAction, RoutineGuardrails, Trigger,
     };
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{Tool, ToolError, ToolOutput};
     use uuid::Uuid;
 
     use crate::support::gateway_workflow_harness::GatewayWorkflowHarness;
     use crate::support::mock_openai_server::{
         MockOpenAiResponse, MockOpenAiRule, MockOpenAiServerBuilder, MockToolCall,
     };
+
+    struct BlockingTool;
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "block_once"
+        }
+
+        fn description(&self) -> &str {
+            "Sleeps long enough for cancellation-path integration tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object"})
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(ToolOutput::text("block complete", Duration::from_secs(30)))
+        }
+    }
 
     #[tokio::test]
     async fn gateway_workflow_harness_chat_and_webhook() {
@@ -439,6 +469,166 @@ mod tests {
         assert_eq!(
             after_count, before_count,
             "run count should not increase for disabled routine"
+        );
+
+        harness.shutdown().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_running_full_job_routine_finalizes_run() {
+        let mock = MockOpenAiServerBuilder::new()
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "create blocking routine",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_create_blocking_1",
+                    "routine_create",
+                    serde_json::json!({
+                        "name": "wf-cancel-full-job",
+                        "description": "Full-job cancellation regression test",
+                        "trigger_type": "manual",
+                        "action_type": "full_job",
+                        "prompt": "Use block_once then finish.",
+                        "max_iterations": 10
+                    }),
+                )]),
+            ))
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "use block_once then finish",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_block_once_1",
+                    "block_once",
+                    serde_json::json!({}),
+                )]),
+            ))
+            .with_default_response(MockOpenAiResponse::Text("ack".to_string()))
+            .start()
+            .await;
+
+        let harness =
+            GatewayWorkflowHarness::start_openai_compatible(&mock.openai_base_url(), "mock-model")
+                .await;
+        harness.register_tool(Arc::new(BlockingTool)).await;
+
+        let thread_id = harness.create_thread().await;
+        harness
+            .send_chat(&thread_id, "create blocking routine")
+            .await;
+        harness
+            .wait_for_turns(&thread_id, 1, Duration::from_secs(10))
+            .await;
+
+        let routine = harness
+            .routine_by_name("wf-cancel-full-job")
+            .await
+            .expect("blocking full-job routine should exist");
+        let routine_id = routine["id"].as_str().expect("routine id missing");
+
+        let trigger = harness
+            .client
+            .post(format!(
+                "{}/api/routines/{routine_id}/trigger",
+                harness.base_url()
+            ))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("trigger request failed")
+            .error_for_status()
+            .expect("trigger non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid trigger response");
+        assert_eq!(trigger["status"].as_str(), Some("triggered"));
+
+        let mut job_id = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            if let Some(found_job_id) = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .and_then(|run| run["job_id"].as_str())
+            {
+                job_id = Some(found_job_id.to_string());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let job_id = job_id.expect("routine run should be linked to a job");
+
+        let mut saw_job_execution_request = false;
+        for _ in 0..50 {
+            if mock.requests().await.len() >= 2 {
+                saw_job_execution_request = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            saw_job_execution_request,
+            "job should issue an execution LLM request before cancellation"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let cancel_response = harness
+            .client
+            .post(format!("{}/api/jobs/{job_id}/cancel", harness.base_url()))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("cancel request failed")
+            .error_for_status()
+            .expect("cancel non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid cancel response");
+        assert_eq!(cancel_response["status"].as_str(), Some("cancelled"));
+
+        let mut final_job = None;
+        for _ in 0..100 {
+            let job = harness
+                .client
+                .get(format!("{}/api/jobs/{job_id}", harness.base_url()))
+                .bearer_auth(&harness.auth_token)
+                .send()
+                .await
+                .expect("final job detail request failed")
+                .error_for_status()
+                .expect("final job detail non-2xx")
+                .json::<serde_json::Value>()
+                .await
+                .expect("invalid final job detail");
+            if job["state"].as_str() == Some("cancelled") {
+                final_job = Some(job);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_job = final_job.expect("job should reach cancelled state");
+        assert_eq!(final_job["state"].as_str(), Some("cancelled"));
+
+        let mut final_run = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            let run = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .cloned()
+                .expect("routine run should exist");
+            if run["status"].as_str() != Some("running") {
+                final_run = Some(run);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_run = final_run.expect("routine run should reach terminal state");
+        assert_eq!(final_run["status"].as_str(), Some("failed"));
+        assert_eq!(final_run["job_id"].as_str(), Some(job_id.as_str()));
+        assert!(
+            final_run["result_summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("finished (failed)")),
+            "expected failed routine summary, got {final_run}"
         );
 
         harness.shutdown().await;

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -488,6 +488,15 @@ impl GatewayWorkflowHarness {
             .expect("invalid routine runs response")
     }
 
+    pub async fn register_tool(&self, tool: Arc<dyn Tool>) {
+        let registry = self
+            .gateway_state
+            .tool_registry
+            .as_ref()
+            .expect("tool registry should be available");
+        registry.register(tool).await;
+    }
+
     pub async fn github_webhook(
         &self,
         event: &str,


### PR DESCRIPTION
## Summary
- add E2E coverage for cron routine metadata/manual trigger and failed routine UI state
- add E2E coverage for event cooldown and pause/resume behavior
- add a gateway integration test for cancelling a running full-job routine
- keep the in-memory event cache runtime fields in sync after a run so cooldown checks apply immediately

## Testing
- python3 -m py_compile tests/e2e/mock_llm.py tests/e2e/scenarios/test_routine_full_job.py tests/e2e/scenarios/test_routine_event_batch.py
- cargo fmt --check
- /Users/henry/near_ai/near_claw/ironclaw/tests/e2e/.venv/bin/pytest scenarios/test_routine_full_job.py -q
- /Users/henry/near_ai/near_claw/ironclaw/tests/e2e/.venv/bin/pytest scenarios/test_routine_event_batch.py -q
- cargo test --test gateway_workflow_integration --features libsql cancelling_running_full_job_routine_finalizes_run -- --nocapture

Closes #1781