### PR TITLE
(fix) WASM channel HTTP SSRF protections

### DIFF
--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -54,10 +54,11 @@ use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse,
 use crate::error::ChannelError;
 use crate::pairing::PairingStore;
 use crate::secrets::SecretsStore;
-use crate::tools::wasm::LogLevel;
-use crate::tools::wasm::WasmResourceLimiter;
 use crate::tools::wasm::credential_injector::{
     InjectedCredentials, host_matches_pattern, inject_credential,
+};
+use crate::tools::wasm::{
+    LogLevel, WasmResourceLimiter, reject_private_ip, ssrf_safe_client_builder,
 };
 use ironclaw_safety::LeakDetector;
 
@@ -391,6 +392,9 @@ impl near::agent::channel_host::Host for ChannelStoreData {
             .map(|h| h.max_response_bytes)
             .unwrap_or(10 * 1024 * 1024);
 
+        // Resolve hostname and reject private/internal IPs to prevent DNS rebinding.
+        reject_private_ip(&url)?;
+
         // Make the HTTP request using a dedicated single-threaded runtime.
         // We're inside spawn_blocking, so we can't rely on the main runtime's
         // I/O driver (it may be busy with WASM compilation or other startup work).
@@ -406,8 +410,8 @@ impl near::agent::channel_host::Host for ChannelStoreData {
         }
         let rt = self.http_runtime.as_ref().expect("just initialized");
         let result = rt.block_on(async {
-            let client = reqwest::Client::builder()
-                .connect_timeout(std::time::Duration::from_secs(10))
+            let client = ssrf_safe_client_builder()
+                .connect_timeout(Duration::from_secs(10))
                 .build()
                 .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
@@ -5483,6 +5487,40 @@ mod tests {
 
         let input = "should not match anything";
         assert_eq!(store.redact_credentials(input), input);
+    }
+
+    #[test]
+    fn test_http_request_rejects_private_ip_targets() {
+        let capabilities =
+            ChannelCapabilities::for_channel("test").with_tool_capabilities(ToolCapabilities {
+                http: Some(HttpCapability::new(vec![EndpointPattern::host(
+                    "127.0.0.1",
+                )])),
+                ..Default::default()
+            });
+        let mut store = super::ChannelStoreData::new(
+            1024 * 1024,
+            "test",
+            capabilities,
+            std::collections::HashMap::new(),
+            Vec::new(),
+            Arc::new(PairingStore::new()),
+        );
+
+        let result = super::near::agent::channel_host::Host::http_request(
+            &mut store,
+            "GET".to_string(),
+            "https://127.0.0.1:1/health".to_string(),
+            "{}".to_string(),
+            None,
+            Some(1_000),
+        );
+
+        assert!(result.is_err(), "loopback targets must be rejected");
+        assert!(
+            result.unwrap_err().contains("private/internal IP"),
+            "expected SSRF guard error"
+        );
     }
 
     #[test]

--- a/src/tools/wasm/http_security.rs
+++ b/src/tools/wasm/http_security.rs
@@ -1,0 +1,140 @@
+//! Shared HTTP SSRF defenses for WASM tool and channel runtimes.
+
+use std::net::{IpAddr, ToSocketAddrs};
+
+/// Build a reqwest client builder with the WASM SSRF redirect policy applied.
+///
+/// Redirects are disabled so callers must explicitly validate each hop instead
+/// of letting reqwest follow `Location` to an unvalidated target.
+pub(crate) fn ssrf_safe_client_builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder().redirect(reqwest::redirect::Policy::none())
+}
+
+/// Resolve the URL's hostname and reject connections to private/internal IP addresses.
+///
+/// This prevents DNS rebinding attacks where an attacker-controlled hostname
+/// passes the allowlist check, then resolves to an internal address.
+pub(crate) fn reject_private_ip(url: &str) -> Result<(), String> {
+    let parsed = url::Url::parse(url).map_err(|e| format!("Failed to parse URL: {e}"))?;
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return Err(format!("Unsupported URL scheme: {}", parsed.scheme()));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err("URL contains userinfo (@) which is not allowed".to_string());
+    }
+
+    let host = parsed
+        .host_str()
+        .map(|h| {
+            h.strip_prefix('[')
+                .and_then(|v| v.strip_suffix(']'))
+                .unwrap_or(h)
+        })
+        .ok_or_else(|| "Failed to parse host from URL".to_string())?;
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return if is_private_ip(ip) {
+            Err(format!(
+                "HTTP request to private/internal IP {} is not allowed",
+                ip
+            ))
+        } else {
+            Ok(())
+        };
+    }
+
+    let addrs: Vec<_> = format!("{}:0", host)
+        .to_socket_addrs()
+        .map_err(|e| format!("DNS resolution failed for {}: {}", host, e))?
+        .collect();
+
+    if addrs.is_empty() {
+        return Err(format!("DNS resolution returned no addresses for {}", host));
+    }
+
+    for addr in &addrs {
+        if is_private_ip(addr.ip()) {
+            return Err(format!(
+                "DNS rebinding detected: {} resolved to private IP {}",
+                host,
+                addr.ip()
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+pub(crate) fn is_private_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_unspecified()
+                || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64
+        }
+        IpAddr::V6(v6) => {
+            v6.is_loopback()
+                || v6.is_unspecified()
+                || (v6.segments()[0] & 0xFE00) == 0xFC00
+                || (v6.segments()[0] & 0xFFC0) == 0xFE80
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use axum::extract::State;
+    use axum::response::Redirect;
+    use axum::routing::get;
+    use axum::{Router, serve};
+    use tokio::net::TcpListener;
+
+    #[tokio::test]
+    async fn test_ssrf_safe_client_builder_disables_redirects() {
+        async fn final_handler(State(hits): State<Arc<AtomicUsize>>) -> &'static str {
+            hits.fetch_add(1, Ordering::SeqCst);
+            "ok"
+        }
+
+        let final_hits = Arc::new(AtomicUsize::new(0));
+        let final_listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let final_addr = final_listener.local_addr().unwrap();
+        let final_app = Router::new()
+            .route("/final", get(final_handler))
+            .with_state(Arc::clone(&final_hits));
+        let final_handle = tokio::spawn(async move {
+            serve(final_listener, final_app).await.unwrap();
+        });
+
+        let redirect_listener = TcpListener::bind(("127.0.0.1", 0)).await.unwrap();
+        let redirect_addr = redirect_listener.local_addr().unwrap();
+        let location = format!("http://{final_addr}/final");
+        let redirect_app = Router::new().route(
+            "/start",
+            get(move || async move { Redirect::temporary(&location) }),
+        );
+        let redirect_handle = tokio::spawn(async move {
+            serve(redirect_listener, redirect_app).await.unwrap();
+        });
+
+        let client = super::ssrf_safe_client_builder().build().unwrap();
+        let response: reqwest::Response = client
+            .get(format!("http://{redirect_addr}/start"))
+            .send()
+            .await
+            .unwrap();
+
+        assert!(response.status().is_redirection());
+        assert_eq!(final_hits.load(Ordering::SeqCst), 0);
+
+        redirect_handle.abort();
+        final_handle.abort();
+    }
+}

--- a/src/tools/wasm/mod.rs
+++ b/src/tools/wasm/mod.rs
@@ -88,6 +88,7 @@ mod capabilities_schema;
 pub(crate) mod credential_injector;
 mod error;
 mod host;
+mod http_security;
 mod limits;
 pub(crate) mod loader;
 mod rate_limiter;
@@ -117,6 +118,7 @@ pub(crate) use credential_injector::inject_credential;
 pub use credential_injector::{
     CredentialInjector, InjectedCredentials, InjectionError, SharedCredentialRegistry,
 };
+pub(crate) use http_security::{is_private_ip, reject_private_ip, ssrf_safe_client_builder};
 pub use rate_limiter::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 
 // Storage (V2)

--- a/src/tools/wasm/mod.rs
+++ b/src/tools/wasm/mod.rs
@@ -118,7 +118,9 @@ pub(crate) use credential_injector::inject_credential;
 pub use credential_injector::{
     CredentialInjector, InjectedCredentials, InjectionError, SharedCredentialRegistry,
 };
-pub(crate) use http_security::{is_private_ip, reject_private_ip, ssrf_safe_client_builder};
+#[cfg(test)]
+pub(crate) use http_security::is_private_ip;
+pub(crate) use http_security::{reject_private_ip, ssrf_safe_client_builder};
 pub use rate_limiter::{LimitType, RateLimitError, RateLimitResult, RateLimiter};
 
 // Storage (V2)

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -28,6 +28,7 @@ use crate::tools::wasm::error::WasmError;
 use crate::tools::wasm::host::{HostState, LogLevel};
 use crate::tools::wasm::limits::{ResourceLimits, WasmResourceLimiter};
 use crate::tools::wasm::runtime::{EPOCH_TICK_INTERVAL, PreparedModule, WasmToolRuntime};
+use crate::tools::wasm::ssrf_safe_client_builder;
 use ironclaw_safety::LeakDetector;
 
 // Generate component model bindings from the WIT file.
@@ -415,9 +416,8 @@ impl near::agent::host::Host for StoreData {
         });
 
         let result = rt.block_on(async {
-            let client = reqwest::Client::builder()
+            let client = ssrf_safe_client_builder()
                 .connect_timeout(Duration::from_secs(10))
-                .redirect(reqwest::redirect::Policy::none())
                 .build()
                 .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
 
@@ -1321,9 +1321,8 @@ async fn refresh_oauth_token(
         return false;
     }
 
-    let client = match reqwest::Client::builder()
+    let client = match ssrf_safe_client_builder()
         .timeout(Duration::from_secs(15))
-        .redirect(reqwest::redirect::Policy::none())
         .build()
     {
         Ok(c) => c,
@@ -1623,84 +1622,12 @@ fn extract_host_from_url(url: &str) -> Option<String> {
     })
 }
 
-/// Resolve the URL's hostname and reject connections to private/internal IP addresses.
-/// This prevents DNS rebinding attacks where an attacker's domain resolves to an
-/// internal IP after passing the allowlist check.
 fn reject_private_ip(url: &str) -> Result<(), String> {
-    let parsed = url::Url::parse(url).map_err(|e| format!("Failed to parse URL: {e}"))?;
-    if !matches!(parsed.scheme(), "http" | "https") {
-        return Err(format!("Unsupported URL scheme: {}", parsed.scheme()));
-    }
-    if !parsed.username().is_empty() || parsed.password().is_some() {
-        return Err("URL contains userinfo (@) which is not allowed".to_string());
-    }
-
-    let host = parsed
-        .host_str()
-        .map(|h| {
-            h.strip_prefix('[')
-                .and_then(|v| v.strip_suffix(']'))
-                .unwrap_or(h)
-        })
-        .ok_or_else(|| "Failed to parse host from URL".to_string())?;
-
-    // If the host is already an IP, check it directly
-    if let Ok(ip) = host.parse::<std::net::IpAddr>() {
-        return if is_private_ip(ip) {
-            Err(format!(
-                "HTTP request to private/internal IP {} is not allowed",
-                ip
-            ))
-        } else {
-            Ok(())
-        };
-    }
-
-    // Resolve DNS and check all addresses
-    use std::net::ToSocketAddrs;
-    // Port 0 is a placeholder; ToSocketAddrs needs host:port but the port
-    // doesn't affect which IPs the hostname resolves to.
-    let addrs: Vec<_> = format!("{}:0", host)
-        .to_socket_addrs()
-        .map_err(|e| format!("DNS resolution failed for {}: {}", host, e))?
-        .collect();
-
-    if addrs.is_empty() {
-        return Err(format!("DNS resolution returned no addresses for {}", host));
-    }
-
-    for addr in &addrs {
-        if is_private_ip(addr.ip()) {
-            return Err(format!(
-                "DNS rebinding detected: {} resolved to private IP {}",
-                host,
-                addr.ip()
-            ));
-        }
-    }
-
-    Ok(())
+    crate::tools::wasm::reject_private_ip(url)
 }
 
-/// Check if an IP address belongs to a private/internal range.
 fn is_private_ip(ip: std::net::IpAddr) -> bool {
-    match ip {
-        std::net::IpAddr::V4(v4) => {
-            v4.is_loopback()           // 127.0.0.0/8
-            || v4.is_private()         // 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16
-            || v4.is_link_local()      // 169.254.0.0/16
-            || v4.is_unspecified()     // 0.0.0.0
-            || v4.octets()[0] == 100 && (v4.octets()[1] & 0xC0) == 64 // 100.64.0.0/10 (CGNAT)
-        }
-        std::net::IpAddr::V6(v6) => {
-            v6.is_loopback()           // ::1
-            || v6.is_unspecified()     // ::
-            // fc00::/7 (unique local)
-            || (v6.segments()[0] & 0xFE00) == 0xFC00
-            // fe80::/10 (link-local)
-            || (v6.segments()[0] & 0xFFC0) == 0xFE80
-        }
-    }
+    crate::tools::wasm::is_private_ip(ip)
 }
 
 fn schema_contains_container_properties(schema: &serde_json::Value) -> bool {

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1626,6 +1626,7 @@ fn reject_private_ip(url: &str) -> Result<(), String> {
     crate::tools::wasm::reject_private_ip(url)
 }
 
+#[cfg(test)]
 fn is_private_ip(ip: std::net::IpAddr) -> bool {
     crate::tools::wasm::is_private_ip(ip)
 }


### PR DESCRIPTION
## Summary
This hardens the WASM channel HTTP request path to use the same SSRF defenses already present in the WASM tool wrapper.

## What changed
- added a shared WASM HTTP security helper for private-IP rejection and no-redirect reqwest client construction
- applied that helper to `src/channels/wasm/wrapper.rs` so channel HTTP requests reject private/internal IPs before connect
- switched the tool wrapper and OAuth refresh path to the same shared helper so the policy cannot drift again
- added a channel regression test proving loopback targets are rejected
- added a shared helper test proving redirects stay disabled

## Root cause
`src/channels/wasm/wrapper.rs` validated only the initial allowlisted URL, then built a default reqwest client without the two SSRF controls already used in `src/tools/wasm/wrapper.rs`:
- private/internal IP rejection after URL parsing and DNS resolution
- `redirect(Policy::none())`

That left the channel path weaker than the tool path and meant an allowlisted first hop could still reach an internal destination via redirect or DNS rebinding.

## Impact
Custom WASM channels now get the same outbound HTTP protections as WASM tools. Requests to loopback/private IPs are rejected up front, and redirect targets are no longer followed implicitly.

## Validation
- `cargo test private_ip --lib`
- `cargo test ssrf_safe_client_builder_disables_redirects --lib`