### PR TITLE
feat: admin management panel — web UI for users and usage monitoring

### DIFF
--- a/src/channels/web/handlers/users.rs
+++ b/src/channels/web/handlers/users.rs
@@ -532,3 +532,65 @@ pub async fn usage_stats_handler(
         "usage": entries,
     })))
 }
+
+/// System-wide usage summary for the admin dashboard.
+pub async fn usage_summary_handler(
+    State(state): State<Arc<GatewayState>>,
+    AdminUser(_user): AdminUser,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+
+    let users = store
+        .list_users(None)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let total = users.len();
+    let active = users.iter().filter(|u| u.status == "active").count();
+    let suspended = users.iter().filter(|u| u.status == "suspended").count();
+    let admins = users.iter().filter(|u| u.role == "admin").count();
+
+    let summary_stats = store
+        .user_summary_stats(None)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let total_jobs: i64 = summary_stats.iter().map(|s| s.job_count).sum();
+    let total_cost: rust_decimal::Decimal = summary_stats.iter().map(|s| s.total_cost).sum();
+
+    let since_30d = chrono::Utc::now() - chrono::Duration::days(30);
+    let usage_stats = store
+        .user_usage_stats(None, since_30d)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let llm_calls: i64 = usage_stats.iter().map(|s| s.call_count).sum();
+    let input_tokens: i64 = usage_stats.iter().map(|s| s.input_tokens).sum();
+    let output_tokens: i64 = usage_stats.iter().map(|s| s.output_tokens).sum();
+    let usage_cost: rust_decimal::Decimal = usage_stats.iter().map(|s| s.total_cost).sum();
+
+    let uptime_seconds = state.startup_time.elapsed().as_secs();
+
+    Ok(Json(serde_json::json!({
+        "users": {
+            "total": total,
+            "active": active,
+            "suspended": suspended,
+            "admins": admins,
+        },
+        "jobs": {
+            "total": total_jobs,
+            "total_cost": total_cost.to_string(),
+        },
+        "usage_30d": {
+            "llm_calls": llm_calls,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_cost": usage_cost.to_string(),
+        },
+        "uptime_seconds": uptime_seconds,
+    })))
+}

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -31,7 +31,7 @@ use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::IncomingMessage;
 use crate::channels::relay::DEFAULT_RELAY_NAME;
 use crate::channels::web::auth::{
-    AdminUser, AuthenticatedUser, CombinedAuthState, UserIdentity, auth_middleware,
+    AuthenticatedUser, CombinedAuthState, UserIdentity, auth_middleware,
 };
 use crate::channels::web::handlers::jobs::{
     job_files_list_handler, job_files_read_handler, jobs_cancel_handler, jobs_detail_handler,
@@ -578,7 +578,10 @@ pub async fn start_server(
             "/api/admin/usage",
             get(super::handlers::users::usage_stats_handler),
         )
-        .route("/api/admin/usage/summary", get(usage_summary_handler))
+        .route(
+            "/api/admin/usage/summary",
+            get(super::handlers::users::usage_summary_handler),
+        )
         // User self-service profile
         .route(
             "/api/profile",
@@ -868,69 +871,6 @@ async fn admin_js_handler() -> impl IntoResponse {
         ],
         include_str!("static/admin.js"),
     )
-}
-
-// --- Admin usage summary ---
-
-async fn usage_summary_handler(
-    State(state): State<Arc<GatewayState>>,
-    AdminUser(_user): AdminUser,
-) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
-    let store = state.store.as_ref().ok_or((
-        StatusCode::SERVICE_UNAVAILABLE,
-        "Database not available".to_string(),
-    ))?;
-
-    let users = store
-        .list_users(None)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    let total = users.len();
-    let active = users.iter().filter(|u| u.status == "active").count();
-    let suspended = users.iter().filter(|u| u.status == "suspended").count();
-    let admins = users.iter().filter(|u| u.role == "admin").count();
-
-    let summary_stats = store
-        .user_summary_stats(None)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    let total_jobs: i64 = summary_stats.iter().map(|s| s.job_count).sum();
-    let total_cost: rust_decimal::Decimal = summary_stats.iter().map(|s| s.total_cost).sum();
-
-    let since_30d = chrono::Utc::now() - chrono::Duration::days(30);
-    let usage_stats = store
-        .user_usage_stats(None, since_30d)
-        .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-    let llm_calls: i64 = usage_stats.iter().map(|s| s.call_count).sum();
-    let input_tokens: i64 = usage_stats.iter().map(|s| s.input_tokens).sum();
-    let output_tokens: i64 = usage_stats.iter().map(|s| s.output_tokens).sum();
-    let usage_cost: rust_decimal::Decimal = usage_stats.iter().map(|s| s.total_cost).sum();
-
-    let uptime_seconds = state.startup_time.elapsed().as_secs();
-
-    Ok(Json(serde_json::json!({
-        "users": {
-            "total": total,
-            "active": active,
-            "suspended": suspended,
-            "admins": admins,
-        },
-        "jobs": {
-            "total": total_jobs,
-            "total_cost": total_cost.to_string(),
-        },
-        "usage_30d": {
-            "llm_calls": llm_calls,
-            "input_tokens": input_tokens,
-            "output_tokens": output_tokens,
-            "total_cost": usage_cost.to_string(),
-        },
-        "uptime_seconds": uptime_seconds,
-    })))
 }
 
 // --- Health ---

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -31,7 +31,7 @@ use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::IncomingMessage;
 use crate::channels::relay::DEFAULT_RELAY_NAME;
 use crate::channels::web::auth::{
-    AuthenticatedUser, CombinedAuthState, UserIdentity, auth_middleware,
+    AdminUser, AuthenticatedUser, CombinedAuthState, UserIdentity, auth_middleware,
 };
 use crate::channels::web::handlers::jobs::{
     job_files_list_handler, job_files_read_handler, jobs_cancel_handler, jobs_detail_handler,
@@ -578,6 +578,7 @@ pub async fn start_server(
             "/api/admin/usage",
             get(super::handlers::users::usage_stats_handler),
         )
+        .route("/api/admin/usage/summary", get(usage_summary_handler))
         // User self-service profile
         .route(
             "/api/profile",
@@ -626,7 +627,13 @@ pub async fn start_server(
         .route("/i18n/index.js", get(i18n_index_handler))
         .route("/i18n/en.js", get(i18n_en_handler))
         .route("/i18n/zh-CN.js", get(i18n_zh_handler))
-        .route("/i18n-app.js", get(i18n_app_handler));
+        .route("/i18n-app.js", get(i18n_app_handler))
+        // Admin panel SPA (auth handled client-side + API layer)
+        .route("/admin", get(admin_html_handler))
+        .route("/admin/", get(admin_html_handler))
+        .route("/admin/{*path}", get(admin_html_handler))
+        .route("/admin.css", get(admin_css_handler))
+        .route("/admin.js", get(admin_js_handler));
 
     // Project file serving (behind auth to prevent unauthorized file access).
     let projects = Router::new()
@@ -829,6 +836,101 @@ async fn i18n_app_handler() -> impl IntoResponse {
         ],
         include_str!("static/i18n-app.js"),
     )
+}
+
+// --- Admin panel static handlers ---
+
+async fn admin_html_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/html; charset=utf-8"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        include_str!("static/admin.html"),
+    )
+}
+
+async fn admin_css_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "text/css"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        include_str!("static/admin.css"),
+    )
+}
+
+async fn admin_js_handler() -> impl IntoResponse {
+    (
+        [
+            (header::CONTENT_TYPE, "application/javascript"),
+            (header::CACHE_CONTROL, "no-cache"),
+        ],
+        include_str!("static/admin.js"),
+    )
+}
+
+// --- Admin usage summary ---
+
+async fn usage_summary_handler(
+    State(state): State<Arc<GatewayState>>,
+    AdminUser(_user): AdminUser,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    let store = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+
+    let users = store
+        .list_users(None)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let total = users.len();
+    let active = users.iter().filter(|u| u.status == "active").count();
+    let suspended = users.iter().filter(|u| u.status == "suspended").count();
+    let admins = users.iter().filter(|u| u.role == "admin").count();
+
+    let summary_stats = store
+        .user_summary_stats(None)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let total_jobs: i64 = summary_stats.iter().map(|s| s.job_count).sum();
+    let total_cost: rust_decimal::Decimal = summary_stats.iter().map(|s| s.total_cost).sum();
+
+    let since_30d = chrono::Utc::now() - chrono::Duration::days(30);
+    let usage_stats = store
+        .user_usage_stats(None, since_30d)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let llm_calls: i64 = usage_stats.iter().map(|s| s.call_count).sum();
+    let input_tokens: i64 = usage_stats.iter().map(|s| s.input_tokens).sum();
+    let output_tokens: i64 = usage_stats.iter().map(|s| s.output_tokens).sum();
+    let usage_cost: rust_decimal::Decimal = usage_stats.iter().map(|s| s.total_cost).sum();
+
+    let uptime_seconds = state.startup_time.elapsed().as_secs();
+
+    Ok(Json(serde_json::json!({
+        "users": {
+            "total": total,
+            "active": active,
+            "suspended": suspended,
+            "admins": admins,
+        },
+        "jobs": {
+            "total": total_jobs,
+            "total_cost": total_cost.to_string(),
+        },
+        "usage_30d": {
+            "llm_calls": llm_calls,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_cost": usage_cost.to_string(),
+        },
+        "uptime_seconds": uptime_seconds,
+    })))
 }
 
 // --- Health ---

