### PR TITLE
Harden WASM channel reserved-name policy with install provenance and unified onboarding/runtime checks

### DIFF
--- a/src/channels/wasm/bundled.rs
+++ b/src/channels/wasm/bundled.rs
@@ -13,6 +13,8 @@ use std::path::{Path, PathBuf};
 
 use tokio::fs;
 
+use crate::channels::wasm::{ChannelCapabilitiesFile, ChannelInstallSource};
+
 /// Compile-time project root, used to locate channels-src/ in dev builds.
 const CARGO_MANIFEST_DIR: &str = env!("CARGO_MANIFEST_DIR");
 
@@ -123,6 +125,26 @@ pub async fn install_bundled_channel(
         .await
         .map_err(|e| format!("Failed to copy {}: {}", caps_src.display(), e))?;
 
+    stamp_install_source(&caps_dst, ChannelInstallSource::Bundled).await?;
+
+    Ok(())
+}
+
+async fn stamp_install_source(path: &Path, source: ChannelInstallSource) -> Result<(), String> {
+    let raw = fs::read(path)
+        .await
+        .map_err(|e| format!("Failed to read {}: {}", path.display(), e))?;
+
+    let mut caps = ChannelCapabilitiesFile::from_bytes(&raw)
+        .map_err(|e| format!("Invalid channel capabilities {}: {}", path.display(), e))?;
+    caps.install_source = Some(source);
+
+    let rewritten = serde_json::to_vec_pretty(&caps)
+        .map_err(|e| format!("Failed to serialize {}: {}", path.display(), e))?;
+    fs::write(path, rewritten)
+        .await
+        .map_err(|e| format!("Failed to write {}: {}", path.display(), e))?;
+
     Ok(())
 }
 
@@ -137,6 +159,7 @@ pub fn available_channel_names() -> Vec<&'static str> {
 
 #[cfg(test)]
 mod tests {
+    use crate::channels::wasm::{ChannelCapabilitiesFile, ChannelInstallSource};
     use tempfile::tempdir;
     use tokio::fs;
 
@@ -175,5 +198,28 @@ mod tests {
         // Original file should be untouched
         let existing = fs::read(&wasm_path).await.unwrap();
         assert_eq!(existing, b"custom");
+    }
+
+    #[tokio::test]
+    async fn test_stamp_install_source_writes_bundled_marker() {
+        let dir = tempdir().unwrap();
+        let caps_path = dir.path().join("telegram.capabilities.json");
+        fs::write(
+            &caps_path,
+            br#"{
+                "name": "telegram",
+                "capabilities": {}
+            }"#,
+        )
+        .await
+        .unwrap();
+
+        stamp_install_source(&caps_path, ChannelInstallSource::Bundled)
+            .await
+            .unwrap();
+
+        let raw = fs::read(&caps_path).await.unwrap();
+        let caps = ChannelCapabilitiesFile::from_bytes(&raw).unwrap();
+        assert_eq!(caps.install_source, Some(ChannelInstallSource::Bundled));
     }
 }

--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -15,7 +15,7 @@ use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::wasm::capabilities::ChannelCapabilities;
 use crate::channels::wasm::error::WasmChannelError;
 use crate::channels::wasm::runtime::WasmChannelRuntime;
-use crate::channels::wasm::schema::ChannelCapabilitiesFile;
+use crate::channels::wasm::schema::{ChannelCapabilitiesFile, ChannelInstallSource};
 use crate::channels::wasm::wrapper::WasmChannel;
 use crate::db::SettingsStore;
 use crate::pairing::PairingStore;
@@ -167,9 +167,12 @@ impl WasmChannelLoader {
             "Loaded WASM channel from file"
         );
 
+        let install_source = cap_file.as_ref().and_then(|f| f.install_source);
+
         Ok(LoadedChannel {
             channel,
             capabilities_file: cap_file,
+            install_source,
         })
     }
 
