### PR TITLE
test(e2e): cover chat approval parity across channels

### DIFF
--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -355,6 +355,16 @@ pub enum StatusUpdate {
     },
 }
 
+/// Shared chat-style approval prompt formatting used by non-web channels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatApprovalPrompt {
+    pub request_id: String,
+    pub tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub allow_always: bool,
+}
+
 impl StatusUpdate {
     /// Build a `ToolCompleted` status with redacted parameters.
     ///
@@ -384,6 +394,96 @@ impl StatusUpdate {
                 None
             },
         }
+    }
+}
+
+impl ChatApprovalPrompt {
+    /// Build a shared chat approval prompt from a status update.
+    pub fn from_status(status: &StatusUpdate) -> Option<Self> {
+        let StatusUpdate::ApprovalNeeded {
+            request_id,
+            tool_name,
+            description,
+            parameters,
+            allow_always,
+        } = status
+        else {
+            return None;
+        };
+
+        Some(Self {
+            request_id: request_id.clone(),
+            tool_name: tool_name.clone(),
+            description: description.clone(),
+            parameters: parameters.clone(),
+            allow_always: *allow_always,
+        })
+    }
+
+    /// Pretty-printed tool parameters for display.
+    pub fn parameters_json(&self) -> String {
+        serde_json::to_string_pretty(&self.parameters)
+            .unwrap_or_else(|_| self.parameters.to_string())
+    }
+
+    /// Shared reply vocabulary summary for compact status surfaces.
+    pub fn reply_summary(&self) -> &'static str {
+        if self.allow_always {
+            "yes (or /approve), no (or /deny), or always (or /always)"
+        } else {
+            "yes (or /approve) or no (or /deny)"
+        }
+    }
+
+    /// Approval prompt formatted for plain-text chat channels.
+    pub fn plain_text_message(&self) -> String {
+        let mut lines = vec![
+            format!("Approval needed: {}", self.tool_name),
+            self.description.clone(),
+            String::new(),
+            format!("Request ID: {}", self.request_id),
+            "Parameters:".to_string(),
+            self.parameters_json(),
+            String::new(),
+            "Reply with:".to_string(),
+            "- yes, y, approve, or /approve to approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "- always, a, or /always to approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("- no, n, deny, or /deny to deny this request".to_string());
+        lines.join("\n")
+    }
+
+    /// Approval prompt formatted for Markdown-capable chat channels.
+    pub fn markdown_message(&self) -> String {
+        let mut lines = vec![
+            "⚠️ *Approval Required*".to_string(),
+            String::new(),
+            format!("*Request ID:* `{}`", self.request_id),
+            format!("*Tool:* {}", self.tool_name),
+            format!("*Description:* {}", self.description),
+            "*Parameters:*".to_string(),
+            format!("```json\n{}\n```", self.parameters_json()),
+            String::new(),
+            "Reply with:".to_string(),
+            "• `yes`, `y`, `approve`, or `/approve` - Approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "• `always`, `a`, or `/always` - Approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("• `no`, `n`, `deny`, or `/deny` - Deny this request".to_string());
+        lines.join("\n")
     }
 }
 
@@ -655,5 +755,40 @@ mod tests {
     fn routing_target_returns_none_for_empty_metadata() {
         let metadata = serde_json::json!({});
         assert!(routing_target_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn chat_approval_prompt_plain_text_includes_all_reply_forms() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-123".into(),
+            tool_name: "http".into(),
+            description: "Fetch weather data".into(),
+            parameters: serde_json::json!({"url": "https://api.weather.test"}),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let text = prompt.plain_text_message();
+        assert!(text.contains("Request ID: req-123"));
+        assert!(text.contains("approve, or /approve"));
+        assert!(text.contains("always, a, or /always"));
+        assert!(text.contains("deny, or /deny"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_hides_always_when_not_allowed() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-456".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({"command": "rm -rf /tmp/demo"}),
+            allow_always: false,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("`/approve`"));
+        assert!(markdown.contains("`/deny`"));
+        assert!(!markdown.contains("`/always`"));
     }
 }

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -365,6 +365,10 @@ pub struct ChatApprovalPrompt {
     pub allow_always: bool,
 }
 
+const APPROVAL_PARAMETER_PREVIEW_BYTES: usize = 1200;
+const APPROVAL_PARAMETER_TRUNCATION_SUFFIX: &str = "\n... [parameters truncated]";
+const APPROVAL_SUMMARY_DESCRIPTION_BYTES: usize = 120;
+
 impl StatusUpdate {
     /// Build a `ToolCompleted` status with redacted parameters.
     ///
@@ -420,10 +424,25 @@ impl ChatApprovalPrompt {
         })
     }
 
-    /// Pretty-printed tool parameters for display.
-    pub fn parameters_json(&self) -> String {
-        serde_json::to_string_pretty(&self.parameters)
-            .unwrap_or_else(|_| self.parameters.to_string())
+    fn truncated_text(input: &str, max_bytes: usize, suffix: &str) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let budget = max_bytes.saturating_sub(suffix.len());
+        let end = crate::util::floor_char_boundary(input, budget);
+        format!("{}{}", &input[..end], suffix)
+    }
+
+    /// Pretty-printed tool parameters for display, bounded for chat channels.
+    pub fn parameters_preview(&self) -> String {
+        let rendered = serde_json::to_string_pretty(&self.parameters)
+            .unwrap_or_else(|_| self.parameters.to_string());
+        Self::truncated_text(
+            &rendered,
+            APPROVAL_PARAMETER_PREVIEW_BYTES,
+            APPROVAL_PARAMETER_TRUNCATION_SUFFIX,
+        )
     }
 
     /// Shared reply vocabulary summary for compact status surfaces.
@@ -435,6 +454,26 @@ impl ChatApprovalPrompt {
         }
     }
 
+    /// Compact approval summary for fallback/accessibility surfaces.
+    pub fn summary_text(&self) -> String {
+        let description = Self::truncated_text(
+            &self.description.replace('\n', " "),
+            APPROVAL_SUMMARY_DESCRIPTION_BYTES,
+            "...",
+        );
+        format!(
+            "Approval needed for {}: {} (Request ID: {}). Reply with {}.",
+            self.tool_name,
+            description,
+            self.request_id,
+            self.reply_summary()
+        )
+    }
+
+    fn markdown_parameters_preview(&self) -> String {
+        self.parameters_preview().replace('`', "\\`")
+    }
+
     /// Approval prompt formatted for plain-text chat channels.
     pub fn plain_text_message(&self) -> String {
         let mut lines = vec![
@@ -443,7 +482,7 @@ impl ChatApprovalPrompt {
             String::new(),
             format!("Request ID: {}", self.request_id),
             "Parameters:".to_string(),
-            self.parameters_json(),
+            self.parameters_preview(),
             String::new(),
             "Reply with:".to_string(),
             "- yes, y, approve, or /approve to approve this request".to_string(),
@@ -469,7 +508,7 @@ impl ChatApprovalPrompt {
             format!("*Tool:* {}", self.tool_name),
             format!("*Description:* {}", self.description),
             "*Parameters:*".to_string(),
-            format!("```json\n{}\n```", self.parameters_json()),
+            format!("```json\n{}\n```", self.markdown_parameters_preview()),
             String::new(),
             "Reply with:".to_string(),
             "• `yes`, `y`, `approve`, or `/approve` - Approve this request".to_string(),
@@ -790,5 +829,40 @@ mod tests {
         assert!(markdown.contains("`/approve`"));
         assert!(markdown.contains("`/deny`"));
         assert!(!markdown.contains("`/always`"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_truncates_large_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-789".into(),
+            tool_name: "http".into(),
+            description: "Fetch large payload".into(),
+            parameters: serde_json::json!({
+                "body": "x".repeat(APPROVAL_PARAMETER_PREVIEW_BYTES + 200),
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let preview = prompt.parameters_preview();
+        assert!(preview.contains("[parameters truncated]"));
+        assert!(preview.len() <= APPROVAL_PARAMETER_PREVIEW_BYTES);
+    }
+
+    #[test]
+    fn chat_approval_prompt_escapes_backticks_in_markdown_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-999".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({
+                "command": "printf '```danger```'"
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("\\`\\`\\`danger\\`\\`\\`"));
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -38,8 +38,9 @@ pub mod web;
 mod webhook_server;
 
 pub use channel::{
-    AttachmentKind, Channel, ChannelSecretUpdater, IncomingAttachment, IncomingMessage,
-    MessageStream, OutgoingResponse, StatusUpdate, ToolDecision, routing_target_from_metadata,
+    AttachmentKind, Channel, ChannelSecretUpdater, ChatApprovalPrompt, IncomingAttachment,
+    IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate, ToolDecision,
+    routing_target_from_metadata,
 };
 pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -172,7 +172,7 @@ impl RelayChannel {
 
         let mut body = serde_json::json!({
             "channel": channel_id,
-            "text": prompt.plain_text_message(),
+            "text": prompt.summary_text(),
             "blocks": blocks,
         });
         if let Some(tid) = thread_id {
@@ -512,8 +512,9 @@ mod tests {
         let text = body["text"].as_str().expect("plain text");
         let block_text = body["blocks"][0]["text"]["text"].as_str().expect("mrkdwn");
 
-        assert!(text.contains("approve, or /approve"));
-        assert!(text.contains("always, a, or /always"));
+        assert!(text.contains("Request ID: req-1"));
+        assert!(text.contains("Reply with yes (or /approve)"));
+        assert!(!text.contains("Parameters:"));
         assert!(block_text.contains("`/approve`"));
         assert!(block_text.contains("`/always`"));
         assert_eq!(body["thread_ts"], "1234567.890");

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::channels::relay::client::{ChannelEvent, RelayClient};
-use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
+use crate::channels::{
+    Channel, ChatApprovalPrompt, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate,
+};
 use crate::error::ChannelError;
 
 /// Default channel name for the Slack relay integration.
@@ -125,6 +127,58 @@ impl RelayChannel {
         self.client
             .proxy_provider(self.provider.as_str(), team_id, method, body)
             .await
+    }
+
+    fn build_approval_body(
+        &self,
+        channel_id: &str,
+        thread_id: Option<&str>,
+        prompt: &ChatApprovalPrompt,
+        approval_token: &str,
+    ) -> serde_json::Value {
+        let value_payload = serde_json::json!({
+            "approval_token": approval_token,
+        });
+        let value_str = value_payload.to_string();
+
+        let blocks = serde_json::json!([
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": prompt.markdown_message(),
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Approve" },
+                        "style": "primary",
+                        "action_id": "approve_tool",
+                        "value": value_str,
+                    },
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Deny" },
+                        "style": "danger",
+                        "action_id": "deny_tool",
+                        "value": value_str,
+                    }
+                ]
+            }
+        ]);
+
+        let mut body = serde_json::json!({
+            "channel": channel_id,
+            "text": prompt.plain_text_message(),
+            "blocks": blocks,
+        });
+        if let Some(tid) = thread_id {
+            body["thread_ts"] = serde_json::Value::String(tid.to_string());
+        }
+        body
     }
 }
 
@@ -260,14 +314,7 @@ impl Channel for RelayChannel {
         metadata: &serde_json::Value,
     ) -> Result<(), ChannelError> {
         // Only handle ApprovalNeeded — all other variants are no-ops
-        let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            parameters,
-            allow_always: _,
-        } = status
-        else {
+        let Some(prompt) = ChatApprovalPrompt::from_status(&status) else {
             return Ok(());
         };
 
@@ -278,7 +325,7 @@ impl Channel for RelayChannel {
             .unwrap_or("");
         if event_type != "direct_message" {
             tracing::warn!(
-                tool = %tool_name,
+                tool = %prompt.tool_name,
                 event_type,
                 "Approval requested in non-DM, skipping buttons"
             );
@@ -303,60 +350,13 @@ impl Channel for RelayChannel {
         // The button value contains ONLY the token — no routing fields.
         let approval_token = self
             .client
-            .create_approval(team_id, channel_id, thread_id, &request_id)
+            .create_approval(team_id, channel_id, thread_id, &prompt.request_id)
             .await
             .map_err(|e| ChannelError::SendFailed {
                 name: self.name().to_string(),
                 reason: format!("Failed to register approval: {e}"),
             })?;
-        let value_payload = serde_json::json!({
-            "approval_token": approval_token,
-        });
-        let value_str = value_payload.to_string();
-
-        // Parameters are already redacted via redact_params() in dispatcher.rs
-        let params_display =
-            serde_json::to_string_pretty(&parameters).unwrap_or_else(|_| parameters.to_string());
-
-        let blocks = serde_json::json!([
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": format!(
-                        "*Tool approval required*\n`{tool_name}`: {description}\n```{params_display}```"
-                    )
-                }
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Approve" },
-                        "style": "primary",
-                        "action_id": "approve_tool",
-                        "value": value_str,
-                    },
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Deny" },
-                        "style": "danger",
-                        "action_id": "deny_tool",
-                        "value": value_str,
-                    }
-                ]
-            }
-        ]);
-
-        let mut body = serde_json::json!({
-            "channel": channel_id,
-            "text": format!("Tool approval required: {tool_name} - {description}"),
-            "blocks": blocks,
-        });
-        if let Some(tid) = thread_id {
-            body["thread_ts"] = serde_json::Value::String(tid.to_string());
-        }
+        let body = self.build_approval_body(channel_id, thread_id, &prompt, &approval_token);
 
         self.proxy_send(team_id, "chat.postMessage", body)
             .await
@@ -497,6 +497,28 @@ mod tests {
         assert_eq!(body["thread_ts"], "1234567.890");
     }
 
+    #[test]
+    fn build_approval_body_includes_chat_reply_instructions() {
+        let channel = make_channel();
+        let prompt = ChatApprovalPrompt {
+            request_id: "req-1".into(),
+            tool_name: "http".into(),
+            description: "HTTP requests to external APIs".into(),
+            parameters: serde_json::json!({"method": "POST", "url": "https://example.com"}),
+            allow_always: true,
+        };
+
+        let body = channel.build_approval_body("C456", Some("1234567.890"), &prompt, "token-123");
+        let text = body["text"].as_str().expect("plain text");
+        let block_text = body["blocks"][0]["text"]["text"].as_str().expect("mrkdwn");
+
+        assert!(text.contains("approve, or /approve"));
+        assert!(text.contains("always, a, or /always"));
+        assert!(block_text.contains("`/approve`"));
+        assert!(block_text.contains("`/always`"));
+        assert_eq!(body["thread_ts"], "1234567.890");
+    }
+
     #[tokio::test]
     async fn start_processes_events() {
         let (tx, rx) = mpsc::channel(64);
@@ -530,6 +552,41 @@ mod tests {
 
         assert_eq!(msg.content, "hello");
         assert_eq!(msg.user_id, "U789");
+    }
+
+    #[tokio::test]
+    async fn start_threaded_message_preserves_thread_scope() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        tx.send(ChannelEvent {
+            id: "threaded-1".into(),
+            event_type: "direct_message".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "D456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("approve".into()),
+            thread_id: Some("1712345678.123".into()),
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(msg.content, "approve");
+        assert_eq!(msg.thread_id.as_deref(), Some("1712345678.123"));
+        assert_eq!(msg.conversation_scope(), Some("1712345678.123"));
     }
 
     #[tokio::test]

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -910,34 +910,10 @@ impl Channel for SignalChannel {
         }
 
         // Send approval prompt to user
-        if let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description: _,
-            parameters,
-            allow_always,
-        } = &status
+        if let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status)
             && let Some(target_str) = metadata.get("signal_target").and_then(|v| v.as_str())
         {
-            let params_json = serde_json::to_string_pretty(parameters).unwrap_or_default();
-            let always_line = if *allow_always {
-                format!(
-                    "\n• `always` or `a` - Approve and auto-approve future {} requests",
-                    tool_name
-                )
-            } else {
-                String::new()
-            };
-            let message = format!(
-                "⚠️ *Approval Required*\n\n\
-                 *Request ID:* `{}`\n\
-                 *Tool:* {}\n\
-                 *Parameters:*\n```\n{}\n```\n\n\
-                 Reply with:\n\
-                 • `yes` or `y` - Approve this request{}\n\
-                 • `no` or `n` - Deny",
-                request_id, tool_name, params_json, always_line
-            );
+            let message = prompt.markdown_message();
             self.send_status_message(target_str, &message).await;
         }
 

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -2298,63 +2298,16 @@ impl WasmChannel {
             StatusUpdate::StreamChunk(_) => {
                 // No-op, too noisy
             }
-            StatusUpdate::ApprovalNeeded {
-                tool_name,
-                description,
-                parameters,
-                allow_always,
-                ..
-            } => {
+            StatusUpdate::ApprovalNeeded { .. } => {
                 // WASM channels (Telegram, Slack, etc.) cannot render
                 // interactive approval overlays.  Send the approval prompt
                 // as an actual message so the user can reply yes/no.
                 self.cancel_typing_task().await;
 
-                let params_preview = parameters
-                    .as_object()
-                    .map(|obj| {
-                        obj.iter()
-                            .map(|(k, v)| {
-                                let val = match v {
-                                    serde_json::Value::String(s) => {
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("\"{}...\"", truncated)
-                                        } else {
-                                            format!("\"{}\"", s)
-                                        }
-                                    }
-                                    other => {
-                                        let s = other.to_string();
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("{}...", truncated)
-                                        } else {
-                                            s
-                                        }
-                                    }
-                                };
-                                format!("  {}: {}", k, val)
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let reply_hint = if *allow_always {
-                    "Reply \"yes\" to approve, \"no\" to deny, or \"always\" to auto-approve."
-                } else {
-                    "Reply \"yes\" to approve or \"no\" to deny."
+                let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status) else {
+                    return Ok(());
                 };
-                let prompt = format!(
-                    "Approval needed: {tool_name}\n\
-                     {description}\n\
-                     \n\
-                     Parameters:\n\
-                     {params_preview}\n\
-                     \n\
-                     {reply_hint}"
-                );
+                let prompt = prompt.plain_text_message();
 
                 let metadata_json = serde_json::to_string(metadata).unwrap_or_default();
                 if let Err(e) = self
@@ -3813,24 +3766,11 @@ fn status_to_wit(
                 metadata_json,
             }
         }
-        StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            allow_always,
-            ..
-        } => {
-            let reply_hint = if *allow_always {
-                "yes (or /approve), no (or /deny), or always (or /always)"
-            } else {
-                "yes (or /approve) or no (or /deny)"
-            };
+        StatusUpdate::ApprovalNeeded { .. } => {
+            let prompt = crate::channels::ChatApprovalPrompt::from_status(status)?;
             wit_channel::StatusUpdate {
                 status: wit_channel::StatusType::ApprovalNeeded,
-                message: format!(
-                    "Approval needed for tool '{}'. {}\nRequest ID: {}\nReply with: {}.",
-                    tool_name, description, request_id, reply_hint
-                ),
+                message: prompt.plain_text_message(),
                 metadata_json,
             }
         }

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -1,7 +1,8 @@
 """Scenario 6: Tool approval overlay UI behavior."""
 
-import pytest
-from helpers import SEL
+import asyncio
+
+from helpers import SEL, api_get, api_post
 
 
 INJECT_APPROVAL_JS = """
@@ -10,6 +11,60 @@ INJECT_APPROVAL_JS = """
     showApproval(data);
 }
 """
+
+
+async def _create_thread(base_url: str) -> str:
+    response = await api_post(base_url, "/api/chat/thread/new", timeout=15)
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def _send_chat_message(base_url: str, thread_id: str, content: str) -> None:
+    response = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={"content": content, "thread_id": thread_id},
+        timeout=30,
+    )
+    assert response.status_code == 202, response.text
+
+
+async def _wait_for_history(
+    base_url: str,
+    thread_id: str,
+    *,
+    expect_pending: bool | None = None,
+    response_fragment: str | None = None,
+    turn_count_at_least: int | None = None,
+    timeout: float = 20.0,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        response = await api_get(
+            base_url,
+            f"/api/chat/history?thread_id={thread_id}",
+            timeout=10,
+        )
+        assert response.status_code == 200, response.text
+        history = response.json()
+        pending = history.get("pending_approval")
+        turns = history.get("turns", [])
+        latest_response = turns[-1].get("response") if turns else None
+
+        pending_ok = expect_pending is None or bool(pending) == expect_pending
+        response_ok = response_fragment is None or (
+            latest_response is not None and response_fragment in latest_response
+        )
+        turns_ok = turn_count_at_least is None or len(turns) >= turn_count_at_least
+        if pending_ok and response_ok and turns_ok:
+            return history
+
+        await asyncio.sleep(0.25)
+
+    raise AssertionError(
+        f"Timed out waiting for history state: expect_pending={expect_pending}, "
+        f"response_fragment={response_fragment!r}"
+    )
 
 
 async def test_approval_card_appears(page):
@@ -186,3 +241,73 @@ async def test_waiting_for_approval_message_no_error_prefix(page):
     assert "HTTP requests to external APIs" in msg_text, (
         f"Expected tool description in message. Got: {msg_text!r}"
     )
+
+
+async def test_chat_reply_approve_resumes_pending_tool(ironclaw_server):
+    """A plain chat reply of 'approve' should resume the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-chat")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "approve")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    assert history.get("pending_approval") is None
+    assert history["turns"][-1]["response"] is not None
+
+
+async def test_chat_reply_deny_rejects_pending_tool(ironclaw_server):
+    """A plain chat reply of 'deny' should reject the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-denied")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "deny")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="was rejected",
+        turn_count_at_least=1,
+    )
+
+    response_text = history["turns"][-1]["response"]
+    assert response_text is not None
+    assert "Tool 'http' was rejected" in response_text
+
+
+async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
+    """A plain chat reply of 'always' should auto-approve the same tool next time."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-a")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "always")
+    await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-b")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=2,
+    )
+
+    assert history.get("pending_approval") is None
+    assert len(history["turns"]) >= 2


### PR DESCRIPTION
## Summary
- centralize chat-style approval prompt formatting for non-web channels
- align Signal, WASM chat channels, and Slack relay DM approval wording and supported reply forms
- add approval chat-flow E2E coverage for approve, deny, and always

## Testing
- cargo fmt --all
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test approval_prompt -- --nocapture
- cargo test build_approval_body -- --nocapture
- cargo test threaded_message_preserves_thread_scope -- --nocapture
- cargo test process_envelope_dm_sets_thread_id_to_uuid -- --nocapture
- /Users/henry/near_ai/near_claw/ironclaw/tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_tool_approval.py -q

Refs #1785