### PR TITLE
[codex] feat: enforce per-workspace RBAC with superadmin controls

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -22,7 +22,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Hub-and-spoke architecture | ✅ | ✅ | Web gateway as central hub |
 | WebSocket control plane | ✅ | ✅ | Gateway with WebSocket + SSE |
 | Single-user system | ✅ | ✅ | Explicit instance owner scope for persistent routines, secrets, jobs, settings, extensions, and workspace memory |
-| First-class workspace entities and sharing | ✅ | ✅ | DB-backed workspaces, membership, scoped jobs/routines/memory/settings, workspace SSE fan-out, archived workspace gating |
+| First-class workspace entities and sharing | ✅ | ✅ | DB-backed workspaces, membership, enforced workspace RBAC, scoped jobs/routines/memory/settings, workspace SSE fan-out, archived workspace gating, superadmin workspace visibility |
 | Multi-agent routing | ✅ | ❌ | Workspace isolation per-agent |
 | Session-based messaging | ✅ | ✅ | Owner scope is separate from sender identity and conversation scope |
 | Loopback-first networking | ✅ | ✅ | HTTP binds to 0.0.0.0 but can be configured |

--- a/docs/USER_MANAGEMENT_API.md
+++ b/docs/USER_MANAGEMENT_API.md
@@ -1,6 +1,6 @@
 # User Management API
 
-DB-backed user management for multi-tenant IronClaw deployments. Covers admin user CRUD, per-user secrets provisioning, self-service profile, API token management, and usage reporting.
+DB-backed user management for multi-tenant IronClaw deployments. Covers superadmin-only user CRUD, per-user secrets provisioning, self-service profile, API token management, and usage reporting.
 
 ## Authentication
 
@@ -12,14 +12,18 @@ DB tokens are SHA-256 hashed at rest; plaintext is returned exactly once at crea
 
 Auth is cached in a bounded LRU (1024 entries, 60s TTL). Suspending a user or revoking a token may take up to 60s to take effect.
 
-## Roles
+## Roles And System Access
 
 | Role | Scope |
 |------|-------|
-| `admin` | Full access to all endpoints |
+| `admin` | Elevated user role for compatibility and future policy; does not by itself unlock `/api/admin/*` |
 | `member` | Self-service profile + own token management only |
 
-Endpoints marked **Admin** return `403 Forbidden` for `member` role.
+Endpoints marked **Admin** require a superadmin identity. In practice that means:
+- the single-user bootstrap/env-var gateway token, or
+- a DB-backed token whose backing user has the internal `is_superadmin` flag.
+
+A plain `admin` role without superadmin status receives `403 Forbidden`.
 
 ---
 
@@ -29,7 +33,7 @@ Endpoints marked **Admin** return `403 Forbidden` for `member` role.
 
 Create a new user. Returns the user record and a one-time plaintext API token.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Request body:**
 
@@ -64,7 +68,7 @@ Create a new user. Returns the user record and a one-time plaintext API token.
 
 The `token` field is the plaintext API token. It is shown **only once** — store it securely.
 
-**Errors:** `400` (missing display_name, invalid role), `403` (not admin), `503` (no database)
+**Errors:** `400` (missing display_name, invalid role), `403` (superadmin required), `503` (no database)
 
 ---
 
@@ -72,7 +76,7 @@ The `token` field is the plaintext API token. It is shown **only once** — stor
 
 List all users.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -100,7 +104,7 @@ List all users.
 
 Get a single user by ID.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -119,7 +123,7 @@ Get a single user by ID.
 }
 ```
 
-**Errors:** `404` (user not found), `403` (not admin)
+**Errors:** `404` (user not found), `403` (superadmin required)
 
 ---
 
@@ -127,7 +131,7 @@ Get a single user by ID.
 
 Update a user's display name and/or metadata. Omitted fields are left unchanged.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Request body:**
 
@@ -146,7 +150,7 @@ Update a user's display name and/or metadata. Omitted fields are left unchanged.
 
 **Response:** `200 OK` — returns the full updated user record (same shape as GET detail, without `last_login_at`/`created_by`).
 
-**Errors:** `404` (user not found), `403` (not admin)
+**Errors:** `404` (user not found), `403` (superadmin required)
 
 ---
 
@@ -154,7 +158,7 @@ Update a user's display name and/or metadata. Omitted fields are left unchanged.
 
 Suspend a user. Suspended users cannot authenticate (DB auth checks user status).
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -165,7 +169,7 @@ Suspend a user. Suspended users cannot authenticate (DB auth checks user status)
 }
 ```
 
-**Errors:** `404` (user not found), `403` (not admin)
+**Errors:** `404` (user not found), `403` (superadmin required)
 
 ---
 
@@ -173,7 +177,7 @@ Suspend a user. Suspended users cannot authenticate (DB auth checks user status)
 
 Re-activate a suspended user.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -184,7 +188,7 @@ Re-activate a suspended user.
 }
 ```
 
-**Errors:** `404` (user not found), `403` (not admin)
+**Errors:** `404` (user not found), `403` (superadmin required)
 
 ---
 
@@ -192,7 +196,7 @@ Re-activate a suspended user.
 
 Permanently delete a user and all associated data (tokens, jobs, conversations, memory, routines, settings, secrets).
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -203,7 +207,7 @@ Permanently delete a user and all associated data (tokens, jobs, conversations, 
 }
 ```
 
-**Errors:** `404` (user not found), `403` (not admin)
+**Errors:** `404` (user not found), `403` (superadmin required)
 
 **Cascade:** Deletes from `api_tokens`, `agent_jobs`, `conversations`, `memory_documents`, `routines`, `secrets`, `settings`, `wasm_tools`, and related tables. On PostgreSQL this uses FK cascades; on libSQL it uses explicit deletes.
 
@@ -211,7 +215,7 @@ Permanently delete a user and all associated data (tokens, jobs, conversations, 
 
 ## Admin: Per-User Secrets
 
-Provision secrets on behalf of individual users. The primary use case is an application backend (acting as admin) that configures per-user credentials so each user's IronClaw agent can call back to external services.
+Provision secrets on behalf of individual users. The primary use case is an application backend (acting as superadmin) that configures per-user credentials so each user's IronClaw agent can call back to external services.
 
 Secrets are encrypted at rest with AES-256-GCM using a per-secret HKDF-derived key. Plaintext values are **never returned** by any endpoint — they can only be used by the agent's tool system at runtime.
 
@@ -219,7 +223,7 @@ Secrets are encrypted at rest with AES-256-GCM using a per-secret HKDF-derived k
 
 Create or update a secret for the specified user. If a secret with the same name already exists, it is overwritten.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Path parameters:**
 
@@ -254,20 +258,20 @@ Create or update a secret for the specified user. If a secret with the same name
 }
 ```
 
-**Errors:** `400` (missing value), `403` (not admin), `503` (secrets store not available)
+**Errors:** `400` (missing value), `403` (superadmin required), `503` (secrets store not available)
 
 **Example — application backend provisioning a callback token:**
 
 ```bash
-# Admin creates a user
+# Superadmin creates a user
 curl -X POST https://ironclaw.example.com/api/admin/users \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Authorization: Bearer $SUPERADMIN_TOKEN" \
   -d '{"display_name": "Alice", "role": "member"}'
 # Response includes: {"id": "alice-uuid", "token": "alice-bearer-token", ...}
 
-# Admin provisions a per-user callback secret
+# Superadmin provisions a per-user callback secret
 curl -X PUT https://ironclaw.example.com/api/admin/users/alice-uuid/secrets/app_callback_token \
-  -H "Authorization: Bearer $ADMIN_TOKEN" \
+  -H "Authorization: Bearer $SUPERADMIN_TOKEN" \
   -d '{"value": "per-user-jwt-for-alice", "provider": "my-app"}'
 
 # Now Alice's IronClaw agent can use the "app_callback_token" secret
@@ -280,7 +284,7 @@ curl -X PUT https://ironclaw.example.com/api/admin/users/alice-uuid/secrets/app_
 
 List a user's secrets. Returns names and providers only — **never values or hashes**.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -300,7 +304,7 @@ List a user's secrets. Returns names and providers only — **never values or ha
 
 Delete a specific secret for a user.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Response:** `200 OK`
 
