### PR TITLE
fix(agent): prevent self-repair notification spam for stuck jobs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -197,8 +197,8 @@ When modifying a module with a spec, read the spec first. Code follows spec; spe
 
 ```
 Pending -> InProgress -> Completed -> Submitted -> Accepted
-                     \-> Failed
-                     \-> Stuck -> InProgress (recovery)
+    \                \-> Failed
+     \-> Failed       \-> Stuck -> InProgress (recovery)
                               \-> Failed
 ```
 

--- a/channels-src/telegram/Cargo.lock
+++ b/channels-src/telegram/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-channel"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -507,12 +507,17 @@ impl Agent {
                         }
                         Ok(RepairResult::Failed { message }) => {
                             tracing::error!("Repair failed: {}", message);
-                            Some(format!(
-                                "Job {} was stuck for {}s, recovery failed permanently: {}",
-                                job.job_id,
-                                job.stuck_duration.as_secs(),
-                                message
-                            ))
+                            // Dedup: only notify once per job (same pattern as ManualRequired)
+                            if notified_manual.insert(job.job_id) {
+                                Some(format!(
+                                    "Job {} was stuck for {}s, recovery failed permanently: {}",
+                                    job.job_id,
+                                    job.stuck_duration.as_secs(),
+                                    message
+                                ))
+                            } else {
+                                None
+                            }
                         }
                         Ok(RepairResult::ManualRequired { message }) => {
                             tracing::warn!("Manual intervention needed: {}", message);

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -482,6 +482,11 @@ impl Agent {
         let repair_channels = self.channels.clone();
         let repair_owner_id = self.owner_id().to_string();
         let repair_handle = tokio::spawn(async move {
+            // Track jobs that have already been escalated to ManualRequired
+            // to prevent sending duplicate notifications every repair cycle.
+            let mut notified_manual: std::collections::HashSet<uuid::Uuid> =
+                std::collections::HashSet::new();
+
             loop {
                 tokio::time::sleep(repair_interval).await;
 
@@ -511,10 +516,17 @@ impl Agent {
                         }
                         Ok(RepairResult::ManualRequired { message }) => {
                             tracing::warn!("Manual intervention needed: {}", message);
-                            Some(format!(
-                                "Job {} needs manual intervention: {}",
-                                job.job_id, message
-                            ))
+                            // Only notify once per job to prevent notification spam.
+                            // The job should have been transitioned to Failed by
+                            // repair_stuck_job, but guard against that failing too.
+                            if notified_manual.insert(job.job_id) {
+                                Some(format!(
+                                    "Job {} needs manual intervention: {}",
+                                    job.job_id, message
+                                ))
+                            } else {
+                                None
+                            }
                         }
                         Ok(RepairResult::Retry { message }) => {
                             tracing::warn!("Repair needs retry: {}", message);

--- a/src/agent/self_repair.rs
+++ b/src/agent/self_repair.rs
@@ -201,9 +201,25 @@ impl SelfRepair for DefaultSelfRepair {
     async fn repair_stuck_job(&self, job: &StuckJob) -> Result<RepairResult, RepairError> {
         // Check if we've exceeded max repair attempts
         if job.repair_attempts >= self.max_repair_attempts {
+            // Transition to Failed so detect_stuck_jobs() stops finding this job.
+            // Without this, the repair loop re-detects the job every cycle and
+            // sends a ManualRequired notification each time (notification spam).
+            let _ = self
+                .context_manager
+                .update_context(job.job_id, |ctx| {
+                    ctx.transition_to(
+                        JobState::Failed,
+                        Some(format!(
+                            "exceeded max repair attempts ({})",
+                            self.max_repair_attempts
+                        )),
+                    )
+                })
+                .await;
+
             return Ok(RepairResult::ManualRequired {
                 message: format!(
-                    "Job {} has exceeded maximum repair attempts ({})",
+                    "Job {} has exceeded maximum repair attempts ({}) and has been marked failed",
                     job.job_id, self.max_repair_attempts
                 ),
             });
@@ -524,7 +540,7 @@ mod tests {
         let cm = Arc::new(ContextManager::new(10));
         let job_id = cm.create_job("Unrepairable", "desc").await.unwrap();
 
-        let repair = DefaultSelfRepair::new(cm, Duration::from_secs(60), 2);
+        let repair = DefaultSelfRepair::new(cm.clone(), Duration::from_secs(60), 2);
 
         let stuck_job = StuckJob {
             job_id,
@@ -539,6 +555,17 @@ mod tests {
             matches!(result, RepairResult::ManualRequired { .. }),
             "Expected ManualRequired, got: {:?}",
             result
+        );
+
+        // Regression: the job must be transitioned to Failed so
+        // detect_stuck_jobs() stops finding it. Without this, the repair
+        // loop re-detects the job every cycle and sends ManualRequired
+        // notifications forever (notification spam bug).
+        let ctx = cm.get_context(job_id).await.unwrap();
+        assert_eq!(
+            ctx.state,
+            JobState::Failed,
+            "Job should be Failed after exceeding max repair attempts"
         );
     }
 

--- a/src/agent/self_repair.rs
+++ b/src/agent/self_repair.rs
@@ -204,19 +204,23 @@ impl SelfRepair for DefaultSelfRepair {
             // Transition to Failed so detect_stuck_jobs() stops finding this job.
             // Without this, the repair loop re-detects the job every cycle and
             // sends a ManualRequired notification each time (notification spam).
-            let transition_ok = self
-                .context_manager
-                .update_context(job.job_id, |ctx| {
-                    ctx.transition_to(
-                        JobState::Failed,
-                        Some(format!(
-                            "exceeded max repair attempts ({})",
-                            self.max_repair_attempts
-                        )),
-                    )
-                })
-                .await
-                .is_ok();
+            // update_context returns Result<Result<(), String>, JobError>.
+            // Outer Err = job not found. Inner Err = invalid state transition.
+            // Both mean the job was NOT transitioned to Failed.
+            let transition_ok = matches!(
+                self.context_manager
+                    .update_context(job.job_id, |ctx| {
+                        ctx.transition_to(
+                            JobState::Failed,
+                            Some(format!(
+                                "exceeded max repair attempts ({})",
+                                self.max_repair_attempts
+                            )),
+                        )
+                    })
+                    .await,
+                Ok(Ok(()))
+            );
 
             if !transition_ok {
                 tracing::error!(
@@ -553,6 +557,18 @@ mod tests {
     async fn repair_stuck_job_returns_manual_when_limit_exceeded() {
         let cm = Arc::new(ContextManager::new(10));
         let job_id = cm.create_job("Unrepairable", "desc").await.unwrap();
+
+        // Transition through the production path: Pending → InProgress → Stuck
+        cm.update_context(job_id, |ctx| ctx.transition_to(JobState::InProgress, None))
+            .await
+            .unwrap()
+            .unwrap();
+        cm.update_context(job_id, |ctx| {
+            ctx.transition_to(JobState::Stuck, Some("test".into()))
+        })
+        .await
+        .unwrap()
+        .unwrap();
 
         let repair = DefaultSelfRepair::new(cm.clone(), Duration::from_secs(60), 2);
 

--- a/src/agent/self_repair.rs
+++ b/src/agent/self_repair.rs
@@ -204,7 +204,7 @@ impl SelfRepair for DefaultSelfRepair {
             // Transition to Failed so detect_stuck_jobs() stops finding this job.
             // Without this, the repair loop re-detects the job every cycle and
             // sends a ManualRequired notification each time (notification spam).
-            let _ = self
+            let transition_ok = self
                 .context_manager
                 .update_context(job.job_id, |ctx| {
                     ctx.transition_to(
@@ -215,12 +215,26 @@ impl SelfRepair for DefaultSelfRepair {
                         )),
                     )
                 })
-                .await;
+                .await
+                .is_ok();
+
+            if !transition_ok {
+                tracing::error!(
+                    job = %job.job_id,
+                    "Failed to transition job to Failed state after exceeding max repair attempts"
+                );
+            }
+
+            let status = if transition_ok {
+                "and has been marked failed"
+            } else {
+                "but could not be marked failed (will be suppressed by dedup)"
+            };
 
             return Ok(RepairResult::ManualRequired {
                 message: format!(
-                    "Job {} has exceeded maximum repair attempts ({}) and has been marked failed",
-                    job.job_id, self.max_repair_attempts
+                    "Job {} has exceeded maximum repair attempts ({}) {}",
+                    job.job_id, self.max_repair_attempts, status
                 ),
             });
         }

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -59,8 +59,9 @@ impl JobState {
 
         matches!(
             (self, target),
-            // From Pending
-            (Pending, InProgress) | (Pending, Cancelled) |
+            // From Pending (Failed added for self-repair: stuck Pending jobs
+            // that exhaust repair attempts must be terminable)
+            (Pending, InProgress) | (Pending, Failed) | (Pending, Cancelled) |
             // From InProgress
             (InProgress, Completed) | (InProgress, Failed) |
             (InProgress, Stuck) | (InProgress, Cancelled) |


### PR DESCRIPTION
## Summary
- Transition stuck jobs to Failed after exceeding max repair attempts, so detect_stuck_jobs() stops re-detecting them
- Add HashSet dedup in agent loop to prevent duplicate ManualRequired notifications per job
- Add Pending -> Failed to state machine (stuck Pending jobs could not be terminated)

## Change Type
- [x] Bug fix (non-breaking change which fixes an issue)

## Linked Issue
None — discovered during live operation: two stuck Pending jobs sent "manual intervention needed" notifications to Telegram every 60 seconds for 6+ hours.

## Validation
- cargo fmt --all -- --check: pass
- cargo clippy --all-features: pass
- cargo test --lib -- self_repair::tests: 12 pass (including regression test for Failed transition)

## Security Impact
None

## Database Impact
None

## Blast Radius
- Jobs that exceed max repair attempts now transition to Failed instead of staying in Pending/Stuck. Previously these jobs were effectively orphaned — they stayed in a non-terminal state forever, requiring manual DB intervention.
- Pending -> Failed state transition is new. Code that assumes Pending can only go to InProgress or Cancelled may need updating, but grep shows no such assumptions outside the state machine itself.

## Rollback Plan
Revert the commit. Jobs will stay in Pending/Stuck after max attempts (pre-existing behavior). The notification spam returns but is not a data integrity issue.

## Review Track
Track B — bug fix in src/agent/ with regression test

## Feature Parity
No FEATURE_PARITY.md changes needed.