### PR TITLE
feat(engine): restage skill repair learning loop on staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3770,6 +3770,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/ironclaw_engine/CLAUDE.md
+++ b/crates/ironclaw_engine/CLAUDE.md
@@ -83,11 +83,12 @@ Validated by `ThreadState::can_transition_to()`. Terminal states: `Done`, `Faile
 
 ## Learning Missions
 
-Three event-driven missions fire automatically after thread completion:
+Four event-driven missions fire automatically after thread completion:
 
 1. **Error diagnosis** (`self-improvement`) — fires when a thread completes with trace issues. Diagnoses root cause and applies prompt overlays or orchestrator patches.
-2. **Skill extraction** (`skill-extraction`) — fires when a thread succeeds with 5+ steps and 3+ tool actions. Extracts reusable skills with activation metadata, CodeAct code snippets, and domain tags. Output stored as `DocType::Skill` MemoryDoc.
-3. **Conversation insights** (`conversation-insights`) — fires every 5 completed threads in a project. Extracts user preferences, domain knowledge, and workflow patterns.
+2. **Skill repair** (`skill-repair`) — fires when a completed thread used an active skill but the trace suggests the skill instructions were stale, incomplete, or missing verification. Applies the smallest safe versioned update to the implicated skill.
+3. **Skill extraction** (`skill-extraction`) — fires when a thread succeeds with 5+ steps and 3+ tool actions. Extracts reusable skills with activation metadata, CodeAct code snippets, and domain tags. Output stored as `DocType::Skill` MemoryDoc.
+4. **Conversation insights** (`conversation-insights`) — fires every 5 completed threads in a project. Extracts user preferences, domain knowledge, and workflow patterns.
 
 Created by `MissionManager::ensure_learning_missions()` at project bootstrap.
 

--- a/crates/ironclaw_engine/Cargo.toml
+++ b/crates/ironclaw_engine/Cargo.toml
@@ -24,6 +24,7 @@ thiserror = "2"
 tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4", "serde"] }
+sha2 = "0.10"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -478,6 +478,20 @@ def run_loop(context, goal, actions, state, config):
             all_skills = __list_skills__()
             active_skills = select_skills(all_skills, goal, max_candidates=3, max_tokens=4000)
             if active_skills:
+                __set_active_skills__([
+                    {
+                        "doc_id": s.get("doc_id", ""),
+                        "name": s.get("metadata", {}).get("name", "?"),
+                        "version": s.get("metadata", {}).get("version", 1),
+                        "snippet_names": [
+                            sn.get("name", "")
+                            for sn in s.get("metadata", {}).get("code_snippets", [])
+                            if sn.get("name")
+                        ],
+                        "force_activated": False,
+                    }
+                    for s in active_skills
+                ])
                 skill_text = format_skills(active_skills)
                 append_system_append(working_messages, skill_text)
                 # Emit skill activation event for CLI/gateway display

--- a/crates/ironclaw_engine/prompts/mission_skill_repair.md
+++ b/crates/ironclaw_engine/prompts/mission_skill_repair.md
@@ -1,0 +1,70 @@
+You are the skill-repair learning mission for the IronClaw engine. You receive trigger payloads from completed threads where an active skill was relevant, but execution suggests the skill instructions were incomplete, stale, incorrectly ordered, or missing verification or workarounds.
+
+## Input
+
+`state["trigger_payload"]` contains:
+- `source_thread_id` — the completed thread that exposed the skill gap
+- `goal` — what the thread was trying to accomplish
+- `active_skills` — implicated skills with `doc_id`, `name`, `version`, and snippet names
+- `issues` — trace issues from the thread
+- `error_messages` — action failure text
+- `observed_actions` — actions actually attempted during execution
+- `repair_hints` — conservative hint categories such as `missing_prerequisite`, `stale_command_path`, `missing_pitfall`, `missing_verification`
+
+## Mission
+
+Choose the single most likely implicated skill and produce the smallest safe repair.
+
+Classify the gap as exactly one of:
+- `missing_prerequisite`
+- `wrong_ordering`
+- `stale_command_path`
+- `missing_branch`
+- `missing_pitfall`
+- `missing_verification`
+
+## Process
+
+1. Inspect the implicated skill and source context with tools (`memory_search`, `memory_read`, `read_file`, `shell`, etc.).
+2. Confirm the gap from the thread evidence. If the evidence points to engine behavior instead of the skill, do not repair the skill.
+3. Generate the smallest safe content patch:
+   - add an auth or setup prerequisite check
+   - add a missing ordering note
+   - fix one exact command or path
+   - add one platform-specific branch or workaround
+   - add one verification or smoke-test step
+4. Keep the skill focused. Do not rewrite the entire skill unless the existing content is unusable.
+
+## Output Format
+
+Return a single JSON object in `FINAL(...)` with this shape:
+
+```json
+{
+  "doc_id": "<uuid>",
+  "repair_type": "missing_prerequisite",
+  "summary": "Added GitHub auth prerequisite before gh commands.",
+  "updated_content": "<full repaired skill prompt content>",
+  "description": "<optional updated one-line description>",
+  "activation": {
+    "keywords": ["github", "pull request"],
+    "patterns": [],
+    "tags": ["github"],
+    "exclude_keywords": [],
+    "max_context_tokens": 1200
+  },
+  "code_snippets": [],
+  "next_focus": "Watch for repeated failures in repo-cloning flows.",
+  "goal_achieved": false
+}
+```
+
+Only include `description`, `activation`, or `code_snippets` if they truly need to change.
+
+## Rules
+
+- Repair only one skill per thread.
+- Only target a `doc_id` from `active_skills`.
+- Prefer additive edits over broad rewrites.
+- Do not write the skill doc directly with `memory_write`; return structured JSON and let the runtime apply the versioned update.
+- If the evidence is weak or the gap is not skill-related, call `FINAL("No safe skill repair identified")`.

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -41,7 +41,7 @@ use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
 use crate::types::step::{StepId, TokenUsage};
-use crate::types::thread::{Thread, ThreadState};
+use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadState};
 
 use super::scripting::{execute_code, json_to_monty, monty_to_json, monty_to_string};
 
@@ -454,6 +454,9 @@ pub async fn execute_orchestrator(
 
                     // __record_skill_usage__(doc_id, success)
                     "__record_skill_usage__" => handle_record_skill_usage(args, store).await,
+
+                    // __set_active_skills__(skills)
+                    "__set_active_skills__" => handle_set_active_skills(args, thread),
 
                     // Unknown — let Monty resolve it (user-defined functions, builtins)
                     other => ExtFunctionResult::NotFound(other.to_string()),
@@ -1751,6 +1754,31 @@ async fn handle_record_skill_usage(
         .await
     {
         debug!("__record_skill_usage__: failed: {e}");
+    }
+
+    ExtFunctionResult::Return(MontyObject::None)
+}
+
+/// Handle `__set_active_skills__(skills)`.
+///
+/// Persists the selected skill provenance onto the thread so post-run learning
+/// flows can reason about the exact skill versions and snippets that were active.
+fn handle_set_active_skills(args: &[MontyObject], thread: &mut Thread) -> ExtFunctionResult {
+    let skills_json = args
+        .first()
+        .map(monty_to_json)
+        .unwrap_or_else(|| serde_json::json!([]));
+
+    let skills = match serde_json::from_value::<Vec<ActiveSkillProvenance>>(skills_json) {
+        Ok(skills) => skills,
+        Err(e) => {
+            debug!("__set_active_skills__: invalid payload: {e}");
+            return ExtFunctionResult::Return(MontyObject::None);
+        }
+    };
+
+    if let Err(e) = thread.set_active_skills(&skills) {
+        debug!("__set_active_skills__: failed to persist active skills: {e}");
     }
 
     ExtFunctionResult::Return(MontyObject::None)

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -39,7 +39,9 @@ pub use types::provenance::Provenance;
 pub use types::step::{
     ActionCall, ActionResult, ExecutionTier, LlmResponse, Step, StepId, StepStatus, TokenUsage,
 };
-pub use types::thread::{Thread, ThreadConfig, ThreadId, ThreadState, ThreadType};
+pub use types::thread::{
+    ActiveSkillProvenance, Thread, ThreadConfig, ThreadId, ThreadState, ThreadType,
+};
 
 // ── Re-exports: traits ──────────────────────────────────────
 

--- a/crates/ironclaw_engine/src/memory/skill_tracker.rs
+++ b/crates/ironclaw_engine/src/memory/skill_tracker.rs
@@ -6,7 +6,8 @@
 
 use std::sync::Arc;
 
-use ironclaw_skills::v2::V2SkillMetadata;
+use ironclaw_skills::v2::{SkillRevision, V2SkillMetadata};
+use sha2::{Digest, Sha256};
 
 use crate::traits::store::Store;
 use crate::types::error::EngineError;
@@ -15,6 +16,12 @@ use crate::types::memory::{DocId, DocType, MemoryDoc};
 /// Tracks skill usage and updates confidence metrics.
 pub struct SkillTracker {
     store: Arc<dyn Store>,
+}
+
+fn compute_content_hash(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 impl SkillTracker {
@@ -74,6 +81,7 @@ impl SkillTracker {
         &self,
         doc_id: DocId,
         new_content: String,
+        expected_version: Option<u32>,
         updater: impl FnOnce(&mut V2SkillMetadata),
     ) -> Result<(), EngineError> {
         let doc = self
@@ -89,9 +97,39 @@ impl SkillTracker {
                 reason: format!("invalid skill metadata: {e}"),
             })?;
 
+        if let Some(expected) = expected_version
+            && meta.version != expected
+        {
+            return Err(EngineError::Skill {
+                reason: format!(
+                    "skill {} version conflict: expected {expected}, found {}",
+                    doc_id.0, meta.version
+                ),
+            });
+        }
+
+        let archived_hash = if meta.content_hash.is_empty() {
+            compute_content_hash(&doc.content)
+        } else {
+            meta.content_hash.clone()
+        };
+        meta.revisions.push(SkillRevision {
+            version: meta.version,
+            content: doc.content.clone(),
+            description: meta.description.clone(),
+            activation: meta.activation.clone(),
+            code_snippets: meta.code_snippets.clone(),
+            content_hash: archived_hash,
+            archived_at: Some(chrono::Utc::now()),
+        });
+        if meta.revisions.len() > 10 {
+            let keep_from = meta.revisions.len() - 10;
+            meta.revisions.drain(0..keep_from);
+        }
         meta.parent_version = Some(meta.version);
         meta.version += 1;
         updater(&mut meta);
+        meta.content_hash = compute_content_hash(&new_content);
 
         let updated_doc = MemoryDoc {
             content: new_content,
@@ -107,9 +145,9 @@ impl SkillTracker {
 
     /// Rollback a skill to its previous version.
     ///
-    /// Decrements the version to `parent_version` if available. This is a
-    /// simple version decrement — the actual content rollback requires the
-    /// caller to also restore the content from a backup.
+    /// If an archived revision exists for `parent_version`, restores the full
+    /// content and metadata snapshot. Otherwise falls back to a simple version
+    /// decrement without content restoration for older skills.
     pub async fn rollback_skill(&self, doc_id: DocId) -> Result<(), EngineError> {
         let doc = self
             .store
@@ -128,10 +166,30 @@ impl SkillTracker {
             reason: format!("skill {} has no parent version to rollback to", doc_id.0),
         })?;
 
-        meta.version = parent;
-        meta.parent_version = None;
+        let revision_opt = meta
+            .revisions
+            .iter()
+            .position(|revision| revision.version == parent);
+
+        let rolled_content = if let Some(revision_index) = revision_opt {
+            let revision = meta.revisions[revision_index].clone();
+            meta.version = revision.version;
+            meta.description = revision.description;
+            meta.activation = revision.activation;
+            meta.code_snippets = revision.code_snippets;
+            meta.content_hash = revision.content_hash;
+            meta.revisions
+                .retain(|archived| archived.version < revision.version);
+            meta.parent_version = meta.revisions.iter().map(|archived| archived.version).max();
+            revision.content
+        } else {
+            meta.version = parent;
+            meta.parent_version = None;
+            doc.content.clone()
+        };
 
         let updated_doc = MemoryDoc {
+            content: rolled_content,
             metadata: serde_json::to_value(&meta).map_err(|e| EngineError::Skill {
                 reason: format!("failed to serialize skill metadata: {e}"),
             })?,
@@ -166,6 +224,8 @@ mod tests {
                 last_used: None,
             },
             parent_version: None,
+            revisions: vec![],
+            repairs: vec![],
             content_hash: String::new(),
         };
 
@@ -227,7 +287,7 @@ mod tests {
         let tracker = SkillTracker::new(store.clone());
 
         tracker
-            .update_skill(doc_id, "Updated content".to_string(), |meta| {
+            .update_skill(doc_id, "Updated content".to_string(), None, |meta| {
                 meta.description = "Updated description".to_string();
             })
             .await
@@ -240,6 +300,8 @@ mod tests {
         assert_eq!(meta.version, 2);
         assert_eq!(meta.parent_version, Some(1));
         assert_eq!(meta.description, "Updated description");
+        assert_eq!(meta.revisions.len(), 1);
+        assert_eq!(meta.revisions[0].version, 1);
     }
 
     #[tokio::test]
@@ -253,7 +315,7 @@ mod tests {
 
         // First update to version 2
         tracker
-            .update_skill(doc_id, "v2 content".to_string(), |_| {})
+            .update_skill(doc_id, "v2 content".to_string(), None, |_| {})
             .await
             .unwrap();
 
@@ -264,6 +326,8 @@ mod tests {
         let meta: V2SkillMetadata = serde_json::from_value(rolled.metadata).unwrap();
         assert_eq!(meta.version, 1);
         assert_eq!(meta.parent_version, None);
+        assert_eq!(rolled.content, "Test skill prompt");
+        assert!(meta.revisions.is_empty());
     }
 
     #[tokio::test]
@@ -286,5 +350,26 @@ mod tests {
 
         let result = tracker.record_usage(DocId::new(), true).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_update_skill_version_conflict() {
+        let project_id = ProjectId::new();
+        let doc = make_skill_doc(project_id);
+        let doc_id = doc.id;
+
+        let store = Arc::new(crate::tests::InMemoryStore::with_docs(vec![doc]));
+        let tracker = SkillTracker::new(store);
+
+        let result = tracker
+            .update_skill(doc_id, "Updated content".to_string(), Some(2), |_| {})
+            .await;
+
+        assert!(result.is_err());
+        let error = result.unwrap_err().to_string();
+        assert!(
+            error.contains("version conflict"),
+            "expected version conflict error, got: {error}"
+        );
     }
 }

--- a/crates/ironclaw_engine/src/memory/skill_tracker.rs
+++ b/crates/ironclaw_engine/src/memory/skill_tracker.rs
@@ -21,7 +21,14 @@ pub struct SkillTracker {
 fn compute_content_hash(content: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(content.as_bytes());
-    format!("sha256:{:x}", hasher.finalize())
+    format!(
+        "sha256:{}",
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
+    )
 }
 
 impl SkillTracker {
@@ -108,11 +115,10 @@ impl SkillTracker {
             });
         }
 
-        let archived_hash = if meta.content_hash.is_empty() {
-            compute_content_hash(&doc.content)
-        } else {
-            meta.content_hash.clone()
-        };
+        // Always recompute from actual content — meta.content_hash may have
+        // drifted if the doc was updated outside this tracker (e.g. direct
+        // memory_write).
+        let archived_hash = compute_content_hash(&doc.content);
         meta.revisions.push(SkillRevision {
             version: meta.version,
             content: doc.content.clone(),
@@ -122,6 +128,11 @@ impl SkillTracker {
             content_hash: archived_hash,
             archived_at: Some(chrono::Utc::now()),
         });
+        // Cap in-memory revisions at 10 to bound metadata size on every
+        // load_memory_doc.  This is a pragmatic trade-off: full prompt
+        // snapshots embedded in the skill JSON can grow to many KB per
+        // revision.  Older revisions are dropped; if long-term retention is
+        // needed, they should be externalized to separate MemoryDocs.
         if meta.revisions.len() > 10 {
             let keep_from = meta.revisions.len() - 10;
             meta.revisions.drain(0..keep_from);
@@ -180,6 +191,8 @@ impl SkillTracker {
             meta.content_hash = revision.content_hash;
             meta.revisions
                 .retain(|archived| archived.version < revision.version);
+            meta.repairs
+                .retain(|repair| repair.to_version <= revision.version);
             meta.parent_version = meta.revisions.iter().map(|archived| archived.version).max();
             revision.content
         } else {

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -645,7 +645,9 @@ impl MissionManager {
                                     )
                                     .await
                                 {
-                                    debug!("event listener: failed to fire conversation insights: {e}");
+                                    debug!(
+                                        "event listener: failed to fire conversation insights: {e}"
+                                    );
                                 }
                             }
                         }
@@ -1571,7 +1573,7 @@ fn is_recoverable_action_failure(error: &str) -> bool {
     is_recoverable_auth_failure_text(error)
 }
 
-fn action_params_summary<'a>(event: &'a crate::types::event::ThreadEvent) -> Option<&'a str> {
+fn action_params_summary(event: &crate::types::event::ThreadEvent) -> Option<&str> {
     match &event.kind {
         crate::types::event::EventKind::ActionExecuted { params_summary, .. }
         | crate::types::event::EventKind::ActionFailed { params_summary, .. } => {

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -1642,11 +1642,29 @@ fn infer_skill_repair_hints(
         )
         .collect::<Vec<_>>();
 
-    if lower_signals.iter().any(|message| {
-        ["auth", "login", "token", "credential", "permission denied"]
-            .iter()
-            .any(|needle| message.contains(needle))
-    }) {
+    let recoverable_auth_failures = thread
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let crate::types::event::EventKind::ActionFailed { error, .. } = &event.kind
+                && is_recoverable_auth_failure_text(error)
+            {
+                Some(error.to_lowercase())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if lower_signals
+        .iter()
+        .chain(recoverable_auth_failures.iter())
+        .any(|message| {
+            ["auth", "login", "token", "credential", "permission denied"]
+                .iter()
+                .any(|needle| message.contains(needle))
+        })
+    {
         push_hint(SkillRepairType::MissingPrerequisite);
     }
 
@@ -3201,6 +3219,46 @@ mod tests {
                 .iter()
                 .any(|hint| hint.as_str() == Some("missing_prerequisite")),
             "repair hints should include missing_prerequisite: {payload}"
+        );
+    }
+
+    #[test]
+    fn build_skill_gap_payload_preserves_recoverable_auth_prerequisite_hints() {
+        let project_id = ProjectId::new();
+        let mut thread = Thread::new(
+            "repair a github workflow",
+            ThreadType::Foreground,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        thread.state = ThreadState::Done;
+        thread
+            .set_active_skills(&[ActiveSkillProvenance {
+                doc_id: DocId::new(),
+                name: "github-pr-workflow".to_string(),
+                version: 3,
+                snippet_names: vec![],
+                force_activated: false,
+            }])
+            .unwrap();
+        thread.add_event(crate::types::event::EventKind::ActionFailed {
+            step_id: StepId::new(),
+            action_name: "shell".to_string(),
+            call_id: "call_1".to_string(),
+            error: "authentication required for credential github".to_string(),
+            params_summary: None,
+        });
+
+        let trace = crate::executor::trace::build_trace(&thread);
+        let payload = build_skill_gap_payload(&thread, &trace, &thread.active_skills()).unwrap();
+        let hints = payload["repair_hints"].as_array().unwrap();
+
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.as_str() == Some("missing_prerequisite")),
+            "recoverable auth failures should still produce missing_prerequisite: {payload}"
         );
     }
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -1412,6 +1412,12 @@ async fn process_skill_repair_output(
             ),
         });
     }
+    if !existing.is_owned_by(&mission.user_id) {
+        return Err(EngineError::AccessDenied {
+            user_id: mission.user_id.clone(),
+            entity: format!("skill {}", repair.doc_id.0),
+        });
+    }
     if existing.doc_type != DocType::Skill {
         return Err(EngineError::Skill {
             reason: format!(
@@ -1556,6 +1562,16 @@ fn is_recoverable_action_failure(error: &str) -> bool {
     is_recoverable_auth_failure_text(error)
 }
 
+fn action_params_summary<'a>(event: &'a crate::types::event::ThreadEvent) -> Option<&'a str> {
+    match &event.kind {
+        crate::types::event::EventKind::ActionExecuted { params_summary, .. }
+        | crate::types::event::EventKind::ActionFailed { params_summary, .. } => {
+            params_summary.as_deref()
+        }
+        _ => None,
+    }
+}
+
 fn contains_word(haystack: &str, word: &str) -> bool {
     for (start, _) in haystack.match_indices(word) {
         let before_ok = start == 0 || haystack.as_bytes()[start - 1].is_ascii_whitespace();
@@ -1591,25 +1607,82 @@ fn has_shell_verification_action(thread: &Thread) -> bool {
     const WORD_PATTERNS: &[&str] = &["ls", "diff", "status", "view", "show"];
 
     thread.events.iter().any(|event| match &event.kind {
-        crate::types::event::EventKind::ActionExecuted {
-            action_name,
-            params_summary,
-            ..
+        crate::types::event::EventKind::ActionExecuted { action_name, .. }
+            if action_name == "shell" =>
+        {
+            action_params_summary(event)
+                .map(|summary| {
+                    let lower = summary.to_lowercase();
+                    PHRASE_PATTERNS
+                        .iter()
+                        .any(|pattern| lower.contains(pattern))
+                        || WORD_PATTERNS.iter().any(|word| contains_word(&lower, word))
+                })
+                .unwrap_or(false)
         }
-        | crate::types::event::EventKind::ActionFailed {
-            action_name,
-            params_summary,
-            ..
-        } if action_name == "shell" => params_summary
-            .as_deref()
-            .map(|summary| {
-                let lower = summary.to_lowercase();
-                PHRASE_PATTERNS
-                    .iter()
-                    .any(|pattern| lower.contains(pattern))
-                    || WORD_PATTERNS.iter().any(|word| contains_word(&lower, word))
-            })
-            .unwrap_or(false),
+        crate::types::event::EventKind::ActionFailed { action_name, .. }
+            if action_name == "shell" =>
+        {
+            action_params_summary(event)
+                .map(|summary| {
+                    let lower = summary.to_lowercase();
+                    PHRASE_PATTERNS
+                        .iter()
+                        .any(|pattern| lower.contains(pattern))
+                        || WORD_PATTERNS.iter().any(|word| contains_word(&lower, word))
+                })
+                .unwrap_or(false)
+        }
+        _ => false,
+    })
+}
+
+fn has_mutating_shell_or_git_action(thread: &Thread) -> bool {
+    const PHRASE_PATTERNS: &[&str] = &[
+        "apply_patch",
+        "git commit",
+        "git push",
+        "git pull",
+        "git merge",
+        "git rebase",
+        "git cherry-pick",
+        "git revert",
+        "git reset",
+        "git checkout",
+        "git switch",
+        "cargo fmt",
+        "rustfmt",
+        "npm install",
+        "pnpm install",
+        "yarn install",
+        "mkdir ",
+        "rm ",
+        "mv ",
+        "cp ",
+        "touch ",
+        "tee ",
+        "sed -i",
+        "perl -pi",
+    ];
+    const WORD_PATTERNS: &[&str] = &[
+        "write", "create", "delete", "remove", "rename", "patch", "install", "format",
+    ];
+
+    thread.events.iter().any(|event| match &event.kind {
+        crate::types::event::EventKind::ActionExecuted { action_name, .. }
+        | crate::types::event::EventKind::ActionFailed { action_name, .. }
+            if action_name == "shell" || action_name == "git" =>
+        {
+            action_params_summary(event)
+                .map(|summary| {
+                    let lower = summary.to_lowercase();
+                    PHRASE_PATTERNS
+                        .iter()
+                        .any(|pattern| lower.contains(pattern))
+                        || WORD_PATTERNS.iter().any(|word| contains_word(&lower, word))
+                })
+                .unwrap_or(false)
+        }
         _ => false,
     })
 }
@@ -1686,15 +1759,9 @@ fn infer_skill_repair_hints(
     let mutating_actions = observed_actions.iter().any(|action| {
         matches!(
             action.as_str(),
-            "write_file"
-                | "apply_patch"
-                | "memory_write"
-                | "shell"
-                | "git"
-                | "skill_install"
-                | "skill_remove"
+            "write_file" | "apply_patch" | "memory_write" | "skill_install" | "skill_remove"
         )
-    });
+    }) || has_mutating_shell_or_git_action(thread);
     let verification_actions = observed_actions.iter().any(|action| {
         matches!(
             action.as_str(),
@@ -3493,5 +3560,94 @@ mod tests {
         assert_eq!(updated.content, "Original skill content");
         assert_eq!(updated_meta.version, 1);
         assert!(updated_meta.repairs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_skill_repair_output_rejects_shared_skill_updates() {
+        let store = Arc::new(TestStore::new());
+        let project_id = ProjectId::new();
+        let skill_doc = make_skill_doc(project_id, shared_owner_id(), "github-pr-workflow");
+        let skill_doc_id = skill_doc.id;
+        store.save_memory_doc(&skill_doc).await.unwrap();
+
+        let mut mission = Mission::new(
+            project_id,
+            "alice",
+            "skill-repair",
+            SKILL_REPAIR_GOAL,
+            MissionCadence::Manual,
+        );
+        mission.metadata = serde_json::json!({"skill_repair": true});
+        mission.last_trigger_payload = Some(serde_json::json!({
+            "source_thread_id": "thread-123",
+            "active_skills": [{
+                "doc_id": skill_doc_id,
+                "name": "github-pr-workflow",
+                "version": 1,
+                "snippet_names": [],
+                "force_activated": false
+            }]
+        }));
+
+        let response = serde_json::json!({
+            "doc_id": skill_doc_id,
+            "repair_type": "missing_verification",
+            "summary": "Attempted shared skill update.",
+            "updated_content": "1. Verify auth\n2. Run the command"
+        })
+        .to_string();
+
+        let err =
+            process_skill_repair_output(&(store.clone() as Arc<dyn Store>), &mission, &response)
+                .await
+                .unwrap_err();
+        match err {
+            EngineError::AccessDenied { user_id, entity } => {
+                assert_eq!(user_id, "alice");
+                assert!(entity.contains(&skill_doc_id.0.to_string()));
+            }
+            other => panic!("expected access denied, got: {other:?}"),
+        }
+
+        let unchanged = store.load_memory_doc(skill_doc_id).await.unwrap().unwrap();
+        let meta: V2SkillMetadata = serde_json::from_value(unchanged.metadata).unwrap();
+        assert_eq!(unchanged.content, "Original skill content");
+        assert_eq!(meta.version, 1);
+        assert!(meta.repairs.is_empty());
+    }
+
+    #[test]
+    fn build_skill_gap_payload_skips_read_only_shell_workflows() {
+        let project_id = ProjectId::new();
+        let mut thread = Thread::new(
+            "inspect github pull requests",
+            ThreadType::Foreground,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        thread.state = ThreadState::Done;
+        thread
+            .set_active_skills(&[ActiveSkillProvenance {
+                doc_id: DocId::new(),
+                name: "github-pr-workflow".to_string(),
+                version: 1,
+                snippet_names: vec![],
+                force_activated: false,
+            }])
+            .unwrap();
+        thread.add_event(crate::types::event::EventKind::ActionExecuted {
+            step_id: StepId::new(),
+            action_name: "shell".to_string(),
+            call_id: "call_1".to_string(),
+            params_summary: Some("gh pr list --repo nearai/ironclaw".to_string()),
+            duration_ms: 15,
+        });
+
+        let trace = crate::executor::trace::build_trace(&thread);
+        assert!(
+            build_skill_gap_payload(&thread, &trace, &thread.active_skills()).is_none(),
+            "read-only shell workflows should not trigger skill repair"
+        );
     }
 }

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -20,7 +20,7 @@ use crate::runtime::manager::ThreadManager;
 use crate::runtime::messaging::ThreadOutcome;
 use crate::traits::store::Store;
 use crate::types::error::EngineError;
-use crate::types::memory::{DocId, MemoryDoc};
+use crate::types::memory::{DocId, DocType, MemoryDoc};
 use crate::types::mission::{Mission, MissionCadence, MissionId, MissionStatus};
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
@@ -1366,16 +1366,22 @@ async fn process_skill_repair_output(
             reason: format!("invalid skill-repair output: {e}"),
         })?;
 
-    let allowed_doc_ids = allowed_skill_doc_ids(mission);
-    if allowed_doc_ids.is_empty() {
+    let Some(triggered_skill) = triggered_skill_provenance(mission, repair.doc_id) else {
         return Err(EngineError::Skill {
-            reason: "skill-repair requires an active skill trigger payload".into(),
+            reason: if has_skill_trigger_payload(mission) {
+                format!(
+                    "skill-repair attempted to modify untriggered skill {}",
+                    repair.doc_id.0
+                )
+            } else {
+                "skill-repair requires an active skill trigger payload".into()
+            },
         });
-    }
-    if !allowed_doc_ids.contains(&repair.doc_id) {
+    };
+    if repair.updated_content.trim().is_empty() {
         return Err(EngineError::Skill {
             reason: format!(
-                "skill-repair attempted to modify untriggered skill {}",
+                "skill-repair produced empty updated_content for skill {}",
                 repair.doc_id.0
             ),
         });
@@ -1388,11 +1394,28 @@ async fn process_skill_repair_output(
             .ok_or_else(|| EngineError::Skill {
                 reason: format!("skill doc not found: {}", repair.doc_id.0),
             })?;
-    let existing_meta: V2SkillMetadata = serde_json::from_value(existing.metadata.clone())
-        .map_err(|e| EngineError::Skill {
+    if existing.project_id != mission.project_id {
+        return Err(EngineError::Skill {
+            reason: format!(
+                "skill-repair attempted to modify skill {} outside mission project",
+                repair.doc_id.0
+            ),
+        });
+    }
+    if existing.doc_type != DocType::Skill {
+        return Err(EngineError::Skill {
+            reason: format!(
+                "skill-repair attempted to modify non-skill doc {} ({:?})",
+                repair.doc_id.0, existing.doc_type
+            ),
+        });
+    }
+    serde_json::from_value::<V2SkillMetadata>(existing.metadata.clone()).map_err(|e| {
+        EngineError::Skill {
             reason: format!("invalid skill metadata for {}: {e}", repair.doc_id.0),
-        })?;
-    let from_version = existing_meta.version;
+        }
+    })?;
+    let from_version = triggered_skill.version;
     let source_thread_id = mission
         .last_trigger_payload
         .as_ref()
@@ -1410,7 +1433,7 @@ async fn process_skill_repair_output(
         .update_skill(
             repair.doc_id,
             repair.updated_content,
-            Some(from_version),
+            Some(triggered_skill.version),
             move |meta| {
                 if let Some(description) = repair.description {
                     meta.description = description;
@@ -1438,24 +1461,23 @@ async fn process_skill_repair_output(
         .await
 }
 
-fn allowed_skill_doc_ids(mission: &Mission) -> HashSet<DocId> {
+fn has_skill_trigger_payload(mission: &Mission) -> bool {
     mission
         .last_trigger_payload
         .as_ref()
         .and_then(|payload| payload.get("active_skills"))
         .and_then(|value| value.as_array())
-        .map(|skills| {
-            skills
-                .iter()
-                .filter_map(|skill| {
-                    skill
-                        .get("doc_id")
-                        .cloned()
-                        .and_then(|value| serde_json::from_value::<DocId>(value).ok())
-                })
-                .collect()
-        })
-        .unwrap_or_default()
+        .is_some_and(|skills| !skills.is_empty())
+}
+
+fn triggered_skill_provenance(mission: &Mission, doc_id: DocId) -> Option<ActiveSkillProvenance> {
+    mission
+        .last_trigger_payload
+        .as_ref()
+        .and_then(|payload| payload.get("active_skills"))
+        .cloned()
+        .and_then(|value| serde_json::from_value::<Vec<ActiveSkillProvenance>>(value).ok())
+        .and_then(|skills| skills.into_iter().find(|skill| skill.doc_id == doc_id))
 }
 
 fn collect_error_messages(thread: &Thread) -> Vec<String> {
@@ -3301,5 +3323,118 @@ mod tests {
         );
         assert_eq!(meta.revisions.len(), 1);
         assert_eq!(meta.revisions[0].content, "Original skill content");
+    }
+
+    #[tokio::test]
+    async fn process_skill_repair_output_rejects_stale_trigger_version() {
+        let store = Arc::new(TestStore::new());
+        let project_id = ProjectId::new();
+        let mut skill_doc = make_skill_doc(project_id, "alice", "github-pr-workflow");
+        let skill_doc_id = skill_doc.id;
+        skill_doc.content = "Skill content already updated to v2".to_string();
+        let mut meta: V2SkillMetadata = serde_json::from_value(skill_doc.metadata.clone()).unwrap();
+        meta.version = 2;
+        meta.parent_version = Some(1);
+        skill_doc.metadata = serde_json::to_value(&meta).unwrap();
+        store.save_memory_doc(&skill_doc).await.unwrap();
+
+        let mut mission = Mission::new(
+            project_id,
+            "alice",
+            "skill-repair",
+            SKILL_REPAIR_GOAL,
+            MissionCadence::Manual,
+        );
+        mission.metadata = serde_json::json!({"skill_repair": true});
+        mission.last_trigger_payload = Some(serde_json::json!({
+            "source_thread_id": "thread-123",
+            "active_skills": [{
+                "doc_id": skill_doc_id,
+                "name": "github-pr-workflow",
+                "version": 1,
+                "snippet_names": [],
+                "force_activated": false
+            }]
+        }));
+
+        let response = serde_json::json!({
+            "doc_id": skill_doc_id,
+            "repair_type": "missing_verification",
+            "summary": "Stale repair output.",
+            "updated_content": "1. Run the stale command\n2. Verify it"
+        })
+        .to_string();
+
+        let err =
+            process_skill_repair_output(&(store.clone() as Arc<dyn Store>), &mission, &response)
+                .await
+                .unwrap_err();
+        match err {
+            EngineError::Skill { reason } => assert!(
+                reason.contains("version conflict"),
+                "expected version conflict, got: {reason}"
+            ),
+            other => panic!("expected skill error, got: {other:?}"),
+        }
+
+        let updated = store.load_memory_doc(skill_doc_id).await.unwrap().unwrap();
+        let updated_meta: V2SkillMetadata = serde_json::from_value(updated.metadata).unwrap();
+        assert_eq!(updated.content, "Skill content already updated to v2");
+        assert_eq!(updated_meta.version, 2);
+        assert!(updated_meta.repairs.is_empty());
+    }
+
+    #[tokio::test]
+    async fn process_skill_repair_output_rejects_empty_content() {
+        let store = Arc::new(TestStore::new());
+        let project_id = ProjectId::new();
+        let skill_doc = make_skill_doc(project_id, "alice", "github-pr-workflow");
+        let skill_doc_id = skill_doc.id;
+        store.save_memory_doc(&skill_doc).await.unwrap();
+
+        let mut mission = Mission::new(
+            project_id,
+            "alice",
+            "skill-repair",
+            SKILL_REPAIR_GOAL,
+            MissionCadence::Manual,
+        );
+        mission.metadata = serde_json::json!({"skill_repair": true});
+        mission.last_trigger_payload = Some(serde_json::json!({
+            "source_thread_id": "thread-123",
+            "active_skills": [{
+                "doc_id": skill_doc_id,
+                "name": "github-pr-workflow",
+                "version": 1,
+                "snippet_names": [],
+                "force_activated": false
+            }]
+        }));
+
+        let response = serde_json::json!({
+            "doc_id": skill_doc_id,
+            "repair_type": "missing_verification",
+            "summary": "This should be rejected.",
+            "updated_content": "   "
+        })
+        .to_string();
+
+        let err =
+            process_skill_repair_output(&(store.clone() as Arc<dyn Store>), &mission, &response)
+                .await
+                .unwrap_err();
+        match err {
+            EngineError::Skill { reason } => assert!(
+                reason.contains("empty updated_content"),
+                "expected empty-content validation, got: {reason}"
+            ),
+            other => panic!("expected skill error, got: {other:?}"),
+        }
+
+        let updated = store.load_memory_doc(skill_doc_id).await.unwrap().unwrap();
+        let updated_meta: V2SkillMetadata = serde_json::from_value(updated.metadata).unwrap();
+        assert_eq!(updated.content, "Original skill content");
+        assert_eq!(updated_meta.version, 1);
+        assert!(updated_meta.repairs.is_empty());
     }
 }

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -462,7 +462,19 @@ impl MissionManager {
                         }
 
                         let trace = crate::executor::trace::build_trace(&thread);
+                        // Single pass over events for both skill-repair and
+                        // error-diagnosis triggers (avoids repeated iteration
+                        // on large event logs).
+                        let (error_messages, _observed_actions) =
+                            collect_errors_and_actions(&thread);
                         let active_skills = thread.active_skills();
+
+                        // ── Trigger 1: Skill repair ───────────────────────
+                        // NOTE: skill-repair and error-diagnosis can both fire
+                        // for the same thread. Each targets a different mission
+                        // so they won't collide, but both may spawn concurrent
+                        // threads. This is intentional — skill-repair fixes the
+                        // *skill* while error-diagnosis fixes the *prompt/orchestrator*.
                         if !active_skills.is_empty() {
                             let tracker = SkillTracker::new(Arc::clone(&mgr.store));
                             let success = thread_completed_successfully(&thread, &trace);
@@ -505,8 +517,6 @@ impl MissionManager {
                                     })
                                 })
                                 .collect();
-
-                            let error_messages = collect_error_messages(&thread);
 
                             let payload = serde_json::json!({
                                 "source_thread_id": event.thread_id.0.to_string(),
@@ -1480,46 +1490,36 @@ fn triggered_skill_provenance(mission: &Mission, doc_id: DocId) -> Option<Active
         .and_then(|skills| skills.into_iter().find(|skill| skill.doc_id == doc_id))
 }
 
-fn collect_error_messages(thread: &Thread) -> Vec<String> {
-    thread
-        .events
-        .iter()
-        .filter_map(|event| {
-            if let crate::types::event::EventKind::ActionFailed {
-                action_name, error, ..
-            } = &event.kind
-                && !is_recoverable_action_failure(error)
-            {
-                Some(format!("{action_name}: {error}"))
-            } else {
-                None
-            }
-        })
-        .take(10)
-        .collect()
-}
-
-fn collect_observed_actions(thread: &Thread) -> Vec<String> {
+/// Collects error messages and deduplicated observed action names in a single
+/// pass over `thread.events`.  Previous implementation used separate passes
+/// which is wasteful for threads with large event logs.
+fn collect_errors_and_actions(thread: &Thread) -> (Vec<String>, Vec<String>) {
+    let mut error_messages = Vec::new();
     let mut actions = Vec::new();
     let mut seen = HashSet::new();
 
     for event in &thread.events {
-        let action_name = match &event.kind {
-            crate::types::event::EventKind::ActionExecuted { action_name, .. }
-            | crate::types::event::EventKind::ActionFailed { action_name, .. } => {
-                Some(action_name.clone())
+        match &event.kind {
+            crate::types::event::EventKind::ActionFailed {
+                action_name, error, ..
+            } => {
+                if !is_recoverable_action_failure(error) && error_messages.len() < 10 {
+                    error_messages.push(format!("{action_name}: {error}"));
+                }
+                if seen.insert(action_name.clone()) {
+                    actions.push(action_name.clone());
+                }
             }
-            _ => None,
-        };
-
-        if let Some(action_name) = action_name
-            && seen.insert(action_name.clone())
-        {
-            actions.push(action_name);
+            crate::types::event::EventKind::ActionExecuted { action_name, .. } => {
+                if seen.insert(action_name.clone()) {
+                    actions.push(action_name.clone());
+                }
+            }
+            _ => {}
         }
     }
 
-    actions
+    (error_messages, actions)
 }
 
 fn learning_terminal_state(
@@ -1717,8 +1717,7 @@ fn build_skill_gap_payload(
     trace: &ExecutionTrace,
     active_skills: &[ActiveSkillProvenance],
 ) -> Option<serde_json::Value> {
-    let error_messages = collect_error_messages(thread);
-    let observed_actions = collect_observed_actions(thread);
+    let (error_messages, observed_actions) = collect_errors_and_actions(thread);
     let repair_hints = infer_skill_repair_hints(thread, trace, &error_messages, &observed_actions);
     if repair_hints.is_empty() {
         return None;

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -4,21 +4,27 @@
 //! progress. The manager handles lifecycle (create, pause, resume, complete)
 //! and delegates thread spawning to [`ThreadManager`].
 
+use std::collections::HashSet;
 use std::sync::Arc;
 
+use serde::Deserialize;
 use tokio::sync::RwLock;
 use tracing::debug;
 
-use crate::memory::RetrievalEngine;
+use ironclaw_skills::types::ActivationCriteria;
+use ironclaw_skills::v2::{CodeSnippet, SkillRepairRecord, SkillRepairType, V2SkillMetadata};
+
+use crate::executor::trace::{ExecutionTrace, IssueSeverity};
+use crate::memory::{RetrievalEngine, SkillTracker};
 use crate::runtime::manager::ThreadManager;
 use crate::runtime::messaging::ThreadOutcome;
 use crate::traits::store::Store;
 use crate::types::error::EngineError;
-use crate::types::memory::MemoryDoc;
+use crate::types::memory::{DocId, MemoryDoc};
 use crate::types::mission::{Mission, MissionCadence, MissionId, MissionStatus};
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
-use crate::types::thread::{ThreadConfig, ThreadId, ThreadType};
+use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadConfig, ThreadId, ThreadType};
 
 /// Notification emitted when a mission thread completes.
 ///
@@ -414,10 +420,12 @@ impl MissionManager {
     /// Subscribes to the ThreadManager's event broadcast channel and watches
     /// for `StateChanged { to: Done }`. For each completed non-Mission thread:
     ///
-    /// 1. **Error diagnosis** — if trace has issues, fires `thread_completed_with_issues`
-    /// 2. **Skill extraction** — if thread succeeded with many steps/actions,
+    /// 1. **Skill repair** — if an active skill looks stale or incomplete,
+    ///    fires `thread_completed_with_skill_gap`
+    /// 2. **Error diagnosis** — if trace has issues, fires `thread_completed_with_issues`
+    /// 3. **Skill extraction** — if thread succeeded with many steps/actions,
     ///    fires `thread_completed_with_learnings`
-    /// 3. **Conversation insights** — after every N threads in a conversation,
+    /// 4. **Conversation insights** — after every N threads in a conversation,
     ///    fires `conversation_insights_due`
     pub fn start_event_listener(self: &Arc<Self>, _owner_id: String) {
         let mgr = Arc::clone(self);
@@ -438,17 +446,9 @@ impl MissionManager {
             loop {
                 match rx.recv().await {
                     Ok(event) => {
-                        // Only react to threads transitioning to Done
-                        let is_done = matches!(
-                            event.kind,
-                            crate::types::event::EventKind::StateChanged {
-                                to: crate::types::thread::ThreadState::Done,
-                                ..
-                            }
-                        );
-                        if !is_done {
+                        let Some(terminal_state) = learning_terminal_state(&event.kind) else {
                             continue;
-                        }
+                        };
 
                         // Load the completed thread
                         let thread = match mgr.store.load_thread(event.thread_id).await {
@@ -461,8 +461,37 @@ impl MissionManager {
                             continue;
                         }
 
-                        // ── Trigger 1: Error diagnosis ──────────────────
                         let trace = crate::executor::trace::build_trace(&thread);
+                        let active_skills = thread.active_skills();
+                        if !active_skills.is_empty() {
+                            let tracker = SkillTracker::new(Arc::clone(&mgr.store));
+                            let success = thread_completed_successfully(&thread, &trace);
+                            for skill in &active_skills {
+                                if let Err(e) = tracker.record_usage(skill.doc_id, success).await {
+                                    debug!(
+                                        skill_doc_id = %skill.doc_id.0,
+                                        thread_id = %thread.id,
+                                        "event listener: failed to record skill usage: {e}"
+                                    );
+                                }
+                            }
+
+                            if let Some(payload) =
+                                build_skill_gap_payload(&thread, &trace, &active_skills)
+                                && let Err(e) = mgr
+                                    .fire_on_system_event(
+                                        "engine",
+                                        "thread_completed_with_skill_gap",
+                                        &thread.user_id,
+                                        Some(payload),
+                                    )
+                                    .await
+                            {
+                                debug!("event listener: failed to fire skill repair: {e}");
+                            }
+                        }
+
+                        // ── Trigger 2: Error diagnosis ──────────────────
                         if !trace.issues.is_empty() {
                             let issues: Vec<serde_json::Value> = trace
                                 .issues
@@ -470,30 +499,14 @@ impl MissionManager {
                                 .map(|i| {
                                     serde_json::json!({
                                         "severity": format!("{:?}", i.severity),
-                                        "category": i.category,
-                                        "description": i.description,
+                                        "category": i.category.clone(),
+                                        "description": i.description.clone(),
                                         "step": i.step,
                                     })
                                 })
                                 .collect();
 
-                            let error_messages: Vec<String> = thread
-                                .events
-                                .iter()
-                                .filter_map(|e| {
-                                    if let crate::types::event::EventKind::ActionFailed {
-                                        action_name,
-                                        error,
-                                        ..
-                                    } = &e.kind
-                                    {
-                                        Some(format!("{action_name}: {error}"))
-                                    } else {
-                                        None
-                                    }
-                                })
-                                .take(10)
-                                .collect();
+                            let error_messages = collect_error_messages(&thread);
 
                             let payload = serde_json::json!({
                                 "source_thread_id": event.thread_id.0.to_string(),
@@ -515,7 +528,7 @@ impl MissionManager {
                             }
                         }
 
-                        // ── Trigger 2: Skill extraction ──────────────────
+                        // ── Trigger 3: Skill extraction ──────────────────
                         let action_count = thread
                             .events
                             .iter()
@@ -527,7 +540,7 @@ impl MissionManager {
                             })
                             .count();
 
-                        if thread.state == crate::types::thread::ThreadState::Done
+                        if terminal_state == crate::types::thread::ThreadState::Done
                             && trace
                                 .issues
                                 .iter()
@@ -573,7 +586,7 @@ impl MissionManager {
                             }
                         }
 
-                        // ── Trigger 3: Conversation insights ────────────
+                        // ── Trigger 4: Conversation insights ────────────
                         // Use the thread's project_id as a proxy for conversation scope.
                         let conv_key = thread.project_id.0.to_string();
                         let count = conv_thread_counts.entry(conv_key.clone()).or_insert(0);
@@ -701,11 +714,11 @@ impl MissionManager {
         Ok(id)
     }
 
-    /// Ensure all three learning missions exist for the given project.
+    /// Ensure the built-in learning missions exist for the given project.
     ///
-    /// Creates (if missing) the self-improvement, skill extraction, and
-    /// conversation insights missions. This is the preferred entry point —
-    /// call once at project bootstrap.
+    /// Creates (if missing) the self-improvement, skill repair, skill
+    /// extraction, and conversation insights missions. This is the preferred
+    /// entry point — call once at project bootstrap.
     pub async fn ensure_learning_missions(
         &self,
         project_id: ProjectId,
@@ -718,7 +731,23 @@ impl MissionManager {
         self.ensure_self_improvement_mission(project_id, user_id)
             .await?;
 
-        // 2. Skill extraction (formerly playbook extraction)
+        // 2. Skill repair
+        self.ensure_mission_by_metadata(
+            project_id,
+            user_id,
+            "skill_repair",
+            "skill-repair",
+            SKILL_REPAIR_GOAL,
+            MissionCadence::OnSystemEvent {
+                source: "engine".into(),
+                event_type: "thread_completed_with_skill_gap".into(),
+            },
+            "Repair versioned skills when execution reveals stale or incomplete instructions",
+            5,
+        )
+        .await?;
+
+        // 3. Skill extraction (formerly playbook extraction)
         self.ensure_mission_by_metadata(
             project_id,
             user_id,
@@ -734,7 +763,7 @@ impl MissionManager {
         )
         .await?;
 
-        // 3. Conversation insights
+        // 4. Conversation insights
         self.ensure_mission_by_metadata(
             project_id,
             user_id,
@@ -750,7 +779,7 @@ impl MissionManager {
         )
         .await?;
 
-        // 4. Expected behavior (user feedback loop)
+        // 5. Expected behavior (user feedback loop)
         self.ensure_mission_by_metadata(
             project_id,
             user_id,
@@ -1073,6 +1102,15 @@ async fn process_mission_outcome_and_notify(
                     "failed to process self-improvement output: {e}"
                 );
             }
+
+            if is_skill_repair_mission(&mission)
+                && let Err(e) = process_skill_repair_output(store, &mission, text).await
+            {
+                debug!(
+                    mission_id = %mission_id,
+                    "failed to process skill-repair output: {e}"
+                );
+            }
         }
         ThreadOutcome::Completed { response: None } => {}
         ThreadOutcome::Failed { error } => {
@@ -1114,6 +1152,15 @@ fn is_self_improvement_mission(mission: &Mission) -> bool {
     mission
         .metadata
         .get("self_improvement")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+}
+
+/// Check if a mission is the skill-repair mission.
+fn is_skill_repair_mission(mission: &Mission) -> bool {
+    mission
+        .metadata
+        .get("skill_repair")
         .and_then(|v| v.as_bool())
         .unwrap_or(false)
 }
@@ -1287,6 +1334,389 @@ fn extract_json_from_response(response: &str) -> Option<serde_json::Value> {
         .filter(|v| v.is_object())
 }
 
+#[derive(Debug, Deserialize)]
+struct SkillRepairMissionOutput {
+    doc_id: DocId,
+    repair_type: SkillRepairType,
+    updated_content: String,
+    #[serde(default)]
+    summary: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    activation: Option<ActivationCriteria>,
+    #[serde(default)]
+    code_snippets: Option<Vec<CodeSnippet>>,
+}
+
+async fn process_skill_repair_output(
+    store: &Arc<dyn Store>,
+    mission: &Mission,
+    response: &str,
+) -> Result<(), EngineError> {
+    let json_val = match extract_json_from_response(response) {
+        Some(v) => v,
+        None => {
+            debug!("skill-repair: no structured JSON in response");
+            return Ok(());
+        }
+    };
+    let repair: SkillRepairMissionOutput =
+        serde_json::from_value(json_val).map_err(|e| EngineError::Skill {
+            reason: format!("invalid skill-repair output: {e}"),
+        })?;
+
+    let allowed_doc_ids = allowed_skill_doc_ids(mission);
+    if allowed_doc_ids.is_empty() {
+        return Err(EngineError::Skill {
+            reason: "skill-repair requires an active skill trigger payload".into(),
+        });
+    }
+    if !allowed_doc_ids.contains(&repair.doc_id) {
+        return Err(EngineError::Skill {
+            reason: format!(
+                "skill-repair attempted to modify untriggered skill {}",
+                repair.doc_id.0
+            ),
+        });
+    }
+
+    let existing =
+        store
+            .load_memory_doc(repair.doc_id)
+            .await?
+            .ok_or_else(|| EngineError::Skill {
+                reason: format!("skill doc not found: {}", repair.doc_id.0),
+            })?;
+    let existing_meta: V2SkillMetadata = serde_json::from_value(existing.metadata.clone())
+        .map_err(|e| EngineError::Skill {
+            reason: format!("invalid skill metadata for {}: {e}", repair.doc_id.0),
+        })?;
+    let from_version = existing_meta.version;
+    let source_thread_id = mission
+        .last_trigger_payload
+        .as_ref()
+        .and_then(|payload| payload.get("source_thread_id"))
+        .and_then(|value| value.as_str())
+        .map(ToString::to_string);
+    let summary = if repair.summary.trim().is_empty() {
+        format!("Applied {:?} repair", repair.repair_type)
+    } else {
+        repair.summary.clone()
+    };
+
+    let tracker = SkillTracker::new(Arc::clone(store));
+    tracker
+        .update_skill(
+            repair.doc_id,
+            repair.updated_content,
+            Some(from_version),
+            move |meta| {
+                if let Some(description) = repair.description {
+                    meta.description = description;
+                }
+                if let Some(activation) = repair.activation {
+                    meta.activation = activation;
+                }
+                if let Some(code_snippets) = repair.code_snippets {
+                    meta.code_snippets = code_snippets;
+                }
+                meta.repairs.push(SkillRepairRecord {
+                    source_thread_id,
+                    from_version,
+                    to_version: meta.version,
+                    repair_type: repair.repair_type,
+                    summary,
+                    repaired_at: Some(chrono::Utc::now()),
+                });
+                if meta.repairs.len() > 10 {
+                    let keep_from = meta.repairs.len() - 10;
+                    meta.repairs.drain(0..keep_from);
+                }
+            },
+        )
+        .await
+}
+
+fn allowed_skill_doc_ids(mission: &Mission) -> HashSet<DocId> {
+    mission
+        .last_trigger_payload
+        .as_ref()
+        .and_then(|payload| payload.get("active_skills"))
+        .and_then(|value| value.as_array())
+        .map(|skills| {
+            skills
+                .iter()
+                .filter_map(|skill| {
+                    skill
+                        .get("doc_id")
+                        .cloned()
+                        .and_then(|value| serde_json::from_value::<DocId>(value).ok())
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn collect_error_messages(thread: &Thread) -> Vec<String> {
+    thread
+        .events
+        .iter()
+        .filter_map(|event| {
+            if let crate::types::event::EventKind::ActionFailed {
+                action_name, error, ..
+            } = &event.kind
+                && !is_recoverable_action_failure(error)
+            {
+                Some(format!("{action_name}: {error}"))
+            } else {
+                None
+            }
+        })
+        .take(10)
+        .collect()
+}
+
+fn collect_observed_actions(thread: &Thread) -> Vec<String> {
+    let mut actions = Vec::new();
+    let mut seen = HashSet::new();
+
+    for event in &thread.events {
+        let action_name = match &event.kind {
+            crate::types::event::EventKind::ActionExecuted { action_name, .. }
+            | crate::types::event::EventKind::ActionFailed { action_name, .. } => {
+                Some(action_name.clone())
+            }
+            _ => None,
+        };
+
+        if let Some(action_name) = action_name
+            && seen.insert(action_name.clone())
+        {
+            actions.push(action_name);
+        }
+    }
+
+    actions
+}
+
+fn learning_terminal_state(
+    event_kind: &crate::types::event::EventKind,
+) -> Option<crate::types::thread::ThreadState> {
+    match event_kind {
+        crate::types::event::EventKind::StateChanged {
+            to: crate::types::thread::ThreadState::Done,
+            ..
+        } => Some(crate::types::thread::ThreadState::Done),
+        crate::types::event::EventKind::StateChanged {
+            to: crate::types::thread::ThreadState::Failed,
+            ..
+        } => Some(crate::types::thread::ThreadState::Failed),
+        _ => None,
+    }
+}
+
+fn has_action_failures(thread: &Thread) -> bool {
+    thread.events.iter().any(|event| match &event.kind {
+        crate::types::event::EventKind::ActionFailed { error, .. } => {
+            !is_recoverable_action_failure(error)
+        }
+        _ => false,
+    })
+}
+
+fn is_recoverable_auth_failure_text(text: &str) -> bool {
+    text.to_ascii_lowercase()
+        .contains("authentication required for credential ")
+}
+
+fn is_recoverable_action_failure(error: &str) -> bool {
+    is_recoverable_auth_failure_text(error)
+}
+
+fn contains_word(haystack: &str, word: &str) -> bool {
+    for (start, _) in haystack.match_indices(word) {
+        let before_ok = start == 0 || haystack.as_bytes()[start - 1].is_ascii_whitespace();
+        let end = start + word.len();
+        let after_ok = end == haystack.len() || haystack.as_bytes()[end].is_ascii_whitespace();
+        if before_ok && after_ok {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_shell_verification_action(thread: &Thread) -> bool {
+    const PHRASE_PATTERNS: &[&str] = &[
+        "cargo test",
+        "pytest",
+        "npm test",
+        "pnpm test",
+        "yarn test",
+        "go test",
+        "git diff",
+        "git status",
+        "gh pr view",
+        "gh issue view",
+        "cat ",
+        "head ",
+        "tail ",
+        "grep ",
+        "rg ",
+        "find ",
+        "stat ",
+    ];
+    const WORD_PATTERNS: &[&str] = &["ls", "diff", "status", "view", "show"];
+
+    thread.events.iter().any(|event| match &event.kind {
+        crate::types::event::EventKind::ActionExecuted {
+            action_name,
+            params_summary,
+            ..
+        }
+        | crate::types::event::EventKind::ActionFailed {
+            action_name,
+            params_summary,
+            ..
+        } if action_name == "shell" => params_summary
+            .as_deref()
+            .map(|summary| {
+                let lower = summary.to_lowercase();
+                PHRASE_PATTERNS
+                    .iter()
+                    .any(|pattern| lower.contains(pattern))
+                    || WORD_PATTERNS.iter().any(|word| contains_word(&lower, word))
+            })
+            .unwrap_or(false),
+        _ => false,
+    })
+}
+
+fn infer_skill_repair_hints(
+    thread: &Thread,
+    trace: &ExecutionTrace,
+    error_messages: &[String],
+    observed_actions: &[String],
+) -> Vec<SkillRepairType> {
+    let mut hints = Vec::new();
+    let mut push_hint = |hint| {
+        if !hints.contains(&hint) {
+            hints.push(hint);
+        }
+    };
+
+    let lower_signals = error_messages
+        .iter()
+        .map(|message| message.to_lowercase())
+        .chain(
+            trace
+                .issues
+                .iter()
+                .filter(|issue| {
+                    !(issue.category == "tool_error"
+                        && is_recoverable_auth_failure_text(&issue.description))
+                })
+                .map(|issue| issue.description.to_lowercase()),
+        )
+        .collect::<Vec<_>>();
+
+    if lower_signals.iter().any(|message| {
+        ["auth", "login", "token", "credential", "permission denied"]
+            .iter()
+            .any(|needle| message.contains(needle))
+    }) {
+        push_hint(SkillRepairType::MissingPrerequisite);
+    }
+
+    if lower_signals.iter().any(|message| {
+        [
+            "command not found",
+            "no such file",
+            "not found",
+            "could not find",
+            "unknown file",
+            "unknown path",
+        ]
+        .iter()
+        .any(|needle| message.contains(needle))
+    }) {
+        push_hint(SkillRepairType::StaleCommandPath);
+    }
+
+    let mutating_actions = observed_actions.iter().any(|action| {
+        matches!(
+            action.as_str(),
+            "write_file"
+                | "apply_patch"
+                | "memory_write"
+                | "shell"
+                | "git"
+                | "skill_install"
+                | "skill_remove"
+        )
+    });
+    let verification_actions = observed_actions.iter().any(|action| {
+        matches!(
+            action.as_str(),
+            "read_file" | "memory_read" | "memory_search" | "cargo_test" | "pytest"
+        )
+    }) || has_shell_verification_action(thread);
+    if mutating_actions && !verification_actions {
+        push_hint(SkillRepairType::MissingVerification);
+    }
+
+    if !error_messages.is_empty() && thread.state == crate::types::thread::ThreadState::Done {
+        push_hint(SkillRepairType::MissingPitfall);
+    }
+
+    hints
+}
+
+fn build_skill_gap_payload(
+    thread: &Thread,
+    trace: &ExecutionTrace,
+    active_skills: &[ActiveSkillProvenance],
+) -> Option<serde_json::Value> {
+    let error_messages = collect_error_messages(thread);
+    let observed_actions = collect_observed_actions(thread);
+    let repair_hints = infer_skill_repair_hints(thread, trace, &error_messages, &observed_actions);
+    if repair_hints.is_empty() {
+        return None;
+    }
+
+    let issues: Vec<serde_json::Value> = trace
+        .issues
+        .iter()
+        .map(|issue| {
+            serde_json::json!({
+                "severity": format!("{:?}", issue.severity),
+                "category": issue.category.clone(),
+                "description": issue.description.clone(),
+                "step": issue.step,
+            })
+        })
+        .collect();
+
+    Some(serde_json::json!({
+        "source_thread_id": thread.id.0.to_string(),
+        "goal": thread.goal,
+        "active_skills": active_skills,
+        "issues": issues,
+        "error_messages": error_messages,
+        "observed_actions": observed_actions,
+        "repair_hints": repair_hints,
+    }))
+}
+
+fn thread_completed_successfully(thread: &Thread, trace: &ExecutionTrace) -> bool {
+    thread.state == crate::types::thread::ThreadState::Done
+        && !has_action_failures(thread)
+        && trace
+            .issues
+            .iter()
+            .all(|issue| issue.severity != IssueSeverity::Error)
+}
+
 /// The goal for the self-improvement mission (autoresearch-style program).
 ///
 /// This is the "program.md" — a concrete, step-by-step prompt that tells the
@@ -1302,6 +1732,9 @@ pub const FIX_PATTERN_DB_TAG: &str = "fix_patterns";
 
 /// The goal for the skill extraction mission.
 const SKILL_EXTRACTION_GOAL: &str = include_str!("../../prompts/mission_skill_extraction.md");
+
+/// The goal for the skill-repair mission.
+const SKILL_REPAIR_GOAL: &str = include_str!("../../prompts/mission_skill_repair.md");
 
 /// The goal for the conversation insights mission.
 const CONVERSATION_INSIGHTS_GOAL: &str =
@@ -1340,11 +1773,15 @@ mod tests {
     use crate::types::capability::{ActionDef, CapabilityLease};
     use crate::types::error::EngineError;
     use crate::types::event::ThreadEvent;
-    use crate::types::memory::{DocId, MemoryDoc};
+    use crate::types::memory::{DocId, DocType, MemoryDoc};
     use crate::types::mission::{Mission, MissionCadence, MissionId, MissionStatus};
     use crate::types::project::{Project, ProjectId};
+    use crate::types::step::StepId;
     use crate::types::step::{ActionResult, LlmResponse, Step, TokenUsage};
-    use crate::types::thread::{Thread, ThreadId, ThreadState};
+    use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadId, ThreadState, ThreadType};
+    use ironclaw_skills::SkillTrust;
+    use ironclaw_skills::types::ActivationCriteria;
+    use ironclaw_skills::v2::{SkillMetrics, SkillRepairType, V2SkillMetadata, V2SkillSource};
 
     // ── TestStore — in-memory Store that persists missions ───
 
@@ -1362,6 +1799,33 @@ mod tests {
                 docs: tokio::sync::RwLock::new(Vec::new()),
             }
         }
+    }
+
+    fn make_skill_doc(project_id: ProjectId, user_id: &str, name: &str) -> MemoryDoc {
+        let meta = V2SkillMetadata {
+            name: name.to_string(),
+            version: 1,
+            description: format!("{name} description"),
+            activation: ActivationCriteria::default(),
+            source: V2SkillSource::Extracted,
+            trust: SkillTrust::Trusted,
+            code_snippets: vec![],
+            metrics: SkillMetrics::default(),
+            parent_version: None,
+            revisions: vec![],
+            repairs: vec![],
+            content_hash: "sha256:test".to_string(),
+        };
+
+        let mut doc = MemoryDoc::new(
+            project_id,
+            user_id,
+            DocType::Skill,
+            format!("skill:{name}"),
+            "Original skill content",
+        );
+        doc.metadata = serde_json::to_value(&meta).expect("serialize test skill metadata");
+        doc
     }
 
     #[async_trait::async_trait]
@@ -2670,5 +3134,172 @@ mod tests {
             self_imp_count, 1,
             "should not duplicate self-improvement mission"
         );
+    }
+
+    #[test]
+    fn build_skill_gap_payload_uses_active_skill_provenance() {
+        let project_id = ProjectId::new();
+        let mut thread = Thread::new(
+            "repair a github workflow",
+            ThreadType::Foreground,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        thread.state = ThreadState::Done;
+        let skill_doc_id = DocId::new();
+        thread
+            .set_active_skills(&[ActiveSkillProvenance {
+                doc_id: skill_doc_id,
+                name: "github-pr-workflow".to_string(),
+                version: 3,
+                snippet_names: vec!["list_prs".to_string()],
+                force_activated: false,
+            }])
+            .unwrap();
+        thread.add_event(crate::types::event::EventKind::ActionFailed {
+            step_id: StepId::new(),
+            action_name: "shell".to_string(),
+            call_id: "call_1".to_string(),
+            error: "gh auth status: not authenticated".to_string(),
+            params_summary: None,
+        });
+
+        let trace = crate::executor::trace::build_trace(&thread);
+        let active_skills = thread.active_skills();
+        let payload = build_skill_gap_payload(&thread, &trace, &active_skills).unwrap();
+
+        assert_eq!(
+            payload["active_skills"][0]["doc_id"],
+            serde_json::Value::String(skill_doc_id.0.to_string())
+        );
+        let hints = payload["repair_hints"].as_array().unwrap();
+        assert!(
+            hints
+                .iter()
+                .any(|hint| hint.as_str() == Some("missing_prerequisite")),
+            "repair hints should include missing_prerequisite: {payload}"
+        );
+    }
+
+    #[test]
+    fn learning_terminal_state_accepts_failed_threads() {
+        let failed_event = crate::types::event::EventKind::StateChanged {
+            from: ThreadState::Running,
+            to: ThreadState::Failed,
+            reason: Some("boom".into()),
+        };
+        assert_eq!(
+            learning_terminal_state(&failed_event),
+            Some(ThreadState::Failed)
+        );
+
+        let done_event = crate::types::event::EventKind::StateChanged {
+            from: ThreadState::Completed,
+            to: ThreadState::Done,
+            reason: None,
+        };
+        assert_eq!(
+            learning_terminal_state(&done_event),
+            Some(ThreadState::Done)
+        );
+    }
+
+    #[test]
+    fn thread_completed_successfully_requires_done_without_action_failures() {
+        let project_id = ProjectId::new();
+
+        let mut clean_thread = Thread::new(
+            "clean success",
+            ThreadType::Foreground,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        clean_thread.state = ThreadState::Done;
+        let clean_trace = crate::executor::trace::build_trace(&clean_thread);
+        assert!(thread_completed_successfully(&clean_thread, &clean_trace));
+
+        let mut failing_thread = Thread::new(
+            "tool failure",
+            ThreadType::Foreground,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        failing_thread.state = ThreadState::Done;
+        failing_thread.add_event(crate::types::event::EventKind::ActionFailed {
+            step_id: StepId::new(),
+            action_name: "shell".to_string(),
+            call_id: "call_1".to_string(),
+            error: "gh auth status: not authenticated".to_string(),
+            params_summary: Some("gh auth status".to_string()),
+        });
+        let failing_trace = crate::executor::trace::build_trace(&failing_thread);
+        assert!(!thread_completed_successfully(
+            &failing_thread,
+            &failing_trace
+        ));
+    }
+
+    #[tokio::test]
+    async fn process_skill_repair_output_updates_skill_and_records_repair() {
+        let store = Arc::new(TestStore::new());
+        let project_id = ProjectId::new();
+        let skill_doc = make_skill_doc(project_id, "alice", "github-pr-workflow");
+        let skill_doc_id = skill_doc.id;
+        store.save_memory_doc(&skill_doc).await.unwrap();
+
+        let mut mission = Mission::new(
+            project_id,
+            "alice",
+            "skill-repair",
+            SKILL_REPAIR_GOAL,
+            MissionCadence::Manual,
+        );
+        mission.metadata = serde_json::json!({"skill_repair": true});
+        mission.last_trigger_payload = Some(serde_json::json!({
+            "source_thread_id": "thread-123",
+            "active_skills": [{
+                "doc_id": skill_doc_id,
+                "name": "github-pr-workflow",
+                "version": 1,
+                "snippet_names": [],
+                "force_activated": false
+            }]
+        }));
+
+        let response = serde_json::json!({
+            "doc_id": skill_doc_id,
+            "repair_type": "missing_verification",
+            "summary": "Added a smoke-test step after the gh command.",
+            "updated_content": "1. Run `gh auth status`\n2. Run the PR command\n3. Verify with `gh pr view`",
+            "description": "GitHub PR workflow with auth and verification",
+        })
+        .to_string();
+
+        process_skill_repair_output(&(store.clone() as Arc<dyn Store>), &mission, &response)
+            .await
+            .unwrap();
+
+        let updated = store.load_memory_doc(skill_doc_id).await.unwrap().unwrap();
+        let meta: V2SkillMetadata = serde_json::from_value(updated.metadata).unwrap();
+        assert_eq!(meta.version, 2);
+        assert_eq!(meta.parent_version, Some(1));
+        assert_eq!(
+            updated.content,
+            "1. Run `gh auth status`\n2. Run the PR command\n3. Verify with `gh pr view`"
+        );
+        assert_eq!(meta.repairs.len(), 1);
+        assert_eq!(
+            meta.repairs[0].repair_type,
+            SkillRepairType::MissingVerification
+        );
+        assert_eq!(
+            meta.repairs[0].source_thread_id.as_deref(),
+            Some("thread-123")
+        );
+        assert_eq!(meta.revisions.len(), 1);
+        assert_eq!(meta.revisions[0].content, "Original skill content");
     }
 }

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -597,53 +597,56 @@ impl MissionManager {
                         }
 
                         // ── Trigger 4: Conversation insights ────────────
-                        // Use the thread's project_id as a proxy for conversation scope.
-                        let conv_key = thread.project_id.0.to_string();
-                        let count = conv_thread_counts.entry(conv_key.clone()).or_insert(0);
-                        *count += 1;
+                        // Keep insights tied to successful completions only.
+                        if should_count_for_conversation_insights(terminal_state) {
+                            // Use the thread's project_id as a proxy for conversation scope.
+                            let conv_key = thread.project_id.0.to_string();
+                            let count = conv_thread_counts.entry(conv_key.clone()).or_insert(0);
+                            *count += 1;
 
-                        if (*count).is_multiple_of(CONVERSATION_INSIGHTS_INTERVAL) {
-                            // Collect recent thread goals for context
-                            let thread_goals: Vec<String> = match mgr
-                                .store
-                                .list_threads(thread.project_id, &thread.user_id)
-                                .await
-                            {
-                                Ok(threads) => threads
+                            if (*count).is_multiple_of(CONVERSATION_INSIGHTS_INTERVAL) {
+                                // Collect recent thread goals for context
+                                let thread_goals: Vec<String> = match mgr
+                                    .store
+                                    .list_threads(thread.project_id, &thread.user_id)
+                                    .await
+                                {
+                                    Ok(threads) => threads
+                                        .iter()
+                                        .rev()
+                                        .take(CONVERSATION_INSIGHTS_INTERVAL as usize)
+                                        .map(|t| t.goal.clone())
+                                        .collect(),
+                                    Err(_) => vec![thread.goal.clone()],
+                                };
+
+                                // Collect sample user messages from recent threads
+                                let sample_messages: Vec<String> = thread
+                                    .messages
                                     .iter()
-                                    .rev()
-                                    .take(CONVERSATION_INSIGHTS_INTERVAL as usize)
-                                    .map(|t| t.goal.clone())
-                                    .collect(),
-                                Err(_) => vec![thread.goal.clone()],
-                            };
+                                    .filter(|m| m.role == crate::types::message::MessageRole::User)
+                                    .map(|m| m.content.chars().take(200).collect::<String>())
+                                    .take(10)
+                                    .collect();
 
-                            // Collect sample user messages from recent threads
-                            let sample_messages: Vec<String> = thread
-                                .messages
-                                .iter()
-                                .filter(|m| m.role == crate::types::message::MessageRole::User)
-                                .map(|m| m.content.chars().take(200).collect::<String>())
-                                .take(10)
-                                .collect();
+                                let payload = serde_json::json!({
+                                    "project_id": thread.project_id.0.to_string(),
+                                    "completed_thread_count": *count,
+                                    "thread_goals": thread_goals,
+                                    "sample_user_messages": sample_messages,
+                                });
 
-                            let payload = serde_json::json!({
-                                "project_id": thread.project_id.0.to_string(),
-                                "completed_thread_count": *count,
-                                "thread_goals": thread_goals,
-                                "sample_user_messages": sample_messages,
-                            });
-
-                            if let Err(e) = mgr
-                                .fire_on_system_event(
-                                    "engine",
-                                    "conversation_insights_due",
-                                    &thread.user_id,
-                                    Some(payload),
-                                )
-                                .await
-                            {
-                                debug!("event listener: failed to fire conversation insights: {e}");
+                                if let Err(e) = mgr
+                                    .fire_on_system_event(
+                                        "engine",
+                                        "conversation_insights_due",
+                                        &thread.user_id,
+                                        Some(payload),
+                                    )
+                                    .await
+                                {
+                                    debug!("event listener: failed to fire conversation insights: {e}");
+                                }
                             }
                         }
                     }
@@ -1542,6 +1545,12 @@ fn learning_terminal_state(
         } => Some(crate::types::thread::ThreadState::Failed),
         _ => None,
     }
+}
+
+fn should_count_for_conversation_insights(
+    terminal_state: crate::types::thread::ThreadState,
+) -> bool {
+    terminal_state == crate::types::thread::ThreadState::Done
 }
 
 fn has_action_failures(thread: &Thread) -> bool {
@@ -3240,6 +3249,12 @@ mod tests {
             self_imp_count, 1,
             "should not duplicate self-improvement mission"
         );
+    }
+
+    #[test]
+    fn conversation_insights_count_only_done_threads() {
+        assert!(should_count_for_conversation_insights(ThreadState::Done));
+        assert!(!should_count_for_conversation_insights(ThreadState::Failed));
     }
 
     #[test]

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -12,6 +12,7 @@ use uuid::Uuid;
 use crate::types::capability::LeaseId;
 use crate::types::error::EngineError;
 use crate::types::event::{EventKind, ThreadEvent};
+use crate::types::memory::DocId;
 use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
 
@@ -166,6 +167,20 @@ impl Default for ThreadConfig {
     }
 }
 
+/// Provenance for a skill that was active during thread execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActiveSkillProvenance {
+    pub doc_id: DocId,
+    pub name: String,
+    pub version: u32,
+    #[serde(default)]
+    pub snippet_names: Vec<String>,
+    #[serde(default)]
+    pub force_activated: bool,
+}
+
+const ACTIVE_SKILLS_METADATA_KEY: &str = "active_skills";
+
 // ── Thread ──────────────────────────────────────────────────
 
 /// A thread — the unit of work.
@@ -246,6 +261,36 @@ impl Thread {
         self.owner_id().matches_user(user_id)
     }
 
+    /// Persist active skill provenance in thread metadata.
+    pub fn set_active_skills(
+        &mut self,
+        active_skills: &[ActiveSkillProvenance],
+    ) -> Result<(), EngineError> {
+        let metadata = self
+            .metadata
+            .as_object_mut()
+            .ok_or_else(|| EngineError::Store {
+                reason: "thread metadata is not a JSON object".into(),
+            })?;
+        metadata.insert(
+            ACTIVE_SKILLS_METADATA_KEY.into(),
+            serde_json::to_value(active_skills).map_err(|e| EngineError::Store {
+                reason: format!("failed to serialize active skill provenance: {e}"),
+            })?,
+        );
+        self.updated_at = Utc::now();
+        Ok(())
+    }
+
+    /// Load active skill provenance from thread metadata.
+    pub fn active_skills(&self) -> Vec<ActiveSkillProvenance> {
+        self.metadata
+            .get(ACTIVE_SKILLS_METADATA_KEY)
+            .cloned()
+            .and_then(|value| serde_json::from_value(value).ok())
+            .unwrap_or_default()
+    }
+
     /// Transition to a new state, recording an event.
     pub fn transition_to(
         &mut self,
@@ -310,6 +355,7 @@ impl Thread {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::memory::DocId;
 
     fn make_thread() -> Thread {
         Thread::new(
@@ -462,5 +508,21 @@ mod tests {
         )
         .with_parent(parent.id);
         assert_eq!(child.parent_id, Some(parent.id));
+    }
+
+    #[test]
+    fn active_skill_provenance_roundtrips_through_metadata() {
+        let mut thread = make_thread();
+        let skills = vec![ActiveSkillProvenance {
+            doc_id: DocId::new(),
+            name: "github-pr-workflow".to_string(),
+            version: 3,
+            snippet_names: vec!["list_prs".to_string()],
+            force_activated: true,
+        }];
+
+        thread.set_active_skills(&skills).unwrap();
+
+        assert_eq!(thread.active_skills(), skills);
     }
 }

--- a/crates/ironclaw_skills/src/v2.rs
+++ b/crates/ironclaw_skills/src/v2.rs
@@ -70,6 +70,64 @@ impl SkillMetrics {
     }
 }
 
+/// Structured repair categories for versioned skill updates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillRepairType {
+    MissingPrerequisite,
+    WrongOrdering,
+    StaleCommandPath,
+    MissingBranch,
+    MissingPitfall,
+    MissingVerification,
+}
+
+/// Archived pre-update skill state used for content-aware rollback.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillRevision {
+    /// Version number represented by this archived snapshot.
+    pub version: u32,
+    /// Prompt content for that version.
+    pub content: String,
+    /// Description at that version.
+    #[serde(default)]
+    pub description: String,
+    /// Activation criteria at that version.
+    #[serde(default)]
+    pub activation: ActivationCriteria,
+    /// Code snippets at that version.
+    #[serde(default)]
+    pub code_snippets: Vec<CodeSnippet>,
+    /// Content hash at that version.
+    #[serde(default)]
+    pub content_hash: String,
+    /// When this snapshot was archived.
+    #[serde(default)]
+    pub archived_at: Option<DateTime<Utc>>,
+}
+
+/// Metadata describing a repair that updated this skill.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillRepairRecord {
+    /// Source thread that exposed the gap, if known.
+    #[serde(default)]
+    pub source_thread_id: Option<String>,
+    /// Version before the repair.
+    #[serde(default)]
+    pub from_version: u32,
+    /// Version after the repair.
+    #[serde(default)]
+    pub to_version: u32,
+    /// Type of gap that was repaired.
+    pub repair_type: SkillRepairType,
+    /// Short human-readable summary of the fix.
+    #[serde(default)]
+    pub summary: String,
+    /// When the repair was applied.
+    #[serde(default)]
+    pub repaired_at: Option<DateTime<Utc>>,
+}
+
 /// Full metadata for a v2 skill.
 ///
 /// Serialized to/from the `metadata` JSON field of a `MemoryDoc` with
@@ -104,6 +162,12 @@ pub struct V2SkillMetadata {
     /// Previous version number (for rollback).
     #[serde(default)]
     pub parent_version: Option<u32>,
+    /// Archived revisions used for content-aware rollback.
+    #[serde(default)]
+    pub revisions: Vec<SkillRevision>,
+    /// Repair history for this skill.
+    #[serde(default)]
+    pub repairs: Vec<SkillRepairRecord>,
     /// SHA-256 hash of the prompt content.
     #[serde(default)]
     pub content_hash: String,
@@ -181,6 +245,23 @@ mod tests {
                 last_used: None,
             },
             parent_version: Some(2),
+            revisions: vec![SkillRevision {
+                version: 2,
+                content: "previous content".to_string(),
+                description: "old".to_string(),
+                activation: ActivationCriteria::default(),
+                code_snippets: vec![],
+                content_hash: "sha256:def".to_string(),
+                archived_at: None,
+            }],
+            repairs: vec![SkillRepairRecord {
+                source_thread_id: Some("thread-123".to_string()),
+                from_version: 2,
+                to_version: 3,
+                repair_type: SkillRepairType::MissingVerification,
+                summary: "added smoke test step".to_string(),
+                repaired_at: None,
+            }],
             content_hash: "sha256:abc".to_string(),
         };
 
@@ -193,6 +274,8 @@ mod tests {
         assert_eq!(parsed.code_snippets.len(), 1);
         assert_eq!(parsed.metrics.success_count, 4);
         assert_eq!(parsed.parent_version, Some(2));
+        assert_eq!(parsed.revisions.len(), 1);
+        assert_eq!(parsed.repairs.len(), 1);
     }
 
     #[test]
@@ -205,5 +288,7 @@ mod tests {
         assert_eq!(parsed.trust, SkillTrust::Installed);
         assert!(parsed.code_snippets.is_empty());
         assert!((parsed.metrics.confidence() - 1.0).abs() < f64::EPSILON);
+        assert!(parsed.revisions.is_empty());
+        assert!(parsed.repairs.is_empty());
     }
 }

--- a/docs/engine-v2-architecture.md
+++ b/docs/engine-v2-architecture.md
@@ -135,13 +135,15 @@ For trace debugging: `ENGINE_V2_TRACE=1` writes full JSON traces to `engine_trac
 
 ### Learning Missions (replaced Reflection)
 
