### PR TITLE
[codex] Restore TUI approval modal on thread switch

### DIFF
--- a/crates/ironclaw_tui/src/app.rs
+++ b/crates/ironclaw_tui/src/app.rs
@@ -1245,13 +1245,21 @@ async fn handle_event(
         TuiEvent::ConversationHistory {
             thread_id,
             messages,
+            pending_approval,
         } => {
             state.messages.clear();
             state.active_tools.clear();
             state.recent_tools.clear();
             state.is_streaming = false;
             state.status_text.clear();
-            state.pending_approval = None;
+            state.pending_approval = pending_approval.map(|approval| ApprovalRequest {
+                request_id: approval.request_id,
+                tool_name: approval.tool_name,
+                description: approval.description,
+                parameters: approval.parameters,
+                allow_always: approval.allow_always,
+                selected: 0,
+            });
             state.suggestions.clear();
             for thread in &mut state.threads {
                 thread.is_foreground = thread.id == thread_id;
@@ -2241,7 +2249,7 @@ fn encode_rgba_to_png(rgba: &[u8], width: u32, height: u32) -> Option<Vec<u8>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::event::ThreadEntry;
+    use crate::event::{HistoryMessage, ThreadEntry};
     use crate::widgets::approval::ApprovalWidget;
     use crate::widgets::registry::create_default_widgets;
     use crate::widgets::thread_picker::ThreadPickerWidget;
@@ -2477,6 +2485,55 @@ mod tests {
         assert!(state.pending_approval.is_none());
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0].text, "n");
+    }
+
+    #[tokio::test]
+    async fn conversation_history_restores_pending_approval() {
+        let mut state = AppState {
+            pending_approval: Some(ApprovalRequest {
+                request_id: "stale".to_string(),
+                tool_name: "old-tool".to_string(),
+                description: "stale approval".to_string(),
+                parameters: serde_json::json!({"old": true}),
+                allow_always: false,
+                selected: 2,
+            }),
+            ..Default::default()
+        };
+
+        apply_event(
+            &mut state,
+            TuiEvent::ConversationHistory {
+                thread_id: "thread-1".to_string(),
+                messages: vec![HistoryMessage {
+                    role: "assistant".to_string(),
+                    content: "Waiting on approval".to_string(),
+                    timestamp: chrono::Utc::now(),
+                }],
+                pending_approval: Some(crate::event::HistoryApprovalRequest {
+                    request_id: "req-1".to_string(),
+                    tool_name: "shell".to_string(),
+                    description: "Run a command".to_string(),
+                    parameters: serde_json::json!({"command": "[REDACTED]"}),
+                    allow_always: true,
+                }),
+            },
+        )
+        .await;
+
+        let approval = state
+            .pending_approval
+            .as_ref()
+            .expect("pending approval should be restored");
+        assert_eq!(approval.request_id, "req-1");
+        assert_eq!(approval.tool_name, "shell");
+        assert_eq!(approval.description, "Run a command");
+        assert_eq!(
+            approval.parameters,
+            serde_json::json!({"command": "[REDACTED]"})
+        );
+        assert!(approval.allow_always);
+        assert_eq!(approval.selected, 0);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_tui/src/event.rs
+++ b/crates/ironclaw_tui/src/event.rs
@@ -103,6 +103,16 @@ pub struct HistoryMessage {
     pub timestamp: chrono::DateTime<chrono::Utc>,
 }
 
+/// A pending approval restored alongside conversation history.
+#[derive(Debug, Clone)]
+pub struct HistoryApprovalRequest {
+    pub request_id: String,
+    pub tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub allow_always: bool,
+}
+
 /// Events consumed by the TUI run loop.
 #[derive(Debug, Clone)]
 pub enum TuiEvent {
@@ -262,5 +272,6 @@ pub enum TuiEvent {
     ConversationHistory {
         thread_id: String,
         messages: Vec<HistoryMessage>,
+        pending_approval: Option<HistoryApprovalRequest>,
     },
 }

--- a/crates/ironclaw_tui/src/lib.rs
+++ b/crates/ironclaw_tui/src/lib.rs
@@ -41,7 +41,8 @@ pub mod widgets;
 
 pub use app::{TuiAppConfig, TuiAppHandle, start_tui};
 pub use event::{
-    HistoryMessage, ThreadEntry, TuiAttachment, TuiEvent, TuiLogEntry, TuiUserMessage,
+    HistoryApprovalRequest, HistoryMessage, ThreadEntry, TuiAttachment, TuiEvent, TuiLogEntry,
+    TuiUserMessage,
 };
 pub use layout::TuiLayout;
 pub use theme::Theme;

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -16,7 +16,7 @@ use crate::agent::dispatcher::{
 };
 use crate::agent::session::{MAX_PENDING_MESSAGES, PendingApproval, Session, ThreadState};
 use crate::agent::submission::SubmissionResult;
-use crate::channels::{IncomingMessage, StatusUpdate};
+use crate::channels::{ChatApprovalPrompt, HistoryMessage, IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
 use crate::error::Error;
 use crate::llm::{ChatMessage, ToolCall};
@@ -29,6 +29,46 @@ fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     // Gateway-style channels send server-issued conversation UUIDs.
     // Unknown UUIDs should be rejected instead of silently creating a new thread.
     matches!(channel, "gateway" | "test")
+}
+
+fn history_messages_from_thread(thread: &crate::agent::session::Thread) -> Vec<HistoryMessage> {
+    let mut messages = Vec::new();
+
+    for turn in &thread.turns {
+        if !turn.user_input.is_empty() {
+            messages.push(HistoryMessage {
+                role: "user".to_string(),
+                content: turn.user_input.clone(),
+                timestamp: turn.started_at,
+            });
+        }
+
+        if let Some(response) = turn.response.as_ref() {
+            messages.push(HistoryMessage {
+                role: "assistant".to_string(),
+                content: response.clone(),
+                timestamp: turn.completed_at.unwrap_or(turn.started_at),
+            });
+        }
+    }
+
+    messages
+}
+
+fn approval_prompt_from_pending(pending: &PendingApproval) -> ChatApprovalPrompt {
+    let parameters = if pending.display_parameters.is_null() {
+        pending.parameters.clone()
+    } else {
+        pending.display_parameters.clone()
+    };
+
+    ChatApprovalPrompt {
+        request_id: pending.request_id.to_string(),
+        tool_name: pending.tool_name.clone(),
+        description: pending.description.clone(),
+        parameters,
+        allow_always: pending.allow_always,
+    }
 }
 
 impl Agent {
@@ -1848,9 +1888,39 @@ impl Agent {
             .session_manager
             .get_or_create_session(&message.user_id)
             .await;
-        let mut sess = session.lock().await;
+        let (switched, messages, pending_approval) = {
+            let mut sess = session.lock().await;
+            if sess.switch_thread(target_thread_id) {
+                let history = sess
+                    .threads
+                    .get(&target_thread_id)
+                    .map(history_messages_from_thread)
+                    .unwrap_or_default();
+                let pending_approval = sess
+                    .threads
+                    .get(&target_thread_id)
+                    .and_then(|thread| thread.pending_approval.as_ref())
+                    .map(approval_prompt_from_pending);
+                (true, history, pending_approval)
+            } else {
+                (false, Vec::new(), None)
+            }
+        };
 
-        if sess.switch_thread(target_thread_id) {
+        if switched {
+            let _ = self
+                .channels
+                .send_status(
+                    &message.channel,
+                    StatusUpdate::ConversationHistory {
+                        thread_id: target_thread_id.to_string(),
+                        messages,
+                        pending_approval,
+                    },
+                    &message.metadata,
+                )
+                .await;
+
             Ok(SubmissionResult::ok_with_message(format!(
                 "Switched to thread {}",
                 target_thread_id
@@ -1987,6 +2057,19 @@ fn rebuild_chat_messages_from_db(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use crate::agent::AgentDeps;
+    use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+    use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
+    use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
+    use crate::context::ContextManager;
+    use crate::hooks::HookRegistry;
+    use crate::testing::{StubChannel, StubLlm};
+    use crate::tools::ToolRegistry;
+    use ironclaw_safety::SafetyLayer;
 
     #[test]
     fn test_rebuild_chat_messages_user_assistant_only() {
@@ -2158,6 +2241,77 @@ mod tests {
         }
     }
 
+    async fn make_test_agent_with_status_channel(
+        channel_name: &str,
+    ) -> (Agent, Arc<StdMutex<Vec<StatusUpdate>>>) {
+        let (stub, _sender) = StubChannel::new(channel_name);
+        let statuses = stub.captured_statuses_handle();
+        let manager = ChannelManager::new();
+        manager.add(Box::new(stub)).await;
+
+        let deps = AgentDeps {
+            owner_id: "default".to_string(),
+            store: None,
+            llm: Arc::new(StubLlm::default()),
+            cheap_llm: None,
+            safety: Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 100_000,
+                injection_check_enabled: false,
+            })),
+            tools: Arc::new(ToolRegistry::new()),
+            workspace: None,
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: SkillsConfig::default(),
+            hooks: Arc::new(HookRegistry::new()),
+            cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
+            sse_tx: None,
+            http_interceptor: None,
+            transcription: None,
+            document_extraction: None,
+            sandbox_readiness: crate::agent::routine_engine::SandboxReadiness::DisabledByConfig,
+            builder: None,
+            llm_backend: "nearai".to_string(),
+            tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(4, 3)),
+        };
+
+        let agent = Agent::new(
+            AgentConfig {
+                name: "test-agent".to_string(),
+                max_parallel_jobs: 1,
+                job_timeout: Duration::from_secs(60),
+                stuck_threshold: Duration::from_secs(60),
+                repair_check_interval: Duration::from_secs(30),
+                max_repair_attempts: 1,
+                use_planning: false,
+                session_idle_timeout: Duration::from_secs(300),
+                allow_local_tools: false,
+                max_cost_per_day_cents: None,
+                max_actions_per_hour: None,
+                max_cost_per_user_per_day_cents: None,
+                max_tool_iterations: 50,
+                auto_approve_tools: false,
+                default_timezone: "UTC".to_string(),
+                max_jobs_per_user: None,
+                max_tokens_per_job: 0,
+                multi_tenant: false,
+                max_llm_concurrent_per_user: None,
+                max_jobs_concurrent_per_user: None,
+                engine_v2: false,
+            },
+            deps,
+            Arc::new(manager),
+            None,
+            None,
+            None,
+            Some(Arc::new(ContextManager::new(1))),
+            None,
+        );
+
+        (agent, statuses)
+    }
+
     #[tokio::test]
     async fn test_awaiting_approval_rejection_includes_tool_context() {
         // Test that when a thread is in AwaitingApproval state and receives a new message,
@@ -2228,6 +2382,84 @@ mod tests {
             }
             _ => panic!("Expected approval rejection message"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_switch_thread_emits_history_with_pending_approval() {
+        use crate::agent::session::{PendingApproval, Thread};
+        use uuid::Uuid;
+
+        let (agent, statuses) = make_test_agent_with_status_channel("tui").await;
+        let session = agent
+            .session_manager
+            .get_or_create_session("test-user")
+            .await;
+        let session_id = session.lock().await.id;
+
+        let other_thread_id = Uuid::new_v4();
+        let target_thread_id = Uuid::new_v4();
+        let mut target_thread = Thread::with_id(target_thread_id, session_id, Some("tui"));
+        target_thread.start_turn("Review the diff");
+        target_thread.complete_turn("Waiting for approval.");
+        target_thread.await_approval(PendingApproval {
+            request_id: Uuid::new_v4(),
+            tool_name: "shell".to_string(),
+            parameters: serde_json::json!({"command": "echo hello"}),
+            display_parameters: serde_json::json!({"command": "[REDACTED]"}),
+            description: "Execute: echo hello".to_string(),
+            tool_call_id: "call_0".to_string(),
+            context_messages: vec![],
+            deferred_tool_calls: vec![],
+            user_timezone: None,
+            allow_always: true,
+        });
+
+        {
+            let mut sess = session.lock().await;
+            sess.threads.insert(
+                other_thread_id,
+                Thread::with_id(other_thread_id, session_id, Some("tui")),
+            );
+            sess.threads.insert(target_thread_id, target_thread);
+            sess.active_thread = Some(other_thread_id);
+        }
+
+        let message =
+            IncomingMessage::new("tui", "test-user", format!("/thread {target_thread_id}"));
+        let result = agent
+            .process_switch_thread(&message, target_thread_id)
+            .await
+            .expect("switch thread");
+
+        match result {
+            crate::agent::submission::SubmissionResult::Ok {
+                message: Some(text),
+            } => assert!(text.contains(&target_thread_id.to_string())),
+            other => panic!("expected ok switch-thread result, got {other:?}"),
+        }
+
+        let statuses = statuses.lock().expect("poisoned").clone();
+        assert!(
+            statuses.iter().any(|status| matches!(
+                status,
+                StatusUpdate::ConversationHistory {
+                    thread_id,
+                    messages,
+                    pending_approval,
+                } if thread_id == &target_thread_id.to_string()
+                    && messages.len() == 2
+                    && messages[0].role == "user"
+                    && messages[0].content == "Review the diff"
+                    && messages[1].role == "assistant"
+                    && messages[1].content == "Waiting for approval."
+                    && pending_approval
+                        .as_ref()
+                        .is_some_and(|approval| approval.tool_name == "shell"
+                            && approval.parameters == serde_json::json!({"command": "[REDACTED]"})
+                            && approval.allow_always)
+            )),
+            "expected conversation history status with pending approval, got: {statuses:?}"
+        );
     }
 
     #[test]

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -410,6 +410,7 @@ pub enum StatusUpdate {
     ConversationHistory {
         thread_id: String,
         messages: Vec<HistoryMessage>,
+        pending_approval: Option<ChatApprovalPrompt>,
     },
 }
 

--- a/src/channels/tui.rs
+++ b/src/channels/tui.rs
@@ -499,6 +499,7 @@ impl Channel for TuiChannel {
             StatusUpdate::ConversationHistory {
                 thread_id,
                 messages,
+                pending_approval,
             } => TuiEvent::ConversationHistory {
                 thread_id,
                 messages: messages
@@ -509,6 +510,15 @@ impl Channel for TuiChannel {
                         timestamp: m.timestamp,
                     })
                     .collect(),
+                pending_approval: pending_approval.map(|approval| {
+                    ironclaw_tui::HistoryApprovalRequest {
+                        request_id: approval.request_id,
+                        tool_name: approval.tool_name,
+                        description: approval.description,
+                        parameters: approval.parameters,
+                        allow_always: approval.allow_always,
+                    }
+                }),
             },
             StatusUpdate::SkillActivated { .. } | StatusUpdate::ImageGenerated { .. } => {
                 return Ok(());


### PR DESCRIPTION
## Summary
Restores pending approval state when the TUI reloads a thread via conversation history.

## Root cause
The TUI could render live `ApprovalNeeded` events, but the thread-history hydration path cleared `pending_approval` and had no way to restore it. In addition, `process_switch_thread()` did not emit any `ConversationHistory` status for the TUI to hydrate from.

## What changed
- Extended `StatusUpdate::ConversationHistory` with optional pending approval payload.
- Extended the TUI history event with a hydrated approval payload.
- Updated the TUI history handler to restore the approval modal from that payload.
- Emitted `ConversationHistory` from `process_switch_thread()` including redacted pending approval details.
- Added regression tests for both the runtime emission and the TUI hydration.

## Impact
Switching to a thread that is waiting on approval now restores the modal in the terminal UI instead of dropping the approval state on the floor.

## Validation
- `cargo fmt --all`
- `cargo check --features tui --bin ironclaw`
- `cargo test conversation_history_restores_pending_approval -p ironclaw_tui`
- `cargo test test_switch_thread_emits_history_with_pending_approval --lib`

Refs #1983
Stacked on #1973.