### PR TITLE
feat(llm): add prompt caching for Bedrock Converse API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,9 +99,21 @@ NEARAI_AUTH_URL=https://private.near.ai
 # ANTHROPIC_BASE_URL=https://api.anthropic.com  # default
 # Prompt cache retention — controls Anthropic server-side prompt caching:
 #   none  = disabled (no cache_control injected)
-#   short = 5-minute TTL, 1.25× (125%) write surcharge (default)
-#   long  = 1-hour TTL, 2.0× (200%) write surcharge
+#   short = 5-minute TTL, 1.25× write cost (default)
+#   long  = 1-hour TTL, 2.0× write cost
 # ANTHROPIC_CACHE_RETENTION=short
+
+# === AWS Bedrock (native Converse API, requires --features bedrock) ===
+# LLM_BACKEND=bedrock
+# BEDROCK_REGION=us-east-1                        # default
+# BEDROCK_MODEL=anthropic.claude-sonnet-4-20250514-v1:0
+# BEDROCK_CROSS_REGION=us                         # optional: us, eu, apac, global
+# AWS_PROFILE=my-sso-profile                      # optional: named AWS profile
+# Prompt cache retention — controls CachePointBlock injection in Converse API:
+#   none  = disabled (no cache points injected)
+#   short = 5-minute TTL, 1.25× write cost (default)
+#   long  = 1-hour TTL, 2.0× write cost (Claude 4.5/Haiku 4.5 only)
+# BEDROCK_CACHE_RETENTION=short
 
 # === OpenAI Codex (ChatGPT subscription, OAuth) ===
 # LLM_BACKEND=openai_codex

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -239,11 +239,13 @@ impl LlmConfig {
                 .bedrock_profile
                 .clone()
                 .or(optional_env("AWS_PROFILE")?);
+            let cache_retention = resolve_cache_retention("BEDROCK_CACHE_RETENTION")?;
             Some(BedrockConfig {
                 region,
                 model,
                 cross_region,
                 profile,
+                cache_retention,
             })
         } else {
             None
@@ -586,18 +588,8 @@ impl LlmConfig {
         };
 
         // Resolve Anthropic prompt cache retention from env (default: Short).
-        let cache_retention: CacheRetention = if canonical_id == "anthropic" {
-            optional_env("ANTHROPIC_CACHE_RETENTION")?
-                .and_then(|val| match val.parse::<CacheRetention>() {
-                    Ok(r) => Some(r),
-                    Err(e) => {
-                        tracing::warn!(
-                            "Invalid ANTHROPIC_CACHE_RETENTION: {e}; defaulting to short"
-                        );
-                        None
-                    }
-                })
-                .unwrap_or_default()
+        let cache_retention = if canonical_id == "anthropic" {
+            resolve_cache_retention("ANTHROPIC_CACHE_RETENTION")?
         } else {
             CacheRetention::default()
         };
@@ -617,6 +609,19 @@ impl LlmConfig {
             unsupported_params,
         })
     }
+}
+
+/// Resolve a `CacheRetention` from an env var, defaulting to `Short`.
+fn resolve_cache_retention(env_var: &str) -> Result<CacheRetention, ConfigError> {
+    Ok(optional_env(env_var)?
+        .and_then(|val| match val.parse::<CacheRetention>() {
+            Ok(r) => Some(r),
+            Err(e) => {
+                tracing::warn!("Invalid {env_var}: {e}; defaulting to short");
+                None
+            }
+        })
+        .unwrap_or_default())
 }
 
 /// Parse `LLM_EXTRA_HEADERS` value into a list of (key, value) pairs.

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -13,14 +13,15 @@ use aws_config::{BehaviorVersion, Region};
 use aws_sdk_bedrockruntime::Client;
 use aws_sdk_bedrockruntime::operation::converse::ConverseError;
 use aws_sdk_bedrockruntime::types::{
-    AnyToolChoice, AutoToolChoice, ContentBlock, ConversationRole, InferenceConfiguration, Message,
-    StopReason, SystemContentBlock, Tool, ToolChoice, ToolConfiguration, ToolInputSchema,
-    ToolResultBlock, ToolResultContentBlock, ToolResultStatus, ToolSpecification, ToolUseBlock,
+    AnyToolChoice, AutoToolChoice, CachePointBlock, CachePointType, CacheTtl, ContentBlock,
+    ConversationRole, InferenceConfiguration, Message, StopReason, SystemContentBlock, Tool,
+    ToolChoice, ToolConfiguration, ToolInputSchema, ToolResultBlock, ToolResultContentBlock,
+    ToolResultStatus, ToolSpecification, ToolUseBlock,
 };
 use aws_smithy_types::Document;
 use rust_decimal::Decimal;
 