--- a/src/channels/web/static/admin.css
+++ b/src/channels/web/static/admin.css
@@ -1,6 +1,7 @@
 /* IronClaw Admin Panel */
 
 /* === Theme Variables (dark - default) === */
+/* NOTE: Variables copied from style.css — keep in sync when the main theme changes */
 :root {
   --bg: #09090b;
   --bg-secondary: #0f0f11;

--- a/src/channels/web/static/admin.css
+++ b/src/channels/web/static/admin.css
@@ -1,0 +1,828 @@
+/* IronClaw Admin Panel */
+
+/* === Theme Variables (dark - default) === */
+:root {
+  --bg: #09090b;
+  --bg-secondary: #0f0f11;
+  --bg-tertiary: #1a1a1e;
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #fafafa;
+  --text-secondary: #a1a1aa;
+  --text-tertiary: #e0e0e0;
+  --text-muted: #888;
+  --text-dimmed: #666;
+  --text-on-accent: #09090b;
+  --accent: #34d399;
+  --accent-hover: #2fc48d;
+  --accent-subtle: rgba(52, 211, 153, 0.15);
+  --accent-border-subtle: rgba(52, 211, 153, 0.3);
+  --success: #34d399;
+  --warning: #F5A623;
+  --danger: #E64C4C;
+  --danger-subtle: rgba(230, 76, 76, 0.15);
+  --danger-border-subtle: rgba(230, 76, 76, 0.3);
+  --hover-surface: rgba(255, 255, 255, 0.03);
+  --hover-subtle: rgba(255, 255, 255, 0.06);
+  --focus-ring: rgba(52, 211, 153, 0.1);
+  --radius: 8px;
+  --radius-lg: 12px;
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.4);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.3), 0 1px 3px rgba(0,0,0,0.15);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.4), 0 2px 4px rgba(0,0,0,0.2);
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.4);
+  --font-mono: 'IBM Plex Mono', 'SF Mono', 'Fira Code', Consolas, monospace;
+  --border-soft: #2a2a2a;
+  --bg-overlay: rgba(0, 0, 0, 0.5);
+  --text-on-danger: #fff;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --text-xs: 11px;
+  --text-sm: 13px;
+  --text-base: 14px;
+  --text-lg: 16px;
+  --text-xl: 20px;
+  --text-2xl: 24px;
+}
+
+/* === Theme Variables (light) === */
+[data-theme="light"] {
+  --bg: #ffffff;
+  --bg-secondary: #f5f5f7;
+  --bg-tertiary: #ebebed;
+  --border: rgba(0, 0, 0, 0.1);
+  --text: #1a1a2e;
+  --text-secondary: #555555;
+  --text-tertiary: #333333;
+  --text-muted: #777777;
+  --text-dimmed: #999999;
+  --text-on-accent: #ffffff;
+  --accent: #059669;
+  --accent-hover: #047857;
+  --accent-subtle: rgba(5, 150, 105, 0.1);
+  --accent-border-subtle: rgba(5, 150, 105, 0.3);
+  --success: #059669;
+  --warning: #d97706;
+  --danger: #dc2626;
+  --danger-subtle: rgba(220, 38, 38, 0.1);
+  --danger-border-subtle: rgba(220, 38, 38, 0.2);
+  --hover-surface: rgba(0, 0, 0, 0.03);
+  --hover-subtle: rgba(0, 0, 0, 0.04);
+  --focus-ring: rgba(5, 150, 105, 0.15);
+  --shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.06), 0 1px 3px rgba(0,0,0,0.04);
+  --shadow-md: 0 4px 12px rgba(0,0,0,0.08), 0 2px 4px rgba(0,0,0,0.04);
+  --shadow-card: 0 4px 24px rgba(0, 0, 0, 0.08);
+  --border-soft: #e5e5e5;
+  --bg-overlay: rgba(0, 0, 0, 0.3);
+  --text-on-danger: #fff;
+}
+
+/* === Base Reset === */
+*, *::before, *::after {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: 'DM Sans', -apple-system, BlinkMacSystemFont, sans-serif;
+  font-size: var(--text-base);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.5;
+  min-height: 100vh;
+}
+
+/* === Auth Screen === */
+#auth-screen, #access-denied {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: var(--space-4);
+}
+
+.auth-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-8);
+  width: 100%;
+  max-width: 380px;
+  box-shadow: var(--shadow-card);
+}
+
+.auth-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--text-xl);
+  font-weight: 600;
+  margin-bottom: var(--space-6);
+  color: var(--text);
+}
+
+.auth-badge, .sidebar-badge {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  background: var(--accent-subtle);
+  color: var(--accent);
+  padding: 2px 8px;
+  border-radius: 9999px;
+  vertical-align: middle;
+}
+
+.auth-error {
+  background: var(--danger-subtle);
+  border: 1px solid var(--danger-border-subtle);
+  color: var(--danger);
+  padding: var(--space-3);
+  border-radius: var(--radius);
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-4);
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.auth-form input {
+  padding: 10px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: var(--text-base);
+  font-family: var(--font-mono);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.auth-form input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+/* === Buttons === */
+.btn-primary {
+  background: var(--accent);
+  color: var(--text-on-accent);
+  border: none;
+  padding: 10px 20px;
+  border-radius: var(--radius);
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.btn-primary:hover { opacity: 0.9; }
+.btn-primary:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 10px 20px;
+  border-radius: var(--radius);
+  font-size: var(--text-base);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.btn-secondary:hover { background: var(--hover-subtle); }
+
+.btn-small {
+  padding: 4px 10px;
+  font-size: var(--text-xs);
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-secondary);
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.2s;
+  white-space: nowrap;
+}
+
+.btn-small:hover { background: var(--bg-tertiary); }
+
+.btn-danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
+.btn-danger:hover {
+  background: var(--danger);
+  color: var(--text-on-danger);
+}
+
+/* === App Layout === */
+#app {
+  display: flex;
+  min-height: 100vh;
+}
+
+/* === Sidebar === */
+#sidebar {
+  width: 220px;
+  min-width: 220px;
+  background: var(--bg-secondary);
+  border-right: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+}
+
+.sidebar-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-4);
+  font-size: var(--text-lg);
+  font-weight: 600;
+  border-bottom: 1px solid var(--border);
+  color: var(--text);
+}
+
+.sidebar-nav {
+  flex: 1;
+  padding: var(--space-2) 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px var(--space-4);
+  color: var(--text-secondary);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 500;
+  transition: color 0.2s, background 0.2s;
+  border: none;
+  background: none;
+  cursor: pointer;
+  width: 100%;
+  text-align: left;
+  font-family: inherit;
+}
+
+.nav-link:hover {
+  color: var(--text);
+  background: var(--hover-surface);
+}
+
+.nav-link.active {
+  color: var(--accent);
+  background: var(--accent-subtle);
+}
+
+.nav-link-soon {
+  opacity: 0.5;
+}
+
+.nav-link-soon::after {
+  content: "soon";
+  font-size: 9px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  padding: 1px 6px;
+  border-radius: 9999px;
+  margin-left: auto;
+}
+
+.sidebar-footer {
+  border-top: 1px solid var(--border);
+  padding: var(--space-2) 0;
+}
+
+.nav-link-back { color: var(--text-muted); }
+.nav-link-logout { color: var(--text-muted); }
+
+/* === Main Content === */
+#content {
+  flex: 1;
+  padding: var(--space-6);
+  overflow-y: auto;
+  min-height: 100vh;
+}
+
+/* === Page Header === */
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-6);
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.page-header h1 {
+  font-size: var(--text-2xl);
+  font-weight: 600;
+}
+
+/* === Dashboard Metric Cards === */
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+
+.metric-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-4) var(--space-6);
+}
+
+.metric-label {
+  font-size: var(--text-xs);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  font-weight: 500;
+  margin-bottom: var(--space-1);
+}
+
+.metric-value {
+  font-size: var(--text-2xl);
+  font-weight: 700;
+  color: var(--text);
+  font-family: var(--font-mono);
+}
+
+.metric-value.accent { color: var(--accent); }
+.metric-value.warning { color: var(--warning); }
+.metric-value.danger { color: var(--danger); }
+
+/* === Data Tables === */
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.data-table th {
+  padding: 10px 12px;
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.data-table td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-sm);
+  color: var(--text);
+}
+
+.data-table tr:hover td {
+  background: var(--hover-surface);
+}
+
+.data-table .mono {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+}
+
+.data-table .actions {
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+/* === Badges === */
+.badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 9999px;
+  font-size: var(--text-xs);
+  font-weight: 500;
+  line-height: 1.5;
+}
+
+.badge-admin {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.badge-member {
+  background: var(--hover-surface);
+  color: var(--text-secondary);
+}
+
+.badge-active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+.badge-suspended {
+  background: var(--danger-subtle);
+  color: var(--danger);
+}
+
+.badge-deactivated {
+  background: var(--hover-surface);
+  color: var(--text-muted);
+}
+
+/* === Search & Filters === */
+.toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-bottom: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.search-input {
+  padding: 8px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: var(--text-sm);
+  min-width: 240px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.search-input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.filter-btn {
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 9999px;
+  background: var(--bg-secondary);
+  color: var(--text-secondary);
+  font-size: var(--text-xs);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.filter-btn:hover { border-color: var(--accent); color: var(--text); }
+.filter-btn.active { background: var(--accent-subtle); border-color: var(--accent-border-subtle); color: var(--accent); }
+
+/* === Forms === */
+.form-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  margin-bottom: var(--space-6);
+}
+
+.form-row {
+  display: flex;
+  gap: var(--space-3);
+  align-items: end;
+  flex-wrap: wrap;
+  margin-bottom: var(--space-3);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.form-group label {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.form-group input,
+.form-group select {
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: var(--text-sm);
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--focus-ring);
+}
+
+.form-group select {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23a1a1aa' stroke-width='2'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  padding-right: 30px;
+}
+
+/* === Token Banner === */
+.token-banner {
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent-border-subtle);
+  border-radius: var(--radius);
+  padding: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.token-banner p {
+  font-size: var(--text-sm);
+  margin-bottom: var(--space-2);
+  color: var(--text);
+}
+
+.token-banner .token-value {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  background: var(--bg);
+  padding: var(--space-2) var(--space-3);
+  border-radius: 6px;
+  word-break: break-all;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.token-banner .token-value code {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* === Detail Page === */
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-6);
+  margin-bottom: var(--space-6);
+}
+
+.detail-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+}
+
+.detail-card h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+  color: var(--text);
+}
+
+.detail-row {
+  display: flex;
+  justify-content: space-between;
+  padding: var(--space-2) 0;
+  border-bottom: 1px solid var(--border);
+  font-size: var(--text-sm);
+}
+
+.detail-row:last-child { border-bottom: none; }
+
+.detail-label {
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.detail-value {
+  color: var(--text);
+  text-align: right;
+}
+
+/* === Usage Bars === */
+.usage-bar-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.usage-bar {
+  height: 6px;
+  background: var(--accent);
+  border-radius: 3px;
+  min-width: 2px;
+}
+
+/* === Period Selector === */
+.period-selector {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 2px;
+}
+
+.period-btn {
+  padding: 6px 16px;
+  border: none;
+  background: none;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: all 0.2s;
+}
+
+.period-btn:hover { color: var(--text); }
+
+.period-btn.active {
+  background: var(--accent-subtle);
+  color: var(--accent);
+}
+
+/* === Modal === */
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-overlay);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: var(--space-4);
+}
+
+.modal-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  max-width: 480px;
+  width: 100%;
+  box-shadow: var(--shadow-card);
+}
+
+.modal-card h2 {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  margin-bottom: var(--space-4);
+}
+
+.modal-actions {
+  display: flex;
+  gap: var(--space-3);
+  justify-content: flex-end;
+  margin-top: var(--space-6);
+}
+
+/* === Empty & Loading States === */
+.empty-state {
+  text-align: center;
+  padding: 60px var(--space-4);
+  color: var(--text-secondary);
+}
+
+.empty-state svg {
+  margin-bottom: var(--space-4);
+  opacity: 0.3;
+}
+
+.empty-state p {
+  font-size: var(--text-sm);
+}
+
+.coming-soon {
+  text-align: center;
+  padding: 80px var(--space-4);
+}
+
+.coming-soon h2 {
+  font-size: var(--text-xl);
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-3);
+}
+
+.coming-soon p {
+  color: var(--text-muted);
+  font-size: var(--text-sm);
+}
+
+.loading {
+  text-align: center;
+  padding: 60px var(--space-4);
+  color: var(--text-secondary);
+}
+
+.error-message {
+  background: var(--danger-subtle);
+  border: 1px solid var(--danger-border-subtle);
+  color: var(--danger);
+  padding: var(--space-4);
+  border-radius: var(--radius);
+  font-size: var(--text-sm);
+}
+
+/* === Breadcrumb === */
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--text-secondary);
+  margin-bottom: var(--space-4);
+}
+
+.breadcrumb a {
+  color: var(--text-secondary);
+  text-decoration: none;
+}
+
+.breadcrumb a:hover { color: var(--accent); }
+.breadcrumb .sep { opacity: 0.5; }
+
+/* === Responsive === */
+@media (max-width: 768px) {
+  #app {
+    flex-direction: column;
+  }
+
+  #sidebar {
+    width: 100%;
+    min-width: 100%;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .sidebar-nav {
+    flex-direction: row;
+    overflow-x: auto;
+    padding: 0 var(--space-2);
+  }
+
+  .nav-link {
+    white-space: nowrap;
+    padding: var(--space-3) var(--space-3);
+  }
+
+  .sidebar-footer {
+    display: flex;
+    border-top: none;
+    padding: 0 var(--space-2);
+  }
+
+  .sidebar-footer .nav-link {
+    flex: 1;
+    justify-content: center;
+  }
+
+  #content {
+    padding: var(--space-4);
+    min-height: auto;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .data-table {
+    display: block;
+    overflow-x: auto;
+  }
+
+  .search-input {
+    min-width: 100%;
+  }
+
+  .toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}
+
+@media (max-width: 480px) {
+  .metrics-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/channels/web/static/admin.html
+++ b/src/channels/web/static/admin.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <title>IronClaw Admin</title>
+  <link rel="icon" type="image/x-icon" href="/favicon.ico">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/admin.css">
+  <script src="/theme-init.js"></script>
+</head>
+<body>
+
+  <div id="auth-screen">
+    <div class="auth-card">
+      <div class="auth-brand">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+        </svg>
+        <span>IronClaw <span class="auth-badge">Admin</span></span>
+      </div>
+      <div id="auth-error" class="auth-error" style="display:none"></div>
+      <div class="auth-form">
+        <input type="password" id="token-input" placeholder="Enter admin token" autocomplete="off" spellcheck="false">
+        <button id="connect-btn" class="btn-primary">Connect</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="access-denied" style="display:none">
+    <div class="auth-card">
+      <div class="auth-brand">
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+        </svg>
+        <span>IronClaw <span class="auth-badge">Admin</span></span>
+      </div>
+      <div class="auth-error" style="display:block">Admin privileges required. Your account has the <strong>member</strong> role.</div>
+      <div class="auth-form">
+        <a href="/" class="btn-secondary" style="text-align:center;text-decoration:none">Back to IronClaw</a>
+        <button id="logout-btn-denied" class="btn-secondary">Try Different Token</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="app" style="display:none">
+    <nav id="sidebar">
+      <div class="sidebar-brand">
+        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/>
+        </svg>
+        <span>IronClaw <span class="sidebar-badge">Admin</span></span>
+      </div>
+      <div class="sidebar-nav">
+        <a href="#/" class="nav-link" data-route="/">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+          Dashboard
+        </a>
+        <a href="#/users" class="nav-link" data-route="/users">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+          Users
+        </a>
+        <a href="#/usage" class="nav-link" data-route="/usage">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 20V10"/><path d="M12 20V4"/><path d="M6 20v-6"/></svg>
+          Usage
+        </a>
+        <a href="#/workspaces" class="nav-link nav-link-soon" data-route="/workspaces">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"/></svg>
+          Workspaces
+        </a>
+        <a href="#/invitations" class="nav-link nav-link-soon" data-route="/invitations">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+          Invitations
+        </a>
+      </div>
+      <div class="sidebar-footer">
+        <a href="/" class="nav-link nav-link-back">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+          Back to IronClaw
+        </a>
+        <button id="logout-btn" class="nav-link nav-link-logout">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+          Logout
+        </button>
+      </div>
+    </nav>
+    <main id="content">
+    </main>
+  </div>
+
+  <div id="modal-overlay" class="modal-overlay" style="display:none">
+    <div id="modal-content" class="modal-card"></div>
+  </div>
+
+  <script src="/admin.js"></script>
+</body>
+</html>

--- a/src/channels/web/static/admin.js
+++ b/src/channels/web/static/admin.js
@@ -17,9 +17,12 @@
 
   function escapeHtml(str) {
     if (!str) return '';
-    var d = document.createElement('div');
-    d.appendChild(document.createTextNode(str));
-    return d.innerHTML;
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
   }
 
   function formatNumber(n) {
@@ -138,6 +141,7 @@
     return apiFetch('/api/profile').then(function (profile) {
       currentProfile = profile;
       if (profile.role !== 'admin') {
+        token = '';
         showAccessDenied();
         return false;
       }
@@ -145,6 +149,9 @@
       showApp();
       route();
       return true;
+    }).catch(function (err) {
+      token = '';
+      throw err;
     });
   }
 
@@ -180,6 +187,9 @@
             showApp();
             route();
           }
