### PR TITLE
feat(tools): persistent per-user tool permission system

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -20,6 +20,7 @@ use crate::agent::agentic_loop::{
     AgenticLoopConfig, LoopDelegate, LoopOutcome, LoopSignal, TextAction,
 };
 use crate::llm::{ChatMessage, Reasoning, ReasoningContext};
+use crate::tools::permissions::{PermissionState, effective_permission};
 use crate::tools::redact_params;
 
 /// Result of the agentic loop execution.
@@ -199,6 +200,7 @@ impl Agent {
             nudge_at,
             force_text_at,
             user_tz,
+            cached_tool_permissions: std::sync::Mutex::new(None),
         };
 
         // If /skill-name mentions were expanded, rewrite the last user message
@@ -293,6 +295,8 @@ struct ChatDelegate<'a> {
     nudge_at: usize,
     force_text_at: usize,
     user_tz: chrono_tz::Tz,
+    cached_tool_permissions:
+        std::sync::Mutex<Option<std::collections::HashMap<String, PermissionState>>>,
 }
 
 #[async_trait]
@@ -343,6 +347,94 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         } else {
             tool_defs
         };
+
+        // Apply per-user tool permission filtering.
+        //
+        // Load tool_permissions from the per-user DB settings store (same
+        // source as selected_model). Falls back to empty map when no store is
+        // available (test rigs without a tenant) — tier defaults from
+        // TOOL_RISK_DEFAULTS then apply at runtime via effective_permission().
+        // Disabled tools are excluded from the LLM's tool list entirely.
+        // AlwaysAllow tools are pre-approved in session so the approval
+        // flow is skipped — unless the tool declares ApprovalRequirement::Always,
+        // which is an unbypassable hard floor.
+        let tool_permissions = {
+            // Check the cache first (brief lock, no await while held).
+            let cached = {
+                let cache = self
+                    .cached_tool_permissions
+                    .lock()
+                    .unwrap_or_else(|e| e.into_inner());
+                cache.clone()
+            };
+            if let Some(perms) = cached {
+                perms
+            } else {
+                // Cache miss — load from DB (async).
+                let perms = if let Some(store) = self.tenant.store() {
+                    match store.get_all_settings().await {
+                        Ok(db_map) => {
+                            crate::settings::Settings::from_db_map(&db_map).tool_permissions
+                        }
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to load tool permissions, keeping existing session state: {}",
+                                e
+                            );
+                            // Fail closed: preserve the previously filtered available_tools
+                            // rather than publishing the unfiltered tool list, which could
+                            // re-expose tools explicitly marked Disabled.
+                            return None;
+                        }
+                    }
+                } else {
+                    std::collections::HashMap::new()
+                };
+                // Store in cache for subsequent iterations.
+                {
+                    let mut cache = self
+                        .cached_tool_permissions
+                        .lock()
+                        .unwrap_or_else(|e| e.into_inner());
+                    *cache = Some(perms.clone());
+                }
+                perms
+            }
+        };
+
+        // Filter tool definitions and collect AlwaysAllow names for session
+        // pre-approval. We don't need to check ApprovalRequirement::Always here
+        // because the existing approval gate already treats it as an unbypassable
+        // hard floor — even if a tool name is in session.auto_approved_tools, an
+        // ApprovalRequirement::Always tool still requires user confirmation.
+        let mut to_auto_approve: Vec<String> = Vec::new();
+        let tool_defs: Vec<_> = tool_defs
+            .into_iter()
+            .filter_map(|def| {
+                match effective_permission(&def.name, &tool_permissions) {
+                    PermissionState::Disabled => {
+                        tracing::debug!(tool = %def.name, "Excluding disabled tool from LLM context");
+                        None
+                    }
+                    PermissionState::AlwaysAllow => {
+                        to_auto_approve.push(def.name.clone());
+                        Some(def)
+                    }
+                    PermissionState::AskEachTime => Some(def),
+                }
+            })
+            .collect();
+        // Clear and re-populate auto-approvals from current DB state so that
+        // permission downgrades (AlwaysAllow → AskEachTime) take effect
+        // immediately within the same session. "Always Approve" clicks are
+        // persisted to DB via process_approval, so they'll be re-added here.
+        {
+            let mut sess = self.session.lock().await;
+            sess.auto_approved_tools.clear();
+            for name in &to_auto_approve {
+                sess.auto_approve_tool(name);
+            }
+        }
 
         // Update context for this iteration
         reason_ctx.available_tools = tool_defs;
@@ -2738,5 +2830,95 @@ mod tests {
         assert!(content.contains("Tool 'shell' failed:"));
         assert!(!content.contains("\n</tool_output><system>"));
         assert_eq!(message.content, content);
+    }
+
+    // ── Permission filtering unit tests ──────────────────────────────────────
+
+    /// Disabled tools must be excluded from the LLM's tool definition list.
+    #[test]
+    fn test_permission_disabled_tool_excluded_from_definitions() {
+        use crate::llm::ToolDefinition;
+        use crate::tools::permissions::{PermissionState, effective_permission};
+        use std::collections::HashMap;
+
+        let mut tool_permissions: HashMap<String, PermissionState> = HashMap::new();
+        tool_permissions.insert("shell".to_string(), PermissionState::Disabled);
+
+        let tool_defs = vec![
+            ToolDefinition {
+                name: "echo".to_string(),
+                description: "Echo".to_string(),
+                parameters: serde_json::json!({}),
+            },
+            ToolDefinition {
+                name: "shell".to_string(),
+                description: "Shell".to_string(),
+                parameters: serde_json::json!({}),
+            },
+        ];
+
+        // Simulate the filtering logic from before_llm_call.
+        let filtered: Vec<_> = tool_defs
+            .into_iter()
+            .filter(|def| {
+                effective_permission(&def.name, &tool_permissions) != PermissionState::Disabled
+            })
+            .collect();
+
+        assert_eq!(filtered.len(), 1, "Disabled tool must be excluded");
+        assert_eq!(filtered[0].name, "echo");
+    }
+
+    /// AlwaysAllow tool with Never approval requirement must be auto-approved.
+    #[test]
+    fn test_permission_always_allow_never_approval_auto_approved() {
+        use crate::agent::session::Session;
+        use crate::tools::ApprovalRequirement;
+        use crate::tools::permissions::PermissionState;
+
+        let mut session = Session::new("user-perm-1");
+        let tool_name = "http";
+
+        // Simulate: PermissionState::AlwaysAllow and requires_approval → Never.
+        let perm = PermissionState::AlwaysAllow;
+        let requirement = ApprovalRequirement::Never;
+
+        let hard_floor = matches!(requirement, ApprovalRequirement::Always);
+        if perm == PermissionState::AlwaysAllow && !hard_floor {
+            session.auto_approve_tool(tool_name);
+        }
+
+        assert!(
+            session.is_tool_auto_approved(tool_name),
+            "AlwaysAllow with Never approval requirement must be auto-approved in session"
+        );
+    }
+
+    /// AlwaysAllow tool with Always approval requirement must NOT be auto-approved.
+    ///
+    /// This verifies the hard-floor: ApprovalRequirement::Always is never bypassed,
+    /// even when PermissionState is AlwaysAllow.
+    #[test]
+    fn test_permission_always_allow_always_approval_not_auto_approved() {
+        use crate::agent::session::Session;
+        use crate::tools::ApprovalRequirement;
+        use crate::tools::permissions::PermissionState;
+
+        let mut session = Session::new("user-perm-2");
+        let tool_name = "restart";
+
+        // Simulate: PermissionState::AlwaysAllow but requires_approval → Always.
+        let perm = PermissionState::AlwaysAllow;
+        let requirement = ApprovalRequirement::Always;
+
+        let hard_floor = matches!(requirement, ApprovalRequirement::Always);
+        if perm == PermissionState::AlwaysAllow && !hard_floor {
+            session.auto_approve_tool(tool_name);
+        }
+
+        assert!(
+            !session.is_tool_auto_approved(tool_name),
+            "AlwaysAllow with Always approval requirement must NOT be auto-approved (hard floor)"
+        );
     }
 }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1064,7 +1064,7 @@ impl Agent {
         }
 
         if approved {
-            // If always, add to auto-approved set
+            // If always, add to auto-approved set and persist to settings.
             if always {
                 let mut sess = session.lock().await;
                 sess.auto_approve_tool(&pending.tool_name);
@@ -1073,6 +1073,52 @@ impl Agent {
                     pending.tool_name,
                     sess.id
                 );
+                drop(sess);
+
+                // Defense-in-depth: don't persist AlwaysAllow for tools that
+                // declare ApprovalRequirement::Always (the UI hides the
+                // "Always" button for locked tools, but a crafted client
+                // could send it).
+                let tool_ref = self.tools().get(&pending.tool_name).await;
+                let is_locked = tool_ref
+                    .as_ref()
+                    .map(|t| {
+                        matches!(
+                            t.requires_approval(&serde_json::json!({})),
+                            crate::tools::ApprovalRequirement::Always
+                        )
+                    })
+                    .unwrap_or(false);
+
+                if is_locked {
+                    tracing::warn!(
+                        tool = %pending.tool_name,
+                        "Skipping AlwaysAllow persist — tool declares ApprovalRequirement::Always"
+                    );
+                } else {
+                    // Persist AlwaysAllow to the per-user DB settings so the
+                    // preference survives process restarts. Uses the same
+                    // set_setting path as tool_permission_set and the web UI.
+                    let tenant = self.tenant_ctx(&message.user_id).await;
+                    if let Some(store) = tenant.store() {
+                        let key = format!("tool_permissions.{}", pending.tool_name);
+                        let val = serde_json::to_value(
+                            crate::tools::permissions::PermissionState::AlwaysAllow,
+                        )
+                        .unwrap_or(serde_json::Value::String("always_allow".to_string()));
+                        match store.set_setting(&key, &val).await {
+                            Ok(()) => tracing::debug!(
+                                tool = %pending.tool_name,
+                                "Persisted AlwaysAllow permission to DB settings"
+                            ),
+                            Err(e) => tracing::warn!(
+                                "process_approval: failed to persist AlwaysAllow for '{}': {}",
+                                pending.tool_name,
+                                e
+                            ),
+                        }
+                    }
+                } // else (not locked)
             }
 
             // Reset thread state to processing
@@ -2324,6 +2370,8 @@ mod tests {
         // Verify nothing was queued — the fall-through path doesn't touch the queue.
         assert!(t.pending_messages.is_empty());
     }
+
+    // Approval persistence is tested via e2e_builtin_tool_coverage integration tests.
 
     // Helper function to extract the approval message without needing a full Agent instance
     fn extract_approval_message(

--- a/src/app.rs
+++ b/src/app.rs
@@ -367,7 +367,7 @@ impl AppBuilder {
                 self.config.workspace.clone(),
             ));
             tools.register_memory_tools_with_resolver(pool);
-            tracing::info!(
+            tracing::debug!(
                 multi_tenant = is_multi_tenant,
                 "Memory tools configured with per-user workspace resolver"
             );
@@ -739,6 +739,16 @@ impl AppBuilder {
                 catalog_entries.clone(),
             ));
             tools.register_extension_tools(Arc::clone(&manager));
+
+            // Register permission management tool and upgrade tool_list with
+            // builtin registry support.
+            let settings_store_for_perms: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>> =
+                self.db
+                    .as_ref()
+                    .map(|db| Arc::clone(db) as Arc<dyn crate::db::SettingsStore + Send + Sync>);
+            tools.register_permission_tools(settings_store_for_perms.clone());
+            tools.upgrade_tool_list(Arc::clone(&manager), settings_store_for_perms);
+
             tracing::debug!("Extension manager initialized with in-chat discovery tools");
 
             if !startup_mcp_clients.is_empty() {
@@ -937,6 +947,11 @@ impl AppBuilder {
             tools.count()
         );
 
+        // Seed per-user tool permission defaults into the database.
+        // This runs after all tools (built-in, WASM, MCP) are registered so
+        // that every tool name is known.  Existing entries are never overwritten.
+        seed_tool_permissions(&tools, self.db.as_ref(), &self.config.owner_id).await;
+
         Ok(AppComponents {
             config: self.config,
             db: self.db,
@@ -964,6 +979,80 @@ impl AppBuilder {
             dev_loaded_tool_names,
             builder,
         })
+    }
+}
+
+/// Seed tool permission defaults into the database for every registered tool
+/// that has no explicit user override yet.
+///
+/// This is called once at startup after the full tool registry is built.
+/// It is idempotent: existing entries in `tool_permissions.*` are never touched.
+async fn seed_tool_permissions(
+    tools: &crate::tools::ToolRegistry,
+    db: Option<&Arc<dyn Database>>,
+    owner_id: &str,
+) {
+    use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
+
+    let db = match db {
+        Some(db) => db,
+        None => {
+            tracing::debug!("seed_tool_permissions: no database available, skipping");
+            return;
+        }
+    };
+
+    // Load existing tool permission overrides from the DB.
+    let db_map = match db.get_all_settings(owner_id).await {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!("seed_tool_permissions: failed to load settings: {}", e);
+            return;
+        }
+    };
+    let existing = crate::settings::Settings::from_db_map(&db_map).tool_permissions;
+
+    let registered_names = tools.list().await;
+    let mut seeded = 0u32;
+
+    for name in &registered_names {
+        if existing.contains_key(name.as_str()) {
+            // User has an explicit override — do not touch it.
+            continue;
+        }
+
+        // Only insert if the tool appears in the static defaults table.
+        // Unknown/dynamic tools stay absent (they will fall back to AskEachTime
+        // at runtime via effective_permission) to avoid polluting the DB.
+        if TOOL_RISK_DEFAULTS.contains_key(name.as_str()) {
+            let default_state = effective_permission(name, &existing);
+            let json_value = match serde_json::to_value(default_state) {
+                Ok(v) => v,
+                Err(e) => {
+                    tracing::warn!(
+                        "seed_tool_permissions: failed to serialize state for '{}': {}",
+                        name,
+                        e
+                    );
+                    continue;
+                }
+            };
+            if let Err(e) = db
+                .set_setting(owner_id, &format!("tool_permissions.{}", name), &json_value)
+                .await
+            {
+                tracing::warn!("seed_tool_permissions: failed to set '{}': {}", name, e);
+            } else {
+                seeded += 1;
+            }
+        }
+    }
+
+    if seeded > 0 {
+        tracing::debug!(
+            count = seeded,
+            "Seeded tool permission defaults into database"
+        );
     }
 }
 
