### PR TITLE
[codex] Label migration PRs with DB MIGRATION

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -74,12 +74,6 @@
           - src/db/libsql_backend.rs
           - src/db/libsql_migrations.rs
 
-"DB MIGRATION":
-  - changed-files:
-      - any-glob-to-any-file:
-          - migrations/**
-          - src/db/libsql_migrations.rs
-
 "scope: safety":
   - changed-files:
       - any-glob-to-any-file:
@@ -170,3 +164,9 @@
       - any-glob-to-any-file:
           - Cargo.toml
           - Cargo.lock
+
+"DB MIGRATION":
+  - changed-files:
+      - any-glob-to-any-file:
+          - migrations/**
+          - src/db/libsql_migrations.rs

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# Scope labels for actions/labeler@v6
-# Maps file path globs to scope labels. Multiple labels can apply per PR.
+# Labels for actions/labeler@v6
+# Maps file path globs to labels. Multiple labels can apply per PR.
 
 "scope: agent":
   - changed-files:
@@ -66,6 +66,11 @@
   - changed-files:
       - any-glob-to-any-file:
           - src/db/postgres.rs
+          - migrations/**
+
+"DB MIGRATION":
+  - changed-files:
+      - any-glob-to-any-file:
           - migrations/**
 
 "scope: db/libsql":

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,15 +68,16 @@
           - src/db/postgres.rs
           - migrations/**
 
-"DB MIGRATION":
-  - changed-files:
-      - any-glob-to-any-file:
-          - migrations/**
-
 "scope: db/libsql":
   - changed-files:
       - any-glob-to-any-file:
           - src/db/libsql_backend.rs
+          - src/db/libsql_migrations.rs
+
+"DB MIGRATION":
+  - changed-files:
+      - any-glob-to-any-file:
+          - migrations/**
           - src/db/libsql_migrations.rs
 
 "scope: safety":

--- a/.github/scripts/create-labels.sh
+++ b/.github/scripts/create-labels.sh
@@ -63,7 +63,7 @@ create "scope: docs"          "78909C" "Documentation"
 create "scope: dependencies"  "90A4AE" "Dependency updates"
 
 echo "==> Creating coordination labels..."
-create "DB MIGRATION"         "C62828" "PR adds or modifies versioned database migration scripts"
+create "DB MIGRATION"         "C62828" "PR adds or modifies PostgreSQL or libSQL migration definitions"
 
 echo "==> Creating workflow labels..."
 create "skip-regression-check" "9E9E9E" "Acknowledged: fix without regression test"

--- a/.github/scripts/create-labels.sh
+++ b/.github/scripts/create-labels.sh
@@ -62,6 +62,9 @@ create "scope: ci"            "546E7A" "CI/CD workflows"
 create "scope: docs"          "78909C" "Documentation"
 create "scope: dependencies"  "90A4AE" "Dependency updates"
 
+echo "==> Creating coordination labels..."
+create "DB MIGRATION"         "C62828" "PR adds or modifies versioned database migration scripts"
+
 echo "==> Creating workflow labels..."
 create "skip-regression-check" "9E9E9E" "Acknowledged: fix without regression test"
 

--- a/.github/workflows/pr-label-scope.yml
+++ b/.github/workflows/pr-label-scope.yml
@@ -19,7 +19,7 @@ jobs:
           REPO: ${{ github.repository }}
         run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies PostgreSQL or libSQL migration definitions" --force
 
-      - uses: actions/labeler@v5
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false          # additive only — never remove scope labels

--- a/.github/workflows/pr-label-scope.yml
+++ b/.github/workflows/pr-label-scope.yml
@@ -6,12 +6,19 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
   scope:
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure DB MIGRATION label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies versioned database migration scripts" --force
+
       - uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yml

--- a/.github/workflows/pr-label-scope.yml
+++ b/.github/workflows/pr-label-scope.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
-        run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies versioned database migration scripts" --force
+        run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies PostgreSQL or libSQL migration definitions" --force
 
       - uses: actions/labeler@v5
         with:


### PR DESCRIPTION
## Summary
- add a dedicated `DB MIGRATION` label rule in the PR scope labeler for changes under `migrations/**`
- ensure the scope-label workflow creates that label before running `actions/labeler`
- keep the label bootstrap script in sync so manual label setup also includes `DB MIGRATION`

## Why
Migration PRs can otherwise blend into the broader database scope labels, which makes it easier to miss or duplicate migration-tag handling across concurrent PRs. A single dedicated `DB MIGRATION` label gives CI and reviewers a stable signal whenever a versioned migration script changes.

## Impact
PRs that touch `migrations/**` will now always receive the capitalized `DB MIGRATION` label in addition to any existing scope labels.

## Validation
- parsed `.github/labeler.yml`
- parsed `.github/workflows/pr-label-scope.yml`
- ran `bash -n .github/scripts/create-labels.sh`
- ran `git diff --check origin/main...HEAD`

## Notes
- supersedes closed draft PR #1965, which was mistakenly based on staging history