-Instead of a separate reflection pipeline, knowledge extraction is handled by three event-driven **learning missions** that fire automatically after thread completion:
+Instead of a separate reflection pipeline, knowledge extraction is handled by four event-driven **learning missions** that fire automatically after thread completion:
 
 1. **Self-improvement** (`self-improvement`) — fires when a thread completes with trace issues (errors, tool-not-found, etc.). Diagnoses root cause, applies prompt overlays or orchestrator patches. Graduated risk: Level 1 (prompt) → Level 2 (config) → Level 3 (code, propose only).
 
-2. **Skill extraction** (`skill-extraction`) — fires when a thread succeeds with 5+ steps and 3+ distinct tool actions. Extracts reusable skills with structured metadata: activation keywords/patterns, CodeAct code snippets, domain tags. Output is a `DocType::Skill` MemoryDoc with `V2SkillMetadata` JSON.
+2. **Skill repair** (`skill-repair`) — fires when a completed thread used an active skill and the resulting trace suggests that the skill instructions were stale, incomplete, incorrectly ordered, or missing verification. The mission returns a structured repair, and the runtime applies it as a versioned update with rollback history.
 
-3. **Conversation insights** (`conversation-insights`) — fires every 5 completed threads in a project. Extracts user preferences, domain knowledge, workflow patterns, and corrections.
+3. **Skill extraction** (`skill-extraction`) — fires when a thread succeeds with 5+ steps and 3+ distinct tool actions. Extracts reusable skills with structured metadata: activation keywords/patterns, CodeAct code snippets, domain tags. Output is a `DocType::Skill` MemoryDoc with `V2SkillMetadata` JSON.
+
+4. **Conversation insights** (`conversation-insights`) — fires every 5 completed threads in a project. Extracts user preferences, domain knowledge, workflow patterns, and corrections.
 
 ### Context Injection
 

