### PR TITLE
[codex] Re-emit pending approval events on follow-up messages

### DIFF
--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -25,6 +25,33 @@ use ironclaw_common::truncate_preview;
 
 const FORGED_THREAD_ID_ERROR: &str = "Invalid or unauthorized thread ID.";
 
+#[derive(Clone)]
+struct PendingApprovalStatusSnapshot {
+    request_id: String,
+    tool_name: String,
+    description: String,
+    parameters: serde_json::Value,
+    allow_always: bool,
+}
+
+impl From<&PendingApproval> for PendingApprovalStatusSnapshot {
+    fn from(pending: &PendingApproval) -> Self {
+        let parameters = if pending.display_parameters.is_null() {
+            pending.parameters.clone()
+        } else {
+            pending.display_parameters.clone()
+        };
+
+        Self {
+            request_id: pending.request_id.to_string(),
+            tool_name: pending.tool_name.clone(),
+            description: pending.description.clone(),
+            parameters,
+            allow_always: pending.allow_always,
+        }
+    }
+}
+
 fn requires_preexisting_uuid_thread(channel: &str) -> bool {
     // Gateway-style channels send server-issued conversation UUIDs.
     // Unknown UUIDs should be rejected instead of silently creating a new thread.
@@ -227,7 +254,7 @@ impl Agent {
         );
 
         // First check thread state without holding lock during I/O
-        let (thread_state, approval_context) = {
+        let (thread_state, approval_context, approval_status) = {
             let sess = session.lock().await;
             let thread = sess
                 .threads
@@ -238,7 +265,11 @@ impl Agent {
                     crate::agent::agent_loop::truncate_for_preview(&a.description, 80);
                 (a.tool_name.clone(), desc_preview)
             });
-            (thread.state, approval_context)
+            let approval_status = thread
+                .pending_approval
+                .as_ref()
+                .map(PendingApprovalStatusSnapshot::from);
+            (thread.state, approval_context, approval_status)
         };
 
         tracing::debug!(
@@ -324,6 +355,22 @@ impl Agent {
                     thread_id = %thread_id,
                     "Thread awaiting approval, rejecting new input"
                 );
+                if let Some(ref pending) = approval_status {
+                    let _ = self
+                        .channels
+                        .send_status(
+                            &message.channel,
+                            StatusUpdate::ApprovalNeeded {
+                                request_id: pending.request_id.clone(),
+                                tool_name: pending.tool_name.clone(),
+                                description: pending.description.clone(),
+                                parameters: pending.parameters.clone(),
+                                allow_always: pending.allow_always,
+                            },
+                            &message.metadata,
+                        )
+                        .await;
+                }
                 let msg = match approval_context {
                     Some((tool_name, desc_preview)) => format!(
                         "Waiting for approval: {tool_name} — {desc_preview}. Use /interrupt to cancel."
@@ -2022,6 +2069,19 @@ fn rebuild_chat_messages_from_db(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
+
+    use crate::agent::AgentDeps;
+    use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+    use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
+    use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
+    use crate::context::ContextManager;
+    use crate::hooks::HookRegistry;
+    use crate::testing::{StubChannel, StubLlm};
+    use crate::tools::ToolRegistry;
+    use ironclaw_safety::SafetyLayer;
 
     #[test]
     fn test_rebuild_chat_messages_user_assistant_only() {
@@ -2193,6 +2253,77 @@ mod tests {
         }
     }
 
+    async fn make_test_agent_with_status_channel(
+        channel_name: &str,
+    ) -> (Agent, Arc<StdMutex<Vec<StatusUpdate>>>) {
+        let (stub, _sender) = StubChannel::new(channel_name);
+        let statuses = stub.captured_statuses_handle();
+        let manager = ChannelManager::new();
+        manager.add(Box::new(stub)).await;
+
+        let deps = AgentDeps {
+            owner_id: "default".to_string(),
+            store: None,
+            llm: Arc::new(StubLlm::default()),
+            cheap_llm: None,
+            safety: Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 100_000,
+                injection_check_enabled: false,
+            })),
+            tools: Arc::new(ToolRegistry::new()),
+            workspace: None,
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: SkillsConfig::default(),
+            hooks: Arc::new(HookRegistry::new()),
+            cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
+            sse_tx: None,
+            http_interceptor: None,
+            transcription: None,
+            document_extraction: None,
+            sandbox_readiness: crate::agent::routine_engine::SandboxReadiness::DisabledByConfig,
+            builder: None,
+            llm_backend: "nearai".to_string(),
+            tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(4, 3)),
+        };
+
+        let agent = Agent::new(
+            AgentConfig {
+                name: "test-agent".to_string(),
+                max_parallel_jobs: 1,
+                job_timeout: Duration::from_secs(60),
+                stuck_threshold: Duration::from_secs(60),
+                repair_check_interval: Duration::from_secs(30),
+                max_repair_attempts: 1,
+                use_planning: false,
+                session_idle_timeout: Duration::from_secs(300),
+                allow_local_tools: false,
+                max_cost_per_day_cents: None,
+                max_actions_per_hour: None,
+                max_cost_per_user_per_day_cents: None,
+                max_tool_iterations: 50,
+                auto_approve_tools: false,
+                default_timezone: "UTC".to_string(),
+                max_jobs_per_user: None,
+                max_tokens_per_job: 0,
+                multi_tenant: false,
+                max_llm_concurrent_per_user: None,
+                max_jobs_concurrent_per_user: None,
+                engine_v2: false,
+            },
+            deps,
+            Arc::new(manager),
+            None,
+            None,
+            None,
+            Some(Arc::new(ContextManager::new(1))),
+            None,
+        );
+
+        (agent, statuses)
+    }
+
     #[tokio::test]
     async fn test_awaiting_approval_rejection_includes_tool_context() {
         // Test that when a thread is in AwaitingApproval state and receives a new message,
@@ -2263,6 +2394,78 @@ mod tests {
             }
             _ => panic!("Expected approval rejection message"),
         }
+    }
+
+    #[tokio::test]
+    async fn test_awaiting_approval_reemits_status_for_followup_message() {
+        use crate::agent::session::{PendingApproval, Session, Thread};
+
+        let (agent, statuses) = make_test_agent_with_status_channel("tui").await;
+        let mut session = Session::new("test-user");
+        let thread_id = Uuid::new_v4();
+        let mut thread = Thread::with_id(thread_id, session.id, Some("tui"));
+
+        let pending = PendingApproval {
+            request_id: Uuid::new_v4(),
+            tool_name: "shell".to_string(),
+            parameters: serde_json::json!({"command": "echo secret"}),
+            display_parameters: serde_json::json!({"command": "[REDACTED]"}),
+            description: "Execute: echo secret".to_string(),
+            tool_call_id: "call_0".to_string(),
+            context_messages: vec![],
+            deferred_tool_calls: vec![],
+            user_timezone: None,
+            allow_always: true,
+        };
+        thread.await_approval(pending.clone());
+        session.threads.insert(thread_id, thread);
+
+        let session = Arc::new(Mutex::new(session));
+        let rate = agent.deps.tenant_rates.get_or_create("test-user").await;
+        let tenant = crate::tenant::TenantCtx::new(
+            "test-user",
+            None,
+            None,
+            Arc::clone(&agent.deps.cost_guard),
+            rate,
+        );
+        let message = IncomingMessage::new("tui", "test-user", "what now?");
+
+        let result = agent
+            .process_user_input(&message, tenant, session, thread_id, &message.content)
+            .await
+            .expect("process user input");
+
+        match result {
+            crate::agent::submission::SubmissionResult::Ok {
+                message: Some(text),
+            } => {
+                assert!(
+                    text.contains("Waiting for approval"),
+                    "expected waiting text, got: {text}"
+                );
+            }
+            other => panic!("expected pending ok result, got {other:?}"),
+        }
+
+        let statuses = statuses.lock().expect("poisoned").clone();
+        assert!(
+            statuses.iter().any(|status| matches!(
+                status,
+                StatusUpdate::ApprovalNeeded {
+                    request_id,
+                    tool_name,
+                    description,
+                    parameters,
+                    allow_always,
+                } if request_id == &pending.request_id.to_string()
+                    && tool_name == "shell"
+                    && description == "Execute: echo secret"
+                    && parameters == &serde_json::json!({"command": "[REDACTED]"})
+                    && *allow_always
+            )),
+            "expected approval status to be re-emitted, got: {statuses:?}"
+        );
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -51,6 +51,68 @@ fn gate_display_parameters(pending: &PendingGate) -> serde_json::Value {
         .unwrap_or_else(|| pending.parameters.clone())
 }
 
+async fn send_pending_gate_status(agent: &Agent, message: &IncomingMessage, pending: &PendingGate) {
+    let display_parameters = gate_display_parameters(pending);
+
+    match &pending.resume_kind {
+        ironclaw_engine::ResumeKind::Approval { allow_always } => {
+            let _ = agent
+                .channels
+                .send_status(
+                    &message.channel,
+                    StatusUpdate::ApprovalNeeded {
+                        request_id: pending.request_id.to_string(),
+                        tool_name: pending.action_name.clone(),
+                        description: pending.description.clone(),
+                        parameters: display_parameters,
+                        allow_always: *allow_always,
+                    },
+                    &message.metadata,
+                )
+                .await;
+        }
+        ironclaw_engine::ResumeKind::Authentication {
+            credential_name,
+            instructions,
+            auth_url,
+        } => {
+            let _ = agent
+                .channels
+                .send_status(
+                    &message.channel,
+                    StatusUpdate::AuthRequired {
+                        extension_name: credential_name.clone(),
+                        instructions: Some(instructions.clone()),
+                        auth_url: auth_url.clone(),
+                        setup_url: None,
+                    },
+                    &message.metadata,
+                )
+                .await;
+        }
+        ironclaw_engine::ResumeKind::External { .. } => {}
+    }
+}
+
+fn pending_gate_prompt_message(pending: &PendingGate) -> Option<String> {
+    match &pending.resume_kind {
+        ironclaw_engine::ResumeKind::Approval { .. } => Some(format!(
+            "Tool '{}' requires approval. Reply 'yes' to approve, 'no' to deny.",
+            pending.action_name
+        )),
+        ironclaw_engine::ResumeKind::Authentication {
+            credential_name, ..
+        } => Some(format!(
+            "Authentication required for '{}'. Paste your token below (or type 'cancel'):",
+            credential_name
+        )),
+        ironclaw_engine::ResumeKind::External { .. } => Some(format!(
+            "Waiting for external confirmation (gate: {})...",
+            pending.gate_name
+        )),
+    }
+}
+
 fn resumed_action_result_message(
     action_name: &str,
     output: &serde_json::Value,
@@ -93,64 +155,16 @@ async fn insert_and_notify_pending_gate(
         );
     }
 
-    match &pending.resume_kind {
-        ironclaw_engine::ResumeKind::Approval { allow_always } => {
-            let _ = agent
-                .channels
-                .send_status(
-                    &message.channel,
-                    StatusUpdate::ApprovalNeeded {
-                        request_id: pending.request_id.to_string(),
-                        tool_name: pending.action_name.clone(),
-                        description: pending.description.clone(),
-                        parameters: display_parameters,
-                        allow_always: *allow_always,
-                    },
-                    &message.metadata,
-                )
-                .await;
-
-            Ok(Some(format!(
-                "Tool '{}' requires approval. Reply 'yes' to approve, 'no' to deny.",
-                pending.action_name
-            )))
-        }
-        ironclaw_engine::ResumeKind::Authentication {
-            credential_name,
-            instructions,
-            auth_url,
-        } => {
-            let _ = agent
-                .channels
-                .send_status(
-                    &message.channel,
-                    StatusUpdate::AuthRequired {
-                        extension_name: credential_name.clone(),
-                        instructions: Some(instructions.clone()),
-                        auth_url: auth_url.clone(),
-                        setup_url: None,
-                    },
-                    &message.metadata,
-                )
-                .await;
-
-            Ok(Some(format!(
-                "Authentication required for '{}'. Paste your token below (or type 'cancel'):",
-                credential_name
-            )))
-        }
-        ironclaw_engine::ResumeKind::External { callback_id } => {
-            tracing::debug!(
-                gate = %pending.gate_name,
-                callback = %callback_id,
-                "GatePaused(External)"
-            );
-            Ok(Some(format!(
-                "Waiting for external confirmation (gate: {})...",
-                pending.gate_name
-            )))
-        }
+    if let ironclaw_engine::ResumeKind::External { callback_id } = &pending.resume_kind {
+        tracing::debug!(
+            gate = %pending.gate_name,
+            callback = %callback_id,
+            "GatePaused(External)"
+        );
     }
+
+    send_pending_gate_status(agent, message, &pending).await;
+    Ok(pending_gate_prompt_message(&pending))
 }
 
 async fn execute_pending_gate_action(
@@ -1858,33 +1872,42 @@ async fn handle_with_engine_inner(
     let thread_scope = message.conversation_scope();
     let scoped_thread_id = parse_engine_thread_id(thread_scope);
 
-    if let PendingGateResolution::Resolved(gate) =
-        resolve_pending_gate_for_user(&state.pending_gates, &message.user_id, thread_scope).await
-        && matches!(
-            gate.resume_kind,
-            ironclaw_engine::ResumeKind::Authentication { .. }
-        )
+    match resolve_pending_gate_for_user(&state.pending_gates, &message.user_id, thread_scope).await
     {
-        let request_id = gate.request_id;
-        let resolution =
-            if content.trim().is_empty() || content.trim().eq_ignore_ascii_case("cancel") {
-                ironclaw_engine::GateResolution::Cancelled
-            } else {
-                ironclaw_engine::GateResolution::CredentialProvided {
-                    token: content.trim().to_string(),
-                }
-            };
-        drop(guard);
-        return resolve_gate(agent, message, gate.thread_id, request_id, resolution).await;
-    }
-
-    if matches!(
-        resolve_pending_gate_for_user(&state.pending_gates, &message.user_id, thread_scope).await,
-        PendingGateResolution::Ambiguous
-    ) {
-        return Ok(Some(
-            "Multiple authentication prompts are waiting. Reply from the original thread.".into(),
-        ));
+        PendingGateResolution::Resolved(gate)
+            if matches!(
+                gate.resume_kind,
+                ironclaw_engine::ResumeKind::Authentication { .. }
+            ) =>
+        {
+            let request_id = gate.request_id;
+            let resolution =
+                if content.trim().is_empty() || content.trim().eq_ignore_ascii_case("cancel") {
+                    ironclaw_engine::GateResolution::Cancelled
+                } else {
+                    ironclaw_engine::GateResolution::CredentialProvided {
+                        token: content.trim().to_string(),
+                    }
+                };
+            drop(guard);
+            return resolve_gate(agent, message, gate.thread_id, request_id, resolution).await;
+        }
+        PendingGateResolution::Resolved(gate)
+            if matches!(
+                gate.resume_kind,
+                ironclaw_engine::ResumeKind::Approval { .. }
+            ) =>
+        {
+            drop(guard);
+            send_pending_gate_status(agent, message, &gate).await;
+            return Ok(pending_gate_prompt_message(&gate));
+        }
+        PendingGateResolution::Ambiguous => {
+            return Ok(Some(
+                "Multiple pending gates are waiting. Reply from the original thread.".into(),
+            ));
+        }
+        PendingGateResolution::Resolved(_) | PendingGateResolution::None => {}
     }
 
     if let Some(thread_id) = scoped_thread_id
@@ -3266,9 +3289,22 @@ async fn migrate_legacy_user_ids(store: &Arc<dyn ironclaw_engine::Store>, owner_
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     use std::sync::LazyLock;
+    use std::sync::Mutex as StdMutex;
+    use std::time::Duration;
     use tokio::sync::Mutex as TokioMutex;
     use tokio::sync::RwLock as TokioRwLock;
+
+    use crate::agent::AgentDeps;
+    use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
+    use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
+    use crate::config::{AgentConfig, SafetyConfig, SkillsConfig};
+    use crate::context::ContextManager;
+    use crate::hooks::HookRegistry;
+    use crate::testing::{StubChannel, StubLlm};
+    use crate::tools::ToolRegistry;
+    use ironclaw_safety::SafetyLayer;
 
     static ENGINE_STATE_TEST_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
 
@@ -3754,6 +3790,141 @@ mod tests {
             secrets_store: None,
             auth_manager: None,
         }
+    }
+
+    async fn make_test_agent_with_status_channel(
+        channel_name: &str,
+    ) -> (Agent, Arc<StdMutex<Vec<StatusUpdate>>>) {
+        let (stub, _sender) = StubChannel::new(channel_name);
+        let statuses = stub.captured_statuses_handle();
+        let manager = ChannelManager::new();
+        manager.add(Box::new(stub)).await;
+
+        let deps = AgentDeps {
+            owner_id: "default".to_string(),
+            store: None,
+            llm: Arc::new(StubLlm::default()),
+            cheap_llm: None,
+            safety: Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 100_000,
+                injection_check_enabled: false,
+            })),
+            tools: Arc::new(ToolRegistry::new()),
+            workspace: None,
+            extension_manager: None,
+            skill_registry: None,
+            skill_catalog: None,
+            skills_config: SkillsConfig::default(),
+            hooks: Arc::new(HookRegistry::new()),
+            cost_guard: Arc::new(CostGuard::new(CostGuardConfig::default())),
+            sse_tx: None,
+            http_interceptor: None,
+            transcription: None,
+            document_extraction: None,
+            sandbox_readiness: crate::agent::routine_engine::SandboxReadiness::DisabledByConfig,
+            builder: None,
+            llm_backend: "nearai".to_string(),
+            tenant_rates: Arc::new(crate::tenant::TenantRateRegistry::new(4, 3)),
+        };
+
+        let agent = Agent::new(
+            AgentConfig {
+                name: "test-agent".to_string(),
+                max_parallel_jobs: 1,
+                job_timeout: Duration::from_secs(60),
+                stuck_threshold: Duration::from_secs(60),
+                repair_check_interval: Duration::from_secs(30),
+                max_repair_attempts: 1,
+                use_planning: false,
+                session_idle_timeout: Duration::from_secs(300),
+                allow_local_tools: false,
+                max_cost_per_day_cents: None,
+                max_actions_per_hour: None,
+                max_cost_per_user_per_day_cents: None,
+                max_tool_iterations: 50,
+                auto_approve_tools: false,
+                default_timezone: "UTC".to_string(),
+                max_jobs_per_user: None,
+                max_tokens_per_job: 0,
+                multi_tenant: false,
+                max_llm_concurrent_per_user: None,
+                max_jobs_concurrent_per_user: None,
+                engine_v2: true,
+            },
+            deps,
+            Arc::new(manager),
+            None,
+            None,
+            None,
+            Some(Arc::new(ContextManager::new(1))),
+            None,
+        );
+
+        (agent, statuses)
+    }
+
+    #[tokio::test]
+    async fn handle_with_engine_reemits_approval_status_for_pending_gate() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let state = make_expected_test_state(store);
+            let thread_id = ironclaw_engine::ThreadId::new();
+            let pending = sample_pending_gate(
+                "alice",
+                thread_id,
+                ironclaw_engine::ResumeKind::Approval { allow_always: true },
+            );
+            state
+                .pending_gates
+                .insert(pending.clone())
+                .await
+                .expect("insert pending gate");
+
+            *lock.write().await = Some(state);
+
+            let (agent, statuses) = make_test_agent_with_status_channel("tui").await;
+            let message = IncomingMessage::new("tui", "alice", "what now?")
+                .with_thread(thread_id.to_string());
+
+            let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
+                .await
+                .expect("handle with engine");
+
+            let text = result.expect("waiting message");
+            assert!(
+                text.contains("approval"),
+                "expected approval guidance, got: {text}"
+            );
+
+            let statuses = statuses.lock().expect("poisoned").clone();
+            assert!(
+                statuses.iter().any(|status| matches!(
+                    status,
+                    StatusUpdate::ApprovalNeeded {
+                        request_id,
+                        tool_name,
+                        description,
+                        parameters,
+                        allow_always,
+                    } if request_id == &pending.request_id.to_string()
+                        && tool_name == "shell"
+                        && description == "pending gate"
+                        && parameters == &serde_json::json!({"cmd": "ls"})
+                        && *allow_always
+                )),
+                "expected approval status to be re-emitted, got: {statuses:?}"
+            );
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("router approval re-emit test");
     }
 
     /// find_most_recent_thread returns the active thread when one exists.


### PR DESCRIPTION
## Summary
- re-emit `ApprovalNeeded` for classic threads that are already awaiting approval when a user sends a follow-up message
- re-surface pending approval gates in the engine-v2 router instead of falling through into normal message handling
- add regression coverage for both the classic thread path and the engine-v2 pending-gate path

## Root Cause
Pending approval state was being preserved internally, but a follow-up user message did not always re-send the gate status event. In practice that meant the TUI never got another `ApprovalNeeded` signal, so the approval modal could disappear even though the gate was still pending.

## Testing
- `cargo fmt --all`
- `cargo test test_awaiting_approval_reemits_status_for_followup_message --lib`
- `cargo test handle_with_engine_reemits_approval_status_for_pending_gate --lib`
- `cargo check --features tui --bin ironclaw`
- `git diff --check`

Refs #1985