### PR TITLE
fix(llm): invert reasoning default — unknown models skip think/final tags

### DIFF
--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -485,15 +485,6 @@ impl LlmProvider for NearAiChatProvider {
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
 
-        // Resolve alias: when the API returns a different model name (e.g.
-        // "auto" → "Qwen/Qwen3.5-122B-A10B"), update active_model so
-        // subsequent calls use the resolved name for capability checks.
-        if let Some(ref resolved) = response.model
-            && *resolved != self.config.model
-        {
-            let _ = self.set_model(resolved);
-        }
-
         let choice =
             response
                 .choices
@@ -572,13 +563,6 @@ impl LlmProvider for NearAiChatProvider {
         };
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
-
-        // Resolve alias (same as complete — update active_model from response).
-        if let Some(ref resolved) = response.model
-            && *resolved != self.config.model
-        {
-            let _ = self.set_model(resolved);
-        }
 
         let choice =
             response
@@ -1040,10 +1024,6 @@ struct ChatCompletionResponse {
     #[allow(dead_code)]
     #[serde(default)]
     id: Option<String>,
-    /// The actual model that served the request. May differ from the
-    /// configured model when using aliases like `"auto"`.
-    #[serde(default)]
-    model: Option<String>,
     choices: Vec<ChatCompletionChoice>,
     #[serde(default)]
     usage: Option<ChatCompletionUsage>,
@@ -1637,30 +1617,6 @@ mod tests {
             "reasoning (alias) should NOT leak into tool-call responses"
         );
         assert_eq!(tool_calls.len(), 1);
-    }
-
-    /// Verify the response `model` field is deserialized.
-    #[test]
-    fn test_response_model_field_parsed() {
-        let response: ChatCompletionResponse = serde_json::from_value(serde_json::json!({
-            "id": "chatcmpl-test",
-            "model": "Qwen/Qwen3.5-122B-A10B",
-            "choices": [{
-                "message": {
-                    "role": "assistant",
-                    "content": "Hello"
-                },
-                "finish_reason": "stop"
-            }],
-            "usage": { "prompt_tokens": 10, "completion_tokens": 5 }
-        }))
-        .unwrap();
-
-        assert_eq!(
-            response.model.as_deref(),
-            Some("Qwen/Qwen3.5-122B-A10B"),
-            "response.model should be parsed from the API response"
-        );
     }
 
     #[tokio::test]

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -485,6 +485,15 @@ impl LlmProvider for NearAiChatProvider {
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
 
+        // Resolve alias: when the API returns a different model name (e.g.
+        // "auto" → "Qwen/Qwen3.5-122B-A10B"), update active_model so
+        // subsequent calls use the resolved name for capability checks.
+        if let Some(ref resolved) = response.model
+            && *resolved != self.config.model
+        {
+            let _ = self.set_model(resolved);
+        }
+
         let choice =
             response
                 .choices
@@ -563,6 +572,13 @@ impl LlmProvider for NearAiChatProvider {
         };
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
+
+        // Resolve alias (same as complete — update active_model from response).
+        if let Some(ref resolved) = response.model
+            && *resolved != self.config.model
+        {
+            let _ = self.set_model(resolved);
+        }
 
         let choice =
             response
@@ -1024,6 +1040,10 @@ struct ChatCompletionResponse {
     #[allow(dead_code)]
     #[serde(default)]
     id: Option<String>,
+    /// The actual model that served the request. May differ from the
+    /// configured model when using aliases like `"auto"`.
+    #[serde(default)]
+    model: Option<String>,
     choices: Vec<ChatCompletionChoice>,
     #[serde(default)]
     usage: Option<ChatCompletionUsage>,
@@ -1040,9 +1060,10 @@ struct ChatCompletionResponseMessage {
     #[allow(dead_code)]
     role: String,
     content: Option<String>,
-    /// Some models (e.g. GLM-5) return chain-of-thought reasoning here
-    /// instead of in `content`.
-    #[serde(default)]
+    /// Some models return chain-of-thought reasoning here instead of in
+    /// `content`. vLLM/SGLang backends (used by NEAR AI) return the field
+    /// as `reasoning`; other APIs (GLM-5, DeepSeek) use `reasoning_content`.
+    #[serde(default, alias = "reasoning")]
     reasoning_content: Option<String>,
     tool_calls: Option<Vec<ChatCompletionToolCall>>,
 }
@@ -1529,6 +1550,117 @@ mod tests {
             "reasoning_content should be used as fallback for text responses"
         );
         assert!(tool_calls.is_empty());
+    }
+
+    /// The vLLM/SGLang API returns `reasoning` (not `reasoning_content`).
+    /// Verify that the serde alias deserializes it correctly.
+    #[test]
+    fn test_reasoning_field_alias_accepted() {
+        let response: ChatCompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl-test",
+            "model": "Qwen/Qwen3.5-122B-A10B",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning": "The answer is 42."
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": { "prompt_tokens": 50, "completion_tokens": 20 }
+        }))
+        .unwrap();
+
+        let choice = response.choices.into_iter().next().unwrap();
+        let content = choice.message.content.or(choice.message.reasoning_content);
+
+        assert_eq!(
+            content,
+            Some("The answer is 42.".to_string()),
+            "reasoning field (vLLM alias) should deserialize into reasoning_content"
+        );
+    }
+
+    /// Verify that `reasoning` field does NOT leak into tool-call responses
+    /// (same logic as reasoning_content — only used for text fallback).
+    #[test]
+    fn test_reasoning_alias_not_leaked_into_tool_calls() {
+        let response: ChatCompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl-test",
+            "model": "Qwen/Qwen3.5-122B-A10B",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "reasoning": "Let me think about which tool to call...",
+                    "tool_calls": [{
+                        "id": "call_xyz",
+                        "type": "function",
+                        "function": {
+                            "name": "web_search",
+                            "arguments": "{\"query\":\"test\"}"
+                        }
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }],
+            "usage": { "prompt_tokens": 100, "completion_tokens": 50 }
+        }))
+        .unwrap();
+
+        let choice = response.choices.into_iter().next().unwrap();
+        let tool_calls: Vec<ToolCall> = choice
+            .message
+            .tool_calls
+            .unwrap_or_default()
+            .into_iter()
+            .map(|tc| {
+                let arguments = serde_json::from_str(&tc.function.arguments)
+                    .unwrap_or(serde_json::Value::Object(Default::default()));
+                ToolCall {
+                    id: tc.id,
+                    name: tc.function.name,
+                    arguments,
+                    reasoning: None,
+                }
+            })
+            .collect();
+
+        let content = if tool_calls.is_empty() {
+            choice.message.content.or(choice.message.reasoning_content)
+        } else {
+            choice.message.content
+        };
+
+        assert!(
+            content.is_none(),
+            "reasoning (alias) should NOT leak into tool-call responses"
+        );
+        assert_eq!(tool_calls.len(), 1);
+    }
+
+    /// Verify the response `model` field is deserialized.
+    #[test]
+    fn test_response_model_field_parsed() {
+        let response: ChatCompletionResponse = serde_json::from_value(serde_json::json!({
+            "id": "chatcmpl-test",
+            "model": "Qwen/Qwen3.5-122B-A10B",
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": "Hello"
+                },
+                "finish_reason": "stop"
+            }],
+            "usage": { "prompt_tokens": 10, "completion_tokens": 5 }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            response.model.as_deref(),
+            Some("Qwen/Qwen3.5-122B-A10B"),
+            "response.model should be parsed from the API response"
+        );
     }
 
     #[tokio::test]

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -984,21 +984,16 @@ Respond with a JSON plan in this format:
                 .to_string()
         };
 
