### PR TITLE
Publish ironclaw-worker image from Dockerfile.worker

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -20,6 +20,7 @@ on:
 
 env:
   IMAGE_NAME: nearaidev/ironclaw
+  WORKER_IMAGE_NAME: nearaidev/ironclaw-worker
 
 jobs:
   build:
@@ -51,16 +52,22 @@ jobs:
             TAGS="${{ env.IMAGE_NAME }}:${VERSION}"
             TAGS="${TAGS},${{ env.IMAGE_NAME }}:latest"
             TAGS="${TAGS},${{ env.IMAGE_NAME }}:${SHA}"
+            WORKER_TAGS="${{ env.WORKER_IMAGE_NAME }}:${VERSION}"
+            WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:latest"
+            WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:${SHA}"
           else
             # Manual dispatch: :sha-xxx only
             TAGS="${{ env.IMAGE_NAME }}:${SHA}"
+            WORKER_TAGS="${{ env.WORKER_IMAGE_NAME }}:${SHA}"
           fi
 
           # Manual override adds an extra tag (e.g. "staging")
           if [[ -n "${{ inputs.tag }}" ]]; then
             TAGS="${TAGS},${{ env.IMAGE_NAME }}:${{ inputs.tag }}"
+            WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:${{ inputs.tag }}"
           fi
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+          echo "worker_tags=${WORKER_TAGS}" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -71,7 +78,7 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (ironclaw)
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -81,14 +88,30 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build and push (ironclaw-worker)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.worker
+          push: true
+          tags: ${{ steps.tags.outputs.worker_tags }}
+          platforms: linux/amd64
+          cache-from: type=gha,scope=worker
+          cache-to: type=gha,mode=max,scope=worker
+
       - name: Summary
         run: |
           {
-            echo "## Docker Image"
+            echo "## Docker Images"
             echo ""
-            echo "**Tags pushed:**"
+            echo "**ironclaw:**"
             echo '```'
             echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n'
+            echo '```'
+            echo ""
+            echo "**ironclaw-worker:**"
+            echo '```'
+            echo "${{ steps.tags.outputs.worker_tags }}" | tr ',' '\n'
             echo '```'
             echo ""
             echo "- version: \`${{ steps.version.outputs.version }}\`"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,6 +51,7 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SHA="sha-${GITHUB_SHA::7}"
+          echo "sha_tag=${SHA}" >> "$GITHUB_OUTPUT"
 
           if [[ "${{ github.event_name }}" == "workflow_call" ]]; then
             # Release: :version + :latest + :sha-xxx
@@ -106,6 +107,8 @@ jobs:
           file: Dockerfile.worker
           push: true
           tags: ${{ steps.tags.outputs.worker_tags }}
+          build-args: |
+            IRONCLAW_IMAGE=${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}
           platforms: linux/amd64
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -107,8 +107,6 @@ jobs:
           file: Dockerfile.worker
           push: true
           tags: ${{ steps.tags.outputs.worker_tags }}
-          build-args: |
-            IRONCLAW_IMAGE=${{ env.IMAGE_NAME }}:${{ steps.tags.outputs.sha_tag }}
           platforms: linux/amd64
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,9 @@ on:
         required: false
         type: string
         default: ""
+  # Daily staging build from the staging branch
+  schedule:
+    - cron: '0 6 * * *'
 
 env:
   IMAGE_NAME: nearaidev/ironclaw
@@ -33,6 +36,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event_name == 'schedule' && 'staging' || '' }}
 
       - name: Extract version from Cargo.toml
         id: version
@@ -54,6 +59,12 @@ jobs:
             TAGS="${TAGS},${{ env.IMAGE_NAME }}:${SHA}"
             WORKER_TAGS="${{ env.WORKER_IMAGE_NAME }}:${VERSION}"
             WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:latest"
+            WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:${SHA}"
+          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+            # Daily staging: :staging + :sha-xxx
+            TAGS="${{ env.IMAGE_NAME }}:staging"
+            TAGS="${TAGS},${{ env.IMAGE_NAME }}:${SHA}"
+            WORKER_TAGS="${{ env.WORKER_IMAGE_NAME }}:staging"
             WORKER_TAGS="${WORKER_TAGS},${{ env.WORKER_IMAGE_NAME }}:${SHA}"
           else
             # Manual dispatch: :sha-xxx only

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,23 +1,17 @@
-# Multi-stage Dockerfile for the IronClaw worker container.
+# IronClaw worker (sandbox) container.
 #
