### PR TITLE
fix(config): remove duplicate cheap_model and smart_routing_cascade fields in LlmConfig::for_testing

### DIFF
--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -41,8 +41,6 @@ impl LlmConfig {
             gemini_oauth: None,
             openai_codex: None,
             request_timeout_secs: 120,
-            cheap_model: None,
-            smart_routing_cascade: false,
         }
     }
 


### PR DESCRIPTION
## Summary

`LlmConfig::for_testing()` has two duplicate struct field initializers that do not belong at the top level of `LlmConfig`:

- `cheap_model: None` — already set inside `nearai: NearAiConfig { cheap_model: None, ... }`
- `smart_routing_cascade: false` — already set inside the `nearai:` block

These cause a **compile error** (duplicate field names in struct init) in any compilation that activates the `libsql` feature flag.

## Fix

Remove the stray top-level `cheap_model` and `smart_routing_cascade` field initializers. They are already correctly set inside the `nearai:` sub-struct.

## Testing

```bash
cargo check --features libsql
```