-use crate::llm::config::BedrockConfig;
+use crate::llm::config::{BedrockConfig, CacheRetention};
 use crate::llm::error::LlmError;
 use crate::llm::provider::{
     CompletionRequest, CompletionResponse, FinishReason, LlmProvider, ModelMetadata, ToolCall,
@@ -36,6 +37,9 @@ pub struct BedrockProvider {
     cross_region_prefix: String,
     /// Active model ID (with cross-region prefix), switchable at runtime via `set_model()`.
     active_model: RwLock<String>,
+    /// Prompt cache retention policy. When not `None`, injects `CachePointBlock`
+    /// into system, tool, and message content blocks.
+    cache_retention: CacheRetention,
 }
 
 impl BedrockProvider {
@@ -61,11 +65,32 @@ impl BedrockProvider {
 
         let client = Client::new(&sdk_config);
 
+        let cache_retention = if config.cache_retention != CacheRetention::None
+            && !supports_bedrock_cache(&config.model)
+        {
+            tracing::warn!(
+                model = %config.model,
+                "Prompt caching not supported for this model; disabling"
+            );
+            CacheRetention::None
+        } else {
+            config.cache_retention
+        };
+
+        if cache_retention != CacheRetention::None {
+            tracing::info!(
+                retention = %cache_retention,
+                model = %config.model,
+                "Bedrock prompt caching enabled"
+            );
+        }
+
         Ok(Self {
             client,
             display_model: config.model.clone(),
             cross_region_prefix,
             active_model: RwLock::new(model_id),
+            cache_retention,
         })
     }
 
@@ -102,7 +127,7 @@ impl LlmProvider for BedrockProvider {
         // but complete() has no tools to build a toolConfig — strip them.
         strip_tool_blocks(&mut messages);
 
-        let (system_blocks, bedrock_messages) = convert_messages(&messages)?;
+        let (mut system_blocks, mut bedrock_messages) = convert_messages(&messages)?;
 
         if bedrock_messages.is_empty() {
             return Err(LlmError::RequestFailed {
@@ -110,6 +135,16 @@ impl LlmProvider for BedrockProvider {
                 reason: "Bedrock requires at least one user or assistant message".to_string(),
             });
         }
+
+        // Inject cache points (CP1: system, CP3: last user message).
+        // No CP2 because complete() has no tool config.
+        let mut empty_tools = Vec::new();
+        inject_cache_points(
+            self.cache_retention,
+            &mut system_blocks,
+            &mut empty_tools,
+            &mut bedrock_messages,
+        )?;
 
         let mut builder = self
             .client
@@ -134,14 +169,19 @@ impl LlmProvider for BedrockProvider {
 
         let (text, _tool_calls) = extract_content_blocks(response.output())?;
         let (input_tokens, output_tokens) = extract_token_usage(response.usage());
+        let (cache_read, cache_write) = extract_cache_usage(response.usage());
+
+        if cache_read > 0 {
+            tracing::debug!(cache_read, cache_write, "Bedrock prompt cache hit");
+        }
 
         Ok(CompletionResponse {
             content: text,
             input_tokens,
             output_tokens,
             finish_reason: map_stop_reason(response.stop_reason()),
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: cache_write,
+            cache_read_input_tokens: cache_read,
         })
     }
 
@@ -154,15 +194,15 @@ impl LlmProvider for BedrockProvider {
         let mut messages = request.messages;
         crate::llm::provider::sanitize_tool_messages(&mut messages);
 
-        let tool_config = build_tool_config(&request.tools, request.tool_choice.as_deref())?;
+        let tool_specs = build_tool_specs(&request.tools, request.tool_choice.as_deref())?;
 
-        // When tool_config is None (empty tools or tool_choice="none") but messages
+        // When tool_specs is None (empty tools or tool_choice="none") but messages
         // contain tool history, strip tool blocks to avoid Bedrock validation error.
-        if tool_config.is_none() {
+        if tool_specs.is_none() {
             strip_tool_blocks(&mut messages);
         }
 
-        let (system_blocks, bedrock_messages) = convert_messages(&messages)?;
+        let (mut system_blocks, mut bedrock_messages) = convert_messages(&messages)?;
 
         if bedrock_messages.is_empty() {
             return Err(LlmError::RequestFailed {
@@ -170,6 +210,33 @@ impl LlmProvider for BedrockProvider {
                 reason: "Bedrock requires at least one user or assistant message".to_string(),
             });
         }
+
+        // Inject cache points into system, tools, and last user message.
+        // Nova models don't support caching in toolConfig — skip CP2 for them.
+        let enable_tool_cache = supports_tool_cache(&self.display_model);
+        let tool_config = if let Some((mut tools, choice)) = tool_specs {
+            let mut no_tools = Vec::new();
+            inject_cache_points(
+                self.cache_retention,
+                &mut system_blocks,
+                if enable_tool_cache {
+                    &mut tools
+                } else {
+                    &mut no_tools
+                },
+                &mut bedrock_messages,
+            )?;
+            Some(assemble_tool_config(tools, choice)?)
+        } else {
+            let mut empty_tools = Vec::new();
+            inject_cache_points(
+                self.cache_retention,
+                &mut system_blocks,
+                &mut empty_tools,
+                &mut bedrock_messages,
+            )?;
+            None
+        };
 
         let mut builder = self
             .client
@@ -198,6 +265,11 @@ impl LlmProvider for BedrockProvider {
 
         let (text, tool_calls) = extract_content_blocks(response.output())?;
         let (input_tokens, output_tokens) = extract_token_usage(response.usage());
+        let (cache_read, cache_write) = extract_cache_usage(response.usage());
+
+        if cache_read > 0 {
+            tracing::debug!(cache_read, cache_write, "Bedrock prompt cache hit");
+        }
 
         Ok(ToolCompletionResponse {
             content: if text.is_empty() { None } else { Some(text) },
@@ -205,8 +277,8 @@ impl LlmProvider for BedrockProvider {
             input_tokens,
             output_tokens,
             finish_reason: map_stop_reason(response.stop_reason()),
-            cache_creation_input_tokens: 0,
-            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: cache_write,
+            cache_read_input_tokens: cache_read,
         })
     }
 
@@ -240,6 +312,116 @@ impl LlmProvider for BedrockProvider {
         }
         Ok(())
     }
+
+    fn cache_write_multiplier(&self) -> Decimal {
+        self.cache_retention.write_multiplier()
+    }
+
+    fn cache_read_discount(&self) -> Decimal {
+        self.cache_retention.read_discount()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Prompt cache support
+// ---------------------------------------------------------------------------
+
+/// Strip the cross-region inference prefix from a Bedrock model ID.
+fn strip_cross_region_prefix(model: &str) -> &str {
+    model
+        .strip_prefix("us.")
+        .or_else(|| model.strip_prefix("eu."))
+        .or_else(|| model.strip_prefix("apac."))
+        .or_else(|| model.strip_prefix("global."))
+        .unwrap_or(model)
+}
+
+/// Check if a Bedrock model supports prompt caching.
+///
+/// Only Claude 3+ and Amazon Nova models support `CachePointBlock` in the
+/// Converse API. Returns `false` for older Claude models, Llama, Cohere, etc.
+fn supports_bedrock_cache(model: &str) -> bool {
+    let base = strip_cross_region_prefix(model);
+
+    base.starts_with("anthropic.claude-3")
+        || base.starts_with("anthropic.claude-4")
+        || base.starts_with("anthropic.claude-opus")
+        || base.starts_with("anthropic.claude-sonnet")
+        || base.starts_with("anthropic.claude-haiku")
+        || base.starts_with("amazon.nova-")
+}
+
+/// Check if a Bedrock model supports caching in the `tools` field.
+///
+/// Amazon Nova models only support caching in `system` and `messages`,
+/// not in `toolConfig`. Claude models support all three.
+fn supports_tool_cache(model: &str) -> bool {
+    !strip_cross_region_prefix(model).starts_with("amazon.nova-")
+}
+
+/// Build a `CachePointBlock` from the given retention policy.
+///
+/// `Short` produces a block with the server default TTL (5 minutes).
+/// `Long` explicitly sets `CacheTtl::OneHour`.
+fn build_cache_point(retention: CacheRetention) -> Result<CachePointBlock, LlmError> {
+    let mut builder = CachePointBlock::builder().r#type(CachePointType::Default);
+    if retention == CacheRetention::Long {
+        builder = builder.ttl(CacheTtl::OneHour);
+    }
+    builder.build().map_err(|e| LlmError::RequestFailed {
+        provider: "bedrock".to_string(),
+        reason: format!("Failed to build CachePointBlock: {}", e),
+    })
+}
+
+/// Inject cache points into system blocks, tools, and messages.
+///
+/// Up to 3 cache points are inserted:
+/// - CP1: after the last system content block
+/// - CP2: after the last tool definition
+/// - CP3: in the last User message's content blocks
+///
+/// No-op when `retention` is `None` or when the target vector is empty.
+fn inject_cache_points(
+    retention: CacheRetention,
+    system_blocks: &mut Vec<SystemContentBlock>,
+    tools: &mut Vec<Tool>,
+    messages: &mut [Message],
+) -> Result<(), LlmError> {
+    if retention == CacheRetention::None {
+        return Ok(());
+    }
+
+    // CP1: system prompt
+    if !system_blocks.is_empty() {
+        system_blocks.push(SystemContentBlock::CachePoint(build_cache_point(
+            retention,
+        )?));
+    }
+
+    // CP2: tool definitions
+    if !tools.is_empty() {
+        tools.push(Tool::CachePoint(build_cache_point(retention)?));
+    }
+
+    // CP3: last user message — append a CachePoint content block
+    if let Some(idx) = messages
+        .iter()
+        .rposition(|m| *m.role() == ConversationRole::User)
+    {
+        let mut content = messages[idx].content().to_vec();
+        content.push(ContentBlock::CachePoint(build_cache_point(retention)?));
+        messages[idx] = Message::builder()
+            .role(ConversationRole::User)
+            .set_content(Some(content))
+            .build()
+            .map_err(|e| LlmError::RequestFailed {
+                provider: "bedrock".to_string(),
+                reason: format!("Failed to rebuild Message with cache point: {}", e),
+            })?;
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -497,12 +679,24 @@ fn push_message(
 // Tool configuration
 // ---------------------------------------------------------------------------
 
-/// Build Bedrock `ToolConfiguration` from IronClaw tool definitions.
-fn build_tool_config(
+/// Resolved tool specs and tool choice, ready for cache point injection
+/// before assembly into `ToolConfiguration`.
+type ToolSpecs = (Vec<Tool>, Option<ToolChoice>);
+
+/// Build Bedrock tool specs and resolve tool choice from IronClaw definitions.
+///
+/// Returns `None` when tools are empty or `tool_choice` is `"none"`.
+/// The returned `Vec<Tool>` can be mutated (e.g. to inject a `CachePoint`)
+/// before passing to [`assemble_tool_config`].
+fn build_tool_specs(
     tools: &[ToolDefinition],
     tool_choice: Option<&str>,
-) -> Result<Option<ToolConfiguration>, LlmError> {
+) -> Result<Option<ToolSpecs>, LlmError> {
     if tools.is_empty() {
+        return Ok(None);
+    }
+
+    if tool_choice == Some("none") {
         return Ok(None);
     }
 
@@ -524,26 +718,28 @@ fn build_tool_config(
         .collect::<Result<Vec<_>, LlmError>>()?;
 
     let choice = match tool_choice {
-        Some("none") => {
-            // If tool_choice is "none", don't send tool config at all
-            return Ok(None);
-        }
         Some("required") => Some(ToolChoice::Any(AnyToolChoice::builder().build())),
         // "auto" or anything else
         _ => Some(ToolChoice::Auto(AutoToolChoice::builder().build())),
     };
 
-    let mut builder = ToolConfiguration::builder().set_tools(Some(bedrock_tools));
+    Ok(Some((bedrock_tools, choice)))
+}
+
+/// Assemble a `ToolConfiguration` from a (possibly cache-point-injected) tool
+/// list and resolved tool choice.
+fn assemble_tool_config(
+    tools: Vec<Tool>,
+    choice: Option<ToolChoice>,
+) -> Result<ToolConfiguration, LlmError> {
+    let mut builder = ToolConfiguration::builder().set_tools(Some(tools));
     if let Some(c) = choice {
         builder = builder.tool_choice(c);
     }
-
-    let config = builder.build().map_err(|e| LlmError::RequestFailed {
+    builder.build().map_err(|e| LlmError::RequestFailed {
         provider: "bedrock".to_string(),
         reason: format!("Failed to build ToolConfiguration: {}", e),
-    })?;
-
-    Ok(Some(config))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -595,6 +791,28 @@ fn extract_token_usage(usage: Option<&aws_sdk_bedrockruntime::types::TokenUsage>
             u32::try_from(u.input_tokens()).unwrap_or(0),
             u32::try_from(u.output_tokens()).unwrap_or(0),
         ),
+        None => (0, 0),
+    }
+}
+
+/// Extract prompt-cache token counts from the response.
+///
+/// Returns `(cache_read, cache_write)` mapped to
+/// `(cache_read_input_tokens, cache_creation_input_tokens)` in response structs.
+/// Both SDK fields are `Option<i32>`; absent or negative values map to 0.
+fn extract_cache_usage(usage: Option<&aws_sdk_bedrockruntime::types::TokenUsage>) -> (u32, u32) {
+    match usage {
+        Some(u) => {
+            let read = u
+                .cache_read_input_tokens()
+                .and_then(|v| u32::try_from(v).ok())
+                .unwrap_or(0);
+            let write = u
+                .cache_write_input_tokens()
+                .and_then(|v| u32::try_from(v).ok())
+                .unwrap_or(0);
+            (read, write)
+        }
         None => (0, 0),
     }
 }
@@ -749,6 +967,7 @@ pub(crate) fn document_to_json(doc: &Document) -> serde_json::Value {
 mod tests {
     use super::*;
     use crate::llm::provider::{ChatMessage, Role};
+    use rust_decimal_macros::dec;
 
     #[test]
     fn test_json_to_document_round_trip() {
@@ -902,19 +1121,19 @@ mod tests {
     }
 
     #[test]
-    fn test_build_tool_config_empty_tools() {
-        let result = build_tool_config(&[], None).unwrap();
+    fn test_build_tool_specs_empty_tools() {
+        let result = build_tool_specs(&[], None).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_build_tool_config_none_choice() {
-        let result = build_tool_config(&[], Some("none")).unwrap();
+    fn test_build_tool_specs_none_choice() {
+        let result = build_tool_specs(&[], Some("none")).unwrap();
         assert!(result.is_none());
     }
 
     #[test]
-    fn test_build_tool_config_with_tools() {
+    fn test_build_tool_specs_with_tools() {
         let tools = vec![ToolDefinition {
             name: "echo".to_string(),
             description: "Echoes input".to_string(),
@@ -926,7 +1145,7 @@ mod tests {
             }),
         }];
 
-        let result = build_tool_config(&tools, Some("auto")).unwrap();
+        let result = build_tool_specs(&tools, Some("auto")).unwrap();
         assert!(result.is_some());
     }
 
@@ -1136,14 +1355,14 @@ mod tests {
     }
 
     #[test]
-    fn test_build_tool_config_required_choice() {
+    fn test_build_tool_specs_required_choice() {
         let tools = vec![ToolDefinition {
             name: "echo".to_string(),
             description: "Echoes".to_string(),
             parameters: serde_json::json!({"type": "object"}),
         }];
 
-        let result = build_tool_config(&tools, Some("required")).unwrap();
+        let result = build_tool_specs(&tools, Some("required")).unwrap();
         assert!(result.is_some());
     }
 
@@ -1309,7 +1528,7 @@ mod tests {
 
         // Simulate complete_with_tools() with empty tools
         crate::llm::provider::sanitize_tool_messages(&mut messages);
-        let tool_config = build_tool_config(&[], None).unwrap();
+        let tool_config = build_tool_specs(&[], None).unwrap();
         assert!(tool_config.is_none());
 
         if tool_config.is_none() {
@@ -1378,7 +1597,7 @@ mod tests {
 
     #[test]
     fn test_complete_with_tools_choice_none_strips_history() {
-        // tool_choice="none" causes build_tool_config to return None,
+        // tool_choice="none" causes build_tool_specs to return None,
         // which should trigger stripping of tool blocks from messages.
         let tools = vec![ToolDefinition {
             name: "echo".to_string(),
@@ -1400,7 +1619,7 @@ mod tests {
         ];
 
         crate::llm::provider::sanitize_tool_messages(&mut messages);
-        let tool_config = build_tool_config(&tools, Some("none")).unwrap();
+        let tool_config = build_tool_specs(&tools, Some("none")).unwrap();
         assert!(tool_config.is_none());
 
         if tool_config.is_none() {
@@ -1414,6 +1633,406 @@ mod tests {
                 assert!(!block.is_tool_use());
                 assert!(!block.is_tool_result());
             }
+        }
+    }
+
+    // ── Prompt caching tests ────────────────────────────────────────
+
+    #[test]
+    fn test_supports_bedrock_cache_claude3_models() {
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-3-5-haiku-20241022-v1:0"
+        ));
+    }
+
+    #[test]
+    fn test_supports_bedrock_cache_claude4_models() {
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-sonnet-4-20250514-v1:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-opus-4-20250514-v1:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-haiku-4-5-20251001-v1:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "anthropic.claude-4-some-future-model"
+        ));
+    }
+
+    #[test]
+    fn test_supports_bedrock_cache_nova_models() {
+        assert!(supports_bedrock_cache("amazon.nova-micro-v1:0"));
+        assert!(supports_bedrock_cache("amazon.nova-lite-v1:0"));
+        assert!(supports_bedrock_cache("amazon.nova-pro-v1:0"));
+        assert!(supports_bedrock_cache("amazon.nova-premier-v1:0"));
+        assert!(supports_bedrock_cache("amazon.nova-2-lite-v1:0"));
+    }
+
+    #[test]
+    fn test_supports_bedrock_cache_cross_region() {
+        assert!(supports_bedrock_cache(
+            "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
+        ));
+        assert!(supports_bedrock_cache(
+            "eu.anthropic.claude-opus-4-20250514-v1:0"
+        ));
+        assert!(supports_bedrock_cache("apac.amazon.nova-pro-v1:0"));
+        assert!(supports_bedrock_cache(
+            "global.anthropic.claude-3-7-sonnet-20250219-v1:0"
+        ));
+    }
+
+    #[test]
+    fn test_supports_bedrock_cache_unsupported_models() {
+        assert!(!supports_bedrock_cache("anthropic.claude-2"));
+        assert!(!supports_bedrock_cache("anthropic.claude-2.1"));
+        assert!(!supports_bedrock_cache("anthropic.claude-instant-v1"));
+        assert!(!supports_bedrock_cache("meta.llama3-70b-instruct-v1:0"));
+        assert!(!supports_bedrock_cache("cohere.command-r-plus-v1:0"));
+        assert!(!supports_bedrock_cache("mistral.mistral-large-latest"));
+    }
+
+    #[test]
+    fn test_build_cache_point_short() {
+        let point = build_cache_point(CacheRetention::Short).unwrap();
+        assert_eq!(*point.r#type(), CachePointType::Default);
+        assert!(point.ttl().is_none());
+    }
+
+    #[test]
+    fn test_build_cache_point_long() {
+        let point = build_cache_point(CacheRetention::Long).unwrap();
+        assert_eq!(*point.r#type(), CachePointType::Default);
+        assert_eq!(*point.ttl().unwrap(), CacheTtl::OneHour);
+    }
+
+    #[test]
+    fn test_inject_cache_points_none_is_noop() {
+        let mut system = vec![SystemContentBlock::Text("You are helpful.".to_string())];
+        let mut tools = vec![Tool::ToolSpec(
+            ToolSpecification::builder()
+                .name("echo")
+                .description("Echoes")
+                .input_schema(ToolInputSchema::Json(json_to_document(
+                    &serde_json::json!({"type": "object"}),
+                )))
+                .build()
+                .unwrap(),
+        )];
+        let mut messages = vec![
+            Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(vec![ContentBlock::Text("Hello".to_string())]))
+                .build()
+                .unwrap(),
+        ];
+
+        inject_cache_points(CacheRetention::None, &mut system, &mut tools, &mut messages).unwrap();
+
+        assert_eq!(system.len(), 1);
+        assert_eq!(tools.len(), 1);
+        assert_eq!(messages[0].content().len(), 1);
+    }
+
+    #[test]
+    fn test_inject_cache_points_system_and_messages() {
+        let mut system = vec![
+            SystemContentBlock::Text("You are helpful.".to_string()),
+            SystemContentBlock::Text("Be concise.".to_string()),
+        ];
+        let mut tools = Vec::new();
+        let mut messages = vec![
+            Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(vec![ContentBlock::Text("Hello".to_string())]))
+                .build()
+                .unwrap(),
+            Message::builder()
+                .role(ConversationRole::Assistant)
+                .set_content(Some(vec![ContentBlock::Text("Hi!".to_string())]))
+                .build()
+                .unwrap(),
+            Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(vec![ContentBlock::Text("How are you?".to_string())]))
+                .build()
+                .unwrap(),
+        ];
+
+        inject_cache_points(
+            CacheRetention::Short,
+            &mut system,
+            &mut tools,
+            &mut messages,
+        )
+        .unwrap();
+
+        // CP1: system gets a cache point appended
+        assert_eq!(system.len(), 3);
+        assert!(system[2].is_cache_point());
+
+        // CP2: no tools, so no tool cache point
+        assert!(tools.is_empty());
+
+        // CP3: last user message (index 2) gets a cache point
+        let last_user = &messages[2];
+        assert_eq!(last_user.content().len(), 2);
+        assert!(last_user.content()[0].is_text());
+        assert!(last_user.content()[1].is_cache_point());
+
+        // First user message should be untouched
+        assert_eq!(messages[0].content().len(), 1);
+    }
+
+    #[test]
+    fn test_inject_cache_points_with_tools() {
+        let mut system = vec![SystemContentBlock::Text("System.".to_string())];
+        let mut tools = vec![
+            Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name("echo")
+                    .description("Echoes")
+                    .input_schema(ToolInputSchema::Json(json_to_document(
+                        &serde_json::json!({"type": "object"}),
+                    )))
+                    .build()
+                    .unwrap(),
+            ),
+            Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name("search")
+                    .description("Searches")
+                    .input_schema(ToolInputSchema::Json(json_to_document(
+                        &serde_json::json!({"type": "object"}),
+                    )))
+                    .build()
+                    .unwrap(),
+            ),
+        ];
+        let mut messages = vec![
+            Message::builder()
+                .role(ConversationRole::User)
+                .set_content(Some(vec![ContentBlock::Text("Go".to_string())]))
+                .build()
+                .unwrap(),
+        ];
+
+        inject_cache_points(CacheRetention::Long, &mut system, &mut tools, &mut messages).unwrap();
+
+        // CP1: system
+        assert_eq!(system.len(), 2);
+        assert!(system[1].is_cache_point());
+
+        // CP2: tools
+        assert_eq!(tools.len(), 3);
+        assert!(tools[2].is_cache_point());
+        // Verify TTL is 1h for Long retention
+        let cache_tool = tools[2].as_cache_point().unwrap();
+        assert_eq!(*cache_tool.ttl().unwrap(), CacheTtl::OneHour);
+
+        // CP3: last user message
+        assert_eq!(messages[0].content().len(), 2);
+        assert!(messages[0].content()[1].is_cache_point());
+    }
+
+    #[test]
+    fn test_inject_cache_points_empty_inputs() {
+        let mut system = Vec::new();
+        let mut tools = Vec::new();
+        let mut messages: Vec<Message> = Vec::new();
+
+        inject_cache_points(
+            CacheRetention::Short,
+            &mut system,
+            &mut tools,
+            &mut messages,
+        )
+        .unwrap();
+
+        // All empty — no cache points added
+        assert!(system.is_empty());
+        assert!(tools.is_empty());
+        assert!(messages.is_empty());
+    }
+
+    #[test]
+    fn test_inject_cache_points_no_user_messages() {
+        let mut system = vec![SystemContentBlock::Text("System.".to_string())];
+        let mut tools = Vec::new();
+        // Only an assistant message, no user message
+        let mut messages = vec![
+            Message::builder()
+                .role(ConversationRole::Assistant)
+                .set_content(Some(vec![ContentBlock::Text("Hi".to_string())]))
+                .build()
+                .unwrap(),
+        ];
+
+        inject_cache_points(
+            CacheRetention::Short,
+            &mut system,
+            &mut tools,
+            &mut messages,
+        )
+        .unwrap();
+
+        // CP1: system gets cache point
+        assert_eq!(system.len(), 2);
+        assert!(system[1].is_cache_point());
+
+        // CP3: no user message, so assistant message is untouched
+        assert_eq!(messages[0].content().len(), 1);
+        assert!(messages[0].content()[0].is_text());
+    }
+
+    #[test]
+    fn test_extract_cache_usage_present() {
+        let usage = aws_sdk_bedrockruntime::types::TokenUsage::builder()
+            .input_tokens(1000)
+            .output_tokens(200)
+            .total_tokens(1200)
+            .cache_read_input_tokens(500)
+            .cache_write_input_tokens(300)
+            .build()
+            .unwrap();
+        let (read, write) = extract_cache_usage(Some(&usage));
+        assert_eq!(read, 500);
+        assert_eq!(write, 300);
+    }
+
+    #[test]
+    fn test_extract_cache_usage_none() {
+        let (read, write) = extract_cache_usage(None);
+        assert_eq!(read, 0);
+        assert_eq!(write, 0);
+    }
+
+    #[test]
+    fn test_extract_cache_usage_absent_fields() {
+        // TokenUsage without cache fields set
+        let usage = aws_sdk_bedrockruntime::types::TokenUsage::builder()
+            .input_tokens(100)
+            .output_tokens(50)
+            .total_tokens(150)
+            .build()
+            .unwrap();
+        let (read, write) = extract_cache_usage(Some(&usage));
+        assert_eq!(read, 0);
+        assert_eq!(write, 0);
+    }
+
+    #[test]
+    fn test_cache_retention_write_multiplier() {
+        assert_eq!(CacheRetention::None.write_multiplier(), Decimal::ONE);
+        assert_eq!(CacheRetention::Short.write_multiplier(), dec!(1.25));
+        assert_eq!(CacheRetention::Long.write_multiplier(), Decimal::TWO);
+    }
+
+    #[test]
+    fn test_cache_retention_read_discount() {
+        assert_eq!(CacheRetention::None.read_discount(), Decimal::ONE);
+        assert_eq!(CacheRetention::Short.read_discount(), dec!(10));
+        assert_eq!(CacheRetention::Long.read_discount(), dec!(10));
+    }
+
+    #[test]
+    fn test_assemble_tool_config_with_cache_point() {
+        // Verify that assemble_tool_config accepts a tool list with a cache point.
+        let tools = vec![
+            Tool::ToolSpec(
+                ToolSpecification::builder()
+                    .name("echo")
+                    .description("Echoes")
+                    .input_schema(ToolInputSchema::Json(json_to_document(
+                        &serde_json::json!({"type": "object"}),
+                    )))
+                    .build()
+                    .unwrap(),
+            ),
+            Tool::CachePoint(build_cache_point(CacheRetention::Short).unwrap()),
+        ];
+        let choice = Some(ToolChoice::Auto(AutoToolChoice::builder().build()));
+        let config = assemble_tool_config(tools, choice);
+        assert!(config.is_ok());
+    }
+
+    #[test]
+    fn test_supports_tool_cache() {
+        // Claude models support tool caching
+        assert!(supports_tool_cache(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        ));
+        assert!(supports_tool_cache("anthropic.claude-opus-4-20250514-v1:0"));
+        assert!(supports_tool_cache(
+            "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        ));
+
+        // Nova models do NOT support tool caching
+        assert!(!supports_tool_cache("amazon.nova-pro-v1:0"));
+        assert!(!supports_tool_cache("amazon.nova-lite-v1:0"));
+        assert!(!supports_tool_cache("us.amazon.nova-micro-v1:0"));
+    }
+
+    #[test]
+    fn test_cache_retention_from_str_aliases() {
+        assert_eq!(
+            "none".parse::<CacheRetention>().unwrap(),
+            CacheRetention::None
+        );
+        assert_eq!(
+            "off".parse::<CacheRetention>().unwrap(),
+            CacheRetention::None
+        );
+        assert_eq!(
+            "disabled".parse::<CacheRetention>().unwrap(),
+            CacheRetention::None
+        );
+        assert_eq!(
+            "short".parse::<CacheRetention>().unwrap(),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            "5m".parse::<CacheRetention>().unwrap(),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            "ephemeral".parse::<CacheRetention>().unwrap(),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            "long".parse::<CacheRetention>().unwrap(),
+            CacheRetention::Long
+        );
+        assert_eq!(
+            "1h".parse::<CacheRetention>().unwrap(),
+            CacheRetention::Long
+        );
+    }
+
+    #[test]
+    fn test_cache_retention_from_str_invalid() {
+        assert!("bogus".parse::<CacheRetention>().is_err());
+        assert!("".parse::<CacheRetention>().is_err());
+    }
+
+    #[test]
+    fn test_cache_retention_display_round_trip() {
+        for variant in [
+            CacheRetention::None,
+            CacheRetention::Short,
+            CacheRetention::Long,
+        ] {
+            let s = variant.to_string();
+            let parsed: CacheRetention = s.parse().unwrap();
+            assert_eq!(parsed, variant);
         }
     }
 }

--- a/src/llm/bedrock.rs
+++ b/src/llm/bedrock.rs
@@ -94,6 +94,20 @@ impl BedrockProvider {
         })
     }
 
+    /// Compute effective cache retention for the active model, logging if adjusted.
+    fn resolve_retention(&self, model_id: &str) -> CacheRetention {
+        let retention = effective_cache_retention(self.cache_retention, model_id);
+        if retention != self.cache_retention {
+            tracing::debug!(
+                configured = %self.cache_retention,
+                effective = %retention,
+                model = %model_id,
+                "Cache retention adjusted for active model"
+            );
+        }
+        retention
+    }
+
     /// Get the currently active model ID (with cross-region prefix).
     fn current_model_id(&self) -> String {
         match self.active_model.read() {
@@ -138,9 +152,10 @@ impl LlmProvider for BedrockProvider {
 
         // Inject cache points (CP1: system, CP3: last user message).
         // No CP2 because complete() has no tool config.
+        let retention = self.resolve_retention(&model_id);
         let mut empty_tools = Vec::new();
         inject_cache_points(
-            self.cache_retention,
+            retention,
             &mut system_blocks,
             &mut empty_tools,
             &mut bedrock_messages,
@@ -211,13 +226,14 @@ impl LlmProvider for BedrockProvider {
             });
         }
 
-        // Inject cache points into system, tools, and last user message.
+        // Compute effective retention for the active model and inject cache points.
         // Nova models don't support caching in toolConfig — skip CP2 for them.
-        let enable_tool_cache = supports_tool_cache(&self.display_model);
+        let retention = self.resolve_retention(&model_id);
+        let enable_tool_cache = supports_tool_cache(&model_id);
         let tool_config = if let Some((mut tools, choice)) = tool_specs {
             let mut no_tools = Vec::new();
             inject_cache_points(
-                self.cache_retention,
+                retention,
                 &mut system_blocks,
                 if enable_tool_cache {
                     &mut tools
@@ -230,7 +246,7 @@ impl LlmProvider for BedrockProvider {
         } else {
             let mut empty_tools = Vec::new();
             inject_cache_points(
-                self.cache_retention,
+                retention,
                 &mut system_blocks,
                 &mut empty_tools,
                 &mut bedrock_messages,
@@ -357,6 +373,38 @@ fn supports_bedrock_cache(model: &str) -> bool {
 /// not in `toolConfig`. Claude models support all three.
 fn supports_tool_cache(model: &str) -> bool {
     !strip_cross_region_prefix(model).starts_with("amazon.nova-")
+}
+
+/// Check if a Bedrock model supports 1-hour cache TTL.
+///
+/// Per AWS docs, only the Claude 4.5 family (Opus 4.5, Sonnet 4.5, Haiku 4.5)
+/// supports `CacheTtl::OneHour`. All other models only support the default
+/// 5-minute TTL.
+fn supports_long_ttl(model: &str) -> bool {
+    let base = strip_cross_region_prefix(model);
+    base.starts_with("anthropic.claude-opus-4-5")
+        || base.starts_with("anthropic.claude-sonnet-4-5")
+        || base.starts_with("anthropic.claude-haiku-4-5")
+}
+
+/// Compute the effective cache retention for a request given the configured
+/// preference and the active model.
+///
+/// - `None` configured → always `None`.
+/// - Model doesn't support caching → `None`.
+/// - `Long` configured but model doesn't support 1h TTL → downgraded to `Short`.
+/// - Otherwise → configured preference unchanged.
+fn effective_cache_retention(configured: CacheRetention, model: &str) -> CacheRetention {
+    if configured == CacheRetention::None {
+        return CacheRetention::None;
+    }
+    if !supports_bedrock_cache(model) {
+        return CacheRetention::None;
+    }
+    if configured == CacheRetention::Long && !supports_long_ttl(model) {
+        return CacheRetention::Short;
+    }
+    configured
 }
 
 /// Build a `CachePointBlock` from the given retention policy.
@@ -2034,5 +2082,147 @@ mod tests {
             let parsed: CacheRetention = s.parse().unwrap();
             assert_eq!(parsed, variant);
         }
+    }
+
+    // ── Dynamic model-aware retention tests ─────────────────────────
+
+    #[test]
+    fn test_supports_long_ttl_45_models() {
+        assert!(supports_long_ttl("anthropic.claude-opus-4-5-20260101-v1:0"));
+        assert!(supports_long_ttl(
+            "anthropic.claude-sonnet-4-5-20260101-v1:0"
+        ));
+        assert!(supports_long_ttl(
+            "anthropic.claude-haiku-4-5-20251001-v1:0"
+        ));
+        // Cross-region
+        assert!(supports_long_ttl(
+            "us.anthropic.claude-opus-4-5-20260101-v1:0"
+        ));
+        assert!(supports_long_ttl(
+            "eu.anthropic.claude-sonnet-4-5-20260101-v1:0"
+        ));
+        assert!(supports_long_ttl(
+            "global.anthropic.claude-haiku-4-5-20251001-v1:0"
+        ));
+    }
+
+    #[test]
+    fn test_supports_long_ttl_non_45_models() {
+        // Claude 4 (non-4.5) — no 1h TTL
+        assert!(!supports_long_ttl("anthropic.claude-opus-4-20250514-v1:0"));
+        assert!(!supports_long_ttl(
+            "anthropic.claude-sonnet-4-20250514-v1:0"
+        ));
+        // Claude 3.x — no 1h TTL
+        assert!(!supports_long_ttl(
+            "anthropic.claude-3-5-sonnet-20241022-v2:0"
+        ));
+        assert!(!supports_long_ttl(
+            "anthropic.claude-3-7-sonnet-20250219-v1:0"
+        ));
+        // Nova — no 1h TTL
+        assert!(!supports_long_ttl("amazon.nova-pro-v1:0"));
+        // Unsupported
+        assert!(!supports_long_ttl("meta.llama3-70b-instruct-v1:0"));
+    }
+
+    #[test]
+    fn test_effective_cache_retention_none_passthrough() {
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::None,
+                "anthropic.claude-opus-4-5-20260101-v1:0"
+            ),
+            CacheRetention::None
+        );
+        assert_eq!(
+            effective_cache_retention(CacheRetention::None, "meta.llama3-70b-instruct-v1:0"),
+            CacheRetention::None
+        );
+    }
+
+    #[test]
+    fn test_effective_cache_retention_unsupported_model() {
+        assert_eq!(
+            effective_cache_retention(CacheRetention::Short, "meta.llama3-70b-instruct-v1:0"),
+            CacheRetention::None
+        );
+        assert_eq!(
+            effective_cache_retention(CacheRetention::Long, "cohere.command-r-plus-v1:0"),
+            CacheRetention::None
+        );
+    }
+
+    #[test]
+    fn test_effective_cache_retention_long_downgrades_for_non_45() {
+        // Long on non-4.5 Claude → Short
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Long,
+                "anthropic.claude-opus-4-20250514-v1:0"
+            ),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Long,
+                "anthropic.claude-3-5-sonnet-20241022-v2:0"
+            ),
+            CacheRetention::Short
+        );
+        // Long on Nova → Short
+        assert_eq!(
+            effective_cache_retention(CacheRetention::Long, "amazon.nova-pro-v1:0"),
+            CacheRetention::Short
+        );
+    }
+
+    #[test]
+    fn test_effective_cache_retention_long_preserved_for_45() {
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Long,
+                "anthropic.claude-opus-4-5-20260101-v1:0"
+            ),
+            CacheRetention::Long
+        );
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Long,
+                "us.anthropic.claude-sonnet-4-5-20260101-v1:0"
+            ),
+            CacheRetention::Long
+        );
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Long,
+                "anthropic.claude-haiku-4-5-20251001-v1:0"
+            ),
+            CacheRetention::Long
+        );
+    }
+
+    #[test]
+    fn test_effective_cache_retention_short_unchanged() {
+        // Short on any supported model → stays Short
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Short,
+                "anthropic.claude-opus-4-20250514-v1:0"
+            ),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            effective_cache_retention(
+                CacheRetention::Short,
+                "anthropic.claude-opus-4-5-20260101-v1:0"
+            ),
+            CacheRetention::Short
+        );
+        assert_eq!(
+            effective_cache_retention(CacheRetention::Short, "amazon.nova-pro-v1:0"),
+            CacheRetention::Short
+        );
     }
 }

--- a/src/llm/config.rs
+++ b/src/llm/config.rs
@@ -7,6 +7,8 @@
 
 use std::path::PathBuf;
 
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
 use secrecy::SecretString;
 
 use crate::bootstrap::ironclaw_base_dir;
@@ -20,13 +22,17 @@ use crate::llm::session::SessionConfig;
 /// placeholder is never sent over the wire.
 pub const OAUTH_PLACEHOLDER: &str = "oauth-placeholder";
 
-/// Prompt cache retention policy for Anthropic.
+/// Prompt cache retention policy.
 ///
-/// Controls Anthropic's automatic prompt caching via a top-level
-/// `cache_control` field injected through rig-core's `additional_params`.
-/// - `None` — caching disabled, no `cache_control` injected.
-/// - `Short` — 5-minute TTL (default), `{"type": "ephemeral"}`, 1.25× write surcharge.
-/// - `Long` — 1-hour TTL, `{"type": "ephemeral", "ttl": "1h"}`, 2× write surcharge.
+/// Controls server-side prompt caching across providers:
+/// - **Anthropic (RigAdapter):** injects `cache_control` via `additional_params`.
+/// - **Bedrock (Converse API):** injects `CachePointBlock` into system, tool,
+///   and message content blocks.
+///
+/// Variants:
+/// - `None` — caching disabled.
+/// - `Short` — 5-minute TTL (default), 1.25× write surcharge.
+/// - `Long` — 1-hour TTL, 2× write surcharge.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum CacheRetention {
     /// No prompt caching.
@@ -60,6 +66,27 @@ impl std::fmt::Display for CacheRetention {
             Self::None => write!(f, "none"),
             Self::Short => write!(f, "short"),
             Self::Long => write!(f, "long"),
+        }
+    }
+}
+
+impl CacheRetention {
+    /// Cost multiplier for cache-write tokens relative to standard input rate.
+    pub fn write_multiplier(self) -> Decimal {
+        match self {
+            Self::None => Decimal::ONE,
+            Self::Short => dec!(1.25),
+            Self::Long => Decimal::TWO,
+        }
+    }
+
+    /// Discount divisor for cache-read tokens.
+    /// Cached-read cost = `input_rate / read_discount()`.
+    pub fn read_discount(self) -> Decimal {
+        if self != Self::None {
+            dec!(10)
+        } else {
+            Decimal::ONE
         }
     }
 }
@@ -144,6 +171,9 @@ pub struct BedrockConfig {
     pub cross_region: Option<String>,
     /// AWS named profile (for SSO / assume-role workflows).
     pub profile: Option<String>,
+    /// Prompt cache retention policy. Controls `CachePointBlock` injection
+    /// in Converse API requests (5-minute or 1-hour TTL).
+    pub cache_retention: CacheRetention,
 }
 
 /// LLM provider configuration.

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -16,7 +16,6 @@ use rig::message::{
     UserContent,
 };
 use rust_decimal::Decimal;
-use rust_decimal_macros::dec;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use serde_json::Value as JsonValue;
@@ -650,19 +649,11 @@ where
     }
 
     fn cache_write_multiplier(&self) -> Decimal {
-        match self.cache_retention {
-            CacheRetention::None => Decimal::ONE,
-            CacheRetention::Short => Decimal::new(125, 2), // 1.25× (125% of input rate)
-            CacheRetention::Long => Decimal::TWO,          // 2.0×  (200% of input rate)
-        }
+        self.cache_retention.write_multiplier()
     }
 
     fn cache_read_discount(&self) -> Decimal {
-        if self.cache_retention != CacheRetention::None {
-            dec!(10) // Anthropic: 90% discount (cost = input_rate / 10)
-        } else {
-            Decimal::ONE
-        }
+        self.cache_retention.read_discount()
     }
 
     async fn complete(
@@ -1248,37 +1239,24 @@ mod tests {
         );
     }
 
-    /// Verify that the multiplier match arms in `RigAdapter::cache_write_multiplier`
-    /// produce the expected values. We use a standalone helper because constructing
-    /// a real `RigAdapter` requires a rig `Model` (which needs network/provider setup).
-    /// The helper mirrors the same match expression — if the impl drifts, the
-    /// `test_build_rig_request_*` tests will still catch regressions end-to-end.
     #[test]
     fn test_cache_write_multiplier_values() {
         use rust_decimal::Decimal;
-        // None → 1.0× (no surcharge)
+        assert_eq!(CacheRetention::None.write_multiplier(), Decimal::ONE);
         assert_eq!(
-            cache_write_multiplier_for(CacheRetention::None),
-            Decimal::ONE
-        );
-        // Short → 1.25× (25% surcharge)
-        assert_eq!(
-            cache_write_multiplier_for(CacheRetention::Short),
+            CacheRetention::Short.write_multiplier(),
             Decimal::new(125, 2)
         );
-        // Long → 2.0× (100% surcharge)
-        assert_eq!(
-            cache_write_multiplier_for(CacheRetention::Long),
-            Decimal::TWO
-        );
+        assert_eq!(CacheRetention::Long.write_multiplier(), Decimal::TWO);
     }
 
-    fn cache_write_multiplier_for(retention: CacheRetention) -> rust_decimal::Decimal {
-        match retention {
-            CacheRetention::None => rust_decimal::Decimal::ONE,
-            CacheRetention::Short => rust_decimal::Decimal::new(125, 2),
-            CacheRetention::Long => rust_decimal::Decimal::TWO,
-        }
+    #[test]
+    fn test_cache_read_discount_values() {
+        use rust_decimal::Decimal;
+        use rust_decimal_macros::dec;
+        assert_eq!(CacheRetention::None.read_discount(), Decimal::ONE);
+        assert_eq!(CacheRetention::Short.read_discount(), dec!(10));
+        assert_eq!(CacheRetention::Long.read_discount(), dec!(10));
     }
 
     // -- supports_prompt_cache tests --


### PR DESCRIPTION
## Summary

- Add prompt caching support to the Bedrock provider, injecting up to 3 `CachePointBlock`s per Converse API request (system prompt, tool definitions, last user message)
- Extract `write_multiplier()` / `read_discount()` methods onto `CacheRetention` enum, deduplicating identical logic between Bedrock and RigAdapter
- Add `BEDROCK_CACHE_RETENTION` env var (none/short/long, default: short) with shared `resolve_cache_retention()` helper

Implementation follows the [AWS Bedrock Prompt Caching documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html).

## Details

**Cache point placement:**
- CP1: after system content blocks (most stable prefix)
- CP2: after tool definitions (skipped for Nova models — they don't support tool caching per [AWS docs](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html))
- CP3: in the last user message (caches conversation history prefix)

**Model gating:** Only Claude 3+ and Amazon Nova models get cache points. Unsupported models log a warning and silently disable caching. 1-hour TTL (`Long`) is gated to Claude 4.5 models only — non-4.5 models are automatically downgraded to 5-minute TTL (`Short`).

**Dynamic model awareness:** Cache retention is computed per-request based on the active model (via `effective_cache_retention()`), so `set_model()` correctly adjusts caching behavior without stale state.

**Response metrics:** Extracts `cache_read_input_tokens` and `cache_write_input_tokens` from `TokenUsage` — previously hardcoded to 0.

**Refactors:**
- `CacheRetention` doc updated from Anthropic-specific to provider-agnostic
- `build_tool_config()` split into `build_tool_specs()` + `assemble_tool_config()` to allow cache point injection between stages
- Stale `cache_write_multiplier_for` test helper in rig_adapter replaced with direct `CacheRetention` method calls

Closes #1926

## Test plan

- [x] 67 bedrock unit tests pass (model gating, cache point injection, metric extraction, TTL gating, effective retention logic)
- [x] 44 rig_adapter tests pass (delegation to `CacheRetention` methods)
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib` — 4,164 tests pass
- [x] Verify with a real Bedrock endpoint that cache metrics appear in responses