--- a/src/bridge/skill_migration.rs
+++ b/src/bridge/skill_migration.rs
@@ -110,6 +110,8 @@ fn v1_skill_to_memory_doc(skill: &LoadedSkill, project_id: ProjectId) -> MemoryD
         code_snippets: vec![], // v1 skills are prompt-only
         metrics: SkillMetrics::default(),
         parent_version: None,
+        revisions: vec![],
+        repairs: vec![],
         content_hash: skill.content_hash.clone(),
     };
 

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -495,6 +495,87 @@ FINAL(str(result))
     );
 }
 
+/// Verify selected skill provenance is persisted onto the thread for learning flows.
+#[tokio::test]
+async fn skill_codeact_persists_active_skill_provenance() {
+    let project_id = ProjectId::new();
+    let skill_doc = make_github_skill_doc(project_id);
+    let skill_doc_id = skill_doc.id;
+
+    let python_code = r#"
+result = await http(method="GET", url="https://api.github.com/repos/test-org/test-repo/issues?state=open&per_page=5")
+FINAL(str(result))
+"#;
+    let llm = ScriptedLlm::new(vec![LlmOutput {
+        response: LlmResponse::Code {
+            code: python_code.to_string(),
+            content: None,
+        },
+        usage: TokenUsage::default(),
+    }]);
+
+    let mut canned = HashMap::new();
+    canned.insert(
+        "api.github.com/repos/test-org/test-repo/issues".to_string(),
+        canned_github_issues(),
+    );
+    let effects = HttpMockEffects::new(canned);
+    let store = TestStore::new();
+    store.save_memory_doc(&skill_doc).await.unwrap();
+
+    let mut caps = CapabilityRegistry::new();
+    caps.register(Capability {
+        name: "tools".into(),
+        description: "Available tools".into(),
+        actions: vec![ActionDef {
+            name: "http".into(),
+            description: "Make HTTP requests".into(),
+            parameters_schema: serde_json::json!({"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}),
+            effects: vec![EffectType::ReadExternal],
+            requires_approval: false,
+        }],
+        knowledge: vec![],
+        policies: vec![],
+    });
+
+    let mgr = ThreadManager::new(
+        llm,
+        effects,
+        store.clone() as Arc<dyn Store>,
+        Arc::new(caps),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    );
+
+    let tid = mgr
+        .spawn_thread(
+            "show me open github issues for test-org/test-repo",
+            ThreadType::Foreground,
+            project_id,
+            ThreadConfig::default(),
+            None,
+            "test-user",
+        )
+        .await
+        .expect("spawn_thread");
+
+    let outcome = mgr.join_thread(tid).await.expect("join_thread");
+    assert!(
+        matches!(outcome, ThreadOutcome::Completed { .. }),
+        "expected Completed, got: {outcome:?}"
+    );
+
+    let thread = store.load_thread(tid).await.unwrap().unwrap();
+    let active_skills = thread.active_skills();
+    let github_skill = active_skills
+        .iter()
+        .find(|skill| skill.doc_id == skill_doc_id)
+        .unwrap_or_else(|| panic!("expected github skill provenance in {active_skills:?}"));
+    assert_eq!(github_skill.name, "github");
+    assert_eq!(github_skill.version, 1);
+    assert_eq!(github_skill.snippet_names, vec!["list_github_issues"]);
+}
+
 /// Verify that non-matching goals don't activate skills (negative case).
 #[tokio::test]
 async fn non_matching_goal_skips_skill_codeact() {

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -346,6 +346,8 @@ fn make_github_skill_doc(project_id: ProjectId) -> MemoryDoc {
         }],
         metrics: SkillMetrics::default(),
         parent_version: None,
+        revisions: vec![],
+        repairs: vec![],
         content_hash: String::new(),
     };
 


### PR DESCRIPTION
## Summary
- restage the skill-repair learning loop on top of current `staging` instead of carrying the drifted `pr/1821` merge state forward
- add the new `skill-repair` learning mission prompt and mission-manager flow for detecting active-skill gaps on completed threads
- version skill updates with archived revisions, repair records, active-skill provenance, and rollback support across the engine and shared skill metadata types

## Why
The earlier branch had drifted too far from current `staging` and resolving it required compatibility shims in unrelated areas. Reapplying the feature directly on top of current `staging` keeps the diff focused on the actual skill-repair behavior and avoids carrying stale interface assumptions forward.

Supersedes #1821.

## Impact
- completed threads with active skills now record usage outcomes and can trigger a dedicated `skill-repair` mission when execution suggests the skill instructions were stale, incomplete, or missing verification
- repaired skills now keep bounded revision history and explicit repair metadata so updates are auditable and rollback-aware
- v2 skill migration and integration tests understand the expanded metadata shape

## Validation
- `cargo fmt --all`
- `cargo test -p ironclaw_skills v2 -- --nocapture`
- `cargo test -p ironclaw_engine build_skill_gap_payload -- --nocapture`
- `cargo test -p ironclaw_engine skill_repair -- --nocapture`
- `cargo test -p ironclaw_engine thread_completed_successfully -- --nocapture`
- `cargo test -p ironclaw_engine learning_terminal_state -- --nocapture`
- `cargo check --workspace`

## Notes
- I did not wait for `cargo test --test engine_v2_skill_codeact` to finish because it recompiles the full top-level crate in test mode and was redundant after the workspace compile for this feature slice.