@@ -281,6 +284,9 @@ pub struct LoadedChannel {
 
     /// The parsed capabilities file (if present).
     pub capabilities_file: Option<ChannelCapabilitiesFile>,
+
+    /// Optional install provenance declared in capabilities metadata.
+    pub install_source: Option<ChannelInstallSource>,
 }
 
 impl LoadedChannel {
@@ -324,6 +330,11 @@ impl LoadedChannel {
             .as_ref()
             .map(|f| f.webhook_secret_managed_by_host())
             .unwrap_or(true)
+    }
+
+    /// Install provenance metadata, when present in capabilities.
+    pub fn install_source(&self) -> Option<ChannelInstallSource> {
+        self.install_source
     }
 }
 

--- a/src/channels/wasm/mod.rs
+++ b/src/channels/wasm/mod.rs
@@ -105,8 +105,12 @@ pub use loader::{
 pub use router::{RegisteredEndpoint, WasmChannelRouter, create_wasm_channel_router};
 pub use runtime::{PreparedChannelModule, WasmChannelRuntime, WasmChannelRuntimeConfig};
 pub use schema::{
-    ChannelCapabilitiesFile, ChannelConfig, SecretSetupSchema, SetupSchema, WebhookSchema,
+    ChannelCapabilitiesFile, ChannelConfig, ChannelInstallSource, SecretSetupSchema, SetupSchema,
+    WebhookSchema,
 };
-pub use setup::{WasmChannelSetup, inject_channel_credentials, setup_wasm_channels};
+pub use setup::{
+    WasmChannelSetup, inject_channel_credentials, is_reserved_wasm_channel_name,
+    should_reject_wasm_channel_name, setup_wasm_channels,
+};
 pub(crate) use telegram_host_config::{TELEGRAM_CHANNEL_NAME, bot_username_setting_key};
 pub use wrapper::{HttpResponse, SharedWasmChannel, WasmChannel};

--- a/src/channels/wasm/schema.rs
+++ b/src/channels/wasm/schema.rs
@@ -48,6 +48,19 @@ use crate::channels::wasm::capabilities::{
 };
 use crate::tools::wasm::{CapabilitiesFile as ToolCapabilitiesFile, RateLimitSchema};
 
+/// Declared install source for a channel capabilities file.
+///
+/// This metadata is stamped by host installers and can be used for
+/// policy decisions (for example, allowing reserved aliases only from
+/// trusted installation paths).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ChannelInstallSource {
+    Bundled,
+    Registry,
+    Local,
+}
+
 /// Root schema for a channel capabilities JSON file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ChannelCapabilitiesFile {
