### PR TITLE
fix: update CLI help snapshots for --auto-approve and acp

### DIFF
--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -27,6 +27,7 @@ Commands:
   completion  Generate completions
   import      Import from other AI systems
   login       Authenticate with a provider
+  acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -35,5 +36,6 @@ Options:
   -m, --message <MESSAGE>  Single message mode - send one message and exit
   -c, --config <CONFIG>    Configuration file path (optional, uses env vars by default)
       --no-onboard         Skip first-run onboarding check
+      --auto-approve       Auto-approve tool execution (shell, file writes, HTTP, etc.)
   -h, --help               Print help (see more with '--help')
   -V, --version            Print version

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -30,6 +30,7 @@ Commands:
   completion  Generate completions
   import      Import from other AI systems
   login       Authenticate with a provider
+  acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 
 Options:
@@ -47,6 +48,11 @@ Options:
 
       --no-onboard
           Skip first-run onboarding check
+
+      --auto-approve
+          Auto-approve tool execution (shell, file writes, HTTP, etc.)
+          
+          Skips interactive approval prompts for standard tools. Destructive operations still require explicit approval. Other safeguards remain active: rate limits, hooks, authentication gates.
 
   -h, --help
           Print help (see a summary with '-h')


### PR DESCRIPTION
## Summary
- The `import`-feature-gated CLI help snapshot tests (`test_help_output`, `test_long_help_output`) were stale after the `--auto-approve` flag and `acp` subcommand were added
- Only the `without_import` snapshot variants were updated; the `with_import` variants were missed
- This caused `Tests (all-features)` to fail with exit code 101 on the staging promotion PR #1959

## Test plan
- [x] `cargo test --lib cli::tests --all-features` passes locally
- [ ] CI snapshot tests pass on this PR

https://claude.ai/code/session_01Vfo7aFbVDpibtH7EsDAUSE