### PR TITLE
fix:ignore default model override and empty WASM polls

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -22,6 +22,10 @@ use crate::agent::agentic_loop::{
 use crate::llm::{ChatMessage, Reasoning, ReasoningContext};
 use crate::tools::redact_params;
 
+fn selected_model_override(value: &serde_json::Value) -> Option<String> {
+    crate::llm::normalized_model_override(value.as_str()).map(str::to_string)
+}
+
 /// Result of the agentic loop execution.
 pub(super) enum AgenticLoopResult {
     /// Completed with a response.
@@ -362,12 +366,9 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
         if iteration == 0
             && let Some(store) = self.tenant.store()
             && let Ok(Some(value)) = store.get_setting("selected_model").await
-            && let Some(model) = value.as_str()
+            && let Some(model) = selected_model_override(&value)
         {
-            let model = model.trim();
-            if !model.is_empty() {
-                reason_ctx.model_override = Some(model.to_string());
-            }
+            reason_ctx.model_override = Some(model);
         }
 
         let output = match reasoning.respond_with_tools(reason_ctx).await {
@@ -1306,7 +1307,7 @@ mod tests {
     use crate::safety::SafetyLayer;
     use crate::tools::ToolRegistry;
 
-    use super::check_auth_required;
+    use super::{check_auth_required, selected_model_override};
 
     /// Minimal LLM provider for unit tests that always returns a static response.
     struct StaticLlmProvider;
@@ -2168,6 +2169,20 @@ mod tests {
                 "ceiling logic inconsistent for max_iter={max_iter}"
             );
         }
+    }
+
+    #[test]
+    fn selected_model_override_ignores_default_sentinel() {
+        assert_eq!(selected_model_override(&serde_json::json!("default")), None);
+        assert_eq!(
+            selected_model_override(&serde_json::json!("  DEFAULT  ")),
+            None
+        );
+        assert_eq!(selected_model_override(&serde_json::json!("  ")), None);
+        assert_eq!(
+            selected_model_override(&serde_json::json!("claude-opus-4-6")).as_deref(),
+            Some("claude-opus-4-6")
+        );
     }
 
     /// LLM provider that always returns calls to a nonexistent tool, regardless

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -2812,6 +2812,15 @@ impl WasmChannel {
                 .await;
             }
 
+            if emitted.content.trim().is_empty() && emitted.attachments.is_empty() {
+                tracing::debug!(
+                    channel = %dispatch.channel_name,
+                    user_id = %emitted.user_id,
+                    "Skipping empty emitted message"
+                );
+                continue;
+            }
+
             // Send to stream — no locks held across this await
             tracing::info!(
                 channel = %dispatch.channel_name,
@@ -4602,6 +4611,50 @@ mod tests {
         assert_eq!(msg2.content, "Another message"); // safety: test-only assertion
 
         // No more messages
+        assert!(rx.try_recv().is_err()); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_emitted_messages_skips_empty_messages_without_attachments() {
+        use crate::channels::wasm::host::EmittedMessage;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        let message_tx = Arc::new(tokio::sync::RwLock::new(Some(tx)));
+
+        let rate_limiter = Arc::new(tokio::sync::RwLock::new(
+            crate::channels::wasm::host::ChannelEmitRateLimiter::new(
+                crate::channels::wasm::capabilities::EmitRateLimitConfig::default(),
+            ),
+        ));
+
+        let messages = vec![
+            EmittedMessage::new("user1", ""),
+            EmittedMessage::new("user2", "   "),
+            EmittedMessage::new("user3", "real message"),
+        ];
+
+        let last_broadcast_metadata = Arc::new(tokio::sync::RwLock::new(None));
+        let result = WasmChannel::dispatch_emitted_messages(
+            EmitDispatchContext {
+                channel_name: "test-channel",
+                owner_scope_id: "default",
+                owner_actor_id: None,
+                message_tx: &message_tx,
+                rate_limiter: &rate_limiter,
+                last_broadcast_metadata: &last_broadcast_metadata,
+                settings_store: None,
+            },
+            messages,
+        )
+        .await;
+
+        assert!(result.is_ok()); // safety: test-only assertion
+
+        let msg = rx
+            .try_recv()
+            .expect("Should receive only the non-empty message");
+        assert_eq!(msg.user_id, "user3"); // safety: test-only assertion
+        assert_eq!(msg.content, "real message"); // safety: test-only assertion
         assert!(rx.try_recv().is_err()); // safety: test-only assertion
     }
 

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -11,6 +11,11 @@ use crate::llm::session::SessionConfig;
 use crate::settings::Settings;
 
 impl LlmConfig {
+    fn selected_model_override(settings: &Settings) -> Option<String> {
+        crate::llm::normalized_model_override(settings.selected_model.as_deref())
+            .map(str::to_string)
+    }
+
     /// Create a test-friendly config without reading env vars.
     #[cfg(feature = "libsql")]
     pub fn for_testing() -> Self {
@@ -52,7 +57,7 @@ impl LlmConfig {
         settings: &Settings,
         default: &str,
     ) -> Result<String, ConfigError> {
-        if let Some(model) = settings.selected_model.clone() {
+        if let Some(model) = Self::selected_model_override(settings) {
             Ok(model)
         } else if let Some(model) = optional_env(env_var)? {
             Ok(model)
@@ -142,7 +147,7 @@ impl LlmConfig {
             optional_env("NEARAI_API_KEY")?.map(SecretString::from)
         };
         // Model priority: selected_model (DB) > builtin_overrides (DB) > env > default
-        let nearai_model = if let Some(model) = settings.selected_model.clone() {
+        let nearai_model = if let Some(model) = Self::selected_model_override(settings) {
             model
         } else if let Some(model) = nearai_override.and_then(|o| o.model.clone()) {
             model
@@ -206,9 +211,7 @@ impl LlmConfig {
                 tracing::info!("BEDROCK_REGION not set, defaulting to us-east-1");
             }
             let region = explicit_region.unwrap_or_else(|| "us-east-1".to_string());
-            let model = settings
-                .selected_model
-                .clone()
+            let model = Self::selected_model_override(settings)
                 .or(optional_env("BEDROCK_MODEL")?)
                 .ok_or_else(|| ConfigError::MissingRequired {
                     key: "BEDROCK_MODEL".to_string(),
@@ -247,9 +250,7 @@ impl LlmConfig {
         // Resolve OpenAI Codex config
         let openai_codex = if is_openai_codex {
             // Model: settings.selected_model > OPENAI_CODEX_MODEL > OPENAI_MODEL > default
-            let model = settings
-                .selected_model
-                .clone()
+            let model = Self::selected_model_override(settings)
                 .or(optional_env("OPENAI_CODEX_MODEL")?)
                 .or(optional_env("OPENAI_MODEL")?)
                 .unwrap_or_else(|| "gpt-5.3-codex".to_string());
@@ -360,9 +361,7 @@ impl LlmConfig {
             )?;
         }
 
-        let model = settings
-            .selected_model
-            .clone()
+        let model = Self::selected_model_override(settings)
             .or(optional_env("LLM_MODEL")?)
             .or_else(|| custom.default_model.clone())
             .unwrap_or_default();
@@ -534,9 +533,7 @@ impl LlmConfig {
         }
 
         // Resolve model: selected_model (DB) > per-provider override (DB) > env var > registry default
-        let model = settings
-            .selected_model
-            .clone()
+        let model = Self::selected_model_override(settings)
             .or_else(|| {
                 settings
                     .llm_builtin_overrides
@@ -2153,6 +2150,40 @@ mod tests {
         // SAFETY: Under ENV_MUTEX.
         unsafe {
             std::env::remove_var("GROQ_BASE_URL");
+        }
+    }
+
+    #[test]
+    fn selected_model_override_ignores_default_sentinel() {
+        let settings = Settings {
+            selected_model: Some(" default ".to_string()),
+            ..Default::default()
+        };
+
+        assert_eq!(LlmConfig::selected_model_override(&settings), None);
+    }
+
+    #[test]
+    fn nearai_resolve_ignores_default_selected_model() {
+        let _guard = lock_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::set_var("NEARAI_MODEL", "env-model");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("nearai".to_string()),
+            selected_model: Some("default".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        assert_eq!(cfg.nearai.model, "env-model");
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("NEARAI_MODEL");
         }
     }
 }

--- a/src/llm/anthropic_oauth.rs
+++ b/src/llm/anthropic_oauth.rs
@@ -241,7 +241,9 @@ impl AnthropicOAuthProvider {
 #[async_trait]
 impl LlmProvider for AnthropicOAuthProvider {
     async fn complete(&self, mut req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let model = req.model.take().unwrap_or_else(|| self.active_model_name());
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_completion_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 
@@ -279,7 +281,9 @@ impl LlmProvider for AnthropicOAuthProvider {
         &self,
         mut req: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
-        let model = req.model.take().unwrap_or_else(|| self.active_model_name());
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_tool_params(&mut req);
         let (system, messages) = convert_messages(req.messages);
 

--- a/src/llm/github_copilot.rs
+++ b/src/llm/github_copilot.rs
@@ -211,7 +211,9 @@ impl GithubCopilotProvider {
 #[async_trait]
 impl LlmProvider for GithubCopilotProvider {
     async fn complete(&self, mut req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let model = req.model.take().unwrap_or_else(|| self.active_model_name());
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_completion_params(&mut req);
         let messages = convert_messages(req.messages);
 
@@ -267,7 +269,9 @@ impl LlmProvider for GithubCopilotProvider {
         &self,
         mut req: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
-        let model = req.model.take().unwrap_or_else(|| self.active_model_name());
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         self.strip_unsupported_tool_params(&mut req);
         let messages = convert_messages(req.messages);
 

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -59,7 +59,7 @@ pub use openai_codex_session::{OpenAiCodexSession, OpenAiCodexSessionManager};
 pub use provider::{
     ChatMessage, CompletionRequest, CompletionResponse, ContentPart, FinishReason, ImageUrl,
     LlmProvider, ModelMetadata, Role, ToolCall, ToolCompletionRequest, ToolCompletionResponse,
-    ToolDefinition, ToolResult, generate_tool_call_id,
+    ToolDefinition, ToolResult, generate_tool_call_id, normalized_model_override,
 };
 pub use reasoning::{
     ActionPlan, Reasoning, ReasoningContext, RespondOutput, RespondResult, ResponseAnomaly,

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -459,8 +459,10 @@ impl NearAiChatProvider {
 
 #[async_trait]
 impl LlmProvider for NearAiChatProvider {
-    async fn complete(&self, req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
-        let model = req.model.unwrap_or_else(|| self.active_model_name());
+    async fn complete(&self, mut req: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         let mut raw_messages = req.messages;
         crate::llm::provider::sanitize_tool_messages(&mut raw_messages);
         let raw: Vec<ChatCompletionMessage> = raw_messages.into_iter().map(|m| m.into()).collect();
@@ -523,9 +525,11 @@ impl LlmProvider for NearAiChatProvider {
 
     async fn complete_with_tools(
         &self,
-        req: ToolCompletionRequest,
+        mut req: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
-        let model = req.model.unwrap_or_else(|| self.active_model_name());
+        let model = req
+            .take_model_override()
+            .unwrap_or_else(|| self.active_model_name());
         let mut raw_messages = req.messages;
         crate::llm::provider::sanitize_tool_messages(&mut raw_messages);
         let messages: Vec<ChatCompletionMessage> =

--- a/src/llm/provider.rs
+++ b/src/llm/provider.rs
@@ -190,6 +190,13 @@ impl CompletionRequest {
         self.temperature = Some(temperature);
         self
     }
+
+    /// Take the per-request model override, normalizing sentinel values like
+    /// `"default"` and blank strings to `None`.
+    pub fn take_model_override(&mut self) -> Option<String> {
+        let model = self.model.take();
+        normalized_model_override(model.as_deref()).map(str::to_string)
+    }
 }
 
 /// Response from a chat completion.
@@ -332,6 +339,24 @@ impl ToolCompletionRequest {
         self.tool_choice = Some(choice.into());
         self
     }
+
+    /// Take the per-request model override, normalizing sentinel values like
+    /// `"default"` and blank strings to `None`.
+    pub fn take_model_override(&mut self) -> Option<String> {
+        let model = self.model.take();
+        normalized_model_override(model.as_deref()).map(str::to_string)
+    }
+}
+
+/// Normalize a requested model override.
+///
+/// `"default"` is treated as a sentinel meaning "use the provider's active
+/// model", matching the gateway APIs and protecting providers like Anthropic
+/// that reject the literal string as an unknown model ID.
+pub fn normalized_model_override(model: Option<&str>) -> Option<&str> {
+    model
+        .map(str::trim)
+        .filter(|model| !model.is_empty() && !model.eq_ignore_ascii_case("default"))
 }
 
 /// Response from a completion with potential tool calls.
@@ -396,7 +421,7 @@ pub trait LlmProvider: Send + Sync {
     /// Providers that ignore per-request model overrides should override this
     /// and return `active_model_name()`.
     fn effective_model_name(&self, requested_model: Option<&str>) -> String {
-        requested_model
+        normalized_model_override(requested_model)
             .map(std::borrow::ToOwned::to_owned)
             .unwrap_or_else(|| self.active_model_name())
     }
@@ -438,6 +463,95 @@ pub trait LlmProvider: Send + Sync {
     /// OpenAI would return `2` (50% off).
     fn cache_read_discount(&self) -> Decimal {
         Decimal::ONE
+    }
+}
+
+#[cfg(test)]
+mod model_override_tests {
+    use async_trait::async_trait;
+    use rust_decimal::Decimal;
+
+    use super::*;
+    use crate::llm::error::LlmError;
+
+    struct StubProvider;
+
+    #[async_trait]
+    impl LlmProvider for StubProvider {
+        fn model_name(&self) -> &str {
+            "stub-model"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _request: CompletionRequest,
+        ) -> Result<CompletionResponse, LlmError> {
+            unreachable!("test-only stub")
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _request: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            unreachable!("test-only stub")
+        }
+    }
+
+    #[test]
+    fn effective_model_name_treats_default_as_no_override() {
+        let provider = StubProvider;
+        assert_eq!(provider.effective_model_name(Some("default")), "stub-model");
+        assert_eq!(
+            provider.effective_model_name(Some("  DEFAULT  ")),
+            "stub-model"
+        );
+    }
+
+    #[test]
+    fn completion_request_take_model_override_ignores_default_and_blank() {
+        let mut blank = CompletionRequest::new(vec![ChatMessage::user("hi")]).with_model("   ");
+        assert_eq!(blank.take_model_override(), None);
+
+        let mut default =
+            CompletionRequest::new(vec![ChatMessage::user("hi")]).with_model(" default ");
+        assert_eq!(default.take_model_override(), None);
+
+        let mut real =
+            CompletionRequest::new(vec![ChatMessage::user("hi")]).with_model("claude-opus-4-6");
+        assert_eq!(
+            real.take_model_override().as_deref(),
+            Some("claude-opus-4-6")
+        );
+    }
+
+    #[test]
+    fn tool_completion_request_take_model_override_ignores_default_and_blank() {
+        let tools = vec![ToolDefinition {
+            name: "echo".to_string(),
+            description: "Echo input".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "message": { "type": "string" }
+                }
+            }),
+        }];
+
+        let mut blank = ToolCompletionRequest::new(vec![ChatMessage::user("hi")], tools.clone())
+            .with_model("   ");
+        assert_eq!(blank.take_model_override(), None);
+
+        let mut default = ToolCompletionRequest::new(vec![ChatMessage::user("hi")], tools.clone())
+            .with_model("default");
+        assert_eq!(default.take_model_override(), None);
+
+        let mut real =
+            ToolCompletionRequest::new(vec![ChatMessage::user("hi")], tools).with_model("qwen3");
+        assert_eq!(real.take_model_override().as_deref(), Some("qwen3"));
     }
 }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -669,7 +669,7 @@ where
         &self,
         mut request: CompletionRequest,
     ) -> Result<CompletionResponse, LlmError> {
-        let model_override = request.model.take();
+        let model_override = request.take_model_override();
 
         self.strip_unsupported_completion_params(&mut request);
 
@@ -726,7 +726,7 @@ where
         &self,
         mut request: ToolCompletionRequest,
     ) -> Result<ToolCompletionResponse, LlmError> {
-        let model_override = request.model.take();
+        let model_override = request.take_model_override();
 
         self.strip_unsupported_tool_params(&mut request);
 


### PR DESCRIPTION
## Summary
- drop empty emitted WASM messages with no attachments before they enter the agent loop
- treat blank and "default" selected-model overrides as no override throughout dispatcher, config, and provider resolution
- normalize provider call sites and add regression tests for both paths

## Testing
- cargo test --lib llm::provider::model_override_tests::
- cargo test --lib config::llm::tests::selected_model_override_ignores_default_sentinel -- --exact
- cargo test --lib config::llm::tests::nearai_resolve_ignores_default_selected_model -- --exact
- cargo test --lib agent::dispatcher::tests::selected_model_override_ignores_default_sentinel -- --exact
- cargo test --lib channels::wasm::wrapper::tests::test_dispatch_emitted_messages_skips_empty_messages_without_attachments -- --exact
- cargo fmt --all

Fixes #1811