### PR TITLE
fix(cli): char-boundary-safe truncation for MCP tool descriptions

### DIFF
--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -125,13 +125,17 @@ pub enum McpCommand {
     },
 }
 
-/// Truncate a string to fit within `max_len` characters, appending "..." if truncated.
-/// Uses `str::floor_char_boundary` to avoid panicking on multi-byte UTF-8.
+/// Truncate a string to fit within `max_len` UTF-8 bytes, appending "..." if truncated.
+/// Uses `crate::util::floor_char_boundary` to avoid splitting multi-byte characters.
 fn truncate_description(s: &str, max_len: usize) -> String {
     if s.len() <= max_len {
         return s.to_string();
     }
-    let boundary = s.floor_char_boundary(max_len.saturating_sub(3));
+    if max_len < 3 {
+        let boundary = crate::util::floor_char_boundary(s, max_len);
+        return s[..boundary].to_string();
+    }
+    let boundary = crate::util::floor_char_boundary(s, max_len - 3);
     format!("{}...", &s[..boundary])
 }
 
@@ -759,7 +763,8 @@ mod tests {
         let desc = "Tool: 这个工具用于处理中文文本数据并生成报告结果";
         let result = truncate_description(desc, 60);
         assert!(result.ends_with("..."));
-        // Must not panic and must be valid UTF-8
-        assert!(result.is_char_boundary(0));
+        assert!(result.len() <= 60);
+        let prefix = result.strip_suffix("...").unwrap();
+        assert!(desc.is_char_boundary(prefix.len()));
     }
 }

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -125,6 +125,16 @@ pub enum McpCommand {
     },
 }
 
+/// Truncate a string to fit within `max_len` characters, appending "..." if truncated.
+/// Uses `str::floor_char_boundary` to avoid panicking on multi-byte UTF-8.
+fn truncate_description(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        return s.to_string();
+    }
+    let boundary = s.floor_char_boundary(max_len.saturating_sub(3));
+    format!("{}...", &s[..boundary])
+}
+
 fn parse_header(s: &str) -> Result<(String, String), String> {
     let pos = s
         .find(':')
@@ -537,12 +547,7 @@ async fn test_server(name: String, user_id: String) -> anyhow::Result<()> {
                         };
                         println!("    • {}{}", tool.name, approval);
                         if !tool.description.is_empty() {
-                            // Truncate long descriptions
-                            let desc = if tool.description.len() > 60 {
-                                format!("{}...", &tool.description[..57])
-                            } else {
-                                tool.description.clone()
-                            };
+                            let desc = truncate_description(&tool.description, 60);
                             println!("      {}", desc);
                         }
                     }
@@ -700,5 +705,61 @@ mod tests {
         let result = parse_env_var("no-equals-here");
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("invalid env var format"));
+    }
+
+    #[test]
+    fn test_truncate_description_ascii_short() {
+        let desc = "A short description";
+        assert_eq!(truncate_description(desc, 60), "A short description");
+    }
+
+    #[test]
+    fn test_truncate_description_ascii_exact() {
+        let desc = "a".repeat(60);
+        assert_eq!(truncate_description(&desc, 60), desc);
+    }
+
+    #[test]
+    fn test_truncate_description_ascii_long() {
+        let desc = "a".repeat(80);
+        let result = truncate_description(&desc, 60);
+        assert!(result.ends_with("..."));
+        assert!(result.len() <= 60);
+        assert_eq!(result, format!("{}...", "a".repeat(57)));
+    }
+
+    #[test]
+    fn test_truncate_description_empty() {
+        assert_eq!(truncate_description("", 60), "");
+    }
+
+    #[test]
+    fn test_truncate_description_multibyte_cjk() {
+        // Each CJK character is 3 bytes; 25 chars = 75 bytes, exceeds 60
+        let desc = "中".repeat(25);
+        let result = truncate_description(&desc, 60);
+        assert!(result.ends_with("..."));
+        // 57 bytes / 3 bytes per char = 19 CJK chars fit
+        assert_eq!(result, format!("{}...", "中".repeat(19)));
+    }
+
+    #[test]
+    fn test_truncate_description_emoji() {
+        // Each emoji is 4 bytes; 20 emojis = 80 bytes, exceeds 60
+        let desc = "🦀".repeat(20);
+        let result = truncate_description(&desc, 60);
+        assert!(result.ends_with("..."));
+        // 57 bytes / 4 bytes per emoji = 14 emojis fit (56 bytes)
+        assert_eq!(result, format!("{}...", "🦀".repeat(14)));
+    }
+
+    #[test]
+    fn test_truncate_description_mixed_multibyte() {
+        // Mix of ASCII and multi-byte that would panic with byte slicing
+        let desc = "Tool: 这个工具用于处理中文文本数据并生成报告结果";
+        let result = truncate_description(desc, 60);
+        assert!(result.ends_with("..."));
+        // Must not panic and must be valid UTF-8
+        assert!(result.is_char_boundary(0));
     }
 }


### PR DESCRIPTION
## Summary

- Replace byte-index slicing (`&tool.description[..57]`) with `str::floor_char_boundary()` to prevent panics when MCP tool descriptions contain multi-byte UTF-8 characters (CJK, emoji, accented chars)
- Extract `truncate_description()` helper for reusable, safe string truncation with `...` suffix
- Add 7 unit tests covering ASCII, CJK, emoji, mixed multi-byte, empty string, and boundary-length edge cases

Closes #1947

## Test plan

- [x] `cargo fmt` -- no formatting issues
- [x] `cargo clippy --all --benches --tests --examples --all-features` -- zero warnings
- [x] `cargo test -p ironclaw --lib cli::mcp::tests` -- all 14 tests pass (7 existing + 7 new)
- [x] New tests verify: ASCII short/exact/long, empty string, CJK (3-byte chars), emoji (4-byte chars), and mixed multi-byte strings all truncate without panicking
- [x] Verified the 2 pre-existing test failures in `tools::mcp::auth::tests` are unrelated (test ordering issue, pass in isolation)