### PR TITLE
Add Docker Hub workflow and optimize Dockerfile for size

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,84 @@
+name: Docker Image
+
+on:
+  push:
+    branches: [main]
+    tags: ["ironclaw-v*", "v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag override (leave empty for auto-detect)"
+        required: false
+        type: string
+        default: ""
+
+env:
+  IMAGE_NAME: nearaidev/ironclaw
+
+jobs:
+  build:
+    name: Build & Push
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: ${VERSION}"
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            # On main branch: latest + version
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
+            # On version tags: extract semver
+            type=match,pattern=(?:ironclaw-)?v(.*),group=1
+            # Manual override
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+            # Short SHA for all builds
+            type=sha,prefix=
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "## Docker Image"
+            echo ""
+            echo "**Tags pushed:**"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo ""
+            echo "- version: \`${{ steps.version.outputs.version }}\`"
+            echo "- sha: \`${{ github.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,6 +22,7 @@ jobs:
     permissions:
       contents: read
       packages: read
+      actions: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,10 +40,9 @@ jobs:
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |
-            # On main branch: latest + version
+            # On default branch: latest
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ steps.version.outputs.version }},enable={{is_default_branch}}
-            # On version tags: extract semver
+            # On version tags: extract semver (immutable)
             type=match,pattern=(?:ironclaw-)?v(.*),group=1
             # Manual override
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,9 +1,15 @@
 name: Docker Image
 
 on:
-  push:
-    branches: [main]
-    tags: ["ironclaw-v*", "v*"]
+  # Called by release.yml or other workflows
+  workflow_call:
+    inputs:
+      tag:
+        description: "Image tag override (leave empty for auto-detect)"
+        required: false
+        type: string
+        default: ""
+  # On-demand builds
   workflow_dispatch:
     inputs:
       tag:
@@ -34,20 +40,17 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Detected version: ${VERSION}"
 
-      - name: Docker meta
-        id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.IMAGE_NAME }}
-          tags: |
-            # On default branch: latest
-            type=raw,value=latest,enable={{is_default_branch}}
-            # On version tags: extract semver (immutable)
-            type=match,pattern=(?:ironclaw-)?v(.*),group=1
-            # Manual override
-            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
-            # Short SHA for all builds
-            type=sha,prefix=
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+          TAGS="${TAGS},${{ env.IMAGE_NAME }}:latest"
+          TAGS="${TAGS},${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA::7}"
+          # Manual override adds an extra tag
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            TAGS="${TAGS},${{ env.IMAGE_NAME }}:${{ inputs.tag }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -63,8 +66,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.tags.outputs.tags }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -76,9 +78,9 @@ jobs:
             echo ""
             echo "**Tags pushed:**"
             echo '```'
-            echo "${{ steps.meta.outputs.tags }}"
+            echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n'
             echo '```'
             echo ""
             echo "- version: \`${{ steps.version.outputs.version }}\`"
-            echo "- sha: \`${{ github.sha }}\`"
+            echo "- sha: \`${GITHUB_SHA::7}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM rust:1.92-alpine AS chef
 
 RUN apk add --no-cache musl-dev pkgconfig cmake gcc g++ make perl \
     && rustup target add wasm32-wasip2 \
-    && cargo install cargo-chef wasm-tools
+    && cargo install cargo-chef@0.1.77 wasm-tools@1.246.1
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # Uses cargo-chef for dependency caching — only rebuilds deps when
 # Cargo.toml/Cargo.lock change, not on every source edit.
 #
+# Alpine-based build + runtime for minimal image size (~30 MB).
+# Statically links against musl; no glibc or libssl needed at runtime.
+#
 # Build:
 #   docker build --platform linux/amd64 -t ironclaw:latest .
 #
@@ -10,11 +13,9 @@
 #   docker run --env-file .env -p 3000:3000 ironclaw:latest
 
 # Stage 1: Install cargo-chef
-FROM rust:1.92-slim-bookworm AS chef
+FROM rust:1.92-alpine AS chef
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config libssl-dev cmake gcc g++ \
-    && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache musl-dev pkgconfig cmake gcc g++ make perl \
     && rustup target add wasm32-wasip2 \
     && cargo install cargo-chef wasm-tools
 
@@ -40,8 +41,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Stage 3: Build dependencies (cached unless Cargo.toml/lock change)
 FROM chef AS deps
 