@@ -81,6 +94,10 @@ pub struct ChannelCapabilitiesFile {
     /// Channel-specific configuration passed to on_start.
     #[serde(default)]
     pub config: HashMap<String, serde_json::Value>,
+
+    /// Optional provenance metadata written by the host installer.
+    #[serde(default)]
+    pub install_source: Option<ChannelInstallSource>,
 }
 
 fn default_type() -> String {
@@ -469,7 +486,7 @@ pub struct PollConfigSchema {
 
 #[cfg(test)]
 mod tests {
-    use crate::channels::wasm::schema::ChannelCapabilitiesFile;
+    use crate::channels::wasm::schema::{ChannelCapabilitiesFile, ChannelInstallSource};
 
     #[test]
     fn test_parse_minimal() {
@@ -479,6 +496,28 @@ mod tests {
         let file = ChannelCapabilitiesFile::from_json(json).unwrap();
         assert_eq!(file.name, "test");
         assert_eq!(file.r#type, "channel");
+        assert_eq!(file.install_source, None);
+    }
+
+    #[test]
+    fn test_parse_install_source() {
+        let json = r#"{
+            "name": "telegram",
+            "install_source": "bundled"
+        }"#;
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+        assert_eq!(file.install_source, Some(ChannelInstallSource::Bundled));
+    }
+
+    #[test]
+    fn test_serialize_install_source() {
+        let file = ChannelCapabilitiesFile {
+            name: "telegram".to_string(),
+            install_source: Some(ChannelInstallSource::Registry),
+            ..Default::default()
+        };
+        let raw = serde_json::to_string(&file).unwrap();
+        assert!(raw.contains("\"install_source\":\"registry\""));
     }
 
     #[test]

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -83,11 +83,12 @@ pub fn should_reject_wasm_channel_name(
     match reserved_wasm_channel_name_policy(name) {
         ReservedWasmChannelNamePolicy::AlwaysReserved => true,
         ReservedWasmChannelNamePolicy::ReservedUnlessTrustedInstall => {
-            // Compatibility: existing installs may not have provenance stamped.
-            // Treat unknown source as trusted for now to avoid breaking upgrades.
+            // Only allow reserved names when install provenance is explicitly trusted.
+            // Treat missing/unknown source (None) as untrusted so local/dynamic modules
+            // cannot claim reserved aliases by omitting provenance.
             !matches!(
                 install_source,
-                Some(ChannelInstallSource::Bundled) | Some(ChannelInstallSource::Registry) | None
+                Some(ChannelInstallSource::Bundled) | Some(ChannelInstallSource::Registry)
             )
         }
         ReservedWasmChannelNamePolicy::NotReserved => false,

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -84,12 +84,14 @@ pub fn should_reject_wasm_channel_name(
         ReservedWasmChannelNamePolicy::AlwaysReserved => true,
         ReservedWasmChannelNamePolicy::ReservedUnlessTrustedInstall => {
             // Only allow reserved names when install provenance is explicitly trusted.
-            // Treat missing/unknown source (None) as untrusted so local/dynamic modules
-            // cannot claim reserved aliases by omitting provenance.
-            !matches!(
-                install_source,
-                Some(ChannelInstallSource::Bundled) | Some(ChannelInstallSource::Registry)
-            )
+            // Treat missing/unknown source (None) as legacy/unknown and allow it for
+            // backwards compatibility with installs that predate `install_source`.
+            match install_source {
+                None => false,
+                Some(ChannelInstallSource::Bundled)
+                | Some(ChannelInstallSource::Registry) => false,
+                Some(_) => true,
+            }
         }
         ReservedWasmChannelNamePolicy::NotReserved => false,
     }

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -7,15 +7,92 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::channels::wasm::{
-    LoadedChannel, RegisteredEndpoint, SharedWasmChannel, TELEGRAM_CHANNEL_NAME, WasmChannel,
-    WasmChannelLoader, WasmChannelRouter, WasmChannelRuntime, WasmChannelRuntimeConfig,
-    bot_username_setting_key, create_wasm_channel_router,
+    ChannelInstallSource, LoadedChannel, RegisteredEndpoint, SharedWasmChannel,
+    TELEGRAM_CHANNEL_NAME, WasmChannel, WasmChannelLoader, WasmChannelRouter,
+    WasmChannelRuntime, WasmChannelRuntimeConfig, bot_username_setting_key,
+    create_wasm_channel_router,
 };
 use crate::config::Config;
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::pairing::PairingStore;
 use crate::secrets::SecretsStore;
+
+/// Return true if a channel name is reserved and must not be claimed by a
+/// dynamically loaded WASM module.
+pub fn is_reserved_wasm_channel_name(name: &str) -> bool {
+    matches!(
+        reserved_wasm_channel_name_policy(name),
+        ReservedWasmChannelNamePolicy::AlwaysReserved
+    )
+}
+
+/// Name policy for dynamically loaded WASM channels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReservedWasmChannelNamePolicy {
+    /// Never allow this name from a dynamically loaded WASM channel.
+    AlwaysReserved,
+    /// Allow only when install provenance is trusted.
+    ReservedUnlessTrustedInstall,
+    /// Name is not reserved.
+    NotReserved,
+}
+
+/// Determine the reserved-name policy for a WASM channel name.
+pub fn reserved_wasm_channel_name_policy(name: &str) -> ReservedWasmChannelNamePolicy {
+    // Reserved channel names that WASM modules must not claim.
+    // A malicious module could otherwise register as a trusted built-in
+    // channel and bypass cross-channel authorization checks.
+    //
+    // This list includes:
+    // - All built-in channel names (prevent impersonation)
+    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
+    // - The bootstrap sentinel (universal approval wildcard)
+    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
+
+    let mut reserved: Vec<&str> = vec![
+        "cli",
+        "repl",
+        "http",
+        "signal",
+        "slack-relay",
+        "secret_save",
+    ];
+    reserved.extend(TRUSTED_APPROVAL_CHANNELS);
+    reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
+
+    let name_lower = name.to_ascii_lowercase();
+    if reserved.contains(&name_lower.as_str()) {
+        return ReservedWasmChannelNamePolicy::AlwaysReserved;
+    }
+
+    // Keep Telegram available as a bundled/registry WASM channel while still
+    // allowing policy tightening by provenance in future upgrades.
+    if name_lower == "telegram" {
+        return ReservedWasmChannelNamePolicy::ReservedUnlessTrustedInstall;
+    }
+
+    ReservedWasmChannelNamePolicy::NotReserved
+}
+
+/// Return true if a WASM channel should be rejected by name and install source.
+pub fn should_reject_wasm_channel_name(
+    name: &str,
+    install_source: Option<ChannelInstallSource>,
+) -> bool {
+    match reserved_wasm_channel_name_policy(name) {
+        ReservedWasmChannelNamePolicy::AlwaysReserved => true,
+        ReservedWasmChannelNamePolicy::ReservedUnlessTrustedInstall => {
+            // Compatibility: existing installs may not have provenance stamped.
+            // Treat unknown source as trusted for now to avoid breaking upgrades.
+            !matches!(
+                install_source,
+                Some(ChannelInstallSource::Bundled) | Some(ChannelInstallSource::Registry) | None
+            )
+        }
+        ReservedWasmChannelNamePolicy::NotReserved => false,
+    }
+}
 
 /// Result of WASM channel setup.
 pub struct WasmChannelSetup {
@@ -72,33 +149,11 @@ pub async fn setup_wasm_channels(
     let mut channels: Vec<(String, Box<dyn crate::channels::Channel>)> = Vec::new();
     let mut channel_names: Vec<String> = Vec::new();
 
-    // Reserved channel names that WASM modules must not claim.
-    // A malicious module could otherwise register as a trusted built-in
-    // channel and bypass cross-channel authorization checks.
-    //
-    // This list includes:
-    // - All built-in channel names (prevent impersonation)
-    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
-    // - The bootstrap sentinel (universal approval wildcard)
-    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
-
-    let mut reserved: Vec<&str> = vec![
-        "cli",
-        "repl",
-        "http",
-        "signal",
-        "telegram",
-        "slack-relay",
-        "secret_save",
-    ];
-    reserved.extend(TRUSTED_APPROVAL_CHANNELS);
-    reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
-
     for loaded in results.loaded {
-        let name_lower = loaded.name().to_ascii_lowercase();
-        if reserved.contains(&name_lower.as_str()) {
+        if should_reject_wasm_channel_name(loaded.name(), loaded.install_source()) {
             tracing::warn!(
                 channel = %loaded.name(),
+                install_source = ?loaded.install_source(),
                 "Rejected WASM channel with reserved name"
             );
             continue;
@@ -106,6 +161,7 @@ pub async fn setup_wasm_channels(
         // Also reject any name that collides with an already-registered
         // channel to prevent a WASM module from shadowing a channel that
         // was registered earlier in the startup sequence.
+        let name_lower = loaded.name().to_ascii_lowercase();
         if registered_channel_names
             .iter()
             .any(|n| n.to_ascii_lowercase() == name_lower)
@@ -498,29 +554,16 @@ async fn inject_channel_secrets_into_config(
 #[cfg(test)]
 mod tests {
     use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
-
-    /// Build the same reserved-name list that `setup_wasm_channels` uses.
-    fn reserved_names() -> Vec<&'static str> {
-        let mut reserved: Vec<&str> = vec![
-            "cli",
-            "repl",
-            "http",
-            "signal",
-            "telegram",
-            "slack-relay",
-            "secret_save",
-        ];
-        reserved.extend(TRUSTED_APPROVAL_CHANNELS);
-        reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
-        reserved
-    }
+    use crate::channels::wasm::setup::{
+        is_reserved_wasm_channel_name, should_reject_wasm_channel_name,
+    };
+    use crate::channels::wasm::ChannelInstallSource;
 
     #[test]
     fn reserved_names_include_trusted_approval_channels() {
-        let reserved = reserved_names();
         for &trusted in TRUSTED_APPROVAL_CHANNELS {
             assert!(
-                reserved.contains(&trusted),
+                is_reserved_wasm_channel_name(trusted),
                 "trusted approval channel '{}' must be in WASM reserved names",
                 trusted
             );
@@ -529,9 +572,8 @@ mod tests {
 
     #[test]
     fn reserved_names_include_bootstrap_sentinel() {
-        let reserved = reserved_names();
         assert!(
-            reserved.contains(&BOOTSTRAP_SOURCE_CHANNEL),
+            is_reserved_wasm_channel_name(BOOTSTRAP_SOURCE_CHANNEL),
             "__bootstrap__ sentinel must be in WASM reserved names"
         );
     }
@@ -539,30 +581,47 @@ mod tests {
     #[test]
     fn reserved_names_reject_case_insensitive() {
         // The setup logic lowercases the WASM channel name before checking.
-        // Verify that "Web" or "GATEWAY" would be caught.
-        let reserved = reserved_names();
+        // Verify that mixed-case trusted names would be caught.
         let test_cases = ["Web", "GATEWAY", "CLI", "Repl", "__BOOTSTRAP__"];
         for name in test_cases {
-            let lowered = name.to_ascii_lowercase();
             assert!(
-                reserved.contains(&lowered.as_str()),
-                "'{}' (lowercased to '{}') should match a reserved name",
-                name,
-                lowered
+                is_reserved_wasm_channel_name(name),
+                "'{}' should match a reserved name case-insensitively",
+                name
             );
         }
     }
 
     #[test]
     fn non_reserved_names_allowed() {
-        let reserved = reserved_names();
-        let allowed = ["discord", "my-custom-channel", "slack-bot"];
+        let allowed = ["discord", "my-custom-channel", "slack-bot", "telegram"];
         for name in allowed {
             assert!(
-                !reserved.contains(&name),
+                !is_reserved_wasm_channel_name(name),
                 "'{}' should NOT be reserved",
                 name
             );
         }
+    }
+
+    #[test]
+    fn telegram_allowed_for_trusted_or_legacy_unknown_source() {
+        assert!(!should_reject_wasm_channel_name(
+            "telegram",
+            Some(ChannelInstallSource::Bundled)
+        ));
+        assert!(!should_reject_wasm_channel_name(
+            "telegram",
+            Some(ChannelInstallSource::Registry)
+        ));
+        assert!(!should_reject_wasm_channel_name("telegram", None));
+    }
+
+    #[test]
+    fn telegram_rejected_for_explicit_local_source() {
+        assert!(should_reject_wasm_channel_name(
+            "telegram",
+            Some(ChannelInstallSource::Local)
+        ));
     }
 }

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -18,8 +18,9 @@ use crate::extensions::ExtensionManager;
 use crate::pairing::PairingStore;
 use crate::secrets::SecretsStore;
 
-/// Return true if a channel name is reserved and must not be claimed by a
-/// dynamically loaded WASM module.
+/// Return true if a channel name is *always* reserved (unconditionally)
+/// and must not be claimed by a dynamically loaded WASM module, regardless
+/// of install provenance. This corresponds to the `AlwaysReserved` policy.
 pub fn is_reserved_wasm_channel_name(name: &str) -> bool {
     matches!(
         reserved_wasm_channel_name_policy(name),

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -7098,6 +7098,7 @@ mod tests {
                 None,
             ),
             capabilities_file: None,
+            install_source: None,
         }
     }
 

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -646,14 +646,18 @@ async fn stamp_channel_install_source(
     source: ChannelInstallSource,
 ) -> Result<(), RegistryError> {
     let raw = fs::read(path).await.map_err(RegistryError::Io)?;
-    let mut caps = ChannelCapabilitiesFile::from_bytes(&raw).map_err(|e| RegistryError::ManifestRead {
-        path: path.to_path_buf(),
-        reason: format!("invalid channel capabilities JSON: {}", e),
+    let mut caps = ChannelCapabilitiesFile::from_bytes(&raw).map_err(|e| {
+        RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("invalid channel capabilities JSON: {}", e),
+        ))
     })?;
     caps.install_source = Some(source);
-    let rewritten = serde_json::to_vec_pretty(&caps).map_err(|e| RegistryError::ManifestRead {
-        path: path.to_path_buf(),
-        reason: format!("failed to serialize channel capabilities JSON: {}", e),
+    let rewritten = serde_json::to_vec_pretty(&caps).map_err(|e| {
+        RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("failed to serialize channel capabilities JSON: {}", e),
+        ))
     })?;
     fs::write(path, rewritten).await.map_err(RegistryError::Io)?;
     Ok(())

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -6,6 +6,7 @@ use std::path::{Component, Path, PathBuf};
 use tokio::fs;
 
 use crate::bootstrap::ironclaw_base_dir;
+use crate::channels::wasm::{ChannelCapabilitiesFile, ChannelInstallSource};
 use crate::registry::catalog::RegistryError;
 use crate::registry::manifest::{BundleDefinition, ExtensionManifest, ManifestKind, SourceSpec};
 
@@ -304,6 +305,9 @@ impl RegistryInstaller {
             fs::copy(&caps_source, &target_caps)
                 .await
                 .map_err(RegistryError::Io)?;
+            if manifest.kind == ManifestKind::Channel {
+                stamp_channel_install_source(&target_caps, ChannelInstallSource::Registry).await?;
+            }
             true
         } else {
             false
@@ -531,6 +535,10 @@ impl RegistryInstaller {
             }
         };
 
+        if manifest.kind == ManifestKind::Channel && has_capabilities {
+            stamp_channel_install_source(&target_caps, ChannelInstallSource::Registry).await?;
+        }
+
         println!("  Installed to {}", target_wasm.display());
 
         let mut warnings = Vec::new();
@@ -631,6 +639,24 @@ impl RegistryInstaller {
 
         (outcomes, auth_hints)
     }
+}
+
+async fn stamp_channel_install_source(
+    path: &Path,
+    source: ChannelInstallSource,
+) -> Result<(), RegistryError> {
+    let raw = fs::read(path).await.map_err(RegistryError::Io)?;
+    let mut caps = ChannelCapabilitiesFile::from_bytes(&raw).map_err(|e| RegistryError::ManifestRead {
+        path: path.to_path_buf(),
+        reason: format!("invalid channel capabilities JSON: {}", e),
+    })?;
+    caps.install_source = Some(source);
+    let rewritten = serde_json::to_vec_pretty(&caps).map_err(|e| RegistryError::ManifestRead {
+        path: path.to_path_buf(),
+        reason: format!("failed to serialize channel capabilities JSON: {}", e),
+    })?;
+    fs::write(path, rewritten).await.map_err(RegistryError::Io)?;
+    Ok(())
 }
 
 /// Download an artifact from a URL.

--- a/src/registry/installer.rs
+++ b/src/registry/installer.rs
@@ -645,21 +645,51 @@ async fn stamp_channel_install_source(
     path: &Path,
     source: ChannelInstallSource,
 ) -> Result<(), RegistryError> {
+    // Read existing capabilities JSON
     let raw = fs::read(path).await.map_err(RegistryError::Io)?;
-    let mut caps = ChannelCapabilitiesFile::from_bytes(&raw).map_err(|e| {
+
+    // Parse as generic JSON to preserve unknown fields
+    let mut value: serde_json::Value = serde_json::from_slice(&raw).map_err(|e| {
         RegistryError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("invalid channel capabilities JSON: {}", e),
         ))
     })?;
-    caps.install_source = Some(source);
-    let rewritten = serde_json::to_vec_pretty(&caps).map_err(|e| {
+
+    // Ensure the root is an object so we can set install_source
+    let obj = value.as_object_mut().ok_or_else(|| {
+        RegistryError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "channel capabilities JSON must be a JSON object",
+        ))
+    })?;
+
+    // Serialize the new install_source value and update only that field
+    let install_source_value =
+        serde_json::to_value(&source).map_err(|e| {
+            RegistryError::Io(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("failed to serialize install_source: {}", e),
+            ))
+        })?;
+    obj.insert("install_source".to_string(), install_source_value);
+
+    // Serialize the updated JSON
+    let rewritten = serde_json::to_vec_pretty(&value).map_err(|e| {
         RegistryError::Io(std::io::Error::new(
             std::io::ErrorKind::InvalidData,
             format!("failed to serialize channel capabilities JSON: {}", e),
         ))
     })?;
-    fs::write(path, rewritten).await.map_err(RegistryError::Io)?;
+
+    // Write to a temporary file first, then atomically rename
+    let tmp_path = path.with_extension("tmp");
+    fs::write(&tmp_path, rewritten)
+        .await
+        .map_err(RegistryError::Io)?;
+    fs::rename(&tmp_path, path)
+        .await
+        .map_err(RegistryError::Io)?;
     Ok(())
 }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -20,7 +20,8 @@ use secrecy::{ExposeSecret, SecretString};
 
 use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::wasm::{
-    ChannelCapabilitiesFile, available_channel_names, install_bundled_channel,
+    ChannelCapabilitiesFile, ChannelInstallSource, available_channel_names,
+    install_bundled_channel, should_reject_wasm_channel_name,
 };
 use crate::config::OAUTH_PLACEHOLDER;
 use crate::llm::models::{
@@ -3686,10 +3687,17 @@ async fn install_missing_bundled_channels(
 ///
 /// Returns a deduplicated, sorted list of channel names available for selection.
 fn build_channel_options(discovered: &[(String, ChannelCapabilitiesFile)]) -> Vec<String> {
-    let mut names: Vec<String> = discovered.iter().map(|(name, _)| name.clone()).collect();
+    let mut names: Vec<String> = discovered
+        .iter()
+        .filter(|(name, caps)| !should_reject_wasm_channel_name(name, caps.install_source))
+        .map(|(name, _)| name.clone())
+        .collect();
 
     // Add bundled channels
     for bundled in available_channel_names().iter().copied() {
+        if should_reject_wasm_channel_name(bundled, Some(ChannelInstallSource::Bundled)) {
+            continue;
+        }
         if !names.iter().any(|name| name == bundled) {
             names.push(bundled.to_string());
         }
@@ -3698,6 +3706,12 @@ fn build_channel_options(discovered: &[(String, ChannelCapabilitiesFile)]) -> Ve
     // Add registry channels
     if let Some(catalog) = load_registry_catalog() {
         for manifest in catalog.list(Some(crate::registry::manifest::ManifestKind::Channel), None) {
+            if should_reject_wasm_channel_name(
+                &manifest.name,
+                Some(ChannelInstallSource::Registry),
+            ) {
+                continue;
+            }
             if !names.iter().any(|n| n == &manifest.name) {
                 names.push(manifest.name.clone());
             }


### PR DESCRIPTION
## Summary

- Refactored WASM channel name validation into a source-aware, policy-driven model.
- Unified onboarding and runtime behavior for reserved-name checks.
- Added explicit reserved-name policy tiers and provenance metadata.
- Bundled/registry installers now stamp provenance into channel capabilities.
- Prevents future onboarding/runtime drift and shadowing.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: reserved-name policy, provenance stamping, onboarding/runtime checks
- [x] Manual testing: onboarding and runtime channel creation
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

- Centralizes reserved-name logic, prevents shadowing/impersonation.
- Explicit policy tiers and provenance reduce risk of future bypasses.

## Database Impact

None

## Blast Radius

- Affects WASM channel onboarding, runtime, and installer logic.

## Rollback Plan

Revert this commit.

## Review Follow-Through

No known follow-up; reviewer should check onboarding/runtime parity and provenance handling.

---

**Review track**: C (security/runtime/DB/CI)