@@ -1030,5 +1119,57 @@ mod tests {
 
         assert_eq!(user_id, "user-123");
         assert!(!session_id.is_empty());
+    }
+
+    /// Verify that `seed_tool_permissions` is idempotent: an existing user
+    /// override must survive a re-seed.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn seed_tool_permissions_preserves_user_overrides() {
+        use crate::db::Database;
+        use crate::db::libsql::LibSqlBackend;
+        use crate::tools::ToolRegistry;
+        use crate::tools::permissions::PermissionState;
+
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_seed.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        let db: Arc<dyn Database> = Arc::new(backend);
+
+        let registry = ToolRegistry::new();
+        registry.register_builtin_tools();
+
+        let owner = "test-user";
+
+        // 1. Initial seed: creates defaults for all registered tools.
+        super::seed_tool_permissions(&registry, Some(&db), owner).await;
+
+        // Verify "echo" was seeded as AlwaysAllow.
+        let map = db.get_all_settings(owner).await.unwrap();
+        let settings = crate::settings::Settings::from_db_map(&map);
+        assert_eq!(
+            settings.tool_permissions.get("echo"),
+            Some(&PermissionState::AlwaysAllow),
+            "echo should be AlwaysAllow after initial seed"
+        );
+
+        // 2. User overrides echo → Disabled.
+        let disabled_json = serde_json::to_value(PermissionState::Disabled).unwrap();
+        db.set_setting(owner, "tool_permissions.echo", &disabled_json)
+            .await
+            .unwrap();
+
+        // 3. Re-seed (e.g. after a restart).
+        super::seed_tool_permissions(&registry, Some(&db), owner).await;
+
+        // 4. Assert the override survived.
+        let map = db.get_all_settings(owner).await.unwrap();
+        let settings = crate::settings::Settings::from_db_map(&map);
+        assert_eq!(
+            settings.tool_permissions.get("echo"),
+            Some(&PermissionState::Disabled),
+            "user override to Disabled must survive re-seed"
+        );
     }
 }

--- a/src/channels/web/handlers/settings.rs
+++ b/src/channels/web/handlers/settings.rs
@@ -524,6 +524,173 @@ fn mask_settings_api_keys(settings: &mut std::collections::HashMap<String, serde
     }
 }
 
+// ---------------------------------------------------------------------------
+// Tool Permissions API
+// ---------------------------------------------------------------------------
+
+/// `GET /api/settings/tools` — list all tools with current permission state.
+pub async fn settings_tools_list_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+) -> Result<Json<ToolPermissionsResponse>, StatusCode> {
+    use crate::tools::ApprovalRequirement;
+    use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
+
+    let registry = state
+        .tool_registry
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+
+    // Load current user tool permission overrides from the DB.
+    let store = state
+        .store
+        .as_ref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
+    let db_map = store.get_all_settings(&user.user_id).await.map_err(|e| {
+        tracing::error!("Failed to load settings for tool permissions: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let user_overrides = crate::settings::Settings::from_db_map(&db_map).tool_permissions;
+
+    let tools = registry.all().await;
+    let mut entries: Vec<ToolPermissionEntry> = tools
+        .iter()
+        .map(|tool| {
+            let name = tool.name().to_string();
+            let description = tool.description().to_string();
+
+            let current = effective_permission(&name, &user_overrides);
+            let default = TOOL_RISK_DEFAULTS
+                .get(name.as_str())
+                .copied()
+                .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
+
+            let locked = matches!(
+                tool.requires_approval(&serde_json::Value::Null),
+                ApprovalRequirement::Always
+            );
+            let locked_reason = if locked {
+                Some("Always requires approval due to risk level".to_string())
+            } else {
+                None
+            };
+
+            ToolPermissionEntry {
+                name,
+                description,
+                current_state: permission_state_to_str(current).to_string(),
+                default_state: permission_state_to_str(default).to_string(),
+                locked,
+                locked_reason,
+            }
+        })
+        .collect();
+
+    entries.sort_by(|a, b| a.name.cmp(&b.name));
+
+    Ok(Json(ToolPermissionsResponse { tools: entries }))
+}
+
+/// `PUT /api/settings/tools/:name` — update permission state for a single tool.
+pub async fn settings_tools_set_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(name): Path<String>,
+    Json(body): Json<UpdateToolPermissionRequest>,
+) -> Result<Json<ToolPermissionEntry>, (StatusCode, axum::Json<serde_json::Value>)> {
+    use crate::tools::ApprovalRequirement;
+    use crate::tools::permissions::{PermissionState, TOOL_RISK_DEFAULTS};
+
+    let registry = state.tool_registry.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        axum::Json(serde_json::json!({"error": "Tool registry unavailable"})),
+    ))?;
+
+    // Validate tool exists.
+    let tool = registry.get(&name).await.ok_or((
+        StatusCode::NOT_FOUND,
+        axum::Json(serde_json::json!({"error": format!("Tool '{}' not found", name)})),
+    ))?;
+
+    // Reject if tool is locked (ApprovalRequirement::Always).
+    if matches!(
+        tool.requires_approval(&serde_json::Value::Null),
+        ApprovalRequirement::Always
+    ) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            axum::Json(serde_json::json!({
+                "error": format!("Tool '{}' is locked and cannot have its permission changed", name)
+            })),
+        ));
+    }
+
+    // Parse the requested state.
+    let new_state = str_to_permission_state(&body.state).ok_or((
+        StatusCode::UNPROCESSABLE_ENTITY,
+        axum::Json(
+            serde_json::json!({"error": format!("Invalid permission state: '{}'", body.state)}),
+        ),
+    ))?;
+
+    // Persist the permission override to the DB, scoped to the authenticated user.
+    let store = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        axum::Json(serde_json::json!({"error": "Settings store unavailable"})),
+    ))?;
+
+    let json_value = serde_json::to_value(new_state).map_err(|e| {
+        tracing::error!("Failed to serialize permission state: {}", e);
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            axum::Json(serde_json::json!({"error": "Internal error"})),
+        )
+    })?;
+
+    store
+        .set_setting(
+            &user.user_id,
+            &format!("tool_permissions.{}", name),
+            &json_value,
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to set tool permission '{}': {}", name, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                axum::Json(serde_json::json!({"error": "Failed to persist permission"})),
+            )
+        })?;
+
+    // Use new_state directly — we just wrote it, no need for an extra DB round-trip.
+    let default = TOOL_RISK_DEFAULTS
+        .get(name.as_str())
+        .copied()
+        .unwrap_or(PermissionState::AskEachTime);
+
+    Ok(Json(ToolPermissionEntry {
+        description: tool.description().to_string(),
+        name,
+        current_state: permission_state_to_str(new_state).to_string(),
+        default_state: permission_state_to_str(default).to_string(),
+        locked: false,
+        locked_reason: None,
+    }))
+}
+
+fn permission_state_to_str(state: crate::tools::permissions::PermissionState) -> &'static str {
+    use crate::tools::permissions::PermissionState;
+    match state {
+        PermissionState::AlwaysAllow => "always_allow",
+        PermissionState::AskEachTime => "ask_each_time",
+        PermissionState::Disabled => "disabled",
+    }
+}
+
+fn str_to_permission_state(s: &str) -> Option<crate::tools::permissions::PermissionState> {
+    serde_json::from_value(serde_json::Value::String(s.to_string())).ok()
+}
+
 /// Check the secrets store for vaulted API keys and annotate the settings map.
 ///
 /// For builtin overrides and custom providers whose API key was stripped from
