### PR TITLE
test: fix gateway workflow webhook integration cooldown

### DIFF
--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -70,6 +70,10 @@ mod tests {
                         "event_source": "github",
                         "event_type": "issue.opened",
                         "event_filters": {"repository": "nearai/ironclaw"},
+                        // This test fires the same routine via event_emit and then the
+                        // webhook endpoint back-to-back, so cooldown must not suppress
+                        // the second path.
+                        "cooldown_secs": 0,
                         "action_type": "lightweight",
                         "prompt": "Summarize webhook and report issue number"
                     }),


### PR DESCRIPTION
## Summary
- set the gateway webhook workflow test routine cooldown to 0
- document that the test intentionally fires the same routine via event_emit and webhook back-to-back
- keep production routine cooldown behavior unchanged

## Root cause
The test created a system_event routine, fired it once via , then immediately asserted that the webhook path would fire it again. With the routine_create default , the second trigger was correctly suppressed, so the test expectation was stale.

## Verification
- cargo test --features libsql gateway_workflow_harness_chat_and_webhook --test gateway_workflow_integration -- --nocapture
- cargo test --features libsql web_toggle_disables_system_event_routine_without_restart --test gateway_workflow_integration -- --nocapture