### PR TITLE
Add shared-instance benchmark harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ libsql = ["dep:libsql"]
 # Opt-in feature for especially heavy integration-test targets that run in a
 # dedicated CI job instead of the default Rust test matrix.
 integration = []
+bench-runtime = []
 html-to-markdown = ["dep:html-to-markdown-rs", "dep:readabilityrs"]
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 import = ["dep:json5", "libsql"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! IronClaw - Main entry point.
 
+use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -38,15 +39,40 @@ fn main() -> anyhow::Result<()> {
     let _ = dotenvy::dotenv();
     ironclaw::bootstrap::load_ironclaw_env();
 
-    let result = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .build()?
-        .block_on(async_main());
+    let runtime = build_runtime_from_env()?;
+    let result = runtime.block_on(async_main());
 
     if let Err(ref e) = result {
         format_top_level_error(e);
     }
     result
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BenchRuntimeMode {
+    MultiThread,
+    CurrentThread,
+}
+
+fn parse_bench_runtime_mode(value: Option<&str>) -> anyhow::Result<BenchRuntimeMode> {
+    match value.unwrap_or("multi_thread") {
+        "multi_thread" => Ok(BenchRuntimeMode::MultiThread),
+        "current_thread" => Ok(BenchRuntimeMode::CurrentThread),
+        other => anyhow::bail!(
+            "Invalid IRONCLAW_BENCH_RUNTIME_MODE '{other}'. Expected 'multi_thread' or 'current_thread'."
+        ),
+    }
+}
+
+fn build_runtime_from_env() -> anyhow::Result<tokio::runtime::Runtime> {
+    let value = env::var("IRONCLAW_BENCH_RUNTIME_MODE").ok();
+    let mode = parse_bench_runtime_mode(value.as_deref())?;
+    let mut builder = match mode {
+        BenchRuntimeMode::MultiThread => tokio::runtime::Builder::new_multi_thread(),
+        BenchRuntimeMode::CurrentThread => tokio::runtime::Builder::new_current_thread(),
+    };
+    builder.enable_all();
+    builder.build().map_err(Into::into)
 }
 
 /// Format a top-level error with color and recovery hints.
@@ -1214,4 +1240,38 @@ async fn async_main() -> anyhow::Result<()> {
     tracing::debug!("Agent shutdown complete");
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BenchRuntimeMode, parse_bench_runtime_mode};
+
+    #[test]
+    fn bench_runtime_mode_defaults_to_multi_thread() {
+        let mode = parse_bench_runtime_mode(None).expect("default mode should parse");
+        assert_eq!(mode, BenchRuntimeMode::MultiThread);
+    }
+
+    #[test]
+    fn bench_runtime_mode_accepts_current_thread() {
+        let mode =
+            parse_bench_runtime_mode(Some("current_thread")).expect("current_thread should parse");
+        assert_eq!(mode, BenchRuntimeMode::CurrentThread);
+    }
+
+    #[test]
+    fn bench_runtime_mode_accepts_multi_thread() {
+        let mode =
+            parse_bench_runtime_mode(Some("multi_thread")).expect("multi_thread should parse");
+        assert_eq!(mode, BenchRuntimeMode::MultiThread);
+    }
+
+    #[test]
+    fn bench_runtime_mode_rejects_invalid_values() {
+        let err = parse_bench_runtime_mode(Some("single_thread")).expect_err("must reject");
+        assert!(
+            err.to_string().contains("IRONCLAW_BENCH_RUNTIME_MODE"),
+            "unexpected error: {err:#}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,5 @@
 //! IronClaw - Main entry point.
 
-use std::env;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -68,7 +67,7 @@ fn parse_bench_runtime_mode(value: Option<&str>) -> anyhow::Result<BenchRuntimeM
 
 #[cfg(feature = "bench-runtime")]
 fn build_runtime_from_env() -> anyhow::Result<tokio::runtime::Runtime> {
-    let value = env::var("IRONCLAW_BENCH_RUNTIME_MODE").ok();
+    let value = std::env::var("IRONCLAW_BENCH_RUNTIME_MODE").ok();
     let mode = parse_bench_runtime_mode(value.as_deref())?;
     let mut builder = match mode {
         BenchRuntimeMode::MultiThread => tokio::runtime::Builder::new_multi_thread(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,12 +48,14 @@ fn main() -> anyhow::Result<()> {
     result
 }
 
+#[cfg(feature = "bench-runtime")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BenchRuntimeMode {
     MultiThread,
     CurrentThread,
 }
 
+#[cfg(feature = "bench-runtime")]
 fn parse_bench_runtime_mode(value: Option<&str>) -> anyhow::Result<BenchRuntimeMode> {
     match value.unwrap_or("multi_thread") {
         "multi_thread" => Ok(BenchRuntimeMode::MultiThread),
@@ -64,6 +66,7 @@ fn parse_bench_runtime_mode(value: Option<&str>) -> anyhow::Result<BenchRuntimeM
     }
 }
 
+#[cfg(feature = "bench-runtime")]
 fn build_runtime_from_env() -> anyhow::Result<tokio::runtime::Runtime> {
     let value = env::var("IRONCLAW_BENCH_RUNTIME_MODE").ok();
     let mode = parse_bench_runtime_mode(value.as_deref())?;
@@ -71,6 +74,13 @@ fn build_runtime_from_env() -> anyhow::Result<tokio::runtime::Runtime> {
         BenchRuntimeMode::MultiThread => tokio::runtime::Builder::new_multi_thread(),
         BenchRuntimeMode::CurrentThread => tokio::runtime::Builder::new_current_thread(),
     };
+    builder.enable_all();
+    builder.build().map_err(Into::into)
+}
+
+#[cfg(not(feature = "bench-runtime"))]
+fn build_runtime_from_env() -> anyhow::Result<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
     builder.build().map_err(Into::into)
 }
@@ -1242,7 +1252,7 @@ async fn async_main() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "bench-runtime"))]
 mod tests {
     use super::{BenchRuntimeMode, parse_bench_runtime_mode};
 

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -1,0 +1,132 @@
+# Shared-Instance Benchmarks
+
+This directory contains manual benchmark workflows for shared-instance IronClaw performance work, starting with issue `#1775`.
+
+## Scope
+
+The initial benchmark is intentionally narrow:
+
+- one IronClaw instance
+- one machine
+- multiple authenticated users
+- multiple SSE connections per user
+- concurrent chat requests
+- mock LLM backend so inference-service variance does not dominate the results
+
+This is not a soak-test platform, a multi-process benchmark suite, or a CI load job.
+
+## Prerequisites
+
+- Rust toolchain
+- Python 3.11+
+- Python dependencies used by the existing E2E harness:
+
+```bash
+cd tests/e2e
+pip install -e .
+```
+
+The benchmark driver reuses `aiohttp` and `httpx`, plus the existing mock LLM server in [`tests/e2e/mock_llm.py`](/Users/henry/near_ai/near_claw/ironclaw/.worktrees/bench-shared-instance-baseline/tests/e2e/mock_llm.py).
+
+## Baseline Run
+
+From the repo root:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label baseline \
+  --user-count 20 \
+  --sse-connections-per-user 2 \
+  --senders-per-user 1 \
+  --messages-per-user 5 \
+  --max-in-flight-requests 20
+```
+
+The script will:
+
+1. build `ironclaw` if needed
+2. start the mock LLM server
+3. start one IronClaw gateway instance with libSQL
+4. create benchmark users through `POST /api/admin/users`
+5. pre-create one thread per measured request
+6. open `user_count * sse_connections_per_user` SSE streams
+7. run the measured chat workload against `POST /api/chat/send`
+
+Results are written to `/tmp/ironclaw-benchmarks/` by default.
+
+## Variant Runs
+
+Current-thread Tokio runtime:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label runtime-current-thread \
+  --runtime-mode current_thread
+```
+
+Lower global parallel jobs:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label lower-agent-jobs \
+  --agent-max-parallel-jobs 8
+```
+
+Tighter per-user LLM concurrency:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label tighter-tenant-llm \
+  --tenant-max-llm-concurrent 2
+```
+
+Tighter per-user job concurrency:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label tighter-tenant-jobs \
+  --tenant-max-jobs-concurrent 1
+```
+
+## Workload Model
+
+- one or more sender tasks per user
+- one unique thread per measured request
+- additional SSE streams for the same user act as passive listeners
+- the benchmark records whether every open stream for that user observed any event and a final event for the request
+
+Using unique thread IDs per measured request avoids ambiguity from trailing events on reused threads while keeping the workload on the real gateway path.
+
+To exercise per-tenant concurrency directly, increase `--senders-per-user`. For example:
+
+```bash
+python tests/benchmarks/shared_instance_benchmark.py \
+  --label tenant-llm-2senders \
+  --user-count 20 \
+  --sse-connections-per-user 2 \
+  --senders-per-user 2 \
+  --messages-per-user 6 \
+  --max-in-flight-requests 20 \
+  --tenant-max-llm-concurrent 1
+```
+
+With `--senders-per-user 1`, requests overlap across users but not within a single user. With `--senders-per-user > 1`, requests can overlap within the same tenant and the per-user concurrency knobs become meaningful.
+
+## Reported Metrics
+
+Each JSON result file includes:
+
+- requests completed
+- error count
+- timeout count
+- p50/p95/p99 `time_to_first_event_ms`
+- p50/p95/p99 `time_to_final_event_ms`
+- SSE delivery rates across all expected per-user connections
+- CPU samples for the IronClaw process
+- RSS samples for the IronClaw process
+
+## Notes
+
+- The gateway currently limits total SSE plus WebSocket connections to `100`. Keep `user_count * sse_connections_per_user <= 100`.
+- The default workload does not use tools. If you add a tool-inclusive variant later, pair it with `--auto-approve-tools` so the run does not stall on approval UI.
+- This benchmark targets IronClaw shared-instance behavior, not provider throughput. It intentionally routes all LLM calls to the local mock server.

--- a/tests/benchmarks/README.md
+++ b/tests/benchmarks/README.md
@@ -26,7 +26,7 @@ cd tests/e2e
 pip install -e .
 ```
 
-The benchmark driver reuses `aiohttp` and `httpx`, plus the existing mock LLM server in [`tests/e2e/mock_llm.py`](/Users/henry/near_ai/near_claw/ironclaw/.worktrees/bench-shared-instance-baseline/tests/e2e/mock_llm.py).
+The benchmark driver reuses `aiohttp` and `httpx`, plus the existing mock LLM server in [tests/e2e/mock_llm.py](../e2e/mock_llm.py).
 
 ## Baseline Run
 
@@ -44,7 +44,7 @@ python tests/benchmarks/shared_instance_benchmark.py \
 
 The script will:
 
-1. build `ironclaw` if needed
+1. build `ironclaw` with the benchmark runtime feature if needed
 2. start the mock LLM server
 3. start one IronClaw gateway instance with libSQL
 4. create benchmark users through `POST /api/admin/users`
@@ -52,7 +52,7 @@ The script will:
 6. open `user_count * sse_connections_per_user` SSE streams
 7. run the measured chat workload against `POST /api/chat/send`
 
-Results are written to `/tmp/ironclaw-benchmarks/` by default.
+Results are written to the system temp directory under `ironclaw-benchmarks/` by default.
 
 ## Variant Runs
 

--- a/tests/benchmarks/RESULTS.md
+++ b/tests/benchmarks/RESULTS.md
@@ -1,0 +1,99 @@
+# Shared-Instance Benchmark Results
+
+These results were collected on March 31, 2026 with the benchmark harness in this directory.
+
+At the time of these runs, the harness used `senders_per_user=1`. The harness now supports `--senders-per-user > 1` so future runs can exercise per-tenant concurrency limits directly.
+
+All runs used:
+
+- one local IronClaw instance
+- mock OpenAI-compatible LLM backend
+- libSQL
+- `20` users
+- `5` measured messages per user
+- `20` max in-flight requests
+- no tools
+
+## Run Matrix
+
+| Label | SSE/user | Runtime | Extra knobs | Requests | p50 first | p95 first | p99 first | p50 final | p95 final | p99 final | SSE delivery | CPU avg / max | RSS avg / max |
+|------|---------:|---------|-------------|---------:|----------:|----------:|----------:|----------:|----------:|----------:|-------------:|--------------:|--------------:|
+| `baseline-20u-2sse` | 2 | `multi_thread` | none | 100 | 18.97 ms | 1785.61 ms | 2220.03 ms | 35.17 ms | 1807.29 ms | 2240.16 ms | 1.000 / 1.000 | 68.01 / 96.30 % | 89.50 / 92.05 MB |
+| `fanout-20u-4sse` | 4 | `multi_thread` | none | 100 | 18.56 ms | 1534.93 ms | 1935.07 ms | 34.68 ms | 1554.27 ms | 1954.12 ms | 1.000 / 1.000 | 85.15 / 98.90 % | 98.94 / 102.00 MB |
+| `runtime-current-thread-20u-2sse` | 2 | `current_thread` | none | 100 | 18.90 ms | 1491.55 ms | 1881.39 ms | 35.23 ms | 1509.86 ms | 1899.91 ms | 1.000 / 1.000 | 83.03 / 98.00 % | 87.05 / 90.12 MB |
+| `lower-agent-jobs-8-20u-2sse` | 2 | `multi_thread` | `AGENT_MAX_PARALLEL_JOBS=8` | 100 | 15.78 ms | 1479.68 ms | 1874.28 ms | 31.67 ms | 1500.67 ms | 1893.37 ms | 1.000 / 1.000 | 82.02 / 97.80 % | 86.43 / 90.09 MB |
+| `tenant-llm-1-20u-2sse` | 2 | `multi_thread` | `TENANT_MAX_LLM_CONCURRENT=1` | 100 | 22.63 ms | 1470.68 ms | 1859.03 ms | 38.77 ms | 1489.23 ms | 1878.14 ms | 1.000 / 1.000 | 79.52 / 97.80 % | 87.54 / 90.12 MB |
+
+`SSE delivery` is reported as `any-event delivery / final-event delivery`.
+
+## Observed Bottlenecks
+
+### 1. Tail latency is the first visible bottleneck
+
+Across every `20`-user run, median latency stayed low while p95 and p99 rose sharply:
+
+- p50 first-event latency stayed around `16-23 ms`
+- p95 first-event latency stayed around `1.47-1.79 s`
+- p99 first-event latency stayed around `1.86-2.22 s`
+
+That pattern points to burst queueing or scheduler contention under concurrent load rather than a uniformly slow request path.
+
+### 2. CPU pressure rises before SSE fanout breaks
+
+Increasing from `2` to `4` SSE streams per user:
+
+- kept delivery perfect at `1.000 / 1.000`
+- increased CPU average from `68.01%` to `85.15%`
+- increased RSS average from `89.50 MB` to `98.94 MB`
+
+So the first fanout cost in this workload is higher process overhead, not dropped SSE delivery.
+
+### 3. No SSE loss was observed up to 80 open streams
+
+The `fanout-20u-4sse` run held `80` SSE connections open and all expected streams received both any-event and final-event delivery for every measured request.
+
+At this workload level, SSE correctness and per-user fanout looked stable.
+
+### 4. Current-thread runtime did not regress this workload
+
+The `current_thread` run completed cleanly and slightly improved long-tail latency relative to the baseline run on this machine:
+
+- p95 first-event: `1491.55 ms` vs `1785.61 ms`
+- p99 first-event: `1881.39 ms` vs `2220.03 ms`
+
+This is only one local sample, so it should be treated as directional rather than conclusive, but it does support keeping the benchmark-only runtime gate.
+
+## Important Workload Limitations
+
+### Per-user concurrency knobs are not strongly exercised yet
+
+The current harness uses:
+
+- one sender task per user
+- sequential message submission within each user
+
+That means `TENANT_MAX_LLM_CONCURRENT` is only weakly exercised, and `TENANT_MAX_JOBS_CONCURRENT` is not meaningfully exercised at all because this workload does not launch jobs.
+
+The `tenant-llm-1-20u-2sse` result stayed close to the other runs, which is consistent with the workload shape rather than proof that the knob is irrelevant.
+
+If we want to benchmark per-user concurrency limits directly, the harness needs a `senders_per_user` or per-user in-flight request knob.
+
+## Takeaways
+
+- The first meaningful performance signal is high tail latency under bursty shared-instance chat load.
+- SSE fanout looked robust through `80` open streams, but it raises CPU and memory usage.
+- `current_thread` is worth keeping in the benchmark matrix because it did not obviously lose on this workload.
+- The next benchmark improvement should be adding parallel senders per user so per-tenant concurrency limits can be tested directly.
+
+## Harness Update: Multi-Sender Validation
+
+After the runs above, the harness was extended with `--senders-per-user` so requests can overlap within the same user.
+
+Two small validation runs completed successfully:
+
+| Label | Users | SSE/user | Senders/user | Messages/user | Extra knobs | Requests | p50 first | p95 first | p50 final | p95 final |
+|------|------:|---------:|-------------:|--------------:|-------------|---------:|----------:|----------:|----------:|----------:|
+| `multisender-smoke` | 6 | 2 | 2 | 4 | none | 24 | 58.46 ms | 693.35 ms | 78.72 ms | 709.40 ms |
+| `multisender-tenant-llm-1-smoke` | 6 | 2 | 2 | 4 | `TENANT_MAX_LLM_CONCURRENT=1` | 24 | 51.00 ms | 671.41 ms | 69.53 ms | 688.55 ms |
+
+These were only correctness-oriented validation runs, not full comparison runs, but they confirm that the harness can now overlap requests inside the same tenant and is ready for a fuller per-user-concurrency benchmark pass.

--- a/tests/benchmarks/shared_instance_benchmark.py
+++ b/tests/benchmarks/shared_instance_benchmark.py
@@ -594,11 +594,16 @@ async def create_threads(
 
 async def iter_sse_events(response: aiohttp.ClientResponse):
     data_lines: list[str] = []
-    async for raw_line in response.content:
-        line = raw_line.decode("utf-8", errors="replace").strip()
+    while True:
+        raw_line = await response.content.readline()
+        if not raw_line:
+            break
+
+        line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
         if not line:
             if not data_lines:
                 continue
+
             payload = "\n".join(data_lines)
             data_lines.clear()
             try:
@@ -607,8 +612,18 @@ async def iter_sse_events(response: aiohttp.ClientResponse):
                 continue
             continue
 
+        if line.startswith(":"):
+            continue
+
         if line.startswith("data:"):
             data_lines.append(line[5:].lstrip())
+
+    if data_lines:
+        payload = "\n".join(data_lines)
+        try:
+            yield json.loads(payload)
+        except json.JSONDecodeError:
+            return
 
 
 async def sse_listener(
@@ -616,26 +631,37 @@ async def sse_listener(
     base_url: str,
     user_state: UserState,
     connection_index: int,
-    ready_event: asyncio.Event,
+    startup_future: asyncio.Future[None],
     stop_event: asyncio.Event,
 ) -> None:
     timeout = aiohttp.ClientTimeout(total=None, sock_read=None, connect=30.0)
-    async with aiohttp.ClientSession(timeout=timeout) as session:
-        async with session.get(
-            f"{base_url}/api/chat/events?token={user_state.token}",
-            headers={"Accept": "text/event-stream"},
-        ) as response:
-            if response.status != 200:
-                body = await response.text()
-                raise RuntimeError(
-                    f"SSE connection {connection_index} for user {user_state.user_id} "
-                    f"failed with {response.status}: {body}"
-                )
-            ready_event.set()
-            async for event in iter_sse_events(response):
-                if stop_event.is_set():
-                    break
-                await user_state.handle_event(connection_index, event, time.monotonic())
+    try:
+        async with aiohttp.ClientSession(timeout=timeout) as session:
+            async with session.get(
+                f"{base_url}/api/chat/events?token={user_state.token}",
+                headers={"Accept": "text/event-stream"},
+            ) as response:
+                if response.status != 200:
+                    body = await response.text()
+                    raise RuntimeError(
+                        f"SSE connection {connection_index} for user {user_state.user_id} "
+                        f"failed with {response.status}: {body}"
+                    )
+                if not startup_future.done():
+                    startup_future.set_result(None)
+                async for event in iter_sse_events(response):
+                    if stop_event.is_set():
+                        break
+                    await user_state.handle_event(connection_index, event, time.monotonic())
+    except asyncio.CancelledError:
+        if not startup_future.done():
+            startup_future.cancel()
+        raise
+    except Exception as exc:
+        if not startup_future.done():
+            startup_future.set_exception(exc)
+            return
+        raise
 
 
 async def run_user_workload(
@@ -961,25 +987,25 @@ async def async_main(args: argparse.Namespace) -> int:
                 client, base_url, users, threads_per_user=args.messages_per_user
             )
 
-            ready_events: list[asyncio.Event] = []
+            startup_futures: list[asyncio.Future[None]] = []
             for user_state in user_states:
                 for connection_index in range(args.sse_connections_per_user):
-                    ready_event = asyncio.Event()
-                    ready_events.append(ready_event)
+                    startup_future = asyncio.get_running_loop().create_future()
+                    startup_futures.append(startup_future)
                     sse_tasks.append(
                         asyncio.create_task(
                             sse_listener(
                                 base_url=base_url,
                                 user_state=user_state,
                                 connection_index=connection_index,
-                                ready_event=ready_event,
+                                startup_future=startup_future,
                                 stop_event=sse_stop_event,
                             )
                         )
                     )
 
             await asyncio.wait_for(
-                asyncio.gather(*(event.wait() for event in ready_events)),
+                asyncio.gather(*startup_futures),
                 timeout=args.startup_timeout,
             )
 

--- a/tests/benchmarks/shared_instance_benchmark.py
+++ b/tests/benchmarks/shared_instance_benchmark.py
@@ -1,0 +1,1104 @@
+#!/usr/bin/env python3
+"""Shared-instance benchmark harness for IronClaw issue #1775.
+
+Runs one real IronClaw gateway instance against the existing mock OpenAI-
+compatible LLM server, provisions multiple DB-backed users, opens multiple SSE
+connections per user, and sends concurrent chat requests to stress IronClaw
+itself rather than external inference services.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import shlex
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import aiohttp
+import httpx
+
+
+DEFAULT_ADMIN_TOKEN = "bench-admin-token"
+DEFAULT_OWNER_ID = "bench-owner"
+DEFAULT_MOCK_MODEL = "mock-model"
+DEFAULT_RESULTS_DIR = Path(tempfile.gettempdir()) / "ironclaw-benchmarks"
+GATEWAY_CONNECTION_LIMIT = 100
+
+
+@dataclass
+class RuntimeSample:
+    timestamp: float
+    cpu_percent: float
+    rss_mb: float
+
+
+@dataclass
+class RequestOutcome:
+    user_id: str
+    thread_id: str
+    sequence: int
+    status: str
+    send_accepted: bool
+    request_post_latency_ms: float | None
+    time_to_first_event_ms: float | None
+    time_to_final_event_ms: float | None
+    connections_with_any_event: int
+    connections_with_final_event: int
+    all_connections_saw_any_event: bool
+    all_connections_saw_final_event: bool
+    final_event_type: str | None
+    error_message: str | None
+
+
+@dataclass
+class ConnectionObservation:
+    saw_any_event: bool = False
+    saw_final_event: bool = False
+
+
+@dataclass
+class RequestTracker:
+    user_id: str
+    thread_id: str
+    sequence: int
+    connection_count: int
+    send_started_at: float
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    final_event: asyncio.Event = field(default_factory=asyncio.Event)
+    post_completed_at: float | None = None
+    first_event_at: float | None = None
+    final_event_at: float | None = None
+    final_event_type: str | None = None
+    error_message: str | None = None
+    send_accepted: bool = False
+    connection_observations: dict[int, ConnectionObservation] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.connection_observations = {
+            idx: ConnectionObservation() for idx in range(self.connection_count)
+        }
+
+    async def mark_post_result(self, accepted: bool, completed_at: float, error: str | None) -> None:
+        async with self.lock:
+            self.send_accepted = accepted
+            self.post_completed_at = completed_at
+            if error:
+                self.error_message = error
+                self.final_event_type = "post_error"
+                self.final_event_at = completed_at
+                self.final_event.set()
+
+    async def record_event(self, connection_index: int, event: dict[str, Any], timestamp: float) -> None:
+        event_type = event.get("type")
+        if event_type == "heartbeat":
+            return
+
+        async with self.lock:
+            observation = self.connection_observations[connection_index]
+            observation.saw_any_event = True
+
+            if self.first_event_at is None:
+                self.first_event_at = timestamp
+
+            if event_type in {"response", "error"}:
+                observation.saw_final_event = True
+                if self.final_event_at is None:
+                    self.final_event_at = timestamp
+                    self.final_event_type = str(event_type)
+                    if event_type == "error":
+                        self.error_message = event.get("message")
+                    self.final_event.set()
+
+    async def finalize_timeout(self, message: str) -> None:
+        async with self.lock:
+            if self.final_event_at is None:
+                now = time.monotonic()
+                self.final_event_at = now
+                self.final_event_type = "timeout"
+                self.error_message = message
+                self.final_event.set()
+
+    async def snapshot(self) -> RequestOutcome:
+        async with self.lock:
+            any_event_count = sum(
+                1 for obs in self.connection_observations.values() if obs.saw_any_event
+            )
+            final_event_count = sum(
+                1 for obs in self.connection_observations.values() if obs.saw_final_event
+            )
+            request_post_latency_ms = None
+            if self.post_completed_at is not None:
+                request_post_latency_ms = (self.post_completed_at - self.send_started_at) * 1000.0
+
+            first_event_ms = None
+            if self.first_event_at is not None:
+                first_event_ms = (self.first_event_at - self.send_started_at) * 1000.0
+
+            final_event_ms = None
+            if self.final_event_at is not None:
+                final_event_ms = (self.final_event_at - self.send_started_at) * 1000.0
+
+            return RequestOutcome(
+                user_id=self.user_id,
+                thread_id=self.thread_id,
+                sequence=self.sequence,
+                status=self.final_event_type or "unknown",
+                send_accepted=self.send_accepted,
+                request_post_latency_ms=request_post_latency_ms,
+                time_to_first_event_ms=first_event_ms,
+                time_to_final_event_ms=final_event_ms,
+                connections_with_any_event=any_event_count,
+                connections_with_final_event=final_event_count,
+                all_connections_saw_any_event=any_event_count == self.connection_count,
+                all_connections_saw_final_event=final_event_count == self.connection_count,
+                final_event_type=self.final_event_type,
+                error_message=self.error_message,
+            )
+
+
+@dataclass
+class UserState:
+    user_id: str
+    token: str
+    thread_ids: list[str]
+    active_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    active_requests: dict[str, RequestTracker] = field(default_factory=dict)
+
+    async def set_active_request(self, tracker: RequestTracker) -> None:
+        async with self.active_lock:
+            self.active_requests[tracker.thread_id] = tracker
+
+    async def clear_active_request(self, tracker: RequestTracker) -> None:
+        async with self.active_lock:
+            current = self.active_requests.get(tracker.thread_id)
+            if current is tracker:
+                self.active_requests.pop(tracker.thread_id, None)
+
+    async def handle_event(self, connection_index: int, event: dict[str, Any], timestamp: float) -> None:
+        event_thread_id = event.get("thread_id")
+        if event_thread_id is None:
+            return
+
+        async with self.active_lock:
+            tracker = self.active_requests.get(event_thread_id)
+
+        if tracker is None:
+            return
+
+        await tracker.record_event(connection_index, event, timestamp)
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def primary_worktree_root(root: Path) -> Path:
+    try:
+        output = subprocess.check_output(
+            ["git", "worktree", "list", "--porcelain"],
+            cwd=root,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return root
+
+    for line in output.splitlines():
+        if line.startswith("worktree "):
+            return Path(line.split(" ", 1)[1])
+    return root
+
+
+def latest_mtime(path: Path) -> float:
+    """Return the newest mtime under a file or directory."""
+    if not path.exists():
+        return 0.0
+    if path.is_file():
+        return path.stat().st_mtime
+
+    latest = path.stat().st_mtime
+    for root, dirnames, filenames in os.walk(path):
+        dirnames[:] = [dirname for dirname in dirnames if dirname != "target"]
+        for name in filenames:
+            child = Path(root) / name
+            try:
+                latest = max(latest, child.stat().st_mtime)
+            except FileNotFoundError:
+                continue
+    return latest
+
+
+def binary_needs_rebuild(binary: Path, root: Path) -> bool:
+    """Rebuild when the binary is missing or older than embedded sources."""
+    if not binary.exists():
+        return True
+
+    binary_mtime = binary.stat().st_mtime
+    inputs = [
+        root / "Cargo.toml",
+        root / "Cargo.lock",
+        root / "build.rs",
+        root / "providers.json",
+        root / "src",
+        root / "channels-src",
+        root / "crates",
+    ]
+    return any(latest_mtime(path) > binary_mtime for path in inputs)
+
+
+def find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+async def wait_for_ready(url: str, *, timeout: float = 60.0, interval: float = 0.5) -> None:
+    deadline = time.monotonic() + timeout
+    async with httpx.AsyncClient() as client:
+        while time.monotonic() < deadline:
+            try:
+                response = await client.get(url, timeout=5.0)
+                if response.status_code == 200:
+                    return
+            except (httpx.ConnectError, httpx.ReadError, httpx.TimeoutException):
+                pass
+            await asyncio.sleep(interval)
+    raise TimeoutError(f"Service at {url} not ready after {timeout}s")
+
+
+async def wait_for_port_line(process: asyncio.subprocess.Process, pattern: str, *, timeout: float) -> int:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            line = await asyncio.wait_for(process.stdout.readline(), timeout=remaining)
+        except asyncio.TimeoutError:
+            break
+        if not line:
+            continue
+        decoded = line.decode("utf-8", errors="replace").strip()
+        match = re.search(pattern, decoded)
+        if match:
+            return int(match.group(1))
+    raise TimeoutError(f"Port pattern '{pattern}' not found after {timeout}s")
+
+
+async def stop_process(
+    process: asyncio.subprocess.Process,
+    *,
+    sig: int | None = None,
+    timeout: float = 10.0,
+) -> None:
+    if process.returncode is not None:
+        return
+
+    try:
+        if sig is None:
+            process.kill()
+        else:
+            process.send_signal(sig)
+    except ProcessLookupError:
+        return
+
+    try:
+        await asyncio.wait_for(process.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        if sig is not None and process.returncode is None:
+            process.kill()
+            try:
+                await asyncio.wait_for(process.wait(), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
+
+
+async def sample_process(pid: int, interval_secs: float, stop_event: asyncio.Event) -> list[RuntimeSample]:
+    samples: list[RuntimeSample] = []
+    while not stop_event.is_set():
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "ps",
+                "-o",
+                "rss=",
+                "-o",
+                "%cpu=",
+                "-p",
+                str(pid),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            )
+            stdout, _ = await proc.communicate()
+            fields = stdout.decode("utf-8", errors="replace").strip().split()
+            if len(fields) >= 2:
+                rss_mb = float(fields[0]) / 1024.0
+                cpu_percent = float(fields[1])
+                samples.append(
+                    RuntimeSample(
+                        timestamp=time.monotonic(),
+                        cpu_percent=cpu_percent,
+                        rss_mb=rss_mb,
+                    )
+                )
+        except (ValueError, OSError):
+            pass
+
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_secs)
+        except asyncio.TimeoutError:
+            continue
+    return samples
+
+
+def percentile(values: list[float], pct: float) -> float | None:
+    if not values:
+        return None
+    if len(values) == 1:
+        return values[0]
+
+    ordered = sorted(values)
+    rank = (len(ordered) - 1) * pct
+    low = int(rank)
+    high = min(low + 1, len(ordered) - 1)
+    weight = rank - low
+    return ordered[low] * (1.0 - weight) + ordered[high] * weight
+
+
+def utc_timestamp() -> str:
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def json_default(value: Any) -> Any:
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, RuntimeSample):
+        return asdict(value)
+    if isinstance(value, RequestOutcome):
+        return asdict(value)
+    raise TypeError(f"Unsupported value: {type(value)!r}")
+
+
+async def start_mock_llm(root: Path, *, startup_timeout: float) -> tuple[asyncio.subprocess.Process, str]:
+    script = root / "tests" / "e2e" / "mock_llm.py"
+    process = await asyncio.create_subprocess_exec(
+        sys.executable,
+        str(script),
+        "--port",
+        "0",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    port = await wait_for_port_line(process, r"MOCK_LLM_PORT=(\d+)", timeout=startup_timeout)
+    url = f"http://127.0.0.1:{port}"
+    await wait_for_ready(f"{url}/v1/models", timeout=startup_timeout)
+    return process, url
+
+
+def benchmark_env(
+    *,
+    home_dir: str,
+    db_path: str,
+    gateway_port: int,
+    http_port: int,
+    mock_llm_url: str,
+    args: argparse.Namespace,
+) -> tuple[dict[str, str], dict[str, Any]]:
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+        "RUST_LOG": args.rust_log,
+        "RUST_BACKTRACE": "1",
+        "IRONCLAW_OWNER_ID": DEFAULT_OWNER_ID,
+        "GATEWAY_ENABLED": "true",
+        "GATEWAY_HOST": "127.0.0.1",
+        "GATEWAY_PORT": str(gateway_port),
+        "GATEWAY_AUTH_TOKEN": DEFAULT_ADMIN_TOKEN,
+        "HTTP_HOST": "127.0.0.1",
+        "HTTP_PORT": str(http_port),
+        "CLI_ENABLED": "false",
+        "LLM_BACKEND": "openai_compatible",
+        "LLM_BASE_URL": mock_llm_url,
+        "LLM_MODEL": DEFAULT_MOCK_MODEL,
+        "DATABASE_BACKEND": "libsql",
+        "LIBSQL_PATH": db_path,
+        "SANDBOX_ENABLED": "false",
+        "SKILLS_ENABLED": "false",
+        "ROUTINES_ENABLED": "false",
+        "HEARTBEAT_ENABLED": "false",
+        "EMBEDDING_ENABLED": "false",
+        "WASM_ENABLED": "false",
+        "ONBOARD_COMPLETED": "true",
+        "IRONCLAW_BENCH_RUNTIME_MODE": args.runtime_mode,
+    }
+
+    public_overrides: dict[str, Any] = {
+        "IRONCLAW_BENCH_RUNTIME_MODE": args.runtime_mode,
+        "LLM_BACKEND": env["LLM_BACKEND"],
+        "DATABASE_BACKEND": env["DATABASE_BACKEND"],
+        "HTTP_HOST": env["HTTP_HOST"],
+        "HTTP_PORT": http_port,
+        "SANDBOX_ENABLED": env["SANDBOX_ENABLED"],
+        "SKILLS_ENABLED": env["SKILLS_ENABLED"],
+        "ROUTINES_ENABLED": env["ROUTINES_ENABLED"],
+        "HEARTBEAT_ENABLED": env["HEARTBEAT_ENABLED"],
+        "EMBEDDING_ENABLED": env["EMBEDDING_ENABLED"],
+        "WASM_ENABLED": env["WASM_ENABLED"],
+    }
+
+    if args.agent_max_parallel_jobs is not None:
+        env["AGENT_MAX_PARALLEL_JOBS"] = str(args.agent_max_parallel_jobs)
+        public_overrides["AGENT_MAX_PARALLEL_JOBS"] = args.agent_max_parallel_jobs
+    if args.tenant_max_llm_concurrent is not None:
+        env["TENANT_MAX_LLM_CONCURRENT"] = str(args.tenant_max_llm_concurrent)
+        public_overrides["TENANT_MAX_LLM_CONCURRENT"] = args.tenant_max_llm_concurrent
+    if args.tenant_max_jobs_concurrent is not None:
+        env["TENANT_MAX_JOBS_CONCURRENT"] = str(args.tenant_max_jobs_concurrent)
+        public_overrides["TENANT_MAX_JOBS_CONCURRENT"] = args.tenant_max_jobs_concurrent
+    if args.auto_approve_tools:
+        env["AGENT_AUTO_APPROVE_TOOLS"] = "true"
+        public_overrides["AGENT_AUTO_APPROVE_TOOLS"] = True
+
+    return env, public_overrides
+
+
+async def start_ironclaw(
+    root: Path,
+    binary: Path,
+    *,
+    gateway_port: int,
+    http_port: int,
+    mock_llm_url: str,
+    args: argparse.Namespace,
+    home_dir: str,
+    db_path: str,
+) -> tuple[asyncio.subprocess.Process, str, dict[str, Any]]:
+    env, public_overrides = benchmark_env(
+        home_dir=home_dir,
+        db_path=db_path,
+        gateway_port=gateway_port,
+        http_port=http_port,
+        mock_llm_url=mock_llm_url,
+        args=args,
+    )
+    process = await asyncio.create_subprocess_exec(
+        str(binary),
+        "--no-onboard",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+    base_url = f"http://127.0.0.1:{gateway_port}"
+    try:
+        await wait_for_ready(f"{base_url}/api/health", timeout=args.startup_timeout)
+    except TimeoutError as exc:
+        stderr_bytes = b""
+        if process.stderr is not None:
+            try:
+                stderr_bytes = await asyncio.wait_for(process.stderr.read(8192), timeout=2.0)
+            except asyncio.TimeoutError:
+                pass
+        await stop_process(process, timeout=2.0)
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        raise RuntimeError(
+            f"IronClaw failed to start within {args.startup_timeout}s.\nstderr:\n{stderr_text}"
+        ) from exc
+    return process, base_url, public_overrides
+
+
+async def api_post_json(
+    client: httpx.AsyncClient,
+    base_url: str,
+    path: str,
+    token: str,
+    payload: dict[str, Any] | None = None,
+    *,
+    timeout: float = 30.0,
+) -> httpx.Response:
+    request_kwargs: dict[str, Any] = {
+        "headers": {"Authorization": f"Bearer {token}"},
+        "timeout": timeout,
+    }
+    if payload is not None:
+        request_kwargs["json"] = payload
+    return await client.post(
+        f"{base_url}{path}",
+        **request_kwargs,
+    )
+
+
+async def create_users(
+    client: httpx.AsyncClient, base_url: str, user_count: int
+) -> list[dict[str, str]]:
+    users: list[dict[str, str]] = []
+    for index in range(user_count):
+        response = await api_post_json(
+            client,
+            base_url,
+            "/api/admin/users",
+            DEFAULT_ADMIN_TOKEN,
+            {
+                "display_name": f"Bench User {index + 1:03d}",
+                "role": "member",
+            },
+        )
+        response.raise_for_status()
+        payload = response.json()
+        users.append({"id": payload["id"], "token": payload["token"]})
+    return users
+
+
+async def create_threads(
+    client: httpx.AsyncClient,
+    base_url: str,
+    users: list[dict[str, str]],
+    threads_per_user: int,
+) -> list[UserState]:
+    user_states: list[UserState] = []
+    for user in users:
+        thread_ids: list[str] = []
+        for _ in range(threads_per_user):
+            response = await api_post_json(
+                client,
+                base_url,
+                "/api/chat/thread/new",
+                user["token"],
+                None,
+            )
+            response.raise_for_status()
+            payload = response.json()
+            thread_ids.append(payload["id"])
+        user_states.append(
+            UserState(
+                user_id=user["id"],
+                token=user["token"],
+                thread_ids=thread_ids,
+            )
+        )
+    return user_states
+
+
+async def iter_sse_events(response: aiohttp.ClientResponse):
+    data_lines: list[str] = []
+    async for raw_line in response.content:
+        line = raw_line.decode("utf-8", errors="replace").strip()
+        if not line:
+            if not data_lines:
+                continue
+            payload = "\n".join(data_lines)
+            data_lines.clear()
+            try:
+                yield json.loads(payload)
+            except json.JSONDecodeError:
+                continue
+            continue
+
+        if line.startswith("data:"):
+            data_lines.append(line[5:].lstrip())
+
+
+async def sse_listener(
+    *,
+    base_url: str,
+    user_state: UserState,
+    connection_index: int,
+    ready_event: asyncio.Event,
+    stop_event: asyncio.Event,
+) -> None:
+    timeout = aiohttp.ClientTimeout(total=None, sock_read=None, connect=30.0)
+    async with aiohttp.ClientSession(timeout=timeout) as session:
+        async with session.get(
+            f"{base_url}/api/chat/events?token={user_state.token}",
+            headers={"Accept": "text/event-stream"},
+        ) as response:
+            if response.status != 200:
+                body = await response.text()
+                raise RuntimeError(
+                    f"SSE connection {connection_index} for user {user_state.user_id} "
+                    f"failed with {response.status}: {body}"
+                )
+            ready_event.set()
+            async for event in iter_sse_events(response):
+                if stop_event.is_set():
+                    break
+                await user_state.handle_event(connection_index, event, time.monotonic())
+
+
+async def run_user_workload(
+    *,
+    client: httpx.AsyncClient,
+    base_url: str,
+    user_state: UserState,
+    max_in_flight: asyncio.Semaphore,
+    args: argparse.Namespace,
+) -> list[RequestOutcome]:
+    pending_requests: asyncio.Queue[tuple[int, str]] = asyncio.Queue()
+    for sequence, thread_id in enumerate(user_state.thread_ids, start=1):
+        pending_requests.put_nowait((sequence, thread_id))
+
+    async def worker() -> list[RequestOutcome]:
+        worker_outcomes: list[RequestOutcome] = []
+        while True:
+            try:
+                sequence, thread_id = pending_requests.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+
+            tracker = RequestTracker(
+                user_id=user_state.user_id,
+                thread_id=thread_id,
+                sequence=sequence,
+                connection_count=args.sse_connections_per_user,
+                send_started_at=time.monotonic(),
+            )
+
+            async with max_in_flight:
+                await user_state.set_active_request(tracker)
+                try:
+                    content = (
+                        f"[bench user={user_state.user_id} seq={sequence}] "
+                        "What is 2 + 2?"
+                    )
+                    response = await api_post_json(
+                        client,
+                        base_url,
+                        "/api/chat/send",
+                        user_state.token,
+                        {"content": content, "thread_id": thread_id},
+                        timeout=args.request_timeout,
+                    )
+                    error_message = None
+                    accepted = response.status_code == 202
+                    if not accepted:
+                        error_message = (
+                            f"POST /api/chat/send returned {response.status_code}: {response.text}"
+                        )
+                    await tracker.mark_post_result(
+                        accepted=accepted,
+                        completed_at=time.monotonic(),
+                        error=error_message,
+                    )
+
+                    if accepted:
+                        try:
+                            await asyncio.wait_for(
+                                tracker.final_event.wait(), timeout=args.request_timeout
+                            )
+                        except asyncio.TimeoutError:
+                            await tracker.finalize_timeout(
+                                "Timed out waiting for final SSE event after "
+                                f"{args.request_timeout}s"
+                            )
+
+                    await asyncio.sleep(args.delivery_grace_secs)
+                    worker_outcomes.append(await tracker.snapshot())
+                finally:
+                    await user_state.clear_active_request(tracker)
+                    pending_requests.task_done()
+
+        return worker_outcomes
+
+    worker_count = min(args.senders_per_user, len(user_state.thread_ids))
+    per_worker_outcomes = await asyncio.gather(*(worker() for _ in range(worker_count)))
+    return [outcome for outcomes in per_worker_outcomes for outcome in outcomes]
+
+
+def summarize_results(
+    *,
+    request_outcomes: list[RequestOutcome],
+    runtime_samples: list[RuntimeSample],
+    workload_started_at: float,
+    workload_finished_at: float,
+    args: argparse.Namespace,
+    env_overrides: dict[str, Any],
+    base_url: str,
+) -> dict[str, Any]:
+    completed = sum(1 for outcome in request_outcomes if outcome.status == "response")
+    errors = sum(
+        1
+        for outcome in request_outcomes
+        if outcome.status not in {"response", "timeout"}
+    )
+    timeouts = sum(1 for outcome in request_outcomes if outcome.status == "timeout")
+    first_event_latencies = [
+        outcome.time_to_first_event_ms
+        for outcome in request_outcomes
+        if outcome.time_to_first_event_ms is not None
+    ]
+    final_event_latencies = [
+        outcome.time_to_final_event_ms
+        for outcome in request_outcomes
+        if outcome.time_to_final_event_ms is not None
+    ]
+
+    expected_connection_deliveries = len(request_outcomes) * args.sse_connections_per_user
+    actual_any_event_deliveries = sum(
+        outcome.connections_with_any_event for outcome in request_outcomes
+    )
+    actual_final_event_deliveries = sum(
+        outcome.connections_with_final_event for outcome in request_outcomes
+    )
+    any_event_delivery_rate = (
+        actual_any_event_deliveries / expected_connection_deliveries
+        if expected_connection_deliveries
+        else 0.0
+    )
+    final_event_delivery_rate = (
+        actual_final_event_deliveries / expected_connection_deliveries
+        if expected_connection_deliveries
+        else 0.0
+    )
+
+    cpu_values = [sample.cpu_percent for sample in runtime_samples]
+    rss_values = [sample.rss_mb for sample in runtime_samples]
+
+    return {
+        "label": args.label,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "benchmark": {
+            "base_url": base_url,
+            "runtime_mode": args.runtime_mode,
+            "user_count": args.user_count,
+            "sse_connections_per_user": args.sse_connections_per_user,
+            "senders_per_user": args.senders_per_user,
+            "messages_per_user": args.messages_per_user,
+            "max_in_flight_requests": args.max_in_flight_requests,
+            "request_timeout_secs": args.request_timeout,
+            "delivery_grace_secs": args.delivery_grace_secs,
+            "sampling_interval_secs": args.sample_interval_secs,
+        },
+        "env_overrides": env_overrides,
+        "workload_timing": {
+            "started_at_monotonic": workload_started_at,
+            "finished_at_monotonic": workload_finished_at,
+            "duration_secs": workload_finished_at - workload_started_at,
+        },
+        "summary": {
+            "requests_total": len(request_outcomes),
+            "requests_completed": completed,
+            "errors": errors,
+            "timeouts": timeouts,
+            "time_to_first_event_ms": {
+                "p50": percentile(first_event_latencies, 0.50),
+                "p95": percentile(first_event_latencies, 0.95),
+                "p99": percentile(first_event_latencies, 0.99),
+            },
+            "time_to_final_event_ms": {
+                "p50": percentile(final_event_latencies, 0.50),
+                "p95": percentile(final_event_latencies, 0.95),
+                "p99": percentile(final_event_latencies, 0.99),
+            },
+            "sse_delivery": {
+                "expected_connection_deliveries": expected_connection_deliveries,
+                "any_event_delivery_rate": any_event_delivery_rate,
+                "final_event_delivery_rate": final_event_delivery_rate,
+                "requests_all_connections_saw_any_event": sum(
+                    1 for outcome in request_outcomes if outcome.all_connections_saw_any_event
+                ),
+                "requests_all_connections_saw_final_event": sum(
+                    1 for outcome in request_outcomes if outcome.all_connections_saw_final_event
+                ),
+            },
+            "cpu_percent": {
+                "avg": statistics.fmean(cpu_values) if cpu_values else None,
+                "max": max(cpu_values) if cpu_values else None,
+            },
+            "rss_mb": {
+                "avg": statistics.fmean(rss_values) if rss_values else None,
+                "max": max(rss_values) if rss_values else None,
+            },
+        },
+        "runtime_samples": runtime_samples,
+        "requests": request_outcomes,
+    }
+
+
+def print_summary(summary: dict[str, Any], output_path: Path) -> None:
+    time_to_first = summary["summary"]["time_to_first_event_ms"]
+    time_to_final = summary["summary"]["time_to_final_event_ms"]
+    sse_delivery = summary["summary"]["sse_delivery"]
+    cpu = summary["summary"]["cpu_percent"]
+    rss = summary["summary"]["rss_mb"]
+
+    print()
+    print(f"label: {summary['label']}")
+    print(
+        f"requests: {summary['summary']['requests_completed']}/"
+        f"{summary['summary']['requests_total']} completed, "
+        f"errors={summary['summary']['errors']}, "
+        f"timeouts={summary['summary']['timeouts']}"
+    )
+    print(
+        "time_to_first_event_ms: "
+        f"p50={format_metric(time_to_first['p50'])} "
+        f"p95={format_metric(time_to_first['p95'])} "
+        f"p99={format_metric(time_to_first['p99'])}"
+    )
+    print(
+        "time_to_final_event_ms: "
+        f"p50={format_metric(time_to_final['p50'])} "
+        f"p95={format_metric(time_to_final['p95'])} "
+        f"p99={format_metric(time_to_final['p99'])}"
+    )
+    print(
+        "sse_delivery: "
+        f"any={sse_delivery['any_event_delivery_rate']:.3f} "
+        f"final={sse_delivery['final_event_delivery_rate']:.3f}"
+    )
+    print(
+        "resource_usage: "
+        f"cpu_avg={format_metric(cpu['avg'])}% "
+        f"cpu_max={format_metric(cpu['max'])}% "
+        f"rss_avg={format_metric(rss['avg'])}MB "
+        f"rss_max={format_metric(rss['max'])}MB"
+    )
+    print(f"results_json: {output_path}")
+
+
+def format_metric(value: float | None) -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.2f}"
+
+
+def build_command_for_display(command: list[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+async def async_main(args: argparse.Namespace) -> int:
+    if args.user_count <= 0:
+        raise ValueError("--user-count must be positive")
+    if args.sse_connections_per_user <= 0:
+        raise ValueError("--sse-connections-per-user must be positive")
+    if args.messages_per_user <= 0:
+        raise ValueError("--messages-per-user must be positive")
+    if args.senders_per_user <= 0:
+        raise ValueError("--senders-per-user must be positive")
+    if args.max_in_flight_requests <= 0:
+        raise ValueError("--max-in-flight-requests must be positive")
+    if args.user_count * args.sse_connections_per_user > GATEWAY_CONNECTION_LIMIT:
+        raise ValueError(
+            "Requested SSE fanout exceeds the gateway connection limit of "
+            f"{GATEWAY_CONNECTION_LIMIT}: "
+            f"{args.user_count} users * {args.sse_connections_per_user} connections"
+        )
+
+    root = repo_root()
+    main_root = primary_worktree_root(root)
+    default_binary = main_root / "target" / "debug" / "ironclaw"
+    binary = Path(args.ironclaw_binary) if args.ironclaw_binary else default_binary
+    if not args.skip_build and binary_needs_rebuild(binary, root):
+        build_cmd = ["cargo", "build", "--no-default-features", "--features", "libsql"]
+        print(f"building ironclaw: {build_command_for_display(build_cmd)}")
+        subprocess.run(build_cmd, cwd=root, check=True, timeout=900)
+
+    if not binary.exists():
+        raise FileNotFoundError(
+            f"IronClaw binary not found at {binary}. Run cargo build or omit --skip-build."
+        )
+
+    artifacts_tmpdir: tempfile.TemporaryDirectory[str] | None = None
+    if args.keep_artifacts:
+        artifacts_root = Path(tempfile.mkdtemp(prefix="ironclaw-bench-"))
+    else:
+        artifacts_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-bench-")
+        artifacts_root = Path(artifacts_tmpdir.name)
+
+    home_dir = artifacts_root / "home"
+    db_dir = artifacts_root / "db"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    db_dir.mkdir(parents=True, exist_ok=True)
+    db_path = db_dir / "benchmark.db"
+    gateway_port = find_free_port()
+    http_port = find_free_port()
+
+    mock_llm_process: asyncio.subprocess.Process | None = None
+    ironclaw_process: asyncio.subprocess.Process | None = None
+    sse_stop_event = asyncio.Event()
+    sampler_stop_event = asyncio.Event()
+    sse_tasks: list[asyncio.Task[Any]] = []
+    sampler_task: asyncio.Task[list[RuntimeSample]] | None = None
+
+    try:
+        mock_llm_process, mock_llm_url = await start_mock_llm(
+            root, startup_timeout=args.startup_timeout
+        )
+        ironclaw_process, base_url, env_overrides = await start_ironclaw(
+            root,
+            binary,
+            gateway_port=gateway_port,
+            http_port=http_port,
+            mock_llm_url=mock_llm_url,
+            args=args,
+            home_dir=str(home_dir),
+            db_path=str(db_path),
+        )
+
+        async with httpx.AsyncClient() as client:
+            users = await create_users(client, base_url, args.user_count)
+            user_states = await create_threads(
+                client, base_url, users, threads_per_user=args.messages_per_user
+            )
+
+            ready_events: list[asyncio.Event] = []
+            for user_state in user_states:
+                for connection_index in range(args.sse_connections_per_user):
+                    ready_event = asyncio.Event()
+                    ready_events.append(ready_event)
+                    sse_tasks.append(
+                        asyncio.create_task(
+                            sse_listener(
+                                base_url=base_url,
+                                user_state=user_state,
+                                connection_index=connection_index,
+                                ready_event=ready_event,
+                                stop_event=sse_stop_event,
+                            )
+                        )
+                    )
+
+            await asyncio.wait_for(
+                asyncio.gather(*(event.wait() for event in ready_events)),
+                timeout=args.startup_timeout,
+            )
+
+            sampler_task = asyncio.create_task(
+                sample_process(
+                    ironclaw_process.pid,
+                    args.sample_interval_secs,
+                    sampler_stop_event,
+                )
+            )
+
+            workload_started_at = time.monotonic()
+            max_in_flight = asyncio.Semaphore(args.max_in_flight_requests)
+            per_user_results = await asyncio.gather(
+                *(
+                    run_user_workload(
+                        client=client,
+                        base_url=base_url,
+                        user_state=user_state,
+                        max_in_flight=max_in_flight,
+                        args=args,
+                    )
+                    for user_state in user_states
+                )
+            )
+            workload_finished_at = time.monotonic()
+
+        request_outcomes = [
+            outcome for user_results in per_user_results for outcome in user_results
+        ]
+        sampler_stop_event.set()
+        runtime_samples = await sampler_task if sampler_task is not None else []
+
+        summary = summarize_results(
+            request_outcomes=request_outcomes,
+            runtime_samples=runtime_samples,
+            workload_started_at=workload_started_at,
+            workload_finished_at=workload_finished_at,
+            args=args,
+            env_overrides=env_overrides,
+            base_url=base_url,
+        )
+
+        output_dir = Path(args.results_dir).expanduser()
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_dir / f"{args.label}-{utc_timestamp()}.json"
+        output_path.write_text(json.dumps(summary, indent=2, default=json_default) + "\n")
+        print_summary(summary, output_path)
+
+        return 0
+    finally:
+        sse_stop_event.set()
+        sampler_stop_event.set()
+        if sse_tasks:
+            for task in sse_tasks:
+                task.cancel()
+            await asyncio.gather(*sse_tasks, return_exceptions=True)
+        if sampler_task is not None and not sampler_task.done():
+            await asyncio.gather(sampler_task, return_exceptions=True)
+        if ironclaw_process is not None:
+            await stop_process(ironclaw_process, sig=signal.SIGINT, timeout=10.0)
+        if mock_llm_process is not None:
+            await stop_process(mock_llm_process, sig=signal.SIGTERM, timeout=5.0)
+        if args.keep_artifacts:
+            print(f"artifacts_dir: {artifacts_root}")
+        if artifacts_tmpdir is not None:
+            artifacts_tmpdir.cleanup()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--label", default="baseline", help="Result label written into the JSON output.")
+    parser.add_argument(
+        "--ironclaw-binary",
+        help="Path to a prebuilt ironclaw binary. Defaults to target/debug/ironclaw.",
+    )
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Do not run cargo build even if the binary looks stale or missing.",
+    )
+    parser.add_argument("--user-count", type=int, default=20)
+    parser.add_argument("--sse-connections-per-user", type=int, default=2)
+    parser.add_argument("--senders-per-user", type=int, default=1)
+    parser.add_argument("--messages-per-user", type=int, default=5)
+    parser.add_argument("--max-in-flight-requests", type=int, default=20)
+    parser.add_argument("--request-timeout", type=float, default=30.0)
+    parser.add_argument("--startup-timeout", type=float, default=60.0)
+    parser.add_argument("--delivery-grace-secs", type=float, default=0.75)
+    parser.add_argument("--sample-interval-secs", type=float, default=1.0)
+    parser.add_argument(
+        "--runtime-mode",
+        choices=["multi_thread", "current_thread"],
+        default="multi_thread",
+        help="Sets IRONCLAW_BENCH_RUNTIME_MODE for the spawned server.",
+    )
+    parser.add_argument("--agent-max-parallel-jobs", type=int)
+    parser.add_argument("--tenant-max-llm-concurrent", type=int)
+    parser.add_argument("--tenant-max-jobs-concurrent", type=int)
+    parser.add_argument(
+        "--auto-approve-tools",
+        action="store_true",
+        help="Sets AGENT_AUTO_APPROVE_TOOLS=true for tool-inclusive variants.",
+    )
+    parser.add_argument(
+        "--results-dir",
+        default=str(DEFAULT_RESULTS_DIR),
+        help="Directory for JSON benchmark result files.",
+    )
+    parser.add_argument(
+        "--keep-artifacts",
+        action="store_true",
+        help="Leave the temporary HOME and libSQL database on disk for inspection.",
+    )
+    parser.add_argument(
+        "--rust-log",
+        default="ironclaw=warn",
+        help="RUST_LOG value for the spawned IronClaw process.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    return asyncio.run(async_main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmarks/shared_instance_benchmark.py
+++ b/tests/benchmarks/shared_instance_benchmark.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from collections import deque
 import json
 import os
 import re
@@ -36,6 +37,7 @@ DEFAULT_OWNER_ID = "bench-owner"
 DEFAULT_MOCK_MODEL = "mock-model"
 DEFAULT_RESULTS_DIR = Path(tempfile.gettempdir()) / "ironclaw-benchmarks"
 GATEWAY_CONNECTION_LIMIT = 100
+PROCESS_OUTPUT_TAIL_LINES = 200
 
 
 @dataclass
@@ -43,6 +45,19 @@ class RuntimeSample:
     timestamp: float
     cpu_percent: float
     rss_mb: float
+
+
+@dataclass
+class StreamTail:
+    lines: deque[str] = field(
+        default_factory=lambda: deque(maxlen=PROCESS_OUTPUT_TAIL_LINES)
+    )
+
+    def append(self, text: str) -> None:
+        self.lines.append(text)
+
+    def render(self) -> str:
+        return "".join(self.lines).strip()
 
 
 @dataclass
@@ -363,6 +378,22 @@ async def sample_process(pid: int, interval_secs: float, stop_event: asyncio.Eve
     return samples
 
 
+async def drain_stream(
+    stream: asyncio.StreamReader | None,
+    *,
+    capture: StreamTail | None = None,
+) -> None:
+    if stream is None:
+        return
+
+    while True:
+        line = await stream.readline()
+        if not line:
+            break
+        if capture is not None:
+            capture.append(line.decode("utf-8", errors="replace"))
+
+
 def percentile(values: list[float], pct: float) -> float | None:
     if not values:
         return None
@@ -391,7 +422,12 @@ def json_default(value: Any) -> Any:
     raise TypeError(f"Unsupported value: {type(value)!r}")
 
 
-async def start_mock_llm(root: Path, *, startup_timeout: float) -> tuple[asyncio.subprocess.Process, str]:
+async def start_mock_llm(
+    root: Path,
+    *,
+    startup_timeout: float,
+    drain_tasks: list[asyncio.Task[None]],
+) -> tuple[asyncio.subprocess.Process, str]:
     script = root / "tests" / "e2e" / "mock_llm.py"
     process = await asyncio.create_subprocess_exec(
         sys.executable,
@@ -401,7 +437,9 @@ async def start_mock_llm(root: Path, *, startup_timeout: float) -> tuple[asyncio
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
     )
+    drain_tasks.append(asyncio.create_task(drain_stream(process.stderr)))
     port = await wait_for_port_line(process, r"MOCK_LLM_PORT=(\d+)", timeout=startup_timeout)
+    drain_tasks.append(asyncio.create_task(drain_stream(process.stdout)))
     url = f"http://127.0.0.1:{port}"
     await wait_for_ready(f"{url}/v1/models", timeout=startup_timeout)
     return process, url
@@ -485,6 +523,7 @@ async def start_ironclaw(
     args: argparse.Namespace,
     home_dir: str,
     db_path: str,
+    drain_tasks: list[asyncio.Task[None]],
 ) -> tuple[asyncio.subprocess.Process, str, dict[str, Any]]:
     env, public_overrides = benchmark_env(
         home_dir=home_dir,
@@ -502,18 +541,17 @@ async def start_ironclaw(
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
+    stderr_tail = StreamTail()
+    drain_tasks.append(asyncio.create_task(drain_stream(process.stdout)))
+    drain_tasks.append(
+        asyncio.create_task(drain_stream(process.stderr, capture=stderr_tail))
+    )
     base_url = f"http://127.0.0.1:{gateway_port}"
     try:
         await wait_for_ready(f"{base_url}/api/health", timeout=args.startup_timeout)
     except TimeoutError as exc:
-        stderr_bytes = b""
-        if process.stderr is not None:
-            try:
-                stderr_bytes = await asyncio.wait_for(process.stderr.read(8192), timeout=2.0)
-            except asyncio.TimeoutError:
-                pass
         await stop_process(process, timeout=2.0)
-        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        stderr_text = stderr_tail.render()
         raise RuntimeError(
             f"IronClaw failed to start within {args.startup_timeout}s.\nstderr:\n{stderr_text}"
         ) from exc
@@ -638,7 +676,8 @@ async def sse_listener(
     try:
         async with aiohttp.ClientSession(timeout=timeout) as session:
             async with session.get(
-                f"{base_url}/api/chat/events?token={user_state.token}",
+                f"{base_url}/api/chat/events",
+                params={"token": user_state.token},
                 headers={"Accept": "text/event-stream"},
             ) as response:
                 if response.status != 200:
@@ -964,11 +1003,14 @@ async def async_main(args: argparse.Namespace) -> int:
     sse_stop_event = asyncio.Event()
     sampler_stop_event = asyncio.Event()
     sse_tasks: list[asyncio.Task[Any]] = []
+    process_drain_tasks: list[asyncio.Task[None]] = []
     sampler_task: asyncio.Task[list[RuntimeSample]] | None = None
 
     try:
         mock_llm_process, mock_llm_url = await start_mock_llm(
-            root, startup_timeout=args.startup_timeout
+            root,
+            startup_timeout=args.startup_timeout,
+            drain_tasks=process_drain_tasks,
         )
         ironclaw_process, base_url, env_overrides = await start_ironclaw(
             root,
@@ -979,6 +1021,7 @@ async def async_main(args: argparse.Namespace) -> int:
             args=args,
             home_dir=str(home_dir),
             db_path=str(db_path),
+            drain_tasks=process_drain_tasks,
         )
 
         async with httpx.AsyncClient() as client:
@@ -1069,6 +1112,8 @@ async def async_main(args: argparse.Namespace) -> int:
             await stop_process(ironclaw_process, sig=signal.SIGINT, timeout=10.0)
         if mock_llm_process is not None:
             await stop_process(mock_llm_process, sig=signal.SIGTERM, timeout=5.0)
+        if process_drain_tasks:
+            await asyncio.gather(*process_drain_tasks, return_exceptions=True)
         if args.keep_artifacts:
             print(f"artifacts_dir: {artifacts_root}")
         if artifacts_tmpdir is not None:

--- a/tests/benchmarks/shared_instance_benchmark.py
+++ b/tests/benchmarks/shared_instance_benchmark.py
@@ -378,7 +378,7 @@ def percentile(values: list[float], pct: float) -> float | None:
 
 
 def utc_timestamp() -> str:
-    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%S.%fZ")
 
 
 def json_default(value: Any) -> Any:
@@ -901,10 +901,17 @@ async def async_main(args: argparse.Namespace) -> int:
     main_root = primary_worktree_root(root)
     default_binary = main_root / "target" / "debug" / "ironclaw"
     binary = Path(args.ironclaw_binary) if args.ironclaw_binary else default_binary
-    if not args.skip_build and binary_needs_rebuild(binary, root):
-        build_cmd = ["cargo", "build", "--no-default-features", "--features", "libsql"]
+    build_root = main_root if args.ironclaw_binary is None else root
+    if not args.skip_build and binary_needs_rebuild(binary, build_root):
+        build_cmd = [
+            "cargo",
+            "build",
+            "--no-default-features",
+            "--features",
+            "libsql,bench-runtime",
+        ]
         print(f"building ironclaw: {build_command_for_display(build_cmd)}")
-        subprocess.run(build_cmd, cwd=root, check=True, timeout=900)
+        subprocess.run(build_cmd, cwd=build_root, check=True, timeout=900)
 
     if not binary.exists():
         raise FileNotFoundError(


### PR DESCRIPTION
## Summary
- add a benchmark-only Tokio runtime mode gate via IRONCLAW_BENCH_RUNTIME_MODE
- add an in-repo shared-instance benchmark harness that provisions DB-backed users, opens multiple SSE streams per user, and drives concurrent chat load against a mock LLM
- document the workflow and initial benchmark findings, including multi-sender validation for per-user overlap

## Testing
- cargo test --no-default-features --features libsql --bin ironclaw bench_runtime_mode
- python3 -m py_compile tests/benchmarks/shared_instance_benchmark.py
- ran smoke, baseline, fanout, current-thread, lower-agent-jobs, tenant-llm, and multi-sender benchmark runs

## Notes
- initial benchmark findings are captured in tests/benchmarks/RESULTS.md
- the clearest bottleneck observed so far is tail latency in the shared request-processing path; SSE delivery stayed lossless through 80 open streams