### PR TITLE
fix(extensions): skip host webhook secret for channels with managed_b…

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -4734,11 +4734,16 @@ impl ExtensionManager {
         config_updates.extend(self.load_channel_runtime_config_overrides(name).await);
         let mut should_rerun_on_start = false;
 
-        // Refresh webhook secret
-        if let Ok(secret) = self
-            .secrets
-            .get_decrypted(user_id, &webhook_secret_name)
-            .await
+        // Refresh webhook secret (only if managed by host)
+        let managed_by_host = capabilities_file
+            .as_ref()
+            .map(|f| f.webhook_secret_managed_by_host())
+            .unwrap_or(true);
+        if managed_by_host
+            && let Ok(secret) = self
+                .secrets
+                .get_decrypted(user_id, &webhook_secret_name)
+                .await
         {
             router
                 .update_secret(name, secret.expose().to_string())


### PR DESCRIPTION
fix(extensions): skip host webhook secret for channels with `managed_by_host=false`

## Summary

<!-- 2-5 bullet points: what changed and why -->
- `ExtensionManager.refresh_channel_credentials()` unconditionally called `router.update_secret()` for all channels, registering the webhook secret in the host-level router. For channels like `Feishu` where `managed_by_host=false` (verification token is in the request body, not a header), this caused the router to require a header-based secret that Feishu never sends, resulting in `401 Unauthorized` on every webhook.

- Now checks `webhook_secret_managed_by_host()` from the capabilities file before registering the secret with the router. Channels that validate their own webhook authentication (Feishu) are no longer blocked by the host-level secret check.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: <!-- describe what you tested --> Test against feishu bot, `401 Unauthorized` resolved
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". --> None

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". --> None

## Blast Radius

<!-- What subsystems does this touch? What could break? --> extensions

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. --> No need

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) --> B