+ENV CARGO_PROFILE_DIST_PANIC=abort \
+    CARGO_PROFILE_DIST_CODEGEN_UNITS=1
+
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --profile dist --recipe-path recipe.json
 
 # Stage 4: Build the actual binary (only recompiles ironclaw source)
 FROM deps AS builder
@@ -58,21 +62,18 @@ COPY channels-src/ channels-src/
 COPY wit/ wit/
 COPY providers.json providers.json
 
-RUN cargo build --release --bin ironclaw
+RUN cargo build --profile dist --bin ironclaw
 
-# Stage 5: Runtime
-FROM debian:bookworm-slim
+# Stage 5: Minimal runtime
+FROM alpine:3.21
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates
 
-COPY --from=builder /app/target/release/ironclaw /usr/local/bin/ironclaw
+COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
 COPY --from=builder /app/migrations /app/migrations
 
 # Non-root user
-RUN useradd -m -u 1000 -s /bin/bash ironclaw
+RUN adduser -D -u 1000 ironclaw
 USER ironclaw
 
 EXPOSE 3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Uses cargo-chef for dependency caching — only rebuilds deps when
 # Cargo.toml/Cargo.lock change, not on every source edit.
 #
-# Alpine-based build + runtime for minimal image size (~30 MB).
+# Alpine-based build + runtime for a minimal image size.
 # Statically links against musl; no glibc or libssl needed at runtime.
 #
 # Build:
@@ -41,6 +41,8 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Stage 3: Build dependencies (cached unless Cargo.toml/lock change)
 FROM chef AS deps
 
+# Docker-only overrides for the dist profile (not in Cargo.toml because
+# cargo-dist uses dist for release binaries that need unwinding).
 ENV CARGO_PROFILE_DIST_PANIC=abort \
     CARGO_PROFILE_DIST_CODEGEN_UNITS=1
 


### PR DESCRIPTION
## Summary

- Switch Dockerfile from Debian bookworm-slim to Alpine for both build and runtime stages, reducing image size from **162MB to 64MB** (60% reduction)
- Add GitHub Actions workflow to build and push to `nearaidev/ironclaw` on Docker Hub
- Binary size reduced from 74MB to 53MB via thin LTO, `panic=abort`, and `codegen-units=1`

### Dockerfile changes
- **Alpine + musl**: runtime base drops from ~88MB to ~11MB; no `libssl` needed (project uses rustls throughout)
- **`--profile dist`**: thin LTO eliminates dead code across crate boundaries
- **`panic=abort` + `codegen-units=1`**: removes unwinding tables, enables better whole-program optimization
- **Pinned tool versions**: cargo-chef@0.1.77, wasm-tools@1.246.1 for reproducible builds

### Workflow (`docker.yml`)
- Triggers via `workflow_call` (for release.yml integration) and `workflow_dispatch` (on-demand)
- No `push` trigger — avoids publishing on every staging→main promotion
- Tags: version from Cargo.toml + `latest` + `sha-<short>`
- Uses Docker Buildx with GitHub Actions layer cache
- Requires `DOCKER_REGISTRY_USER` (variable) and `DOCKER_REGISTRY_TOKEN` (secret) — same as ironclaw-dind repo

To wire into releases, add to `release.yml`:
```yaml
docker:
  needs: [publish]
  uses: ./.github/workflows/docker.yml
```

## Test plan

- [x] Built image locally on macOS (Docker Desktop, linux/amd64)
- [x] Built and tested on gpu07 (Ubuntu, native amd64)
- [x] Verified ~700ms startup time
- [x] Verified health endpoint: `GET /api/health` → `{"status":"healthy"}`
- [x] Verified web UI serves (HTML, CSS, JS — all 200)
- [x] Verified authenticated endpoints: gateway status, chat threads, tools list, memory tree, settings, profile, admin users, routines, extensions
- [x] Verified SSE streaming (`/api/chat/events`, `/api/logs/events`)
- [x] Verified chat send: `POST /api/chat/send` → `{"status":"accepted"}`
- [x] Verified DB migrations apply (libSQL, 4 incremental migrations)

| Metric | Before (Debian) | After (Alpine) | Change |
|--------|-----------------|----------------|--------|
| Image size | 162 MB | 64 MB | -60% |
| Binary size | 74 MB | 53 MB | -28% |
| Compressed | ~55 MB | 24 MB | -56% |