@@ -312,7 +316,7 @@ Delete a specific secret for a user.
 }
 ```
 
-**Errors:** `404` (secret not found), `403` (not admin), `503` (secrets store not available)
+**Errors:** `404` (secret not found), `403` (superadmin required), `503` (secrets store not available)
 
 ---
 
@@ -322,7 +326,7 @@ Delete a specific secret for a user.
 
 Per-user LLM usage statistics aggregated from `llm_calls` via `agent_jobs.user_id`.
 
-**Auth:** Admin
+**Auth:** Superadmin
 
 **Query parameters:**
 
@@ -499,7 +503,7 @@ All error responses return a plain text body with the error message and the corr
 |------|---------|
 | `400` | Bad request (missing fields, invalid input) |
 | `401` | Missing or invalid bearer token |
-| `403` | Authenticated but insufficient role (member accessing admin endpoint) |
+| `403` | Authenticated but insufficient privileges (for example, a non-superadmin calling `/api/admin/*`) |
 | `404` | Resource not found |
 | `503` | Database or secrets store not available |
 | `500` | Internal server error |

--- a/migrations/V18__users_superadmin.sql
+++ b/migrations/V18__users_superadmin.sql
@@ -1,0 +1,6 @@
+ALTER TABLE users
+ADD COLUMN is_superadmin BOOLEAN NOT NULL DEFAULT FALSE;
+
+UPDATE users
+SET is_superadmin = TRUE
+WHERE role = 'admin';

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -92,7 +92,7 @@ Browser-facing HTTP API and SSE/WebSocket real-time streaming. Axum-based, singl
 | DELETE | `/api/routines/{id}` | Delete a routine |
 | GET | `/api/routines/{id}/runs` | List runs for a specific routine |
 
-### User Management (admin — requires `admin` role, see `docs/USER_MANAGEMENT_API.md`)
+### User Management (admin — requires superadmin identity, see `docs/USER_MANAGEMENT_API.md`)
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/admin/users` | Create a new user (returns one-time token) |

--- a/src/channels/web/auth.rs
+++ b/src/channels/web/auth.rs
@@ -69,6 +69,8 @@ pub struct UserIdentity {
     pub user_id: String,
     /// `admin` or `member`.
     pub role: String,
+    /// System-wide privilege for cross-workspace administration.
+    pub is_superadmin: bool,
     /// Legacy compatibility scopes that can extend the personal workspace's
     /// read view during migration.
     pub workspace_read_scopes: Vec<String>,
@@ -118,6 +120,7 @@ impl MultiAuthState {
                 UserIdentity {
                     user_id,
                     role: "admin".to_string(),
+                    is_superadmin: true,
                     workspace_read_scopes: Vec::new(),
                 },
             )],
@@ -262,6 +265,7 @@ impl DbAuthenticator {
         let identity = UserIdentity {
             user_id: user_record.id.clone(),
             role: user_record.role.clone(),
+            is_superadmin: user_record.is_superadmin,
             workspace_read_scopes: Vec::new(),
         };
 
@@ -335,7 +339,7 @@ where
     }
 }
 
-/// Axum extractor that requires the authenticated user to have the `admin` role.
+/// Axum extractor that requires the authenticated user to be a superadmin.
 ///
 /// Use instead of `AuthenticatedUser` on endpoints that modify system-wide
 /// state (user management, model selection, extension/skill installation).
@@ -353,8 +357,8 @@ where
             .get::<UserIdentity>()
             .cloned()
             .ok_or((StatusCode::UNAUTHORIZED, "Not authenticated"))?;
-        if identity.role != "admin" {
-            return Err((StatusCode::FORBIDDEN, "Admin role required"));
+        if !identity.is_superadmin {
+            return Err((StatusCode::FORBIDDEN, "Superadmin required"));
         }
         Ok(AdminUser(identity))
     }
@@ -1081,6 +1085,7 @@ pub async fn auth_middleware(
                 let identity = UserIdentity {
                     user_id: sub,
                     role: "member".to_string(),
+                    is_superadmin: false,
                     workspace_read_scopes: Vec::new(),
                 };
                 request.extensions_mut().insert(identity);
@@ -1141,6 +1146,7 @@ mod tests {
             UserIdentity {
                 user_id: "alice".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: Vec::new(),
             },
         );
@@ -1149,6 +1155,7 @@ mod tests {
             UserIdentity {
                 user_id: "bob".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: Vec::new(),
             },
         );
@@ -1749,6 +1756,7 @@ mod tests {
             UserIdentity {
                 user_id: "alice".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: vec!["shared".to_string()],
             },
         );
@@ -1757,6 +1765,7 @@ mod tests {
             UserIdentity {
                 user_id: "bob".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: vec!["shared".to_string(), "alice".to_string()],
             },
         );

--- a/src/channels/web/handlers/auth.rs
+++ b/src/channels/web/handlers/auth.rs
@@ -747,6 +747,7 @@ async fn resolve_user(
         display_name,
         status: "active".to_string(),
         role: role.to_string(),
+        is_superadmin: false,
         created_at: now,
         updated_at: now,
         last_login_at: Some(now),

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -4,7 +4,10 @@ use std::sync::Arc;
 
 use crate::channels::IncomingMessage;
 use crate::channels::web::auth::AuthenticatedUser;
-use crate::channels::web::handlers::workspaces::{WorkspaceQuery, resolve_requested_workspace_id};
+use crate::channels::web::handlers::workspaces::{
+    WorkspaceQuery, resolve_requested_workspace_id, resolve_workspace_scope,
+};
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::channels::web::util::{
@@ -32,10 +35,16 @@ pub async fn chat_send_handler(
         ));
     }
 
-    let workspace_id =
+    let workspace_id = if let Some(store) = state.store.as_ref() {
+        let scope =
+            resolve_workspace_scope(store, &identity, workspace_query.workspace.as_deref()).await?;
+        require_workspace_permission(&identity, scope.as_ref(), Permission::WorkspaceWrite)?;
+        scope.map(|scope| scope.workspace.id.to_string())
+    } else {
         resolve_requested_workspace_id(&state, &identity, workspace_query.workspace.as_deref())
             .await?
-            .map(|id| id.to_string());
+            .map(|id| id.to_string())
+    };
     let mut msg = IncomingMessage::new("gateway", &identity.user_id, &req.content);
     if let Some(ref workspace_id) = workspace_id {
         msg.workspace_id = Some(workspace_id.clone());

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -22,6 +22,9 @@ use axum::{
 use serde::Deserialize;
 use uuid::Uuid;
 
+// TODO: consolidate with crate::channels::web::server::chat_send_handler —
+// that copy is the canonical version used by route wiring and has timezone
+// header extraction, image attachments, and detailed trace logging.
 pub async fn chat_send_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(identity): AuthenticatedUser,
@@ -98,6 +101,9 @@ pub async fn chat_send_handler(
     ))
 }
 
+// TODO: consolidate with crate::channels::web::server::chat_approval_handler —
+// that copy is the canonical version used by route wiring and called by
+// chat_gate_resolve_handler.
 pub async fn chat_approval_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(identity): AuthenticatedUser,

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -13,6 +13,7 @@ use uuid::Uuid;
 
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::handlers::workspaces::{WorkspaceQuery, resolve_workspace_scope};
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 
@@ -381,7 +382,14 @@ pub async fn jobs_cancel_handler(
 ) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
     let job_id = Uuid::parse_str(&id)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid job ID".to_string()))?;
-    let scope = resolve_job_scope(&state, &user, &workspace_query).await?;
+    let scope = if let Some(store) = state.store.as_ref() {
+        let scope =
+            resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref()).await?;
+        require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
+        scope.map(|scope| scope.workspace.id)
+    } else {
+        None
+    };
 
     // Try sandbox job cancellation.
     if let Some(ref store) = state.store {
@@ -480,7 +488,10 @@ pub async fn jobs_restart_handler(
     let old_job_id = Uuid::parse_str(&id)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid job ID".to_string()))?;
 
-    let scope = resolve_job_scope(&state, &user, &workspace_query).await?;
+    let resolved_scope =
+        resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref()).await?;
+    require_workspace_permission(&user, resolved_scope.as_ref(), Permission::WorkspaceWrite)?;
+    let scope = resolved_scope.as_ref().map(|scope| scope.workspace.id);
     // Try sandbox job restart first.
     match store.get_sandbox_job(old_job_id).await {
         Ok(Some(old_job)) => {
@@ -709,7 +720,14 @@ pub async fn jobs_prompt_handler(
         .to_string();
 
     let done = body.get("done").and_then(|v| v.as_bool()).unwrap_or(false);
-    let scope = resolve_job_scope(&state, &user, &workspace_query).await?;
+    let scope = if let Some(store) = state.store.as_ref() {
+        let scope =
+            resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref()).await?;
+        require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
+        scope.map(|scope| scope.workspace.id)
+    } else {
+        None
+    };
 
     // Try sandbox job path first: verify ownership, then route to Claude Code or reject.
     if let Some(ref s) = state.store

--- a/src/channels/web/handlers/memory.rs
+++ b/src/channels/web/handlers/memory.rs
@@ -11,6 +11,7 @@ use serde::Deserialize;
 
 use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
 use crate::channels::web::handlers::workspaces::{WorkspaceQuery, resolve_workspace_scope};
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::workspace::Workspace;
@@ -163,6 +164,11 @@ pub async fn memory_write_handler(
     Query(workspace_query): Query<WorkspaceQuery>,
     Json(req): Json<MemoryWriteRequest>,
 ) -> Result<Json<MemoryWriteResponse>, (StatusCode, String)> {
+    if let Some(store) = state.store.as_ref() {
+        let scope =
+            resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref()).await?;
+        require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
+    }
     let workspace = resolve_workspace(&state, &user, Some(&workspace_query)).await?;
 
     // Route through layer-aware methods when a layer is specified.

--- a/src/channels/web/handlers/routines.rs
+++ b/src/channels/web/handlers/routines.rs
@@ -15,7 +15,10 @@ use crate::agent::routine::{
     routine_display_status_for_verification, routine_verification_status,
 };
 use crate::channels::web::auth::AuthenticatedUser;
-use crate::channels::web::handlers::workspaces::{WorkspaceQuery, resolve_workspace_scope};
+use crate::channels::web::handlers::workspaces::{
+    ResolvedWorkspace, WorkspaceQuery, resolve_workspace_scope,
+};
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::db::Database;
@@ -25,12 +28,8 @@ async fn resolve_routine_scope(
     store: &Arc<dyn Database>,
     user: &crate::channels::web::auth::UserIdentity,
     query: &WorkspaceQuery,
-) -> Result<Option<uuid::Uuid>, (StatusCode, String)> {
-    Ok(
-        resolve_workspace_scope(store, user, query.workspace.as_deref())
-            .await?
-            .map(|scope| scope.workspace.id),
-    )
+) -> Result<Option<ResolvedWorkspace>, (StatusCode, String)> {
+    resolve_workspace_scope(store, user, query.workspace.as_deref()).await
 }
 
 async fn load_visible_routine(
@@ -45,9 +44,9 @@ async fn load_visible_routine(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    let scope_id = resolve_routine_scope(store, user, query).await?;
-    match scope_id {
-        Some(workspace_id) if routine.workspace_id == Some(workspace_id) => Ok(routine),
+    let scope = resolve_routine_scope(store, user, query).await?;
+    match scope {
+        Some(scope) if routine.workspace_id == Some(scope.workspace.id) => Ok(routine),
         None if routine.workspace_id.is_none() && routine.user_id == user.user_id => Ok(routine),
         _ => Err((StatusCode::NOT_FOUND, "Routine not found".to_string())),
     }
@@ -63,18 +62,18 @@ pub async fn routines_list_handler(
         "Database not available".to_string(),
     ))?;
 
-    let routines =
-        if let Some(workspace_id) = resolve_routine_scope(store, &user, &workspace_query).await? {
-            store
-                .list_routines_for_workspace(workspace_id)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        } else {
-            store
-                .list_routines(&user.user_id)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        };
+    let scope = resolve_routine_scope(store, &user, &workspace_query).await?;
+    let routines = if let Some(workspace_id) = scope.as_ref().map(|scope| scope.workspace.id) {
+        store
+            .list_routines_for_workspace(workspace_id)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    } else {
+        store
+            .list_routines(&user.user_id)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    };
 
     let routine_ids: Vec<Uuid> = routines.iter().map(|routine| routine.id).collect();
     let last_run_statuses = store
@@ -102,18 +101,18 @@ pub async fn routines_summary_handler(
         "Database not available".to_string(),
     ))?;
 
-    let routines =
-        if let Some(workspace_id) = resolve_routine_scope(store, &user, &workspace_query).await? {
-            store
-                .list_routines_for_workspace(workspace_id)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        } else {
-            store
-                .list_routines(&user.user_id)
-                .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
-        };
+    let scope = resolve_routine_scope(store, &user, &workspace_query).await?;
+    let routines = if let Some(workspace_id) = scope.as_ref().map(|scope| scope.workspace.id) {
+        store
+            .list_routines_for_workspace(workspace_id)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    } else {
+        store
+            .list_routines(&user.user_id)
+            .await
+            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+    };
 
     let routine_ids: Vec<Uuid> = routines.iter().map(|routine| routine.id).collect();
     let last_run_statuses = store
@@ -263,6 +262,8 @@ pub async fn routines_trigger_handler(
         StatusCode::SERVICE_UNAVAILABLE,
         "Database not available".to_string(),
     ))?;
+    let scope = resolve_routine_scope(store, &user, &workspace_query).await?;
+    require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
     let _routine = load_visible_routine(store, &user, &workspace_query, routine_id).await?;
 
     let run_id = engine
@@ -297,6 +298,8 @@ pub async fn routines_toggle_handler(
     let routine_id = Uuid::parse_str(&id)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid routine ID".to_string()))?;
 
+    let scope = resolve_routine_scope(store, &user, &workspace_query).await?;
+    require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
     let mut routine = load_visible_routine(store, &user, &workspace_query, routine_id).await?;
 
     let was_enabled = routine.enabled;
@@ -356,6 +359,8 @@ pub async fn routines_delete_handler(
     let routine_id = Uuid::parse_str(&id)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid routine ID".to_string()))?;
 
+    let scope = resolve_routine_scope(store, &user, &workspace_query).await?;
+    require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
     // Verify ownership before deleting.
     let _routine = load_visible_routine(store, &user, &workspace_query, routine_id).await?;
 

--- a/src/channels/web/handlers/settings.rs
+++ b/src/channels/web/handlers/settings.rs
@@ -12,8 +12,9 @@ use uuid::Uuid;
 
 use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::handlers::workspaces::{
-    WorkspaceQuery, resolve_workspace_scope, workspace_scope_user_id,
+    ResolvedWorkspace, WorkspaceQuery, resolve_workspace_scope, workspace_scope_user_id,
 };
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::secrets::{CreateSecretParams, SecretsStore};
@@ -25,7 +26,7 @@ async fn resolve_settings_scope(
     state: &GatewayState,
     user: &crate::channels::web::auth::UserIdentity,
     query: &WorkspaceQuery,
-) -> Result<Option<Uuid>, StatusCode> {
+) -> Result<Option<ResolvedWorkspace>, StatusCode> {
     let Some(store) = state.store.as_ref() else {
         if query.workspace.is_some() {
             return Err(StatusCode::SERVICE_UNAVAILABLE);
@@ -35,7 +36,6 @@ async fn resolve_settings_scope(
 
     resolve_workspace_scope(store, user, query.workspace.as_deref())
         .await
-        .map(|scope| scope.map(|resolved| resolved.workspace.id))
         .map_err(|(status, _)| status)
 }
 
@@ -49,7 +49,8 @@ pub async fn settings_list_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let scope = resolve_settings_scope(&state, &user, &workspace_query).await?;
-    let rows = match scope {
+    let workspace_id = scope.as_ref().map(|resolved| resolved.workspace.id);
+    let rows = match workspace_id {
         Some(workspace_id) => store.list_settings_for_workspace(workspace_id).await,
         None => store.list_settings(&user.user_id).await,
     }
@@ -60,7 +61,7 @@ pub async fn settings_list_handler(
 
     // Build a map of sensitive keys so we can annotate and mask them.
     let sensitive_keys = ["llm_builtin_overrides", "llm_custom_providers"];
-    let settings_secret_scope = scope
+    let settings_secret_scope = workspace_id
         .map(workspace_scope_user_id)
         .unwrap_or_else(|| user.user_id.clone());
     let mut sensitive_map: std::collections::HashMap<String, serde_json::Value> = rows
@@ -106,7 +107,8 @@ pub async fn settings_get_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let scope = resolve_settings_scope(&state, &user, &workspace_query).await?;
-    let row = match scope {
+    let workspace_id = scope.as_ref().map(|resolved| resolved.workspace.id);
+    let row = match workspace_id {
         Some(workspace_id) => {
             store
                 .get_setting_full_for_workspace(workspace_id, &key)
@@ -121,7 +123,7 @@ pub async fn settings_get_handler(
     .ok_or(StatusCode::NOT_FOUND)?;
 
     // Mask any plaintext API keys that may exist from legacy data.
-    let settings_secret_scope = scope
+    let settings_secret_scope = workspace_id
         .map(workspace_scope_user_id)
         .unwrap_or_else(|| user.user_id.clone());
     let value = if matches!(
@@ -155,17 +157,20 @@ pub async fn settings_set_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let scope = resolve_settings_scope(&state, &user, &workspace_query).await?;
+    require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceManageSettings)
+        .map_err(|(status, _)| status)?;
+    let workspace_id = scope.as_ref().map(|resolved| resolved.workspace.id);
 
     // Guard: cannot remove a custom provider that is currently active.
     if key == "llm_custom_providers" {
-        guard_active_provider_not_removed(store.as_ref(), &user.user_id, scope, &body.value)
+        guard_active_provider_not_removed(store.as_ref(), &user.user_id, workspace_id, &body.value)
             .await?;
         validate_custom_providers(&body.value)?;
     }
 
     // Extract API keys from LLM settings and vault them in the secrets store.
     // The sanitized value has api_key fields removed (stored encrypted instead).
-    let settings_secret_scope = scope
+    let settings_secret_scope = workspace_id
         .map(workspace_scope_user_id)
         .unwrap_or_else(|| user.user_id.clone());
     let sanitized_value = match key.as_str() {
@@ -178,7 +183,7 @@ pub async fn settings_set_handler(
         _ => body.value.clone(),
     };
 
-    match scope {
+    match workspace_id {
         Some(workspace_id) => {
             store
                 .set_setting_for_workspace(workspace_id, &key, &sanitized_value)
@@ -326,6 +331,9 @@ pub async fn settings_delete_handler(
         .as_ref()
         .ok_or(StatusCode::SERVICE_UNAVAILABLE)?;
     let scope = resolve_settings_scope(&state, &user, &workspace_query).await?;
+    require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceManageSettings)
+        .map_err(|(status, _)| status)?;
+    let workspace_id = scope.as_ref().map(|resolved| resolved.workspace.id);
 
     // Guard: deleting llm_custom_providers is equivalent to setting it to [].
     // Reject if the active backend is a custom provider that would be removed.
@@ -333,13 +341,13 @@ pub async fn settings_delete_handler(
         guard_active_provider_not_removed(
             store.as_ref(),
             &user.user_id,
-            scope,
+            workspace_id,
             &serde_json::Value::Array(vec![]),
         )
         .await?;
     }
 
-    match scope {
+    match workspace_id {
         Some(workspace_id) => store.delete_setting_for_workspace(workspace_id, &key).await,
         None => store.delete_setting(&user.user_id, &key).await,
     }
@@ -814,6 +822,7 @@ mod tests {
             display_name: id.to_string(),
             status: "active".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             created_at: now,
             updated_at: now,
             last_login_at: None,

--- a/src/channels/web/handlers/users.rs
+++ b/src/channels/web/handlers/users.rs
@@ -93,6 +93,7 @@ pub async fn users_create_handler(
         display_name: display_name.clone(),
         status: "active".to_string(),
         role,
+        is_superadmin: false,
         created_at: now,
         updated_at: now,
         last_login_at: None,

--- a/src/channels/web/handlers/workspaces.rs
+++ b/src/channels/web/handlers/workspaces.rs
@@ -1,6 +1,8 @@
 //! Shared workspace API handlers and scope resolution helpers.
 
-use std::sync::Arc;
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use axum::{
     Json,
@@ -11,6 +13,7 @@ use serde::Deserialize;
 use uuid::Uuid;
 
 use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
+use crate::channels::web::permissions::{Permission, Role, superadmin_workspace_role};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::db::{Database, WorkspaceMembership, WorkspaceRecord};
@@ -20,6 +23,101 @@ const WORKSPACE_ROLE_OWNER: &str = "owner";
 const WORKSPACE_ROLE_ADMIN: &str = "admin";
 const WORKSPACE_ROLE_MEMBER: &str = "member";
 const WORKSPACE_ROLE_VIEWER: &str = "viewer";
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct WorkspaceMembershipCacheKey {
+    workspace_id: Uuid,
+    user_id: String,
+}
+
+#[derive(Debug, Clone)]
+struct WorkspaceMembershipCacheEntry {
+    role: Option<String>,
+    inserted_at: Instant,
+}
+
+struct WorkspaceMembershipCache {
+    entries: Mutex<lru::LruCache<WorkspaceMembershipCacheKey, WorkspaceMembershipCacheEntry>>,
+    ttl: Duration,
+}
+
+impl WorkspaceMembershipCache {
+    // SAFETY: 4096 is non-zero, so the unwrap in `new()` is infallible.
+    const MAX_ENTRIES: NonZeroUsize = match NonZeroUsize::new(4096) {
+        Some(value) => value,
+        None => unreachable!(),
+    };
+
+    fn new() -> Self {
+        let ttl_secs = std::env::var("GATEWAY_WORKSPACE_MEMBERSHIP_CACHE_TTL_SECS")
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(60);
+        Self {
+            entries: Mutex::new(lru::LruCache::new(Self::MAX_ENTRIES)),
+            ttl: Duration::from_secs(ttl_secs),
+        }
+    }
+
+    fn get(&self, workspace_id: Uuid, user_id: &str) -> Option<Option<String>> {
+        let key = WorkspaceMembershipCacheKey {
+            workspace_id,
+            user_id: user_id.to_string(),
+        };
+        let mut entries = self.lock_entries();
+        if let Some(entry) = entries.get(&key)
+            && entry.inserted_at.elapsed() < self.ttl
+        {
+            return Some(entry.role.clone());
+        }
+        entries.pop(&key);
+        None
+    }
+
+    fn insert(&self, workspace_id: Uuid, user_id: &str, role: Option<String>) {
+        self.lock_entries().put(
+            WorkspaceMembershipCacheKey {
+                workspace_id,
+                user_id: user_id.to_string(),
+            },
+            WorkspaceMembershipCacheEntry {
+                role,
+                inserted_at: Instant::now(),
+            },
+        );
+    }
+
+    fn invalidate(&self, workspace_id: Uuid, user_id: &str) {
+        self.lock_entries().pop(&WorkspaceMembershipCacheKey {
+            workspace_id,
+            user_id: user_id.to_string(),
+        });
+    }
+
+    fn lock_entries(
+        &self,
+    ) -> std::sync::MutexGuard<
+        '_,
+        lru::LruCache<WorkspaceMembershipCacheKey, WorkspaceMembershipCacheEntry>,
+    > {
+        match self.entries.lock() {
+            Ok(entries) => entries,
+            Err(poisoned) => {
+                tracing::warn!("WorkspaceMembershipCache lock poisoned; recovering");
+                poisoned.into_inner()
+            }
+        }
+    }
+}
+
+fn workspace_membership_cache() -> &'static WorkspaceMembershipCache {
+    static CACHE: OnceLock<WorkspaceMembershipCache> = OnceLock::new();
+    CACHE.get_or_init(WorkspaceMembershipCache::new)
+}
+
+pub(crate) fn invalidate_workspace_membership_cache(workspace_id: Uuid, user_id: &str) {
+    workspace_membership_cache().invalidate(workspace_id, user_id);
+}
 
 #[derive(Debug, Clone, Deserialize, Default)]
 pub struct WorkspaceQuery {
@@ -39,18 +137,11 @@ fn workspace_role_error() -> String {
 }
 
 fn is_valid_workspace_role(role: &str) -> bool {
-    matches!(
-        role,
-        WORKSPACE_ROLE_OWNER | WORKSPACE_ROLE_ADMIN | WORKSPACE_ROLE_MEMBER | WORKSPACE_ROLE_VIEWER
-    )
+    Role::parse(role).is_ok()
 }
 
 fn workspace_role_is_owner(role: &str) -> bool {
     role == WORKSPACE_ROLE_OWNER
-}
-
-fn workspace_role_is_manager(role: &str) -> bool {
-    matches!(role, WORKSPACE_ROLE_OWNER | WORKSPACE_ROLE_ADMIN)
 }
 
 fn validate_workspace_name(name: &str) -> Result<(), (StatusCode, String)> {
@@ -96,6 +187,42 @@ pub fn workspace_scope_user_id(workspace_id: Uuid) -> String {
     format!("{WORKSPACE_SCOPE_PREFIX}{workspace_id}")
 }
 
+async fn resolve_workspace_scope_for_workspace(
+    store: &Arc<dyn Database>,
+    user: &UserIdentity,
+    workspace: WorkspaceRecord,
+) -> Result<ResolvedWorkspace, (StatusCode, String)> {
+    if workspace.status == "archived" {
+        return Err((StatusCode::GONE, "Workspace is archived".to_string()));
+    }
+
+    if user.is_superadmin {
+        return Ok(ResolvedWorkspace {
+            workspace,
+            role: superadmin_workspace_role().as_str().to_string(),
+        });
+    }
+
+    let membership_role = match workspace_membership_cache().get(workspace.id, &user.user_id) {
+        Some(cached) => cached,
+        None => {
+            let fetched = store
+                .get_member_role(workspace.id, &user.user_id)
+                .await
+                .map_err(internal_db_error)?;
+            workspace_membership_cache().insert(workspace.id, &user.user_id, fetched.clone());
+            fetched
+        }
+    };
+    let role = match membership_role {
+        Some(role) => role,
+        None => return Err((StatusCode::FORBIDDEN, "Workspace access denied".to_string())),
+    };
+    Role::parse(&role)?;
+
+    Ok(ResolvedWorkspace { workspace, role })
+}
+
 pub async fn resolve_workspace_scope(
     store: &Arc<dyn Database>,
     user: &UserIdentity,
@@ -111,21 +238,26 @@ pub async fn resolve_workspace_scope(
         .map_err(internal_db_error)?
         .ok_or((StatusCode::NOT_FOUND, "Workspace not found".to_string()))?;
 
-    if workspace.status == "archived" {
-        return Err((StatusCode::GONE, "Workspace is archived".to_string()));
-    }
-
-    let role = store
-        .get_member_role(workspace.id, &user.user_id)
+    resolve_workspace_scope_for_workspace(store, user, workspace)
         .await
-        .map_err(internal_db_error)?
-        .ok_or((StatusCode::FORBIDDEN, "Workspace access denied".to_string()))?;
+        .map(Some)
+}
 
-    Ok(Some(ResolvedWorkspace { workspace, role }))
+pub async fn resolve_workspace_scope_by_id(
+    store: &Arc<dyn Database>,
+    user: &UserIdentity,
+    workspace_id: Uuid,
+) -> Result<ResolvedWorkspace, (StatusCode, String)> {
+    let workspace = store
+        .get_workspace(workspace_id)
+        .await
+        .map_err(internal_db_error)?;
+    let workspace = workspace.ok_or((StatusCode::NOT_FOUND, "Workspace not found".to_string()))?;
+    resolve_workspace_scope_for_workspace(store, user, workspace).await
 }
 
 pub fn require_workspace_manager(role: &str) -> Result<(), (StatusCode, String)> {
-    if workspace_role_is_manager(role) {
+    if Role::parse(role)?.has_permission(Permission::WorkspaceManageMembers) {
         Ok(())
     } else {
         Err((
@@ -136,7 +268,7 @@ pub fn require_workspace_manager(role: &str) -> Result<(), (StatusCode, String)>
 }
 
 pub fn require_workspace_owner(role: &str) -> Result<(), (StatusCode, String)> {
-    if workspace_role_is_owner(role) {
+    if Role::parse(role)? >= Role::Owner {
         Ok(())
     } else {
         Err((
@@ -212,13 +344,25 @@ pub async fn workspaces_list_handler(
         "Database not available".to_string(),
     ))?;
 
-    let workspaces = store
-        .list_workspaces_for_user(&user.user_id)
-        .await
-        .map_err(internal_db_error)?
-        .into_iter()
-        .map(workspace_info_from_membership)
-        .collect();
+    let workspaces = if user.is_superadmin {
+        store
+            .list_all_workspaces()
+            .await
+            .map_err(internal_db_error)?
+            .into_iter()
+            .map(|workspace| {
+                workspace_info(workspace, superadmin_workspace_role().as_str().to_string())
+            })
+            .collect()
+    } else {
+        store
+            .list_workspaces_for_user(&user.user_id)
+            .await
+            .map_err(internal_db_error)?
+            .into_iter()
+            .map(workspace_info_from_membership)
+            .collect()
+    };
 
     Ok(Json(WorkspaceListResponse { workspaces }))
 }
@@ -305,7 +449,7 @@ pub async fn workspaces_archive_handler(
     ))?;
     let resolved = resolve_workspace_scope(store, &user, Some(&slug)).await?;
     let resolved = resolved.ok_or((StatusCode::NOT_FOUND, "Workspace not found".to_string()))?;
-    require_workspace_manager(&resolved.role)?;
+    require_workspace_owner(&resolved.role)?;
 
     let archived = store
         .archive_workspace(resolved.workspace.id)
@@ -403,6 +547,50 @@ pub async fn workspace_members_upsert_handler(
         return Err((StatusCode::NOT_FOUND, "User not found".to_string()));
     }
 
+    if workspace_role_is_owner(role) && member_user_id != user.user_id {
+        if existing_role
+            .as_deref()
+            .is_some_and(workspace_role_is_owner)
+        {
+            return Ok(StatusCode::NO_CONTENT);
+        }
+
+        let owners: Vec<String> = store
+            .list_workspace_members(resolved.workspace.id)
+            .await
+            .map_err(internal_db_error)?
+            .into_iter()
+            .filter(|(_, membership)| workspace_role_is_owner(&membership.role))
+            .map(|(owner_user, _)| owner_user.id)
+            .collect();
+        let [current_owner_id] = owners.as_slice() else {
+            return Err((
+                StatusCode::CONFLICT,
+                "Workspace ownership transfer requires exactly one current owner".to_string(),
+            ));
+        };
+
+        let transferred = store
+            .transfer_workspace_ownership(
+                resolved.workspace.id,
+                current_owner_id,
+                &member_user_id,
+                Some(&user.user_id),
+            )
+            .await
+            .map_err(internal_db_error)?;
+        if !transferred {
+            return Err((
+                StatusCode::CONFLICT,
+                "Workspace ownership transfer failed".to_string(),
+            ));
+        }
+
+        invalidate_workspace_membership_cache(resolved.workspace.id, current_owner_id);
+        invalidate_workspace_membership_cache(resolved.workspace.id, &member_user_id);
+        return Ok(StatusCode::NO_CONTENT);
+    }
+
     store
         .add_workspace_member(
             resolved.workspace.id,
@@ -412,6 +600,7 @@ pub async fn workspace_members_upsert_handler(
         )
         .await
         .map_err(internal_db_error)?;
+    invalidate_workspace_membership_cache(resolved.workspace.id, &member_user_id);
 
     Ok(StatusCode::NO_CONTENT)
 }
@@ -456,6 +645,7 @@ pub async fn workspace_members_delete_handler(
         .await
         .map_err(internal_db_error)?;
     if deleted {
+        invalidate_workspace_membership_cache(resolved.workspace.id, &member_user_id);
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err((

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -37,6 +37,8 @@ pub mod test_helpers;
 #[cfg(test)]
 mod tests;
 
+/// Re-exported for integration tests. The canonical definition lives in
+/// `handlers::workspaces` but that module is `pub(crate)`.
 pub use self::handlers::workspaces::workspace_scope_user_id;
 
 use std::net::SocketAddr;

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod handlers;
 pub mod log_layer;
 pub mod oauth;
 pub mod openai_compat;
+pub mod permissions;
 pub mod responses_api;
 pub mod server;
 pub mod sse;
@@ -35,6 +36,8 @@ pub mod test_helpers;
 
 #[cfg(test)]
 mod tests;
+
+pub use self::handlers::workspaces::workspace_scope_user_id;
 
 use std::net::SocketAddr;
 use std::sync::Arc;

--- a/src/channels/web/permissions.rs
+++ b/src/channels/web/permissions.rs
@@ -1,0 +1,163 @@
+use axum::http::StatusCode;
+
+use crate::channels::web::auth::UserIdentity;
+use crate::channels::web::handlers::workspaces::ResolvedWorkspace;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Role {
+    Viewer,
+    Member,
+    Admin,
+    Owner,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Permission {
+    WorkspaceRead,
+    WorkspaceWrite,
+    WorkspaceManageMembers,
+    WorkspaceManageSettings,
+    WorkspaceManageAdmins,
+    WorkspaceDelete,
+    SystemManageUsers,
+    SystemViewAll,
+}
+
+impl Role {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Viewer => "viewer",
+            Self::Member => "member",
+            Self::Admin => "admin",
+            Self::Owner => "owner",
+        }
+    }
+
+    pub fn parse(role: &str) -> Result<Self, (StatusCode, String)> {
+        match role {
+            "viewer" => Ok(Self::Viewer),
+            "member" => Ok(Self::Member),
+            "admin" => Ok(Self::Admin),
+            "owner" => Ok(Self::Owner),
+            _ => Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Unknown workspace role '{role}'"),
+            )),
+        }
+    }
+
+    pub fn has_permission(self, permission: Permission) -> bool {
+        match permission {
+            Permission::WorkspaceRead => true,
+            Permission::WorkspaceWrite => self >= Self::Member,
+            Permission::WorkspaceManageMembers => self >= Self::Admin,
+            Permission::WorkspaceManageSettings => self >= Self::Admin,
+            Permission::WorkspaceManageAdmins => self >= Self::Owner,
+            Permission::WorkspaceDelete => self >= Self::Owner,
+            Permission::SystemManageUsers | Permission::SystemViewAll => false,
+        }
+    }
+}
+
+pub fn superadmin_workspace_role() -> Role {
+    Role::Owner
+}
+
+pub fn require_system_permission(
+    user: &UserIdentity,
+    permission: Permission,
+) -> Result<(), (StatusCode, String)> {
+    if user.is_superadmin {
+        return Ok(());
+    }
+
+    Err((
+        StatusCode::FORBIDDEN,
+        match permission {
+            Permission::SystemManageUsers | Permission::SystemViewAll => "Superadmin required",
+            _ => "Insufficient permissions",
+        }
+        .to_string(),
+    ))
+}
+
+pub fn require_workspace_permission(
+    user: &UserIdentity,
+    scope: Option<&ResolvedWorkspace>,
+    permission: Permission,
+) -> Result<(), (StatusCode, String)> {
+    let Some(scope) = scope else {
+        return Ok(());
+    };
+
+    if user.is_superadmin {
+        return Ok(());
+    }
+
+    let role = Role::parse(&scope.role)?;
+    if role.has_permission(permission) {
+        Ok(())
+    } else {
+        Err((StatusCode::FORBIDDEN, permission_denied_message(permission)))
+    }
+}
+
+fn permission_denied_message(permission: Permission) -> String {
+    match permission {
+        Permission::WorkspaceRead => "Workspace read access required".to_string(),
+        Permission::WorkspaceWrite => "Workspace member role required".to_string(),
+        Permission::WorkspaceManageMembers | Permission::WorkspaceManageSettings => {
+            "Workspace admin or owner role required".to_string()
+        }
+        Permission::WorkspaceManageAdmins | Permission::WorkspaceDelete => {
+            "Workspace owner role required".to_string()
+        }
+        Permission::SystemManageUsers | Permission::SystemViewAll => {
+            "Superadmin required".to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Permission, Role};
+
+    #[test]
+    fn workspace_permission_matrix_matches_issue_1608() {
+        let matrix = [
+            (Role::Viewer, Permission::WorkspaceRead, true),
+            (Role::Viewer, Permission::WorkspaceWrite, false),
+            (Role::Viewer, Permission::WorkspaceManageMembers, false),
+            (Role::Viewer, Permission::WorkspaceManageSettings, false),
+            (Role::Viewer, Permission::WorkspaceManageAdmins, false),
+            (Role::Viewer, Permission::WorkspaceDelete, false),
+            (Role::Member, Permission::WorkspaceRead, true),
+            (Role::Member, Permission::WorkspaceWrite, true),
+            (Role::Member, Permission::WorkspaceManageMembers, false),
+            (Role::Member, Permission::WorkspaceManageSettings, false),
+            (Role::Member, Permission::WorkspaceManageAdmins, false),
+            (Role::Member, Permission::WorkspaceDelete, false),
+            (Role::Admin, Permission::WorkspaceRead, true),
+            (Role::Admin, Permission::WorkspaceWrite, true),
+            (Role::Admin, Permission::WorkspaceManageMembers, true),
+            (Role::Admin, Permission::WorkspaceManageSettings, true),
+            (Role::Admin, Permission::WorkspaceManageAdmins, false),
+            (Role::Admin, Permission::WorkspaceDelete, false),
+            (Role::Owner, Permission::WorkspaceRead, true),
+            (Role::Owner, Permission::WorkspaceWrite, true),
+            (Role::Owner, Permission::WorkspaceManageMembers, true),
+            (Role::Owner, Permission::WorkspaceManageSettings, true),
+            (Role::Owner, Permission::WorkspaceManageAdmins, true),
+            (Role::Owner, Permission::WorkspaceDelete, true),
+        ];
+
+        for (role, permission, allowed) in matrix {
+            assert_eq!(
+                role.has_permission(permission),
+                allowed,
+                "role={} permission={permission:?}",
+                role.as_str()
+            );
+        }
+    }
+}

--- a/src/channels/web/permissions.rs
+++ b/src/channels/web/permissions.rs
@@ -40,7 +40,7 @@ impl Role {
             "admin" => Ok(Self::Admin),
             "owner" => Ok(Self::Owner),
             _ => Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
+                StatusCode::FORBIDDEN,
                 format!("Unknown workspace role '{role}'"),
             )),
         }

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -24,7 +24,10 @@ use tokio_stream::StreamExt;
 use uuid::Uuid;
 
 use crate::channels::IncomingMessage;
-use crate::channels::web::handlers::workspaces::{WorkspaceQuery, resolve_workspace_scope};
+use crate::channels::web::handlers::workspaces::{
+    WorkspaceQuery, resolve_workspace_scope, resolve_workspace_scope_by_id,
+};
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::types::AppEvent;
 use crate::db::Database;
 
@@ -695,8 +698,25 @@ pub async fn create_response_handler(
     // Each POST gets its own unique response UUID.
     let response_uuid = Uuid::new_v4();
 
-    let requested_workspace_id =
-        resolve_requested_workspace_id(&state, &user, workspace_query.workspace.as_deref()).await?;
+    let requested_workspace_scope = if let Some(store) = state.store.as_ref() {
+        let scope = resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref())
+            .await
+            .map_err(|(status, message)| api_error(status, message, "invalid_request_error"))?;
+        require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)
+            .map_err(|(status, message)| api_error(status, message, "invalid_request_error"))?;
+        scope
+    } else if workspace_query.workspace.is_some() {
+        return Err(api_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Database not configured",
+            "server_error",
+        ));
+    } else {
+        None
+    };
+    let requested_workspace_id = requested_workspace_scope
+        .as_ref()
+        .map(|scope| scope.workspace.id);
     let mut workspace_id = requested_workspace_id;
     if req.previous_response_id.is_some() {
         let store = state.store.as_ref().ok_or_else(|| {
@@ -716,6 +736,13 @@ pub async fn create_response_handler(
                 "Response not found",
                 "invalid_request_error",
             ));
+        }
+        if let Some(thread_workspace_id) = thread_workspace_id {
+            let thread_scope = resolve_workspace_scope_by_id(store, &user, thread_workspace_id)
+                .await
+                .map_err(|(status, message)| api_error(status, message, "invalid_request_error"))?;
+            require_workspace_permission(&user, Some(&thread_scope), Permission::WorkspaceWrite)
+                .map_err(|(status, message)| api_error(status, message, "invalid_request_error"))?;
         }
         workspace_id = thread_workspace_id;
     }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -1675,6 +1675,9 @@ fn mime_to_ext(mime: &str) -> &str {
     }
 }
 
+// TODO: consolidate with handlers::chat::chat_send_handler — this is the
+// canonical version (has timezone header extraction, image attachments, and
+// detailed trace logging that the handlers::chat copy lacks).
 async fn chat_send_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(user): AuthenticatedUser,
@@ -1774,6 +1777,8 @@ async fn chat_send_handler(
     ))
 }
 
+// TODO: consolidate with handlers::chat::chat_approval_handler — this is the
+// canonical version (also called by chat_gate_resolve_handler below).
 async fn chat_approval_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(user): AuthenticatedUser,

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -76,6 +76,7 @@ use crate::channels::web::handlers::workspaces::{
     workspaces_update_handler,
 };
 use crate::channels::web::log_layer::LogBroadcaster;
+use crate::channels::web::permissions::{Permission, require_workspace_permission};
 use crate::channels::web::sse::SseManager;
 use crate::channels::web::types::*;
 use crate::channels::web::util::{build_turns_from_db_messages, truncate_preview};
@@ -1694,11 +1695,19 @@ async fn chat_send_handler(
         ));
     }
 
-    let workspace_id =
-        resolve_requested_workspace_id(&state, &user, workspace_query.workspace.as_deref()).await?;
+    let workspace_id = if let Some(store) = state.store.as_ref() {
+        let scope =
+            resolve_workspace_scope(store, &user, workspace_query.workspace.as_deref()).await?;
+        require_workspace_permission(&user, scope.as_ref(), Permission::WorkspaceWrite)?;
+        scope.map(|scope| scope.workspace.id.to_string())
+    } else {
+        resolve_requested_workspace_id(&state, &user, workspace_query.workspace.as_deref())
+            .await?
+            .map(|id| id.to_string())
+    };
     let mut msg = IncomingMessage::new("gateway", &user.user_id, &req.content);
-    if let Some(workspace_id) = workspace_id {
-        msg.workspace_id = Some(workspace_id.to_string());
+    if let Some(ref workspace_id) = workspace_id {
+        msg.workspace_id = Some(workspace_id.clone());
     }
     // Prefer timezone from JSON body, fall back to X-Timezone header
     let tz = req
@@ -1711,7 +1720,7 @@ async fn chat_send_handler(
 
     // Always include user_id in metadata so downstream SSE broadcasts can scope events.
     let mut meta = serde_json::json!({"user_id": &user.user_id});
-    if let Some(workspace_id) = workspace_id {
+    if let Some(ref workspace_id) = workspace_id {
         meta["workspace_id"] = serde_json::json!(workspace_id);
     }
     if let Some(ref thread_id) = req.thread_id {
@@ -3812,6 +3821,7 @@ mod tests {
         req.extensions_mut().insert(UserIdentity {
             user_id: "test".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         });
 
@@ -3897,6 +3907,7 @@ mod tests {
         req.extensions_mut().insert(UserIdentity {
             user_id: "test".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         });
 
@@ -3998,6 +4009,7 @@ mod tests {
         req.extensions_mut().insert(UserIdentity {
             user_id: "test".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         });
 

--- a/src/channels/web/tests/multi_tenant.rs
+++ b/src/channels/web/tests/multi_tenant.rs
@@ -34,6 +34,7 @@ fn two_user_auth() -> MultiAuthState {
         UserIdentity {
             user_id: "alice".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["shared".to_string()],
         },
     );
@@ -42,6 +43,7 @@ fn two_user_auth() -> MultiAuthState {
         UserIdentity {
             user_id: "bob".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["shared".to_string(), "alice".to_string()],
         },
     );
@@ -205,6 +207,7 @@ mod workspace_pool {
         let identity = UserIdentity {
             user_id: "alice".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec![],
         };
         let ws = pool.get_or_create(&identity).await;
@@ -234,6 +237,7 @@ mod workspace_pool {
         let identity = UserIdentity {
             user_id: "alice".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec![],
         };
         let ws = pool.get_or_create(&identity).await;
@@ -258,6 +262,7 @@ mod workspace_pool {
         let identity = UserIdentity {
             user_id: "bob".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["alice".to_string(), "shared".to_string()],
         };
         let ws = pool.get_or_create(&identity).await;
@@ -285,6 +290,7 @@ mod workspace_pool {
         let identity = UserIdentity {
             user_id: "bob".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["legacy-shared".to_string()],
         };
         let workspace = ResolvedWorkspace {
@@ -328,11 +334,13 @@ mod workspace_pool {
         let alice_id = UserIdentity {
             user_id: "alice".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec![],
         };
         let bob_id = UserIdentity {
             user_id: "bob".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec![],
         };
 
@@ -365,6 +373,7 @@ mod workspace_pool {
         let identity = UserIdentity {
             user_id: "alice".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["token-scope".to_string()],
         };
         let ws = pool.get_or_create(&identity).await;
@@ -891,6 +900,7 @@ mod admin_role_enforcement {
             UserIdentity {
                 user_id: "admin-user".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: vec![],
             },
         );
@@ -899,6 +909,7 @@ mod admin_role_enforcement {
             UserIdentity {
                 user_id: "member-user".to_string(),
                 role: "member".to_string(),
+                is_superadmin: false,
                 workspace_read_scopes: vec![],
             },
         );
@@ -977,6 +988,7 @@ mod admin_role_enforcement {
             UserIdentity {
                 user_id: "admin-user".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: vec![],
             },
         );
@@ -1016,6 +1028,7 @@ mod admin_role_enforcement {
             display_name: "Admin".to_string(),
             status: "active".to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             created_at: now,
             updated_at: now,
             last_login_at: None,
@@ -1031,6 +1044,7 @@ mod admin_role_enforcement {
             UserIdentity {
                 user_id: "admin-user".to_string(),
                 role: "admin".to_string(),
+                is_superadmin: true,
                 workspace_read_scopes: vec![],
             },
         );
@@ -1088,6 +1102,7 @@ mod db_auth_cache {
                         UserIdentity {
                             user_id: format!("user-{i}"),
                             role: "member".to_string(),
+                            is_superadmin: false,
                             workspace_read_scopes: vec![],
                         },
                         Instant::now(),

--- a/src/db/libsql/identities.rs
+++ b/src/db/libsql/identities.rs
@@ -177,15 +177,16 @@ impl IdentityStore for LibSqlBackend {
         // Insert user
         let user_result = conn
             .execute(
-                "INSERT INTO users (id, email, display_name, status, role, created_at, \
+                "INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, \
                  updated_at, last_login_at, created_by, metadata) \
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
                 params![
                     user.id.as_str(),
                     opt_text(user.email.as_deref()),
                     user.display_name.as_str(),
                     user.status.as_str(),
                     user.role.as_str(),
+                    if user.is_superadmin { 1i64 } else { 0i64 },
                     fmt_ts(&user.created_at),
                     fmt_ts(&user.updated_at),
                     fmt_opt_ts(&user.last_login_at),
@@ -233,7 +234,7 @@ impl IdentityStore for LibSqlBackend {
         // see an empty users table and both get role=admin.
         let promote_result = conn
             .execute(
-                "UPDATE users SET role = 'admin' \
+                "UPDATE users SET role = 'admin', is_superadmin = 1 \
                  WHERE id = ?1 AND (SELECT COUNT(*) FROM users) = 1",
                 params![user.id.as_str()],
             )
@@ -277,6 +278,7 @@ mod tests {
             display_name: "Alice".to_string(),
             status: "active".to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             created_at: now,
             updated_at: now,
             last_login_at: None,
@@ -341,6 +343,7 @@ mod tests {
             display_name: "Bob".to_string(),
             status: "active".to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             created_at: now,
             updated_at: now,
             last_login_at: None,
@@ -382,6 +385,7 @@ mod tests {
             display_name: "Carol".to_string(),
             status: "active".to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             created_at: now,
             updated_at: now,
             last_login_at: None,

--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -10,7 +10,7 @@ use crate::db::libsql::LibSqlBackend;
 use crate::db::{ApiTokenRecord, DatabaseError, UserRecord, UserStore};
 
 fn row_to_user(row: &libsql::Row) -> Result<UserRecord, DatabaseError> {
-    let metadata_str = get_text(row, 9);
+    let metadata_str = get_text(row, 10);
     let metadata: serde_json::Value = serde_json::from_str(&metadata_str)
         .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
     Ok(UserRecord {
@@ -19,10 +19,11 @@ fn row_to_user(row: &libsql::Row) -> Result<UserRecord, DatabaseError> {
         display_name: get_text(row, 2),
         status: get_text(row, 3),
         role: get_text(row, 4),
-        created_at: get_ts(row, 5),
-        updated_at: get_ts(row, 6),
-        last_login_at: get_opt_ts(row, 7),
-        created_by: get_opt_text(row, 8),
+        is_superadmin: row.get::<i64>(5).unwrap_or(0) != 0,
+        created_at: get_ts(row, 6),
+        updated_at: get_ts(row, 7),
+        last_login_at: get_opt_ts(row, 8),
+        created_by: get_opt_text(row, 9),
         metadata,
     })
 }
@@ -53,8 +54,8 @@ impl UserStore for LibSqlBackend {
 
         conn.execute(
             r#"
-            INSERT INTO users (id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata)
-            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+            INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
             "#,
             params![
                 user.id.as_str(),
@@ -62,6 +63,7 @@ impl UserStore for LibSqlBackend {
                 user.display_name.as_str(),
                 user.status.as_str(),
                 user.role.as_str(),
+                if user.is_superadmin { 1i64 } else { 0i64 },
                 fmt_ts(&user.created_at),
                 fmt_ts(&user.updated_at),
                 fmt_opt_ts(&user.last_login_at),
@@ -79,7 +81,7 @@ impl UserStore for LibSqlBackend {
         let mut rows = conn
             .query(
                 r#"
-                SELECT id, email, display_name, status, role, created_at, updated_at,
+                SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at,
                        last_login_at, created_by, metadata
                 FROM users WHERE id = ?1
                 "#,
@@ -103,7 +105,7 @@ impl UserStore for LibSqlBackend {
         let mut rows = conn
             .query(
                 r#"
-                SELECT id, email, display_name, status, role, created_at, updated_at,
+                SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at,
                        last_login_at, created_by, metadata
                 FROM users WHERE LOWER(email) = LOWER(?1)
                 "#,
@@ -129,7 +131,7 @@ impl UserStore for LibSqlBackend {
         let mut rows = if let Some(status) = status {
             conn.query(
                 r#"
-                SELECT id, email, display_name, status, role, created_at, updated_at,
+                SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at,
                        last_login_at, created_by, metadata
                 FROM users WHERE status = ?1
                 ORDER BY created_at DESC
@@ -141,7 +143,7 @@ impl UserStore for LibSqlBackend {
         } else {
             conn.query(
                 r#"
-                SELECT id, email, display_name, status, role, created_at, updated_at,
+                SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at,
                        last_login_at, created_by, metadata
                 FROM users
                 ORDER BY created_at DESC
@@ -313,7 +315,7 @@ impl UserStore for LibSqlBackend {
                 SELECT
                     t.id, t.user_id, t.name, t.token_prefix, t.expires_at,
                     t.last_used_at, t.created_at, t.revoked_at,
-                    u.id, u.email, u.display_name, u.status, u.role, u.created_at,
+                    u.id, u.email, u.display_name, u.status, u.role, u.is_superadmin, u.created_at,
                     u.updated_at, u.last_login_at, u.created_by, u.metadata
                 FROM api_tokens t
                 JOIN users u ON u.id = t.user_id
@@ -348,7 +350,7 @@ impl UserStore for LibSqlBackend {
                     revoked_at: get_opt_ts(&row, 7),
                 };
 
-                let metadata_str = get_text(&row, 17);
+                let metadata_str = get_text(&row, 18);
                 let metadata: serde_json::Value = serde_json::from_str(&metadata_str)
                     .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
 
@@ -358,10 +360,11 @@ impl UserStore for LibSqlBackend {
                     display_name: get_text(&row, 10),
                     status: get_text(&row, 11),
                     role: get_text(&row, 12),
-                    created_at: get_ts(&row, 13),
-                    updated_at: get_ts(&row, 14),
-                    last_login_at: get_opt_ts(&row, 15),
-                    created_by: get_opt_text(&row, 16),
+                    is_superadmin: row.get::<i64>(13).unwrap_or(0) != 0,
+                    created_at: get_ts(&row, 14),
+                    updated_at: get_ts(&row, 15),
+                    last_login_at: get_opt_ts(&row, 16),
+                    created_by: get_opt_text(&row, 17),
                     metadata,
                 };
 
@@ -565,8 +568,8 @@ impl UserStore for LibSqlBackend {
         if let Err(e) = conn
             .execute(
                 r#"
-                INSERT INTO users (id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+                INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
                 "#,
                 params![
                     user.id.as_str(),
@@ -574,6 +577,7 @@ impl UserStore for LibSqlBackend {
                     user.display_name.as_str(),
                     user.status.as_str(),
                     user.role.as_str(),
+                    if user.is_superadmin { 1i64 } else { 0i64 },
                     fmt_ts(&user.created_at),
                     fmt_ts(&user.updated_at),
                     fmt_opt_ts(&user.last_login_at),
@@ -723,6 +727,7 @@ mod tests {
             display_name: id.to_string(),
             status: "active".to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             created_at: Utc::now(),
             updated_at: Utc::now(),
             last_login_at: None,

--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -1026,4 +1026,48 @@ mod tests {
         let gpt35 = stats.iter().find(|s| s.model == "gpt-3.5").unwrap();
         assert_eq!(gpt35.call_count, 1);
     }
+
+    /// Verify that the migration-18 backfill SQL (`UPDATE users SET
+    /// is_superadmin = 1 WHERE role = 'admin'`) correctly promotes existing
+    /// admin users.  We simulate the pre-migration state by inserting an
+    /// admin user with `is_superadmin = false`, then executing the backfill
+    /// UPDATE and asserting the flag flipped.
+    #[tokio::test]
+    async fn test_migration_backfill_sets_superadmin_for_admin_role() {
+        let (db, _dir) = setup().await;
+
+        // Create admin user with is_superadmin = false (simulates a user that
+        // existed before migration 18).
+        let mut admin = test_user("admin1");
+        admin.role = "admin".to_string();
+        admin.is_superadmin = false;
+        db.create_user(&admin).await.unwrap();
+
+        // Also create a regular member to ensure they are NOT promoted.
+        let member = test_user("member1");
+        db.create_user(&member).await.unwrap();
+
+        // Run the backfill SQL (same statement from migration 18).
+        let conn = db.connect().await.unwrap();
+        conn.execute(
+            "UPDATE users SET is_superadmin = 1 WHERE role = 'admin'",
+            (),
+        )
+        .await
+        .unwrap();
+
+        // Admin should now be superadmin.
+        let found_admin = db.get_user("admin1").await.unwrap().unwrap();
+        assert!(
+            found_admin.is_superadmin,
+            "admin user should have is_superadmin = true after backfill"
+        );
+
+        // Member should remain unchanged.
+        let found_member = db.get_user("member1").await.unwrap().unwrap();
+        assert!(
+            !found_member.is_superadmin,
+            "member user should still have is_superadmin = false after backfill"
+        );
+    }
 }

--- a/src/db/libsql/workspaces.rs
+++ b/src/db/libsql/workspaces.rs
@@ -32,20 +32,21 @@ fn row_to_workspace(row: &libsql::Row) -> Result<WorkspaceRecord, DatabaseError>
 }
 
 fn row_to_user(row: &libsql::Row, offset: i32) -> Result<UserRecord, DatabaseError> {
-    let metadata = get_json(row, offset + 9);
+    let metadata = get_json(row, offset + 10);
     Ok(UserRecord {
         id: get_text(row, offset),
         email: get_opt_text(row, offset + 1),
         display_name: get_text(row, offset + 2),
         status: get_text(row, offset + 3),
         role: get_text(row, offset + 4),
-        created_at: get_ts(row, offset + 5),
-        updated_at: get_ts(row, offset + 6),
-        last_login_at: get_opt_text(row, offset + 7)
+        is_superadmin: row.get::<i64>(offset + 5).unwrap_or(0) != 0,
+        created_at: get_ts(row, offset + 6),
+        updated_at: get_ts(row, offset + 7),
+        last_login_at: get_opt_text(row, offset + 8)
             .map(|s| super::parse_timestamp(&s))
             .transpose()
             .map_err(DatabaseError::Serialization)?,
-        created_by: get_opt_text(row, offset + 8),
+        created_by: get_opt_text(row, offset + 9),
         metadata,
     })
 }
@@ -209,6 +210,32 @@ impl WorkspaceMgmtStore for LibSqlBackend {
         Ok(memberships)
     }
 
+    async fn list_all_workspaces(&self) -> Result<Vec<WorkspaceRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, name, slug, description, status, created_at, updated_at, created_by, settings
+                FROM workspaces
+                WHERE status != 'archived'
+                ORDER BY created_at DESC
+                "#,
+                (),
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let mut workspaces = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            workspaces.push(row_to_workspace(&row)?);
+        }
+        Ok(workspaces)
+    }
+
     async fn update_workspace(
         &self,
         id: Uuid,
@@ -302,7 +329,7 @@ impl WorkspaceMgmtStore for LibSqlBackend {
             .query(
                 r#"
                 SELECT
-                    u.id, u.email, u.display_name, u.status, u.role, u.created_at, u.updated_at, u.last_login_at, u.created_by, u.metadata,
+                    u.id, u.email, u.display_name, u.status, u.role, u.is_superadmin, u.created_at, u.updated_at, u.last_login_at, u.created_by, u.metadata,
                     wm.workspace_id, wm.user_id, wm.role, wm.joined_at, wm.invited_by
                 FROM workspace_members wm
                 JOIN users u ON u.id = wm.user_id
@@ -323,13 +350,13 @@ impl WorkspaceMgmtStore for LibSqlBackend {
             let user = row_to_user(&row, 0)?;
             let membership = WorkspaceMemberRecord {
                 workspace_id: parse_uuid_field(
-                    &get_text(&row, 10),
+                    &get_text(&row, 11),
                     "workspace_members.workspace_id",
                 )?,
-                user_id: get_text(&row, 11),
-                role: get_text(&row, 12),
-                joined_at: get_ts(&row, 13),
-                invited_by: get_opt_text(&row, 14),
+                user_id: get_text(&row, 12),
+                role: get_text(&row, 13),
+                joined_at: get_ts(&row, 14),
+                invited_by: get_opt_text(&row, 15),
             };
             members.push((user, membership));
         }
@@ -407,6 +434,70 @@ impl WorkspaceMgmtStore for LibSqlBackend {
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(updated > 0)
+    }
+
+    async fn transfer_workspace_ownership(
+        &self,
+        workspace_id: Uuid,
+        current_owner_user_id: &str,
+        new_owner_user_id: &str,
+        invited_by: Option<&str>,
+    ) -> Result<bool, DatabaseError> {
+        let conn = self.connect().await?;
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let result: Result<bool, DatabaseError> = async {
+            let demoted = conn
+                .execute(
+                    r#"
+                    UPDATE workspace_members
+                    SET role = 'admin'
+                    WHERE workspace_id = ?1 AND user_id = ?2 AND role = 'owner'
+                    "#,
+                    params![workspace_id.to_string(), current_owner_user_id],
+                )
+                .await
+                .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            if demoted == 0 {
+                return Ok(false);
+            }
+
+            conn.execute(
+                r#"
+                INSERT INTO workspace_members (workspace_id, user_id, role, joined_at, invited_by)
+                VALUES (?1, ?2, 'owner', ?3, ?4)
+                ON CONFLICT (workspace_id, user_id) DO UPDATE SET
+                    role = 'owner',
+                    invited_by = excluded.invited_by
+                "#,
+                params![
+                    workspace_id.to_string(),
+                    new_owner_user_id,
+                    fmt_ts(&Utc::now()),
+                    opt_text(invited_by)
+                ],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+            Ok(true)
+        }
+        .await;
+
+        match &result {
+            Ok(_) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| DatabaseError::Query(e.to_string()))?;
+            }
+            Err(_) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+            }
+        }
+
+        result
     }
 
     async fn is_workspace_member(

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -1162,6 +1162,7 @@ CREATE INDEX IF NOT EXISTS idx_user_identities_email ON user_identities(email) W
         "users_superadmin",
         r#"
 ALTER TABLE users ADD COLUMN is_superadmin INTEGER NOT NULL DEFAULT 0;
+UPDATE users SET is_superadmin = 1 WHERE role = 'admin';
 "#,
     ),
 ];

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -37,6 +37,7 @@ CREATE TABLE IF NOT EXISTS users (
     display_name TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'active',
     role TEXT NOT NULL DEFAULT 'member',
+    is_superadmin INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_login_at TEXT,
@@ -679,6 +680,7 @@ CREATE TABLE IF NOT EXISTS users (
     display_name TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'active',
     role TEXT NOT NULL DEFAULT 'member',
+    is_superadmin INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_login_at TEXT,
@@ -890,6 +892,7 @@ CREATE TABLE IF NOT EXISTS users (
     display_name TEXT NOT NULL,
     status TEXT NOT NULL DEFAULT 'active',
     role TEXT NOT NULL DEFAULT 'member',
+    is_superadmin INTEGER NOT NULL DEFAULT 0,
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     last_login_at TEXT,
@@ -1154,13 +1157,22 @@ CREATE INDEX IF NOT EXISTS idx_user_identities_user ON user_identities(user_id);
 CREATE INDEX IF NOT EXISTS idx_user_identities_email ON user_identities(email) WHERE email IS NOT NULL;
 "#,
     ),
+    (
+        18,
+        "users_superadmin",
+        r#"
+ALTER TABLE users ADD COLUMN is_superadmin INTEGER NOT NULL DEFAULT 0;
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already
 /// exists (e.g. because the base SCHEMA was updated to include it).
 /// Each entry is `(version, table_name, column_name)`.
-const IDEMPOTENT_ADD_COLUMN_MIGRATIONS: &[(i64, &str, &str)] =
-    &[(15, "conversations", "source_channel")];
+const IDEMPOTENT_ADD_COLUMN_MIGRATIONS: &[(i64, &str, &str)] = &[
+    (15, "conversations", "source_channel"),
+    (18, "users", "is_superadmin"),
+];
 /// Check whether `table` already contains `column` via `pragma_table_info`.
 async fn column_exists(
     conn: &libsql::Connection,

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -322,6 +322,8 @@ pub struct UserRecord {
     pub status: String,
     /// `admin` or `member`.
     pub role: String,
+    /// System-wide privilege for cross-workspace administration.
+    pub is_superadmin: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
     pub last_login_at: Option<DateTime<Utc>>,
@@ -1140,6 +1142,7 @@ pub trait WorkspaceMgmtStore: Send + Sync {
         &self,
         user_id: &str,
     ) -> Result<Vec<WorkspaceMembership>, DatabaseError>;
+    async fn list_all_workspaces(&self) -> Result<Vec<WorkspaceRecord>, DatabaseError>;
     async fn update_workspace(
         &self,
         id: Uuid,
@@ -1179,6 +1182,13 @@ pub trait WorkspaceMgmtStore: Send + Sync {
         workspace_id: Uuid,
         user_id: &str,
         role: &str,
+    ) -> Result<bool, DatabaseError>;
+    async fn transfer_workspace_ownership(
+        &self,
+        workspace_id: Uuid,
+        current_owner_user_id: &str,
+        new_owner_user_id: &str,
+        invited_by: Option<&str>,
     ) -> Result<bool, DatabaseError>;
     async fn is_workspace_member(
         &self,

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1294,6 +1294,26 @@ impl WorkspaceMgmtStore for PgBackend {
             .collect())
     }
 
+    async fn list_all_workspaces(&self) -> Result<Vec<WorkspaceRecord>, DatabaseError> {
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(format!("Failed to get client: {e}")))?;
+        let rows = client
+            .query(
+                r#"
+                SELECT id, name, slug, description, status, created_at, updated_at, created_by, settings
+                FROM workspaces
+                WHERE status != 'archived'
+                ORDER BY created_at DESC
+                "#,
+                &[],
+            )
+            .await?;
+        Ok(rows.into_iter().map(|row| row_to_workspace(&row)).collect())
+    }
+
     async fn update_workspace(
         &self,
         id: Uuid,
@@ -1395,7 +1415,7 @@ impl WorkspaceMgmtStore for PgBackend {
             .query(
                 r#"
                 SELECT
-                    u.id, u.email, u.display_name, u.status, u.role AS user_role, u.created_at, u.updated_at,
+                    u.id, u.email, u.display_name, u.status, u.role AS user_role, u.is_superadmin, u.created_at, u.updated_at,
                     u.last_login_at, u.created_by, u.metadata,
                     wm.workspace_id, wm.user_id AS member_user_id, wm.role AS member_role, wm.joined_at, wm.invited_by
                 FROM workspace_members wm
@@ -1416,6 +1436,7 @@ impl WorkspaceMgmtStore for PgBackend {
                         display_name: row.get("display_name"),
                         status: row.get("status"),
                         role: row.get("user_role"),
+                        is_superadmin: row.get("is_superadmin"),
                         created_at: row.get("created_at"),
                         updated_at: row.get("updated_at"),
                         last_login_at: row.get("last_login_at"),
@@ -1498,6 +1519,51 @@ impl WorkspaceMgmtStore for PgBackend {
             )
             .await?;
         Ok(updated > 0)
+    }
+
+    async fn transfer_workspace_ownership(
+        &self,
+        workspace_id: Uuid,
+        current_owner_user_id: &str,
+        new_owner_user_id: &str,
+        invited_by: Option<&str>,
+    ) -> Result<bool, DatabaseError> {
+        let mut client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(format!("Failed to get client: {e}")))?;
+        let tx = client.transaction().await?;
+
+        let demoted = tx
+            .execute(
+                r#"
+                UPDATE workspace_members
+                SET role = 'admin'
+                WHERE workspace_id = $1 AND user_id = $2 AND role = 'owner'
+                "#,
+                &[&workspace_id, &current_owner_user_id],
+            )
+            .await?;
+        if demoted == 0 {
+            tx.rollback().await?;
+            return Ok(false);
+        }
+
+        tx.execute(
+            r#"
+            INSERT INTO workspace_members (workspace_id, user_id, role, invited_by)
+            VALUES ($1, $2, 'owner', $3)
+            ON CONFLICT (workspace_id, user_id) DO UPDATE SET
+                role = 'owner',
+                invited_by = EXCLUDED.invited_by
+            "#,
+            &[&workspace_id, &new_owner_user_id, &invited_by],
+        )
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     async fn is_workspace_member(
@@ -1623,15 +1689,16 @@ impl IdentityStore for PgBackend {
         let tx = conn.transaction().await?;
 
         tx.execute(
-            "INSERT INTO users (id, email, display_name, status, role, created_at, \
+            "INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, \
              updated_at, last_login_at, created_by, metadata) \
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
             &[
                 &user.id,
                 &user.email,
                 &user.display_name,
                 &user.status,
                 &user.role,
+                &user.is_superadmin,
                 &user.created_at,
                 &user.updated_at,
                 &user.last_login_at,
@@ -1672,7 +1739,7 @@ impl IdentityStore for PgBackend {
         )
         .await?;
         tx.execute(
-            "UPDATE users SET role = 'admin' \
+            "UPDATE users SET role = 'admin', is_superadmin = true \
              WHERE id = $1 AND (SELECT COUNT(*) FROM users) = 1",
             &[&user.id],
         )

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -2713,8 +2713,8 @@ impl Store {
         let conn = self.conn().await?;
         conn.execute(
             r#"
-            INSERT INTO users (id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             "#,
             &[
                 &user.id,
@@ -2722,6 +2722,7 @@ impl Store {
                 &user.display_name,
                 &user.status,
                 &user.role,
+                &user.is_superadmin,
                 &user.created_at,
                 &user.updated_at,
                 &user.last_login_at,
@@ -2737,7 +2738,7 @@ impl Store {
     pub async fn get_user(&self, id: &str) -> Result<Option<UserRecord>, DatabaseError> {
         let conn = self.conn().await?;
         let row = conn
-            .query_opt("SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE id = $1", &[&id])
+            .query_opt("SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE id = $1", &[&id])
             .await?;
         Ok(row.map(|r| row_to_user(&r)))
     }
@@ -2749,7 +2750,7 @@ impl Store {
     ) -> Result<Option<UserRecord>, DatabaseError> {
         let conn = self.conn().await?;
         let row = conn
-            .query_opt("SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE LOWER(email) = LOWER($1)", &[&email])
+            .query_opt("SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE LOWER(email) = LOWER($1)", &[&email])
             .await?;
         Ok(row.map(|r| row_to_user(&r)))
     }
@@ -2760,13 +2761,13 @@ impl Store {
         let rows = match status {
             Some(s) => {
                 conn.query(
-                    "SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE status = $1 ORDER BY created_at DESC",
+                    "SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE status = $1 ORDER BY created_at DESC",
                     &[&s],
                 )
                 .await?
             }
             None => {
-                conn.query("SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users ORDER BY created_at DESC", &[])
+                conn.query("SELECT id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata FROM users ORDER BY created_at DESC", &[])
                     .await?
             }
         };
@@ -2876,8 +2877,8 @@ impl Store {
 
         tx.execute(
             r#"
-            INSERT INTO users (id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            INSERT INTO users (id, email, display_name, status, role, is_superadmin, created_at, updated_at, last_login_at, created_by, metadata)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
             "#,
             &[
                 &user.id,
@@ -2885,6 +2886,7 @@ impl Store {
                 &user.display_name,
                 &user.status,
                 &user.role,
+                &user.is_superadmin,
                 &user.created_at,
                 &user.updated_at,
                 &user.last_login_at,
@@ -2974,7 +2976,7 @@ impl Store {
             .query_opt(
                 r#"
                 SELECT t.id, t.user_id, t.name, t.token_prefix, t.expires_at, t.last_used_at, t.created_at, t.revoked_at,
-                       u.id as u_id, u.email, u.display_name, u.status, u.role, u.created_at as u_created_at, u.updated_at, u.last_login_at, u.created_by, u.metadata
+                       u.id as u_id, u.email, u.display_name, u.status, u.role, u.is_superadmin, u.created_at as u_created_at, u.updated_at, u.last_login_at, u.created_by, u.metadata
                 FROM api_tokens t
                 JOIN users u ON t.user_id = u.id
                 WHERE t.token_hash = $1
@@ -3002,6 +3004,7 @@ impl Store {
                 display_name: r.get("display_name"),
                 status: r.get("status"),
                 role: r.get("role"),
+                is_superadmin: r.get("is_superadmin"),
                 created_at: r.get("u_created_at"),
                 updated_at: r.get("updated_at"),
                 last_login_at: r.get("last_login_at"),
@@ -3219,6 +3222,7 @@ fn row_to_user(row: &tokio_postgres::Row) -> UserRecord {
         display_name: row.get("display_name"),
         status: row.get("status"),
         role: row.get("role"),
+        is_superadmin: row.get("is_superadmin"),
         created_at: row.get("created_at"),
         updated_at: row.get("updated_at"),
         last_login_at: row.get("last_login_at"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -662,6 +662,7 @@ async fn async_main() -> anyhow::Result<()> {
                     display_name: config.owner_id.clone(),
                     status: "active".to_string(),
                     role: "admin".to_string(),
+                    is_superadmin: true,
                     created_at: now,
                     updated_at: now,
                     last_login_at: None,

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -50,6 +50,7 @@ fn two_user_auth() -> MultiAuthState {
         UserIdentity {
             user_id: ALICE_USER_ID.to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         },
     );
@@ -58,6 +59,7 @@ fn two_user_auth() -> MultiAuthState {
         UserIdentity {
             user_id: BOB_USER_ID.to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: vec!["shared".to_string()],
         },
     );
@@ -604,6 +606,7 @@ async fn start_owner_scoped_sender_server() -> (
         UserIdentity {
             user_id: OWNER_SCOPE_ID.to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         },
     );
@@ -612,6 +615,7 @@ async fn start_owner_scoped_sender_server() -> (
         UserIdentity {
             user_id: BOB_USER_ID.to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             workspace_read_scopes: Vec::new(),
         },
     );

--- a/tests/oauth_greeting_integration.rs
+++ b/tests/oauth_greeting_integration.rs
@@ -44,6 +44,7 @@ mod tests {
                 UserIdentity {
                     user_id: user_id.to_string(),
                     role: "admin".to_string(),
+                    is_superadmin: true,
                     workspace_read_scopes: Vec::new(),
                 },
             );

--- a/tests/workspaces_integration.rs
+++ b/tests/workspaces_integration.rs
@@ -7,18 +7,30 @@ use chrono::Utc;
 use ironclaw::agent::SessionManager;
 use ironclaw::channels::IncomingMessage;
 use ironclaw::channels::web::auth::{MultiAuthState, UserIdentity};
+use ironclaw::channels::web::server::{
+    ActiveConfigSnapshot, GatewayState, PerUserRateLimiter, RateLimiter, WorkspacePool,
+    start_server,
+};
+use ironclaw::channels::web::sse::SseManager;
 use ironclaw::channels::web::test_helpers::TestGatewayBuilder;
+use ironclaw::channels::web::workspace_scope_user_id;
+use ironclaw::channels::web::ws::WsConnectionTracker;
 use ironclaw::db::libsql::LibSqlBackend;
-use ironclaw::db::{ConversationStore, Database, UserRecord, UserStore, WorkspaceMgmtStore};
+use ironclaw::db::{
+    ConversationStore, Database, RoutineStore, UserRecord, UserStore, WorkspaceMgmtStore,
+    WorkspaceStore,
+};
 use serde_json::json;
 use uuid::Uuid;
 
 const ALICE_TOKEN: &str = "tok-alice-workspace";
 const BOB_TOKEN: &str = "tok-bob-workspace";
 const CHARLIE_TOKEN: &str = "tok-charlie-workspace";
+const DANA_TOKEN: &str = "tok-dana-workspace";
 const ALICE_USER_ID: &str = "alice";
 const BOB_USER_ID: &str = "bob";
 const CHARLIE_USER_ID: &str = "charlie";
+const DANA_USER_ID: &str = "dana";
 
 fn workspace_auth() -> MultiAuthState {
     let mut tokens = HashMap::new();
@@ -27,6 +39,7 @@ fn workspace_auth() -> MultiAuthState {
         UserIdentity {
             user_id: ALICE_USER_ID.to_string(),
             role: "admin".to_string(),
+            is_superadmin: true,
             workspace_read_scopes: Vec::new(),
         },
     );
@@ -35,6 +48,7 @@ fn workspace_auth() -> MultiAuthState {
         UserIdentity {
             user_id: BOB_USER_ID.to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
             workspace_read_scopes: Vec::new(),
         },
     );
@@ -43,13 +57,23 @@ fn workspace_auth() -> MultiAuthState {
         UserIdentity {
             user_id: CHARLIE_USER_ID.to_string(),
             role: "member".to_string(),
+            is_superadmin: false,
+            workspace_read_scopes: Vec::new(),
+        },
+    );
+    tokens.insert(
+        DANA_TOKEN.to_string(),
+        UserIdentity {
+            user_id: DANA_USER_ID.to_string(),
+            role: "admin".to_string(),
+            is_superadmin: false,
             workspace_read_scopes: Vec::new(),
         },
     );
     MultiAuthState::multi(tokens)
 }
 
-fn test_user(id: &str, role: &str) -> UserRecord {
+fn test_user(id: &str, role: &str, is_superadmin: bool) -> UserRecord {
     let now = Utc::now();
     UserRecord {
         id: id.to_string(),
@@ -57,6 +81,7 @@ fn test_user(id: &str, role: &str) -> UserRecord {
         display_name: id.to_string(),
         status: "active".to_string(),
         role: role.to_string(),
+        is_superadmin,
         created_at: now,
         updated_at: now,
         last_login_at: None,
@@ -69,15 +94,19 @@ async fn setup_store() -> Arc<LibSqlBackend> {
     let store = Arc::new(LibSqlBackend::new_memory().await.unwrap());
     store.run_migrations().await.unwrap();
     store
-        .create_user(&test_user(ALICE_USER_ID, "admin"))
+        .create_user(&test_user(ALICE_USER_ID, "admin", true))
         .await
         .unwrap();
     store
-        .create_user(&test_user(BOB_USER_ID, "member"))
+        .create_user(&test_user(BOB_USER_ID, "member", false))
         .await
         .unwrap();
     store
-        .create_user(&test_user(CHARLIE_USER_ID, "member"))
+        .create_user(&test_user(CHARLIE_USER_ID, "member", false))
+        .await
+        .unwrap();
+    store
+        .create_user(&test_user(DANA_USER_ID, "admin", false))
         .await
         .unwrap();
     store
@@ -112,6 +141,61 @@ async fn start_workspace_server_with_state(
         builder = builder.msg_tx(tx);
     }
     builder.start_multi(workspace_auth()).await.unwrap()
+}
+
+async fn start_workspace_server_with_pool(
+    store: Arc<LibSqlBackend>,
+    msg_tx: Option<tokio::sync::mpsc::Sender<IncomingMessage>>,
+) -> SocketAddr {
+    let state = Arc::new(GatewayState {
+        msg_tx: tokio::sync::RwLock::new(msg_tx),
+        sse: Arc::new(SseManager::new()),
+        workspace: None,
+        workspace_pool: Some(Arc::new(WorkspacePool::new(
+            store.clone(),
+            None,
+            ironclaw::workspace::EmbeddingCacheConfig::default(),
+            ironclaw::config::WorkspaceSearchConfig::default(),
+            ironclaw::config::WorkspaceConfig::default(),
+        ))),
+        session_manager: Some(Arc::new(SessionManager::new())),
+        log_broadcaster: None,
+        log_level_handle: None,
+        extension_manager: None,
+        tool_registry: None,
+        store: Some(store),
+        job_manager: None,
+        prompt_queue: None,
+        owner_id: ALICE_USER_ID.to_string(),
+        shutdown_tx: tokio::sync::RwLock::new(None),
+        ws_tracker: Some(Arc::new(WsConnectionTracker::new())),
+        llm_provider: None,
+        skill_registry: None,
+        skill_catalog: None,
+        scheduler: None,
+        chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+        webhook_rate_limiter: RateLimiter::new(10, 60),
+        registry_entries: Vec::new(),
+        cost_guard: None,
+        routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+        startup_time: std::time::Instant::now(),
+        active_config: ActiveConfigSnapshot::default(),
+        secrets_store: None,
+        db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
+    });
+    let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+    start_server(addr, state, workspace_auth().into())
+        .await
+        .unwrap()
 }
 
 #[tokio::test]
@@ -483,6 +567,43 @@ async fn archived_workspaces_are_hidden_from_workspace_lists() {
 }
 
 #[tokio::test]
+async fn superadmin_can_list_workspaces_without_membership() {
+    let store = setup_store().await;
+    let addr = start_workspace_server(store, None).await;
+    let client = reqwest::Client::new();
+
+    let create_resp = client
+        .post(format!("http://{addr}/api/workspaces"))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .json(&json!({
+            "name": "Dana Space",
+            "slug": "dana-space",
+            "description": "",
+            "settings": {}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), 200);
+
+    let superadmin_list = client
+        .get(format!("http://{addr}/api/workspaces"))
+        .header("Authorization", format!("Bearer {ALICE_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(superadmin_list.status(), 200);
+    let superadmin_json: serde_json::Value = superadmin_list.json().await.unwrap();
+    let workspaces = superadmin_json["workspaces"].as_array().unwrap();
+    assert!(
+        workspaces
+            .iter()
+            .any(|workspace| workspace["slug"] == "dana-space"),
+        "superadmin should see workspaces without direct membership"
+    );
+}
+
+#[tokio::test]
 async fn workspace_scoped_chat_send_sets_workspace_id_on_forwarded_message() {
     let store = setup_store().await;
     let workspace = store
@@ -490,7 +611,7 @@ async fn workspace_scoped_chat_send_sets_workspace_id_on_forwarded_message() {
         .await
         .unwrap();
     store
-        .add_workspace_member(workspace.id, BOB_USER_ID, "member", Some(ALICE_USER_ID))
+        .add_workspace_member(workspace.id, BOB_USER_ID, "admin", Some(ALICE_USER_ID))
         .await
         .unwrap();
 
@@ -523,6 +644,351 @@ async fn workspace_scoped_chat_send_sets_workspace_id_on_forwarded_message() {
 }
 
 #[tokio::test]
+async fn workspace_role_matrix_enforces_chat_settings_and_archive_permissions() {
+    let store = setup_store().await;
+    let workspace = store
+        .create_workspace("Role Matrix", "role-matrix", "", ALICE_USER_ID, &json!({}))
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, BOB_USER_ID, "viewer", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, CHARLIE_USER_ID, "member", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, DANA_USER_ID, "admin", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+
+    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(8);
+    let addr = start_workspace_server(store, Some(agent_tx)).await;
+    let client = reqwest::Client::new();
+
+    let viewer_read = client
+        .get(format!("http://{addr}/api/workspaces/role-matrix"))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_read.status(), 200);
+
+    let viewer_chat = client
+        .post(format!("http://{addr}/api/chat/send?workspace=role-matrix"))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .json(&json!({ "content": "viewer mutation" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_chat.status(), 403);
+
+    let member_chat = client
+        .post(format!("http://{addr}/api/chat/send?workspace=role-matrix"))
+        .header("Authorization", format!("Bearer {CHARLIE_TOKEN}"))
+        .json(&json!({ "content": "member mutation" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_chat.status(), 202);
+    let forwarded = tokio::time::timeout(Duration::from_secs(2), agent_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(forwarded.content, "member mutation");
+    assert_eq!(
+        forwarded.workspace_id.as_deref(),
+        Some(workspace.id.to_string().as_str())
+    );
+
+    let viewer_setting = client
+        .put(format!(
+            "http://{addr}/api/settings/theme?workspace=role-matrix"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .json(&json!({ "value": "viewer-write" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_setting.status(), 403);
+
+    let member_setting = client
+        .put(format!(
+            "http://{addr}/api/settings/theme?workspace=role-matrix"
+        ))
+        .header("Authorization", format!("Bearer {CHARLIE_TOKEN}"))
+        .json(&json!({ "value": "member-write" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_setting.status(), 403);
+
+    let admin_setting = client
+        .put(format!(
+            "http://{addr}/api/settings/theme?workspace=role-matrix"
+        ))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .json(&json!({ "value": "admin-write" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(admin_setting.status(), 204);
+
+    let admin_archive = client
+        .post(format!("http://{addr}/api/workspaces/role-matrix/archive"))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(admin_archive.status(), 403);
+
+    let owner_archive = client
+        .post(format!("http://{addr}/api/workspaces/role-matrix/archive"))
+        .header("Authorization", format!("Bearer {ALICE_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(owner_archive.status(), 204);
+}
+
+#[tokio::test]
+async fn workspace_role_changes_take_effect_immediately() {
+    let store = setup_store().await;
+    let workspace = store
+        .create_workspace(
+            "Immediate Roles",
+            "immediate-roles",
+            "",
+            ALICE_USER_ID,
+            &json!({}),
+        )
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, BOB_USER_ID, "viewer", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+
+    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(8);
+    let addr = start_workspace_server(store, Some(agent_tx)).await;
+    let client = reqwest::Client::new();
+
+    let viewer_chat = client
+        .post(format!(
+            "http://{addr}/api/chat/send?workspace=immediate-roles"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .json(&json!({ "content": "blocked as viewer" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_chat.status(), 403);
+
+    let promote_member = client
+        .put(format!(
+            "http://{addr}/api/workspaces/immediate-roles/members/{BOB_USER_ID}"
+        ))
+        .header("Authorization", format!("Bearer {ALICE_TOKEN}"))
+        .json(&json!({ "role": "member" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(promote_member.status(), 204);
+
+    let member_chat = client
+        .post(format!(
+            "http://{addr}/api/chat/send?workspace=immediate-roles"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .json(&json!({ "content": "allowed as member" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_chat.status(), 202);
+
+    let forwarded = tokio::time::timeout(Duration::from_secs(2), agent_rx.recv())
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(forwarded.content, "allowed as member");
+    assert_eq!(
+        forwarded.workspace_id.as_deref(),
+        Some(workspace.id.to_string().as_str())
+    );
+}
+
+#[tokio::test]
+async fn viewer_cannot_write_workspace_memory_but_can_read() {
+    let store = setup_store().await;
+    let workspace = store
+        .create_workspace(
+            "Memory Scope",
+            "memory-scope",
+            "",
+            ALICE_USER_ID,
+            &json!({}),
+        )
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, BOB_USER_ID, "viewer", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, CHARLIE_USER_ID, "member", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+
+    let scoped_user_id = workspace_scope_user_id(workspace.id);
+    let doc = store
+        .get_or_create_document_by_path(&scoped_user_id, None, "notes.md")
+        .await
+        .unwrap();
+    store.update_document(doc.id, "seeded").await.unwrap();
+
+    let addr = start_workspace_server_with_pool(store, None).await;
+    let client = reqwest::Client::new();
+
+    let read_resp = client
+        .get(format!(
+            "http://{addr}/api/memory/read?workspace=memory-scope&path=notes.md"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(read_resp.status(), 200);
+    let read_json: serde_json::Value = read_resp.json().await.unwrap();
+    assert_eq!(read_json["content"], "seeded");
+
+    let viewer_write = client
+        .post(format!(
+            "http://{addr}/api/memory/write?workspace=memory-scope"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .json(&json!({ "path": "notes.md", "content": "viewer", "append": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_write.status(), 403);
+
+    let member_write = client
+        .post(format!(
+            "http://{addr}/api/memory/write?workspace=memory-scope"
+        ))
+        .header("Authorization", format!("Bearer {CHARLIE_TOKEN}"))
+        .json(&json!({ "path": "notes.md", "content": "member", "append": false }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_write.status(), 200);
+}
+
+#[tokio::test]
+async fn viewer_cannot_toggle_workspace_routines() {
+    let store = setup_store().await;
+    let workspace = store
+        .create_workspace(
+            "Routine Scope",
+            "routine-scope",
+            "",
+            ALICE_USER_ID,
+            &json!({}),
+        )
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, BOB_USER_ID, "viewer", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+    store
+        .add_workspace_member(workspace.id, CHARLIE_USER_ID, "member", Some(ALICE_USER_ID))
+        .await
+        .unwrap();
+
+    let now = Utc::now();
+    let routine = ironclaw::agent::routine::Routine {
+        id: Uuid::new_v4(),
+        name: "workspace-routine".to_string(),
+        description: "viewer should not mutate".to_string(),
+        user_id: ALICE_USER_ID.to_string(),
+        workspace_id: Some(workspace.id),
+        enabled: true,
+        trigger: ironclaw::agent::routine::Trigger::Manual,
+        action: ironclaw::agent::routine::RoutineAction::Lightweight {
+            prompt: "hello".to_string(),
+            context_paths: Vec::new(),
+            max_tokens: 256,
+            use_tools: false,
+            max_tool_rounds: 1,
+        },
+        guardrails: ironclaw::agent::routine::RoutineGuardrails {
+            cooldown: Duration::from_secs(0),
+            max_concurrent: 1,
+            dedup_window: None,
+        },
+        notify: ironclaw::agent::routine::NotifyConfig::default(),
+        last_run_at: None,
+        next_fire_at: None,
+        run_count: 0,
+        consecutive_failures: 0,
+        state: json!({}),
+        created_at: now,
+        updated_at: now,
+    };
+    store.create_routine(&routine).await.unwrap();
+
+    let addr = start_workspace_server(store, None).await;
+    let client = reqwest::Client::new();
+
+    let viewer_toggle = client
+        .post(format!(
+            "http://{addr}/api/routines/{}/toggle?workspace=routine-scope",
+            routine.id
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(viewer_toggle.status(), 403);
+
+    let member_toggle = client
+        .post(format!(
+            "http://{addr}/api/routines/{}/toggle?workspace=routine-scope",
+            routine.id
+        ))
+        .header("Authorization", format!("Bearer {CHARLIE_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(member_toggle.status(), 200);
+}
+
+#[tokio::test]
+async fn user_management_endpoints_require_superadmin() {
+    let store = setup_store().await;
+    let addr = start_workspace_server(store, None).await;
+    let client = reqwest::Client::new();
+
+    let plain_admin = client
+        .get(format!("http://{addr}/api/admin/users"))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(plain_admin.status(), 403);
+
+    let superadmin = client
+        .get(format!("http://{addr}/api/admin/users"))
+        .header("Authorization", format!("Bearer {ALICE_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(superadmin.status(), 200);
+}
+
+#[tokio::test]
 async fn workspace_scoped_settings_are_separate_from_personal_settings() {
     let store = setup_store().await;
     let workspace = store
@@ -536,7 +1002,7 @@ async fn workspace_scoped_settings_are_separate_from_personal_settings() {
         .await
         .unwrap();
     store
-        .add_workspace_member(workspace.id, BOB_USER_ID, "member", Some(ALICE_USER_ID))
+        .add_workspace_member(workspace.id, BOB_USER_ID, "admin", Some(ALICE_USER_ID))
         .await
         .unwrap();
 
@@ -584,6 +1050,91 @@ async fn workspace_scoped_settings_are_separate_from_personal_settings() {
     assert_eq!(workspace_get.status(), 200);
     let workspace_json: serde_json::Value = workspace_get.json().await.unwrap();
     assert_eq!(workspace_json["value"], "workspace-light");
+}
+
+#[tokio::test]
+async fn assigning_owner_role_transfers_ownership() {
+    let store = setup_store().await;
+    let addr = start_workspace_server(store, None).await;
+    let client = reqwest::Client::new();
+
+    let create_resp = client
+        .post(format!("http://{addr}/api/workspaces"))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .json(&json!({
+            "name": "Ownership Transfer",
+            "slug": "ownership-transfer",
+            "description": "",
+            "settings": {}
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(create_resp.status(), 200);
+
+    let add_bob = client
+        .put(format!(
+            "http://{addr}/api/workspaces/ownership-transfer/members/{BOB_USER_ID}"
+        ))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .json(&json!({ "role": "admin" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(add_bob.status(), 204);
+
+    let transfer_owner = client
+        .put(format!(
+            "http://{addr}/api/workspaces/ownership-transfer/members/{BOB_USER_ID}"
+        ))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .json(&json!({ "role": "owner" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(transfer_owner.status(), 204);
+
+    let members_resp = client
+        .get(format!(
+            "http://{addr}/api/workspaces/ownership-transfer/members"
+        ))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(members_resp.status(), 200);
+    let members_json: serde_json::Value = members_resp.json().await.unwrap();
+    let members = members_json["members"].as_array().unwrap();
+    assert!(
+        members
+            .iter()
+            .any(|member| member["user_id"] == DANA_USER_ID && member["role"] == "admin")
+    );
+    assert!(
+        members
+            .iter()
+            .any(|member| member["user_id"] == BOB_USER_ID && member["role"] == "owner")
+    );
+
+    let old_owner_archive = client
+        .post(format!(
+            "http://{addr}/api/workspaces/ownership-transfer/archive"
+        ))
+        .header("Authorization", format!("Bearer {DANA_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(old_owner_archive.status(), 403);
+
+    let new_owner_archive = client
+        .post(format!(
+            "http://{addr}/api/workspaces/ownership-transfer/archive"
+        ))
+        .header("Authorization", format!("Bearer {BOB_TOKEN}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(new_owner_archive.status(), 204);
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

This stacked PR implements `#1608` on top of `#1734` by introducing explicit per-workspace RBAC enforcement and a separate system-level superadmin capability.

Before this change, workspace membership existed, but the gateway still relied on scattered, endpoint-specific checks. That left important gaps:

- role semantics were not encoded in one place
- read/write/admin/owner behavior was not consistently enforced across all workspace-scoped routes
- system-wide admin routes were still coupled to the legacy user `role` field instead of a dedicated superadmin concept
- ownership transfer and role changes did not have a single authoritative permission path

This PR closes that gap by making workspace authorization explicit, centralized, and enforced across the major browser-facing APIs.

## Problem Statement

Issue `#1608` calls for role-based access control with a per-workspace permission matrix. The workspace-entities work in `#1734` created the right substrate, but it did not yet fully define or enforce the higher-level policy model required for production use.

In particular, we needed to answer these questions consistently:

- what can a `viewer` do vs a `member`, `admin`, or `owner`
- which routes are read-only, write-level, admin-level, or owner-only
- how shared workspaces interact with personal scope
- how system user management relates to workspace roles
- how superusers can inspect or manage the system without being manually added to every workspace

This PR makes those rules first-class and wires them through the web gateway and DB-backed auth path.

## Core RBAC Model

This branch adds a central permission matrix in `src/channels/web/permissions.rs`.

Workspace roles:

- `viewer`
- `member`
- `admin`
- `owner`

Workspace permissions:

- `WorkspaceRead`
- `WorkspaceWrite`
- `WorkspaceManageMembers`
- `WorkspaceManageSettings`
- `WorkspaceManageAdmins`
- `WorkspaceDelete`

System permissions:

- `SystemManageUsers`
- `SystemViewAll`

Effective role behavior:

- `viewer`: can read workspace-scoped data, but cannot mutate
- `member`: can perform normal workspace writes
- `admin`: can manage members and workspace settings
- `owner`: required for owner-only and destructive workspace operations
- `superadmin`: bypasses workspace role checks and is allowed through system-level admin paths

The permission matrix is unit-tested directly so the role contract is explicit and not inferred from route behavior.

## Superadmin Separation From User Role

This PR intentionally separates workspace/system administration from the existing user-facing `role` column semantics.

New behavior:

- users now have a persisted `is_superadmin` flag
- auth propagation carries that flag through `UserIdentity`
- the `AdminUser` extractor now means "superadmin required"
- `/api/admin/*` is no longer unlocked by plain `role = admin`

Why this matters:

- workspace `admin` is scoped to a workspace
- user `role = admin` was too broad and ambiguous for true system administration
- `is_superadmin` creates a clear distinction between normal elevated users and platform-wide operators

Bootstrap behavior also stays coherent: the initial bootstrap/single-user admin path is promoted into superadmin capability, so existing top-level deployments still work as expected.

## Database And Backend Changes

The PR adds a new migration:

- `migrations/V18__users_superadmin.sql`

That migration introduces:

- `users.is_superadmin BOOLEAN NOT NULL DEFAULT FALSE`
- backfill behavior so existing admin users become superadmins during migration

The same persistence behavior is implemented in both backends:

- PostgreSQL
- libSQL

DB abstraction changes include:

- `UserRecord` / auth-facing identity changes to carry `is_superadmin`
- workspace management trait additions for listing all workspaces and performing ownership transfer
- backend-specific implementations for those new operations in both DB backends

This keeps the repository invariant intact: new persistence behavior is implemented through the shared trait first, then carried through both backends.

## Workspace Scope Resolution And Membership Handling

Workspace access control now runs through the workspace resolution layer instead of being left to ad hoc handler logic.

Key changes:

- archived workspaces are blocked during scope resolution
- superadmins resolve with effective owner-level authority for workspace checks
- non-superadmin membership lookups use a TTL cache
- membership cache entries are invalidated on role/member changes

The cache exists to avoid repeated DB lookups on high-traffic workspace routes while still keeping membership changes responsive.

Configuration:

- `GATEWAY_WORKSPACE_MEMBERSHIP_CACHE_TTL_SECS`
- default: `60`

This is intentionally small and conservative. Role changes are also invalidated directly where possible, so the normal update path does not wait on TTL expiry.

## Ownership Transfer Semantics

This PR makes owner transfer an explicit, atomic operation.

Behavior:

- assigning `owner` to another member is treated as ownership transfer, not as "add another owner"
- the previous owner is demoted to `admin`
- the new owner is promoted in the same DB operation
- owner-level permission is required for that change

This avoids inconsistent states such as multiple effective owners created by piecemeal updates or partial role rewrites.

## Endpoint-Level Enforcement

The largest practical change in this PR is that the permission model is now enforced across the actual API surface rather than just defined in docs or helper methods.

### Member-or-higher write enforcement

Workspace-scoped write operations now require `WorkspaceWrite`:

- chat send flows
- memory writes
- routine mutation endpoints
- job prompt/restart/cancel endpoints
- Responses API request creation

This means `viewer` can no longer use write paths that were previously reachable through partial membership checks.

### Admin-or-owner enforcement

Workspace admin operations now require `WorkspaceManageMembers` or `WorkspaceManageSettings`:

- workspace member management
- workspace settings writes/deletes
- workspace metadata updates

This means `member` is no longer treated as sufficient for routes that materially administer a shared workspace.

### Owner-only enforcement

Owner-only operations now require `WorkspaceManageAdmins` / `WorkspaceDelete`:

- workspace archive
- ownership transfer / assigning `owner`

This prevents workspace admins from taking owner-level actions.

### System-level enforcement

System-wide user-management routes now require `SystemManageUsers`, which is currently mapped to superadmin-only access:

- list users
- fetch user detail
- create users
- patch users
- suspend / activate users
- delete users
- manage per-user secrets through admin endpoints

This is the main behavior change for deployments that previously treated plain admin tokens as sufficient for `/api/admin/*`.

## Superadmin Workspace Visibility

Superadmins can now inspect all non-archived workspaces through the existing workspace list API without requiring explicit membership rows.

This is important for operational support and tenant administration because otherwise a system operator would need to be manually added to every workspace before being able to inspect or repair it.

The implementation uses the existing `GET /api/workspaces` endpoint rather than adding a one-off admin route, which keeps the API surface smaller while still preserving a clean authorization boundary.

## Personal Workspace Compatibility

This PR preserves backward compatibility for the personal scope model introduced before first-class workspace entities.

Behavior remains:

- no explicit `workspace` scope means the request operates on the caller's personal space
- personal data paths are not blocked by workspace membership checks
- shared workspace authorization only applies when the request resolves into a shared workspace scope

That matters because this branch is tightening shared-workspace behavior, not turning personal usage into a new RBAC burden.

## Tests Added And Expanded

This branch adds and expands targeted coverage for the actual issue behavior.

Notable cases now covered:

- permission matrix unit coverage for the role model itself
- viewer can read but cannot mutate
- viewer cannot write workspace memory
- viewer cannot toggle workspace routines
- member-level write paths are allowed
- admin can manage settings and members
- owner is required for archive
- superadmin can list workspaces without membership
- user-management endpoints require superadmin
- role changes take effect immediately
- assigning `owner` transfers ownership instead of duplicating it

Most of the end-to-end behavior is exercised in `tests/workspaces_integration.rs`, with additional auth/system coverage in multi-tenant tests.

## Documentation Updates

The PR also updates documentation so the implementation and operator-facing docs stay aligned:

- `docs/USER_MANAGEMENT_API.md`
- `src/channels/web/CLAUDE.md`
- `FEATURE_PARITY.md`

The user-management docs now explicitly describe `/api/admin/*` as superadmin-only rather than plain-admin accessible.

## Risk And Compatibility Notes

This is a high-risk area because it touches:

- auth
- persistence
- route authorization
- workspace membership semantics

Main compatibility implications:

- plain `admin` users without `is_superadmin` will now receive `403` on system admin endpoints
- `viewer` users may lose access to mutation paths that were previously under-protected
- owner-only actions are now stricter by design

Those changes are intentional and align the gateway with the policy described in `#1608`.

## Validation

Targeted verification completed on this branch:

- `cargo test --test workspaces_integration -- --nocapture`
- `cargo test multi_tenant --lib -- --nocapture`
- `cargo test workspace_permission_matrix_matches_issue_1608 --lib`
- `cargo clippy --all-features --tests -- -D warnings`

## Stack Context

- Base branch: `feat/1607-workspace-entities-db-users`
- Base PR: `#1734`
- This PR is the RBAC/policy layer that sits on top of the workspace-entities substrate

## Closes

- `#1608`