@@ -954,5 +1121,201 @@ mod tests {
     fn test_validate_custom_providers_non_array_is_ok() {
         let input = serde_json::json!("not-an-array");
         assert!(validate_custom_providers(&input).is_ok());
+    }
+
+    // --- Tool permissions helpers ---
+
+    #[test]
+    fn test_permission_state_roundtrip() {
+        use crate::tools::permissions::PermissionState;
+
+        for (state, expected) in [
+            (PermissionState::AlwaysAllow, "always_allow"),
+            (PermissionState::AskEachTime, "ask_each_time"),
+            (PermissionState::Disabled, "disabled"),
+        ] {
+            let s = permission_state_to_str(state);
+            assert_eq!(s, expected);
+            let back = str_to_permission_state(s).expect("roundtrip failed");
+            assert_eq!(back, state);
+        }
+    }
+
+    #[test]
+    fn test_str_to_permission_state_rejects_unknown() {
+        assert!(str_to_permission_state("invalid_value").is_none());
+        assert!(str_to_permission_state("").is_none());
+        assert!(str_to_permission_state("ALWAYS_ALLOW").is_none());
+    }
+
+    /// `PUT /api/settings/tools/:name` must return 400 for locked tools.
+    ///
+    /// A tool that returns `ApprovalRequirement::Always` from `requires_approval`
+    /// is locked — callers cannot override its permission state via the API.
+    /// We test this by checking the rejection path directly via the handler
+    /// function using a minimal in-memory tool registry containing a mock
+    /// "always-locked" tool.
+    #[tokio::test]
+    async fn test_put_locked_tool_returns_400() {
+        use std::sync::Arc;
+
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+        use crate::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+        use axum::Json;
+        use axum::extract::{Path, State};
+
+        // Minimal locked tool implementation.
+        struct LockedTool;
+
+        #[async_trait::async_trait]
+        impl Tool for LockedTool {
+            fn name(&self) -> &str {
+                "locked_shell"
+            }
+            fn description(&self) -> &str {
+                "A high-risk tool that always requires approval"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type":"object","properties":{}})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                unreachable!("should never be called in this test")
+            }
+            fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+                ApprovalRequirement::Always
+            }
+        }
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(LockedTool)).await;
+
+        let state = Arc::new(GatewayState {
+            tool_registry: Some(registry),
+            ..test_gateway_state(test_secrets_store())
+        });
+
+        let result = settings_tools_set_handler(
+            State(state),
+            crate::channels::web::auth::AuthenticatedUser(
+                crate::channels::web::auth::UserIdentity {
+                    user_id: "test".to_string(),
+                    role: "admin".to_string(),
+                    workspace_read_scopes: vec![],
+                },
+            ),
+            Path::<String>("locked_shell".to_string()),
+            Json(UpdateToolPermissionRequest {
+                state: "always_allow".to_string(),
+            }),
+        )
+        .await;
+
+        let (status, _body) = result.unwrap_err();
+        assert_eq!(
+            status,
+            axum::http::StatusCode::BAD_REQUEST,
+            "locked tools should return 400"
+        );
+    }
+
+    /// `GET /api/settings/tools` must return a list with the expected shape.
+    ///
+    /// Registers a single unlocked tool and verifies the response contains
+    /// name, description, current_state, default_state, and locked=false.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_get_tools_returns_expected_shape() {
+        use std::sync::Arc;
+
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+        use crate::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+        use axum::extract::State;
+
+        struct EchoLikeTool;
+
+        #[async_trait::async_trait]
+        impl Tool for EchoLikeTool {
+            fn name(&self) -> &str {
+                "echo_test"
+            }
+            fn description(&self) -> &str {
+                "Test echo tool"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type":"object","properties":{}})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                unreachable!()
+            }
+            fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+                ApprovalRequirement::Never
+            }
+        }
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(EchoLikeTool)).await;
+
+        // Provide a file-backed temp DB so the handler can load tool permissions.
+        // In-memory databases do not share state between connections in libsql,
+        // so we use a temporary file instead.
+        use crate::db::Database;
+        let tmp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = tmp_dir.path().join("test.db");
+        let db = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("temp db");
+        db.run_migrations().await.expect("migrations");
+        let db: Arc<dyn Database> = Arc::new(db);
+
+        let state = Arc::new(GatewayState {
+            tool_registry: Some(registry),
+            store: Some(db),
+            ..test_gateway_state(test_secrets_store())
+        });
+
+        let result = settings_tools_list_handler(
+            State(state),
+            crate::channels::web::auth::AuthenticatedUser(
+                crate::channels::web::auth::UserIdentity {
+                    user_id: "test".to_string(),
+                    role: "admin".to_string(),
+                    workspace_read_scopes: vec![],
+                },
+            ),
+        )
+        .await;
+
+        let axum::Json(response) = result.expect("handler should succeed");
+        assert!(!response.tools.is_empty(), "should have at least one tool");
+
+        let entry = response
+            .tools
+            .iter()
+            .find(|t| t.name == "echo_test")
+            .expect("echo_test tool should be in the list");
+
+        assert_eq!(entry.name, "echo_test");
+        assert_eq!(entry.description, "Test echo tool");
+        assert!(!entry.locked);
+        assert!(entry.locked_reason.is_none());
+        // current_state and default_state must be valid strings
+        assert!(matches!(
+            entry.current_state.as_str(),
+            "always_allow" | "ask_each_time" | "disabled"
+        ));
+        assert!(matches!(
+            entry.default_state.as_str(),
+            "always_allow" | "ask_each_time" | "disabled"
+        ));
     }
 }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -60,6 +60,7 @@ use crate::channels::web::handlers::routines::{
 use crate::channels::web::handlers::settings::{
     settings_delete_handler, settings_export_handler, settings_get_handler,
     settings_import_handler, settings_list_handler, settings_set_handler,
+    settings_tools_list_handler, settings_tools_set_handler,
 };
 use crate::channels::web::handlers::skills::{
     skills_install_handler, skills_list_handler, skills_remove_handler, skills_search_handler,
@@ -649,6 +650,14 @@ pub async fn start_server(
         .route("/api/settings", get(settings_list_handler))
         .route("/api/settings/export", get(settings_export_handler))
         .route("/api/settings/import", post(settings_import_handler))
+        // NOTE: These static routes intentionally shadow `/api/settings/{key}` when
+        // key="tools". Axum resolves static routes before parameterized ones, so this
+        // works correctly. Avoid adding a setting named literally "tools".
+        .route("/api/settings/tools", get(settings_tools_list_handler))
+        .route(
+            "/api/settings/tools/{name}",
+            axum::routing::put(settings_tools_set_handler),
+        )
         .route("/api/settings/{key}", get(settings_get_handler))
         .route(
             "/api/settings/{key}",

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -5789,6 +5789,110 @@ document.getElementById('skill-search-input').addEventListener('keydown', functi
   if (e.key === 'Enter') searchClawHub();
 });
 
+// --- Tool Permissions ---
+
+function loadToolsPermissions() {
+  var container = document.getElementById('tools-permissions-list');
+  if (!container) return;
+  container.innerHTML = '<div class="empty-state">' + I18n.t('common.loading') + '</div>';
+  apiFetch('/api/settings/tools').then(function(data) {
+    if (!data.tools || data.tools.length === 0) {
+      container.innerHTML = '<div class="empty-state">' + I18n.t('tools.noTools') + '</div>';
+      return;
+    }
+    container.innerHTML = '';
+    for (var i = 0; i < data.tools.length; i++) {
+      container.appendChild(renderToolPermissionRow(data.tools[i]));
+    }
+  }).catch(function(err) {
+    container.innerHTML = '<div class="empty-state">' + I18n.t('common.loadFailed') + ': ' + escapeHtml(err.message) + '</div>';
+  });
+}
+
+function renderToolPermissionRow(tool) {
+  var row = document.createElement('div');
+  row.className = 'tool-permission-row';
+  row.dataset.toolName = tool.name;
+
+  // Left: name + description
+  var info = document.createElement('div');
+  info.className = 'tool-permission-info';
+
+  var name = document.createElement('span');
+  name.className = 'tool-permission-name';
+  name.textContent = tool.name;
+
+  var desc = document.createElement('span');
+  desc.className = 'tool-permission-desc';
+  desc.textContent = tool.description;
+
+  info.appendChild(name);
+  info.appendChild(desc);
+
+  // Right: lock icon or toggle + default badge
+  var controls = document.createElement('div');
+  controls.className = 'tool-permission-controls';
+
+  if (tool.locked) {
+    var lock = document.createElement('span');
+    lock.className = 'tool-lock-icon';
+    lock.title = I18n.t('tools.lockedTooltip');
+    lock.textContent = '\uD83D\uDD12';
+    controls.appendChild(lock);
+  } else {
+    var toggle = document.createElement('div');
+    toggle.className = 'tool-permission-toggle';
+
+    var states = [
+      { value: 'always_allow', label: I18n.t('tools.alwaysAllow') },
+      { value: 'ask_each_time', label: I18n.t('tools.askEachTime') },
+      { value: 'disabled', label: I18n.t('tools.disabled') },
+    ];
+
+    for (var j = 0; j < states.length; j++) {
+      (function(state) {
+        var btn = document.createElement('button');
+        btn.textContent = state.label;
+        btn.dataset.state = state.value;
+        btn.setAttribute('aria-pressed', tool.current_state === state.value);
+        if (tool.current_state === state.value) btn.classList.add('active');
+        btn.addEventListener('click', function() {
+          setToolPermission(tool.name, state.value, row);
+        });
+        toggle.appendChild(btn);
+      })(states[j]);
+    }
+
+    controls.appendChild(toggle);
+  }
+
+  if (tool.current_state === tool.default_state) {
+    var badge = document.createElement('span');
+    badge.className = 'tool-default-badge';
+    badge.textContent = I18n.t('tools.defaultBadge');
+    controls.appendChild(badge);
+  }
+
+  row.appendChild(info);
+  row.appendChild(controls);
+  return row;
+}
+
+function setToolPermission(toolName, newState, rowEl) {
+  apiFetch('/api/settings/tools/' + encodeURIComponent(toolName), {
+    method: 'PUT',
+    body: { state: newState },
+  }).then(function(updated) {
+    // Re-render just this row in-place.
+    var newRow = renderToolPermissionRow(updated);
+    if (rowEl && rowEl.parentNode) {
+      rowEl.parentNode.replaceChild(newRow, rowEl);
+    }
+  }).catch(function(err) {
+    showToast(I18n.t('tools.saveFailed', { message: err.message }), 'error');
+  });
+}
+
 // --- Keyboard shortcuts ---
 
 document.addEventListener('keydown', (e) => {
@@ -5895,6 +5999,7 @@ function loadSettingsSubtab(subtab) {
   else if (subtab === 'mcp') loadMcpServers();
   else if (subtab === 'skills') loadSkills();
   else if (subtab === 'users') loadUsers();
+  else if (subtab === 'tools') loadToolsPermissions();
   if (subtab !== 'extensions' && subtab !== 'channels') stopPairingPoll();
 }
 

--- a/src/channels/web/static/i18n/en.js
+++ b/src/channels/web/static/i18n/en.js
@@ -363,6 +363,16 @@ I18n.register('en', {
   'tool.running': 'Running',
   'tool.used': '{count} tool(s) used',
   'tool.requiresApproval': 'Tool requires approval',
+
+  // Tool Permissions Tab
+  'settings.tools': 'Tools',
+  'tools.alwaysAllow': 'Always Allow',
+  'tools.askEachTime': 'Ask Each Time',
+  'tools.disabled': 'Disabled',
+  'tools.lockedTooltip': 'Always requires approval',
+  'tools.defaultBadge': 'Default',
+  'tools.noTools': 'No tools registered',
+  'tools.saveFailed': 'Failed to save: {message}',
   
   
   // TEE

--- a/src/channels/web/static/index.html
+++ b/src/channels/web/static/index.html
@@ -392,6 +392,7 @@
           <button class="settings-subtab" data-settings-subtab="mcp" data-i18n="settings.mcp">MCP</button>
           <button class="settings-subtab" data-settings-subtab="skills" data-i18n="tab.skills">Skills</button>
           <button class="settings-subtab" data-settings-subtab="users" data-i18n="settings.users">Users</button>
+          <button class="settings-subtab" data-settings-subtab="tools" data-i18n="settings.tools">Tools</button>
           <button class="settings-theme-toggle" id="settings-theme-toggle" data-i18n="theme.tooltipSystem" title="Toggle theme">Theme</button>
         </div>
         <div class="settings-content">
@@ -525,6 +526,16 @@
                 <tbody id="users-tbody"></tbody>
               </table>
               <div id="users-empty" class="empty-state" style="display:none" data-i18n="users.emptyState">No users found. Create the first user to get started.</div>
+            </div>
+          </div>
+          <div class="settings-subpanel" id="settings-tools">
+            <div class="extensions-container">
+              <div class="extensions-section">
+                <h3 data-i18n="settings.tools">Tool Permissions</h3>
+                <div id="tools-permissions-list">
+                  <div class="empty-state" data-i18n="common.loading">Loading...</div>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -6233,3 +6233,83 @@ body.theme-transition *:not(svg):not(path):not(line):not(circle):not(rect) {
 .btn-primary { background: var(--accent); color: #fff; border: none; padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
 .btn-primary:hover { opacity: 0.9; }
 .btn-secondary { background: var(--bg-tertiary); color: var(--text-primary); border: 1px solid var(--border); padding: 0.4rem 0.8rem; border-radius: 6px; cursor: pointer; font-size: 0.85rem; }
+
+/* --- Tool Permissions Tab --- */
+.tool-permission-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.tool-permission-row:last-child { border-bottom: none; }
+.tool-permission-row:hover { background: var(--bg-secondary); border-radius: var(--radius-md); }
+
+.tool-permission-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.tool-permission-name {
+  font-weight: 600;
+  font-size: var(--text-sm);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+}
+.tool-permission-desc {
+  font-size: var(--text-xs);
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tool-permission-controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-shrink: 0;
+}
+
+.tool-permission-toggle {
+  display: flex;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+.tool-permission-toggle button {
+  padding: 4px 10px;
+  border: none;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: var(--text-xs);
+  transition: background var(--transition-fast), color var(--transition-fast);
+  border-right: 1px solid var(--border);
+}
+.tool-permission-toggle button:last-child { border-right: none; }
+.tool-permission-toggle button:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+.tool-permission-toggle button.active {
+  background: var(--accent);
+  color: #fff;
+  font-weight: 600;
+}
+
+.tool-lock-icon {
+  font-size: 0.9rem;
+  color: var(--text-muted);
+  cursor: help;
+}
+
+.tool-default-badge {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-size: 0.7rem;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  white-space: nowrap;
+}

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -847,6 +847,31 @@ pub struct SettingsExportResponse {
     pub settings: std::collections::HashMap<String, serde_json::Value>,
 }
 
+// --- Tool Permissions ---
+
+/// Single tool entry returned by `GET /api/settings/tools`.
+#[derive(Debug, Serialize)]
+pub struct ToolPermissionEntry {
+    pub name: String,
+    pub description: String,
+    pub current_state: String,
+    pub default_state: String,
+    pub locked: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locked_reason: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ToolPermissionsResponse {
+    pub tools: Vec<ToolPermissionEntry>,
+}
+
+/// Body for `PUT /api/settings/tools/:name`.
+#[derive(Debug, Deserialize)]
+pub struct UpdateToolPermissionRequest {
+    pub state: String,
+}
+
 // --- Health ---
 
 #[derive(Debug, Serialize)]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -220,6 +220,15 @@ pub struct Settings {
     /// Transcription configuration.
     #[serde(default)]
     pub transcription: Option<TranscriptionSettings>,
+
+    /// Per-tool permission overrides.
+    ///
+    /// Keys are tool names; values override the built-in tier defaults from
+    /// `TOOL_RISK_DEFAULTS`.  Absent tools fall back to the tier default, or
+    /// `AskEachTime` if the tool is unknown.
+    #[serde(default)]
+    pub tool_permissions:
+        std::collections::HashMap<String, crate::tools::permissions::PermissionState>,
 }
 
 /// Source for the secrets master key.

--- a/src/tools/builtin/extension_tools.rs
+++ b/src/tools/builtin/extension_tools.rs
@@ -9,6 +9,8 @@ use async_trait::async_trait;
 
 use crate::context::JobContext;
 use crate::extensions::{ExtensionKind, ExtensionManager};
+use crate::tools::permissions::{TOOL_RISK_DEFAULTS, effective_permission};
+use crate::tools::registry::ToolRegistry;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 
 fn activation_error_requires_auth(err: &str) -> bool {
@@ -373,11 +375,32 @@ impl Tool for ToolActivateTool {
 
 pub struct ToolListTool {
     manager: Arc<ExtensionManager>,
+    registry: Option<Arc<ToolRegistry>>,
+    settings_store: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
 }
 
 impl ToolListTool {
     pub fn new(manager: Arc<ExtensionManager>) -> Self {
-        Self { manager }
+        Self {
+            manager,
+            registry: None,
+            settings_store: None,
+        }
+    }
+
+    /// Attach a tool registry so `kind="builtin"` listings are available.
+    pub fn with_registry(mut self, registry: Arc<ToolRegistry>) -> Self {
+        self.registry = Some(registry);
+        self
+    }
+
+    /// Attach a settings store so permission states can be read per user.
+    pub fn with_settings_store(
+        mut self,
+        store: Arc<dyn crate::db::SettingsStore + Send + Sync>,
+    ) -> Self {
+        self.settings_store = Some(store);
+        self
     }
 }
 
@@ -388,8 +411,9 @@ impl Tool for ToolListTool {
     }
 
     fn description(&self) -> &str {
-        "List extensions with their authentication and activation status. \
-         Set include_available:true to also show registry entries not yet installed."
+        "List extensions and built-in tools with their authentication, activation, and permission \
+         status. Set include_available:true to also show registry entries not yet installed. \
+         Use kind=\"builtin\" to list only built-in Rust tools."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -398,8 +422,8 @@ impl Tool for ToolListTool {
             "properties": {
                 "kind": {
                     "type": "string",
-                    "enum": ["mcp_server", "wasm_tool", "wasm_channel"],
-                    "description": "Filter by extension type (omit to list all)"
+                    "enum": ["mcp_server", "wasm_tool", "wasm_channel", "builtin"],
+                    "description": "Filter by extension type (omit to list all, including builtins)"
                 },
                 "include_available": {
                     "type": "boolean",
@@ -417,31 +441,89 @@ impl Tool for ToolListTool {
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
 
-        let kind_filter = params
-            .get("kind")
-            .and_then(|v| v.as_str())
-            .and_then(|k| match k {
-                "mcp_server" => Some(ExtensionKind::McpServer),
-                "wasm_tool" => Some(ExtensionKind::WasmTool),
-                "wasm_channel" => Some(ExtensionKind::WasmChannel),
-                _ => None,
-            });
+        let kind_str = params.get("kind").and_then(|v| v.as_str());
+        let want_builtin = kind_str.is_none() || kind_str == Some("builtin");
+        let want_extensions = kind_str.is_none() || kind_str != Some("builtin");
 
         let include_available = params
             .get("include_available")
             .and_then(|v| v.as_bool())
             .unwrap_or(false);
 
-        let extensions = self
-            .manager
-            .list(kind_filter, include_available, &ctx.user_id)
-            .await
-            .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+        // Load per-user permission overrides (best-effort; empty map on any failure).
+        let perm_overrides: std::collections::HashMap<
+            String,
+            crate::tools::permissions::PermissionState,
+        > = if let Some(ref store) = self.settings_store {
+            match store.get_all_settings(&ctx.user_id).await {
+                Ok(map) => {
+                    let settings = crate::settings::Settings::from_db_map(&map);
+                    settings.tool_permissions
+                }
+                Err(e) => {
+                    tracing::warn!("Failed to load tool permissions: {}", e);
+                    std::collections::HashMap::new()
+                }
+            }
+        } else {
+            std::collections::HashMap::new()
+        };
 
-        let output = serde_json::json!({
-            "extensions": extensions,
-            "count": extensions.len(),
-        });
+        let mut output = serde_json::json!({});
+
+        // Built-in tools section — restrict to tools registered via register_sync()
+        // so that dynamically-installed WASM/MCP tools are not duplicated here.
+        if want_builtin && let Some(ref registry) = self.registry {
+            let builtin_names = registry.builtin_tool_names().await;
+            let tools = registry.all().await;
+            let empty_params = serde_json::json!({});
+            let builtin_list: Vec<serde_json::Value> = tools
+                .iter()
+                .filter(|tool| builtin_names.contains(tool.name()))
+                .map(|tool| {
+                    let name = tool.name().to_string();
+                    let perm_state = effective_permission(&name, &perm_overrides);
+                    let default_state = TOOL_RISK_DEFAULTS
+                        .get(name.as_str())
+                        .copied()
+                        .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
+                    let locked = matches!(
+                        tool.requires_approval(&empty_params),
+                        ApprovalRequirement::Always
+                    );
+                    serde_json::json!({
+                        "name": name,
+                        "description": tool.description(),
+                        "permission_state": perm_state,
+                        "default_state": default_state,
+                        "locked": locked,
+                    })
+                })
+                .collect();
+            let count = builtin_list.len();
+            output["builtins"] = serde_json::json!(builtin_list);
+            output["builtin_count"] = serde_json::json!(count);
+        }
+
+        // Extension (MCP / WASM) section.
+        if want_extensions {
+            let kind_filter = kind_str.and_then(|k| match k {
+                "mcp_server" => Some(ExtensionKind::McpServer),
+                "wasm_tool" => Some(ExtensionKind::WasmTool),
+                "wasm_channel" => Some(ExtensionKind::WasmChannel),
+                _ => None,
+            });
+
+            let extensions = self
+                .manager
+                .list(kind_filter, include_available, &ctx.user_id)
+                .await
+                .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+
+            let count = extensions.len();
+            output["extensions"] = serde_json::json!(extensions);
+            output["count"] = serde_json::json!(count);
+        }
 
         Ok(ToolOutput::success(output, start.elapsed()))
     }
@@ -628,6 +710,170 @@ impl Tool for ExtensionInfoTool {
     }
 }
 
+// ── tool_permission_set ───────────────────────────────────────────────────
+
+pub struct ToolPermissionSetTool {
+    registry: Arc<ToolRegistry>,
+    settings_store: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
+}
+
+impl ToolPermissionSetTool {
+    pub fn new(
+        registry: Arc<ToolRegistry>,
+        settings_store: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
+    ) -> Self {
+        Self {
+            registry,
+            settings_store,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for ToolPermissionSetTool {
+    fn name(&self) -> &str {
+        "tool_permission_set"
+    }
+
+    fn description(&self) -> &str {
+        "Get or set the permission state for a tool. Use to view current permissions or propose \
+         a change (requires user approval). States: always_allow (no prompt), ask_each_time \
+         (approval required), disabled (tool hidden from LLM)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tool_name": {
+                    "type": "string",
+                    "description": "Name of the tool to configure"
+                },
+                "state": {
+                    "type": "string",
+                    "enum": ["always_allow", "ask_each_time", "disabled"],
+                    "description": "New permission state. Omit to just read the current state."
+                }
+            },
+            "required": ["tool_name"]
+        })
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Always
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = std::time::Instant::now();
+
+        let tool_name = require_str(&params, "tool_name")?;
+
+        // Verify that the target tool exists in the registry.
+        let target_tool =
+            self.registry.get(tool_name).await.ok_or_else(|| {
+                ToolError::InvalidParameters(format!("Unknown tool: '{tool_name}'"))
+            })?;
+
+        // Load current settings for the user.
+        let settings = if let Some(ref store) = self.settings_store {
+            match store.get_all_settings(&ctx.user_id).await {
+                Ok(map) => crate::settings::Settings::from_db_map(&map),
+                Err(e) => {
+                    return Err(ToolError::ExecutionFailed(format!(
+                        "Failed to load settings: {e}"
+                    )));
+                }
+            }
+        } else {
+            crate::settings::Settings::default()
+        };
+
+        let prev_state =
+            crate::tools::permissions::effective_permission(tool_name, &settings.tool_permissions);
+
+        // Read-only mode when no state param; reject non-string state values.
+        let state_str = match params.get("state") {
+            None => {
+                let default_state = TOOL_RISK_DEFAULTS
+                    .get(tool_name)
+                    .copied()
+                    .unwrap_or(crate::tools::permissions::PermissionState::AskEachTime);
+                let output = serde_json::json!({
+                    "tool_name": tool_name,
+                    "current_state": prev_state,
+                    "default_state": default_state,
+                    "locked": matches!(
+                        target_tool.requires_approval(&serde_json::json!({})),
+                        ApprovalRequirement::Always
+                    ),
+                });
+                return Ok(ToolOutput::success(output, start.elapsed()));
+            }
+            Some(v) => v.as_str().ok_or_else(|| {
+                ToolError::InvalidParameters(
+                    "'state' must be a string: always_allow, ask_each_time, or disabled"
+                        .to_string(),
+                )
+            })?,
+        };
+
+        // Check that the target tool doesn't always require approval (locked tools
+        // cannot have their permission lowered — they will always prompt).
+        let empty_params = serde_json::json!({});
+        if matches!(
+            target_tool.requires_approval(&empty_params),
+            ApprovalRequirement::Always
+        ) {
+            return Err(ToolError::InvalidParameters(format!(
+                "'{tool_name}' always requires approval and its permission cannot be changed"
+            )));
+        }
+
+        // Parse the requested new state.
+        let new_state = match state_str {
+            "always_allow" => crate::tools::permissions::PermissionState::AlwaysAllow,
+            "ask_each_time" => crate::tools::permissions::PermissionState::AskEachTime,
+            "disabled" => crate::tools::permissions::PermissionState::Disabled,
+            other => {
+                return Err(ToolError::InvalidParameters(format!(
+                    "Invalid state '{other}'; expected always_allow, ask_each_time, or disabled"
+                )));
+            }
+        };
+
+        // Persist the updated permission.
+        if let Some(ref store) = self.settings_store {
+            let new_state_json = serde_json::to_value(new_state)
+                .map_err(|e| ToolError::ExecutionFailed(e.to_string()))?;
+            store
+                .set_setting(
+                    &ctx.user_id,
+                    &format!("tool_permissions.{tool_name}"),
+                    &new_state_json,
+                )
+                .await
+                .map_err(|e| {
+                    ToolError::ExecutionFailed(format!("Failed to save permission: {e}"))
+                })?;
+        } else {
+            return Err(ToolError::ExecutionFailed(
+                "No settings store configured — permission changes cannot be persisted".to_string(),
+            ));
+        }
+
+        let output = serde_json::json!({
+            "tool_name": tool_name,
+            "prev_state": prev_state,
+            "new_state": new_state,
+        });
+        Ok(ToolOutput::success(output, start.elapsed()))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -717,9 +963,7 @@ mod tests {
     #[test]
     fn test_tool_list_schema() {
         use crate::tools::tool::ApprovalRequirement;
-        let tool = ToolListTool {
-            manager: test_manager_stub(),
-        };
+        let tool = ToolListTool::new(test_manager_stub());
         assert_eq!(tool.name(), "tool_list");
         assert_eq!(
             tool.requires_approval(&serde_json::json!({})),
@@ -727,6 +971,15 @@ mod tests {
         );
         let schema = tool.parameters_schema();
         assert!(schema["properties"].get("kind").is_some());
+        // Verify the new "builtin" kind is included in the enum.
+        let enum_vals = schema["properties"]["kind"]["enum"]
+            .as_array()
+            .expect("kind must have an enum array");
+        let kind_names: Vec<&str> = enum_vals.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            kind_names.contains(&"builtin"),
+            "tool_list kind enum must include 'builtin'"
+        );
     }
 
     #[test]
@@ -842,5 +1095,175 @@ mod tests {
             None,
             Vec::new(),
         ))
+    }
+
+    // ── tool_permission_set tests ─────────────────────────────────────────
+
+    /// A simple tool used in tests that requires approval Always (locked).
+    struct LockedTool;
+
+    #[async_trait]
+    impl Tool for LockedTool {
+        fn name(&self) -> &str {
+            "locked_tool"
+        }
+        fn description(&self) -> &str {
+            "A test tool that always requires approval"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            unreachable!()
+        }
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::Always
+        }
+    }
+
+    /// A simple tool used in tests that does not lock its permission.
+    struct NormalTool;
+
+    #[async_trait]
+    impl Tool for NormalTool {
+        fn name(&self) -> &str {
+            "normal_tool"
+        }
+        fn description(&self) -> &str {
+            "A normal test tool"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({ "type": "object", "properties": {} })
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            unreachable!()
+        }
+    }
+
+    #[tokio::test]
+    async fn test_tool_permission_set_unknown_tool_returns_error() {
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        // Do not register any tool — asking for "unknown_xyz" should fail.
+        let tool = ToolPermissionSetTool::new(Arc::clone(&registry), None);
+        let ctx = JobContext::default();
+        let result = tool
+            .execute(serde_json::json!({"tool_name": "unknown_xyz"}), &ctx)
+            .await;
+        assert!(result.is_err(), "expected error for unknown tool");
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParameters(_)),
+            "expected InvalidParameters, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_permission_set_locked_tool_rejected() {
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(LockedTool)).await;
+
+        let tool = ToolPermissionSetTool::new(Arc::clone(&registry), None);
+        let ctx = JobContext::default();
+
+        // Trying to change the permission state of a locked tool must fail.
+        let result = tool
+            .execute(
+                serde_json::json!({"tool_name": "locked_tool", "state": "always_allow"}),
+                &ctx,
+            )
+            .await;
+        assert!(
+            result.is_err(),
+            "locked tool permission change must be rejected"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            matches!(err, ToolError::InvalidParameters(_)),
+            "expected InvalidParameters for locked tool, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_tool_permission_set_always_requires_approval() {
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        let tool = ToolPermissionSetTool::new(Arc::clone(&registry), None);
+        assert_eq!(
+            tool.requires_approval(&serde_json::json!({})),
+            ApprovalRequirement::Always,
+            "tool_permission_set must always require approval"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_tool_list_includes_builtin_kind() {
+        use crate::context::JobContext;
+        use crate::tools::ToolRegistry;
+
+        let registry = Arc::new(ToolRegistry::new());
+        // Use register_sync (built-in path) so the tool appears in builtin_tool_names().
+        registry.register_sync(Arc::new(NormalTool));
+
+        let manager = test_manager_stub();
+        let list_tool = ToolListTool::new(manager).with_registry(Arc::clone(&registry));
+
+        let ctx = JobContext::default();
+        let result = list_tool
+            .execute(serde_json::json!({"kind": "builtin"}), &ctx)
+            .await
+            .expect("tool_list kind=builtin should succeed");
+
+        let builtins = result.result["builtins"]
+            .as_array()
+            .expect("result should have builtins array");
+        assert!(
+            !builtins.is_empty(),
+            "builtins list should not be empty when registry has tools"
+        );
+        let names: Vec<&str> = builtins
+            .iter()
+            .filter_map(|entry| entry["name"].as_str())
+            .collect();
+        assert!(
+            names.contains(&"normal_tool"),
+            "registered normal_tool should appear in builtins listing"
+        );
+        // Each entry must have required fields.
+        for entry in builtins {
+            assert!(entry.get("name").is_some(), "missing name field");
+            assert!(
+                entry.get("description").is_some(),
+                "missing description field"
+            );
+            assert!(
+                entry.get("permission_state").is_some(),
+                "missing permission_state"
+            );
+            assert!(
+                entry.get("default_state").is_some(),
+                "missing default_state"
+            );
+            assert!(entry.get("locked").is_some(), "missing locked field");
+        }
+        // Extensions should not be present for kind=builtin.
+        assert!(
+            result.result.get("extensions").is_none(),
+            "kind=builtin should not return extensions"
+        );
     }
 }

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -21,7 +21,7 @@ mod tool_info;
 pub use echo::EchoTool;
 pub use extension_tools::{
     ExtensionInfoTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
-    ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
+    ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
 };
 pub use file::{ApplyPatchTool, ListDirTool, ReadFileTool, WriteFileTool};
 pub use http::{HttpTool, extract_host_from_params};

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -13,6 +13,7 @@ pub mod builtin;
 mod coercion;
 pub mod execute;
 pub mod mcp;
+pub mod permissions;
 pub mod rate_limiter;
 pub mod redaction;
 pub mod schema_validator;

--- a/src/tools/permissions.rs
+++ b/src/tools/permissions.rs
@@ -1,0 +1,186 @@
+//! Per-user tool permission system.
+//!
+//! Each tool has a `PermissionState` that controls whether it runs without
+//! confirmation, asks the user each time, or is fully disabled.  A static
+//! table of tier defaults (`TOOL_RISK_DEFAULTS`) is used as the fallback when
+//! no per-user override exists.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use serde::{Deserialize, Serialize};
+
+/// How a tool may be invoked by the agent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionState {
+    /// Run automatically without asking the user first.
+    AlwaysAllow,
+    /// Pause and ask the user before every invocation.
+    AskEachTime,
+    /// Refuse to run the tool at all.
+    Disabled,
+}
+
+/// Static map of built-in tool names → their default `PermissionState`.
+///
+/// Tools present here default to `AlwaysAllow` (read-only / low-risk) or
+/// `AskEachTime` (write / destructive / network).  Tools **absent** from the
+/// map fall back to `AskEachTime` in `effective_permission`.
+pub static TOOL_RISK_DEFAULTS: LazyLock<HashMap<&'static str, PermissionState>> =
+    LazyLock::new(|| {
+        let mut m = HashMap::new();
+
+        // --- AlwaysAllow: informational, low-risk, or safe writes ---
+        for name in &[
+            "echo",
+            "time",
+            "json",
+            "memory_search",
+            "memory_read",
+            "memory_write",
+            "memory_tree",
+            "tool_list",
+            "tool_info",
+            "tool_search",
+            "skill_list",
+            "skill_search",
+            "list_jobs",
+            "job_status",
+            "job_events",
+            "image_analyze",
+            "message",
+        ] {
+            m.insert(*name, PermissionState::AlwaysAllow);
+        }
+
+        // --- AskEachTime: write, destructive, code-execution, or network ---
+        for name in &[
+            "shell",
+            "read_file",
+            "write_file",
+            "list_dir",
+            "apply_patch",
+            "http",
+            "create_job",
+            "event_emit",
+            "routine_create",
+            "routine_update",
+            "cancel_job",
+            "job_prompt",
+            "routine_delete",
+            "routine_fire",
+            "tool_install",
+            "tool_auth",
+            "tool_activate",
+            "tool_remove",
+            "tool_upgrade",
+            "skill_install",
+            "skill_remove",
+            "secret_list",
+            "secret_delete",
+            "image_generate",
+            "image_edit",
+            "restart",
+            "build_software",
+            "tool_permission_set",
+        ] {
+            m.insert(*name, PermissionState::AskEachTime);
+        }
+
+        m
+    });
+
+/// Return the effective `PermissionState` for `tool_name`.
+///
+/// Lookup order:
+/// 1. Per-user `overrides` map (highest priority).
+/// 2. `TOOL_RISK_DEFAULTS` static table.
+/// 3. `AskEachTime` as the safe fallback for any unknown tool.
+pub fn effective_permission(
+    tool_name: &str,
+    overrides: &HashMap<String, PermissionState>,
+) -> PermissionState {
+    if let Some(state) = overrides.get(tool_name) {
+        return *state;
+    }
+    if let Some(state) = TOOL_RISK_DEFAULTS.get(tool_name) {
+        return *state;
+    }
+    PermissionState::AskEachTime
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::settings::Settings;
+
+    #[test]
+    fn test_effective_permission_user_override_wins() {
+        let mut overrides = HashMap::new();
+        // Override "shell" (default: AskEachTime) to AlwaysAllow.
+        overrides.insert("shell".to_string(), PermissionState::AlwaysAllow);
+
+        assert_eq!(
+            effective_permission("shell", &overrides),
+            PermissionState::AlwaysAllow,
+            "user override should take precedence over tier default"
+        );
+    }
+
+    #[test]
+    fn test_effective_permission_tier_default_fallback() {
+        let overrides = HashMap::new();
+
+        // "echo" has AlwaysAllow in the defaults table.
+        assert_eq!(
+            effective_permission("echo", &overrides),
+            PermissionState::AlwaysAllow,
+            "tier default should be returned when no user override exists"
+        );
+
+        // "shell" has AskEachTime in the defaults table.
+        assert_eq!(
+            effective_permission("shell", &overrides),
+            PermissionState::AskEachTime,
+            "tier default should be returned when no user override exists"
+        );
+    }
+
+    #[test]
+    fn test_effective_permission_unknown_tool_defaults_to_ask() {
+        let overrides = HashMap::new();
+
+        assert_eq!(
+            effective_permission("completely_unknown_tool_xyz", &overrides),
+            PermissionState::AskEachTime,
+            "unknown tool should default to AskEachTime"
+        );
+    }
+
+    #[test]
+    fn test_settings_serde_roundtrip() {
+        let mut settings = Settings::default();
+        settings
+            .tool_permissions
+            .insert("shell".to_string(), PermissionState::AlwaysAllow);
+        settings
+            .tool_permissions
+            .insert("restart".to_string(), PermissionState::Disabled);
+
+        // Round-trip through JSON (the primary serialization format).
+        let json = serde_json::to_string(&settings).expect("serialize");
+        let loaded: Settings = serde_json::from_str(&json).expect("deserialize");
+
+        assert_eq!(
+            loaded.tool_permissions.get("shell"),
+            Some(&PermissionState::AlwaysAllow)
+        );
+        assert_eq!(
+            loaded.tool_permissions.get("restart"),
+            Some(&PermissionState::Disabled)
+        );
+        // Tool not in the map should be absent (not defaulted to anything).
+        assert!(!loaded.tool_permissions.contains_key("echo"));
+    }
+}

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -19,8 +19,8 @@ use crate::tools::builtin::{
     JobEventsTool, JobPromptTool, JobStatusTool, JsonTool, ListDirTool, ListJobsTool,
     MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool, PlanUpdateTool, PromptQueue,
     ReadFileTool, ShellTool, SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool,
-    TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool, ToolRemoveTool,
-    ToolSearchTool, ToolUpgradeTool, WriteFileTool,
+    TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool, ToolPermissionSetTool,
+    ToolRemoveTool, ToolSearchTool, ToolUpgradeTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolDiscoverySummary, ToolDomain};
@@ -78,6 +78,7 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "image_edit",
     "image_analyze",
     "tool_info",
+    "tool_permission_set",
 ];
 
 /// Registry of available tools.
@@ -144,8 +145,16 @@ impl ToolRegistry {
     }
 
     /// Register a tool. Rejects dynamic tools that try to shadow a protected built-in name.
+    /// Also rejects tool names containing `.` which conflicts with settings path parsing.
     pub async fn register(&self, tool: Arc<dyn Tool>) {
         let name = tool.name().to_string();
+        if name.contains('.') {
+            tracing::warn!(
+                tool = %name,
+                "Rejecting tool registration: name contains '.' which conflicts with settings path parsing"
+            );
+            return;
+        }
         if PROTECTED_TOOL_NAMES.contains(&name.as_str())
             && self.builtin_names.read().await.contains(&name)
         {
@@ -160,8 +169,16 @@ impl ToolRegistry {
     }
 
     /// Register a tool (sync version for startup, marks as built-in).
+    /// Also rejects tool names containing `.` which conflicts with settings path parsing.
     pub fn register_sync(&self, tool: Arc<dyn Tool>) {
         let name = tool.name().to_string();
+        if name.contains('.') {
+            tracing::warn!(
+                tool = %name,
+                "Rejecting tool registration: name contains '.' which conflicts with settings path parsing"
+            );
+            return;
+        }
         if let Ok(mut tools) = self.tools.try_write() {
             tools.insert(name.clone(), tool);
             if let Ok(mut builtins) = self.builtin_names.try_write() {
@@ -490,6 +507,38 @@ impl ToolRegistry {
         self.register_sync(Arc::new(ToolUpgradeTool::new(Arc::clone(&manager))));
         self.register_sync(Arc::new(ExtensionInfoTool::new(manager)));
         tracing::debug!("Registered 8 extension management tools");
+    }
+
+    /// Register the permission management tool (`tool_permission_set`).
+    ///
+    /// This tool allows users or the LLM to view and modify tool permissions,
+    /// subject to approval.
+    pub fn register_permission_tools(
+        self: &Arc<Self>,
+        settings_store: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
+    ) {
+        self.register_sync(Arc::new(ToolPermissionSetTool::new(
+            Arc::clone(self),
+            settings_store.clone(),
+        )));
+        tracing::debug!("Registered tool_permission_set");
+    }
+
+    /// Upgrade `tool_list` to include built-in tool listings and per-user permission states.
+    ///
+    /// Call this after `register_extension_tools()` and after the registry itself
+    /// is behind an `Arc`.
+    pub fn upgrade_tool_list(
+        self: &Arc<Self>,
+        manager: Arc<ExtensionManager>,
+        settings_store: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
+    ) {
+        let mut list_tool = ToolListTool::new(manager).with_registry(Arc::clone(self));
+        if let Some(store) = settings_store {
+            list_tool = list_tool.with_settings_store(store);
+        }
+        self.register_sync(Arc::new(list_tool));
+        tracing::debug!("Upgraded tool_list with builtin registry support");
     }
 
     /// Register skill management tools (list, search, install, remove).

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -121,6 +121,12 @@ SEL = {
     "plan_status_badge":        ".plan-status-badge",
     "plan_title":               ".plan-title",
     "plan_summary":             ".plan-summary",
+    # Tool permissions (Settings → Tools tab)
+    "tools_tab":                "button[data-settings-subtab='tools']",
+    "tool_permission_row":      ".tool-permission-row",
+    "tool_permission_toggle":   ".tool-permission-toggle",
+    "tool_lock_icon":           ".tool-lock-icon",
+    "tool_default_badge":       ".tool-default-badge",
 }
 
 TABS = ["chat", "memory", "jobs", "routines", "settings"]

--- a/tests/e2e/scenarios/test_tool_permissions.py
+++ b/tests/e2e/scenarios/test_tool_permissions.py
@@ -1,0 +1,233 @@
+"""Scenario: Tool permissions UI and REST API."""
+
+import httpx
+
+from helpers import AUTH_TOKEN, SEL
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _headers() -> dict[str, str]:
+    return {"Authorization": f"Bearer {AUTH_TOKEN}"}
+
+
+async def _open_tools_tab(page) -> None:
+    """Navigate to the Settings panel and click the Tools subtab."""
+    # First, click the main Settings tab to ensure the Settings panel is active
+    settings_tab = page.locator(SEL["tab_button"].format(tab="settings"))
+    await settings_tab.click()
+    await page.locator(SEL["tab_panel"].format(tab="settings")).wait_for(
+        state="visible", timeout=5000
+    )
+
+    # Then click the Tools subtab within Settings
+    tools_subtab = page.locator(SEL["settings_subtab"].format(subtab="tools"))
+    await tools_subtab.wait_for(state="visible", timeout=5000)
+    await tools_subtab.click()
+
+    # Wait for the Tools panel to be visible
+    await page.locator(SEL["settings_subpanel"].format(subtab="tools")).wait_for(
+        state="visible", timeout=5000
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_tools_tab_visible(page):
+    """Settings panel has a Tools tab; clicking it shows tool list with at least one row."""
+    await _open_tools_tab(page)
+
+    # At least one tool-permission row should appear
+    rows = page.locator(SEL["tool_permission_row"])
+    await rows.first.wait_for(state="visible", timeout=5000)
+    count = await rows.count()
+    assert count >= 1, f"Expected at least one tool-permission row, got {count}"
+
+
+async def test_tool_permission_toggle_persists(page, ironclaw_server):
+    """Toggle a tool from AlwaysAllow → AskEachTime via UI; reload; confirm persisted."""
+    headers = _headers()
+
+    # Set echo to a known initial state via REST
+    async with httpx.AsyncClient() as client:
+        r = await client.put(
+            f"{ironclaw_server}/api/settings/tools/echo",
+            json={"state": "always_allow"},
+            headers=headers,
+            timeout=10,
+        )
+        assert r.status_code == 200, f"Precondition PUT failed: {r.text}"
+
+    # Open the Tools tab
+    await _open_tools_tab(page)
+
+    # Find the echo row and its toggle group
+    echo_row = page.locator(f"{SEL['tool_permission_row']}[data-tool-name='echo']")
+    await echo_row.wait_for(state="visible", timeout=5000)
+
+    # Click the "Ask Each Time" option inside the toggle group
+    ask_btn = echo_row.locator(f"{SEL['tool_permission_toggle']} button[data-state='ask_each_time']")
+    await ask_btn.wait_for(state="visible", timeout=5000)
+    await ask_btn.click()
+
+    # Wait for the PUT to complete and the button to become active before reloading
+    active_indicator = echo_row.locator(
+        f"{SEL['tool_permission_toggle']} button[data-state='ask_each_time'].active"
+    )
+    await active_indicator.wait_for(state="visible", timeout=5000)
+
+    # Reload the page and re-open the Tools tab
+    await page.reload()
+    await page.locator("#auth-screen").wait_for(state="hidden", timeout=15000)
+    await _open_tools_tab(page)
+
+    # After reload, echo row should reflect "Ask Each Time" as the active state
+    echo_row_reloaded = page.locator(f"{SEL['tool_permission_row']}[data-tool-name='echo']")
+    await echo_row_reloaded.wait_for(state="visible", timeout=5000)
+
+    active_btn = echo_row_reloaded.locator(
+        f"{SEL['tool_permission_toggle']} button[data-state='ask_each_time'][aria-pressed='true'],"
+        f"{SEL['tool_permission_toggle']} button[data-state='ask_each_time'].active"
+    )
+    await active_btn.wait_for(state="visible", timeout=5000)
+
+    # Also confirm via REST that the state actually persisted
+    async with httpx.AsyncClient() as client:
+        r2 = await client.get(
+            f"{ironclaw_server}/api/settings/tools",
+            headers=headers,
+            timeout=10,
+        )
+        assert r2.status_code == 200, r2.text
+        tools = r2.json()["tools"]
+        echo = next((t for t in tools if t["name"] == "echo"), None)
+        assert echo is not None, "echo tool not found in GET /api/settings/tools response"
+        assert echo["current_state"] == "ask_each_time", (
+            f"Expected ask_each_time, got {echo['current_state']!r}"
+        )
+
+    # Cleanup: restore echo to always_allow
+    async with httpx.AsyncClient() as client:
+        await client.put(
+            f"{ironclaw_server}/api/settings/tools/echo",
+            json={"state": "always_allow"},
+            headers=headers,
+            timeout=10,
+        )
+
+
+async def test_locked_tool_shows_lock_icon(page):
+    """tool_remove always returns ApprovalRequirement::Always — shows lock icon and no toggles."""
+    await _open_tools_tab(page)
+
+    locked_row = page.locator(f"{SEL['tool_permission_row']}[data-tool-name='tool_remove']")
+    await locked_row.wait_for(state="visible", timeout=5000)
+
+    # Lock icon must be visible
+    lock_icon = locked_row.locator(SEL["tool_lock_icon"])
+    await lock_icon.wait_for(state="visible", timeout=5000)
+
+    # Locked tools render NO toggle group at all (the toggle div is only
+    # created in the non-locked branch of renderToolPermissionRow).
+    toggle_group = locked_row.locator(SEL["tool_permission_toggle"])
+    count = await toggle_group.count()
+    assert count == 0, (
+        f"Expected no toggle group for locked tool tool_remove, found {count}"
+    )
+
+
+async def test_always_approve_persists_across_sessions(browser, ironclaw_server):
+    """PUT always_allow persists to DB; a fresh browser context confirms the state survives."""
+    headers = _headers()
+
+    # Set echo to always_allow via REST
+    async with httpx.AsyncClient() as client:
+        r = await client.put(
+            f"{ironclaw_server}/api/settings/tools/echo",
+            json={"state": "always_allow"},
+            headers=headers,
+            timeout=10,
+        )
+        assert r.status_code == 200, f"PUT failed: {r.text}"
+
+    # Create a fresh browser context (new session — no shared cookies/storage)
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    try:
+        pg = await context.new_page()
+        await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
+        await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+
+        # Verify via REST from the new session that the state persisted
+        async with httpx.AsyncClient() as client:
+            r2 = await client.get(
+                f"{ironclaw_server}/api/settings/tools",
+                headers=headers,
+                timeout=10,
+            )
+            assert r2.status_code == 200, r2.text
+            tools = r2.json()["tools"]
+            echo = next((t for t in tools if t["name"] == "echo"), None)
+            assert echo is not None, "echo tool not found in GET /api/settings/tools"
+            assert echo["current_state"] == "always_allow", (
+                f"Expected always_allow, got {echo['current_state']!r}"
+            )
+    finally:
+        await context.close()
+
+
+async def test_disabled_tool_state_is_persisted(ironclaw_server):
+    """PUT disabled for echo → GET confirms disabled state."""
+    headers = _headers()
+
+    async with httpx.AsyncClient() as client:
+        r = await client.put(
+            f"{ironclaw_server}/api/settings/tools/echo",
+            json={"state": "disabled"},
+            headers=headers,
+            timeout=10,
+        )
+        assert r.status_code == 200, f"PUT /api/settings/tools/echo failed: {r.text}"
+
+        r2 = await client.get(
+            f"{ironclaw_server}/api/settings/tools",
+            headers=headers,
+            timeout=10,
+        )
+        assert r2.status_code == 200, r2.text
+        tools = r2.json()["tools"]
+        echo = next((t for t in tools if t["name"] == "echo"), None)
+        assert echo is not None, "echo tool not found in GET /api/settings/tools"
+        assert echo["current_state"] == "disabled", (
+            f"Expected disabled, got {echo['current_state']!r}"
+        )
+
+    # Reset: restore to always_allow
+    async with httpx.AsyncClient() as client:
+        await client.put(
+            f"{ironclaw_server}/api/settings/tools/echo",
+            json={"state": "always_allow"},
+            headers=headers,
+            timeout=10,
+        )
+
+
+async def test_locked_tool_put_returns_400(ironclaw_server):
+    """PUT always_allow for tool_remove (locked) → 400."""
+    headers = _headers()
+
+    async with httpx.AsyncClient() as client:
+        r = await client.put(
+            f"{ironclaw_server}/api/settings/tools/tool_remove",
+            json={"state": "always_allow"},
+            headers=headers,
+            timeout=10,
+        )
+        assert r.status_code == 400, (
+            f"Expected 400 for locked tool tool_remove, got {r.status_code}: {r.text}"
+        )


### PR DESCRIPTION
## Summary

Adds a persistent, per-user tool permission system so that safe built-in tools (memory, time, json, etc.) run without approval prompts by default, while destructive tools (shell, file writes, secret management) still require explicit user confirmation. Users can manage tool states via the web settings UI, in-conversation via text-based approval, or through the LLM-callable `tool_permission_set` tool.

**Problem**: Today all tools use `ApprovalRequirement::UnlessAutoApproved` or `Always` hardcoded in Rust, and the "Always Approve" session state is in-memory only — cleared on every restart. Non-technical users are overwhelmed by repeated approval prompts for safe tools like `memory_search` or `time`.

**Solution**: Three-state permission model (`AlwaysAllow | AskEachTime | Disabled`) with tiered defaults, backed by per-user DB settings.

## Architecture

### Permission Model

```
PermissionState::AlwaysAllow   → executes without prompting
PermissionState::AskEachTime   → existing approval card/text flow
PermissionState::Disabled      → excluded from tool_definitions; LLM never sees it
```

### Precedence (highest → lowest)
1. `ApprovalRequirement::Always` on the Tool trait → **hard floor, unoverrideable** — always prompts regardless of user setting
2. `PermissionState::Disabled` → excluded from tool_definitions
3. `PermissionState::AlwaysAllow` + trait is NOT `Always` → auto-executes
4. `PermissionState::AskEachTime` → existing approval flow

### Persistence
- **DB = source of truth** (per-user via `TenantScope`). Works for both single-tenant and multi-tenant deployments.
- **Settings struct = in-memory cache** loaded from DB via `get_all_settings()` + `Settings::from_db_map()`
- **`TOOL_RISK_DEFAULTS`** static map seeds the DB at startup for the owner — other users get tier defaults at runtime via `effective_permission()` fallback (no explicit DB rows needed)

### Tier Defaults

| Always Allow (safe, read/create) | Ask Each Time (destructive, install, execute, network) |
|---|---|
| echo, time, json | shell, read_file, write_file, list_dir, apply_patch |
| memory_search/read/write/tree | cancel_job, job_prompt |
| tool_list, tool_info, tool_search | routine_delete, routine_fire |
| skill_list, skill_search | tool_install/auth/activate/remove/upgrade |
| list_jobs, job_status, job_events | skill_install, skill_remove |
| image_analyze | secret_list, secret_delete |
| message | image_generate, image_edit |
 | restart, build_software, tool_permission_set |

## Changes

### New files
- **`src/tools/permissions.rs`** — `PermissionState` enum, `TOOL_RISK_DEFAULTS` static map, `effective_permission()` resolution function
- **`tests/e2e/scenarios/test_tool_permissions.py`** — 6 Playwright E2E test scenarios

### Modified files
- **`src/settings.rs`** — Added `tool_permissions: HashMap<String, PermissionState>` field with `#[serde(default)]`
- **`src/app.rs`** — `seed_tool_permissions()` writes tier defaults to DB at startup; `register_permission_tools()` + `upgrade_tool_list()` wire new tools
- **`src/agent/dispatcher.rs`** — `before_llm_call()`: loads tool_permissions from per-user DB, filters `Disabled` tools from LLM context, batch-approves `AlwaysAllow` tools in session (single lock acquisition)
- **`src/agent/thread_ops.rs`** — `process_approval()`: when user clicks "Always Approve" (web) or types "always" (text), persists `AlwaysAllow` to per-user DB settings
- **`src/tools/builtin/extension_tools.rs`** — New `tool_permission_set` tool (always requires `ApprovalRequirement::Always`); extended `tool_list` with `kind="builtin"` filter and permission state fields
- **`src/tools/registry.rs`** — Registration for `tool_permission_set`, protected name
- **`src/channels/web/handlers/settings.rs`** — `GET /api/settings/tools` and `PUT /api/settings/tools/:name` endpoints (DB-backed, per-user scoped)
- **`src/channels/web/server.rs`** — Route wiring for new endpoints
- **`src/channels/web/static/app.js`** — Tools settings tab with 3-way toggle, lock icons for hard-floor tools
- **`src/channels/web/static/style.css`** — Styles for tool permission rows, toggles, lock icons, default badges
- **`src/channels/web/static/index.html`** — Tools tab button in settings sidebar
- **`src/channels/web/static/i18n/en.js`** — i18n strings for permission states and UI labels
- **`src/channels/web/types.rs`** — `ToolPermissionEntry`, `ToolPermissionsResponse`, `UpdateToolPermissionRequest` DTOs
- **`tests/e2e/helpers.py`** — New selectors for Tools tab UI elements

## Security

- `ApprovalRequirement::Always` on the Tool trait is an **unbypassable hard floor** — even if a user sets a tool to `AlwaysAllow`, if the tool returns `Always` from `requires_approval()`, it still prompts. The existing approval gate enforces this independently of session auto-approve state.
- `tool_permission_set` itself returns `ApprovalRequirement::Always` — the LLM can never silently change permissions; every proposed change shows an approval card/text prompt requiring explicit user confirmation.
- Locked tools (those returning `ApprovalRequirement::Always`) cannot have their permission changed via either the web UI (returns 400) or the LLM tool (returns error).
- All DB operations are scoped to the authenticated `user_id` via `TenantScope` — one user's permission changes cannot affect another user in multi-tenant deployments.
- Note: `TenantScope.get_all_settings()` and `TenantScope.set_setting()` automatically bind `user_id` internally — callers do not pass `user_id` separately.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test` — 4,148+ tests pass, 0 failures
- [ ] `pytest tests/e2e/scenarios/test_tool_permissions.py` — 6 E2E scenarios (requires running server)
- [ ] Manual: web UI toggle persists across page reload
- [ ] Manual: Telegram "always" response persists across agent restart
- [ ] Manual: `tool_permission_set` via LLM shows approval card, persists on approve

Supersedes #1908 (closed — had merge commits inflating diff to 105 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)