-# This image runs the ironclaw binary in worker mode inside Docker containers.
+# Runs the ironclaw binary in worker mode inside nested Docker containers.
 # The orchestrator creates instances of this image for sandboxed job execution.
+# Copies the binary from the base nearaidev/ironclaw image — no Rust compilation.
 #
 # Build:
-#   docker build -f Dockerfile.worker -t ironclaw-worker .
+#   docker build -f Dockerfile.worker --build-arg IRONCLAW_IMAGE=nearaidev/ironclaw:latest -t ironclaw-worker .
 #
 # The image includes common development tools so workers can build software,
 # run tests, and execute shell commands.
 
-FROM rust:1.92-bookworm AS builder
-
-WORKDIR /build
-COPY . .
-
-# Build only the ironclaw binary (release mode)
-RUN cargo build --release --bin ironclaw
-
-# ---
+ARG IRONCLAW_IMAGE=nearaidev/ironclaw:latest
+FROM ${IRONCLAW_IMAGE} AS ironclaw-bin
 
 FROM debian:bookworm-slim
 
@@ -52,8 +46,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 # Install Claude Code CLI (for claude-bridge mode)
 RUN npm install -g @anthropic-ai/claude-code@latest
 
-# Copy the binary
-COPY --from=builder /build/target/release/ironclaw /usr/local/bin/ironclaw
+# Copy the binary from the base ironclaw image
+COPY --from=ironclaw-bin /usr/local/bin/ironclaw /usr/local/bin/ironclaw
 
 # Create non-root user (UID 1000 matches the orchestrator's container config)
 RUN useradd -m -u 1000 -s /bin/bash sandbox \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,17 +1,23 @@
-# IronClaw worker (sandbox) container.
+# Multi-stage Dockerfile for the IronClaw worker container.
 #
-# Runs the ironclaw binary in worker mode inside nested Docker containers.
+# This image runs the ironclaw binary in worker mode inside Docker containers.
 # The orchestrator creates instances of this image for sandboxed job execution.
-# Copies the binary from the base nearaidev/ironclaw image — no Rust compilation.
 #
 # Build:
-#   docker build -f Dockerfile.worker --build-arg IRONCLAW_IMAGE=nearaidev/ironclaw:latest -t ironclaw-worker .
+#   docker build -f Dockerfile.worker -t ironclaw-worker .
 #
 # The image includes common development tools so workers can build software,
 # run tests, and execute shell commands.
 
-ARG IRONCLAW_IMAGE=nearaidev/ironclaw:latest
-FROM ${IRONCLAW_IMAGE} AS ironclaw-bin
+FROM rust:1.92-bookworm AS builder
+
+WORKDIR /build
+COPY . .
+
+# Build only the ironclaw binary (release mode)
+RUN cargo build --release --bin ironclaw
+
+# ---
 
 FROM debian:bookworm-slim
 
@@ -46,8 +52,8 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --de
 # Install Claude Code CLI (for claude-bridge mode)
 RUN npm install -g @anthropic-ai/claude-code@latest
 
-# Copy the binary from the base ironclaw image
-COPY --from=ironclaw-bin /usr/local/bin/ironclaw /usr/local/bin/ironclaw
+# Copy the binary
+COPY --from=builder /build/target/release/ironclaw /usr/local/bin/ironclaw
 
 # Create non-root user (UID 1000 matches the orchestrator's container config)
 RUN useradd -m -u 1000 -s /bin/bash sandbox \


### PR DESCRIPTION
## Summary

- Build and push `nearaidev/ironclaw-worker` from `Dockerfile.worker` in the same Docker workflow
- Both images share the same tag scheme: `:version`, `:latest`, `:sha-xxx`, and manual override tags
- Separate GHA cache scope (`worker`) to avoid cache collisions with the main image

This lets `ironclaw-dind` pull `nearaidev/ironclaw-worker:latest` for sandbox baking instead of cloning the repo and building from source each time.

## Test plan

- [ ] Run workflow_dispatch with a tag override — both images should be pushed
- [ ] Verify `nearaidev/ironclaw-worker` tags appear on Docker Hub
- [ ] Verify `ironclaw-dind` bake step can pull the worker image