+        }).catch(function () {
+          oidcProxyAuth = false;
+          showAuth();
         });
       }
       showAuth();

--- a/src/channels/web/static/admin.js
+++ b/src/channels/web/static/admin.js
@@ -1,0 +1,922 @@
+/* IronClaw Admin Panel */
+
+(function () {
+  'use strict';
+
+  // ---------------------------------------------------------------------------
+  // State
+  // ---------------------------------------------------------------------------
+
+  var token = '';
+  var oidcProxyAuth = false;
+  var currentProfile = null;
+
+  // ---------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------
+
+  function escapeHtml(str) {
+    if (!str) return '';
+    var d = document.createElement('div');
+    d.appendChild(document.createTextNode(str));
+    return d.innerHTML;
+  }
+
+  function formatNumber(n) {
+    if (n == null) return '0';
+    return Number(n).toLocaleString();
+  }
+
+  function formatTokenCount(n) {
+    if (n == null || n === 0) return '0';
+    if (n >= 1000000) return (n / 1000000).toFixed(1) + 'M';
+    if (n >= 1000) return (n / 1000).toFixed(1) + 'K';
+    return String(n);
+  }
+
+  function formatCost(v) {
+    if (v == null) return '$0.00';
+    var n = parseFloat(v);
+    if (isNaN(n)) return '$0.00';
+    return '$' + n.toFixed(2);
+  }
+
+  function formatUptime(secs) {
+    if (!secs) return '0s';
+    var d = Math.floor(secs / 86400);
+    var h = Math.floor((secs % 86400) / 3600);
+    var m = Math.floor((secs % 3600) / 60);
+    if (d > 0) return d + 'd ' + h + 'h';
+    if (h > 0) return h + 'h ' + m + 'm';
+    return m + 'm';
+  }
+
+  function formatRelativeTime(iso) {
+    if (!iso) return 'Never';
+    var diff = (Date.now() - new Date(iso).getTime()) / 1000;
+    if (diff < 0) diff = 0;
+    if (diff < 60) return 'Just now';
+    if (diff < 3600) return Math.floor(diff / 60) + 'm ago';
+    if (diff < 86400) return Math.floor(diff / 3600) + 'h ago';
+    if (diff < 2592000) return Math.floor(diff / 86400) + 'd ago';
+    return new Date(iso).toLocaleDateString();
+  }
+
+  function statusBadge(status) {
+    var cls = 'badge badge-' + escapeHtml(status || 'active');
+    return '<span class="' + cls + '">' + escapeHtml(status || 'active') + '</span>';
+  }
+
+  function roleBadge(role) {
+    var cls = 'badge badge-' + escapeHtml(role || 'member');
+    return '<span class="' + cls + '">' + escapeHtml(role || 'member') + '</span>';
+  }
+
+  function truncateId(id) {
+    if (!id) return '';
+    return id.length > 12 ? id.slice(0, 12) + '\u2026' : id;
+  }
+
+  // ---------------------------------------------------------------------------
+  // API
+  // ---------------------------------------------------------------------------
+
+  function apiFetch(path, options) {
+    var opts = options || {};
+    opts.headers = opts.headers || {};
+    if (token && !oidcProxyAuth) {
+      opts.headers['Authorization'] = 'Bearer ' + token;
+    }
+    if (opts.body && typeof opts.body === 'object') {
+      opts.headers['Content-Type'] = 'application/json';
+      opts.body = JSON.stringify(opts.body);
+    }
+    return fetch(path, opts).then(function (res) {
+      if (!res.ok) {
+        return res.text().then(function (body) {
+          var err = new Error(body || res.status + ' ' + res.statusText);
+          err.status = res.status;
+          throw err;
+        });
+      }
+      if (res.status === 204) return null;
+      return res.json();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Auth
+  // ---------------------------------------------------------------------------
+
+  function showAuth() {
+    document.getElementById('auth-screen').style.display = 'flex';
+    document.getElementById('access-denied').style.display = 'none';
+    document.getElementById('app').style.display = 'none';
+  }
+
+  function showAccessDenied() {
+    document.getElementById('auth-screen').style.display = 'none';
+    document.getElementById('access-denied').style.display = 'flex';
+    document.getElementById('app').style.display = 'none';
+  }
+
+  function showApp() {
+    document.getElementById('auth-screen').style.display = 'none';
+    document.getElementById('access-denied').style.display = 'none';
+    document.getElementById('app').style.display = 'flex';
+  }
+
+  function logout() {
+    token = '';
+    currentProfile = null;
+    sessionStorage.removeItem('ironclaw_token');
+    showAuth();
+  }
+
+  function authenticate(t) {
+    token = t;
+    return apiFetch('/api/profile').then(function (profile) {
+      currentProfile = profile;
+      if (profile.role !== 'admin') {
+        showAccessDenied();
+        return false;
+      }
+      sessionStorage.setItem('ironclaw_token', t);
+      showApp();
+      route();
+      return true;
+    });
+  }
+
+  function autoAuth() {
+    // Check URL param
+    var params = new URLSearchParams(window.location.search);
+    var urlToken = params.get('token');
+    if (urlToken) {
+      // Clean URL
+      var clean = window.location.pathname + window.location.hash;
+      window.history.replaceState(null, '', clean);
+      authenticate(urlToken).catch(function () { showAuth(); });
+      return;
+    }
+
+    // Check sessionStorage
+    var saved = sessionStorage.getItem('ironclaw_token');
+    if (saved) {
+      authenticate(saved).catch(function () { showAuth(); });
+      return;
+    }
+
+    // Check OIDC proxy
+    fetch('/api/gateway/status').then(function (res) {
+      if (res.ok) {
+        oidcProxyAuth = true;
+        token = '';
+        return apiFetch('/api/profile').then(function (profile) {
+          currentProfile = profile;
+          if (profile.role !== 'admin') {
+            showAccessDenied();
+          } else {
+            showApp();
+            route();
+          }
+        });
+      }
+      showAuth();
+    }).catch(function () {
+      showAuth();
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Router
+  // ---------------------------------------------------------------------------
+
+  function parseHash() {
+    var hash = window.location.hash || '#/';
+    if (hash.charAt(0) === '#') hash = hash.slice(1);
+    if (!hash || hash.charAt(0) !== '/') hash = '/';
+    return hash;
+  }
+
+  function route() {
+    var path = parseHash();
+    var content = document.getElementById('content');
+
+    // Update active nav link
+    var links = document.querySelectorAll('.nav-link[data-route]');
+    for (var i = 0; i < links.length; i++) {
+      var r = links[i].getAttribute('data-route');
+      var isActive = path === r || (r !== '/' && path.indexOf(r) === 0);
+      links[i].classList.toggle('active', isActive);
+    }
+
+    // Route dispatch
+    if (path === '/') {
+      renderDashboard(content);
+    } else if (path === '/users') {
+      renderUsers(content);
+    } else if (path.indexOf('/users/') === 0) {
+      var userId = decodeURIComponent(path.slice(7));
+      renderUserDetail(content, userId);
+    } else if (path === '/usage') {
+      renderUsage(content, 'day');
+    } else if (path === '/workspaces') {
+      renderStub(content, 'Workspaces', 'Workspace management is coming soon.', '#1607');
+    } else if (path === '/invitations') {
+      renderStub(content, 'Invitations', 'Invitation management is coming soon.', '#1608');
+    } else {
+      content.innerHTML = '<div class="empty-state"><p>Page not found</p></div>';
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Pages
+  // ---------------------------------------------------------------------------
+
+  // --- Dashboard ---
+
+  function renderDashboard(el) {
+    el.innerHTML = '<div class="loading">Loading dashboard...</div>';
+
+    Promise.all([
+      apiFetch('/api/admin/usage/summary'),
+      apiFetch('/api/admin/users')
+    ]).then(function (results) {
+      var summary = results[0];
+      var rawUsers = results[1] || {};
+      var users = Array.isArray(rawUsers) ? rawUsers : (rawUsers.users || []);
+
+      var u = summary.users || {};
+      var j = summary.jobs || {};
+      var usage = summary.usage_30d || {};
+
+      var html = '<div class="page-header"><h1>Dashboard</h1></div>';
+
+      // Metrics
+      html += '<div class="metrics-grid">';
+      html += metricCard('Total Users', formatNumber(u.total));
+      html += metricCard('Active Users', formatNumber(u.active), 'accent');
+      html += metricCard('Suspended', formatNumber(u.suspended), u.suspended > 0 ? 'danger' : '');
+      html += metricCard('Admins', formatNumber(u.admins));
+      html += metricCard('Total Jobs', formatNumber(j.total));
+      html += metricCard('30d LLM Calls', formatNumber(usage.llm_calls));
+      html += metricCard('30d Cost', formatCost(usage.total_cost), 'accent');
+      html += metricCard('Uptime', formatUptime(summary.uptime_seconds));
+      html += '</div>';
+
+      // Recent users table
+      var recent = users.slice().sort(function (a, b) {
+        var ta = a.last_active_at || a.created_at || '';
+        var tb = b.last_active_at || b.created_at || '';
+        return tb.localeCompare(ta);
+      }).slice(0, 5);
+
+      html += '<div class="detail-card">';
+      html += '<h2>Recent Users</h2>';
+      if (recent.length === 0) {
+        html += '<div class="empty-state"><p>No users yet</p></div>';
+      } else {
+        html += '<table class="data-table"><thead><tr>';
+        html += '<th>Name</th><th>Role</th><th>Status</th><th>Jobs</th><th>Last Active</th>';
+        html += '</tr></thead><tbody>';
+        for (var i = 0; i < recent.length; i++) {
+          var ru = recent[i];
+          html += '<tr>';
+          html += '<td><a href="#/users/' + encodeURIComponent(ru.id) + '" style="color:var(--accent);text-decoration:none">' + escapeHtml(ru.display_name) + '</a></td>';
+          html += '<td>' + roleBadge(ru.role) + '</td>';
+          html += '<td>' + statusBadge(ru.status) + '</td>';
+          html += '<td class="mono">' + formatNumber(ru.job_count) + '</td>';
+          html += '<td>' + formatRelativeTime(ru.last_active_at) + '</td>';
+          html += '</tr>';
+        }
+        html += '</tbody></table>';
+      }
+      html += '</div>';
+
+      el.innerHTML = html;
+    }).catch(function (err) {
+      el.innerHTML = '<div class="error-message">Failed to load dashboard: ' + escapeHtml(err.message) + '</div>';
+    });
+  }
+
+  function metricCard(label, value, cls) {
+    return '<div class="metric-card">' +
+      '<div class="metric-label">' + escapeHtml(label) + '</div>' +
+      '<div class="metric-value' + (cls ? ' ' + cls : '') + '">' + escapeHtml(value) + '</div>' +
+      '</div>';
+  }
+
+  // --- Users List ---
+
+  var usersCache = null;
+  var usersFilter = 'all';
+  var usersSearch = '';
+
+  function renderUsers(el) {
+    el.innerHTML = '<div class="loading">Loading users...</div>';
+    usersCache = null;
+    usersFilter = 'all';
+    usersSearch = '';
+
+    apiFetch('/api/admin/users').then(function (raw) {
+      usersCache = Array.isArray(raw) ? raw : (raw && raw.users ? raw.users : []);
+      renderUsersPage(el);
+    }).catch(function (err) {
+      el.innerHTML = '<div class="error-message">Failed to load users: ' + escapeHtml(err.message) + '</div>';
+    });
+  }
+
+  function renderUsersPage(el) {
+    var users = filterUsers(usersCache || []);
+
+    var html = '<div class="page-header"><h1>Users</h1>';
+    html += '<button class="btn-primary" data-action="show-create-form">+ New User</button>';
+    html += '</div>';
+
+    // Create user form (hidden by default)
+    html += '<div id="create-user-form" class="form-card" style="display:none">';
+    html += '<div class="form-row">';
+    html += '<div class="form-group"><label>Display Name</label><input type="text" id="new-user-name" placeholder="Jane Doe"></div>';
+    html += '<div class="form-group"><label>Email (optional)</label><input type="text" id="new-user-email" placeholder="jane@example.com"></div>';
+    html += '<div class="form-group"><label>Role</label><select id="new-user-role"><option value="member">Member</option><option value="admin">Admin</option></select></div>';
+    html += '<div class="form-group" style="align-self:end"><button class="btn-primary" data-action="create-user">Create</button> ';
+    html += '<button class="btn-secondary" data-action="hide-create-form">Cancel</button></div>';
+    html += '</div></div>';
+
+    // Token banner
+    html += '<div id="user-token-banner" style="display:none"></div>';
+
+    // Toolbar
+    html += '<div class="toolbar">';
+    html += '<input type="text" class="search-input" id="users-search" placeholder="Search by name or email..." value="' + escapeHtml(usersSearch) + '">';
+    html += '<button class="filter-btn' + (usersFilter === 'all' ? ' active' : '') + '" data-action="filter" data-filter="all">All</button>';
+    html += '<button class="filter-btn' + (usersFilter === 'active' ? ' active' : '') + '" data-action="filter" data-filter="active">Active</button>';
+    html += '<button class="filter-btn' + (usersFilter === 'suspended' ? ' active' : '') + '" data-action="filter" data-filter="suspended">Suspended</button>';
+    html += '<button class="filter-btn' + (usersFilter === 'admin' ? ' active' : '') + '" data-action="filter" data-filter="admin">Admins</button>';
+    html += '</div>';
+
+    // Table
+    if (users.length === 0) {
+      html += '<div class="empty-state"><p>No users found</p></div>';
+    } else {
+      html += '<table class="data-table"><thead><tr>';
+      html += '<th>ID</th><th>Name</th><th>Email</th><th>Role</th><th>Status</th>';
+      html += '<th>Jobs</th><th>Cost</th><th>Last Active</th><th>Actions</th>';
+      html += '</tr></thead><tbody>';
+      for (var i = 0; i < users.length; i++) {
+        var u = users[i];
+        html += '<tr>';
+        html += '<td class="mono">' + escapeHtml(truncateId(u.id)) + '</td>';
+        html += '<td><a href="#/users/' + encodeURIComponent(u.id) + '" style="color:var(--accent);text-decoration:none">' + escapeHtml(u.display_name) + '</a></td>';
+        html += '<td>' + escapeHtml(u.email || '') + '</td>';
+        html += '<td>' + roleBadge(u.role) + '</td>';
+        html += '<td>' + statusBadge(u.status) + '</td>';
+        html += '<td class="mono">' + formatNumber(u.job_count) + '</td>';
+        html += '<td class="mono">' + formatCost(u.total_cost) + '</td>';
+        html += '<td>' + formatRelativeTime(u.last_active_at) + '</td>';
+        html += '<td class="actions">';
+        if (u.status === 'active') {
+          html += '<button class="btn-small" data-action="suspend" data-id="' + escapeHtml(u.id) + '">Suspend</button>';
+        } else {
+          html += '<button class="btn-small" data-action="activate" data-id="' + escapeHtml(u.id) + '">Activate</button>';
+        }
+        if (u.role === 'admin') {
+          html += '<button class="btn-small" data-action="change-role" data-id="' + escapeHtml(u.id) + '" data-role="member">Demote</button>';
+        } else {
+          html += '<button class="btn-small" data-action="change-role" data-id="' + escapeHtml(u.id) + '" data-role="admin">Promote</button>';
+        }
+        html += '<button class="btn-small" data-action="create-token" data-id="' + escapeHtml(u.id) + '" data-name="' + escapeHtml(u.display_name) + '">Token</button>';
+        html += '</td>';
+        html += '</tr>';
+      }
+      html += '</tbody></table>';
+    }
+
+    el.innerHTML = html;
+
+    // Search input handler
+    var searchEl = document.getElementById('users-search');
+    if (searchEl) {
+      searchEl.addEventListener('input', function () {
+        usersSearch = searchEl.value;
+        renderUsersPage(el);
+      });
+      searchEl.focus();
+      searchEl.setSelectionRange(usersSearch.length, usersSearch.length);
+    }
+  }
+
+  function filterUsers(users) {
+    var result = users;
+    if (usersFilter === 'active') {
+      result = result.filter(function (u) { return u.status === 'active'; });
+    } else if (usersFilter === 'suspended') {
+      result = result.filter(function (u) { return u.status === 'suspended'; });
+    } else if (usersFilter === 'admin') {
+      result = result.filter(function (u) { return u.role === 'admin'; });
+    }
+    if (usersSearch) {
+      var q = usersSearch.toLowerCase();
+      result = result.filter(function (u) {
+        return (u.display_name && u.display_name.toLowerCase().indexOf(q) >= 0) ||
+               (u.email && u.email.toLowerCase().indexOf(q) >= 0) ||
+               (u.id && u.id.toLowerCase().indexOf(q) >= 0);
+      });
+    }
+    return result;
+  }
+
+  // --- User Detail ---
+
+  function renderUserDetail(el, userId) {
+    el.innerHTML = '<div class="loading">Loading user...</div>';
+
+    Promise.all([
+      apiFetch('/api/admin/users/' + encodeURIComponent(userId)),
+      apiFetch('/api/admin/usage?user_id=' + encodeURIComponent(userId) + '&period=month')
+    ]).then(function (results) {
+      var user = results[0];
+      var usageData = results[1];
+
+      var html = '<div class="breadcrumb"><a href="#/users">Users</a><span class="sep">/</span><span>' + escapeHtml(user.display_name) + '</span></div>';
+
+      html += '<div class="page-header"><h1>' + escapeHtml(user.display_name) + '</h1>';
+      html += '<div class="actions">';
+      if (user.status === 'active') {
+        html += '<button class="btn-small" data-action="suspend" data-id="' + escapeHtml(user.id) + '">Suspend</button>';
+      } else {
+        html += '<button class="btn-small" data-action="activate" data-id="' + escapeHtml(user.id) + '">Activate</button>';
+      }
+      html += '<button class="btn-small" data-action="create-token" data-id="' + escapeHtml(user.id) + '" data-name="' + escapeHtml(user.display_name) + '">Create Token</button>';
+      html += '<button class="btn-small btn-danger" data-action="delete-user" data-id="' + escapeHtml(user.id) + '" data-name="' + escapeHtml(user.display_name) + '">Delete</button>';
+      html += '</div></div>';
+
+      // Token banner slot
+      html += '<div id="user-token-banner" style="display:none"></div>';
+
+      // Profile + Stats grid
+      html += '<div class="detail-grid">';
+
+      // Profile card
+      html += '<div class="detail-card"><h2>Profile</h2>';
+      html += detailRow('ID', '<span class="mono">' + escapeHtml(user.id) + '</span>');
+      html += detailRow('Email', escapeHtml(user.email || 'Not set'));
+      html += detailRow('Role', roleBadge(user.role));
+      html += detailRow('Status', statusBadge(user.status));
+      html += detailRow('Created', formatRelativeTime(user.created_at));
+      html += detailRow('Last Login', formatRelativeTime(user.last_login_at));
+      if (user.created_by) {
+        html += detailRow('Created By', '<span class="mono">' + escapeHtml(truncateId(user.created_by)) + '</span>');
+      }
+      html += '</div>';
+
+      // Stats card
+      html += '<div class="detail-card"><h2>Summary</h2>';
+      html += detailRow('Jobs', formatNumber(user.job_count));
+      html += detailRow('Total Cost', formatCost(user.total_cost));
+      html += detailRow('Last Active', formatRelativeTime(user.last_active_at));
+      html += '</div>';
+
+      html += '</div>';
+
+      // Role management
+      html += '<div class="detail-card" style="margin-bottom:var(--space-6)">';
+      html += '<h2>Role Management</h2>';
+      html += '<div class="form-row">';
+      html += '<div class="form-group"><label>Current Role</label>';
+      html += '<select id="role-select" data-id="' + escapeHtml(user.id) + '">';
+      html += '<option value="member"' + (user.role === 'member' ? ' selected' : '') + '>Member</option>';
+      html += '<option value="admin"' + (user.role === 'admin' ? ' selected' : '') + '>Admin</option>';
+      html += '</select></div>';
+      html += '<div class="form-group" style="align-self:end"><button class="btn-primary" data-action="save-role" data-id="' + escapeHtml(user.id) + '">Save Role</button></div>';
+      html += '</div></div>';
+
+      // Usage table
+      var entries = (usageData && usageData.usage) || [];
+      html += '<div class="detail-card">';
+      html += '<h2>Usage (Last 30 Days)</h2>';
+      if (entries.length === 0) {
+        html += '<div class="empty-state"><p>No usage data</p></div>';
+      } else {
+        html += '<table class="data-table"><thead><tr>';
+        html += '<th>Model</th><th>Calls</th><th>Input Tokens</th><th>Output Tokens</th><th>Cost</th>';
+        html += '</tr></thead><tbody>';
+        for (var i = 0; i < entries.length; i++) {
+          var e = entries[i];
+          html += '<tr>';
+          html += '<td class="mono">' + escapeHtml(e.model) + '</td>';
+          html += '<td class="mono">' + formatNumber(e.call_count) + '</td>';
+          html += '<td class="mono">' + formatTokenCount(e.input_tokens) + '</td>';
+          html += '<td class="mono">' + formatTokenCount(e.output_tokens) + '</td>';
+          html += '<td class="mono">' + formatCost(e.total_cost) + '</td>';
+          html += '</tr>';
+        }
+        html += '</tbody></table>';
+      }
+      html += '</div>';
+
+      el.innerHTML = html;
+    }).catch(function (err) {
+      el.innerHTML = '<div class="breadcrumb"><a href="#/users">Users</a><span class="sep">/</span><span>Error</span></div>' +
+        '<div class="error-message">Failed to load user: ' + escapeHtml(err.message) + '</div>';
+    });
+  }
+
+  function detailRow(label, value) {
+    return '<div class="detail-row"><span class="detail-label">' + escapeHtml(label) + '</span><span class="detail-value">' + value + '</span></div>';
+  }
+
+  // --- Usage ---
+
+  function renderUsage(el, period) {
+    el.innerHTML = '<div class="loading">Loading usage data...</div>';
+
+    apiFetch('/api/admin/usage?period=' + encodeURIComponent(period)).then(function (data) {
+      var entries = (data && data.usage) || [];
+
+      var html = '<div class="page-header"><h1>Usage</h1>';
+      html += '<div class="period-selector">';
+      html += '<button class="period-btn' + (period === 'day' ? ' active' : '') + '" data-action="period" data-period="day">24h</button>';
+      html += '<button class="period-btn' + (period === 'week' ? ' active' : '') + '" data-action="period" data-period="week">7d</button>';
+      html += '<button class="period-btn' + (period === 'month' ? ' active' : '') + '" data-action="period" data-period="month">30d</button>';
+      html += '</div></div>';
+
+      if (entries.length === 0) {
+        html += '<div class="empty-state"><p>No usage data for this period</p></div>';
+        el.innerHTML = html;
+        return;
+      }
+
+      // Aggregate by user
+      var byUser = {};
+      var maxCost = 0;
+      for (var i = 0; i < entries.length; i++) {
+        var e = entries[i];
+        if (!byUser[e.user_id]) {
+          byUser[e.user_id] = { user_id: e.user_id, calls: 0, input_tokens: 0, output_tokens: 0, cost: 0 };
+        }
+        byUser[e.user_id].calls += e.call_count || 0;
+        byUser[e.user_id].input_tokens += e.input_tokens || 0;
+        byUser[e.user_id].output_tokens += e.output_tokens || 0;
+        byUser[e.user_id].cost += parseFloat(e.total_cost) || 0;
+      }
+
+      var userList = Object.keys(byUser).map(function (k) { return byUser[k]; });
+      userList.sort(function (a, b) { return b.cost - a.cost; });
+
+      for (var j = 0; j < userList.length; j++) {
+        if (userList[j].cost > maxCost) maxCost = userList[j].cost;
+      }
+
+      // Summary row
+      var totalCalls = 0, totalInput = 0, totalOutput = 0, totalCostVal = 0;
+      for (var k = 0; k < userList.length; k++) {
+        totalCalls += userList[k].calls;
+        totalInput += userList[k].input_tokens;
+        totalOutput += userList[k].output_tokens;
+        totalCostVal += userList[k].cost;
+      }
+
+      html += '<div class="metrics-grid" style="margin-bottom:var(--space-6)">';
+      html += metricCard('Total Calls', formatNumber(totalCalls));
+      html += metricCard('Input Tokens', formatTokenCount(totalInput));
+      html += metricCard('Output Tokens', formatTokenCount(totalOutput));
+      html += metricCard('Total Cost', formatCost(totalCostVal.toFixed(2)), 'accent');
+      html += '</div>';
+
+      // Per-user table
+      html += '<div class="detail-card">';
+      html += '<h2>Per-User Breakdown</h2>';
+      html += '<table class="data-table"><thead><tr>';
+      html += '<th>User</th><th>Calls</th><th>Input Tokens</th><th>Output Tokens</th><th>Cost</th><th></th>';
+      html += '</tr></thead><tbody>';
+      for (var m = 0; m < userList.length; m++) {
+        var uu = userList[m];
+        var pct = maxCost > 0 ? (uu.cost / maxCost * 100) : 0;
+        html += '<tr>';
+        html += '<td><a href="#/users/' + encodeURIComponent(uu.user_id) + '" class="mono" style="color:var(--accent);text-decoration:none">' + escapeHtml(truncateId(uu.user_id)) + '</a></td>';
+        html += '<td class="mono">' + formatNumber(uu.calls) + '</td>';
+        html += '<td class="mono">' + formatTokenCount(uu.input_tokens) + '</td>';
+        html += '<td class="mono">' + formatTokenCount(uu.output_tokens) + '</td>';
+        html += '<td class="mono">' + formatCost(uu.cost.toFixed(2)) + '</td>';
+        html += '<td class="usage-bar-cell"><div class="usage-bar" style="width:' + pct.toFixed(1) + '%"></div></td>';
+        html += '</tr>';
+      }
+      html += '</tbody></table></div>';
+
+      // Per-model table
+      var byModel = {};
+      for (var n = 0; n < entries.length; n++) {
+        var em = entries[n];
+        if (!byModel[em.model]) {
+          byModel[em.model] = { model: em.model, calls: 0, input_tokens: 0, output_tokens: 0, cost: 0 };
+        }
+        byModel[em.model].calls += em.call_count || 0;
+        byModel[em.model].input_tokens += em.input_tokens || 0;
+        byModel[em.model].output_tokens += em.output_tokens || 0;
+        byModel[em.model].cost += parseFloat(em.total_cost) || 0;
+      }
+
+      var modelList = Object.keys(byModel).map(function (k) { return byModel[k]; });
+      modelList.sort(function (a, b) { return b.cost - a.cost; });
+
+      html += '<div class="detail-card" style="margin-top:var(--space-6)">';
+      html += '<h2>Per-Model Breakdown</h2>';
+      html += '<table class="data-table"><thead><tr>';
+      html += '<th>Model</th><th>Calls</th><th>Input Tokens</th><th>Output Tokens</th><th>Cost</th>';
+      html += '</tr></thead><tbody>';
+      for (var p = 0; p < modelList.length; p++) {
+        var mm = modelList[p];
+        html += '<tr>';
+        html += '<td class="mono">' + escapeHtml(mm.model) + '</td>';
+        html += '<td class="mono">' + formatNumber(mm.calls) + '</td>';
+        html += '<td class="mono">' + formatTokenCount(mm.input_tokens) + '</td>';
+        html += '<td class="mono">' + formatTokenCount(mm.output_tokens) + '</td>';
+        html += '<td class="mono">' + formatCost(mm.cost.toFixed(2)) + '</td>';
+        html += '</tr>';
+      }
+      html += '</tbody></table></div>';
+
+      el.innerHTML = html;
+    }).catch(function (err) {
+      el.innerHTML = '<div class="error-message">Failed to load usage: ' + escapeHtml(err.message) + '</div>';
+    });
+  }
+
+  // --- Stub pages ---
+
+  function renderStub(el, title, desc, issue) {
+    el.innerHTML = '<div class="coming-soon">' +
+      '<h2>' + escapeHtml(title) + '</h2>' +
+      '<p>' + escapeHtml(desc) + '</p>' +
+      '<p style="margin-top:var(--space-3);font-size:var(--text-xs);color:var(--text-dimmed)">Tracking: ' + escapeHtml(issue) + '</p>' +
+      '</div>';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Actions (event delegation)
+  // ---------------------------------------------------------------------------
+
+  function handleAction(target) {
+    var action = target.getAttribute('data-action');
+    if (!action) return;
+
+    var id = target.getAttribute('data-id');
+    var content = document.getElementById('content');
+
+    switch (action) {
+      case 'show-create-form':
+        var form = document.getElementById('create-user-form');
+        if (form) form.style.display = 'block';
+        break;
+
+      case 'hide-create-form':
+        var formH = document.getElementById('create-user-form');
+        if (formH) formH.style.display = 'none';
+        break;
+
+      case 'create-user':
+        createUser(content);
+        break;
+
+      case 'suspend':
+        apiFetch('/api/admin/users/' + encodeURIComponent(id) + '/suspend', { method: 'POST' })
+          .then(function () { refreshCurrentPage(); })
+          .catch(function (err) { alert('Failed to suspend: ' + err.message); });
+        break;
+
+      case 'activate':
+        apiFetch('/api/admin/users/' + encodeURIComponent(id) + '/activate', { method: 'POST' })
+          .then(function () { refreshCurrentPage(); })
+          .catch(function (err) { alert('Failed to activate: ' + err.message); });
+        break;
+
+      case 'change-role':
+        var newRole = target.getAttribute('data-role');
+        apiFetch('/api/admin/users/' + encodeURIComponent(id), {
+          method: 'PATCH',
+          body: { role: newRole }
+        }).then(function () { refreshCurrentPage(); })
+          .catch(function (err) { alert('Failed to change role: ' + err.message); });
+        break;
+
+      case 'save-role':
+        var sel = document.getElementById('role-select');
+        if (sel) {
+          apiFetch('/api/admin/users/' + encodeURIComponent(id), {
+            method: 'PATCH',
+            body: { role: sel.value }
+          }).then(function () { refreshCurrentPage(); })
+            .catch(function (err) { alert('Failed to save role: ' + err.message); });
+        }
+        break;
+
+      case 'create-token':
+        var userName = target.getAttribute('data-name') || 'user';
+        var tokenName = prompt('Token name for ' + userName + ':');
+        if (!tokenName) return;
+        apiFetch('/api/tokens', {
+          method: 'POST',
+          body: { name: tokenName, user_id: id }
+        }).then(function (res) {
+          showTokenBanner(res.token || res.plaintext_token);
+        }).catch(function (err) { alert('Failed to create token: ' + err.message); });
+        break;
+
+      case 'delete-user':
+        var name = target.getAttribute('data-name') || id;
+        showConfirmModal(
+          'Delete User',
+          'Are you sure you want to delete <strong>' + escapeHtml(name) + '</strong>? This action cannot be undone.',
+          'Delete',
+          function () {
+            apiFetch('/api/admin/users/' + encodeURIComponent(id), { method: 'DELETE' })
+              .then(function () { window.location.hash = '#/users'; })
+              .catch(function (err) { alert('Failed to delete: ' + err.message); });
+          }
+        );
+        break;
+
+      case 'filter':
+        usersFilter = target.getAttribute('data-filter') || 'all';
+        renderUsersPage(content);
+        break;
+
+      case 'period':
+        var period = target.getAttribute('data-period') || 'day';
+        renderUsage(content, period);
+        break;
+
+      case 'copy-token':
+        var tokenVal = target.getAttribute('data-token');
+        if (tokenVal && navigator.clipboard) {
+          navigator.clipboard.writeText(tokenVal);
+          target.textContent = 'Copied!';
+          setTimeout(function () { target.textContent = 'Copy'; }, 2000);
+        }
+        break;
+
+      case 'modal-close':
+        closeModal();
+        break;
+    }
+  }
+
+  function createUser(el) {
+    var nameEl = document.getElementById('new-user-name');
+    var emailEl = document.getElementById('new-user-email');
+    var roleEl = document.getElementById('new-user-role');
+    if (!nameEl || !nameEl.value.trim()) {
+      alert('Display name is required');
+      return;
+    }
+    var body = { display_name: nameEl.value.trim(), role: roleEl ? roleEl.value : 'member' };
+    if (emailEl && emailEl.value.trim()) body.email = emailEl.value.trim();
+
+    apiFetch('/api/admin/users', { method: 'POST', body: body }).then(function (res) {
+      var formEl = document.getElementById('create-user-form');
+      if (formEl) formEl.style.display = 'none';
+      if (nameEl) nameEl.value = '';
+      if (emailEl) emailEl.value = '';
+
+      if (res && (res.token || res.plaintext_token)) {
+        showTokenBanner(res.token || res.plaintext_token);
+      }
+
+      // Reload users list
+      apiFetch('/api/admin/users').then(function (raw) {
+        usersCache = Array.isArray(raw) ? raw : (raw && raw.users ? raw.users : []);
+        renderUsersPage(el);
+      });
+    }).catch(function (err) {
+      alert('Failed to create user: ' + err.message);
+    });
+  }
+
+  function showTokenBanner(tokenValue) {
+    var banner = document.getElementById('user-token-banner');
+    if (!banner) return;
+    var loginUrl = window.location.origin + '/?token=' + encodeURIComponent(tokenValue);
+    banner.innerHTML = '<div class="token-banner">' +
+      '<p><strong>Token created!</strong> Copy this now — it will not be shown again.</p>' +
+      '<div class="token-value"><code>' + escapeHtml(tokenValue) + '</code>' +
+      '<button class="btn-small" data-action="copy-token" data-token="' + escapeHtml(tokenValue) + '">Copy</button></div>' +
+      '<p style="margin-top:var(--space-2);font-size:var(--text-xs);color:var(--text-muted)">Login URL: ' + escapeHtml(loginUrl) + '</p>' +
+      '</div>';
+    banner.style.display = 'block';
+  }
+
+  function refreshCurrentPage() {
+    route();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Modal
+  // ---------------------------------------------------------------------------
+
+  function showConfirmModal(title, message, confirmText, onConfirm) {
+    var overlay = document.getElementById('modal-overlay');
+    var content = document.getElementById('modal-content');
+    if (!overlay || !content) return;
+
+    content.innerHTML = '<h2>' + escapeHtml(title) + '</h2>' +
+      '<p style="color:var(--text-secondary);margin-top:var(--space-3)">' + message + '</p>' +
+      '<div class="modal-actions">' +
+      '<button class="btn-secondary" data-action="modal-close">Cancel</button>' +
+      '<button class="btn-primary btn-danger" id="modal-confirm">' + escapeHtml(confirmText) + '</button>' +
+      '</div>';
+    overlay.style.display = 'flex';
+
+    var confirmBtn = document.getElementById('modal-confirm');
+    if (confirmBtn) {
+      confirmBtn.onclick = function () {
+        closeModal();
+        onConfirm();
+      };
+    }
+  }
+
+  function closeModal() {
+    var overlay = document.getElementById('modal-overlay');
+    if (overlay) overlay.style.display = 'none';
+  }
+
+  // ---------------------------------------------------------------------------
+  // Event Listeners
+  // ---------------------------------------------------------------------------
+
+  document.addEventListener('click', function (e) {
+    var target = e.target;
+    // Walk up to find data-action
+    while (target && target !== document) {
+      if (target.getAttribute && target.getAttribute('data-action')) {
+        e.preventDefault();
+        handleAction(target);
+        return;
+      }
+      target = target.parentElement;
+    }
+  });
+
+  document.addEventListener('keydown', function (e) {
+    if (e.key === 'Escape') closeModal();
+  });
+
+  // Modal overlay click to close
+  var overlay = document.getElementById('modal-overlay');
+  if (overlay) {
+    overlay.addEventListener('click', function (e) {
+      if (e.target === overlay) closeModal();
+    });
+  }
+
+  // Auth form
+  var connectBtn = document.getElementById('connect-btn');
+  if (connectBtn) {
+    connectBtn.addEventListener('click', function () {
+      var input = document.getElementById('token-input');
+      var errEl = document.getElementById('auth-error');
+      if (!input || !input.value.trim()) return;
+
+      connectBtn.disabled = true;
+      connectBtn.textContent = 'Connecting...';
+
+      authenticate(input.value.trim()).catch(function (err) {
+        if (errEl) {
+          errEl.textContent = 'Authentication failed: ' + err.message;
+          errEl.style.display = 'block';
+        }
+        connectBtn.disabled = false;
+        connectBtn.textContent = 'Connect';
+      });
+    });
+  }
+
+  var tokenInput = document.getElementById('token-input');
+  if (tokenInput) {
+    tokenInput.addEventListener('keydown', function (e) {
+      if (e.key === 'Enter' && connectBtn) connectBtn.click();
+    });
+  }
+
+  // Logout buttons
+  var logoutBtn = document.getElementById('logout-btn');
+  if (logoutBtn) logoutBtn.addEventListener('click', logout);
+  var logoutDenied = document.getElementById('logout-btn-denied');
+  if (logoutDenied) logoutDenied.addEventListener('click', logout);
+
+  // Hash-based routing
+  window.addEventListener('hashchange', function () {
+    if (document.getElementById('app').style.display !== 'none') {
+      route();
+    }
+  });
+
+  // ---------------------------------------------------------------------------
+  // Init
+  // ---------------------------------------------------------------------------
+
+  autoAuth();
+
+})();


### PR DESCRIPTION
## Summary

Adds a standalone admin management panel served from `/admin/*` routes, addressing #1609. The panel is a separate embedded SPA (vanilla HTML/CSS/JS, no build system) that provides:

- **Dashboard** — System-wide metrics: user counts, total jobs, 30-day LLM usage/cost, server uptime, and a recent users table
- **Users page** — Full user CRUD: list with search/filter, create user with one-time token, suspend/activate, role management (promote/demote), token generation, delete with confirmation
- **User detail page** — Profile card, role management dropdown, 30-day usage breakdown by model
- **Usage page** — Period selector (24h/7d/30d), per-user and per-model breakdowns with proportional cost bars
- **Workspaces & Invitations** — Stubbed as "Coming soon" (see caveats below)

### Backend changes (`server.rs` only)
- 3 static file handlers serving embedded `admin.html`, `admin.css`, `admin.js` via `include_str!`
- 5 routes in the `statics` router: `/admin`, `/admin/`, `/admin/{*path}` (SPA catch-all), `/admin.css`, `/admin.js`
- 1 new API endpoint: `GET /api/admin/usage/summary` — composes existing `list_users`, `user_summary_stats`, and `user_usage_stats` DB methods (no new DB trait methods, no migrations)

### Frontend architecture
- Standalone SPA independent of the main chat UI
- Hash-based client-side routing (`#/users`, `#/users/:id`, `#/usage`, etc.)
- Shared auth token with main SPA via `sessionStorage` (no re-login when navigating between them)
- OIDC proxy auth support
- Admin role verification via `/api/profile` — non-admins see an "access denied" screen
- Full dark/light theme support (inherits from `theme-init.js`)
- Responsive layout: sidebar collapses on mobile, tables scroll horizontally
- All mutation controls (suspend, delete, role change) enforced server-side via `AdminUser` extractor

### No changes to
- Database trait or implementations (postgres/libsql)
- Migrations
- Existing API endpoints
- Main SPA (`index.html`, `app.js`, `style.css`)

## Caveats

- **Workspaces page** is stubbed — depends on #1607 (Workspace Management) which hasn't landed. The sidebar link shows "soon" badge and the page displays a "Coming soon" placeholder.
- **Invitations page** is stubbed — depends on #1608 (RBAC) which hasn't landed. Same treatment as workspaces.
- **No i18n** — The admin panel is English-only for now. The main SPA's i18n system could be extended later.
- **No audit log UI** — Out of scope per the issue spec.
- **Binary size** — Adds ~60KB of embedded assets (HTML+CSS+JS). No external libraries.

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo check` compiles with default features
- [x] `GET /admin` returns 200 with admin HTML
- [x] `GET /admin/anything` returns 200 (SPA catch-all)
- [x] Auth: enter valid admin token → dashboard loads
- [x] Auth: enter member token → "Admin privileges required" screen
- [x] Auth: shared token from main SPA works without re-login
- [x] Dashboard: metrics cards render with correct data
- [x] Users: list, search, filter by status/role all work
- [ ] Users: create user → token banner displayed
- [ ] Users: suspend/activate/role change/delete work
- [ ] User detail: profile, role management, usage table render
- [x] Usage: period selector (24h/7d/30d) re-fetches data
- [x] Responsive: sidebar collapses at 768px, tables scroll
- [x] Dark/light theme inherited correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)