-        // Models with native thinking (Qwen3, DeepSeek-R1, etc.) produce their
-        // own <think> tags or reasoning_content. Injecting our <think>/<final>
-        // format collides with their native behavior, causing thinking-only
-        // responses that clean to empty strings. See issue #789.
-        let has_native_thinking = self
+        // Default: direct-answer format. Only inject <think>/<final> tags for
+        // models explicitly known to require them. Unknown models, aliases like
+        // "auto", and native-thinking models all get the safe direct-answer
+        // format. See issue #789.
+        let needs_tags = self
             .model_name
             .as_ref()
-            .is_some_and(|n| crate::llm::reasoning_models::has_native_thinking(n));
+            .is_some_and(|n| crate::llm::reasoning_models::requires_think_final_tags(n));
 
-        let response_format = if has_native_thinking {
-            r#"## Response Format
-
-Respond directly with your answer. Do not wrap your response in any special tags.
-Your reasoning process is handled natively — just provide the final user-facing answer."#
-        } else {
+        let response_format = if needs_tags {
             r#"## Response Format — CRITICAL
 
 ALL internal reasoning MUST be inside <think>...</think> tags.
@@ -1010,6 +1005,11 @@ Only text inside <final> is shown to the user; everything else is discarded.
 Example:
 <think>The user is asking about X.</think>
 <final>Here is the answer about X.</final>"#
+        } else {
+            r#"## Response Format
+
+Respond directly with your answer. Do not wrap your response in any special tags.
+Your reasoning process is handled natively — just provide the final user-facing answer."#
         };
 
         format!(
@@ -3007,7 +3007,7 @@ That's my plan."#;
     }
 
     #[test]
-    fn test_system_prompt_skips_think_final_for_native_thinking() {
+    fn test_system_prompt_direct_answer_for_native_thinking_model() {
         let reasoning = make_reasoning_with_model("qwen3-8b");
         let prompt = reasoning.build_system_prompt_with_tools(&[]);
         assert!(
@@ -3018,27 +3018,47 @@ That's my plan."#;
     }
 
     #[test]
-    fn test_system_prompt_includes_think_final_for_regular_model() {
+    fn test_system_prompt_direct_answer_for_regular_model() {
+        // Regular models also get direct-answer format by default (inverted default)
         let reasoning = make_reasoning_with_model("llama-3.1-70b");
         let prompt = reasoning.build_system_prompt_with_tools(&[]);
-        assert!(prompt.contains("<think>"));
-        assert!(prompt.contains("<final>"));
+        assert!(!prompt.contains("<think>"));
+        assert!(!prompt.contains("<final>"));
+        assert!(prompt.contains("Respond directly"));
     }
 
     #[test]
-    fn test_system_prompt_defaults_to_think_final_when_no_model() {
+    fn test_system_prompt_defaults_to_direct_answer_when_no_model() {
         use crate::testing::StubLlm;
         let reasoning = Reasoning::new(Arc::new(StubLlm::new("test")));
         let prompt = reasoning.build_system_prompt_with_tools(&[]);
-        assert!(prompt.contains("<think>"));
-        assert!(prompt.contains("<final>"));
+        // No model name → safe default → direct-answer (no tags)
+        assert!(!prompt.contains("<think>"));
+        assert!(!prompt.contains("<final>"));
+        assert!(prompt.contains("Respond directly"));
     }
 
     #[test]
-    fn test_system_prompt_deepseek_r1_skips_think_final() {
+    fn test_system_prompt_direct_answer_for_deepseek_r1() {
         let reasoning = make_reasoning_with_model("deepseek-r1-distill-qwen-32b");
         let prompt = reasoning.build_system_prompt_with_tools(&[]);
         assert!(!prompt.contains("CRITICAL"));
+        assert!(prompt.contains("Respond directly"));
+    }
+
+    #[test]
+    fn test_system_prompt_direct_answer_for_auto_alias() {
+        let reasoning = make_reasoning_with_model("auto");
+        let prompt = reasoning.build_system_prompt_with_tools(&[]);
+        assert!(!prompt.contains("<think>"));
+        assert!(prompt.contains("Respond directly"));
+    }
+
+    #[test]
+    fn test_system_prompt_direct_answer_for_resolved_qwen() {
+        let reasoning = make_reasoning_with_model("Qwen/Qwen3.5-122B-A10B");
+        let prompt = reasoning.build_system_prompt_with_tools(&[]);
+        assert!(!prompt.contains("<think>"));
         assert!(prompt.contains("Respond directly"));
     }
 
@@ -3332,13 +3352,15 @@ That's my plan."#;
         );
         assert!(prompt.contains("Respond directly"));
 
-        // Now create reasoning WITHOUT with_model_name — should get default prompt
+        // Now create reasoning WITHOUT with_model_name — should get direct-answer
+        // default (inverted default: unknown models are native-thinking-safe)
         let reasoning_no_model = Reasoning::new(llm);
         let prompt2 = reasoning_no_model.build_system_prompt_with_tools(&[]);
         assert!(
-            prompt2.contains("<think>"),
-            "Without model name, should get default think/final prompt"
+            !prompt2.contains("<think>"),
+            "Without model name, should get direct-answer prompt (safe default)"
         );
+        assert!(prompt2.contains("Respond directly"));
     }
 
     // ---- Issue #789: case-insensitive truncation ----

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1008,8 +1008,7 @@ Example:
         } else {
             r#"## Response Format
 
-Respond directly with your answer. Do not wrap your response in any special tags.
-Your reasoning process is handled natively — just provide the final user-facing answer."#
+Respond directly with your final answer. Do not wrap your response in any special tags."#
         };
 
         format!(
@@ -3014,7 +3013,7 @@ That's my plan."#;
             !prompt.contains("<think>"),
             "Native thinking model should NOT have <think> in system prompt"
         );
-        assert!(prompt.contains("Respond directly with your answer"));
+        assert!(prompt.contains("Respond directly"));
     }
 
     #[test]

--- a/src/llm/reasoning_models.rs
+++ b/src/llm/reasoning_models.rs
@@ -1,69 +1,69 @@
 //! Reasoning/thinking model detection utilities.
 //!
-//! Models with native thinking support produce structured chain-of-thought
-//! via `reasoning_content` fields or built-in `<think>` tags. Injecting
-//! IronClaw's own `<think>/<final>` format instructions into the system
-//! prompt collides with these models' native behavior, causing:
-//! - Thinking-only responses with no visible content
-//! - Double-wrapped thinking tags that confuse response cleaning
+//! ## Default: assume native thinking
 //!
-//! When a model has native thinking, we skip the `<think>/<final>` prompt
-//! injection and let the model use its own format. The response cleaning
-//! pipeline already handles stripping all known thinking tag variants.
+//! Most modern LLMs either have built-in thinking (Qwen3, DeepSeek-R1, GLM-5)
+//! or work fine without `<think>/<final>` prompt injection (GPT-4o, Claude,
+//! Llama). Injecting `<think>/<final>` tags into a native-thinking model's
+//! system prompt causes broken responses: the model puts reasoning in its
+//! native `reasoning` field and only `<think>` tags in `content`, which the
+//! response cleaner strips to empty.
 //!
-//! ## Design note: why match broadly (e.g. all Qwen3)?
+//! We therefore **default to NOT injecting** `<think>/<final>` tags. Only
+//! models explicitly listed in `REQUIRES_THINK_FINAL_PATTERNS` get the strict
+//! tag format. This is the safe default because:
 //!
-//! Some families (Qwen3) have ALL variants trained with native `<think>` tags,
-//! even tiny models like 0.6B. Thinking can be disabled at inference time via
-//! `enable_thinking=false`, but we can't detect that from the model name alone.
-//! We err on the safe side: skip injection for all variants because:
-//! - False negative (inject when model thinks natively) = broken responses
-//! - False positive (skip injection for non-thinking model) = less structured
-//!   but working responses
+//! - Skipping injection for a model that could use it = slightly less
+//!   structured but working responses
+//! - Injecting into a native-thinking model = broken/empty responses
 //!
-//! For families where only SOME variants reason (GLM-4), we match specific
-//! sub-families (glm-z1, glm-4-plus) to avoid false positives.
+//! This also handles model aliases like NEAR AI's `"auto"` which resolve
+//! server-side to models like `Qwen/Qwen3.5-122B-A10B`. Since `"auto"`
+//! doesn't match any pattern, it falls through to the safe default.
 
-/// Known model families with native thinking/reasoning support.
+/// Models that explicitly require `<think>/<final>` prompt injection.
 ///
-/// These models produce chain-of-thought reasoning either via a dedicated
-/// `reasoning_content` response field or via built-in `<think>` tags that
-/// the model was trained to emit without prompt injection.
-const NATIVE_THINKING_PATTERNS: &[&str] = &[
-    // Qwen3 family — ALL variants (0.6B through 235B) emit native <think> tags
-    // by default. Thinking can be toggled via `enable_thinking` parameter or
-    // `/think` `/no_think` soft switches, but the default is ON and we can't
-    // detect the runtime setting from the model name.
-    "qwen3",
-    // QwQ is Qwen's dedicated reasoning model (based on Qwen2.5-32B + RL).
-    // Always thinks, no disable toggle.
-    "qwq",
-    // DeepSeek reasoning models — native reasoning_content field
-    "deepseek-r1",
-    "deepseek-reasoner",
-    // GLM reasoning variants only (glm-4-flash, glm-4-air, glm-4v do NOT reason)
-    "glm-z1",
-    "glm-4-plus",
-    "glm-5",
-    // Nanbeige reasoning models
-    "nanbeige",
-    // Step reasoning models (3.5+ have native thinking; step-3 base does not)
-    "step-3.5",
-    // MiniMax reasoning models
-    "minimax-m2",
+/// These are models proven to benefit from structured thinking tags AND
+/// that do NOT have native thinking support. The list is intentionally
+/// empty/minimal — the safe default is to skip injection.
+const REQUIRES_THINK_FINAL_PATTERNS: &[&str] = &[
+    // Currently empty: no models have been identified that require
+    // <think>/<final> injection to function correctly. Add patterns
+    // here only when a specific model is proven to need them.
 ];
 
-/// Check if a model name indicates native thinking/reasoning support.
+/// Check if a model requires explicit `<think>/<final>` prompt injection.
 ///
-/// Models that return `true` should NOT have IronClaw's `<think>/<final>`
-/// format instructions injected into their system prompt, as this collides
-/// with their built-in reasoning behavior.
+/// Returns `true` only for models in the allowlist that are known to need
+/// structured thinking tags. All other models — including unknown names,
+/// aliases like `"auto"`, and native-thinking models — return `false` and
+/// get the direct-answer prompt format.
+pub fn requires_think_final_tags(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    REQUIRES_THINK_FINAL_PATTERNS
+        .iter()
+        .any(|p| lower.contains(p))
+}
+
+/// Legacy helper — returns `true` for known native-thinking models.
 ///
-/// Note: this is a best-effort heuristic based on model name. Some models
-/// support toggling thinking at runtime (e.g. Qwen3's `enable_thinking`),
-/// which we cannot detect here. We default to assuming thinking is ON for
-/// models that have it, since that's the default behavior.
+/// Retained for call sites that need to know whether a model has native
+/// thinking (e.g. for response parsing heuristics), but no longer used
+/// for prompt injection decisions. Use [`requires_think_final_tags`] for
+/// that instead.
 pub fn has_native_thinking(model: &str) -> bool {
+    const NATIVE_THINKING_PATTERNS: &[&str] = &[
+        "qwen3",
+        "qwq",
+        "deepseek-r1",
+        "deepseek-reasoner",
+        "glm-z1",
+        "glm-4-plus",
+        "glm-5",
+        "nanbeige",
+        "step-3.5",
+        "minimax-m2",
+    ];
     let lower = model.to_ascii_lowercase();
     NATIVE_THINKING_PATTERNS.iter().any(|p| lower.contains(p))
 }
@@ -72,15 +72,53 @@ pub fn has_native_thinking(model: &str) -> bool {
 mod tests {
     use super::*;
 
+    // ── requires_think_final_tags tests ──
+
+    #[test]
+    fn unknown_models_do_not_require_tags() {
+        assert!(!requires_think_final_tags("gpt-4o"));
+        assert!(!requires_think_final_tags("claude-3-5-sonnet"));
+        assert!(!requires_think_final_tags("llama-3.1-70b"));
+        assert!(!requires_think_final_tags("mistral-7b"));
+        assert!(!requires_think_final_tags("gemini-2.0-flash"));
+    }
+
+    #[test]
+    fn auto_alias_does_not_require_tags() {
+        assert!(!requires_think_final_tags("auto"));
+    }
+
+    #[test]
+    fn resolved_qwen_does_not_require_tags() {
+        assert!(!requires_think_final_tags("Qwen/Qwen3.5-122B-A10B"));
+        assert!(!requires_think_final_tags("qwen3-8b"));
+        assert!(!requires_think_final_tags("Qwen3.5-35B"));
+    }
+
+    #[test]
+    fn native_thinking_models_do_not_require_tags() {
+        assert!(!requires_think_final_tags("deepseek-r1-distill-qwen-32b"));
+        assert!(!requires_think_final_tags("deepseek-reasoner"));
+        assert!(!requires_think_final_tags("glm-z1-airx"));
+        assert!(!requires_think_final_tags("GLM-5"));
+        assert!(!requires_think_final_tags("qwq-32b"));
+    }
+
+    #[test]
+    fn empty_and_unusual_names_do_not_require_tags() {
+        assert!(!requires_think_final_tags(""));
+        assert!(!requires_think_final_tags("some-custom-model-v2"));
+    }
+
+    // ── has_native_thinking legacy tests ──
+
     #[test]
     fn detects_qwen3_models() {
-        // All Qwen3 variants have native thinking (even small ones)
         assert!(has_native_thinking("qwen3-coder-next-80b"));
         assert!(has_native_thinking("Qwen3.5-35B"));
         assert!(has_native_thinking("qwen3-0.6b"));
         assert!(has_native_thinking("qwen3:8b"));
         assert!(has_native_thinking("qwen3-30b-a3b"));
-        // Ollama-style tag format
         assert!(has_native_thinking("qwen3-coder:latest"));
     }
 
@@ -123,14 +161,11 @@ mod tests {
 
     #[test]
     fn rejects_non_reasoning_variants_in_same_family() {
-        // Qwen2.5 does NOT have native thinking (only Qwen3/QwQ do)
         assert!(!has_native_thinking("qwen2.5:7b"));
         assert!(!has_native_thinking("qwen2.5-instruct"));
-        // GLM-4 base variants do NOT have reasoning_content
         assert!(!has_native_thinking("glm-4-flash"));
         assert!(!has_native_thinking("glm-4-air"));
         assert!(!has_native_thinking("glm-4v"));
-        // step-3 base does not reason (only 3.5+)
         assert!(!has_native_thinking("step-3-mini"));
     }
 }


### PR DESCRIPTION
## Summary

- **Invert reasoning default**: New `requires_think_final_tags()` with empty allowlist — unknown/alias models (including NEAR AI `auto`) get the safe direct-answer prompt instead of `<think>/<final>` injection
- **Fix field name mismatch**: Add `#[serde(alias = "reasoning")]` so vLLM/SGLang's `reasoning` field is accepted (was only reading `reasoning_content`)
- **Fix direct-answer prompt wording**: Removed misleading "native reasoning" reference; prompt now reads "Respond directly with your final answer. Do not wrap your response in any special tags." — applicable to all model types
- **Remove model alias resolution**: Dropped `active_model` update from `response.model` — `requires_think_final_tags()` returns `false` for both alias and resolved names, so resolution is unnecessary

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: unit tests for `requires_think_final_tags()`, system prompt formatting, `reasoning` serde alias
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: confirmed via direct curl testing against NEAR AI staging API; `cargo test --lib` — 4174 passed, 0 failed

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches `src/llm/reasoning.rs`, `src/llm/reasoning_models.rs`, `src/llm/nearai_chat.rs`. Could affect prompt formatting for all models routed through the NEAR AI provider, but the change is conservative — unknown/alias models now default to the simpler direct-answer prompt rather than injecting `<think>/<final>` tags.

## Rollback Plan

Revert commits on this branch. No schema or config changes; rollback is a straight revert.

## Review Follow-Through

- Model alias resolution (`active_model` from `response.model`) was prototyped and removed — `requires_think_final_tags()` returns `false` for both `"auto"` and any resolved name, making the resolution unnecessary.
- Direct-answer system prompt wording was updated to be model-agnostic per reviewer feedback.

---

**Review track**: B (feature/maintainer-requested refactor)