### PR TITLE
fix(self-repair): skip built-in tools in broken tool detection and repair

### DIFF
--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -18,7 +18,8 @@ See `src/db/CLAUDE.md` for full schema, dialect differences, and libSQL limitati
 4. Implement in `src/db/libsql/<module>.rs` (use `self.connect().await?` per operation)
 5. Add migration if needed:
    - PostgreSQL: new `migrations/VN__description.sql`
-   - libSQL: add `CREATE TABLE IF NOT EXISTS` to `libsql_migrations.rs`
+   - libSQL: add entry to `INCREMENTAL_MIGRATIONS` in `libsql_migrations.rs`
+   - **Version numbering**: always number after the highest version on `staging`/`main` — those migrations may already be in production. Check with `git ls-tree origin/staging migrations/` and staging's `INCREMENTAL_MIGRATIONS`. Never reuse or insert before an existing version.
 6. Test feature isolation:
    ```bash
    cargo check                                          # postgres (default)

--- a/.env.example
+++ b/.env.example
@@ -191,10 +191,9 @@ HEARTBEAT_NOTIFY_CHANNEL=cli
 HEARTBEAT_NOTIFY_USER=default
 
 # Memory hygiene settings (automatic cleanup of stale workspace documents)
-# Runs on each heartbeat tick; identity files (IDENTITY.md, SOUL.md) are never deleted
+# Runs on each heartbeat tick; discovers cleanup targets from .config metadata
 # MEMORY_HYGIENE_ENABLED=true
-# MEMORY_HYGIENE_DAILY_RETENTION_DAYS=30         # delete daily/ docs older than this many days
-# MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS=7   # delete conversations/ docs older than this many days
+# MEMORY_HYGIENE_VERSION_KEEP_COUNT=50           # max versions to keep per document
 # MEMORY_HYGIENE_CADENCE_HOURS=12                # minimum hours between cleanup passes
 
 # Docker Sandbox

--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,12 @@ HEARTBEAT_NOTIFY_USER=default
 # SANDBOX_TIMEOUT_SECS=120
 # SANDBOX_MEMORY_LIMIT_MB=2048
 
+# ACP (Agent Client Protocol) agents
+# ACP_ENABLED=false                       # Enable ACP agent sandbox mode
+# ACP_MEMORY_LIMIT_MB=4096               # Memory limit for ACP containers
+# ACP_TIMEOUT_SECS=1800                  # Maximum session timeout
+# Configure agents via CLI: ironclaw acp add goose --command goose --arg "--stdio"
+
 # Safety settings
 SAFETY_MAX_OUTPUT_LENGTH=100000
 SAFETY_INJECTION_CHECK_ENABLED=true

--- a/.env.example
+++ b/.env.example
@@ -225,5 +225,63 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # IRONCLAW_RESTART_DELAY=5          # default wait before exit (seconds, range: 1-30)
 # IRONCLAW_MAX_FAILURES=10          # max consecutive failures before container exits
 
+# ─── OAuth / Social Login ────────────────────────────────────────────────
+# Enable direct OAuth login (Google, GitHub). Disabled by default.
+# OAUTH_ENABLED=true
+
+# Base URL for OAuth callback URLs. Defaults to http://localhost:{GATEWAY_PORT}.
+# Set this to your public URL in production (e.g., https://myapp.example.com).
+# OAUTH_BASE_URL=https://myapp.example.com
+
+# Restrict OAuth login to specific email domains (comma-separated).
+# When set, only users with verified emails from these domains can log in.
+# Applies to all OAuth providers and OIDC. Leave unset to allow all domains.
+# OAUTH_ALLOWED_DOMAINS=company.com,partner.org
+
+# Google OAuth — Create credentials at https://console.cloud.google.com/apis/credentials
+#   1. Create an OAuth 2.0 Client ID (Web application type)
+#   2. Add authorized redirect URI: {OAUTH_BASE_URL}/auth/callback/google
+#   3. Copy Client ID and Client Secret below
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
+
+# Restrict Google login to a specific Workspace (G Suite) domain.
+# Adds the `hd` parameter to the authorization URL and validates server-side.
+# GOOGLE_ALLOWED_HD=company.com
+
+# Apple Sign In — Configure in https://developer.apple.com/account/resources/identifiers
+#   1. Register a Services ID (e.g. com.example.myapp) under Identifiers
+#   2. Enable "Sign In with Apple" and configure the return URL: {OAUTH_BASE_URL}/auth/callback/apple
+#   3. Create a key (Keys section), enable "Sign In with Apple", download the .p8 file
+#   4. Note your Team ID (top right of developer portal) and Key ID
+# APPLE_CLIENT_ID=com.example.myapp
+# APPLE_TEAM_ID=XXXXXXXXXX
+# APPLE_KEY_ID=YYYYYYYYYY
+# APPLE_PRIVATE_KEY_PATH=/path/to/AuthKey_YYYYYYYYYY.p8
+# Or inline: APPLE_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
+
+# GitHub OAuth — Create an OAuth App at https://github.com/settings/developers
+#   1. Create a new OAuth App
+#   2. Set Authorization callback URL to: {OAUTH_BASE_URL}/auth/callback/github
+#   3. Copy Client ID and generate a Client Secret below
+# GITHUB_CLIENT_ID=
+# GITHUB_CLIENT_SECRET=
+
+# NEAR Wallet — No external setup needed. Users sign in with any NEAR wallet
+#   (HOT, Meteor, MyNearWallet, etc.) via the near-connect SDK.
+# NEAR_AUTH_ENABLED=true
+# NEAR_AUTH_NETWORK=mainnet                  # or testnet
+# NEAR_AUTH_RPC_URL=https://rpc.mainnet.near.org  # auto-detected from network
+
+# ─── OIDC / SSO (Okta, Cognito, etc.) ──────────────────────────────────
+# For reverse-proxy SSO (e.g., AWS ALB + Okta). The gateway validates JWTs
+# from the configured header. See also OAUTH_ALLOWED_DOMAINS above, which
+# applies to OIDC logins too.
+# GATEWAY_OIDC_ENABLED=true
+# GATEWAY_OIDC_JWKS_URL=https://your-idp.example.com/.well-known/jwks.json
+# GATEWAY_OIDC_HEADER=x-amzn-oidc-data
+# GATEWAY_OIDC_ISSUER=https://your-idp.example.com
+# GATEWAY_OIDC_AUDIENCE=your-client-id
+
 # Logging
 RUST_LOG=ironclaw=debug,tower_http=debug

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,86 @@
+name: Docker Image
+
+on:
+  # Called by release.yml or other workflows
+  workflow_call:
+    inputs:
+      tag:
+        description: "Image tag override (leave empty for auto-detect)"
+        required: false
+        type: string
+        default: ""
+  # On-demand builds
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag override (leave empty for auto-detect)"
+        required: false
+        type: string
+        default: ""
+
+env:
+  IMAGE_NAME: nearaidev/ironclaw
+
+jobs:
+  build:
+    name: Build & Push
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Extract version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Detected version: ${VERSION}"
+
+      - name: Determine tags
+        id: tags
+        run: |
+          TAGS="${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}"
+          TAGS="${TAGS},${{ env.IMAGE_NAME }}:latest"
+          TAGS="${TAGS},${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA::7}"
+          # Manual override adds an extra tag
+          if [[ -n "${{ inputs.tag }}" ]]; then
+            TAGS="${TAGS},${{ env.IMAGE_NAME }}:${{ inputs.tag }}"
+          fi
+          echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKER_REGISTRY_USER }}
+          password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "## Docker Image"
+            echo ""
+            echo "**Tags pushed:**"
+            echo '```'
+            echo "${{ steps.tags.outputs.tags }}" | tr ',' '\n'
+            echo '```'
+            echo ""
+            echo "- version: \`${{ steps.version.outputs.version }}\`"
+            echo "- sha: \`${GITHUB_SHA::7}\`"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
           - group: features
             files: "tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"
           - group: extensions
-            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
+            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
           - group: routines
             files: "tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1139,6 +1139,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,6 +1542,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "time",
+ "version_check",
 ]
 
 [[package]]
@@ -3445,11 +3464,13 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "bollard",
+ "bs58",
  "bytes",
  "chrono",
  "chrono-tz",
  "clap",
  "clap_complete",
+ "cookie",
  "criterion",
  "cron",
  "crossterm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c56a59cf6315e99f874d2c1f96c69d2da5ffe0087d211297fc4a41f849770a2"
+dependencies = [
+ "agent-client-protocol-schema",
+ "anyhow",
+ "async-broadcast",
+ "async-trait",
+ "derive_more",
+ "futures",
+ "log",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0497b9a95a404e35799904835c57c6f8c69b9d08ccfd3cb5b7d746425cd6789"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "strum",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2099,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 2.0.117",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -3402,6 +3434,7 @@ name = "ironclaw"
 version = "0.24.0"
 dependencies = [
  "aes-gcm",
+ "agent-client-protocol",
  "aho-corasick",
  "anyhow",
  "async-trait",
@@ -3481,6 +3514,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-tungstenite 0.26.2",
+ "tokio-util",
  "toml",
  "tower 0.5.3",
  "tower-http 0.6.8",
@@ -6338,6 +6372,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6878,6 +6933,7 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,13 @@ eula = false
 # Async runtime
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["sync"] }
+tokio-util = { version = "0.7", features = ["compat"] }
 futures = "0.3"
 tokio-tungstenite = { version = "0.26", features = ["rustls-tls-native-roots"] }
 eventsource-stream = "0.2"
+
+# Agent Client Protocol (ACP) — standard communication with coding agents
+agent-client-protocol = "0.10"
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "multipart", "rustls-tls-native-roots", "stream"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ hyper-util = { version = "0.1", features = ["server", "tokio", "http1", "http2"]
 http-body-util = "0.1"
 bytes = "1"
 base64 = "0.22.1"
+cookie = "0.18"
 jsonwebtoken = "9"
 mime_guess = "2.0.5"
 clap_complete = "4.5.0"
@@ -186,6 +187,7 @@ lru = "0.16.3"
 html-to-markdown-rs = { version = "2.3", optional = true }
 readabilityrs = { version = "0.1.2", optional = true }
 ed25519-dalek = { version = "2.2.0", features = ["std"] }
+bs58 = "0.5"
 hex = "0.4.3"
 
 # OpenClaw import (feature gated)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@
 # Uses cargo-chef for dependency caching — only rebuilds deps when
 # Cargo.toml/Cargo.lock change, not on every source edit.
 #
+# Alpine-based build + runtime for a minimal image size.
+# Statically links against musl; no glibc or libssl needed at runtime.
+#
 # Build:
 #   docker build --platform linux/amd64 -t ironclaw:latest .
 #
@@ -10,13 +13,11 @@
 #   docker run --env-file .env -p 3000:3000 ironclaw:latest
 
 # Stage 1: Install cargo-chef
-FROM rust:1.92-slim-bookworm AS chef
+FROM rust:1.92-alpine AS chef
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config libssl-dev cmake gcc g++ \
-    && rm -rf /var/lib/apt/lists/* \
+RUN apk add --no-cache musl-dev pkgconfig cmake gcc g++ make perl \
     && rustup target add wasm32-wasip2 \
-    && cargo install cargo-chef wasm-tools
+    && cargo install cargo-chef@0.1.77 wasm-tools@1.246.1
 
 WORKDIR /app
 
@@ -40,8 +41,13 @@ RUN cargo chef prepare --recipe-path recipe.json
 # Stage 3: Build dependencies (cached unless Cargo.toml/lock change)
 FROM chef AS deps
 
+# Docker-only overrides for the dist profile (not in Cargo.toml because
+# cargo-dist uses dist for release binaries that need unwinding).
+ENV CARGO_PROFILE_DIST_PANIC=abort \
+    CARGO_PROFILE_DIST_CODEGEN_UNITS=1
+
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+RUN cargo chef cook --profile dist --recipe-path recipe.json
 
 # Stage 4: Build the actual binary (only recompiles ironclaw source)
 FROM deps AS builder
@@ -58,21 +64,18 @@ COPY channels-src/ channels-src/
 COPY wit/ wit/
 COPY providers.json providers.json
 
-RUN cargo build --release --bin ironclaw
+RUN cargo build --profile dist --bin ironclaw
 
-# Stage 5: Runtime
-FROM debian:bookworm-slim
+# Stage 5: Minimal runtime
+FROM alpine:3.21
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libssl3 \
-    && update-ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk add --no-cache ca-certificates
 
-COPY --from=builder /app/target/release/ironclaw /usr/local/bin/ironclaw
+COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
 COPY --from=builder /app/migrations /app/migrations
 
 # Non-root user
-RUN useradd -m -u 1000 -s /bin/bash ironclaw
+RUN adduser -D -u 1000 ironclaw
 USER ironclaw
 
 EXPOSE 3000

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -97,6 +97,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Cron/heartbeat topic targeting | ✅ | ❌ | Messages land in correct topic |
 | DM topics support | ✅ | ❌ | Agent/topic bindings in DMs and agent-scoped SessionKeys |
 | Persistent ACP topic binding | ✅ | ❌ | ACP harness sessions can pin to Telegram forum or DM topics |
+| sendVoice (voice note replies) | ✅ | ✅ | audio/ogg attachments sent as voice notes; prerequisite for TTS (#90) |
 
 ### Discord-Specific Features (since Feb 2025)
 

--- a/channels-src/telegram/Cargo.lock
+++ b/channels-src/telegram/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-channel"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/channels-src/telegram/Cargo.toml
+++ b/channels-src/telegram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-channel"
-version = "0.2.1"
+version = "0.2.6"
 edition = "2021"
 description = "Telegram Bot API channel for IronClaw"
 license = "MIT OR Apache-2.0"

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -407,7 +407,8 @@ fn split_message(text: &str) -> Vec<String> {
         let window = &remaining[..window_bytes];
 
         // 1. Double newline — best paragraph boundary
-        let split_at = window.rfind("\n\n")
+        let split_at = window
+            .rfind("\n\n")
             // 2. Single newline
             .or_else(|| window.rfind('\n'))
             // 3. Sentence-ending punctuation followed by space.
@@ -417,9 +418,9 @@ fn split_message(text: &str) -> Vec<String> {
             .or_else(|| {
                 let bytes = window.as_bytes();
                 // Search backwards for '. ', '! ', '? '
-                (1..bytes.len()).rev().find(|&i| {
-                    matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' '
-                })
+                (1..bytes.len())
+                    .rev()
+                    .find(|&i| matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' ')
             })
             // 4. Word boundary (last space)
             .or_else(|| window.rfind(' '))
@@ -427,7 +428,11 @@ fn split_message(text: &str) -> Vec<String> {
             .unwrap_or(window_bytes);
 
         // Avoid empty chunks (e.g. text starting with \n\n).
-        let split_at = if split_at == 0 { window_bytes } else { split_at };
+        let split_at = if split_at == 0 {
+            window_bytes
+        } else {
+            split_at
+        };
 
         // Trim whitespace at chunk boundaries for clean Telegram display.
         // Note: this drops leading/trailing spaces at split points, which is
@@ -1090,11 +1095,8 @@ fn download_telegram_file(file_id: &str) -> Result<Vec<u8>, String> {
 }
 
 // ============================================================================
-// Attachment Sending (Photo / Document)
+// Attachment Sending (Photo / Voice / Document)
 // ============================================================================
-
-/// Maximum photo size for Telegram sendPhoto (10 MB).
-const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
 
 /// Write a multipart/form-data text field.
 fn write_multipart_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
@@ -1138,6 +1140,95 @@ fn write_multipart_file(
     body.extend_from_slice(b"\r\n");
 }
 
+/// Image MIME types that Telegram's sendPhoto API supports.
+const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Audio MIME types that Telegram's sendVoice API supports (ogg/opus container).
+const VOICE_MIME_TYPES: &[&str] = &["audio/ogg", "audio/opus"];
+
+/// Maximum photo size for Telegram sendPhoto (10 MB).
+const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum voice note size for Telegram sendVoice (50 MB).
+const MAX_VOICE_SIZE: usize = 50 * 1024 * 1024;
+
+/// Send a multipart file upload to a Telegram Bot API endpoint.
+///
+/// Shared implementation for sendPhoto, sendVoice, and sendDocument.
+/// `api_method` is the Telegram method name (e.g. "sendPhoto"),
+/// `field_name` is the multipart field (e.g. "photo", "voice", "document").
+#[allow(clippy::too_many_arguments)]
+fn send_multipart_upload(
+    api_method: &str,
+    field_name: &str,
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    let message_thread_id = normalize_thread_id(message_thread_id);
+
+    let boundary = format!("ironclaw-{}", channel_host::now_millis());
+    let mut body = Vec::new();
+
+    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
+    if let Some(msg_id) = reply_to_message_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "reply_to_message_id",
+            &msg_id.to_string(),
+        );
+    }
+    if let Some(thread_id) = message_thread_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "message_thread_id",
+            &thread_id.to_string(),
+        );
+    }
+    write_multipart_file(&mut body, &boundary, field_name, filename, mime_type, data);
+    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+    let headers = serde_json::json!({
+        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
+    });
+
+    let url = format!(
+        "https://api.telegram.org/bot{{TELEGRAM_BOT_TOKEN}}/{}",
+        api_method
+    );
+
+    let result = channel_host::http_request(
+        "POST",
+        &url,
+        &headers.to_string(),
+        Some(&body),
+        Some(60_000), // 60s timeout for file uploads
+    );
+
+    match result {
+        Ok(resp) if resp.status == 200 => {
+            channel_host::log(
+                channel_host::LogLevel::Debug,
+                &format!("Sent {} '{}' to chat {}", field_name, filename, chat_id),
+            );
+            Ok(())
+        }
+        Ok(resp) => {
+            let body_str = String::from_utf8_lossy(&resp.body);
+            Err(format!(
+                "{} failed (HTTP {}): {}",
+                api_method, resp.status, body_str
+            ))
+        }
+        Err(e) => Err(format!("{} HTTP request failed: {}", api_method, e)),
+    }
+}
+
 /// Send a photo via the Telegram Bot API (multipart upload).
 ///
 /// Falls back to `send_document()` if the photo exceeds 10 MB.
@@ -1149,8 +1240,6 @@ fn send_photo(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
     if data.len() > MAX_PHOTO_SIZE {
         channel_host::log(
             channel_host::LogLevel::Info,
@@ -1169,59 +1258,16 @@ fn send_photo(
             message_thread_id,
         );
     }
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "photo", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendPhoto",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent photo '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendPhoto failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendPhoto HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendPhoto",
+        "photo",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
 /// Send a document via the Telegram Bot API (multipart upload).
@@ -1233,64 +1279,60 @@ fn send_document(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "document", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendDocument",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent document '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendDocument failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendDocument HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendDocument",
+        "document",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
-/// Image MIME types that Telegram's sendPhoto API supports.
-const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+/// Send a voice note via the Telegram Bot API (multipart upload).
+///
+/// Telegram's `sendVoice` requires ogg/opus audio and displays it as an
+/// in-chat voice note with waveform and playback controls.
+/// Falls back to `send_document()` if the voice note exceeds 50 MB.
+fn send_voice(
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    if data.len() > MAX_VOICE_SIZE {
+        channel_host::log(
+            channel_host::LogLevel::Info,
+            &format!(
+                "Voice note {} exceeds 50MB ({}), sending as document",
+                filename,
+                data.len()
+            ),
+        );
+        return send_document(
+            chat_id,
+            filename,
+            mime_type,
+            data,
+            reply_to_message_id,
+            message_thread_id,
+        );
+    }
+    send_multipart_upload(
+        "sendVoice",
+        "voice",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
+}
 
 /// Send a full agent response (attachments + text) to a chat.
 ///
@@ -1321,7 +1363,13 @@ fn send_response(
 
     for (i, chunk) in chunks.into_iter().enumerate() {
         // Try Markdown, fall back to plain text on parse errors
-        let result = send_message(chat_id, &chunk, reply_to, Some("Markdown"), message_thread_id);
+        let result = send_message(
+            chat_id,
+            &chunk,
+            reply_to,
+            Some("Markdown"),
+            message_thread_id,
+        );
 
         let msg_id = match result {
             Ok(id) => {
@@ -1371,31 +1419,65 @@ fn send_response(
     Ok(())
 }
 
-/// Send a single attachment, choosing sendPhoto or sendDocument based on MIME type.
+/// Extract the base MIME type, stripping any parameters after `;`.
+///
+/// e.g. `"audio/ogg; codecs=opus"` → `"audio/ogg"`
+fn base_mime_type(mime: &str) -> &str {
+    mime.split(';').next().unwrap_or(mime).trim()
+}
+
+/// Attachment routing category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachmentKind {
+    Photo,
+    Voice,
+    Document,
+}
+
+/// Classify an attachment's send method based on its MIME type.
+fn classify_attachment(mime_type: &str) -> AttachmentKind {
+    let base = base_mime_type(mime_type);
+    if PHOTO_MIME_TYPES.contains(&base) {
+        AttachmentKind::Photo
+    } else if VOICE_MIME_TYPES.contains(&base) {
+        AttachmentKind::Voice
+    } else {
+        AttachmentKind::Document
+    }
+}
+
+/// Send a single attachment, choosing sendPhoto, sendVoice, or sendDocument based on MIME type.
 fn send_attachment(
     chat_id: i64,
     attachment: &Attachment,
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    if PHOTO_MIME_TYPES.contains(&attachment.mime_type.as_str()) {
-        send_photo(
+    match classify_attachment(&attachment.mime_type) {
+        AttachmentKind::Photo => send_photo(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
-    } else {
-        send_document(
+        ),
+        AttachmentKind::Voice => send_voice(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
+        ),
+        AttachmentKind::Document => send_document(
+            chat_id,
+            &attachment.filename,
+            &attachment.mime_type,
+            &attachment.data,
+            reply_to_message_id,
+            message_thread_id,
+        ),
     }
 }
 
@@ -2968,5 +3050,39 @@ mod tests {
     fn test_max_download_size_constant() {
         // Verify the constant is 20 MB, matching the Slack channel limit
         assert_eq!(MAX_DOWNLOAD_SIZE_BYTES, 20 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_base_mime_type() {
+        assert_eq!(base_mime_type("audio/ogg"), "audio/ogg");
+        assert_eq!(base_mime_type("audio/ogg; codecs=opus"), "audio/ogg");
+        assert_eq!(base_mime_type("image/jpeg"), "image/jpeg");
+        assert_eq!(base_mime_type("text/plain; charset=utf-8"), "text/plain");
+        assert_eq!(base_mime_type(""), "");
+    }
+
+    #[test]
+    fn test_classify_attachment_routing() {
+        // Photos
+        assert_eq!(classify_attachment("image/jpeg"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/png"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/gif"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/webp"), AttachmentKind::Photo);
+
+        // Voice notes — exact and parameterized
+        assert_eq!(classify_attachment("audio/ogg"), AttachmentKind::Voice);
+        assert_eq!(classify_attachment("audio/opus"), AttachmentKind::Voice);
+        assert_eq!(
+            classify_attachment("audio/ogg; codecs=opus"),
+            AttachmentKind::Voice
+        );
+
+        // Everything else falls through to document
+        assert_eq!(
+            classify_attachment("application/pdf"),
+            AttachmentKind::Document
+        );
+        assert_eq!(classify_attachment("audio/mpeg"), AttachmentKind::Document);
+        assert_eq!(classify_attachment("video/mp4"), AttachmentKind::Document);
     }
 }

--- a/channels-src/telegram/telegram.capabilities.json
+++ b/channels-src/telegram/telegram.capabilities.json
@@ -18,6 +18,14 @@
         "name": "telegram_bot_token",
         "prompt": "Enter your Telegram Bot API token (from @BotFather)",
         "optional": false
+      },
+      {
+        "name": "telegram_webhook_secret",
+        "prompt": "Webhook secret (leave empty to auto-generate)",
+        "optional": true,
+        "auto_generate": {
+          "length": 64
+        }
       }
     ],
     "setup_url": "https://t.me/BotFather",

--- a/channels-src/whatsapp/Cargo.lock
+++ b/channels-src/whatsapp/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-channel"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -5,3 +5,8 @@ mod util;
 
 pub use event::{AppEvent, ToolDecisionDto};
 pub use util::truncate_preview;
+
+/// Maximum worker agent loop iterations. Used by the orchestrator (server-side
+/// clamp in `create_job_inner`) and the worker runtime (`worker/job.rs`).
+/// A single source of truth prevents the two from drifting.
+pub const MAX_WORKER_ITERATIONS: u32 = 500;

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -33,7 +33,7 @@ ironclaw onboard
 When prompted, enable the Telegram channel and paste your bot token. The wizard will:
 
 - Validate the token
-- Optionally configure a webhook secret
+- Auto-generate a webhook secret for webhook mode
 - Set up tunnel (if you want webhook mode)
 
 ### 3. (Optional) Configure Tunnel for Webhooks

--- a/migrations/V15__conversation_source_channel.sql
+++ b/migrations/V15__conversation_source_channel.sql
@@ -1,0 +1,4 @@
+-- Add source_channel to conversations for cross-channel approval authorization.
+-- Tracks which channel originally created a conversation so that approval
+-- messages from other channels can be validated.
+ALTER TABLE conversations ADD COLUMN source_channel TEXT;

--- a/migrations/V15__user_identities.sql
+++ b/migrations/V15__user_identities.sql
@@ -1,0 +1,23 @@
+-- Linked external identities for OAuth/social login.
+--
+-- Maps provider-specific user IDs (Google `sub`, GitHub user ID, etc.)
+-- to internal user records, enabling multi-provider login and automatic
+-- account linking by verified email.
+
+CREATE TABLE user_identities (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,                 -- 'google', 'github', 'apple', 'near', 'email'
+    provider_user_id TEXT NOT NULL,         -- provider-specific unique ID
+    email TEXT,                             -- email from the provider (for linking)
+    email_verified BOOLEAN NOT NULL DEFAULT false,
+    display_name TEXT,                      -- provider-sourced display name
+    avatar_url TEXT,                        -- provider-sourced avatar URL
+    raw_profile JSONB NOT NULL DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (provider, provider_user_id)
+);
+
+CREATE INDEX idx_user_identities_user ON user_identities(user_id);
+CREATE INDEX idx_user_identities_email ON user_identities(email) WHERE email IS NOT NULL;

--- a/migrations/V16__document_versions.sql
+++ b/migrations/V16__document_versions.sql
@@ -1,0 +1,24 @@
+-- Document version history for workspace files.
+-- Every content update saves the previous content as a version,
+-- enabling rollback and audit trails.
+
+CREATE TABLE memory_document_versions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    document_id UUID NOT NULL REFERENCES memory_documents(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    changed_by TEXT,
+    UNIQUE(document_id, version)
+);
+
+CREATE INDEX idx_doc_versions_lookup
+    ON memory_document_versions(document_id, version DESC);
+
+-- GIN index on metadata for future JSON containment queries
+-- (e.g., WHERE metadata @> '{"hygiene": {"enabled": true}}').
+-- Not used by current queries (which use path LIKE) but enables
+-- efficient metadata-based filtering without a full table scan.
+CREATE INDEX idx_memory_documents_metadata
+    ON memory_documents USING GIN (metadata jsonb_path_ops);

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -4,13 +4,15 @@
   "kind": "tool",
   "version": "0.2.2",
   "wit_version": "0.3.0",
-  "description": "GitHub integration for issues, PRs, repos, and code search",
+  "description": "GitHub integration for repositories, issues, pull requests, search, branches, file writes, releases, and workflows",
   "keywords": [
     "git",
     "code",
     "issues",
     "pull-requests",
-    "repositories"
+    "repositories",
+    "search",
+    "releases"
   ],
   "source": {
     "dir": "tools-src/github",

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -843,7 +843,10 @@ impl Agent {
             {
                 use crate::agent::session::Thread;
                 let mut sess = session.lock().await;
-                let thread = Thread::with_id(id, sess.id);
+                // Bootstrap thread has no incoming message -- use the
+                // "__bootstrap__" sentinel so approvals from any channel are
+                // permitted. None means "deny by default" (fail-closed).
+                let thread = Thread::with_id(id, sess.id, Some("__bootstrap__"));
                 sess.active_thread = Some(id);
                 sess.threads.entry(id).or_insert(thread);
             }
@@ -1148,7 +1151,37 @@ impl Agent {
                 .get_or_create_session(&message.user_id)
                 .await;
             let mut sess = session.lock().await;
-            if sess.threads.contains_key(&target_thread_id) {
+            if let Some(thread) = sess.threads.get(&target_thread_id) {
+                // Verify the thread actually has a pending approval before
+                // allowing approval-shaped messages to target it. Without this
+                // check, an attacker could use approval messages to hijack any
+                // thread by UUID.
+                if thread.pending_approval.is_none() {
+                    tracing::warn!(
+                        %target_thread_id,
+                        approval_channel = %message.channel,
+                        "Blocked approval for thread with no pending approval"
+                    );
+                    drop(sess);
+                    return Ok(Some("Error: no pending approval on this thread".into()));
+                }
+
+                let authorized = crate::agent::session::is_approval_authorized(
+                    thread.source_channel.as_deref(),
+                    &message.channel,
+                );
+                if !authorized {
+                    tracing::warn!(
+                        %target_thread_id,
+                        source_channel = ?thread.source_channel,
+                        approval_channel = %message.channel,
+                        "Blocked cross-channel approval attempt"
+                    );
+                    drop(sess);
+                    return Ok(Some(
+                        "Error: approval not authorized for this channel".into(),
+                    ));
+                }
                 sess.active_thread = Some(target_thread_id);
                 sess.last_active_at = chrono::Utc::now();
                 drop(sess);

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -35,11 +35,6 @@ use crate::workspace::Workspace;
 
 /// Static greeting persisted to DB and broadcast on first launch.
 ///
-/// Sent before the LLM is involved so the user sees something immediately.
-/// The conversational onboarding (profile building, channel setup) happens
-/// organically in the subsequent turns driven by BOOTSTRAP.md.
-const BOOTSTRAP_GREETING: &str = include_str!("../workspace/seeds/GREETING.md");
-
 /// Collapse a tool output string into a single-line preview for display.
 pub(crate) fn truncate_for_preview(output: &str, max_chars: usize) -> String {
     let collapsed: String = output
@@ -436,31 +431,8 @@ impl Agent {
 
     /// Run the agent main loop.
     pub async fn run(self) -> Result<(), Error> {
-        // Proactive bootstrap: persist the static greeting to DB *before*
-        // starting channels so the first web client sees it via history.
-        let bootstrap_thread_id = if self
-            .workspace()
-            .is_some_and(|ws| ws.take_bootstrap_pending())
-        {
-            tracing::debug!(
-                "Fresh workspace detected — persisting static bootstrap greeting to DB"
-            );
-            if let Some(store) = self.store() {
-                let thread_id = store
-                    .get_or_create_assistant_conversation("default", "gateway")
-                    .await
-                    .ok();
-                if let Some(id) = thread_id {
-                    self.persist_assistant_response(id, "gateway", "default", BOOTSTRAP_GREETING)
-                        .await;
-                }
-                thread_id
-            } else {
-                None
-            }
-        } else {
-            None
-        };
+        // Bootstrap greeting is now handled by chat_threads_handler in server.rs
+        // when the assistant conversation is first created with zero messages.
 
         // Start channels
         let mut message_stream = self.channels.start_all().await?;
@@ -836,29 +808,6 @@ impl Agent {
         // broadcast the greeting via SSE for any clients already connected.
         // The greeting was already persisted to DB before start_all(), so
         // clients that connect after this point will see it via history.
-        if let Some(id) = bootstrap_thread_id {
-            // Use get_or_create_session (not resolve_thread) to avoid creating
-            // an orphan thread. Then insert the DB-sourced thread directly.
-            let session = self.session_manager.get_or_create_session("default").await;
-            {
-                use crate::agent::session::Thread;
-                let mut sess = session.lock().await;
-                // Bootstrap thread has no incoming message -- use the
-                // "__bootstrap__" sentinel so approvals from any channel are
-                // permitted. None means "deny by default" (fail-closed).
-                let thread = Thread::with_id(id, sess.id, Some("__bootstrap__"));
-                sess.active_thread = Some(id);
-                sess.threads.entry(id).or_insert(thread);
-            }
-            self.session_manager
-                .register_thread("default", "gateway", id, session)
-                .await;
-
-            let mut out = OutgoingResponse::text(BOOTSTRAP_GREETING.to_string());
-            out.thread_id = Some(id.to_string());
-            let _ = self.channels.broadcast("gateway", "default", out).await;
-        }
-
         // Main message loop
         tracing::debug!("Agent {} ready and listening", self.config.name);
 
@@ -1307,34 +1256,6 @@ impl Agent {
 
         // Build per-tenant execution context once; threaded through all handlers.
         let tenant = self.tenant_ctx(&message.user_id).await;
-
-        // Per-user bootstrap: if this user's workspace was just seeded (fresh),
-        // persist the static greeting to their assistant conversation and
-        // broadcast it so the web client shows it immediately.
-        if tenant
-            .workspace()
-            .is_some_and(|ws| ws.take_bootstrap_pending())
-        {
-            tracing::info!(
-                user_id = message.user_id,
-                "Fresh user workspace — persisting bootstrap greeting"
-            );
-            if let Some(store) = tenant.store()
-                && let Ok(conv_id) = store
-                    .get_or_create_assistant_conversation(&message.channel)
-                    .await
-            {
-                let _ = store
-                    .add_conversation_message(conv_id, "assistant", BOOTSTRAP_GREETING)
-                    .await;
-                let mut out = OutgoingResponse::text(BOOTSTRAP_GREETING.to_string());
-                out.thread_id = Some(conv_id.to_string());
-                let _ = self
-                    .channels
-                    .broadcast(&message.channel, &message.user_id, out)
-                    .await;
-            }
-        }
 
         let session_for_empty_exit = Arc::clone(&session);
 

--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_format_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("Hello");
         thread.complete_turn("Hi there");
         thread.start_turn("How are you?");
@@ -351,7 +351,7 @@ mod tests {
     /// Helper: build a thread with `n` completed turns.
     /// Turn `i` has user_input "msg-{i}" and response "resp-{i}".
     fn make_thread(n: usize) -> Thread {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         for i in 0..n {
             thread.start_turn(format!("msg-{}", i));
             thread.complete_turn(format!("resp-{}", i));
@@ -457,7 +457,7 @@ mod tests {
     async fn test_compact_truncate_empty_turns() {
         let llm = Arc::new(StubLlm::new("unused"));
         let compactor = make_compactor(llm);
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         assert!(thread.turns.is_empty());
 
         let result = compactor
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_format_turns_for_storage_with_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("Search for X");
         // Record a tool call on the current turn
         if let Some(turn) = thread.turns.last_mut() {
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_format_turns_for_storage_incomplete_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("In progress message");
         // Don't complete the turn
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -2313,7 +2313,7 @@ mod tests {
         // Initialize a thread in the session so the loop can record tool calls.
         let thread_id = {
             let mut sess = session.lock().await;
-            sess.create_thread().id
+            sess.create_thread(Some("test")).id
         };
 
         let message = IncomingMessage::new("test", "test-user", "do something");
@@ -2426,7 +2426,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("test-user")));
         let thread_id = {
             let mut sess = session.lock().await;
-            sess.create_thread().id
+            sess.create_thread(Some("test")).id
         };
 
         let message = IncomingMessage::new("test", "test-user", "keep calling tools");

--- a/src/agent/heartbeat.rs
+++ b/src/agent/heartbeat.rs
@@ -276,8 +276,8 @@ impl HeartbeatRunner {
                         .await;
                 if report.had_work() {
                     tracing::info!(
-                        daily_logs_deleted = report.daily_logs_deleted,
-                        conversation_docs_deleted = report.conversation_docs_deleted,
+                        directories_cleaned = ?report.directories_cleaned,
+                        versions_pruned = report.versions_pruned,
                         "heartbeat: memory hygiene deleted stale documents"
                     );
                 }
@@ -616,8 +616,8 @@ pub fn spawn_multi_user_heartbeat(
                     if report.had_work() {
                         tracing::info!(
                             user_id = uid,
-                            daily_logs_deleted = report.daily_logs_deleted,
-                            conversation_docs_deleted = report.conversation_docs_deleted,
+                            directories_cleaned = ?report.directories_cleaned,
+                            versions_pruned = report.versions_pruned,
                             "multi-user heartbeat: memory hygiene deleted stale documents"
                         );
                     }

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1119,48 +1119,141 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
     // Increment running count (atomic: survives panics in the execution below)
     ctx.running_count.fetch_add(1, Ordering::Relaxed);
 
-    let result = match &routine.action {
-        RoutineAction::Lightweight {
-            prompt,
-            context_paths,
-            max_tokens,
-            use_tools,
-            max_tool_rounds,
-        } => {
-            execute_lightweight(
-                &ctx,
-                &routine,
-                prompt,
-                context_paths,
-                *max_tokens,
-                *use_tools,
-                *max_tool_rounds,
-            )
-            .await
+    // Retry constants for transient lightweight execution failures.
+    //
+    // NOTE: Multiplicative retry budgets — `ctx.llm` is wrapped in `RetryProvider`
+    // which has its own retry budget (default 3). Although `LlmFailed` errors are
+    // excluded from outer retry (only `EmptyResponse`/`TruncatedResponse` retry
+    // here), be aware that each outer attempt triggers a full inner retry budget
+    // for the LLM call itself. With MAX_RETRIES=2, worst case is 2 outer x 3 inner
+    // = 6 LLM calls per routine run.
+    const MAX_RETRIES: u32 = 2;
+    const BASE_DELAY_MS: u64 = 1000;
+
+    let is_lightweight = matches!(routine.action, RoutineAction::Lightweight { .. });
+
+    // The retry block returns both the execution result and any accumulated
+    // token count so that usage is preserved even on final failure.
+    let (result, accumulated_tokens) = {
+        let mut attempt = 0u32;
+        // Track accumulated tokens as Option to preserve None semantics:
+        // None = no attempt reported tokens; Some(n) = at least one attempt did.
+        let mut accumulated_tokens: Option<i32> = None;
+        let uses_tools = matches!(
+            routine.action,
+            RoutineAction::Lightweight {
+                use_tools: true,
+                ..
+            }
+        ) && ctx.config.lightweight_tools_enabled;
+
+        /// Extract partial_tokens from any RoutineError variant that carries them.
+        fn extract_partial_tokens(e: &RoutineError) -> Option<i32> {
+            match e {
+                RoutineError::LlmFailed {
+                    partial_tokens: Some(t),
+                    ..
+                }
+                | RoutineError::EmptyResponse {
+                    partial_tokens: Some(t),
+                }
+                | RoutineError::TruncatedResponse {
+                    partial_tokens: Some(t),
+                } => Some(*t),
+                _ => None,
+            }
         }
-        RoutineAction::FullJob {
-            title,
-            description,
-            max_iterations,
-        } => {
-            let execution = FullJobExecutionConfig {
-                title,
-                description,
-                max_iterations: *max_iterations,
+
+        /// Merge an optional partial token count into the accumulator,
+        /// only materializing Some when at least one source had Some.
+        fn accumulate(acc: Option<i32>, partial: Option<i32>) -> Option<i32> {
+            match (acc, partial) {
+                (Some(a), Some(p)) => Some(a.saturating_add(p)),
+                (Some(a), None) => Some(a),
+                (None, p) => p,
+            }
+        }
+
+        loop {
+            let execution_result = match &routine.action {
+                RoutineAction::Lightweight {
+                    prompt,
+                    context_paths,
+                    max_tokens,
+                    use_tools,
+                    max_tool_rounds,
+                } => {
+                    execute_lightweight(
+                        &ctx,
+                        &routine,
+                        prompt,
+                        context_paths,
+                        *max_tokens,
+                        *use_tools,
+                        *max_tool_rounds,
+                    )
+                    .await
+                }
+                RoutineAction::FullJob {
+                    title,
+                    description,
+                    max_iterations,
+                } => {
+                    let execution = FullJobExecutionConfig {
+                        title,
+                        description,
+                        max_iterations: *max_iterations,
+                    };
+                    execute_full_job(&ctx, &routine, &run, &execution).await
+                }
             };
-            execute_full_job(&ctx, &routine, &run, &execution).await
+
+            match execution_result {
+                Ok((status, summary, tokens)) => {
+                    // Merge tokens: only produce Some when at least one source had Some.
+                    let total = accumulate(accumulated_tokens, tokens);
+                    break (Ok((status, summary, total)), accumulated_tokens);
+                }
+                Err(ref e)
+                    if is_lightweight
+                        && !uses_tools
+                        && e.is_retryable()
+                        // Skip outer retry for LlmFailed — RetryProvider already
+                        // retries transient LLM errors with its own budget. Retrying
+                        // here would create a multiplicative retry count.
+                        && !matches!(e, RoutineError::LlmFailed { .. })
+                        && attempt < MAX_RETRIES =>
+                {
+                    // Accumulate partial tokens from the failed attempt.
+                    accumulated_tokens = accumulate(accumulated_tokens, extract_partial_tokens(e));
+
+                    attempt += 1;
+
+                    let delay = Duration::from_millis(
+                        BASE_DELAY_MS.saturating_mul(2u64.saturating_pow(attempt - 1)),
+                    );
+                    tracing::event!(target: "transient_routine_errors", tracing::Level::WARN, routine = %routine.name, attempt = attempt, max_retries = MAX_RETRIES, delay_ms = delay.as_millis() as u64, "Transient routine error, retrying: {}", e);
+                    tokio::time::sleep(delay).await;
+                }
+                Err(e) => {
+                    // Accumulate tokens from the final failed attempt.
+                    accumulated_tokens = accumulate(accumulated_tokens, extract_partial_tokens(&e));
+                    break (Err(e), accumulated_tokens);
+                }
+            }
         }
     };
 
     // Decrement running count
     ctx.running_count.fetch_sub(1, Ordering::Relaxed);
 
-    // Process result
+    // Process result — on failure, preserve accumulated token total from
+    // earlier retry attempts so usage reporting stays accurate.
     let (status, summary, tokens) = match result {
         Ok(execution) => execution,
         Err(e) => {
             tracing::error!(routine = %routine.name, "Execution failed: {}", e);
-            (RunStatus::Failed, Some(e.to_string()), None)
+            (RunStatus::Failed, Some(e.to_string()), accumulated_tokens)
         }
     };
 
@@ -1590,13 +1683,17 @@ async fn execute_lightweight_no_tools(
         .with_max_tokens(effective_max_tokens)
         .with_temperature(0.3);
 
-    let response = ctx
-        .llm
-        .complete(request)
-        .await
-        .map_err(|e| RoutineError::LlmFailed {
+    let response = ctx.llm.complete(request).await.map_err(|e| {
+        let retryable = crate::llm::retry::is_retryable(&e);
+        RoutineError::LlmFailed {
             reason: e.to_string(),
-        })?;
+            // No partial tokens: the LLM call itself failed, so the response
+            // (and its token counts) is unavailable. If providers start returning
+            // partial usage on error responses, this should be updated.
+            partial_tokens: None,
+            retryable,
+        }
+    })?;
 
     handle_text_response(
         &response.content,
@@ -1604,6 +1701,17 @@ async fn execute_lightweight_no_tools(
         response.input_tokens,
         response.output_tokens,
     )
+}
+
+/// Convert raw `u32` token counts into `Option<i32>`, preserving `None` semantics.
+///
+/// Providers that don't report token usage return `(0, 0)`. Wrapping that in
+/// `Some(0)` would change the stored meaning from "unknown/not tracked" to "zero",
+/// leaking incorrect data to downstream reporting. Only materialize `Some` when
+/// at least one count is non-zero.
+fn tokens_to_option(input: u32, output: u32) -> Option<i32> {
+    let total = input.saturating_add(output);
+    if total > 0 { Some(total as i32) } else { None }
 }
 
 /// Handle a text-only LLM response in lightweight routine execution.
@@ -1617,22 +1725,28 @@ fn handle_text_response(
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
     let content = content.trim();
 
-    // Empty content guard
+    // Empty content guard — carry consumed tokens so the retry loop can
+    // accumulate them even when the response shape is invalid.
     if content.is_empty() {
+        let consumed = tokens_to_option(total_input_tokens, total_output_tokens);
         return if finish_reason == FinishReason::Length {
-            Err(RoutineError::TruncatedResponse)
+            Err(RoutineError::TruncatedResponse {
+                partial_tokens: consumed,
+            })
         } else {
-            Err(RoutineError::EmptyResponse)
+            Err(RoutineError::EmptyResponse {
+                partial_tokens: consumed,
+            })
         };
     }
 
     // Check for the "nothing to do" sentinel (exact match on trimmed content).
     if content == "ROUTINE_OK" {
-        let total_tokens = Some((total_input_tokens + total_output_tokens) as i32);
+        let total_tokens = tokens_to_option(total_input_tokens, total_output_tokens);
         return Ok((RunStatus::Ok, None, total_tokens));
     }
 
-    let total_tokens = Some((total_input_tokens + total_output_tokens) as i32);
+    let total_tokens = tokens_to_option(total_input_tokens, total_output_tokens);
     Ok((
         RunStatus::Attention,
         Some(content.to_string()),
@@ -1710,13 +1824,14 @@ async fn execute_lightweight_with_tools(
                 .with_max_tokens(effective_max_tokens)
                 .with_temperature(0.3);
 
-            let response =
-                ctx.llm
-                    .complete(request)
-                    .await
-                    .map_err(|e| RoutineError::LlmFailed {
-                        reason: e.to_string(),
-                    })?;
+            let response = ctx.llm.complete(request).await.map_err(|e| {
+                let retryable = crate::llm::retry::is_retryable(&e);
+                RoutineError::LlmFailed {
+                    reason: e.to_string(),
+                    partial_tokens: tokens_to_option(total_input_tokens, total_output_tokens),
+                    retryable,
+                }
+            })?;
 
             total_input_tokens += response.input_tokens;
             total_output_tokens += response.output_tokens;
@@ -1743,8 +1858,11 @@ async fn execute_lightweight_with_tools(
                 .with_temperature(0.3);
 
             let response = ctx.llm.complete_with_tools(request).await.map_err(|e| {
+                let retryable = crate::llm::retry::is_retryable(&e);
                 RoutineError::LlmFailed {
                     reason: e.to_string(),
+                    partial_tokens: tokens_to_option(total_input_tokens, total_output_tokens),
+                    retryable,
                 }
             })?;
 
@@ -1917,6 +2035,7 @@ async fn execute_routine_tool(
 }
 
 /// Send a notification based on the routine's notify config and run status.
+#[allow(clippy::too_many_arguments)]
 async fn send_notification(
     tx: &mpsc::Sender<OutgoingResponse>,
     notify: &NotifyConfig,
@@ -2596,6 +2715,104 @@ mod tests {
                 "{:?} should not finalize the routine run",
                 state
             );
+        }
+    }
+
+    /// Regression test for #1320: transient errors are retried for lightweight
+    /// routines but not for full-job routines or hard failures.
+    #[test]
+    fn test_retry_classification_for_routine_errors() {
+        use crate::error::RoutineError;
+
+        // Transient errors (retryable for lightweight routines)
+        let transient_errors: Vec<RoutineError> = vec![
+            RoutineError::LlmFailed {
+                reason: "rate limit".into(),
+                partial_tokens: None,
+                retryable: true,
+            },
+            RoutineError::LlmFailed {
+                reason: "network timeout".into(),
+                partial_tokens: Some(42),
+                retryable: true,
+            },
+            RoutineError::EmptyResponse {
+                partial_tokens: None,
+            },
+            RoutineError::TruncatedResponse {
+                partial_tokens: Some(100),
+            },
+        ];
+        for err in &transient_errors {
+            assert!(err.is_retryable(), "{} should be retryable", err);
+        }
+
+        // Permanent LLM failures that should NOT be retried
+        // (retryable: false is set at conversion time by llm::retry::is_retryable)
+        let permanent_llm_errors: Vec<RoutineError> = vec![
+            RoutineError::LlmFailed {
+                reason: "Authentication failed for provider openai".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "invalid_api_key: bad key".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "content policy violation".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "content_filter triggered".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "context length exceeded: 150000 tokens used, 128000 allowed".into(),
+                partial_tokens: Some(100),
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "model not available on provider anthropic".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+            RoutineError::LlmFailed {
+                reason: "content moderation flagged".into(),
+                partial_tokens: None,
+                retryable: false,
+            },
+        ];
+        for err in &permanent_llm_errors {
+            assert!(!err.is_retryable(), "{} should NOT be retryable", err);
+        }
+
+        // Hard failures (never retried)
+        let hard_errors: Vec<RoutineError> = vec![
+            RoutineError::Disabled {
+                name: "test".into(),
+            },
+            RoutineError::NotFound {
+                id: uuid::Uuid::new_v4(),
+            },
+            RoutineError::NotAuthorized {
+                id: uuid::Uuid::new_v4(),
+            },
+            RoutineError::MaxConcurrent {
+                name: "test".into(),
+            },
+            RoutineError::JobDispatchFailed {
+                reason: "no docker".into(),
+            },
+            RoutineError::Database {
+                reason: "connection refused".into(),
+            },
+        ];
+        for err in &hard_errors {
+            assert!(!err.is_retryable(), "{} should NOT be retryable", err);
         }
     }
 

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -97,6 +97,10 @@ pub(crate) fn routine_matches_message(routine: &Routine, message: &IncomingMessa
     true
 }
 
+fn trigger_uses_event_cache(trigger: &Trigger) -> bool {
+    matches!(trigger, Trigger::Event { .. } | Trigger::SystemEvent { .. })
+}
+
 /// The routine execution engine.
 pub struct RoutineEngine {
     config: RoutineConfig,
@@ -666,7 +670,7 @@ impl RoutineEngine {
             None
         };
 
-        if let Err(e) = self
+        let runtime_updated = match self
             .store
             .update_routine_runtime(
                 routine.id,
@@ -678,10 +682,25 @@ impl RoutineEngine {
             )
             .await
         {
-            tracing::error!(
-                routine = %routine.name,
-                "Failed to update routine runtime after dispatched run: {}", e
-            );
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    routine = %routine.name,
+                    "Failed to update routine runtime after dispatched run: {}", e
+                );
+                false
+            }
+        };
+
+        if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+            update_cached_event_runtime(
+                self.event_cache.as_ref(),
+                routine.id,
+                now,
+                routine.run_count + 1,
+                new_failures,
+            )
+            .await;
         }
 
         // Persist result to the routine's conversation thread
@@ -812,6 +831,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -897,6 +917,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -951,6 +972,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         // Record the run in DB, then spawn execution
@@ -1089,6 +1111,7 @@ struct EngineContext {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     sandbox_readiness: SandboxReadiness,
+    event_cache: Arc<RwLock<Vec<EventMatcher>>>,
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
@@ -1175,7 +1198,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         0
     };
 
-    if let Err(e) = ctx
+    let runtime_updated = match ctx
         .store
         .update_routine_runtime(
             routine.id,
@@ -1187,7 +1210,22 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         )
         .await
     {
-        tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+            false
+        }
+    };
+
+    if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+        update_cached_event_runtime(
+            ctx.event_cache.as_ref(),
+            routine.id,
+            now,
+            routine.run_count + 1,
+            new_failures,
+        )
+        .await;
     }
 
     // Persist routine result to its dedicated conversation thread
@@ -1234,6 +1272,27 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         thread_id.as_deref(),
     )
     .await;
+}
+
+async fn update_cached_event_runtime(
+    event_cache: &RwLock<Vec<EventMatcher>>,
+    routine_id: Uuid,
+    last_run_at: chrono::DateTime<Utc>,
+    run_count: u64,
+    consecutive_failures: u32,
+) {
+    let mut cache = event_cache.write().await;
+    for matcher in cache.iter_mut() {
+        let routine = match matcher {
+            EventMatcher::Message { routine, .. } | EventMatcher::System { routine } => routine,
+        };
+        if routine.id == routine_id {
+            routine.last_run_at = Some(last_run_at);
+            routine.run_count = run_count;
+            routine.consecutive_failures = consecutive_failures;
+            break;
+        }
+    }
 }
 
 /// Sanitize a routine name for use in workspace paths.

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1613,13 +1613,23 @@ async fn execute_lightweight_with_tools(
     let mut total_input_tokens = 0;
     let mut total_output_tokens = 0;
 
-    // Create a minimal job context for tool execution with unique run ID
+    // Create a minimal job context for tool execution with unique run ID.
+    // Carry the routine's notify config in metadata so the message tool can
+    // resolve channel/target — mirrors the full-job path in execute_full_job().
     let run_id = Uuid::new_v4();
+    let mut lw_metadata = serde_json::json!({
+        "owner_id": routine.user_id
+    });
+    if let Some(channel) = &routine.notify.channel {
+        lw_metadata["notify_channel"] = serde_json::json!(channel);
+    }
+    lw_metadata["notify_user"] = serde_json::json!(&routine.notify.user);
     let job_ctx = JobContext {
         job_id: run_id,
         user_id: routine.user_id.clone(),
         title: "Lightweight Routine".to_string(),
         description: routine.name.clone(),
+        metadata: lw_metadata,
         ..Default::default()
     };
     let allowed_tools =
@@ -2574,5 +2584,32 @@ mod tests {
         let result = sanitize_summary(&s);
         assert!(result.len() <= 503);
         assert!(result.ends_with("..."));
+    }
+
+    /// Regression: lightweight routines must carry notify metadata in JobContext
+    /// so the message tool can route to the correct channel. Previously,
+    /// `..Default::default()` left metadata as null, causing messages to land
+    /// in the user's DM instead of the originating Slack channel.
+    #[test]
+    fn test_build_lightweight_prompt_preserves_notify_config() {
+        let notify = NotifyConfig {
+            channel: Some("slack-relay".to_string()),
+            user: Some("C088K6C3SQZ".to_string()),
+            on_attention: true,
+            on_failure: true,
+            on_success: false,
+        };
+
+        let prompt =
+            super::build_lightweight_prompt("Send Ping in this channel.", &[], None, &notify, true);
+
+        assert!(
+            prompt.contains("slack-relay"),
+            "prompt should mention configured delivery channel: {prompt}",
+        );
+        assert!(
+            prompt.contains("C088K6C3SQZ"),
+            "prompt should mention configured delivery target: {prompt}",
+        );
     }
 }

--- a/src/agent/scheduler.rs
+++ b/src/agent/scheduler.rs
@@ -197,26 +197,28 @@ impl Scheduler {
             })
             .unwrap_or(self.config.max_tokens_per_job);
 
-        // Apply both metadata and token budget in one closure (Issue #813: atomic update).
-        // Use update_context_and_get to ensure atomicity: no gap where concurrent workers
-        // can modify the context between update and DB persist (Issue #807).
-        let ctx = if let Some(meta) = metadata {
+        // Apply metadata, token budget, and approval context in one closure
+        // (Issue #813: atomic update). Use update_context_and_get to ensure atomicity:
+        // no gap where concurrent workers can modify the context between update and
+        // DB persist (Issue #807).
+        let needs_update = metadata.is_some() || max_tokens > 0 || approval_context.is_some();
+        let ctx = if needs_update {
             self.context_manager
                 .update_context_and_get(job_id, |ctx| {
-                    ctx.metadata = meta;
+                    if let Some(meta) = metadata {
+                        ctx.metadata = meta;
+                    }
                     if max_tokens > 0 {
                         ctx.max_tokens = max_tokens;
                     }
-                })
-                .await?
-        } else if max_tokens > 0 {
-            self.context_manager
-                .update_context_and_get(job_id, |ctx| {
-                    ctx.max_tokens = max_tokens;
+                    if let Some(ref approval) = approval_context {
+                        ctx.approval_context = Some(approval.clone());
+                    }
                 })
                 .await?
         } else {
-            // No metadata or token budget to set; get the initial context
+            // Currently unreachable via dispatch_job() which always provides
+            // Some(approval_context), but kept as a safe fallback.
             self.context_manager.get_context(job_id).await?
         };
 

--- a/src/agent/self_repair.rs
+++ b/src/agent/self_repair.rs
@@ -48,6 +48,22 @@ pub enum RepairResult {
 }
 
 /// Trait for self-repair implementations.
+///
+/// # Built-in tool exclusion
+///
+/// Built-in tools (those checked by [`is_protected_tool_name`](crate::tools::is_protected_tool_name))
+/// must be excluded from repair workflows. Errors on built-in tools are
+/// caller-side issues (bad LLM parameters), not tool defects — attempting to
+/// rebuild them via `SoftwareBuilder` wastes tokens and cannot succeed.
+///
+/// `DefaultSelfRepair` enforces this at two levels:
+/// - **Detection**: `detect_broken_tools` filters out protected names before
+///   returning results.
+/// - **Repair**: `repair_broken_tool` rejects protected names as a
+///   defense-in-depth guard (returns `RepairResult::Success` with a skip
+///   message).
+///
+/// Custom implementations should follow the same convention.
 #[async_trait]
 pub trait SelfRepair: Send + Sync {
     /// Detect stuck jobs.
@@ -56,10 +72,17 @@ pub trait SelfRepair: Send + Sync {
     /// Attempt to repair a stuck job.
     async fn repair_stuck_job(&self, job: &StuckJob) -> Result<RepairResult, RepairError>;
 
-    /// Detect broken tools.
+    /// Detect broken tools that need repair.
+    ///
+    /// Implementations should exclude built-in/protected tools from the
+    /// returned list — see the trait-level documentation.
     async fn detect_broken_tools(&self) -> Vec<BrokenTool>;
 
     /// Attempt to repair a broken tool.
+    ///
+    /// Implementations should reject built-in/protected tool names early as
+    /// a defense-in-depth measure, even though `detect_broken_tools` should
+    /// have already filtered them out.
     async fn repair_broken_tool(&self, tool: &BrokenTool) -> Result<RepairResult, RepairError>;
 }
 
@@ -251,10 +274,29 @@ impl SelfRepair for DefaultSelfRepair {
         // Threshold: 5 failures before considering a tool broken
         match store.get_broken_tools(5).await {
             Ok(tools) => {
-                if !tools.is_empty() {
-                    tracing::info!("Detected {} broken tools needing repair", tools.len());
+                // Filter out built-in tools — their errors are caller-side (bad
+                // parameters from the LLM), not tool defects. Attempting to rebuild
+                // them via SoftwareBuilder wastes LLM tokens and cannot fix anything.
+                let repairable: Vec<BrokenTool> = tools
+                    .into_iter()
+                    .filter(|t| {
+                        if crate::tools::is_protected_tool_name(&t.name) {
+                            tracing::debug!(
+                                tool = %t.name,
+                                failure_count = t.failure_count,
+                                "Skipping built-in tool in broken detection (caller-side errors)"
+                            );
+                            false
+                        } else {
+                            true
+                        }
+                    })
+                    .collect();
+
+                if !repairable.is_empty() {
+                    tracing::info!("Detected {} broken tools needing repair", repairable.len());
                 }
-                tools
+                repairable
             }
             Err(e) => {
                 tracing::warn!("Failed to detect broken tools: {}", e);
@@ -264,6 +306,21 @@ impl SelfRepair for DefaultSelfRepair {
     }
 
     async fn repair_broken_tool(&self, tool: &BrokenTool) -> Result<RepairResult, RepairError> {
+        // Defense-in-depth: reject built-in tools even if detect_broken_tools
+        // failed to filter them. Built-in tools cannot be rebuilt.
+        if crate::tools::is_protected_tool_name(&tool.name) {
+            tracing::debug!(
+                tool = %tool.name,
+                "Skipping repair of built-in tool (caller-side errors, not a tool defect)"
+            );
+            return Ok(RepairResult::Success {
+                message: format!(
+                    "Tool '{}' is a built-in — errors are caller-side, skipping repair",
+                    tool.name
+                ),
+            });
+        }
+
         let Some(ref builder) = self.builder else {
             return Ok(RepairResult::ManualRequired {
                 message: format!("Builder not available for repairing tool '{}'", tool.name),
@@ -585,6 +642,76 @@ mod tests {
         assert_eq!(ctx.state, JobState::InProgress);
     }
 
+    /// Regression: built-in tools (http, shell, json, etc.) must be filtered
+    /// out of broken tool detection. Errors on built-in tools are caller-side
+    /// (bad LLM parameters), not tool defects. Attempting to rebuild them via
+    /// SoftwareBuilder wastes LLM tokens and cannot fix anything.
+    #[test]
+    fn is_protected_tool_name_covers_common_builtins() {
+        use crate::tools::is_protected_tool_name;
+
+        // Built-in tools that triggered the original bug
+        assert!(is_protected_tool_name("http"));
+        assert!(is_protected_tool_name("shell"));
+        assert!(is_protected_tool_name("json"));
+        assert!(is_protected_tool_name("message"));
+        assert!(is_protected_tool_name("read_file"));
+        assert!(is_protected_tool_name("memory_write"));
+
+        // Job, extension, skill, secret tools
+        assert!(is_protected_tool_name("job_events"));
+        assert!(is_protected_tool_name("extension_info"));
+        assert!(is_protected_tool_name("skill_list"));
+        assert!(is_protected_tool_name("secret_list"));
+        assert!(is_protected_tool_name("tool_upgrade"));
+        assert!(is_protected_tool_name("routine_fire"));
+
+        // Dynamic tools should NOT be protected
+        assert!(!is_protected_tool_name("my_custom_tool"));
+        assert!(!is_protected_tool_name("weather_fetcher"));
+    }
+
+    /// Regression: repair_broken_tool must reject built-in tools as a
+    /// defense-in-depth measure, even if detect_broken_tools failed to
+    /// filter them out.
+    #[tokio::test]
+    async fn repair_broken_tool_skips_builtin() {
+        let cm = Arc::new(ContextManager::new(10));
+        let builder = Arc::new(MockBuilder::new());
+        let tools = Arc::new(crate::tools::ToolRegistry::new());
+
+        let repair = DefaultSelfRepair::new(cm, Duration::from_secs(60), 3).with_builder(
+            Arc::clone(&builder) as Arc<dyn crate::tools::SoftwareBuilder>,
+            tools,
+        );
+
+        // "http" is a built-in tool — repair should skip it without invoking
+        // the builder.
+        let broken = BrokenTool {
+            name: "http".to_string(),
+            failure_count: 20,
+            last_error: Some("invalid params".to_string()),
+            first_failure: Utc::now(),
+            last_failure: Utc::now(),
+            last_build_result: None,
+            repair_attempts: 0,
+        };
+
+        let result = repair.repair_broken_tool(&broken).await.unwrap();
+        assert!(
+            matches!(result, RepairResult::Success { .. }),
+            "Built-in tool repair should return Success (skip), got: {:?}",
+            result
+        );
+
+        // Builder must NOT have been called
+        assert_eq!(
+            builder.builds(),
+            0,
+            "Builder should not be invoked for built-in tools"
+        );
+    }
+
     #[tokio::test]
     async fn detect_broken_tools_returns_empty_without_store() {
         let cm = Arc::new(ContextManager::new(10));
@@ -775,6 +902,38 @@ mod tests {
         ) -> Result<crate::tools::BuildResult, crate::error::ToolError> {
             unimplemented!("not needed for this test")
         }
+    }
+
+    /// Regression: detect_broken_tools must filter out built-in tools from the
+    /// database results. Seed failures for both a built-in ("http") and a
+    /// dynamic tool, then verify only the dynamic tool is returned.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn detect_broken_tools_filters_out_builtins() {
+        let cm = Arc::new(ContextManager::new(10));
+        let (db, _tmp_dir) = crate::testing::test_db().await;
+        let store = crate::tenant::AdminScope::new(Arc::clone(&db));
+
+        // Seed 6 failures for "http" (built-in) and "my_custom_tool" (dynamic).
+        // The threshold is 5, so both would qualify as "broken" without filtering.
+        for _ in 0..6 {
+            store
+                .record_tool_failure("http", "invalid params")
+                .await
+                .unwrap();
+            store
+                .record_tool_failure("my_custom_tool", "runtime crash")
+                .await
+                .unwrap();
+        }
+
+        let repair = DefaultSelfRepair::new(cm, Duration::from_secs(60), 3).with_store(store);
+
+        let broken = repair.detect_broken_tools().await;
+
+        // Only the dynamic tool should be returned; "http" must be filtered.
+        assert_eq!(broken.len(), 1, "Expected 1 broken tool, got: {:?}", broken);
+        assert_eq!(broken[0].name, "my_custom_tool");
     }
 
     /// E2E test: stuck job detected -> repaired -> transitions back to InProgress,

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -68,8 +68,8 @@ impl Session {
     }
 
     /// Create a new thread in this session.
-    pub fn create_thread(&mut self) -> &mut Thread {
-        let thread = Thread::new(self.id);
+    pub fn create_thread(&mut self, channel: Option<&str>) -> &mut Thread {
+        let thread = Thread::new(self.id, channel);
         let thread_id = thread.id;
         self.active_thread = Some(thread_id);
         self.last_active_at = Utc::now();
@@ -87,9 +87,9 @@ impl Session {
     }
 
     /// Get or create the active thread.
-    pub fn get_or_create_thread(&mut self) -> &mut Thread {
+    pub fn get_or_create_thread(&mut self, channel: Option<&str>) -> &mut Thread {
         match self.active_thread {
-            None => self.create_thread(),
+            None => self.create_thread(channel),
             Some(id) => {
                 if self.threads.contains_key(&id) {
                     // Entry existence confirmed by contains_key above.
@@ -100,7 +100,7 @@ impl Session {
                 } else {
                     // Stale active_thread ID: create a new thread, which
                     // updates self.active_thread to the new thread's ID.
-                    self.create_thread()
+                    self.create_thread(channel)
                 }
             }
         }
@@ -225,6 +225,9 @@ pub struct Thread {
     /// Messages queued while the thread was processing a turn.
     #[serde(default, skip_serializing_if = "VecDeque::is_empty")]
     pub pending_messages: VecDeque<String>,
+    /// Channel that created this thread (for approval authorization).
+    #[serde(default)]
+    pub source_channel: Option<String>,
 }
 
 /// Maximum number of messages that can be queued while a thread is processing.
@@ -233,9 +236,34 @@ pub struct Thread {
 /// rapid follow-ups. The drain loop processes them as one newline-delimited turn.
 pub const MAX_PENDING_MESSAGES: usize = 10;
 
+/// Sentinel value for bootstrap threads that accept approvals from any channel.
+pub const BOOTSTRAP_SOURCE_CHANNEL: &str = "__bootstrap__";
+
+/// Channels that are always authorized to approve tool calls on any thread,
+/// regardless of which channel originally created the thread. These are
+/// trusted UI surfaces (the web dashboard and its gateway).
+pub const TRUSTED_APPROVAL_CHANNELS: &[&str] = &["web", "gateway"];
+
+/// Check whether an approval from `requesting_channel` is authorized for a
+/// thread whose `source_channel` is `source`.
+///
+/// Rules:
+/// - `None` (unknown origin) -> denied (fail-closed)
+/// - `Some("__bootstrap__")` -> authorized from any channel
+/// - `Some(src) == requesting` -> same channel, authorized
+/// - requesting is in `TRUSTED_APPROVAL_CHANNELS` -> always authorized
+/// - Otherwise -> denied
+pub fn is_approval_authorized(source: Option<&str>, requesting: &str) -> bool {
+    match source {
+        None => false,
+        Some(src) if src == BOOTSTRAP_SOURCE_CHANNEL => true,
+        Some(src) => src == requesting || TRUSTED_APPROVAL_CHANNELS.contains(&requesting),
+    }
+}
+
 impl Thread {
     /// Create a new thread.
-    pub fn new(session_id: Uuid) -> Self {
+    pub fn new(session_id: Uuid, source_channel: Option<&str>) -> Self {
         let now = Utc::now();
         Self {
             id: Uuid::new_v4(),
@@ -248,11 +276,12 @@ impl Thread {
             pending_approval: None,
             pending_auth: None,
             pending_messages: VecDeque::new(),
+            source_channel: source_channel.map(String::from),
         }
     }
 
     /// Create a thread with a specific ID (for DB hydration).
-    pub fn with_id(id: Uuid, session_id: Uuid) -> Self {
+    pub fn with_id(id: Uuid, session_id: Uuid, source_channel: Option<&str>) -> Self {
         let now = Utc::now();
         Self {
             id,
@@ -265,6 +294,7 @@ impl Thread {
             pending_approval: None,
             pending_auth: None,
             pending_messages: VecDeque::new(),
+            source_channel: source_channel.map(String::from),
         }
     }
 
@@ -787,13 +817,13 @@ mod tests {
         let mut session = Session::new("user-123");
         assert!(session.active_thread.is_none());
 
-        session.create_thread();
+        session.create_thread(None);
         assert!(session.active_thread.is_some());
     }
 
     #[test]
     fn test_thread_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Hello");
         assert_eq!(thread.state, ThreadState::Processing);
@@ -806,7 +836,7 @@ mod tests {
 
     #[test]
     fn test_thread_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("First message");
         thread.complete_turn("First response");
@@ -829,7 +859,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // First add some turns
         thread.start_turn("Original message");
@@ -855,7 +885,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_incomplete_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Messages with incomplete last turn (no assistant response)
         let messages = vec![
@@ -874,7 +904,7 @@ mod tests {
     #[test]
     fn test_enter_auth_mode() {
         let before = Utc::now();
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         assert!(thread.pending_auth.is_none());
 
         thread.enter_auth_mode("telegram".to_string());
@@ -887,7 +917,7 @@ mod tests {
 
     #[test]
     fn test_take_pending_auth() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.enter_auth_mode("notion".to_string());
 
         let pending = thread.take_pending_auth();
@@ -902,7 +932,7 @@ mod tests {
 
     #[test]
     fn test_pending_auth_serialization() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.enter_auth_mode("openai".to_string());
 
         let json = serde_json::to_string(&thread).expect("should serialize");
@@ -932,7 +962,7 @@ mod tests {
     #[test]
     fn test_pending_auth_default_none() {
         // Deserialization of old data without pending_auth should default to None
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.pending_auth = None;
         let json = serde_json::to_string(&thread).expect("serialize");
 
@@ -946,7 +976,7 @@ mod tests {
     fn test_thread_with_id() {
         let specific_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let thread = Thread::with_id(specific_id, session_id);
+        let thread = Thread::with_id(specific_id, session_id, None);
 
         assert_eq!(thread.id, specific_id);
         assert_eq!(thread.session_id, session_id);
@@ -958,7 +988,7 @@ mod tests {
     fn test_thread_with_id_restore_messages() {
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
 
         let messages = vec![
             ChatMessage::user("Hello from DB"),
@@ -977,7 +1007,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_empty() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Add a turn first, then restore with empty vec
         thread.start_turn("hello");
@@ -993,7 +1023,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_only_assistant_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Only assistant messages (no user messages to anchor turns)
         let messages = vec![
@@ -1010,7 +1040,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_multiple_user_messages_in_a_row() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Two user messages with no assistant response between them
         let messages = vec![
@@ -1037,8 +1067,8 @@ mod tests {
     fn test_thread_switch() {
         let mut session = Session::new("user-1");
 
-        let t1_id = session.create_thread().id;
-        let t2_id = session.create_thread().id;
+        let t1_id = session.create_thread(None).id;
+        let t2_id = session.create_thread(None).id;
 
         // After creating two threads, active should be the last one
         assert_eq!(session.active_thread, Some(t2_id));
@@ -1058,8 +1088,8 @@ mod tests {
     fn test_get_or_create_thread_idempotent() {
         let mut session = Session::new("user-1");
 
-        let tid1 = session.get_or_create_thread().id;
-        let tid2 = session.get_or_create_thread().id;
+        let tid1 = session.get_or_create_thread(None).id;
+        let tid2 = session.get_or_create_thread(None).id;
 
         // Should return the same thread (not create a new one each time)
         assert_eq!(tid1, tid2);
@@ -1068,7 +1098,7 @@ mod tests {
 
     #[test]
     fn test_truncate_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         for i in 0..5 {
             thread.start_turn(format!("msg-{}", i));
@@ -1092,7 +1122,7 @@ mod tests {
 
     #[test]
     fn test_truncate_turns_noop_when_fewer() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("only one");
         thread.complete_turn("response");
@@ -1104,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_thread_interrupt_and_resume() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("do something");
         assert_eq!(thread.state, ThreadState::Processing);
@@ -1122,7 +1152,7 @@ mod tests {
 
     #[test]
     fn test_resume_only_from_interrupted() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Idle thread: resume should be a no-op
         assert_eq!(thread.state, ThreadState::Idle);
@@ -1138,7 +1168,7 @@ mod tests {
 
     #[test]
     fn test_turn_fail() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("risky operation");
         thread.fail_turn("connection timed out");
@@ -1154,7 +1184,7 @@ mod tests {
 
     #[test]
     fn test_messages_with_incomplete_last_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("first");
         thread.complete_turn("first reply");
@@ -1170,7 +1200,7 @@ mod tests {
 
     #[test]
     fn test_thread_serialization_round_trip() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("hello");
         thread.complete_turn("world");
@@ -1188,7 +1218,7 @@ mod tests {
     #[test]
     fn test_session_serialization_round_trip() {
         let mut session = Session::new("user-ser");
-        session.create_thread();
+        session.create_thread(None);
         session.auto_approve_tool("echo");
 
         let json = serde_json::to_string(&session).unwrap();
@@ -1226,7 +1256,7 @@ mod tests {
 
     #[test]
     fn test_turn_number_increments() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Before any turns, turn_number() is 1 (1-indexed for display)
         assert_eq!(thread.turn_number(), 1);
@@ -1241,7 +1271,7 @@ mod tests {
 
     #[test]
     fn test_complete_turn_on_empty_thread() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Completing a turn when there are no turns should be a safe no-op
         thread.complete_turn("phantom response");
@@ -1251,7 +1281,7 @@ mod tests {
 
     #[test]
     fn test_fail_turn_on_empty_thread() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Failing a turn when there are no turns should be a safe no-op
         thread.fail_turn("phantom error");
@@ -1261,7 +1291,7 @@ mod tests {
 
     #[test]
     fn test_pending_approval_flow() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let approval = PendingApproval {
             request_id: Uuid::new_v4(),
@@ -1288,7 +1318,7 @@ mod tests {
 
     #[test]
     fn test_clear_pending_approval() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let approval = PendingApproval {
             request_id: Uuid::new_v4(),
@@ -1317,7 +1347,7 @@ mod tests {
         assert!(session.active_thread().is_none());
         assert!(session.active_thread_mut().is_none());
 
-        let tid = session.create_thread().id;
+        let tid = session.create_thread(None).id;
 
         assert!(session.active_thread().is_some());
         assert_eq!(session.active_thread().unwrap().id, tid);
@@ -1334,7 +1364,7 @@ mod tests {
 
     #[test]
     fn test_messages_includes_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Search for X");
         {
@@ -1366,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_messages_multiple_tool_calls_per_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Do two things");
         {
@@ -1393,7 +1423,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_with_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Build a message sequence with tool calls
         let tc = ToolCall {
@@ -1425,7 +1455,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_with_tool_error() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let tc = ToolCall {
             id: "call_0".to_string(),
@@ -1456,7 +1486,7 @@ mod tests {
     fn test_messages_round_trip_with_tools() {
         // Build a thread with tool calls, get messages(), restore, get messages() again
         // The two message sequences should be equivalent.
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Do search");
         {
@@ -1469,7 +1499,7 @@ mod tests {
         let messages_original = thread.messages();
 
         // Restore into a new thread
-        let mut thread2 = Thread::new(Uuid::new_v4());
+        let mut thread2 = Thread::new(Uuid::new_v4(), None);
         thread2.restore_from_messages(messages_original.clone());
 
         let messages_restored = thread2.messages();
@@ -1491,7 +1521,7 @@ mod tests {
 
     #[test]
     fn test_restore_multi_stage_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let tc1 = ToolCall {
             id: "call_a".to_string(),
@@ -1534,7 +1564,7 @@ mod tests {
 
     #[test]
     fn test_messages_truncates_large_tool_results() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Read big file");
         {
@@ -1557,7 +1587,7 @@ mod tests {
 
     #[test]
     fn test_thread_message_queue() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Queue is initially empty
         assert!(thread.pending_messages.is_empty());
@@ -1593,7 +1623,7 @@ mod tests {
 
     #[test]
     fn test_thread_message_queue_serialization() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Empty queue should not appear in serialization (skip_serializing_if)
         let json = serde_json::to_string(&thread).unwrap();
@@ -1613,7 +1643,7 @@ mod tests {
     #[test]
     fn test_thread_message_queue_default_on_old_data() {
         // Deserialization of old data without pending_messages should default to empty
-        let thread = Thread::new(Uuid::new_v4());
+        let thread = Thread::new(Uuid::new_v4(), None);
         let json = serde_json::to_string(&thread).unwrap();
 
         // The field is absent (skip_serializing_if), simulating old data
@@ -1624,7 +1654,7 @@ mod tests {
 
     #[test]
     fn test_interrupt_clears_pending_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Start a turn so there's something to interrupt
         thread.start_turn("initial input");
@@ -1643,7 +1673,7 @@ mod tests {
 
     #[test]
     fn test_thread_state_idle_after_full_drain() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Simulate a full drain cycle: start turn, queue messages, complete turn,
         // then drain all queued messages as a single merged turn (#259).
@@ -1671,7 +1701,7 @@ mod tests {
 
     #[test]
     fn test_drain_pending_messages_merges_with_newlines() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Empty queue returns None
         assert!(thread.drain_pending_messages().is_none());
@@ -1700,7 +1730,7 @@ mod tests {
 
     #[test]
     fn test_requeue_drained_preserves_content_at_front() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Re-queue into empty queue
         thread.requeue_drained("failed batch".to_string());
@@ -1809,6 +1839,202 @@ mod tests {
         assert_eq!(
             turn.tool_calls[0].result.as_ref().unwrap(),
             &serde_json::json!("done")
+        );
+    }
+
+    #[test]
+    fn test_thread_new_stores_source_channel() {
+        let thread = Thread::new(Uuid::new_v4(), Some("telegram"));
+        assert_eq!(thread.source_channel.as_deref(), Some("telegram"));
+    }
+
+    #[test]
+    fn test_thread_new_none_channel() {
+        let thread = Thread::new(Uuid::new_v4(), None);
+        assert!(thread.source_channel.is_none());
+    }
+
+    #[test]
+    fn test_source_channel_serde_backcompat() {
+        // Simulate deserializing a Thread from older DB records that lack source_channel.
+        let thread = Thread::new(Uuid::new_v4(), Some("cli"));
+        let json = serde_json::to_string(&thread).unwrap();
+
+        // Remove the source_channel field to simulate an old record.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("source_channel");
+        let old_json = serde_json::to_string(&value).unwrap();
+
+        let deserialized: Thread = serde_json::from_str(&old_json).unwrap();
+        assert!(
+            deserialized.source_channel.is_none(),
+            "missing source_channel should deserialize as None"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_same_channel() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "telegram"),
+            "same channel should be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_different_channel_blocked() {
+        assert!(
+            !is_approval_authorized(Some("telegram"), "http"),
+            "different channel should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_web_always_allowed() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "web"),
+            "web channel should always be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_gateway_always_allowed() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "gateway"),
+            "gateway channel should always be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_none_denied() {
+        assert!(
+            !is_approval_authorized(None, "telegram"),
+            "None source_channel should be denied (fail-closed)"
+        );
+        assert!(
+            !is_approval_authorized(None, "web"),
+            "None source_channel should be denied even for web"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_bootstrap_any_channel() {
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "telegram"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "http"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "cli"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_uses_trusted_channels_constant() {
+        // Every channel in TRUSTED_APPROVAL_CHANNELS should be authorized
+        // against any source, ensuring the constant drives the logic.
+        for &trusted in TRUSTED_APPROVAL_CHANNELS {
+            assert!(
+                is_approval_authorized(Some("any-source"), trusted),
+                "TRUSTED_APPROVAL_CHANNELS entry '{}' should always be authorized",
+                trusted
+            );
+        }
+    }
+
+    #[test]
+    fn test_approval_blocks_thread_without_pending_approval() {
+        // A thread with no pending_approval should not be eligible for
+        // approval routing. This test verifies the data-level invariant
+        // that `agent_loop.rs` checks before calling is_approval_authorized.
+        let thread = Thread::new(Uuid::new_v4(), Some("telegram"));
+        assert!(
+            thread.pending_approval.is_none(),
+            "new thread should have no pending approval"
+        );
+
+        // Set up a thread WITH a pending approval to contrast
+        let mut thread_with_approval = Thread::new(Uuid::new_v4(), Some("telegram"));
+        thread_with_approval.pending_approval = Some(PendingApproval {
+            request_id: Uuid::new_v4(),
+            tool_name: "shell".to_string(),
+            parameters: serde_json::json!({"cmd": "rm -rf /"}),
+            display_parameters: serde_json::json!({"cmd": "rm -rf /"}),
+            description: "run shell command".to_string(),
+            tool_call_id: "call_1".to_string(),
+            context_messages: vec![],
+            deferred_tool_calls: vec![],
+            user_timezone: None,
+            allow_always: true,
+        });
+        assert!(
+            thread_with_approval.pending_approval.is_some(),
+            "thread with pending approval should be eligible"
+        );
+
+        // Authorization check should pass for the thread with pending approval
+        // (same channel), confirming the two checks compose correctly.
+        assert!(is_approval_authorized(
+            thread_with_approval.source_channel.as_deref(),
+            "telegram"
+        ));
+    }
+
+    #[test]
+    fn test_approval_wasm_channel_cannot_impersonate_trusted() {
+        // A WASM channel named "web" or "gateway" would bypass authorization.
+        // This test documents the invariant that WASM setup must reject these
+        // names (tested separately in wasm/setup.rs).
+        // Here we verify the authorization logic itself treats them as trusted.
+        assert!(is_approval_authorized(Some("telegram"), "web"));
+        assert!(is_approval_authorized(Some("telegram"), "gateway"));
+        // But a random WASM channel name should NOT be trusted
+        assert!(!is_approval_authorized(Some("telegram"), "my-wasm-channel"));
+    }
+
+    #[test]
+    fn test_approval_bootstrap_sentinel_not_a_normal_channel() {
+        // If a channel happens to be named __bootstrap__, it should be treated
+        // as the source (always authorized), NOT as a requesting channel with
+        // special trust. Only TRUSTED_APPROVAL_CHANNELS get that privilege.
+        assert!(
+            !is_approval_authorized(Some("telegram"), BOOTSTRAP_SOURCE_CHANNEL),
+            "__bootstrap__ as requesting channel should not have special trust"
+        );
+    }
+
+    #[test]
+    fn test_create_thread_propagates_channel() {
+        let mut session = Session::new("user-chan");
+        let tid = session.create_thread(Some("signal")).id;
+        let thread = session.threads.get(&tid).unwrap();
+        assert_eq!(thread.source_channel.as_deref(), Some("signal"));
+    }
+
+    #[test]
+    fn test_get_or_create_thread_propagates_channel() {
+        let mut session = Session::new("user-chan2");
+        // First call creates
+        let tid = session.get_or_create_thread(Some("http")).id;
+        assert_eq!(
+            session.threads.get(&tid).unwrap().source_channel.as_deref(),
+            Some("http")
+        );
+        // Second call returns existing (channel param ignored)
+        let tid2 = session.get_or_create_thread(Some("different")).id;
+        assert_eq!(tid, tid2);
+        assert_eq!(
+            session
+                .threads
+                .get(&tid2)
+                .unwrap()
+                .source_channel
+                .as_deref(),
+            Some("http"),
+            "existing thread should keep its original source_channel"
         );
     }
 }

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -200,7 +200,7 @@ impl SessionManager {
         // Create new thread (always create a new one for a new key)
         let thread_id = {
             let mut sess = session.lock().await;
-            let thread = sess.create_thread();
+            let thread = sess.create_thread(Some(channel));
             thread.id
         };
 
@@ -476,7 +476,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-hydrate")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(thread_id, sess.id);
+            let thread = Thread::with_id(thread_id, sess.id, None);
             sess.threads.insert(thread_id, thread);
             sess.active_thread = Some(thread_id);
         }
@@ -600,7 +600,7 @@ mod tests {
         // Simulate hydration: create thread with a known UUID
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_uuid, session_id);
+            let thread = Thread::with_id(known_uuid, session_id, None);
             sess.threads.insert(known_uuid, thread);
         }
 
@@ -627,7 +627,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-idem")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -656,7 +656,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-undo")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -680,7 +680,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-new")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -788,7 +788,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-cross")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -815,7 +815,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-cross")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -966,7 +966,7 @@ mod tests {
         let adopted_id = Uuid::new_v4();
         {
             let mut sess = session1.lock().await;
-            let thread = Thread::with_id(adopted_id, sess.id);
+            let thread = Thread::with_id(adopted_id, sess.id, None);
             sess.threads.insert(adopted_id, thread);
         }
         // Resolve with the UUID as external_thread_id -- should adopt it
@@ -992,7 +992,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-direct")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
         {
@@ -1030,7 +1030,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1057,7 +1057,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1081,7 +1081,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1100,6 +1100,21 @@ mod tests {
         assert_ne!(
             resolved, known_id,
             "should NOT adopt UUID when external_thread_id is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_thread_stores_source_channel() {
+        let manager = SessionManager::new();
+
+        let (session, thread_id) = manager.resolve_thread("user-1", "telegram", None).await;
+
+        let sess = session.lock().await;
+        let thread = sess.threads.get(&thread_id).unwrap();
+        assert_eq!(
+            thread.source_channel.as_deref(),
+            Some("telegram"),
+            "resolve_thread should store source_channel from the channel parameter"
         );
     }
 }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -135,13 +135,52 @@ impl Agent {
             msg_count = 0;
         }
 
-        // Create thread with the historical ID and restore messages
+        // Create thread with the historical ID and restore messages.
+        // Read source_channel from DB so the authorization check uses the
+        // original creator's channel, not the requesting message's channel.
+        //
+        // Fail-closed policy: if the DB lookup fails or the conversation has
+        // no stored source_channel (legacy row), the thread is hydrated with
+        // source_channel = None.  `is_approval_authorized(None, _)` returns
+        // false, so approvals are denied until the conversation is backfilled
+        // with a source_channel via an explicit migration or re-creation.
+        let db_source_channel = if let Some(store) = self.store() {
+            match store.get_conversation_source_channel(thread_uuid).await {
+                Ok(sc) => {
+                    if sc.is_none() {
+                        tracing::warn!(
+                            thread_id = %thread_uuid,
+                            "Legacy thread has no stored source_channel; \
+                             cross-channel approvals will be denied (fail-closed)"
+                        );
+                    }
+                    sc
+                }
+                Err(e) => {
+                    tracing::error!(
+                        thread_id = %thread_uuid,
+                        error = %e,
+                        "Failed to read source_channel from DB; \
+                         cross-channel approvals will be denied (fail-closed)"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let effective_source_channel = db_source_channel.as_deref();
+
         let session_id = {
             let sess = session.lock().await;
             sess.id
         };
 
-        let mut thread = crate::agent::session::Thread::with_id(thread_uuid, session_id);
+        let mut thread = crate::agent::session::Thread::with_id(
+            thread_uuid,
+            session_id,
+            effective_source_channel,
+        );
         if !chat_messages.is_empty() {
             thread.restore_from_messages(chat_messages);
         }
@@ -636,7 +675,7 @@ impl Agent {
         user_id: &str,
     ) -> bool {
         match store
-            .ensure_conversation(thread_id, channel, user_id, None)
+            .ensure_conversation(thread_id, channel, user_id, None, Some(channel))
             .await
         {
             Ok(true) => true,
@@ -1781,7 +1820,7 @@ impl Agent {
             .get_or_create_session(&message.user_id)
             .await;
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some(&message.channel));
         let thread_id = thread.id;
         Ok(SubmissionResult::ok_with_message(format!(
             "New thread: {}",
@@ -2117,7 +2156,7 @@ mod tests {
 
         let session_id = Uuid::new_v4();
         let thread_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
 
         // Set thread to AwaitingApproval with a pending tool approval
         let pending = PendingApproval {
@@ -2185,7 +2224,7 @@ mod tests {
         use crate::agent::session::{MAX_PENDING_MESSAGES, Thread, ThreadState};
         use uuid::Uuid;
 
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("processing something");
         assert_eq!(thread.state, ThreadState::Processing);
 
@@ -2211,7 +2250,7 @@ mod tests {
         use crate::agent::session::{Thread, ThreadState};
         use uuid::Uuid;
 
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("processing");
 
         thread.queue_message("pending-1".to_string());
@@ -2241,7 +2280,7 @@ mod tests {
 
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
         thread.start_turn("working");
         assert_eq!(thread.state, ThreadState::Processing);
 
@@ -2268,7 +2307,7 @@ mod tests {
 
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
         thread.start_turn("working");
         assert_eq!(thread.state, ThreadState::Processing);
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -751,6 +751,31 @@ impl AppBuilder {
             Some(manager)
         };
 
+        // Validate ACP agent configs at startup (lightweight — no connections, just config check).
+        {
+            let acp_agents = if let Some(ref d) = self.db {
+                crate::config::acp::load_acp_agents_from_db(d.as_ref(), &self.config.owner_id).await
+            } else {
+                crate::config::acp::load_acp_agents().await
+            };
+            match acp_agents {
+                Ok(file) => {
+                    let enabled: Vec<_> = file.enabled_agents().collect();
+                    if !enabled.is_empty() {
+                        let names: Vec<&str> = enabled.iter().map(|a| a.name.as_str()).collect();
+                        tracing::info!(
+                            "ACP agents configured: {} ({} enabled)",
+                            names.join(", "),
+                            enabled.len()
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!("No ACP agents configured ({})", e);
+                }
+            }
+        }
+
         // register_builder_tool() already calls register_dev_tools() internally,
         // so only register them here when the builder didn't already do it.
         let builder_registered_dev_tools = self.config.builder.enabled

--- a/src/boot_screen.rs
+++ b/src/boot_screen.rs
@@ -25,6 +25,7 @@ pub struct BootInfo {
     pub sandbox_enabled: bool,
     pub docker_status: crate::sandbox::detect::DockerStatus,
     pub claude_code_enabled: bool,
+    pub acp_enabled: bool,
     pub routines_enabled: bool,
     pub skills_enabled: bool,
     pub channels: Vec<String>,
@@ -208,6 +209,11 @@ pub fn print_boot_screen(info: &BootInfo) {
         tags.push("claude-code".to_string());
     }
 
+    // ACP agents
+    if info.acp_enabled {
+        tags.push("acp".to_string());
+    }
+
     if !tags.is_empty() {
         println!(
             "  {}{:<width$}{}  {}",
@@ -270,6 +276,7 @@ mod tests {
             sandbox_enabled: true,
             docker_status: DockerStatus::Available,
             claude_code_enabled: false,
+            acp_enabled: false,
             routines_enabled: true,
             skills_enabled: true,
             channels: vec![
@@ -304,6 +311,7 @@ mod tests {
             sandbox_enabled: false,
             docker_status: DockerStatus::Disabled,
             claude_code_enabled: false,
+            acp_enabled: false,
             routines_enabled: false,
             skills_enabled: false,
             channels: vec![],
@@ -334,6 +342,7 @@ mod tests {
             sandbox_enabled: false,
             docker_status: DockerStatus::Disabled,
             claude_code_enabled: false,
+            acp_enabled: false,
             routines_enabled: false,
             skills_enabled: false,
             channels: vec!["repl".to_string()],

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -201,28 +201,26 @@ impl IncomingMessage {
 }
 
 /// Extract a channel-specific proactive routing target from message metadata.
+///
+/// Checked keys (first match wins):
+/// - `signal_target` — Signal phone number or group ID
+/// - `chat_id` — Telegram chat ID
+/// - `channel_id` — Slack channel/DM ID (used by channel-relay)
+/// - `target` — generic fallback
 pub fn routing_target_from_metadata(metadata: &serde_json::Value) -> Option<String> {
-    metadata
-        .get("signal_target")
-        .and_then(|value| match value {
+    // Helper to extract a string or numeric value from a JSON key.
+    let extract = |key: &str| -> Option<String> {
+        metadata.get(key).and_then(|value| match value {
             serde_json::Value::String(s) => Some(s.clone()),
             serde_json::Value::Number(n) => Some(n.to_string()),
             _ => None,
         })
-        .or_else(|| {
-            metadata.get("chat_id").and_then(|value| match value {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-        })
-        .or_else(|| {
-            metadata.get("target").and_then(|value| match value {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-        })
+    };
+
+    extract("signal_target")
+        .or_else(|| extract("chat_id"))
+        .or_else(|| extract("channel_id"))
+        .or_else(|| extract("target"))
 }
 
 /// Stream of incoming messages.
@@ -611,5 +609,51 @@ mod tests {
     fn test_incoming_message_with_timezone() {
         let msg = IncomingMessage::new("test", "user1", "hello").with_timezone("America/New_York");
         assert_eq!(msg.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn routing_target_extracts_slack_channel_id() {
+        // Slack relay messages carry channel_id in metadata — this must be
+        // picked up for proactive broadcasts to land in the correct channel
+        // instead of falling back to sender_id (which routes to DMs).
+        let metadata = serde_json::json!({
+            "team_id": "T05CUBCSQPL",
+            "channel_id": "C088K6C3SQZ",
+            "sender_id": "UCBGL1WNS",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("C088K6C3SQZ"),
+        );
+    }
+
+    #[test]
+    fn routing_target_prefers_signal_over_channel_id() {
+        let metadata = serde_json::json!({
+            "signal_target": "+15551234567",
+            "channel_id": "C088K6C3SQZ",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("+15551234567"),
+        );
+    }
+
+    #[test]
+    fn routing_target_prefers_chat_id_over_channel_id() {
+        let metadata = serde_json::json!({
+            "chat_id": "123456789",
+            "channel_id": "C088K6C3SQZ",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("123456789"),
+        );
+    }
+
+    #[test]
+    fn routing_target_returns_none_for_empty_metadata() {
+        let metadata = serde_json::json!({});
+        assert!(routing_target_from_metadata(&metadata).is_none());
     }
 }

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -355,6 +355,20 @@ pub enum StatusUpdate {
     },
 }
 
+/// Shared chat-style approval prompt formatting used by non-web channels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatApprovalPrompt {
+    pub request_id: String,
+    pub tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub allow_always: bool,
+}
+
+const APPROVAL_PARAMETER_PREVIEW_BYTES: usize = 1200;
+const APPROVAL_PARAMETER_TRUNCATION_SUFFIX: &str = "\n... [parameters truncated]";
+const APPROVAL_SUMMARY_DESCRIPTION_BYTES: usize = 120;
+
 impl StatusUpdate {
     /// Build a `ToolCompleted` status with redacted parameters.
     ///
@@ -384,6 +398,131 @@ impl StatusUpdate {
                 None
             },
         }
+    }
+}
+
+impl ChatApprovalPrompt {
+    /// Build a shared chat approval prompt from a status update.
+    pub fn from_status(status: &StatusUpdate) -> Option<Self> {
+        let StatusUpdate::ApprovalNeeded {
+            request_id,
+            tool_name,
+            description,
+            parameters,
+            allow_always,
+        } = status
+        else {
+            return None;
+        };
+
+        Some(Self {
+            request_id: request_id.clone(),
+            tool_name: tool_name.clone(),
+            description: description.clone(),
+            parameters: parameters.clone(),
+            allow_always: *allow_always,
+        })
+    }
+
+    fn truncated_text(input: &str, max_bytes: usize, suffix: &str) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let budget = max_bytes.saturating_sub(suffix.len());
+        let end = crate::util::floor_char_boundary(input, budget);
+        format!("{}{}", &input[..end], suffix)
+    }
+
+    /// Pretty-printed tool parameters for display, bounded for chat channels.
+    pub fn parameters_preview(&self) -> String {
+        let rendered = serde_json::to_string_pretty(&self.parameters)
+            .unwrap_or_else(|_| self.parameters.to_string());
+        Self::truncated_text(
+            &rendered,
+            APPROVAL_PARAMETER_PREVIEW_BYTES,
+            APPROVAL_PARAMETER_TRUNCATION_SUFFIX,
+        )
+    }
+
+    /// Shared reply vocabulary summary for compact status surfaces.
+    pub fn reply_summary(&self) -> &'static str {
+        if self.allow_always {
+            "yes (or /approve), no (or /deny), or always (or /always)"
+        } else {
+            "yes (or /approve) or no (or /deny)"
+        }
+    }
+
+    /// Compact approval summary for fallback/accessibility surfaces.
+    pub fn summary_text(&self) -> String {
+        let description = Self::truncated_text(
+            &self.description.replace('\n', " "),
+            APPROVAL_SUMMARY_DESCRIPTION_BYTES,
+            "...",
+        );
+        format!(
+            "Approval needed for {}: {} (Request ID: {}). Reply with {}.",
+            self.tool_name,
+            description,
+            self.request_id,
+            self.reply_summary()
+        )
+    }
+
+    fn markdown_parameters_preview(&self) -> String {
+        self.parameters_preview().replace('`', "\\`")
+    }
+
+    /// Approval prompt formatted for plain-text chat channels.
+    pub fn plain_text_message(&self) -> String {
+        let mut lines = vec![
+            format!("Approval needed: {}", self.tool_name),
+            self.description.clone(),
+            String::new(),
+            format!("Request ID: {}", self.request_id),
+            "Parameters:".to_string(),
+            self.parameters_preview(),
+            String::new(),
+            "Reply with:".to_string(),
+            "- yes, y, approve, or /approve to approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "- always, a, or /always to approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("- no, n, deny, or /deny to deny this request".to_string());
+        lines.join("\n")
+    }
+
+    /// Approval prompt formatted for Markdown-capable chat channels.
+    pub fn markdown_message(&self) -> String {
+        let mut lines = vec![
+            "⚠️ *Approval Required*".to_string(),
+            String::new(),
+            format!("*Request ID:* `{}`", self.request_id),
+            format!("*Tool:* {}", self.tool_name),
+            format!("*Description:* {}", self.description),
+            "*Parameters:*".to_string(),
+            format!("```json\n{}\n```", self.markdown_parameters_preview()),
+            String::new(),
+            "Reply with:".to_string(),
+            "• `yes`, `y`, `approve`, or `/approve` - Approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "• `always`, `a`, or `/always` - Approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("• `no`, `n`, `deny`, or `/deny` - Deny this request".to_string());
+        lines.join("\n")
     }
 }
 
@@ -655,5 +794,75 @@ mod tests {
     fn routing_target_returns_none_for_empty_metadata() {
         let metadata = serde_json::json!({});
         assert!(routing_target_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn chat_approval_prompt_plain_text_includes_all_reply_forms() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-123".into(),
+            tool_name: "http".into(),
+            description: "Fetch weather data".into(),
+            parameters: serde_json::json!({"url": "https://api.weather.test"}),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let text = prompt.plain_text_message();
+        assert!(text.contains("Request ID: req-123"));
+        assert!(text.contains("approve, or /approve"));
+        assert!(text.contains("always, a, or /always"));
+        assert!(text.contains("deny, or /deny"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_hides_always_when_not_allowed() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-456".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({"command": "rm -rf /tmp/demo"}),
+            allow_always: false,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("`/approve`"));
+        assert!(markdown.contains("`/deny`"));
+        assert!(!markdown.contains("`/always`"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_truncates_large_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-789".into(),
+            tool_name: "http".into(),
+            description: "Fetch large payload".into(),
+            parameters: serde_json::json!({
+                "body": "x".repeat(APPROVAL_PARAMETER_PREVIEW_BYTES + 200),
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let preview = prompt.parameters_preview();
+        assert!(preview.contains("[parameters truncated]"));
+        assert!(preview.len() <= APPROVAL_PARAMETER_PREVIEW_BYTES);
+    }
+
+    #[test]
+    fn chat_approval_prompt_escapes_backticks_in_markdown_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-999".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({
+                "command": "printf '```danger```'"
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("\\`\\`\\`danger\\`\\`\\`"));
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -38,8 +38,9 @@ pub mod web;
 mod webhook_server;
 
 pub use channel::{
-    AttachmentKind, Channel, ChannelSecretUpdater, IncomingAttachment, IncomingMessage,
-    MessageStream, OutgoingResponse, StatusUpdate, ToolDecision, routing_target_from_metadata,
+    AttachmentKind, Channel, ChannelSecretUpdater, ChatApprovalPrompt, IncomingAttachment,
+    IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate, ToolDecision,
+    routing_target_from_metadata,
 };
 pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -194,12 +194,18 @@ impl Channel for RelayChannel {
                         "sender_id": event.sender_id,
                         "sender_name": event.display_name(),
                         "event_type": event.event_type,
-                        "thread_id": event.thread_id,
+                        "thread_id": event.thread_id.as_deref().unwrap_or(&event.id),
                         "provider": event.provider,
                     }));
 
+                // Use the original thread_id if present (already in a thread),
+                // otherwise use the message timestamp (event.id) so that
+                // responses are threaded under the user's message in channels.
+                // Fall back to channel_id only if event.id is missing.
                 let msg = if let Some(ref thread_id) = event.thread_id {
                     msg.with_thread(thread_id)
+                } else if !event.id.is_empty() {
+                    msg.with_thread(&event.id)
                 } else {
                     msg.with_thread(&event.channel_id)
                 };
@@ -646,6 +652,53 @@ mod tests {
         assert!(
             err.contains("channel_id"),
             "expected channel_id error, got: {err}"
+        );
+    }
+
+    /// Regression: channel mentions must use the message timestamp (event.id)
+    /// as thread_id, not the channel_id. Slack requires thread_ts to be a
+    /// message timestamp for threading to work.
+    #[tokio::test]
+    async fn start_uses_message_ts_as_thread_id_for_mentions() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        // Simulate a channel mention (no thread_id, id = message ts)
+        tx.send(ChannelEvent {
+            id: "1609459200.000100".into(),
+            event_type: "mention".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "C456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("hello bot".into()),
+            thread_id: None,
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // thread_id should be the message timestamp, NOT the channel_id
+        assert_eq!(
+            msg.thread_id.as_deref(),
+            Some("1609459200.000100"),
+            "thread_id should be the message ts for threading, not the channel_id"
+        );
+        // metadata should also have the correct thread_id
+        assert_eq!(
+            msg.metadata.get("thread_id").and_then(|v| v.as_str()),
+            Some("1609459200.000100"),
         );
     }
 

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::channels::relay::client::{ChannelEvent, RelayClient};
-use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
+use crate::channels::{
+    Channel, ChatApprovalPrompt, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate,
+};
 use crate::error::ChannelError;
 
 /// Default channel name for the Slack relay integration.
@@ -125,6 +127,58 @@ impl RelayChannel {
         self.client
             .proxy_provider(self.provider.as_str(), team_id, method, body)
             .await
+    }
+
+    fn build_approval_body(
+        &self,
+        channel_id: &str,
+        thread_id: Option<&str>,
+        prompt: &ChatApprovalPrompt,
+        approval_token: &str,
+    ) -> serde_json::Value {
+        let value_payload = serde_json::json!({
+            "approval_token": approval_token,
+        });
+        let value_str = value_payload.to_string();
+
+        let blocks = serde_json::json!([
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": prompt.markdown_message(),
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Approve" },
+                        "style": "primary",
+                        "action_id": "approve_tool",
+                        "value": value_str,
+                    },
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Deny" },
+                        "style": "danger",
+                        "action_id": "deny_tool",
+                        "value": value_str,
+                    }
+                ]
+            }
+        ]);
+
+        let mut body = serde_json::json!({
+            "channel": channel_id,
+            "text": prompt.summary_text(),
+            "blocks": blocks,
+        });
+        if let Some(tid) = thread_id {
+            body["thread_ts"] = serde_json::Value::String(tid.to_string());
+        }
+        body
     }
 }
 
@@ -266,14 +320,7 @@ impl Channel for RelayChannel {
         metadata: &serde_json::Value,
     ) -> Result<(), ChannelError> {
         // Only handle ApprovalNeeded — all other variants are no-ops
-        let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            parameters,
-            allow_always: _,
-        } = status
-        else {
+        let Some(prompt) = ChatApprovalPrompt::from_status(&status) else {
             return Ok(());
         };
 
@@ -284,7 +331,7 @@ impl Channel for RelayChannel {
             .unwrap_or("");
         if event_type != "direct_message" {
             tracing::warn!(
-                tool = %tool_name,
+                tool = %prompt.tool_name,
                 event_type,
                 "Approval requested in non-DM, skipping buttons"
             );
@@ -309,60 +356,13 @@ impl Channel for RelayChannel {
         // The button value contains ONLY the token — no routing fields.
         let approval_token = self
             .client
-            .create_approval(team_id, channel_id, thread_id, &request_id)
+            .create_approval(team_id, channel_id, thread_id, &prompt.request_id)
             .await
             .map_err(|e| ChannelError::SendFailed {
                 name: self.name().to_string(),
                 reason: format!("Failed to register approval: {e}"),
             })?;
-        let value_payload = serde_json::json!({
-            "approval_token": approval_token,
-        });
-        let value_str = value_payload.to_string();
-
-        // Parameters are already redacted via redact_params() in dispatcher.rs
-        let params_display =
-            serde_json::to_string_pretty(&parameters).unwrap_or_else(|_| parameters.to_string());
-
-        let blocks = serde_json::json!([
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": format!(
-                        "*Tool approval required*\n`{tool_name}`: {description}\n```{params_display}```"
-                    )
-                }
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Approve" },
-                        "style": "primary",
-                        "action_id": "approve_tool",
-                        "value": value_str,
-                    },
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Deny" },
-                        "style": "danger",
-                        "action_id": "deny_tool",
-                        "value": value_str,
-                    }
-                ]
-            }
-        ]);
-
-        let mut body = serde_json::json!({
-            "channel": channel_id,
-            "text": format!("Tool approval required: {tool_name} - {description}"),
-            "blocks": blocks,
-        });
-        if let Some(tid) = thread_id {
-            body["thread_ts"] = serde_json::Value::String(tid.to_string());
-        }
+        let body = self.build_approval_body(channel_id, thread_id, &prompt, &approval_token);
 
         self.proxy_send(team_id, "chat.postMessage", body)
             .await
@@ -503,6 +503,29 @@ mod tests {
         assert_eq!(body["thread_ts"], "1234567.890");
     }
 
+    #[test]
+    fn build_approval_body_includes_chat_reply_instructions() {
+        let channel = make_channel();
+        let prompt = ChatApprovalPrompt {
+            request_id: "req-1".into(),
+            tool_name: "http".into(),
+            description: "HTTP requests to external APIs".into(),
+            parameters: serde_json::json!({"method": "POST", "url": "https://example.com"}),
+            allow_always: true,
+        };
+
+        let body = channel.build_approval_body("C456", Some("1234567.890"), &prompt, "token-123");
+        let text = body["text"].as_str().expect("plain text");
+        let block_text = body["blocks"][0]["text"]["text"].as_str().expect("mrkdwn");
+
+        assert!(text.contains("Request ID: req-1"));
+        assert!(text.contains("Reply with yes (or /approve)"));
+        assert!(!text.contains("Parameters:"));
+        assert!(block_text.contains("`/approve`"));
+        assert!(block_text.contains("`/always`"));
+        assert_eq!(body["thread_ts"], "1234567.890");
+    }
+
     #[tokio::test]
     async fn start_processes_events() {
         let (tx, rx) = mpsc::channel(64);
@@ -536,6 +559,41 @@ mod tests {
 
         assert_eq!(msg.content, "hello");
         assert_eq!(msg.user_id, "U789");
+    }
+
+    #[tokio::test]
+    async fn start_threaded_message_preserves_thread_scope() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        tx.send(ChannelEvent {
+            id: "threaded-1".into(),
+            event_type: "direct_message".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "D456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("approve".into()),
+            thread_id: Some("1712345678.123".into()),
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(msg.content, "approve");
+        assert_eq!(msg.thread_id.as_deref(), Some("1712345678.123"));
+        assert_eq!(msg.conversation_scope(), Some("1712345678.123"));
     }
 
     #[tokio::test]

--- a/src/channels/relay/client.rs
+++ b/src/channels/relay/client.rs
@@ -277,9 +277,30 @@ impl RelayClient {
             });
         }
 
-        resp.json()
+        let json: serde_json::Value = resp
+            .json()
             .await
-            .map_err(|e| RelayError::Protocol(e.to_string()))
+            .map_err(|e| RelayError::Protocol(e.to_string()))?;
+
+        // Slack API always returns HTTP 200 but signals errors via {"ok": false}.
+        // Surface these as relay errors so callers get actionable feedback.
+        if json.get("ok") == Some(&serde_json::Value::Bool(false)) {
+            let slack_error = json
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            tracing::warn!(
+                relay_url = %url,
+                slack_error = %slack_error,
+                "RelayClient::proxy_provider: Slack API returned ok=false"
+            );
+            return Err(RelayError::Api {
+                status: 200,
+                message: format!("Slack API error: {slack_error}"),
+            });
+        }
+
+        Ok(json)
     }
 
     /// Fetch the per-instance callback signing secret from channel-relay.

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -910,34 +910,10 @@ impl Channel for SignalChannel {
         }
 
         // Send approval prompt to user
-        if let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description: _,
-            parameters,
-            allow_always,
-        } = &status
+        if let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status)
             && let Some(target_str) = metadata.get("signal_target").and_then(|v| v.as_str())
         {
-            let params_json = serde_json::to_string_pretty(parameters).unwrap_or_default();
-            let always_line = if *allow_always {
-                format!(
-                    "\n• `always` or `a` - Approve and auto-approve future {} requests",
-                    tool_name
-                )
-            } else {
-                String::new()
-            };
-            let message = format!(
-                "⚠️ *Approval Required*\n\n\
-                 *Request ID:* `{}`\n\
-                 *Tool:* {}\n\
-                 *Parameters:*\n```\n{}\n```\n\n\
-                 Reply with:\n\
-                 • `yes` or `y` - Approve this request{}\n\
-                 • `no` or `n` - Deny",
-                request_id, tool_name, params_json, always_line
-            );
+            let message = prompt.markdown_message();
             self.send_status_message(target_str, &message).await;
         }
 

--- a/src/channels/wasm/schema.rs
+++ b/src/channels/wasm/schema.rs
@@ -702,6 +702,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_telegram_bundled_setup_includes_webhook_secret() {
+        let json = include_str!("../../../channels-src/telegram/telegram.capabilities.json");
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+
+        let webhook_secret = file
+            .setup
+            .required_secrets
+            .iter()
+            .find(|secret| secret.name == "telegram_webhook_secret")
+            .expect("telegram webhook secret should be declared in the bundled manifest");
+
+        assert!(webhook_secret.optional);
+        assert_eq!(
+            webhook_secret
+                .auto_generate
+                .as_ref()
+                .expect("telegram webhook secret should auto-generate")
+                .length,
+            64
+        );
+    }
+
     // ── Category 5: Discord Capabilities Setup & Configuration ──────────
 
     #[test]

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -34,6 +34,7 @@ pub async fn setup_wasm_channels(
     secrets_store: &Option<Arc<dyn SecretsStore + Send + Sync>>,
     extension_manager: Option<&Arc<ExtensionManager>>,
     database: Option<&Arc<dyn Database>>,
+    registered_channel_names: &[String],
 ) -> Option<WasmChannelSetup> {
     let runtime = match WasmChannelRuntime::new(WasmChannelRuntimeConfig::default()) {
         Ok(r) => Arc::new(r),
@@ -71,7 +72,51 @@ pub async fn setup_wasm_channels(
     let mut channels: Vec<(String, Box<dyn crate::channels::Channel>)> = Vec::new();
     let mut channel_names: Vec<String> = Vec::new();
 
+    // Reserved channel names that WASM modules must not claim.
+    // A malicious module could otherwise register as a trusted built-in
+    // channel and bypass cross-channel authorization checks.
+    //
+    // This list includes:
+    // - All built-in channel names (prevent impersonation)
+    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
+    // - The bootstrap sentinel (universal approval wildcard)
+    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
+
+    let mut reserved: Vec<&str> = vec![
+        "cli",
+        "repl",
+        "http",
+        "signal",
+        "telegram",
+        "slack-relay",
+        "secret_save",
+    ];
+    reserved.extend(TRUSTED_APPROVAL_CHANNELS);
+    reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
+
     for loaded in results.loaded {
+        let name_lower = loaded.name().to_ascii_lowercase();
+        if reserved.contains(&name_lower.as_str()) {
+            tracing::warn!(
+                channel = %loaded.name(),
+                "Rejected WASM channel with reserved name"
+            );
+            continue;
+        }
+        // Also reject any name that collides with an already-registered
+        // channel to prevent a WASM module from shadowing a channel that
+        // was registered earlier in the startup sequence.
+        if registered_channel_names
+            .iter()
+            .any(|n| n.to_ascii_lowercase() == name_lower)
+        {
+            tracing::warn!(
+                channel = %loaded.name(),
+                "Rejected WASM channel that collides with already-registered channel"
+            );
+            continue;
+        }
+
         let (name, channel) = register_channel(
             loaded,
             config,
@@ -446,6 +491,78 @@ async fn inject_channel_secrets_into_config(
                     );
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
+
+    /// Build the same reserved-name list that `setup_wasm_channels` uses.
+    fn reserved_names() -> Vec<&'static str> {
+        let mut reserved: Vec<&str> = vec![
+            "cli",
+            "repl",
+            "http",
+            "signal",
+            "telegram",
+            "slack-relay",
+            "secret_save",
+        ];
+        reserved.extend(TRUSTED_APPROVAL_CHANNELS);
+        reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
+        reserved
+    }
+
+    #[test]
+    fn reserved_names_include_trusted_approval_channels() {
+        let reserved = reserved_names();
+        for &trusted in TRUSTED_APPROVAL_CHANNELS {
+            assert!(
+                reserved.contains(&trusted),
+                "trusted approval channel '{}' must be in WASM reserved names",
+                trusted
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_names_include_bootstrap_sentinel() {
+        let reserved = reserved_names();
+        assert!(
+            reserved.contains(&BOOTSTRAP_SOURCE_CHANNEL),
+            "__bootstrap__ sentinel must be in WASM reserved names"
+        );
+    }
+
+    #[test]
+    fn reserved_names_reject_case_insensitive() {
+        // The setup logic lowercases the WASM channel name before checking.
+        // Verify that "Web" or "GATEWAY" would be caught.
+        let reserved = reserved_names();
+        let test_cases = ["Web", "GATEWAY", "CLI", "Repl", "__BOOTSTRAP__"];
+        for name in test_cases {
+            let lowered = name.to_ascii_lowercase();
+            assert!(
+                reserved.contains(&lowered.as_str()),
+                "'{}' (lowercased to '{}') should match a reserved name",
+                name,
+                lowered
+            );
+        }
+    }
+
+    #[test]
+    fn non_reserved_names_allowed() {
+        let reserved = reserved_names();
+        let allowed = ["discord", "my-custom-channel", "slack-bot"];
+        for name in allowed {
+            assert!(
+                !reserved.contains(&name),
+                "'{}' should NOT be reserved",
+                name
+            );
         }
     }
 }

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -2298,63 +2298,16 @@ impl WasmChannel {
             StatusUpdate::StreamChunk(_) => {
                 // No-op, too noisy
             }
-            StatusUpdate::ApprovalNeeded {
-                tool_name,
-                description,
-                parameters,
-                allow_always,
-                ..
-            } => {
+            StatusUpdate::ApprovalNeeded { .. } => {
                 // WASM channels (Telegram, Slack, etc.) cannot render
                 // interactive approval overlays.  Send the approval prompt
                 // as an actual message so the user can reply yes/no.
                 self.cancel_typing_task().await;
 
-                let params_preview = parameters
-                    .as_object()
-                    .map(|obj| {
-                        obj.iter()
-                            .map(|(k, v)| {
-                                let val = match v {
-                                    serde_json::Value::String(s) => {
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("\"{}...\"", truncated)
-                                        } else {
-                                            format!("\"{}\"", s)
-                                        }
-                                    }
-                                    other => {
-                                        let s = other.to_string();
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("{}...", truncated)
-                                        } else {
-                                            s
-                                        }
-                                    }
-                                };
-                                format!("  {}: {}", k, val)
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let reply_hint = if *allow_always {
-                    "Reply \"yes\" to approve, \"no\" to deny, or \"always\" to auto-approve."
-                } else {
-                    "Reply \"yes\" to approve or \"no\" to deny."
+                let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status) else {
+                    return Ok(());
                 };
-                let prompt = format!(
-                    "Approval needed: {tool_name}\n\
-                     {description}\n\
-                     \n\
-                     Parameters:\n\
-                     {params_preview}\n\
-                     \n\
-                     {reply_hint}"
-                );
+                let prompt = prompt.plain_text_message();
 
                 let metadata_json = serde_json::to_string(metadata).unwrap_or_default();
                 if let Err(e) = self
@@ -3813,24 +3766,11 @@ fn status_to_wit(
                 metadata_json,
             }
         }
-        StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            allow_always,
-            ..
-        } => {
-            let reply_hint = if *allow_always {
-                "yes (or /approve), no (or /deny), or always (or /always)"
-            } else {
-                "yes (or /approve) or no (or /deny)"
-            };
+        StatusUpdate::ApprovalNeeded { .. } => {
+            let prompt = crate::channels::ChatApprovalPrompt::from_status(status)?;
             wit_channel::StatusUpdate {
                 status: wit_channel::StatusType::ApprovalNeeded,
-                message: format!(
-                    "Approval needed for tool '{}'. {}\nRequest ID: {}\nReply with: {}.",
-                    tool_name, description, request_id, reply_hint
-                ),
+                message: prompt.plain_text_message(),
                 metadata_json,
             }
         }

--- a/src/channels/web/auth.rs
+++ b/src/channels/web/auth.rs
@@ -57,6 +57,10 @@ use tokio::sync::RwLock;
 use crate::config::GatewayOidcConfig;
 use crate::db::Database;
 
+/// Cookie name for OAuth browser sessions. Shared between the auth middleware
+/// (cookie extraction) and the auth handlers (cookie set/clear).
+pub const SESSION_COOKIE_NAME: &str = "ironclaw_session";
+
 // ── User identity ────────────────────────────────────────────────────────
 
 /// Identity resolved from a bearer token or OIDC JWT.
@@ -271,7 +275,7 @@ impl DbAuthenticator {
     }
 }
 
-// ── Combined auth state ─────────────────────────────────────────────────���
+// ── Combined auth state ────────────────────────────────────────────────────
 
 /// Combined auth state: tries env-var tokens first, then DB-backed tokens,
 /// then OIDC JWT (if configured).
@@ -283,6 +287,8 @@ pub struct CombinedAuthState {
     pub db_auth: Option<DbAuthenticator>,
     /// OIDC JWT auth state (None when OIDC is disabled).
     pub oidc: Option<OidcState>,
+    /// Email domains allowed for OIDC login. Empty means allow all.
+    pub oidc_allowed_domains: Vec<String>,
 }
 
 impl From<MultiAuthState> for CombinedAuthState {
@@ -291,6 +297,7 @@ impl From<MultiAuthState> for CombinedAuthState {
             env_auth,
             db_auth: None,
             oidc: None,
+            oidc_allowed_domains: Vec::new(),
         }
     }
 }
@@ -841,14 +848,22 @@ async fn validate_oidc_jwt(oidc: &OidcState, jwt: &str) -> Result<String, OidcEr
     let mut validation = Validation::new(resolved_alg);
     validation.insecure_disable_signature_validation();
 
+    // Build the set of required claims. `exp` is required by default.
+    // When issuer/audience are configured, require their presence in the
+    // JWT — not just mismatch rejection — to prevent tokens that omit
+    // these claims entirely from passing validation.
+    let mut required = vec!["exp".to_string()];
     if let Some(ref iss) = oidc.config.issuer {
         validation.set_issuer(&[iss]);
+        required.push("iss".to_string());
     }
     if let Some(ref aud) = oidc.config.audience {
         validation.set_audience(&[aud]);
+        required.push("aud".to_string());
     } else {
         validation.validate_aud = false;
     }
+    validation.set_required_spec_claims(&required);
 
     let data = jsonwebtoken::decode::<serde_json::Value>(&normalized, &key, &validation)
         .map_err(|e| OidcError::InvalidClaims(format!("{e}")))?;
@@ -861,6 +876,43 @@ async fn validate_oidc_jwt(oidc: &OidcState, jwt: &str) -> Result<String, OidcEr
         .ok_or_else(|| OidcError::InvalidClaims("missing `sub` claim".to_string()))?;
 
     Ok(sub)
+}
+
+/// Extract `email` and `email_verified` claims from an OIDC JWT without
+/// signature validation.
+///
+/// Used only after signature has been validated by `validate_oidc_jwt()` to
+/// enforce domain restrictions.
+fn extract_oidc_email_claims(jwt: &str) -> (Option<String>, bool) {
+    let normalized = normalize_jwt_for_claims(jwt);
+    let mut validation = Validation::default();
+    validation.insecure_disable_signature_validation();
+    validation.validate_aud = false;
+    validation.validate_exp = false;
+
+    let data = match jsonwebtoken::decode::<serde_json::Value>(
+        &normalized,
+        &DecodingKey::from_secret(&[]),
+        &validation,
+    ) {
+        Ok(d) => d,
+        Err(_) => return (None, false),
+    };
+
+    let email = data
+        .claims
+        .get("email")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string());
+
+    // email_verified may be a boolean or a string "true"/"false".
+    let verified = match data.claims.get("email_verified") {
+        Some(serde_json::Value::Bool(b)) => *b,
+        Some(serde_json::Value::String(s)) => s == "true",
+        _ => false,
+    };
+
+    (email, verified)
 }
 
 // ── Token extraction helpers ─────────────────────────────────────────────
@@ -888,15 +940,37 @@ fn allows_query_token_auth(request: &Request) -> bool {
 }
 
 /// Extract the `token` query parameter value, URL-decoded.
+/// Returns `None` for empty/whitespace-only tokens so they don't override
+/// a valid session cookie.
 fn query_token(request: &Request) -> Option<String> {
     let query = request.uri().query()?;
     url::form_urlencoded::parse(query.as_bytes()).find_map(|(k, v)| {
         if k == "token" {
-            Some(v.into_owned())
+            let trimmed = v.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
         } else {
             None
         }
     })
+}
+
+pub(crate) fn extract_cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
+    let cookie_header = headers.get(axum::http::header::COOKIE)?.to_str().ok()?;
+    cookie::Cookie::split_parse(cookie_header)
+        .filter_map(Result::ok)
+        .find(|cookie| cookie.name() == name)
+        .and_then(|cookie| {
+            let value = cookie.value_trimmed();
+            if value.is_empty() {
+                None
+            } else {
+                Some(value.to_string())
+            }
+        })
 }
 
 /// Extract a bearer token from the Authorization header or query parameter.
@@ -910,12 +984,16 @@ fn extract_token(headers: &HeaderMap, request: &Request) -> Option<String> {
         return Some(value[7..].to_string());
     }
 
-    // Fall back to query parameter for SSE/WS endpoints.
-    if allows_query_token_auth(request) {
-        return query_token(request);
+    // Try query parameter for SSE/WS endpoints (explicit token always wins
+    // over cookie so `?token=B` is not silently overridden by cookie A).
+    if allows_query_token_auth(request)
+        && let Some(t) = query_token(request)
+    {
+        return Some(t);
     }
 
-    None
+    // Fall back to session cookie (for OAuth-authenticated browser sessions).
+    extract_cookie_value(headers, SESSION_COOKIE_NAME)
 }
 
 // ── Middleware ────────────────────────────────────────────────────────────
@@ -968,6 +1046,28 @@ pub async fn auth_middleware(
     {
         match validate_oidc_jwt(oidc, jwt).await {
             Ok(sub) => {
+                // Enforce email domain restriction if configured.
+                // Require a verified email — an unverified email could be
+                // set to any value and bypass the domain allowlist.
+                if !auth.oidc_allowed_domains.is_empty() {
+                    let (email, email_verified) = extract_oidc_email_claims(jwt);
+                    if !email_verified {
+                        tracing::warn!(sub = %sub, email = ?email, "OIDC login rejected: domain restriction requires verified email");
+                        return (
+                            StatusCode::FORBIDDEN,
+                            "Login requires a verified email address from an authorized domain."
+                                .to_string(),
+                        )
+                            .into_response();
+                    }
+                    if let Err(msg) = crate::channels::web::handlers::auth::check_email_domain(
+                        email.as_deref(),
+                        &auth.oidc_allowed_domains,
+                    ) {
+                        tracing::warn!(sub = %sub, error = %msg, "OIDC login rejected by domain restriction");
+                        return (StatusCode::FORBIDDEN, msg).into_response();
+                    }
+                }
                 tracing::debug!(sub = %sub, "OIDC auth succeeded");
                 let identity = UserIdentity {
                     user_id: sub,
@@ -1050,8 +1150,23 @@ mod tests {
         assert_eq!(identity.user_id, "user1");
     }
 
+    #[test]
+    fn test_extract_cookie_value_uses_cookie_parser() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_static("other=\"quoted;value\"; ironclaw_session=abc123"),
+        );
+
+        assert_eq!(
+            extract_cookie_value(&headers, SESSION_COOKIE_NAME),
+            Some("abc123".to_string())
+        );
+    }
+
     use axum::Router;
     use axum::body::Body;
+    use axum::http::HeaderValue;
     use axum::middleware;
     use axum::routing::{get, post};
     use tower::ServiceExt;
@@ -1264,7 +1379,77 @@ mod tests {
         assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
     }
 
-    // ── OIDC unit tests ───────────────────────────────────────────���──────
+    // ── Cookie session tests ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_cookie_session_authenticates() {
+        let app = test_app(TEST_AUTH_SECRET_TOKEN);
+        let req = Request::builder()
+            .uri("/api/chat/history")
+            .header(
+                "Cookie",
+                format!("ironclaw_session={TEST_AUTH_SECRET_TOKEN}"),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_bearer_header_takes_priority_over_cookie() {
+        let app = test_app(TEST_AUTH_SECRET_TOKEN);
+        // Valid bearer header + invalid cookie → should succeed (header wins)
+        let req = Request::builder()
+            .uri("/api/chat/history")
+            .header("Authorization", format!("Bearer {TEST_AUTH_SECRET_TOKEN}"))
+            .header("Cookie", "ironclaw_session=wrong-token")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_empty_cookie_ignored() {
+        let app = test_app(TEST_AUTH_SECRET_TOKEN);
+        let req = Request::builder()
+            .uri("/api/chat/history")
+            .header("Cookie", "ironclaw_session=")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_cookie_among_multiple() {
+        let app = test_app(TEST_AUTH_SECRET_TOKEN);
+        let req = Request::builder()
+            .uri("/api/chat/history")
+            .header(
+                "Cookie",
+                format!("other=foo; ironclaw_session={TEST_AUTH_SECRET_TOKEN}; bar=baz"),
+            )
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_wrong_cookie_name_ignored() {
+        let app = test_app(TEST_AUTH_SECRET_TOKEN);
+        let req = Request::builder()
+            .uri("/api/chat/history")
+            .header("Cookie", format!("other_cookie={TEST_AUTH_SECRET_TOKEN}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // ── OIDC unit tests ──────────────────────────────────────────────────
 
     #[test]
     fn test_normalize_jwt_noop_for_rfc_compliant() {
@@ -1754,6 +1939,7 @@ mod tests {
             ),
             db_auth: None,
             oidc: Some(test_oidc_state().await),
+            oidc_allowed_domains: Vec::new(),
         }
     }
 
@@ -2065,14 +2251,12 @@ mod tests {
         assert!(result.is_err(), "wrong issuer should be rejected");
     }
 
-    /// Issuer configured but JWT omits `iss` entirely.
+    /// Issuer configured but JWT omits `iss` entirely → rejected.
     ///
-    /// Note: `jsonwebtoken` v9 only validates `iss` when present; a missing
-    /// `iss` claim passes validation. This test documents that behavior.
-    /// If we decide to enforce presence, add an explicit check in
-    /// `validate_oidc_jwt` after claim extraction.
+    /// We add `iss` to `required_spec_claims` when configured, so a JWT
+    /// missing the claim entirely is now rejected (not just mismatches).
     #[tokio::test]
-    async fn test_oidc_issuer_configured_but_missing_in_jwt_passes() {
+    async fn test_oidc_issuer_configured_but_missing_in_jwt_rejected() {
         let mut config = test_oidc_config();
         config.issuer = Some("https://idp.example.com".to_string());
         let oidc = test_oidc_state_with_config(config).await;
@@ -2081,10 +2265,9 @@ mod tests {
             Some(OIDC_KID),
         );
         let result = validate_oidc_jwt(&oidc, &jwt).await;
-        // jsonwebtoken allows missing iss — only rejects mismatches.
         assert!(
-            result.is_ok(),
-            "missing iss is not rejected by jsonwebtoken: {result:?}"
+            result.is_err(),
+            "missing iss should be rejected when issuer is configured"
         );
     }
 
@@ -2124,14 +2307,12 @@ mod tests {
         assert!(result.is_err(), "wrong audience should be rejected");
     }
 
-    /// Audience configured but JWT omits `aud` entirely.
+    /// Audience configured but JWT omits `aud` entirely → rejected.
     ///
-    /// Note: `jsonwebtoken` v9 only validates `aud` when present; a missing
-    /// `aud` claim passes validation even with `set_audience` called. This
-    /// test documents that behavior. If we need to enforce `aud` presence,
-    /// add an explicit check in `validate_oidc_jwt` after claim extraction.
+    /// We add `aud` to `required_spec_claims` when configured, so a JWT
+    /// missing the claim entirely is now rejected (not just mismatches).
     #[tokio::test]
-    async fn test_oidc_audience_configured_but_missing_in_jwt_passes() {
+    async fn test_oidc_audience_configured_but_missing_in_jwt_rejected() {
         let mut config = test_oidc_config();
         config.audience = Some("my-client-id".to_string());
         let oidc = test_oidc_state_with_config(config).await;
@@ -2140,10 +2321,9 @@ mod tests {
             Some(OIDC_KID),
         );
         let result = validate_oidc_jwt(&oidc, &jwt).await;
-        // jsonwebtoken allows missing aud — only rejects mismatches.
         assert!(
-            result.is_ok(),
-            "missing aud is not rejected by jsonwebtoken: {result:?}"
+            result.is_err(),
+            "missing aud should be rejected when audience is configured"
         );
     }
 

--- a/src/channels/web/handlers/auth.rs
+++ b/src/channels/web/handlers/auth.rs
@@ -1,0 +1,918 @@
+//! OAuth authentication handlers.
+//!
+//! Public (no auth required) endpoints for initiating and completing
+//! OAuth login flows via configured providers (Google, GitHub).
+
+use std::sync::Arc;
+
+use axum::{
+    Json,
+    extract::{Path, Query, State},
+    http::{HeaderValue, StatusCode, header},
+    response::{IntoResponse, Redirect, Response},
+};
+use base64::Engine;
+use rand::RngCore;
+use rand::rngs::OsRng;
+use uuid::Uuid;
+
+use crate::channels::web::oauth::state_store::{OAuthStateStore, new_oauth_flow};
+use crate::channels::web::server::GatewayState;
+use crate::db::{UserIdentityRecord, UserRecord};
+
+use crate::channels::web::auth::SESSION_COOKIE_NAME;
+/// Session lifetime: 30 days (cookie Max-Age and token expiry).
+const SESSION_LIFETIME_SECS: i64 = 30 * 24 * 60 * 60;
+
+/// Query parameters for the login redirect.
+#[derive(serde::Deserialize)]
+pub struct LoginParams {
+    /// Optional URL to redirect to after login (default: `/`).
+    redirect_after: Option<String>,
+}
+
+/// Parameters from the OAuth provider callback (query string or form body).
+#[derive(serde::Deserialize)]
+pub struct CallbackParams {
+    code: Option<String>,
+    state: Option<String>,
+    error: Option<String>,
+    error_description: Option<String>,
+    /// Apple-specific: JSON-encoded user info (name), sent only on first authorization.
+    user: Option<String>,
+}
+
+/// GET /auth/providers — list enabled OAuth providers.
+pub async fn providers_handler(State(state): State<Arc<GatewayState>>) -> Json<serde_json::Value> {
+    let mut providers: Vec<&str> = match state.oauth_providers.as_ref() {
+        Some(map) => map.keys().map(|s| s.as_str()).collect(),
+        None => Vec::new(),
+    };
+    if state.near_nonce_store.is_some() {
+        providers.push("near");
+    }
+    providers.sort_unstable();
+    let mut resp = serde_json::json!({ "providers": providers });
+    if let Some(ref network) = state.near_network {
+        resp["near_network"] = serde_json::json!(network);
+    }
+    Json(resp)
+}
+
+/// GET /auth/login/{provider} — initiate OAuth flow (redirect to provider).
+pub async fn login_handler(
+    State(state): State<Arc<GatewayState>>,
+    Path(provider_name): Path<String>,
+    headers: axum::http::HeaderMap,
+    Query(params): Query<LoginParams>,
+) -> Result<Response, (StatusCode, String)> {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(&headers)) {
+        return Err((StatusCode::TOO_MANY_REQUESTS, "Rate limited".to_string()));
+    }
+
+    let providers = state
+        .oauth_providers
+        .as_ref()
+        .ok_or((StatusCode::NOT_FOUND, "OAuth is not enabled".to_string()))?;
+
+    let provider = providers.get(&provider_name).ok_or((
+        StatusCode::NOT_FOUND,
+        format!("Unknown OAuth provider: {provider_name}"),
+    ))?;
+
+    let state_store = state.oauth_state_store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "OAuth state store not available".to_string(),
+    ))?;
+
+    let base_url = state.oauth_base_url.as_deref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "OAuth base URL not configured".to_string(),
+    ))?;
+
+    let flow = new_oauth_flow(provider_name.clone(), params.redirect_after);
+    let code_challenge = OAuthStateStore::code_challenge(&flow.code_verifier);
+    let csrf_state = state_store.insert(flow).await;
+
+    let callback_url = format!("{base_url}/auth/callback/{provider_name}");
+    let auth_url = provider.authorization_url(&callback_url, &csrf_state, &code_challenge);
+
+    Ok(Redirect::temporary(&auth_url).into_response())
+}
+
+/// GET /auth/callback/{provider} — OAuth callback (query params, used by Google/GitHub).
+pub async fn callback_handler(
+    State(state): State<Arc<GatewayState>>,
+    Path(provider_name): Path<String>,
+    headers: axum::http::HeaderMap,
+    Query(params): Query<CallbackParams>,
+) -> Response {
+    handle_callback(state, provider_name, params, &headers).await
+}
+
+/// POST /auth/callback/{provider} — OAuth callback (form post, used by Apple Sign In).
+pub async fn callback_post_handler(
+    State(state): State<Arc<GatewayState>>,
+    Path(provider_name): Path<String>,
+    headers: axum::http::HeaderMap,
+    axum::Form(params): axum::Form<CallbackParams>,
+) -> Response {
+    handle_callback(state, provider_name, params, &headers).await
+}
+
+/// Shared callback logic for both GET (query) and POST (form) callbacks.
+async fn handle_callback(
+    state: Arc<GatewayState>,
+    provider_name: String,
+    params: CallbackParams,
+    headers: &axum::http::HeaderMap,
+) -> Response {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(headers)) {
+        return error_page("Too many requests. Please try again later.");
+    }
+
+    // Check for error from the OAuth provider (e.g. user denied consent).
+    if let Some(ref error) = params.error {
+        let desc = params
+            .error_description
+            .as_deref()
+            .unwrap_or(error.as_str());
+        return error_page(desc);
+    }
+
+    let code = match params.code.as_deref() {
+        Some(c) if !c.is_empty() => c,
+        _ => return error_page("Missing authorization code"),
+    };
+
+    let csrf_state = match params.state.as_deref() {
+        Some(s) if !s.is_empty() => s,
+        _ => return error_page("Missing state parameter"),
+    };
+
+    // Validate CSRF state and retrieve the PKCE code verifier.
+    let state_store = match state.oauth_state_store.as_ref() {
+        Some(s) => s,
+        None => return error_page("OAuth not configured"),
+    };
+
+    let flow = match state_store.take(csrf_state).await {
+        Some(f) => f,
+        None => return error_page("Invalid or expired OAuth state. Please try logging in again."),
+    };
+
+    // Verify the provider matches (prevent cross-provider state replay).
+    if flow.provider != provider_name {
+        return error_page("OAuth provider mismatch");
+    }
+
+    let providers = match state.oauth_providers.as_ref() {
+        Some(p) => p,
+        None => return error_page("OAuth not configured"),
+    };
+
+    let provider = match providers.get(&provider_name) {
+        Some(p) => p,
+        None => return error_page("Unknown OAuth provider"),
+    };
+
+    let store = match state.store.as_ref() {
+        Some(s) => s,
+        None => return error_page("Database not available"),
+    };
+
+    let base_url = match state.oauth_base_url.as_deref() {
+        Some(u) => u,
+        None => return error_page("OAuth base URL not configured"),
+    };
+
+    let callback_url = format!("{base_url}/auth/callback/{provider_name}");
+
+    // Exchange the authorization code for a user profile.
+    let mut profile = match provider
+        .exchange_code(code, &callback_url, &flow.code_verifier)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(error = %e, provider = %provider_name, "OAuth code exchange failed");
+            return error_page("Failed to complete login. Please try again.");
+        }
+    };
+
+    // Apple sends the user's name only on the FIRST authorization via the
+    // `user` form field. Merge it into the profile if present.
+    if profile.display_name.is_none()
+        && let Some(ref user_json) = params.user
+        && let Ok(user) = serde_json::from_str::<serde_json::Value>(user_json)
+    {
+        let first = user
+            .get("name")
+            .and_then(|n| n.get("firstName"))
+            .and_then(|v| v.as_str());
+        let last = user
+            .get("name")
+            .and_then(|n| n.get("lastName"))
+            .and_then(|v| v.as_str());
+        profile.display_name = match (first, last) {
+            (Some(f), Some(l)) => Some(format!("{f} {l}")),
+            (Some(f), None) => Some(f.to_string()),
+            (None, Some(l)) => Some(l.to_string()),
+            _ => None,
+        };
+    }
+
+    // Validate email domain restriction. Only trust verified emails — an
+    // unverified email could be set to any value by the user.
+    if !state.oauth_allowed_domains.is_empty() {
+        if !profile.email_verified {
+            tracing::warn!(
+                provider = %provider_name,
+                email = ?profile.email,
+                "OAuth login rejected: domain restriction requires a verified email"
+            );
+            return error_page(
+                "Login requires a verified email address from an authorized domain.",
+            );
+        }
+        if let Err(msg) = check_email_domain(profile.email.as_deref(), &state.oauth_allowed_domains)
+        {
+            tracing::warn!(
+                provider = %provider_name,
+                email = ?profile.email,
+                "OAuth login rejected by domain restriction"
+            );
+            return error_page(&msg);
+        }
+    }
+
+    // Resolve user: find existing, link by email, or create new.
+    let (user_id, is_new) = match resolve_user(store.as_ref(), &provider_name, &profile).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!(error = %e, "OAuth user resolution failed");
+            return error_page("Failed to create or link user account.");
+        }
+    };
+
+    // Record login.
+    if let Err(e) = store.record_login(&user_id).await {
+        tracing::warn!(error = %e, user_id = %user_id, "Failed to record login");
+    }
+
+    // Generate an API token for the new session.
+    let mut token_bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut token_bytes);
+    let plaintext_token = hex::encode(token_bytes);
+    let token_hash = crate::channels::web::auth::hash_token(&plaintext_token);
+    let token_prefix = &plaintext_token[..8];
+
+    let token_name = if is_new {
+        format!("oauth-{provider_name}-initial")
+    } else {
+        format!("oauth-{provider_name}-login")
+    };
+
+    let expires_at = Some(chrono::Utc::now() + chrono::Duration::seconds(SESSION_LIFETIME_SECS));
+    if let Err(e) = store
+        .create_api_token(&user_id, &token_name, &token_hash, token_prefix, expires_at)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to create API token for OAuth login");
+        return error_page("Failed to create session. Please try again.");
+    }
+
+    // Invalidate the DbAuthenticator cache so the new token is immediately usable.
+    if let Some(ref db_auth) = state.db_auth {
+        db_auth.invalidate_user(&user_id).await;
+    }
+
+    // Re-validate redirect_after before use (defense in depth — sanitized at
+    // insertion time, but re-check in case the store is ever extended).
+    let redirect_to = flow
+        .redirect_after
+        .as_deref()
+        .filter(|u| crate::channels::web::oauth::state_store::is_safe_redirect(u))
+        .unwrap_or("/");
+
+    // Build the response with a session cookie.
+    // Use 303 See Other (not 307 Temporary) so POST callbacks (Apple form_post)
+    // are converted to GET on redirect, preventing the browser from re-POSTing.
+    let cookie_value = build_session_cookie(&plaintext_token, is_secure(base_url));
+    let mut response = Redirect::to(redirect_to).into_response();
+    if let Ok(hv) = HeaderValue::from_str(&cookie_value) {
+        response.headers_mut().insert(header::SET_COOKIE, hv);
+    }
+
+    response
+}
+
+/// POST /auth/logout — revoke session token and clear cookie.
+pub async fn logout_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    // Try to revoke the API token backing this session.
+    if let Some(token) = extract_session_cookie(&headers)
+        && let Some(ref store) = state.store
+    {
+        let token_hash = crate::channels::web::auth::hash_token(&token);
+        if let Ok(Some((record, user))) = store.authenticate_token(&token_hash).await {
+            let _ = store.revoke_api_token(record.id, &user.id).await;
+            if let Some(ref db_auth) = state.db_auth {
+                db_auth.invalidate_user(&user.id).await;
+            }
+        }
+    }
+
+    let secure = state
+        .oauth_base_url
+        .as_deref()
+        .map(is_secure)
+        .unwrap_or(false);
+    let cookie = build_session_cookie_clear(secure);
+    let mut response = (StatusCode::OK, "Logged out").into_response();
+    if let Ok(hv) = HeaderValue::from_str(&cookie) {
+        response.headers_mut().insert(header::SET_COOKIE, hv);
+    }
+    response
+}
+
+// ── NEAR wallet auth ─────────────────────────────────────────────────────
+
+/// GET /auth/near/challenge — generate a nonce for NEAR wallet signing.
+pub async fn near_challenge_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<serde_json::Value>, (StatusCode, String)> {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(&headers)) {
+        return Err((StatusCode::TOO_MANY_REQUESTS, "Rate limited".to_string()));
+    }
+
+    let nonce_store = state.near_nonce_store.as_ref().ok_or((
+        StatusCode::NOT_FOUND,
+        "NEAR authentication is not enabled".to_string(),
+    ))?;
+
+    let nonce = nonce_store.generate().await;
+    let message = format!("Sign in to IronClaw\nNonce: {nonce}");
+
+    Ok(Json(serde_json::json!({
+        "nonce": nonce,
+        "message": message,
+        "recipient": "ironclaw",
+    })))
+}
+
+/// Request body for NEAR wallet verification.
+#[derive(serde::Deserialize)]
+pub struct NearVerifyRequest {
+    pub account_id: String,
+    pub public_key: String,
+    pub signature: String,
+    pub nonce: String,
+}
+
+/// POST /auth/near/verify — verify NEAR wallet signature and issue session.
+pub async fn near_verify_handler(
+    State(state): State<Arc<GatewayState>>,
+    headers: axum::http::HeaderMap,
+    Json(body): Json<NearVerifyRequest>,
+) -> Response {
+    if !state.oauth_rate_limiter.check(&rate_limit_key(&headers)) {
+        return (StatusCode::TOO_MANY_REQUESTS, "Rate limited").into_response();
+    }
+
+    let nonce_store = match state.near_nonce_store.as_ref() {
+        Some(s) => s,
+        None => return (StatusCode::NOT_FOUND, "NEAR auth not enabled").into_response(),
+    };
+
+    let near_rpc_url = match state.near_rpc_url.as_deref() {
+        Some(u) => u,
+        None => {
+            return (StatusCode::SERVICE_UNAVAILABLE, "NEAR RPC not configured").into_response();
+        }
+    };
+
+    let store = match state.store.as_ref() {
+        Some(s) => s,
+        None => return (StatusCode::SERVICE_UNAVAILABLE, "Database not available").into_response(),
+    };
+
+    // Validate nonce (single-use, TTL-checked).
+    if !nonce_store.consume(&body.nonce).await {
+        return (StatusCode::BAD_REQUEST, "Invalid or expired nonce").into_response();
+    }
+
+    // Validate input lengths to prevent abuse.
+    if body.account_id.len() > 64 || body.public_key.len() > 128 || body.signature.len() > 256 {
+        return (StatusCode::BAD_REQUEST, "Invalid input").into_response();
+    }
+
+    tracing::debug!(
+        account_id = %body.account_id,
+        public_key = %body.public_key,
+        signature_len = body.signature.len(),
+        signature_prefix = &body.signature[..body.signature.len().min(20)],
+        "NEAR verify: decoding credentials"
+    );
+
+    // Decode the public key and signature.
+    // NEAR wallets may return base58, hex, or base64.
+    let pub_key_bytes: [u8; 32] = match decode_near_public_key(&body.public_key) {
+        Ok(b) => b,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+
+    let sig_bytes: [u8; 64] = match decode_near_signature(&body.signature) {
+        Ok(b) => b,
+        Err(e) => return (StatusCode::BAD_REQUEST, e).into_response(),
+    };
+
+    // Build the exact NEP-413 payload the wallet signed. The nonce in the
+    // challenge is hex-encoded; convert back to 32 raw bytes for NEP-413.
+    let nonce_bytes: [u8; 32] = match hex::decode(&body.nonce) {
+        Ok(b) if b.len() == 32 => {
+            let mut arr = [0u8; 32];
+            arr.copy_from_slice(&b);
+            arr
+        }
+        _ => return (StatusCode::BAD_REQUEST, "Invalid nonce format").into_response(),
+    };
+    let message_str = format!("Sign in to IronClaw\nNonce: {}", body.nonce);
+
+    // Try multiple payload formats — different wallets implement NEP-413 differently.
+    if let Err(e) = crate::channels::web::oauth::near::verify_near_signature(
+        &pub_key_bytes,
+        &sig_bytes,
+        &message_str,
+        &nonce_bytes,
+        "ironclaw",
+    ) {
+        tracing::warn!(
+            account_id = %body.account_id,
+            error = %e,
+            "NEAR signature verification failed (all payload formats)"
+        );
+        return (StatusCode::UNAUTHORIZED, "Invalid signature").into_response();
+    }
+
+    // Normalize the public key to NEAR's canonical format for the RPC call.
+    let canonical_pubkey = format!("ed25519:{}", bs58::encode(&pub_key_bytes).into_string());
+
+    // Verify the public key is an active access key on the NEAR account.
+    static NEAR_HTTP: std::sync::LazyLock<reqwest::Client> = std::sync::LazyLock::new(|| {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(10))
+            .build()
+            .unwrap_or_else(|_| reqwest::Client::new())
+    });
+    if let Err(e) = crate::channels::web::oauth::near::verify_access_key(
+        near_rpc_url,
+        &body.account_id,
+        &canonical_pubkey,
+        &NEAR_HTTP,
+    )
+    .await
+    {
+        tracing::warn!(
+            account_id = %body.account_id,
+            public_key = %body.public_key,
+            error = %e,
+            "NEAR access key verification failed"
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            "Access key not valid for this account",
+        )
+            .into_response();
+    }
+
+    // Domain restriction check for NEAR account IDs.
+    // Allowed domains match as a suffix with a dot boundary:
+    //   "company.near" allows "alice.company.near" but NOT "evilcompany.near".
+    //   "near" allows "alice.near" (exact TLD match).
+    if !state.oauth_allowed_domains.is_empty() {
+        let account = body.account_id.to_ascii_lowercase();
+        let allowed = state.oauth_allowed_domains.iter().any(|d| {
+            let d_lower = d.to_ascii_lowercase();
+            account == d_lower || account.ends_with(&format!(".{d_lower}"))
+        });
+        if !allowed {
+            return (
+                StatusCode::FORBIDDEN,
+                "Your NEAR account is not authorized. Contact your administrator.",
+            )
+                .into_response();
+        }
+    }
+
+    // Use the OAuth user resolution pipeline.
+    let profile = crate::channels::web::oauth::OAuthUserProfile {
+        provider_user_id: body.account_id.clone(),
+        email: None,
+        email_verified: false,
+        display_name: Some(body.account_id.clone()),
+        avatar_url: None,
+        raw: serde_json::json!({
+            "account_id": body.account_id,
+            "public_key": body.public_key,
+        }),
+    };
+
+    let (user_id, is_new) = match resolve_user(store.as_ref(), "near", &profile).await {
+        Ok(result) => result,
+        Err(e) => {
+            tracing::error!(error = %e, "NEAR user resolution failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to create user account",
+            )
+                .into_response();
+        }
+    };
+
+    if let Err(e) = store.record_login(&user_id).await {
+        tracing::warn!(error = %e, user_id = %user_id, "Failed to record login");
+    }
+
+    // Issue API token.
+    let mut token_bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut token_bytes);
+    let plaintext_token = hex::encode(token_bytes);
+    let token_hash = crate::channels::web::auth::hash_token(&plaintext_token);
+    let token_prefix = &plaintext_token[..8];
+
+    let token_name = if is_new {
+        "near-wallet-initial".to_string()
+    } else {
+        "near-wallet-login".to_string()
+    };
+
+    let expires_at = Some(chrono::Utc::now() + chrono::Duration::seconds(SESSION_LIFETIME_SECS));
+    if let Err(e) = store
+        .create_api_token(&user_id, &token_name, &token_hash, token_prefix, expires_at)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to create API token for NEAR login");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to create session",
+        )
+            .into_response();
+    }
+
+    if let Some(ref db_auth) = state.db_auth {
+        db_auth.invalidate_user(&user_id).await;
+    }
+
+    // Set session cookie (consistent with OAuth flow) and return user info.
+    let base_url = state
+        .oauth_base_url
+        .as_deref()
+        .unwrap_or("http://localhost");
+    let cookie_value = build_session_cookie(&plaintext_token, is_secure(base_url));
+    let mut response = Json(serde_json::json!({
+        "user_id": user_id,
+        "account_id": body.account_id,
+        "is_new": is_new,
+    }))
+    .into_response();
+    if let Ok(hv) = HeaderValue::from_str(&cookie_value) {
+        response.headers_mut().insert(header::SET_COOKIE, hv);
+    }
+    response
+}
+
+/// Truncate a string safely for error messages (no byte-index panic on multibyte).
+fn safe_truncate(s: &str, max_chars: usize) -> &str {
+    match s.char_indices().nth(max_chars) {
+        Some((idx, _)) => &s[..idx],
+        None => s,
+    }
+}
+
+/// Decode a NEAR public key. NEAR keys always use the `ed25519:` prefix with
+/// base58 encoding. We enforce this format to avoid ambiguity with base64.
+fn decode_near_public_key(key: &str) -> Result<[u8; 32], String> {
+    let raw = key.strip_prefix("ed25519:").ok_or_else(|| {
+        format!(
+            "Expected ed25519: prefix, got: {}...",
+            safe_truncate(key, 20)
+        )
+    })?;
+    let bytes = bs58::decode(raw)
+        .into_vec()
+        .map_err(|e| format!("Invalid base58 in public key: {e}"))?;
+    if bytes.len() != 32 {
+        return Err(format!(
+            "Public key decoded to {} bytes, expected 32",
+            bytes.len()
+        ));
+    }
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    Ok(arr)
+}
+
+/// Decode a NEAR signature. Wallets return signatures as base64 (HOT, Meteor)
+/// or base58 (MyNearWallet). We try base64 first (most common from near-connect),
+/// then base58.
+fn decode_near_signature(sig: &str) -> Result<[u8; 64], String> {
+    // Try base64 standard first (most wallets via near-connect), then URL-safe,
+    // then base58 (MyNearWallet). Each must decode to exactly 64 bytes.
+    let candidates = [
+        base64::engine::general_purpose::STANDARD.decode(sig).ok(),
+        base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .decode(sig)
+            .ok(),
+        bs58::decode(sig).into_vec().ok(),
+    ];
+    for bytes in candidates.into_iter().flatten() {
+        if bytes.len() == 64 {
+            let mut arr = [0u8; 64];
+            arr.copy_from_slice(&bytes);
+            return Ok(arr);
+        }
+    }
+    Err(format!(
+        "Invalid signature (expected 64 bytes base64/base58, got: {}...)",
+        safe_truncate(sig, 20)
+    ))
+}
+
+/// Extract the session cookie value from request headers.
+fn extract_session_cookie(headers: &axum::http::HeaderMap) -> Option<String> {
+    crate::channels::web::auth::extract_cookie_value(headers, SESSION_COOKIE_NAME)
+}
+
+// ── User resolution ──────────────────────────────────────────────────────
+
+/// Resolve the OAuth profile to an existing or new user.
+///
+/// Returns `(user_id, is_new_user)`.
+async fn resolve_user(
+    store: &dyn crate::db::Database,
+    provider: &str,
+    profile: &crate::channels::web::oauth::OAuthUserProfile,
+) -> Result<(String, bool), String> {
+    // 1. Check if this provider identity is already linked.
+    if let Some(existing) = store
+        .get_identity_by_provider(provider, &profile.provider_user_id)
+        .await
+        .map_err(|e| e.to_string())?
+    {
+        // Verify the user is still active.
+        if let Some(user) = store
+            .get_user(&existing.user_id)
+            .await
+            .map_err(|e| e.to_string())?
+        {
+            if user.status != "active" {
+                return Err(format!("Account is {}", user.status));
+            }
+            // Update profile fields that may have changed at the provider.
+            let _ = store
+                .update_identity_profile(
+                    provider,
+                    &profile.provider_user_id,
+                    profile.display_name.as_deref(),
+                    profile.avatar_url.as_deref(),
+                )
+                .await;
+            return Ok((existing.user_id, false));
+        }
+    }
+
+    // 2. Try to link by verified email.
+    if let Some(ref email) = profile.email
+        && profile.email_verified
+    {
+        // Check user_identities for a verified email match.
+        if let Some(identity) = store
+            .find_identity_by_verified_email(email)
+            .await
+            .map_err(|e| e.to_string())?
+        {
+            // Verify the linked user is still active before linking.
+            if let Some(user) = store
+                .get_user(&identity.user_id)
+                .await
+                .map_err(|e| e.to_string())?
+                && user.status == "active"
+            {
+                let new_identity = build_identity_record(&identity.user_id, provider, profile);
+                store
+                    .create_identity(&new_identity)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                return Ok((identity.user_id, false));
+            }
+        }
+
+        // Check the users table directly for email match.
+        if let Some(user) = store
+            .get_user_by_email(email)
+            .await
+            .map_err(|e| e.to_string())?
+            && user.status == "active"
+        {
+            let new_identity = build_identity_record(&user.id, provider, profile);
+            store
+                .create_identity(&new_identity)
+                .await
+                .map_err(|e| e.to_string())?;
+            return Ok((user.id, false));
+        }
+    }
+
+    // 3. Create a new user.
+    // Role is always "member" here — create_user_with_identity atomically
+    // promotes to "admin" inside the DB transaction if this is the sole user,
+    // preventing the TOCTOU race where two concurrent first logins both get admin.
+    let role = "member";
+
+    let user_id = Uuid::new_v4().to_string();
+    let now = chrono::Utc::now();
+
+    let display_name = profile
+        .display_name
+        .clone()
+        .unwrap_or_else(|| profile.email.clone().unwrap_or_else(|| "User".to_string()));
+
+    let user = UserRecord {
+        id: user_id.clone(),
+        email: profile.email.as_ref().map(|e| e.to_ascii_lowercase()),
+        display_name,
+        status: "active".to_string(),
+        role: role.to_string(),
+        created_at: now,
+        updated_at: now,
+        last_login_at: Some(now),
+        created_by: None,
+        metadata: serde_json::json!({}),
+    };
+
+    let identity = build_identity_record(&user_id, provider, profile);
+
+    store
+        .create_user_with_identity(&user, &identity)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok((user_id, true))
+}
+
+fn build_identity_record(
+    user_id: &str,
+    provider: &str,
+    profile: &crate::channels::web::oauth::OAuthUserProfile,
+) -> UserIdentityRecord {
+    let now = chrono::Utc::now();
+    UserIdentityRecord {
+        id: Uuid::new_v4(),
+        user_id: user_id.to_string(),
+        provider: provider.to_string(),
+        provider_user_id: profile.provider_user_id.clone(),
+        email: profile.email.as_ref().map(|e| e.to_ascii_lowercase()),
+        email_verified: profile.email_verified,
+        display_name: profile.display_name.clone(),
+        avatar_url: profile.avatar_url.clone(),
+        raw_profile: profile.raw.clone(),
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+fn build_session_cookie(token: &str, secure: bool) -> String {
+    let secure_flag = if secure { "; Secure" } else { "" };
+    format!(
+        "{SESSION_COOKIE_NAME}={token}; HttpOnly; SameSite=Lax; Path=/; Max-Age={SESSION_LIFETIME_SECS}{secure_flag}"
+    )
+}
+
+fn build_session_cookie_clear(secure: bool) -> String {
+    let secure_flag = if secure { "; Secure" } else { "" };
+    format!("{SESSION_COOKIE_NAME}=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0{secure_flag}")
+}
+
+fn is_secure(base_url: &str) -> bool {
+    base_url.starts_with("https://")
+}
+
+/// Extract a rate-limit key from request headers (X-Forwarded-For or fallback).
+fn rate_limit_key(headers: &axum::http::HeaderMap) -> String {
+    crate::channels::web::server::rate_limit_key_from_headers(headers)
+}
+
+/// Check that the email belongs to one of the allowed domains.
+///
+/// Used by both OAuth callback and OIDC middleware to enforce domain
+/// restrictions.
+pub(crate) fn check_email_domain(
+    email: Option<&str>,
+    allowed_domains: &[String],
+) -> Result<(), String> {
+    let email = email.ok_or_else(|| {
+        "Login requires an email address, but your account does not have one.".to_string()
+    })?;
+    let domain = email
+        .rsplit_once('@')
+        .map(|(_, d)| d.to_ascii_lowercase())
+        .unwrap_or_default();
+    if allowed_domains
+        .iter()
+        .any(|d| d.eq_ignore_ascii_case(&domain))
+    {
+        Ok(())
+    } else {
+        Err(format!(
+            "Your email domain '{domain}' is not authorized. \
+             Contact your administrator for access."
+        ))
+    }
+}
+
+fn error_page(message: &str) -> Response {
+    let escaped = message
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;");
+    axum::response::Html(format!(
+        "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
+         <h2>Login Failed</h2>\
+         <p>{escaped}</p>\
+         <p><a href='/'>Return to home</a></p>\
+         </body></html>"
+    ))
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn domains(ds: &[&str]) -> Vec<String> {
+        ds.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn test_check_email_domain_allows_matching() {
+        let allowed = domains(&["company.com", "partner.org"]);
+        assert!(check_email_domain(Some("alice@company.com"), &allowed).is_ok());
+        assert!(check_email_domain(Some("bob@partner.org"), &allowed).is_ok());
+    }
+
+    #[test]
+    fn test_check_email_domain_rejects_non_matching() {
+        let allowed = domains(&["company.com"]);
+        assert!(check_email_domain(Some("alice@gmail.com"), &allowed).is_err());
+    }
+
+    #[test]
+    fn test_check_email_domain_case_insensitive() {
+        let allowed = domains(&["company.com"]);
+        assert!(check_email_domain(Some("alice@COMPANY.COM"), &allowed).is_ok());
+        assert!(check_email_domain(Some("alice@Company.Com"), &allowed).is_ok());
+    }
+
+    #[test]
+    fn test_check_email_domain_rejects_missing_email() {
+        let allowed = domains(&["company.com"]);
+        assert!(check_email_domain(None, &allowed).is_err());
+    }
+
+    #[test]
+    fn test_check_email_domain_rejects_malformed_email() {
+        let allowed = domains(&["company.com"]);
+        assert!(check_email_domain(Some("no-at-sign"), &allowed).is_err());
+    }
+
+    #[test]
+    fn test_extract_session_cookie_handles_quoted_neighbors() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            axum::http::header::COOKIE,
+            HeaderValue::from_static("other=\"quoted;value\"; ironclaw_session=abc123"),
+        );
+
+        assert_eq!(extract_session_cookie(&headers), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn test_rate_limit_key_ignores_invalid_forwarded_for_values() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("garbage, 203.0.113.9, more-garbage"),
+        );
+
+        assert_eq!(rate_limit_key(&headers), "203.0.113.9");
+    }
+}

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -574,7 +574,7 @@ pub async fn chat_new_thread_handler(
         .await;
     let (thread_id, info) = {
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some("web"));
         let id = thread.id;
         let info = ThreadInfo {
             id: thread.id,
@@ -593,7 +593,13 @@ pub async fn chat_new_thread_handler(
     // so that the subsequent loadThreads() call from the frontend sees it.
     if let Some(ref store) = state.store {
         match store
-            .ensure_conversation(thread_id, "gateway", &identity.user_id, None)
+            .ensure_conversation(
+                thread_id,
+                "gateway",
+                &identity.user_id,
+                None,
+                Some("gateway"),
+            )
             .await
         {
             Ok(true) => {}

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -131,6 +131,7 @@ pub async fn extensions_install_handler(
         "wasm_tool" => Some(crate::extensions::ExtensionKind::WasmTool),
         "wasm_channel" => Some(crate::extensions::ExtensionKind::WasmChannel),
         "channel_relay" => Some(crate::extensions::ExtensionKind::ChannelRelay),
+        "acp_agent" => Some(crate::extensions::ExtensionKind::AcpAgent),
         _ => None,
     });
 

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -456,7 +456,10 @@ pub async fn jobs_restart_handler(
                     &task,
                     Some(project_dir),
                     mode,
-                    credential_grants,
+                    crate::orchestrator::job_manager::JobCreationParams {
+                        credential_grants,
+                        ..Default::default()
+                    },
                 )
                 .await
                 .map_err(|e| {

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -23,6 +23,37 @@ fn db_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
     )
 }
 
+async fn resolve_sandbox_restart_mode(
+    store: &dyn crate::db::Database,
+    stored_mode: &str,
+    user_id: &str,
+) -> Result<
+    (
+        crate::orchestrator::job_manager::JobMode,
+        Option<crate::config::acp::AcpAgentConfig>,
+    ),
+    crate::config::acp::AcpConfigError,
+> {
+    if stored_mode == "claude_code" {
+        return Ok((crate::orchestrator::job_manager::JobMode::ClaudeCode, None));
+    }
+
+    if let Some(agent_name) = stored_mode.strip_prefix("acp:") {
+        let agent =
+            crate::config::acp::get_enabled_acp_agent_for_user(Some(store), user_id, agent_name)
+                .await?;
+        return Ok((crate::orchestrator::job_manager::JobMode::Acp, Some(agent)));
+    }
+
+    if stored_mode == "acp" {
+        return Err(crate::config::acp::AcpConfigError::InvalidConfig {
+            reason: "legacy ACP jobs without an agent name cannot be restarted".to_string(),
+        });
+    }
+
+    Ok((crate::orchestrator::job_manager::JobMode::Worker, None))
+}
+
 pub async fn jobs_list_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(user): AuthenticatedUser,
@@ -198,7 +229,9 @@ pub async fn jobs_detail_handler(
             }
 
             let mode = store.get_sandbox_job_mode(job.id).await.ok().flatten();
-            let is_claude_code = mode.as_deref() == Some("claude_code");
+            let supports_prompts = mode
+                .as_deref()
+                .is_some_and(|m| m == "claude_code" || m.starts_with("acp"));
 
             return Ok(Json(JobDetailResponse {
                 id: job.id,
@@ -215,7 +248,7 @@ pub async fn jobs_detail_handler(
                 job_mode: mode.filter(|m| m != "worker"),
                 transitions,
                 can_restart: state.job_manager.is_some(),
-                can_prompt: is_claude_code && state.prompt_queue.is_some(),
+                can_prompt: supports_prompts && state.prompt_queue.is_some(),
                 job_kind: Some("sandbox".to_string()),
             }));
         }
@@ -413,6 +446,16 @@ pub async fn jobs_restart_handler(
             let new_job_id = Uuid::new_v4();
             let now = chrono::Utc::now();
 
+            let stored_mode = store
+                .get_sandbox_job_mode(old_job_id)
+                .await
+                .map_err(|e| db_error("jobs_restart_handler", e))?
+                .unwrap_or_default();
+
+            let (mode, acp_agent) =
+                resolve_sandbox_restart_mode(store.as_ref(), &stored_mode, &old_job.user_id)
+                    .await
+                    .map_err(|e| (StatusCode::CONFLICT, format!("Cannot restart job: {}", e)))?;
             let record = crate::history::SandboxJobRecord {
                 id: new_job_id,
                 task: task.clone(),
@@ -429,14 +472,25 @@ pub async fn jobs_restart_handler(
             store
                 .save_sandbox_job(&record)
                 .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                .map_err(|e| db_error("jobs_restart_handler", e))?;
 
-            let mode = match store.get_sandbox_job_mode(old_job_id).await {
-                Ok(Some(m)) if m == "claude_code" => {
-                    crate::orchestrator::job_manager::JobMode::ClaudeCode
-                }
-                _ => crate::orchestrator::job_manager::JobMode::Worker,
-            };
+            if mode != crate::orchestrator::job_manager::JobMode::Worker {
+                let mode_str = if mode == crate::orchestrator::job_manager::JobMode::Acp {
+                    format!(
+                        "acp:{}",
+                        acp_agent
+                            .as_ref()
+                            .map(|agent| agent.name.as_str())
+                            .unwrap_or_default()
+                    )
+                } else {
+                    mode.as_str().to_string()
+                };
+                store
+                    .update_sandbox_job_mode(new_job_id, &mode_str)
+                    .await
+                    .map_err(|e| db_error("jobs_restart_handler", e))?;
+            }
 
             let credential_grants: Vec<crate::orchestrator::auth::CredentialGrant> =
                 serde_json::from_str(&old_job.credential_grants_json).unwrap_or_else(|e| {
@@ -450,7 +504,7 @@ pub async fn jobs_restart_handler(
                 });
 
             let project_dir = std::path::PathBuf::from(&old_job.project_dir);
-            let _token = jm
+            let create_result = jm
                 .create_job(
                     new_job_id,
                     &task,
@@ -458,21 +512,36 @@ pub async fn jobs_restart_handler(
                     mode,
                     crate::orchestrator::job_manager::JobCreationParams {
                         credential_grants,
+                        acp_agent,
                         ..Default::default()
                     },
                 )
-                .await
-                .map_err(|e| {
-                    (
+                .await;
+            let _token = match create_result {
+                Ok(token) => token,
+                Err(e) => {
+                    let error_text = e.to_string();
+                    let _ = store
+                        .update_sandbox_job_status(
+                            new_job_id,
+                            "failed",
+                            Some(false),
+                            Some(error_text.as_str()),
+                            None,
+                            Some(chrono::Utc::now()),
+                        )
+                        .await;
+                    return Err((
                         StatusCode::INTERNAL_SERVER_ERROR,
-                        format!("Failed to create container: {}", e),
-                    )
-                })?;
+                        format!("Failed to create container: {}", error_text),
+                    ));
+                }
+            };
 
             store
                 .update_sandbox_job_status(new_job_id, "running", None, None, Some(now), None)
                 .await
-                .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+                .map_err(|e| db_error("jobs_restart_handler", e))?;
 
             return Ok(Json(serde_json::json!({
                 "status": "restarted",
@@ -482,7 +551,7 @@ pub async fn jobs_restart_handler(
         }
         Ok(None) => {}
         Err(e) => {
-            return Err(db_error("jobs_handler", e));
+            return Err(db_error("jobs_restart_handler", e));
         }
     }
 
@@ -578,12 +647,15 @@ pub async fn jobs_prompt_handler(
             return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
         }
 
-        // It's a sandbox job. Check if Claude Code mode.
+        // It's a sandbox job. Check if Claude Code or ACP mode (both support follow-up prompts).
         let mode = s.get_sandbox_job_mode(job_id).await.ok().flatten();
-        if mode.as_deref() == Some("claude_code") {
+        if mode
+            .as_deref()
+            .is_some_and(|m| m == "claude_code" || m.starts_with("acp"))
+        {
             let prompt_queue = state.prompt_queue.as_ref().ok_or((
                 StatusCode::NOT_IMPLEMENTED,
-                "Claude Code not configured".to_string(),
+                "Follow-up prompts are not configured".to_string(),
             ))?;
             let prompt = crate::orchestrator::api::PendingPrompt { content, done };
             {
@@ -829,6 +901,60 @@ pub async fn job_files_read_handler(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn sandbox_restart_mode_uses_original_job_owner_scope() {
+        let (db, _tmp) = crate::testing::test_db().await;
+
+        let mut agents = crate::config::acp::AcpAgentsFile::default();
+        agents.upsert(crate::config::acp::AcpAgentConfig::new(
+            "codex",
+            "codex",
+            vec!["acp".into()],
+            std::collections::HashMap::new(),
+        ));
+        crate::config::acp::save_acp_agents_for_user(Some(db.as_ref()), "owner-123", &agents)
+            .await
+            .unwrap();
+
+        let (mode, agent) = resolve_sandbox_restart_mode(db.as_ref(), "acp:codex", "owner-123")
+            .await
+            .unwrap();
+
+        assert_eq!(mode, crate::orchestrator::job_manager::JobMode::Acp);
+        assert_eq!(
+            agent.as_ref().map(|agent| agent.name.as_str()),
+            Some("codex")
+        );
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn sandbox_restart_mode_rejects_disabled_acp_agent() {
+        let (db, _tmp) = crate::testing::test_db().await;
+
+        let mut agents = crate::config::acp::AcpAgentsFile::default();
+        let mut agent = crate::config::acp::AcpAgentConfig::new(
+            "codex",
+            "codex",
+            vec!["acp".into()],
+            std::collections::HashMap::new(),
+        );
+        agent.enabled = false;
+        agents.upsert(agent);
+        crate::config::acp::save_acp_agents_for_user(Some(db.as_ref()), "owner-123", &agents)
+            .await
+            .unwrap();
+
+        let err = resolve_sandbox_restart_mode(db.as_ref(), "acp:codex", "owner-123")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            crate::config::acp::AcpConfigError::AgentDisabled { .. }
+        ));
+    }
 
     #[test]
     fn test_db_error_does_not_leak_details() {

--- a/src/channels/web/handlers/mod.rs
+++ b/src/channels/web/handlers/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Each module groups related endpoint handlers by domain.
 
+pub mod auth;
 pub mod jobs;
 pub mod llm;
 pub mod memory;

--- a/src/channels/web/handlers/settings.rs
+++ b/src/channels/web/handlers/settings.rs
@@ -693,7 +693,7 @@ mod tests {
             skill_registry: None,
             skill_catalog: None,
             chat_rate_limiter: crate::channels::web::server::PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: crate::channels::web::server::RateLimiter::new(10, 60),
+            oauth_rate_limiter: crate::channels::web::server::PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: crate::channels::web::server::RateLimiter::new(10, 60),
             registry_entries: Vec::new(),
             cost_guard: None,
@@ -702,6 +702,14 @@ mod tests {
             active_config: crate::channels::web::server::ActiveConfigSnapshot::default(),
             secrets_store: Some(secrets),
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         }
     }
 

--- a/src/channels/web/handlers/users.rs
+++ b/src/channels/web/handlers/users.rs
@@ -430,12 +430,29 @@ pub async fn profile_get_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "User not found".to_string()))?;
 
+    // Try to get avatar_url from linked OAuth identities.
+    let identities = match store.list_identities_for_user(&user.user_id).await {
+        Ok(ids) => ids,
+        Err(e) => {
+            tracing::warn!(user_id = %user.user_id, error = %e, "Failed to fetch identities for avatar");
+            Vec::new()
+        }
+    };
+    let avatar_url = identities.iter().find_map(|id| id.avatar_url.clone());
+    tracing::trace!(
+        user_id = %user.user_id,
+        identity_count = identities.len(),
+        avatar_url = ?avatar_url,
+        "Profile handler: fetched avatar_url from identities"
+    );
+
     Ok(Json(serde_json::json!({
         "id": record.id,
         "email": record.email,
         "display_name": record.display_name,
         "status": record.status,
         "role": record.role,
+        "avatar_url": avatar_url,
         "created_at": record.created_at.to_rfc3339(),
         "last_login_at": record.last_login_at.map(|dt| dt.to_rfc3339()),
     })))

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -17,6 +17,7 @@
 pub mod auth;
 pub(crate) mod handlers;
 pub mod log_layer;
+pub mod oauth;
 pub mod openai_compat;
 pub mod responses_api;
 pub mod server;
@@ -104,6 +105,7 @@ impl GatewayChannel {
             env_auth: MultiAuthState::single(auth_token, owner_id.clone()),
             db_auth: None,
             oidc: oidc_state,
+            oidc_allowed_domains: Vec::new(),
         };
 
         let state = Arc::new(GatewayState {
@@ -127,7 +129,7 @@ impl GatewayChannel {
             skill_registry: None,
             skill_catalog: None,
             chat_rate_limiter: server::PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: server::RateLimiter::new(10, 60),
+            oauth_rate_limiter: server::PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: server::RateLimiter::new(10, 60),
             registry_entries: Vec::new(),
             cost_guard: None,
@@ -136,6 +138,14 @@ impl GatewayChannel {
             active_config: server::ActiveConfigSnapshot::default(),
             secrets_store: None,
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         });
 
         Self {
@@ -169,7 +179,7 @@ impl GatewayChannel {
             skill_registry: self.state.skill_registry.clone(),
             skill_catalog: self.state.skill_catalog.clone(),
             chat_rate_limiter: server::PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: server::RateLimiter::new(10, 60),
+            oauth_rate_limiter: server::PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: server::RateLimiter::new(10, 60),
             registry_entries: self.state.registry_entries.clone(),
             cost_guard: self.state.cost_guard.clone(),
@@ -178,6 +188,14 @@ impl GatewayChannel {
             active_config: self.state.active_config.clone(),
             secrets_store: self.state.secrets_store.clone(),
             db_auth: self.state.db_auth.clone(),
+            oauth_providers: self.state.oauth_providers.clone(),
+            oauth_state_store: self.state.oauth_state_store.clone(),
+            oauth_base_url: self.state.oauth_base_url.clone(),
+            oauth_allowed_domains: self.state.oauth_allowed_domains.clone(),
+            near_nonce_store: self.state.near_nonce_store.clone(),
+            near_rpc_url: self.state.near_rpc_url.clone(),
+            near_network: self.state.near_network.clone(),
+            oauth_sweep_shutdown: None, // sweep tasks are managed by with_oauth
         };
         mutate(&mut new_state);
         self.state = Arc::new(new_state);
@@ -312,6 +330,137 @@ impl GatewayChannel {
         store: Arc<dyn crate::secrets::SecretsStore + Send + Sync>,
     ) -> Self {
         self.rebuild_state(|s| s.secrets_store = Some(store));
+        self
+    }
+
+    /// Enable OAuth social login with the given configuration.
+    ///
+    /// Creates provider instances for each configured provider, initializes
+    /// the in-memory state store, and resolves the callback base URL.
+    pub fn with_oauth(mut self, config: crate::config::OAuthConfig, gateway_port: u16) -> Self {
+        if !config.enabled {
+            return self;
+        }
+
+        use crate::channels::web::oauth::providers::{
+            AppleProvider, GitHubProvider, GoogleProvider, OAuthProvider,
+        };
+        use crate::channels::web::oauth::state_store::OAuthStateStore;
+        use std::collections::HashMap;
+
+        let mut providers: HashMap<String, Arc<dyn OAuthProvider>> = HashMap::new();
+
+        if let Some(ref google) = config.google {
+            providers.insert(
+                "google".to_string(),
+                Arc::new(GoogleProvider::new(
+                    google.client_id.clone(),
+                    google.client_secret.clone(),
+                    google.allowed_hd.clone(),
+                )),
+            );
+        }
+
+        if let Some(ref github) = config.github {
+            providers.insert(
+                "github".to_string(),
+                Arc::new(GitHubProvider::new(
+                    github.client_id.clone(),
+                    github.client_secret.clone(),
+                )),
+            );
+        }
+
+        if let Some(ref apple) = config.apple {
+            providers.insert(
+                "apple".to_string(),
+                Arc::new(AppleProvider::new(
+                    apple.client_id.clone(),
+                    apple.team_id.clone(),
+                    apple.key_id.clone(),
+                    apple.private_key_pem.clone(),
+                )),
+            );
+        }
+
+        // Apply domain restrictions to OIDC regardless of whether OAuth providers
+        // are configured — OIDC runs via reverse-proxy header, not our providers.
+        let allowed_domains = config.allowed_domains;
+        if !allowed_domains.is_empty() {
+            self.auth.oidc_allowed_domains = allowed_domains.clone();
+        }
+
+        // Shutdown signal for background sweep tasks. When the sender is dropped
+        // (e.g., gateway rebuild or process shutdown), the sweep loops exit.
+        let (shutdown_tx, _) = tokio::sync::watch::channel(());
+
+        // Set up NEAR wallet auth if configured (independent of OAuth providers).
+        let near_nonce_store = config.near.as_ref().map(|_| {
+            let store = Arc::new(crate::channels::web::oauth::near::NearNonceStore::new());
+            let sweep = Arc::clone(&store);
+            let mut shutdown_rx = shutdown_tx.subscribe();
+            tokio::spawn(async move {
+                let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => sweep.sweep_expired().await,
+                        _ = shutdown_rx.changed() => break,
+                    }
+                }
+            });
+            store
+        });
+        let near_rpc_url = config.near.as_ref().map(|n| n.rpc_url.clone());
+        let near_network = config.near.as_ref().map(|n| n.network.clone());
+
+        let has_near = near_nonce_store.is_some();
+
+        if providers.is_empty() && !has_near {
+            // No OAuth providers and no NEAR — still apply domain restrictions
+            // to OIDC if configured.
+            self.rebuild_state(|s| {
+                s.oauth_allowed_domains = allowed_domains;
+            });
+            if !self.auth.oidc_allowed_domains.is_empty() {
+                return self;
+            }
+            tracing::warn!("OAuth enabled but no providers configured");
+            return self;
+        }
+
+        let base_url = config
+            .base_url
+            .unwrap_or_else(|| format!("http://localhost:{gateway_port}"));
+
+        let provider_names: Vec<&str> = providers.keys().map(|s| s.as_str()).collect();
+        tracing::info!(?provider_names, "OAuth social login enabled");
+
+        let providers = Arc::new(providers);
+        let state_store = Arc::new(OAuthStateStore::new());
+
+        // Spawn a background task to sweep expired OAuth states.
+        let sweep_store = Arc::clone(&state_store);
+        let mut shutdown_rx2 = shutdown_tx.subscribe();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
+            loop {
+                tokio::select! {
+                    _ = interval.tick() => sweep_store.sweep_expired().await,
+                    _ = shutdown_rx2.changed() => break,
+                }
+            }
+        });
+
+        self.rebuild_state(|s| {
+            s.oauth_providers = Some(providers);
+            s.oauth_state_store = Some(state_store);
+            s.oauth_base_url = Some(base_url);
+            s.oauth_allowed_domains = allowed_domains;
+            s.near_nonce_store = near_nonce_store;
+            s.near_rpc_url = near_rpc_url;
+            s.near_network = near_network;
+            s.oauth_sweep_shutdown = Some(shutdown_tx);
+        });
         self
     }
 

--- a/src/channels/web/oauth/mod.rs
+++ b/src/channels/web/oauth/mod.rs
@@ -1,0 +1,44 @@
+//! OAuth/social login support for the web gateway.
+//!
+//! Provides direct authentication via Google, GitHub, Apple (OAuth/OIDC) and
+//! NEAR wallet (Ed25519 signature verification). On successful login, the
+//! system creates or links a user via the existing `UserStore`, issues an
+//! API token, and sets it as an HttpOnly cookie.
+
+pub mod near;
+pub mod providers;
+pub mod state_store;
+
+use serde::{Deserialize, Serialize};
+
+/// User profile information extracted from an OAuth provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthUserProfile {
+    /// Provider-specific unique user identifier (Google `sub`, GitHub user ID).
+    pub provider_user_id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+    /// Full JSON profile payload from the provider.
+    pub raw: serde_json::Value,
+}
+
+/// OAuth-specific errors.
+#[derive(Debug, thiserror::Error)]
+pub enum OAuthError {
+    #[error("OAuth provider not configured: {0}")]
+    NotConfigured(String),
+    #[error("Invalid OAuth state (CSRF mismatch or expired)")]
+    InvalidState,
+    #[error("Code exchange failed: {0}")]
+    CodeExchange(String),
+    #[error("Failed to fetch user profile: {0}")]
+    ProfileFetch(String),
+    #[error("Signature verification failed: {0}")]
+    SignatureVerification(String),
+    #[error("Database error: {0}")]
+    Database(String),
+    #[error("Rate limited")]
+    RateLimited,
+}

--- a/src/channels/web/oauth/near.rs
+++ b/src/channels/web/oauth/near.rs
@@ -1,0 +1,376 @@
+//! NEAR wallet authentication via NEP-413 signature verification.
+//!
+//! Unlike OAuth providers, NEAR uses a challenge-response flow:
+//! 1. Server generates a random nonce (`GET /auth/near/challenge`)
+//! 2. Client signs `{ message, nonce, recipient }` with a NEAR wallet
+//! 3. Client sends signature + account_id + public_key to `POST /auth/near/verify`
+//! 4. Server verifies the Ed25519 signature and confirms the public key
+//!    is an active access key on the claimed NEAR account via RPC
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use ed25519_dalek::{Signature, VerifyingKey};
+use rand::RngCore;
+use rand::rngs::OsRng;
+use tokio::sync::RwLock;
+
+use super::OAuthError;
+
+const NONCE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+const MAX_NONCES: usize = 4096;
+
+/// In-memory nonce store for NEAR auth challenges.
+#[derive(Default)]
+pub struct NearNonceStore {
+    nonces: RwLock<HashMap<String, Instant>>,
+}
+
+impl NearNonceStore {
+    pub fn new() -> Self {
+        Self {
+            nonces: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Generate and store a random 32-byte nonce, returned as hex.
+    pub async fn generate(&self) -> String {
+        let mut bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut bytes);
+        let nonce = hex::encode(bytes);
+
+        let mut nonces = self.nonces.write().await;
+
+        // Evict expired nonces if near capacity.
+        if nonces.len() >= MAX_NONCES {
+            let now = Instant::now();
+            nonces.retain(|_, created| now.duration_since(*created) < NONCE_TTL);
+        }
+
+        nonces.insert(nonce.clone(), Instant::now());
+        nonce
+    }
+
+    /// Consume a nonce — returns true if valid (exists and not expired).
+    /// Single-use: the nonce is removed regardless.
+    pub async fn consume(&self, nonce: &str) -> bool {
+        let mut nonces = self.nonces.write().await;
+        match nonces.remove(nonce) {
+            Some(created) => Instant::now().duration_since(created) < NONCE_TTL,
+            None => false,
+        }
+    }
+
+    /// Remove expired nonces. Call periodically from a background task.
+    pub async fn sweep_expired(&self) {
+        let mut nonces = self.nonces.write().await;
+        let now = Instant::now();
+        nonces.retain(|_, created| now.duration_since(*created) < NONCE_TTL);
+    }
+}
+
+/// NEP-413 tag: `2^31 + 413 = 2147484061`.
+const NEP413_TAG: u32 = (1 << 31) + 413;
+
+/// Build the NEP-413 borsh-serialized payload (tag → message → nonce → recipient → callback_url).
+///
+/// This is the original NEP-413 spec field order from the NEAR Enhancement Proposal.
+fn build_nep413_v1(message: &str, nonce: &[u8; 32], recipient: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&NEP413_TAG.to_le_bytes());
+    buf.extend_from_slice(&(message.len() as u32).to_le_bytes());
+    buf.extend_from_slice(message.as_bytes());
+    buf.extend_from_slice(nonce);
+    buf.extend_from_slice(&(recipient.len() as u32).to_le_bytes());
+    buf.extend_from_slice(recipient.as_bytes());
+    buf.push(0); // None for callback_url
+    buf
+}
+
+/// Build NEP-413 payload with alternative field order (tag → message → recipient → nonce).
+///
+/// Some wallet implementations (near-connect, HOT) use this field order
+/// as documented at docs.near.org/web3-apps/backend-login.
+fn build_nep413_v2(message: &str, nonce: &[u8; 32], recipient: &str) -> Vec<u8> {
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&NEP413_TAG.to_le_bytes());
+    buf.extend_from_slice(&(message.len() as u32).to_le_bytes());
+    buf.extend_from_slice(message.as_bytes());
+    buf.extend_from_slice(&(recipient.len() as u32).to_le_bytes());
+    buf.extend_from_slice(recipient.as_bytes());
+    buf.extend_from_slice(nonce);
+    buf
+}
+
+/// Verify an Ed25519 signature over a message.
+fn verify_ed25519(public_key_bytes: &[u8; 32], signature_bytes: &[u8; 64], message: &[u8]) -> bool {
+    let Ok(key) = VerifyingKey::from_bytes(public_key_bytes) else {
+        return false;
+    };
+    let sig = Signature::from_bytes(signature_bytes);
+    use ed25519_dalek::Verifier;
+    key.verify(message, &sig).is_ok()
+}
+
+/// Verify an Ed25519 signature over a NEP-413 structured payload.
+///
+/// Only accepts properly structured NEP-413 payloads that include the nonce,
+/// ensuring the signature is bound to a specific challenge. Raw message bytes
+/// are intentionally NOT accepted — they lack nonce binding and would allow
+/// signature replay.
+///
+/// Tries both known NEP-413 field orderings:
+/// - v1 (spec): tag → msg → nonce → recipient → callback_url(None)
+/// - v2 (near-connect/HOT): tag → msg → recipient → nonce
+///
+/// For each, tries the direct borsh payload and its SHA256 hash (some wallets
+/// sign the hash rather than the raw bytes).
+pub fn verify_near_signature(
+    public_key_bytes: &[u8; 32],
+    signature_bytes: &[u8; 64],
+    message: &str,
+    nonce: &[u8; 32],
+    recipient: &str,
+) -> Result<(), OAuthError> {
+    use sha2::{Digest, Sha256};
+
+    // Build both known NEP-413 field orderings.
+    let payloads = [
+        build_nep413_v1(message, nonce, recipient), // tag → msg → nonce → recipient → callback
+        build_nep413_v2(message, nonce, recipient), // tag → msg → recipient → nonce
+    ];
+
+    for payload in &payloads {
+        // Direct borsh payload
+        if verify_ed25519(public_key_bytes, signature_bytes, payload) {
+            return Ok(());
+        }
+        // SHA256 of the borsh payload
+        if verify_ed25519(public_key_bytes, signature_bytes, &Sha256::digest(payload)) {
+            return Ok(());
+        }
+    }
+
+    Err(OAuthError::SignatureVerification(
+        "No matching NEP-413 payload format verified".to_string(),
+    ))
+}
+
+/// Verify that a public key is an active access key on a NEAR account via RPC.
+pub async fn verify_access_key(
+    rpc_url: &str,
+    account_id: &str,
+    public_key: &str,
+    http: &reqwest::Client,
+) -> Result<(), OAuthError> {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "ironclaw",
+        "method": "query",
+        "params": {
+            "request_type": "view_access_key",
+            "finality": "final",
+            "account_id": account_id,
+            "public_key": public_key,
+        }
+    });
+
+    let resp = http
+        .post(rpc_url)
+        .json(&body)
+        .send()
+        .await
+        .map_err(|e| OAuthError::ProfileFetch(format!("NEAR RPC request failed: {e}")))?;
+
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(OAuthError::ProfileFetch(format!(
+            "NEAR RPC returned HTTP {status}: {body}"
+        )));
+    }
+
+    let json: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| OAuthError::ProfileFetch(format!("NEAR RPC response parse error: {e}")))?;
+
+    // Check for RPC-level error (key doesn't exist, account doesn't exist, etc.)
+    if let Some(error) = json.get("error") {
+        let msg = error
+            .get("cause")
+            .and_then(|c| c.get("name"))
+            .and_then(|n| n.as_str())
+            .unwrap_or("unknown error");
+        return Err(OAuthError::ProfileFetch(format!(
+            "Access key not found on account '{account_id}': {msg}"
+        )));
+    }
+
+    // Verify we got a result (not an error response).
+    if json.get("result").is_none() {
+        return Err(OAuthError::ProfileFetch(
+            "NEAR RPC returned no result for access key query".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_nonce_generate_and_consume() {
+        let store = NearNonceStore::new();
+        let nonce = store.generate().await;
+        assert_eq!(nonce.len(), 64); // 32 bytes hex-encoded
+
+        assert!(store.consume(&nonce).await);
+        // Second consume should fail (single-use).
+        assert!(!store.consume(&nonce).await);
+    }
+
+    #[tokio::test]
+    async fn test_nonce_unknown_rejected() {
+        let store = NearNonceStore::new();
+        assert!(!store.consume("nonexistent").await);
+    }
+
+    #[tokio::test]
+    async fn test_nonce_sweep() {
+        let store = NearNonceStore::new();
+        // Insert an already-expired nonce.
+        {
+            let mut nonces = store.nonces.write().await;
+            nonces.insert(
+                "old-nonce".to_string(),
+                Instant::now() - Duration::from_secs(600),
+            );
+            nonces.insert("fresh-nonce".to_string(), Instant::now());
+        }
+        store.sweep_expired().await;
+        let nonces = store.nonces.read().await;
+        assert_eq!(nonces.len(), 1);
+        assert!(nonces.contains_key("fresh-nonce"));
+    }
+
+    #[test]
+    fn test_verify_near_signature_nep413_v1() {
+        use ed25519_dalek::{Signer, SigningKey};
+        let signing_key = SigningKey::from_bytes(&{
+            let mut b = [0u8; 32];
+            OsRng.fill_bytes(&mut b);
+            b
+        });
+        let verifying_key = signing_key.verifying_key();
+
+        let message = "Sign in to IronClaw\nNonce: abcd1234";
+        let nonce = [0u8; 32];
+
+        // Sign the v1 NEP-413 payload (tag → message → nonce → recipient → callback).
+        let payload = build_nep413_v1(message, &nonce, "ironclaw");
+        let signature = signing_key.sign(&payload);
+
+        assert!(
+            verify_near_signature(
+                verifying_key.as_bytes(),
+                &signature.to_bytes(),
+                message,
+                &nonce,
+                "ironclaw",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_verify_near_signature_rejects_raw_message() {
+        use ed25519_dalek::{Signer, SigningKey};
+        let signing_key = SigningKey::from_bytes(&{
+            let mut b = [0u8; 32];
+            OsRng.fill_bytes(&mut b);
+            b
+        });
+        let verifying_key = signing_key.verifying_key();
+
+        let message = "Sign in to IronClaw\nNonce: abcd1234";
+        let nonce = [0u8; 32];
+
+        // Sign the raw message bytes — this should be REJECTED because raw
+        // messages lack nonce binding (signature replay risk).
+        let signature = signing_key.sign(message.as_bytes());
+
+        assert!(
+            verify_near_signature(
+                verifying_key.as_bytes(),
+                &signature.to_bytes(),
+                message,
+                &nonce,
+                "ironclaw",
+            )
+            .is_err(),
+            "raw message signatures must be rejected (no nonce binding)"
+        );
+    }
+
+    #[test]
+    fn test_verify_near_signature_nep413_v2() {
+        use ed25519_dalek::{Signer, SigningKey};
+        let signing_key = SigningKey::from_bytes(&{
+            let mut b = [0u8; 32];
+            OsRng.fill_bytes(&mut b);
+            b
+        });
+        let verifying_key = signing_key.verifying_key();
+
+        let message = "Sign in to IronClaw\nNonce: abcd1234";
+        let nonce = [42u8; 32];
+
+        // Sign the v2 NEP-413 payload (tag → message → recipient → nonce).
+        let payload = build_nep413_v2(message, &nonce, "ironclaw");
+        let signature = signing_key.sign(&payload);
+
+        assert!(
+            verify_near_signature(
+                verifying_key.as_bytes(),
+                &signature.to_bytes(),
+                message,
+                &nonce,
+                "ironclaw",
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_verify_near_signature_wrong_key() {
+        use ed25519_dalek::{Signer, SigningKey};
+        let signing_key = SigningKey::from_bytes(&{
+            let mut b = [0u8; 32];
+            OsRng.fill_bytes(&mut b);
+            b
+        });
+        let wrong_key = SigningKey::from_bytes(&{
+            let mut b = [0u8; 32];
+            OsRng.fill_bytes(&mut b);
+            b
+        });
+
+        let message = "test message";
+        let nonce = [0u8; 32];
+        let signature = signing_key.sign(message.as_bytes());
+
+        assert!(
+            verify_near_signature(
+                wrong_key.verifying_key().as_bytes(),
+                &signature.to_bytes(),
+                message,
+                &nonce,
+                "ironclaw",
+            )
+            .is_err()
+        );
+    }
+}

--- a/src/channels/web/oauth/providers.rs
+++ b/src/channels/web/oauth/providers.rs
@@ -1,0 +1,609 @@
+//! OAuth provider trait and implementations (Google, GitHub).
+
+use async_trait::async_trait;
+use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
+
+use super::{OAuthError, OAuthUserProfile};
+
+/// Trait for OAuth providers.
+///
+/// Each provider knows how to build an authorization URL and exchange an
+/// authorization code for a user profile.
+#[async_trait]
+pub trait OAuthProvider: Send + Sync {
+    /// Provider name (e.g. `google`, `github`).
+    fn name(&self) -> &str;
+
+    /// Build the authorization URL for redirecting the user.
+    fn authorization_url(&self, callback_url: &str, state: &str, code_challenge: &str) -> String;
+
+    /// Exchange an authorization code for a user profile.
+    async fn exchange_code(
+        &self,
+        code: &str,
+        callback_url: &str,
+        code_verifier: &str,
+    ) -> Result<OAuthUserProfile, OAuthError>;
+}
+
+// ── Google (OIDC) ────────────────────────────────────────────────────────
+
+const GOOGLE_AUTH_URL: &str = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_TOKEN_URL: &str = "https://oauth2.googleapis.com/token";
+
+pub struct GoogleProvider {
+    client_id: String,
+    client_secret: SecretString,
+    /// Optional hosted domain restriction (Google Workspace).
+    allowed_hd: Option<String>,
+    http: reqwest::Client,
+}
+
+impl GoogleProvider {
+    pub fn new(client_id: String, client_secret: SecretString, allowed_hd: Option<String>) -> Self {
+        Self {
+            client_id,
+            client_secret,
+            allowed_hd,
+            http: reqwest::Client::new(),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GoogleTokenResponse {
+    id_token: Option<String>,
+    #[allow(dead_code)]
+    access_token: String,
+}
+
+#[derive(Deserialize, serde::Serialize)]
+struct GoogleIdTokenClaims {
+    sub: String,
+    email: Option<String>,
+    email_verified: Option<bool>,
+    name: Option<String>,
+    picture: Option<String>,
+    /// Google Workspace hosted domain (e.g. `company.com`).
+    hd: Option<String>,
+}
+
+#[async_trait]
+impl OAuthProvider for GoogleProvider {
+    fn name(&self) -> &str {
+        "google"
+    }
+
+    fn authorization_url(&self, callback_url: &str, state: &str, code_challenge: &str) -> String {
+        let mut url = format!(
+            "{GOOGLE_AUTH_URL}?\
+             response_type=code\
+             &client_id={client_id}\
+             &redirect_uri={redirect_uri}\
+             &scope={scope}\
+             &state={state}\
+             &code_challenge={code_challenge}\
+             &code_challenge_method=S256\
+             &access_type=online",
+            client_id = urlencoding::encode(&self.client_id),
+            redirect_uri = urlencoding::encode(callback_url),
+            scope = urlencoding::encode("openid email profile"),
+            state = urlencoding::encode(state),
+            code_challenge = urlencoding::encode(code_challenge),
+        );
+        // Hint Google to show only accounts from this hosted domain.
+        if let Some(ref hd) = self.allowed_hd {
+            url.push_str(&format!("&hd={}", urlencoding::encode(hd)));
+        }
+        url
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        callback_url: &str,
+        code_verifier: &str,
+    ) -> Result<OAuthUserProfile, OAuthError> {
+        // Exchange the authorization code for tokens.
+        let resp = self
+            .http
+            .post(GOOGLE_TOKEN_URL)
+            .form(&[
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", callback_url),
+                ("client_id", &self.client_id),
+                ("client_secret", self.client_secret.expose_secret()),
+                ("code_verifier", code_verifier),
+            ])
+            .send()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(OAuthError::CodeExchange(format!(
+                "Google token endpoint returned error: {body}"
+            )));
+        }
+
+        let token_resp: GoogleTokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        // Decode the id_token JWT to extract user profile claims.
+        // We received this directly from Google over TLS, so we skip
+        // signature verification (the token is authentic by transport).
+        let id_token = token_resp.id_token.ok_or_else(|| {
+            OAuthError::CodeExchange("Google did not return an id_token".to_string())
+        })?;
+
+        // Validate the id_token JWT claims. We skip signature verification
+        // because the token was received directly from Google over TLS.
+        // However, we MUST validate `aud` to prevent token substitution from
+        // a different OAuth client.
+        let mut validation = jsonwebtoken::Validation::default();
+        validation.insecure_disable_signature_validation();
+        validation.set_audience(&[&self.client_id]);
+        validation.set_issuer(&["https://accounts.google.com"]);
+
+        let token_data = jsonwebtoken::decode::<GoogleIdTokenClaims>(
+            &id_token,
+            &jsonwebtoken::DecodingKey::from_secret(&[]),
+            &validation,
+        )
+        .map_err(|e| OAuthError::ProfileFetch(format!("Failed to decode id_token: {e}")))?;
+
+        let claims = token_data.claims;
+
+        // Server-side hosted domain validation — the `hd` URL parameter is
+        // only a UI hint; a user could bypass it by editing the URL.
+        if let Some(ref required_hd) = self.allowed_hd {
+            match claims.hd.as_deref() {
+                Some(hd) if hd.eq_ignore_ascii_case(required_hd) => {}
+                _ => {
+                    return Err(OAuthError::ProfileFetch(format!(
+                        "Account is not from the required domain '{required_hd}'"
+                    )));
+                }
+            }
+        }
+
+        tracing::debug!(
+            sub = %claims.sub,
+            picture = ?claims.picture,
+            name = ?claims.name,
+            "Google id_token claims decoded"
+        );
+
+        Ok(OAuthUserProfile {
+            provider_user_id: claims.sub.clone(),
+            email: claims.email.clone(),
+            email_verified: claims.email_verified.unwrap_or(false),
+            display_name: claims.name.clone(),
+            avatar_url: claims.picture.clone(),
+            raw: serde_json::to_value(&claims).unwrap_or_default(),
+        })
+    }
+}
+
+// ── GitHub ────────────────────────────────────────────────────────────────
+
+const GITHUB_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
+const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
+const GITHUB_USER_URL: &str = "https://api.github.com/user";
+const GITHUB_EMAILS_URL: &str = "https://api.github.com/user/emails";
+
+pub struct GitHubProvider {
+    client_id: String,
+    client_secret: SecretString,
+    http: reqwest::Client,
+}
+
+impl GitHubProvider {
+    pub fn new(client_id: String, client_secret: SecretString) -> Self {
+        Self {
+            client_id,
+            client_secret,
+            http: reqwest::Client::builder()
+                .user_agent("IronClaw")
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct GitHubTokenResponse {
+    access_token: String,
+}
+
+#[derive(Deserialize)]
+struct GitHubUser {
+    id: u64,
+    login: String,
+    name: Option<String>,
+    email: Option<String>,
+    avatar_url: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct GitHubEmail {
+    email: String,
+    verified: bool,
+    primary: bool,
+}
+
+#[async_trait]
+impl OAuthProvider for GitHubProvider {
+    fn name(&self) -> &str {
+        "github"
+    }
+
+    fn authorization_url(&self, callback_url: &str, state: &str, _code_challenge: &str) -> String {
+        // GitHub does not support PKCE; CSRF is protected via the state param.
+        format!(
+            "{GITHUB_AUTH_URL}?\
+             client_id={client_id}\
+             &redirect_uri={redirect_uri}\
+             &scope={scope}\
+             &state={state}",
+            client_id = urlencoding::encode(&self.client_id),
+            redirect_uri = urlencoding::encode(callback_url),
+            scope = urlencoding::encode("read:user user:email"),
+            state = urlencoding::encode(state),
+        )
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        callback_url: &str,
+        _code_verifier: &str,
+    ) -> Result<OAuthUserProfile, OAuthError> {
+        // Exchange the code for an access token.
+        let resp = self
+            .http
+            .post(GITHUB_TOKEN_URL)
+            .header("Accept", "application/json")
+            .form(&[
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.expose_secret()),
+                ("code", code),
+                ("redirect_uri", callback_url),
+            ])
+            .send()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(OAuthError::CodeExchange(format!(
+                "GitHub token endpoint error: {body}"
+            )));
+        }
+
+        let token_resp: GitHubTokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        // Fetch user profile.
+        let user: GitHubUser = self
+            .http
+            .get(GITHUB_USER_URL)
+            .header(
+                "Authorization",
+                format!("Bearer {}", token_resp.access_token),
+            )
+            .send()
+            .await
+            .map_err(|e| OAuthError::ProfileFetch(e.to_string()))?
+            .json()
+            .await
+            .map_err(|e| OAuthError::ProfileFetch(e.to_string()))?;
+
+        // Fetch verified emails (the profile may not include one).
+        let emails: Vec<GitHubEmail> = self
+            .http
+            .get(GITHUB_EMAILS_URL)
+            .header(
+                "Authorization",
+                format!("Bearer {}", token_resp.access_token),
+            )
+            .send()
+            .await
+            .map_err(|e| OAuthError::ProfileFetch(e.to_string()))?
+            .json()
+            .await
+            .map_err(|e| OAuthError::ProfileFetch(format!("Failed to parse GitHub emails: {e}")))?;
+
+        // Pick the primary verified email, or any verified email.
+        let verified_email = emails
+            .iter()
+            .filter(|e| e.verified)
+            .find(|e| e.primary)
+            .or_else(|| emails.iter().find(|e| e.verified));
+
+        let (email, email_verified) = match verified_email {
+            Some(e) => (Some(e.email.clone()), true),
+            None => (user.email.clone(), false),
+        };
+
+        let raw = serde_json::json!({
+            "id": user.id,
+            "login": user.login,
+            "name": user.name,
+            "avatar_url": user.avatar_url,
+        });
+
+        Ok(OAuthUserProfile {
+            provider_user_id: user.id.to_string(),
+            email,
+            email_verified,
+            display_name: user.name.or(Some(user.login)),
+            avatar_url: user.avatar_url,
+            raw,
+        })
+    }
+}
+
+// ── Apple Sign In ─────────────────────────────────────────────────────────
+
+const APPLE_AUTH_URL: &str = "https://appleid.apple.com/auth/authorize";
+const APPLE_TOKEN_URL: &str = "https://appleid.apple.com/auth/token";
+
+/// Apple Sign In provider.
+///
+/// Apple uses OIDC but requires a JWT `client_secret` (ES256-signed, 6-month
+/// lifetime) and sends the callback as a POST with `response_mode=form_post`.
+pub struct AppleProvider {
+    client_id: String,
+    team_id: String,
+    key_id: String,
+    private_key_pem: SecretString,
+    http: reqwest::Client,
+}
+
+impl AppleProvider {
+    pub fn new(
+        client_id: String,
+        team_id: String,
+        key_id: String,
+        private_key_pem: SecretString,
+    ) -> Self {
+        Self {
+            client_id,
+            team_id,
+            key_id,
+            private_key_pem,
+            http: reqwest::Client::new(),
+        }
+    }
+
+    /// Generate a JWT client_secret for Apple's token endpoint.
+    ///
+    /// Apple requires the client_secret to be an ES256-signed JWT with:
+    /// - `iss`: Team ID
+    /// - `sub`: Client (Services) ID
+    /// - `aud`: `https://appleid.apple.com`
+    /// - `iat`: current time
+    /// - `exp`: up to 6 months from now
+    fn generate_client_secret(&self) -> Result<String, OAuthError> {
+        use jsonwebtoken::{Algorithm, EncodingKey, Header};
+
+        let now = chrono::Utc::now().timestamp() as u64;
+        let claims = serde_json::json!({
+            "iss": self.team_id,
+            "sub": self.client_id,
+            "aud": "https://appleid.apple.com",
+            "iat": now,
+            "exp": now + 86400 * 180, // 6 months
+        });
+
+        let mut header = Header::new(Algorithm::ES256);
+        header.kid = Some(self.key_id.clone());
+
+        let key = EncodingKey::from_ec_pem(self.private_key_pem.expose_secret().as_bytes())
+            .map_err(|e| OAuthError::CodeExchange(format!("Invalid Apple private key: {e}")))?;
+
+        jsonwebtoken::encode(&header, &claims, &key).map_err(|e| {
+            OAuthError::CodeExchange(format!("Failed to sign Apple client_secret: {e}"))
+        })
+    }
+}
+
+#[derive(Deserialize)]
+struct AppleTokenResponse {
+    id_token: String,
+}
+
+#[derive(Deserialize, serde::Serialize)]
+struct AppleIdTokenClaims {
+    sub: String,
+    email: Option<String>,
+    email_verified: Option<serde_json::Value>,
+}
+
+#[async_trait]
+impl OAuthProvider for AppleProvider {
+    fn name(&self) -> &str {
+        "apple"
+    }
+
+    fn authorization_url(&self, callback_url: &str, state: &str, _code_challenge: &str) -> String {
+        // Apple requires response_mode=form_post (callback is a POST, not GET).
+        format!(
+            "{APPLE_AUTH_URL}?\
+             response_type=code\
+             &response_mode=form_post\
+             &client_id={client_id}\
+             &redirect_uri={redirect_uri}\
+             &scope={scope}\
+             &state={state}",
+            client_id = urlencoding::encode(&self.client_id),
+            redirect_uri = urlencoding::encode(callback_url),
+            scope = urlencoding::encode("name email"),
+            state = urlencoding::encode(state),
+        )
+    }
+
+    async fn exchange_code(
+        &self,
+        code: &str,
+        callback_url: &str,
+        _code_verifier: &str,
+    ) -> Result<OAuthUserProfile, OAuthError> {
+        let client_secret = self.generate_client_secret()?;
+
+        let resp = self
+            .http
+            .post(APPLE_TOKEN_URL)
+            .form(&[
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", callback_url),
+                ("client_id", &self.client_id),
+                ("client_secret", &client_secret),
+            ])
+            .send()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        if !resp.status().is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(OAuthError::CodeExchange(format!(
+                "Apple token endpoint error: {body}"
+            )));
+        }
+
+        let token_resp: AppleTokenResponse = resp
+            .json()
+            .await
+            .map_err(|e| OAuthError::CodeExchange(e.to_string()))?;
+
+        // Decode the id_token — we skip signature verification because
+        // the token was received directly from Apple over TLS. We validate
+        // `aud` to prevent token substitution.
+        let mut validation = jsonwebtoken::Validation::default();
+        validation.insecure_disable_signature_validation();
+        validation.set_audience(&[&self.client_id]);
+        validation.set_issuer(&["https://appleid.apple.com"]);
+
+        let token_data = jsonwebtoken::decode::<AppleIdTokenClaims>(
+            &token_resp.id_token,
+            &jsonwebtoken::DecodingKey::from_secret(&[]),
+            &validation,
+        )
+        .map_err(|e| OAuthError::ProfileFetch(format!("Failed to decode Apple id_token: {e}")))?;
+
+        let claims = token_data.claims;
+
+        // Apple's email_verified can be a string "true"/"false" or a boolean.
+        let email_verified = match &claims.email_verified {
+            Some(serde_json::Value::Bool(b)) => *b,
+            Some(serde_json::Value::String(s)) => s == "true",
+            _ => false,
+        };
+
+        Ok(OAuthUserProfile {
+            provider_user_id: claims.sub.clone(),
+            email: claims.email.clone(),
+            email_verified,
+            display_name: None, // Apple sends name only on first auth via POST user field
+            avatar_url: None,
+            raw: serde_json::to_value(&claims).unwrap_or_default(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_google_authorization_url_format() {
+        let provider = GoogleProvider::new(
+            "test-client-id".to_string(),
+            SecretString::from("test-secret".to_string()),
+            None,
+        );
+
+        let url = provider.authorization_url(
+            "https://example.com/auth/callback/google",
+            "csrf-state-123",
+            "challenge-abc",
+        );
+
+        assert!(url.starts_with(GOOGLE_AUTH_URL));
+        assert!(url.contains("client_id=test-client-id"));
+        assert!(url.contains("state=csrf-state-123"));
+        assert!(url.contains("code_challenge=challenge-abc"));
+        assert!(url.contains("code_challenge_method=S256"));
+        assert!(url.contains("scope=openid"));
+        assert!(!url.contains("&hd="));
+    }
+
+    #[test]
+    fn test_google_authorization_url_includes_hd() {
+        let provider = GoogleProvider::new(
+            "test-client-id".to_string(),
+            SecretString::from("test-secret".to_string()),
+            Some("company.com".to_string()),
+        );
+
+        let url = provider.authorization_url(
+            "https://example.com/auth/callback/google",
+            "csrf-state-123",
+            "challenge-abc",
+        );
+
+        assert!(url.contains("&hd=company.com"));
+    }
+
+    #[test]
+    fn test_github_authorization_url_format() {
+        let provider = GitHubProvider::new(
+            "gh-client-id".to_string(),
+            SecretString::from("gh-secret".to_string()),
+        );
+
+        let url = provider.authorization_url(
+            "https://example.com/auth/callback/github",
+            "csrf-state-456",
+            "ignored-challenge",
+        );
+
+        assert!(url.starts_with(GITHUB_AUTH_URL));
+        assert!(url.contains("client_id=gh-client-id"));
+        assert!(url.contains("state=csrf-state-456"));
+        assert!(url.contains("scope=read%3Auser"));
+        // GitHub ignores code_challenge, verify it's not included
+        assert!(!url.contains("code_challenge="));
+    }
+
+    #[test]
+    fn test_apple_authorization_url_format() {
+        let provider = AppleProvider::new(
+            "com.example.myapp".to_string(),
+            "TEAM123456".to_string(),
+            "KEY1234567".to_string(),
+            SecretString::from("fake-key".to_string()),
+        );
+
+        let url = provider.authorization_url(
+            "https://example.com/auth/callback/apple",
+            "csrf-state-789",
+            "ignored-challenge",
+        );
+
+        assert!(url.starts_with(APPLE_AUTH_URL));
+        assert!(url.contains("client_id=com.example.myapp"));
+        assert!(url.contains("response_mode=form_post"));
+        assert!(url.contains("state=csrf-state-789"));
+        assert!(url.contains("scope=name"));
+        assert!(!url.contains("code_challenge="));
+    }
+}

--- a/src/channels/web/oauth/state_store.rs
+++ b/src/channels/web/oauth/state_store.rs
@@ -1,0 +1,284 @@
+//! In-memory store for pending OAuth flows.
+//!
+//! Each OAuth login generates a CSRF state token and a PKCE code verifier.
+//! These are stored here temporarily (5 min TTL) until the OAuth callback
+//! completes the exchange. Entries are single-use (taken on callback) and
+//! bounded to prevent memory exhaustion.
+
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use base64::Engine;
+use rand::RngCore;
+use rand::rngs::OsRng;
+use tokio::sync::RwLock;
+
+const STATE_TTL: Duration = Duration::from_secs(300); // 5 minutes
+const MAX_PENDING_STATES: usize = 1024;
+
+/// A pending OAuth flow awaiting callback completion.
+pub struct PendingOAuthFlow {
+    /// Provider name (e.g. "google", "github").
+    pub provider: String,
+    /// PKCE code verifier (base64url-encoded, 43 chars).
+    pub code_verifier: String,
+    /// Optional URL to redirect to after login completes.
+    pub redirect_after: Option<String>,
+    created_at: Instant,
+}
+
+/// Thread-safe in-memory store for pending OAuth flows.
+#[derive(Default)]
+pub struct OAuthStateStore {
+    states: RwLock<HashMap<String, PendingOAuthFlow>>,
+}
+
+impl OAuthStateStore {
+    pub fn new() -> Self {
+        Self {
+            states: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Generate a PKCE code verifier (32 random bytes, base64url-encoded).
+    pub fn generate_code_verifier() -> String {
+        let mut bytes = [0u8; 32];
+        OsRng.fill_bytes(&mut bytes);
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    }
+
+    /// Compute the S256 code challenge from a code verifier.
+    pub fn code_challenge(verifier: &str) -> String {
+        use base64::Engine;
+        use sha2::{Digest, Sha256};
+        let hash = Sha256::digest(verifier.as_bytes());
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hash)
+    }
+
+    /// Insert a new pending OAuth flow. Returns the CSRF state token.
+    ///
+    /// If at capacity, expired entries are evicted first. If still at
+    /// capacity after eviction, the oldest entry is removed.
+    pub async fn insert(&self, flow: PendingOAuthFlow) -> String {
+        let mut states = self.states.write().await;
+
+        // Evict expired entries if near capacity
+        if states.len() >= MAX_PENDING_STATES {
+            let now = Instant::now();
+            states.retain(|_, f| now.duration_since(f.created_at) < STATE_TTL);
+        }
+
+        // If still at capacity, remove the oldest
+        if states.len() >= MAX_PENDING_STATES
+            && let Some(oldest_key) = states
+                .iter()
+                .min_by_key(|(_, f)| f.created_at)
+                .map(|(k, _)| k.clone())
+        {
+            states.remove(&oldest_key);
+        }
+
+        let state_token = generate_state_token();
+        states.insert(state_token.clone(), flow);
+        state_token
+    }
+
+    /// Remove and return the flow for a given state token.
+    ///
+    /// Returns `None` if not found or expired. Single-use: the entry is
+    /// removed regardless.
+    pub async fn take(&self, state: &str) -> Option<PendingOAuthFlow> {
+        let mut states = self.states.write().await;
+        let flow = states.remove(state)?;
+        if Instant::now().duration_since(flow.created_at) >= STATE_TTL {
+            return None;
+        }
+        Some(flow)
+    }
+
+    /// Remove expired entries. Call periodically from a background task.
+    pub async fn sweep_expired(&self) {
+        let mut states = self.states.write().await;
+        let now = Instant::now();
+        states.retain(|_, f| now.duration_since(f.created_at) < STATE_TTL);
+    }
+}
+
+/// Generate a 32-byte hex-encoded CSRF state token.
+fn generate_state_token() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    hex::encode(bytes)
+}
+
+/// Validate a redirect URL to prevent open redirect attacks.
+///
+/// Only allows relative paths that:
+/// - Start with `/` (relative to origin)
+/// - Do not start with `//` or `/\` (protocol-relative)
+/// - Contain only URL-safe characters (blocks encoded separators like `/%09/`)
+///
+/// This is applied both at flow creation and re-validated before use.
+pub(crate) fn sanitize_redirect(url: Option<String>) -> Option<String> {
+    url.filter(|u| is_safe_redirect(u))
+}
+
+/// Check if a redirect path is safe for use.
+///
+/// Validates both the raw URL and its percent-decoded form to prevent
+/// smuggling attacks (e.g., `%2f%2f` decoding to `//`).
+pub(crate) fn is_safe_redirect(url: &str) -> bool {
+    if !check_redirect_chars(url) {
+        return false;
+    }
+    // Percent-decode and re-validate to catch smuggled sequences like
+    // %2f%2f (→ //) or %5c (→ \) that bypass the raw-string guards.
+    let decoded = match urlencoding::decode(url) {
+        Ok(d) => d,
+        Err(_) => return false, // invalid percent-encoding → reject
+    };
+    check_redirect_chars(&decoded)
+}
+
+fn check_redirect_chars(url: &str) -> bool {
+    if !url.starts_with('/') || url.starts_with("//") || url.starts_with("/\\") {
+        return false;
+    }
+    // Only allow unreserved + sub-delimiters + pchar characters from RFC 3986.
+    url.bytes()
+        .all(|b| b.is_ascii_alphanumeric() || b"/_-.~:@!$&'()*+,;=?#[]%".contains(&b))
+}
+
+/// Create a `PendingOAuthFlow` with a fresh code verifier.
+pub fn new_oauth_flow(provider: String, redirect_after: Option<String>) -> PendingOAuthFlow {
+    PendingOAuthFlow {
+        provider,
+        code_verifier: OAuthStateStore::generate_code_verifier(),
+        redirect_after: sanitize_redirect(redirect_after),
+        created_at: Instant::now(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_insert_and_take() {
+        let store = OAuthStateStore::new();
+        let flow = new_oauth_flow("google".to_string(), None);
+        let verifier = flow.code_verifier.clone();
+        let state = store.insert(flow).await;
+
+        let taken = store.take(&state).await;
+        assert!(taken.is_some());
+        let taken = taken.unwrap();
+        assert_eq!(taken.provider, "google");
+        assert_eq!(taken.code_verifier, verifier);
+    }
+
+    #[tokio::test]
+    async fn test_take_removes_entry() {
+        let store = OAuthStateStore::new();
+        let flow = new_oauth_flow("github".to_string(), None);
+        let state = store.insert(flow).await;
+
+        let first = store.take(&state).await;
+        assert!(first.is_some());
+
+        let second = store.take(&state).await;
+        assert!(second.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_take_unknown_returns_none() {
+        let store = OAuthStateStore::new();
+        let result = store.take("nonexistent").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_code_challenge_is_deterministic() {
+        let verifier = "test-verifier-string";
+        let c1 = OAuthStateStore::code_challenge(verifier);
+        let c2 = OAuthStateStore::code_challenge(verifier);
+        assert_eq!(c1, c2);
+        assert!(!c1.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_sweep_expired() {
+        let store = OAuthStateStore::new();
+
+        // Insert a flow with an already-expired timestamp (by manipulating internals)
+        {
+            let mut states = store.states.write().await;
+            states.insert(
+                "expired-state".to_string(),
+                PendingOAuthFlow {
+                    provider: "google".to_string(),
+                    code_verifier: "v".to_string(),
+                    redirect_after: None,
+                    created_at: Instant::now() - Duration::from_secs(600),
+                },
+            );
+            states.insert(
+                "fresh-state".to_string(),
+                PendingOAuthFlow {
+                    provider: "github".to_string(),
+                    code_verifier: "v".to_string(),
+                    redirect_after: None,
+                    created_at: Instant::now(),
+                },
+            );
+        }
+
+        store.sweep_expired().await;
+
+        let states = store.states.read().await;
+        assert_eq!(states.len(), 1);
+        assert!(states.contains_key("fresh-state"));
+    }
+
+    #[test]
+    fn test_is_safe_redirect_allows_normal_paths() {
+        assert!(is_safe_redirect("/"));
+        assert!(is_safe_redirect("/dashboard"));
+        assert!(is_safe_redirect("/settings/profile"));
+        assert!(is_safe_redirect("/path?query=1#hash"));
+    }
+
+    #[test]
+    fn test_is_safe_redirect_blocks_protocol_relative() {
+        assert!(!is_safe_redirect("//evil.com"));
+        assert!(!is_safe_redirect("/\\evil.com"));
+    }
+
+    #[test]
+    fn test_is_safe_redirect_blocks_absolute_urls() {
+        assert!(!is_safe_redirect("https://evil.com"));
+        assert!(!is_safe_redirect("javascript:alert(1)"));
+    }
+
+    #[test]
+    fn test_is_safe_redirect_blocks_encoded_smuggling() {
+        // %2f%2f decodes to // (protocol-relative)
+        assert!(!is_safe_redirect("/%2f%2fevil.com"));
+        assert!(!is_safe_redirect("/%2F%2Fevil.com"));
+        // %5c decodes to \ (backslash smuggling)
+        assert!(!is_safe_redirect("/%5cevil.com"));
+        // %09 (tab) can be used as a separator in some browsers
+        assert!(!is_safe_redirect("/%09/evil.com"));
+    }
+
+    #[test]
+    fn test_sanitize_redirect_filters_unsafe() {
+        assert_eq!(
+            sanitize_redirect(Some("/safe".to_string())),
+            Some("/safe".to_string())
+        );
+        assert_eq!(sanitize_redirect(Some("//evil.com".to_string())), None);
+        assert_eq!(sanitize_redirect(Some("/%2f%2fevil.com".to_string())), None);
+        assert_eq!(sanitize_redirect(None), None);
+    }
+}

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2290,6 +2290,7 @@ async fn extensions_install_handler(
         "mcp_server" => Some(crate::extensions::ExtensionKind::McpServer),
         "wasm_tool" => Some(crate::extensions::ExtensionKind::WasmTool),
         "wasm_channel" => Some(crate::extensions::ExtensionKind::WasmChannel),
+        "acp_agent" => Some(crate::extensions::ExtensionKind::AcpAgent),
         _ => None,
     });
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -26,6 +26,8 @@ use tower_http::cors::{AllowHeaders, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 use uuid::Uuid;
 
+use axum::http::HeaderMap;
+
 use crate::agent::SessionManager;
 use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::IncomingMessage;
@@ -88,6 +90,29 @@ fn redact_oauth_state_for_logs(state: &str) -> String {
         let _ = write!(&mut short_hash, "{byte:02x}");
     }
     format!("sha256:{short_hash}:len={}", state.len())
+}
+
+pub(crate) fn rate_limit_key_from_headers(headers: &HeaderMap) -> String {
+    // Try X-Forwarded-For first (reverse proxy), then X-Real-IP.
+    let xff = headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .into_iter()
+        .flat_map(|s| s.split(','))
+        .map(str::trim)
+        .find_map(|candidate| candidate.parse::<std::net::IpAddr>().ok())
+        .map(|ip| ip.to_string());
+
+    if let Some(ip) = xff {
+        return ip;
+    }
+
+    headers
+        .get("x-real-ip")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.trim().parse::<std::net::IpAddr>().ok())
+        .map(|ip| ip.to_string())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Simple sliding-window rate limiter.
@@ -170,15 +195,21 @@ pub struct ActiveConfigSnapshot {
 ///
 /// Prevents one user from exhausting the rate limit for all users in multi-tenant mode.
 pub struct PerUserRateLimiter {
-    limiters: std::sync::RwLock<std::collections::HashMap<String, RateLimiter>>,
+    limiters: std::sync::Mutex<lru::LruCache<String, RateLimiter>>,
     max_requests: u64,
     window_secs: u64,
 }
 
 impl PerUserRateLimiter {
+    // SAFETY: 2048 is non-zero, so the unwrap in `new()` is infallible.
+    const MAX_KEYS: std::num::NonZeroUsize = match std::num::NonZeroUsize::new(2048) {
+        Some(v) => v,
+        None => unreachable!(),
+    };
+
     pub fn new(max_requests: u64, window_secs: u64) -> Self {
         Self {
-            limiters: std::sync::RwLock::new(std::collections::HashMap::new()),
+            limiters: std::sync::Mutex::new(lru::LruCache::new(Self::MAX_KEYS)),
             max_requests,
             window_secs,
         }
@@ -186,32 +217,16 @@ impl PerUserRateLimiter {
 
     /// Try to consume one request for the given user. Returns `true` if allowed.
     pub fn check(&self, user_id: &str) -> bool {
-        // Fast path: check existing limiter under read lock.
-        // On lock poisoning (another thread panicked while holding the lock),
-        // allow the request rather than crashing the server.
-        {
-            let map = match self.limiters.read() {
-                Ok(m) => m,
-                Err(e) => {
-                    tracing::warn!("PerUserRateLimiter read lock poisoned; recovering");
-                    e.into_inner()
-                }
-            };
-            if let Some(limiter) = map.get(user_id) {
-                return limiter.check();
-            }
-        }
-        // Slow path: create limiter under write lock.
-        let mut map = match self.limiters.write() {
+        let mut map = match self.limiters.lock() {
             Ok(m) => m,
             Err(e) => {
-                tracing::warn!("PerUserRateLimiter write lock poisoned; recovering");
+                tracing::warn!("PerUserRateLimiter lock poisoned; recovering");
                 e.into_inner()
             }
         };
-        let limiter = map
-            .entry(user_id.to_string())
-            .or_insert_with(|| RateLimiter::new(self.max_requests, self.window_secs));
+        let limiter = map.get_or_insert_mut(user_id.to_string(), || {
+            RateLimiter::new(self.max_requests, self.window_secs)
+        });
         limiter.check()
     }
 }
@@ -383,8 +398,8 @@ pub struct GatewayState {
     pub scheduler: Option<crate::tools::builtin::SchedulerSlot>,
     /// Per-user rate limiter for chat endpoints (30 messages per 60 seconds per user).
     pub chat_rate_limiter: PerUserRateLimiter,
-    /// Rate limiter for OAuth callback endpoints (10 requests per 60 seconds).
-    pub oauth_rate_limiter: RateLimiter,
+    /// Per-IP rate limiter for OAuth/auth endpoints (20 requests per 60 seconds per IP).
+    pub oauth_rate_limiter: PerUserRateLimiter,
     /// Rate limiter for webhook trigger endpoints (10 requests per 60 seconds).
     pub webhook_rate_limiter: RateLimiter,
     /// Registry catalog entries for the available extensions API.
@@ -402,6 +417,31 @@ pub struct GatewayState {
     pub secrets_store: Option<Arc<dyn crate::secrets::SecretsStore + Send + Sync>>,
     /// DB auth cache for invalidation on security-critical actions.
     pub db_auth: Option<Arc<crate::channels::web::auth::DbAuthenticator>>,
+    /// OAuth providers for social login (None when OAuth is disabled).
+    pub oauth_providers: Option<
+        Arc<
+            std::collections::HashMap<
+                String,
+                Arc<dyn crate::channels::web::oauth::providers::OAuthProvider>,
+            >,
+        >,
+    >,
+    /// In-memory store for pending OAuth flows (CSRF + PKCE state).
+    pub oauth_state_store: Option<Arc<crate::channels::web::oauth::state_store::OAuthStateStore>>,
+    /// Base URL for constructing OAuth callback URLs.
+    pub oauth_base_url: Option<String>,
+    /// Email domains allowed for OAuth/OIDC login. Empty means allow all.
+    pub oauth_allowed_domains: Vec<String>,
+    /// NEAR wallet auth nonce store (None when NEAR auth is disabled).
+    pub near_nonce_store: Option<Arc<crate::channels::web::oauth::near::NearNonceStore>>,
+    /// NEAR RPC endpoint URL for access key verification.
+    pub near_rpc_url: Option<String>,
+    /// NEAR network name (mainnet/testnet) for the frontend wallet connector.
+    pub near_network: Option<String>,
+    /// Shutdown signal for OAuth/NEAR sweep background tasks.
+    /// When this sender is dropped, the sweep loops exit gracefully.
+    #[allow(dead_code)]
+    pub oauth_sweep_shutdown: Option<tokio::sync::watch::Sender<()>>,
 }
 
 /// Start the gateway HTTP server.
@@ -443,6 +483,33 @@ pub async fn start_server(
         .route(
             "/api/webhooks/u/{user_id}/{path}",
             post(crate::channels::web::handlers::webhooks::webhook_trigger_user_scoped_handler),
+        )
+        // OAuth social login routes (public, no auth required)
+        .route(
+            "/auth/providers",
+            get(crate::channels::web::handlers::auth::providers_handler),
+        )
+        .route(
+            "/auth/login/{provider}",
+            get(crate::channels::web::handlers::auth::login_handler),
+        )
+        .route(
+            "/auth/callback/{provider}",
+            get(crate::channels::web::handlers::auth::callback_handler)
+                .post(crate::channels::web::handlers::auth::callback_post_handler),
+        )
+        .route(
+            "/auth/logout",
+            post(crate::channels::web::handlers::auth::logout_handler),
+        )
+        // NEAR wallet auth (challenge-response, not OAuth redirect)
+        .route(
+            "/auth/near/challenge",
+            get(crate::channels::web::handlers::auth::near_challenge_handler),
+        )
+        .route(
+            "/auth/near/verify",
+            post(crate::channels::web::handlers::auth::near_verify_handler),
         );
 
     // Protected routes (require auth)
@@ -708,15 +775,16 @@ pub async fn start_server(
             header::HeaderName::from_static("content-security-policy"),
             header::HeaderValue::from_static(
                 "default-src 'self'; \
-                 script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com; \
+                 script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh; \
                  style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; \
-                 font-src https://fonts.gstatic.com; \
-                 connect-src 'self'; \
-                 img-src 'self' data:; \
+                 font-src https://fonts.gstatic.com data:; \
+                 connect-src 'self' https://esm.sh https://rpc.mainnet.near.org https://rpc.testnet.near.org; \
+                 img-src 'self' data: blob: https://*.googleusercontent.com https://avatars.githubusercontent.com; \
+                 frame-src https://accounts.google.com https://appleid.apple.com; \
                  object-src 'none'; \
                  frame-ancestors 'none'; \
                  base-uri 'self'; \
-                 form-action 'self'",
+                 form-action 'self' https://accounts.google.com https://github.com https://appleid.apple.com",
             ),
         ))
         .with_state(state.clone());
@@ -1225,10 +1293,12 @@ async fn relay_events_handler(
 /// Query params: `provider`, `team_id`.
 async fn slack_relay_oauth_callback_handler(
     State(state): State<Arc<GatewayState>>,
+    headers: HeaderMap,
     Query(params): Query<std::collections::HashMap<String, String>>,
 ) -> impl IntoResponse {
     // Rate limit
-    if !state.oauth_rate_limiter.check() {
+    let ip = rate_limit_key_from_headers(&headers);
+    if !state.oauth_rate_limiter.check(&ip) {
         return axum::response::Html(
             "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
              <h2>Too Many Requests</h2>\
@@ -1973,6 +2043,20 @@ async fn chat_threads_handler(
             .get_or_create_assistant_conversation(&user.user_id, "gateway")
             .await
             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+        // Seed the bootstrap greeting if this is a brand-new assistant thread.
+        // Use add_conversation_message_if_empty to avoid duplicates on concurrent requests.
+        static GREETING: &str = include_str!("../../workspace/seeds/GREETING.md");
+        if let Err(e) = store
+            .add_conversation_message_if_empty(assistant_id, "assistant", GREETING)
+            .await
+        {
+            tracing::warn!(
+                user_id = %user.user_id,
+                error = %e,
+                "Failed to seed assistant greeting"
+            );
+        }
 
         match store
             .list_conversations_all_channels(&user.user_id, 50)
@@ -3044,7 +3128,7 @@ mod tests {
             skill_catalog: None,
             scheduler: None,
             chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: RateLimiter::new(10, 60),
+            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: RateLimiter::new(10, 60),
             registry_entries: vec![],
             cost_guard: None,
@@ -3053,6 +3137,14 @@ mod tests {
             active_config: ActiveConfigSnapshot::default(),
             secrets_store: None,
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         })
     }
 
@@ -3439,9 +3531,9 @@ mod tests {
         );
         assert!(
             csp_str.contains(
-                "script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com"
+                "script-src 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://esm.sh"
             ),
-            "CSP must allow both marked and DOMPurify script CDNs"
+            "CSP must allow the explicit script CDNs without unsafe-inline"
         );
         assert!(
             csp_str.contains("object-src 'none'"),

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2063,7 +2063,7 @@ async fn chat_new_thread_handler(
     let session = session_manager.get_or_create_session(&user.user_id).await;
     let (thread_id, info) = {
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some("gateway"));
         let id = thread.id;
         let info = ThreadInfo {
             id: thread.id,
@@ -2082,7 +2082,7 @@ async fn chat_new_thread_handler(
     // so that the subsequent loadThreads() call from the frontend sees it.
     if let Some(ref store) = state.store {
         match store
-            .ensure_conversation(thread_id, "gateway", &user.user_id, None)
+            .ensure_conversation(thread_id, "gateway", &user.user_id, None, Some("gateway"))
             .await
         {
             Ok(true) => {}

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -171,12 +171,37 @@ function initApp() {
   connectSSE();
   connectLogSSE();
   startGatewayStatusPolling();
-  // Hide the Users settings tab for non-admin users.
+  // Fetch user profile and render avatar + account menu.
   apiFetch('/api/profile').then(function(profile) {
-    if (profile && profile.role !== 'admin') {
+    if (!profile) return;
+    window._currentUser = profile;
+    // Hide admin tabs for non-admin users.
+    if (profile.role !== 'admin') {
       var usersTab = document.querySelector('[data-settings-subtab="users"]');
       if (usersTab) usersTab.style.display = 'none';
     }
+    // Render avatar.
+    var avatarImg = document.getElementById('user-avatar-img');
+    var avatarInitials = document.getElementById('user-avatar-initials');
+    var displayName = profile.display_name || profile.email || profile.id || '?';
+    if (avatarInitials) {
+      avatarInitials.textContent = displayName.charAt(0).toUpperCase();
+    }
+    if (profile.avatar_url && avatarImg) {
+      avatarImg.referrerPolicy = 'no-referrer';
+      avatarImg.onload = function() {
+        if (avatarInitials) avatarInitials.style.display = 'none';
+      };
+      avatarImg.src = profile.avatar_url;
+      avatarImg.removeAttribute('hidden');
+    }
+    // Populate dropdown.
+    var nameEl = document.getElementById('user-dropdown-name');
+    var emailEl = document.getElementById('user-dropdown-email');
+    var roleEl = document.getElementById('user-dropdown-role');
+    if (nameEl) nameEl.textContent = profile.display_name || profile.id;
+    if (emailEl) emailEl.textContent = profile.email || '';
+    if (roleEl) roleEl.textContent = profile.role;
   }).catch(function() {});
   checkTeeStatus();
   loadThreads();
@@ -227,6 +252,125 @@ function authenticate() {
 document.getElementById('token-input').addEventListener('keydown', (e) => {
   if (e.key === 'Enter') authenticate();
 });
+
+// --- Social login (OAuth + NEAR wallet) ---
+
+// Show the token form (used as fallback when no OAuth providers are available).
+function showTokenForm() {
+  var tokenForm = document.getElementById('auth-token-form');
+  if (tokenForm) {
+    tokenForm.style.display = '';
+    var input = document.getElementById('token-input');
+    if (input) input.focus();
+  }
+}
+
+// Discover enabled providers and show corresponding buttons.
+fetch('/auth/providers', { credentials: 'include' })
+  .then(function(r) { return r.ok ? r.json() : { providers: [] }; })
+  .then(function(data) {
+    var providers = data.providers || [];
+    if (providers.length === 0) { showTokenForm(); return; }
+    // Store NEAR network for the wallet connector.
+    if (data.near_network) window._nearNetwork = data.near_network;
+    var social = document.getElementById('auth-social');
+    if (social) social.style.display = '';
+    providers.forEach(function(p) {
+      var btn = document.getElementById('auth-' + p + '-btn');
+      if (!btn) return;
+      btn.style.display = '';
+      if (p === 'near') {
+        btn.addEventListener('click', authenticateWithNear);
+      } else {
+        btn.addEventListener('click', function() { window.location = '/auth/login/' + p; });
+      }
+    });
+    // When social providers are available, collapse the token form
+    // and show the "or use a token" divider instead.
+    var tokenForm = document.getElementById('auth-token-form');
+    var tokenDivider = document.getElementById('auth-token-divider');
+    if (tokenForm && tokenDivider) {
+      tokenForm.style.display = 'none';
+      tokenDivider.style.display = '';
+      tokenDivider.style.cursor = 'pointer';
+      tokenDivider.addEventListener('click', function() {
+        tokenForm.style.display = '';
+        tokenDivider.style.display = 'none';
+        var input = document.getElementById('token-input');
+        if (input) input.focus();
+      });
+    }
+  })
+  .catch(function() { showTokenForm(); });
+
+// NEAR wallet authentication via near-connect.
+async function authenticateWithNear() {
+  var nearBtn = document.getElementById('auth-near-btn');
+  var errEl = document.getElementById('auth-error');
+  if (nearBtn) { nearBtn.disabled = true; nearBtn.textContent = 'Connecting wallet...'; }
+  if (errEl) errEl.textContent = '';
+
+  try {
+    // 1. Get challenge nonce from the server.
+    var challengeResp = await fetch('/auth/near/challenge', { credentials: 'include' });
+    if (!challengeResp.ok) throw new Error('Failed to get challenge');
+    var challenge = await challengeResp.json();
+
+    // 2. Load near-connect dynamically if not already loaded.
+    if (!window._nearConnector) {
+      var mod = await import('https://esm.sh/@hot-labs/near-connect@0.11');
+      var network = window._nearNetwork || 'mainnet';
+      window._nearConnector = new mod.NearConnector({ network: network });
+    }
+    var connector = window._nearConnector;
+
+    // 3. Connect wallet and request signature.
+    if (nearBtn) nearBtn.textContent = 'Sign with wallet...';
+    var wallet = await connector.connect();
+    var accounts = await wallet.getAccounts();
+    if (!accounts || accounts.length === 0) throw new Error('No NEAR account found');
+
+    var accountId = accounts[0].accountId;
+
+    // Convert hex nonce to Uint8Array for signMessage.
+    var nonceBytes = new Uint8Array(challenge.nonce.match(/.{2}/g).map(function(b) { return parseInt(b, 16); }));
+
+    var signed = await wallet.signMessage({
+      message: challenge.message,
+      recipient: challenge.recipient || 'ironclaw',
+      nonce: nonceBytes,
+    });
+
+    // 4. Send signature to server for verification.
+    if (nearBtn) nearBtn.textContent = 'Verifying...';
+    var verifyResp = await fetch('/auth/near/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({
+        account_id: accountId,
+        public_key: signed.publicKey,
+        signature: signed.signature,
+        nonce: challenge.nonce,
+      }),
+    });
+
+    if (!verifyResp.ok) {
+      var errText = await verifyResp.text();
+      throw new Error(errText || 'Verification failed');
+    }
+
+    await verifyResp.json();
+
+    // 5. Rely on the HttpOnly session cookie created by the backend.
+    token = '';
+    sessionStorage.removeItem('ironclaw_token');
+    initApp();
+  } catch (err) {
+    if (errEl) errEl.textContent = err.message || 'NEAR wallet login failed';
+    if (nearBtn) { nearBtn.disabled = false; nearBtn.textContent = 'Sign in with NEAR'; }
+  }
+}
 
 // Note: main event listener registration is at the bottom of this file (search
 // "Event Listener Registration"). Do NOT add duplicate listeners here.
@@ -396,7 +540,8 @@ function connectSSE() {
 
   eventSource.onopen = () => {
     document.getElementById('sse-dot').classList.remove('disconnected');
-    document.getElementById('sse-status').textContent = I18n.t('status.connected');
+    var statusEl = document.getElementById('sse-status');
+    if (statusEl) statusEl.textContent = I18n.t('status.connected');
     _reconnectAttempts = 0;
 
     // Dismiss connection-lost banner and show reconnected flash
@@ -438,7 +583,8 @@ function connectSSE() {
   eventSource.onerror = () => {
     _reconnectAttempts++;
     document.getElementById('sse-dot').classList.add('disconnected');
-    document.getElementById('sse-status').textContent = I18n.t('status.reconnecting');
+    var statusEl2 = document.getElementById('sse-status');
+    if (statusEl2) statusEl2.textContent = I18n.t('status.reconnecting');
 
     // Update existing banner with attempt count
     const existingBanner = document.getElementById('connection-banner');
@@ -4653,13 +4799,8 @@ function fetchGatewayStatus() {
   }).catch(function() {});
 }
 
-// Show/hide popover on hover
-document.getElementById('gateway-status-trigger').addEventListener('mouseenter', () => {
-  document.getElementById('gateway-popover').classList.add('visible');
-});
-document.getElementById('gateway-status-trigger').addEventListener('mouseleave', () => {
-  document.getElementById('gateway-popover').classList.remove('visible');
-});
+// Gateway popover is now inline in the user dropdown — no hover toggle needed.
+// The popover content is updated by startGatewayStatusPolling() into #gateway-popover.
 
 // --- TEE attestation ---
 
@@ -6176,6 +6317,30 @@ function formatDate(isoString) {
 // --- Event Listener Registration (CSP-safe, no inline handlers) ---
 
 document.getElementById('auth-connect-btn').addEventListener('click', () => authenticate());
+
+// User avatar dropdown toggle.
+document.getElementById('user-avatar-btn').addEventListener('click', function(e) {
+  e.stopPropagation();
+  var dd = document.getElementById('user-dropdown');
+  if (dd) dd.style.display = dd.style.display === 'none' ? '' : 'none';
+});
+// Close dropdown on click outside.
+document.addEventListener('click', function(e) {
+  var dd = document.getElementById('user-dropdown');
+  var account = document.getElementById('user-account');
+  if (dd && account && !account.contains(e.target)) {
+    dd.style.display = 'none';
+  }
+});
+// Logout handler.
+document.getElementById('user-logout-btn').addEventListener('click', function() {
+  fetch('/auth/logout', { method: 'POST', credentials: 'include' })
+    .finally(function() {
+      sessionStorage.removeItem('ironclaw_token');
+      sessionStorage.removeItem('ironclaw_oidc');
+      window.location.reload();
+    });
+});
 document.getElementById('restart-overlay').addEventListener('click', () => cancelRestart());
 document.getElementById('restart-close-btn').addEventListener('click', () => cancelRestart());
 document.getElementById('restart-cancel-btn').addEventListener('click', () => cancelRestart());

--- a/src/channels/web/static/i18n/en.js
+++ b/src/channels/web/static/i18n/en.js
@@ -7,6 +7,13 @@ I18n.register('en', {
   'auth.tokenLabel': 'Gateway Token',
   'auth.tokenPlaceholder': 'Paste your token',
   'auth.connect': 'Connect',
+  'auth.social.google': 'Sign in with Google',
+  'auth.social.github': 'Sign in with GitHub',
+  'auth.social.apple': 'Sign in with Apple',
+  'auth.social.near': 'Sign in with NEAR',
+  'auth.social.tokenDivider': 'or use a token',
+  'auth.signOut': 'Sign out',
+  'auth.accountMenu': 'Account menu',
   'auth.errorRequired': 'Token required',
   'auth.errorInvalid': 'Invalid token',
   // Chat

--- a/src/channels/web/static/i18n/zh-CN.js
+++ b/src/channels/web/static/i18n/zh-CN.js
@@ -7,6 +7,13 @@ I18n.register('zh-CN', {
   'auth.tokenLabel': '网关令牌',
   'auth.tokenPlaceholder': '粘贴你的网关令牌',
   'auth.connect': '连接',
+  'auth.social.google': '使用 Google 登录',
+  'auth.social.github': '使用 GitHub 登录',
+  'auth.social.apple': '使用 Apple 登录',
+  'auth.social.near': '使用 NEAR 登录',
+  'auth.social.tokenDivider': '或使用令牌',
+  'auth.signOut': '退出登录',
+  'auth.accountMenu': '账户菜单',
   'auth.errorRequired': '请输入令牌',
   'auth.errorInvalid': '令牌无效',
   // 聊天

--- a/src/channels/web/static/index.html
+++ b/src/channels/web/static/index.html
@@ -35,9 +35,18 @@
         <h1 data-i18n="auth.title">IronClaw</h1>
         <p class="auth-tagline" data-i18n="auth.tagline">Secure AI Assistant</p>
       </div>
-      <div class="auth-form">
+      <div id="auth-social" style="display:none">
+        <div class="auth-social-buttons">
+          <button id="auth-google-btn" class="auth-social-btn" style="display:none" data-i18n="auth.social.google">Sign in with Google</button>
+          <button id="auth-github-btn" class="auth-social-btn" style="display:none" data-i18n="auth.social.github">Sign in with GitHub</button>
+          <button id="auth-apple-btn" class="auth-social-btn" style="display:none" data-i18n="auth.social.apple">Sign in with Apple</button>
+          <button id="auth-near-btn" class="auth-social-btn" style="display:none" data-i18n="auth.social.near">Sign in with NEAR</button>
+        </div>
+        <div class="auth-divider" id="auth-token-divider" style="display:none"><span data-i18n="auth.social.tokenDivider">or use a token</span></div>
+      </div>
+      <div class="auth-form" id="auth-token-form" style="display:none">
         <label for="token-input" data-i18n="auth.tokenLabel">Gateway Token</label>
-        <input type="password" id="token-input" data-i18n="auth.tokenPlaceholder" data-i18n-attr="placeholder" placeholder="Paste your auth token" autofocus>
+        <input type="password" id="token-input" data-i18n="auth.tokenPlaceholder" data-i18n-attr="placeholder" placeholder="Paste your auth token">
         <button id="auth-connect-btn" data-i18n="auth.connect">Connect</button>
       </div>
       <div id="auth-error"></div>
@@ -181,10 +190,23 @@
         <span id="tee-shield-label" data-i18n="status.teeVerified">TEE Verified</span>
         <div class="tee-popover" id="tee-popover"></div>
       </div>
-      <div class="status" id="gateway-status-trigger">
-        <div class="dot" id="sse-dot"></div>
-        <span id="sse-status" data-i18n="status.connected">Connected</span>
-        <div class="gateway-popover" id="gateway-popover"></div>
+      <div class="user-account" id="user-account">
+        <button class="user-avatar-btn" id="user-avatar-btn" title="Account" aria-label="Account menu" data-i18n="auth.accountMenu" data-i18n-attr="aria-label">
+          <span id="user-avatar-initials" class="user-avatar-initials">?</span>
+          <img id="user-avatar-img" class="user-avatar-img" alt="" referrerpolicy="no-referrer" hidden>
+          <div class="user-avatar-dot" id="sse-dot"></div>
+        </button>
+        <div class="user-dropdown" id="user-dropdown" style="display:none">
+          <div class="user-dropdown-header">
+            <div class="user-dropdown-name" id="user-dropdown-name"></div>
+            <div class="user-dropdown-email" id="user-dropdown-email"></div>
+            <div class="user-dropdown-role" id="user-dropdown-role"></div>
+          </div>
+          <div class="user-dropdown-divider"></div>
+          <div class="user-dropdown-gateway" id="gateway-popover"></div>
+          <div class="user-dropdown-divider"></div>
+          <button class="user-dropdown-item user-dropdown-logout" id="user-logout-btn" data-i18n="auth.signOut">Sign out</button>
+        </div>
       </div>
       <button class="restart-btn" id="restart-btn" data-i18n="status.restartTooltip"
         data-i18n-attr="title" title="Gracefully restart the process" style="display: none;">

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -236,6 +236,49 @@ body {
   text-align: center;
 }
 
+.auth-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-3) 0;
+  color: var(--text-secondary);
+  font-size: var(--text-sm);
+}
+.auth-divider::before,
+.auth-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border);
+}
+.auth-divider[style*="cursor"] span {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.auth-social-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.auth-social-btn {
+  width: 100%;
+  padding: 10px 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg);
+  color: var(--text);
+  font-size: var(--text-sm);
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s;
+}
+.auth-social-btn:hover {
+  background: var(--bg-secondary);
+  border-color: var(--accent);
+}
+
 .auth-hint {
   font-size: 12px;
   color: var(--text-secondary);
@@ -324,22 +367,152 @@ body {
   background: var(--accent-tee-bg);
 }
 
-.tab-bar .status {
+/* ── User account avatar + dropdown ─────────────────────────────── */
+
+.user-account {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: var(--space-2);
-  font-size: 12px;
-  color: var(--text-secondary);
-  position: relative;
-  cursor: pointer;
 }
 
+.user-avatar-btn {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  min-width: 32px;
+  min-height: 32px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+}
+
+.user-avatar-img,
+.user-avatar-initials {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+}
+
+.user-avatar-img {
+  display: block;
+  object-fit: cover;
+  z-index: 2;
+}
+
+.user-avatar-initials {
+  background: var(--accent);
+  color: var(--bg);
+  font-size: 14px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+  z-index: 0;
+}
+
+.user-avatar-dot {
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--success);
+  border: 2px solid var(--tab-bg);
+}
+
+.user-avatar-dot.disconnected {
+  background: var(--danger);
+}
+
+.user-dropdown {
+  position: absolute;
+  top: 100%;
+  right: 0;
+  margin-top: 8px;
+  background: var(--popover-bg, var(--bg-secondary));
+  backdrop-filter: blur(16px);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 0;
+  min-width: 240px;
+  box-shadow: var(--shadow);
+  z-index: 500;
+}
+
+.user-dropdown-header {
+  padding: 12px 16px;
+}
+
+.user-dropdown-name {
+  font-size: var(--text-sm);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.user-dropdown-email {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.user-dropdown-role {
+  font-size: 11px;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 4px;
+}
+
+.user-dropdown-divider {
+  height: 1px;
+  background: var(--border);
+}
+
+.user-dropdown-gateway {
+  padding: 8px 16px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.user-dropdown-item {
+  display: block;
+  width: 100%;
+  padding: 10px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  font-size: var(--text-sm);
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+}
+
+.user-dropdown-item:hover {
+  background: var(--bg-hover, rgba(255,255,255,0.05));
+}
+
+.user-dropdown-logout {
+  color: var(--danger);
+}
+
+/* Keep old .status .dot selector for any remaining references */
 .tab-bar .status .dot {
   width: 8px;
   height: 8px;
   border-radius: 50%;
   background: var(--success);
-  position: relative;
 }
 
 .tab-bar .status .dot.disconnected {

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -84,7 +84,7 @@ impl TestGatewayBuilder {
             skill_catalog: None,
             scheduler: None,
             chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: RateLimiter::new(10, 60),
+            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: RateLimiter::new(10, 60),
             registry_entries: Vec::new(),
             cost_guard: None,
@@ -93,6 +93,14 @@ impl TestGatewayBuilder {
             active_config: crate::channels::web::server::ActiveConfigSnapshot::default(),
             secrets_store: None,
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         })
     }
 

--- a/src/channels/web/tests/multi_tenant.rs
+++ b/src/channels/web/tests/multi_tenant.rs
@@ -74,7 +74,7 @@ fn build_state(
         skill_catalog: None,
         scheduler: None,
         chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: RateLimiter::new(10, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
         webhook_rate_limiter: RateLimiter::new(10, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
@@ -83,6 +83,14 @@ fn build_state(
         active_config: ActiveConfigSnapshot::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     })
 }
 

--- a/src/channels/web/ws.rs
+++ b/src/channels/web/ws.rs
@@ -527,7 +527,7 @@ mod tests {
             skill_registry: None,
             skill_catalog: None,
             chat_rate_limiter: crate::channels::web::server::PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: crate::channels::web::server::RateLimiter::new(10, 60),
+            oauth_rate_limiter: crate::channels::web::server::PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: crate::channels::web::server::RateLimiter::new(10, 60),
             registry_entries: Vec::new(),
             cost_guard: None,
@@ -536,6 +536,14 @@ mod tests {
             active_config: crate::channels::web::server::ActiveConfigSnapshot::default(),
             secrets_store: None,
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         }
     }
 }

--- a/src/cli/acp.rs
+++ b/src/cli/acp.rs
@@ -1,0 +1,354 @@
+//! ACP agent management CLI commands.
+//!
+//! Commands for adding, removing, listing, toggling, and testing ACP agents.
+//! Mirrors the MCP server management CLI (`src/cli/mcp.rs`).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use clap::{Args, Subcommand};
+
+use crate::config::acp::{self, AcpAgentConfig, AcpAgentsFile};
+use crate::db::Database;
+
+/// Arguments for the `acp add` subcommand.
+#[derive(Args, Debug, Clone)]
+pub struct AcpAddArgs {
+    /// Agent name (e.g., "goose", "codex", "gemini")
+    pub name: String,
+
+    /// Command to spawn the agent
+    #[arg(long)]
+    pub command: String,
+
+    /// Command arguments (can be repeated)
+    #[arg(long = "arg", num_args = 1..)]
+    pub args: Vec<String>,
+
+    /// Environment variables (KEY=VALUE format, can be repeated)
+    #[arg(long = "env", value_parser = parse_env_var)]
+    pub env: Vec<(String, String)>,
+
+    /// Agent description
+    #[arg(long)]
+    pub description: Option<String>,
+}
+
+fn parse_env_var(s: &str) -> Result<(String, String), String> {
+    let parts: Vec<&str> = s.splitn(2, '=').collect();
+    if parts.len() != 2 {
+        return Err(format!("invalid env var format '{s}', expected KEY=VALUE"));
+    }
+    Ok((parts[0].to_string(), parts[1].to_string()))
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum AcpCommand {
+    /// Add an ACP agent
+    Add(Box<AcpAddArgs>),
+
+    /// Remove an ACP agent
+    Remove {
+        /// Agent name to remove
+        name: String,
+    },
+
+    /// List configured ACP agents
+    List,
+
+    /// Enable or disable an ACP agent
+    Toggle {
+        /// Agent name to toggle
+        name: String,
+    },
+
+    /// Test an ACP agent connection (spawn, handshake, report)
+    Test {
+        /// Agent name to test
+        name: String,
+    },
+}
+
+/// Run an ACP CLI command.
+pub async fn run_acp_command(cmd: AcpCommand) -> anyhow::Result<()> {
+    match cmd {
+        AcpCommand::Add(args) => add_agent(*args).await,
+        AcpCommand::Remove { name } => remove_agent(&name).await,
+        AcpCommand::List => list_agents().await,
+        AcpCommand::Toggle { name } => toggle_agent(&name).await,
+        AcpCommand::Test { name } => test_agent(&name).await,
+    }
+}
+
+async fn add_agent(args: AcpAddArgs) -> anyhow::Result<()> {
+    let env: HashMap<String, String> = args.env.into_iter().collect();
+    let mut config = AcpAgentConfig::new(&args.name, &args.command, args.args, env);
+    if let Some(desc) = args.description {
+        config = config.with_description(desc);
+    }
+
+    config.validate().map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    let storage = resolve_storage().await;
+    let mut agents = load_agents(storage.db.as_deref(), &storage.owner_id).await?;
+    let is_update = agents.get(&args.name).is_some();
+    agents.upsert(config);
+    save_agents(storage.db.as_deref(), &storage.owner_id, &agents).await?;
+
+    if is_update {
+        println!("Updated ACP agent '{}'", args.name);
+    } else {
+        println!("Added ACP agent '{}'", args.name);
+    }
+    Ok(())
+}
+
+async fn remove_agent(name: &str) -> anyhow::Result<()> {
+    let storage = resolve_storage().await;
+    let mut agents = load_agents(storage.db.as_deref(), &storage.owner_id).await?;
+
+    if !agents.remove(name) {
+        anyhow::bail!("ACP agent '{}' not found", name);
+    }
+
+    save_agents(storage.db.as_deref(), &storage.owner_id, &agents).await?;
+    println!("Removed ACP agent '{}'", name);
+    Ok(())
+}
+
+async fn list_agents() -> anyhow::Result<()> {
+    let storage = resolve_storage().await;
+    let agents = load_agents(storage.db.as_deref(), &storage.owner_id).await?;
+
+    if agents.agents.is_empty() {
+        println!("No ACP agents configured.");
+        println!();
+        println!("Add one with:");
+        println!("  ironclaw acp add goose --command goose --arg \"--stdio\"");
+        return Ok(());
+    }
+
+    println!("ACP Agents:");
+    println!();
+    for agent in &agents.agents {
+        let icon = if agent.enabled { "●" } else { "○" };
+        let status = if agent.enabled { "enabled" } else { "disabled" };
+        println!("  {} {} ({}) [{}]", icon, agent.name, agent.command, status);
+        if !agent.args.is_empty() {
+            println!("    args: {}", agent.args.join(" "));
+        }
+        if !agent.env.is_empty() {
+            println!("    env: {} variable(s)", agent.env.len());
+        }
+        if let Some(ref desc) = agent.description {
+            println!("    {}", desc);
+        }
+    }
+    Ok(())
+}
+
+async fn toggle_agent(name: &str) -> anyhow::Result<()> {
+    let storage = resolve_storage().await;
+    let mut agents = load_agents(storage.db.as_deref(), &storage.owner_id).await?;
+
+    let agent = agents
+        .get_mut(name)
+        .ok_or_else(|| anyhow::anyhow!("ACP agent '{}' not found", name))?;
+
+    agent.enabled = !agent.enabled;
+    let new_state = if agent.enabled { "enabled" } else { "disabled" };
+
+    save_agents(storage.db.as_deref(), &storage.owner_id, &agents).await?;
+    println!("ACP agent '{}' is now {}", name, new_state);
+    Ok(())
+}
+
+async fn test_agent(name: &str) -> anyhow::Result<()> {
+    use agent_client_protocol::{self as acp, Agent as _};
+    use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+
+    use crate::worker::acp_bridge;
+    use crate::worker::api::JobEventPayload;
+
+    /// Event sink that prints agent output to stdout during `ironclaw acp test`.
+    struct PrintEventSink;
+
+    impl acp_bridge::AcpEventSink for PrintEventSink {
+        async fn emit_event(&self, payload: &JobEventPayload) {
+            match payload.event_type.as_str() {
+                "message" => {
+                    if let Some(content) = payload.data["content"].as_str() {
+                        println!("    | {}", content);
+                    }
+                }
+                "tool_use" => {
+                    if let Some(tool) = payload.data["tool_name"].as_str() {
+                        println!("    [tool: {}]", tool);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    let storage = resolve_storage().await;
+    let agent = crate::config::acp::get_enabled_acp_agent_for_user(
+        storage.db.as_deref(),
+        &storage.owner_id,
+        name,
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("{}", e))?;
+
+    println!();
+    println!("  Testing ACP agent '{}'...", name);
+    println!("  Command: {} {}", agent.command, agent.args.join(" "));
+
+    // Spawn the agent subprocess
+    let mut child = tokio::process::Command::new(&agent.command)
+        .args(&agent.args)
+        .envs(&agent.env)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn '{}': {}", agent.command, e))?;
+
+    let child_stdin = child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to capture agent stdin"))?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("failed to capture agent stdout"))?;
+
+    // Run ACP handshake inside a LocalSet (!Send futures).
+    // Uses IronClawAcpClient with a PrintEventSink so the test exercises
+    // the same permission auto-approval and event translation as real jobs.
+    let local_set = tokio::task::LocalSet::new();
+    let result = local_set
+        .run_until(async move {
+            let outgoing = child_stdin.compat_write();
+            let incoming = child_stdout.compat();
+
+            let client = acp_bridge::IronClawAcpClient::new(PrintEventSink);
+
+            let (conn, handle_io) =
+                acp::ClientSideConnection::new(client, outgoing, incoming, |fut| {
+                    tokio::task::spawn_local(fut);
+                });
+            tokio::task::spawn_local(handle_io);
+
+            let handshake = tokio::time::timeout(
+                std::time::Duration::from_secs(15),
+                conn.initialize(acp_bridge::ironclaw_init_request()),
+            )
+            .await;
+
+            match handshake {
+                Ok(Ok(resp)) => {
+                    println!("  \u{2713} ACP handshake successful!");
+                    println!();
+                    println!("  Agent info:");
+                    if let Some(ref info) = resp.agent_info {
+                        println!("    Name: {}", info.name);
+                        println!("    Version: {}", info.version);
+                    }
+                    println!("    Protocol: {}", resp.protocol_version);
+                    Ok(())
+                }
+                Ok(Err(e)) => {
+                    println!("  \u{2717} ACP handshake failed: {}", e);
+                    Err(anyhow::anyhow!("handshake failed: {}", e))
+                }
+                Err(_) => {
+                    println!("  \u{2717} ACP handshake timed out (15s)");
+                    Err(anyhow::anyhow!("handshake timed out"))
+                }
+            }
+        })
+        .await;
+
+    // Clean up child process
+    let _ = child.kill().await;
+    println!();
+    result
+}
+
+// ==================== DB / disk persistence helpers ====================
+
+struct AcpCliStorage {
+    db: Option<Arc<dyn Database>>,
+    owner_id: String,
+}
+
+async fn resolve_storage() -> AcpCliStorage {
+    match crate::config::Config::from_env().await {
+        Ok(config) => AcpCliStorage {
+            db: crate::db::connect_from_config(&config.database)
+                .await
+                .ok()
+                .map(|db| db as Arc<dyn Database>),
+            owner_id: config.owner_id,
+        },
+        Err(_) => AcpCliStorage {
+            db: None,
+            owner_id: "default".to_string(),
+        },
+    }
+}
+
+async fn load_agents(
+    db: Option<&dyn Database>,
+    owner_id: &str,
+) -> Result<AcpAgentsFile, anyhow::Error> {
+    acp::load_acp_agents_for_user(db, owner_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+async fn save_agents(
+    db: Option<&dyn Database>,
+    owner_id: &str,
+    agents: &AcpAgentsFile,
+) -> Result<(), anyhow::Error> {
+    acp::save_acp_agents_for_user(db, owner_id, agents)
+        .await
+        .map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_env_var_valid() {
+        let (k, v) = parse_env_var("FOO=bar").unwrap();
+        assert_eq!(k, "FOO");
+        assert_eq!(v, "bar");
+    }
+
+    #[test]
+    fn test_parse_env_var_with_equals_in_value() {
+        let (k, v) = parse_env_var("KEY=val=ue").unwrap();
+        assert_eq!(k, "KEY");
+        assert_eq!(v, "val=ue");
+    }
+
+    #[test]
+    fn test_parse_env_var_invalid() {
+        let result = parse_env_var("no-equals-sign");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_acp_command_variants() {
+        // Verify all variants exist (compile-time check)
+        let _ = AcpCommand::List;
+        let _ = AcpCommand::Remove { name: "x".into() };
+        let _ = AcpCommand::Toggle { name: "x".into() };
+        let _ = AcpCommand::Test { name: "x".into() };
+    }
+}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -10,6 +10,21 @@ use crate::bootstrap::ironclaw_base_dir;
 use crate::cli::fmt;
 use crate::settings::Settings;
 
+async fn load_acp_agents_for_doctor()
+-> Result<crate::config::acp::AcpAgentsFile, crate::config::acp::AcpConfigError> {
+    match crate::config::Config::from_env().await {
+        Ok(config) => {
+            let db: Option<std::sync::Arc<dyn crate::db::Database>> =
+                crate::db::connect_from_config(&config.database)
+                    .await
+                    .ok()
+                    .map(|db| db as std::sync::Arc<dyn crate::db::Database>);
+            crate::config::acp::load_acp_agents_for_user(db.as_deref(), &config.owner_id).await
+        }
+        Err(_) => crate::config::acp::load_acp_agents().await,
+    }
+}
+
 /// Run all diagnostic checks and print results.
 pub async fn run_doctor_command() -> anyhow::Result<()> {
     println!();
@@ -97,6 +112,14 @@ pub async fn run_doctor_command() -> anyhow::Result<()> {
     check(
         "MCP servers",
         check_mcp_config().await,
+        &mut passed,
+        &mut failed,
+        &mut skipped,
+    );
+
+    check(
+        "ACP agents",
+        check_acp_config().await,
         &mut passed,
         &mut failed,
         &mut skipped,
@@ -513,6 +536,43 @@ async fn check_mcp_config() -> CheckResult {
             let msg = e.to_string();
             if msg.contains("not found") || msg.contains("No such file") {
                 CheckResult::Skip("no MCP config file".into())
+            } else {
+                CheckResult::Fail(format!("config error: {e}"))
+            }
+        }
+    }
+}
+
+async fn check_acp_config() -> CheckResult {
+    match load_acp_agents_for_doctor().await {
+        Ok(file) => {
+            let agents: Vec<_> = file.enabled_agents().collect();
+            if agents.is_empty() {
+                return CheckResult::Skip("no ACP agents configured".into());
+            }
+
+            let mut invalid = Vec::new();
+            for agent in &agents {
+                if let Err(e) = agent.validate() {
+                    invalid.push(format!("{}: {}", agent.name, e));
+                }
+            }
+
+            if invalid.is_empty() {
+                CheckResult::Pass(format!("{} agent(s) configured, all valid", agents.len()))
+            } else {
+                CheckResult::Fail(format!(
+                    "{} agent(s), {} invalid: {}",
+                    agents.len(),
+                    invalid.len(),
+                    invalid.join("; ")
+                ))
+            }
+        }
+        Err(e) => {
+            let msg = e.to_string();
+            if msg.contains("not found") || msg.contains("No such file") {
+                CheckResult::Skip("no ACP config file".into())
             } else {
                 CheckResult::Fail(format!("config error: {e}"))
             }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -80,7 +80,7 @@ pub async fn run_doctor_command() -> anyhow::Result<()> {
 
     check(
         "Routines config",
-        check_routines_config(),
+        check_routines_config(&settings),
         &mut passed,
         &mut failed,
         &mut skipped,
@@ -434,8 +434,8 @@ fn check_embeddings(settings: &Settings) -> CheckResult {
 
 // ── Routines config ─────────────────────────────────────────
 
-fn check_routines_config() -> CheckResult {
-    match crate::config::RoutineConfig::resolve() {
+fn check_routines_config(settings: &Settings) -> CheckResult {
+    match crate::config::RoutineConfig::resolve(settings) {
         Ok(config) => {
             if config.enabled {
                 CheckResult::Pass(format!(
@@ -737,7 +737,8 @@ mod tests {
 
     #[test]
     fn check_routines_config_does_not_panic() {
-        let result = check_routines_config();
+        let settings = Settings::default();
+        let result = check_routines_config(&settings);
         match result {
             CheckResult::Pass(_) | CheckResult::Fail(_) | CheckResult::Skip(_) => {}
         }
@@ -866,7 +867,8 @@ mod tests {
         unsafe {
             std::env::remove_var("ROUTINES_ENABLED");
         }
-        match check_routines_config() {
+        let settings = Settings::default();
+        match check_routines_config(&settings) {
             CheckResult::Pass(msg) => {
                 assert!(
                     msg.contains("enabled"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@
 //! - Viewing gateway logs (`logs`)
 //! - Checking system health (`status`)
 
+pub mod acp;
 mod channels;
 mod completion;
 mod config;
@@ -35,6 +36,7 @@ mod skills;
 pub mod status;
 mod tool;
 
+pub use acp::{AcpCommand, run_acp_command};
 pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
@@ -292,6 +294,14 @@ pub enum Command {
         max_iterations: u32,
     },
 
+    /// Manage ACP (Agent Client Protocol) agents
+    #[command(
+        subcommand,
+        about = "Manage ACP agents",
+        long_about = "Add, list, remove, or test ACP-compliant coding agents.\nExample: ironclaw acp add goose --command goose --arg \"--stdio\""
+    )]
+    Acp(AcpCommand),
+
     /// Run as a Claude Code bridge inside a Docker container (internal use).
     /// Spawns the `claude` CLI and streams output back to the orchestrator.
     #[command(hide = true)]
@@ -311,6 +321,19 @@ pub enum Command {
         /// Claude model to use (e.g. "sonnet", "opus").
         #[arg(long, default_value = "sonnet")]
         model: String,
+    },
+
+    /// Run as an ACP bridge inside a Docker container (internal use).
+    /// Spawns an ACP-compliant agent and streams output back to the orchestrator.
+    #[command(hide = true)]
+    AcpBridge {
+        /// Job ID to execute.
+        #[arg(long)]
+        job_id: uuid::Uuid,
+
+        /// URL of the orchestrator's internal API.
+        #[arg(long, default_value = "http://host.docker.internal:50051")]
+        orchestrator_url: String,
     },
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -288,7 +288,7 @@ pub enum Command {
         orchestrator_url: String,
 
         /// Maximum iterations before stopping.
-        #[arg(long, default_value = "50")]
+        #[arg(long, env = "IRONCLAW_MAX_ITERATIONS", default_value = "50")]
         max_iterations: u32,
     },
 

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 422
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -26,6 +27,7 @@ Commands:
   status      Show system status
   completion  Generate completions
   login       Authenticate with a provider
+  acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 438
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -29,6 +30,7 @@ Commands:
   status      Show system status
   completion  Generate completions
   login       Authenticate with a provider
+  acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 
 Options:

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -35,6 +35,21 @@ fn load_settings_from(json_path: &std::path::Path, toml_path: &std::path::Path) 
     settings
 }
 
+async fn load_acp_agents_for_status()
+-> Result<crate::config::acp::AcpAgentsFile, crate::config::acp::AcpConfigError> {
+    match crate::config::Config::from_env().await {
+        Ok(config) => {
+            let db: Option<std::sync::Arc<dyn crate::db::Database>> =
+                crate::db::connect_from_config(&config.database)
+                    .await
+                    .ok()
+                    .map(|db| db as std::sync::Arc<dyn crate::db::Database>);
+            crate::config::acp::load_acp_agents_for_user(db.as_deref(), &config.owner_id).await
+        }
+        Err(_) => crate::config::acp::load_acp_agents().await,
+    }
+}
+
 /// Run the status command, printing system health info.
 pub async fn run_status_command() -> anyhow::Result<()> {
     let settings = load_settings();
@@ -181,6 +196,17 @@ pub async fn run_status_command() -> anyhow::Result<()> {
         Err(_) => "none configured".to_string(),
     };
     println!("{}", fmt::kv_line("MCP Servers", &mcp_value, 12));
+
+    // ACP agents
+    let acp_value = match load_acp_agents_for_status().await {
+        Ok(agents) => {
+            let enabled = agents.agents.iter().filter(|a| a.enabled).count();
+            let total = agents.agents.len();
+            format!("{} enabled / {} configured", enabled, total)
+        }
+        Err(_) => "none configured".to_string(),
+    };
+    println!("{}", fmt::kv_line("ACP Agents", &acp_value, 12));
 
     // Config path
     println!();

--- a/src/config/acp.rs
+++ b/src/config/acp.rs
@@ -1,0 +1,633 @@
+//! ACP (Agent Client Protocol) agent configuration.
+//!
+//! Stores configuration for ACP-compliant coding agents that can be spawned
+//! as subprocesses inside Docker containers. Configuration is persisted at
+//! `~/.ironclaw/acp-agents.json` (disk fallback) and in the database settings
+//! table under key `"acp_agents"`.
+//!
+//! Mirrors the MCP server config pattern (`src/tools/mcp/config.rs`).
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+
+use crate::bootstrap::ironclaw_base_dir;
+
+/// Configuration for a single ACP-compliant agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpAgentConfig {
+    /// Unique name for this agent (e.g., "goose", "codex", "gemini").
+    pub name: String,
+
+    /// Command to spawn the agent subprocess.
+    pub command: String,
+
+    /// Arguments to pass to the command.
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    /// Additional environment variables for the agent process.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+
+    /// Whether this agent is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Optional description for the agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl AcpAgentConfig {
+    /// Create a new ACP agent configuration.
+    pub fn new(
+        name: impl Into<String>,
+        command: impl Into<String>,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            command: command.into(),
+            args,
+            env,
+            enabled: true,
+            description: None,
+        }
+    }
+
+    /// Builder: attach a description.
+    pub fn with_description(mut self, desc: impl Into<String>) -> Self {
+        self.description = Some(desc.into());
+        self
+    }
+
+    /// Validate the agent configuration.
+    pub fn validate(&self) -> Result<(), AcpConfigError> {
+        if self.name.is_empty() {
+            return Err(AcpConfigError::InvalidConfig {
+                reason: "agent name cannot be empty".to_string(),
+            });
+        }
+        if self.command.is_empty() {
+            return Err(AcpConfigError::InvalidConfig {
+                reason: format!("agent '{}': command cannot be empty", self.name),
+            });
+        }
+        Ok(())
+    }
+}
+
+/// Container for all configured ACP agents.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpAgentsFile {
+    /// List of configured ACP agents.
+    #[serde(default)]
+    pub agents: Vec<AcpAgentConfig>,
+
+    /// Schema version for future compatibility.
+    #[serde(default = "default_schema_version")]
+    pub schema_version: u32,
+}
+
+fn default_schema_version() -> u32 {
+    1
+}
+
+impl Default for AcpAgentsFile {
+    fn default() -> Self {
+        Self {
+            agents: Vec::new(),
+            schema_version: default_schema_version(),
+        }
+    }
+}
+
+impl AcpAgentsFile {
+    /// Get an agent by name.
+    pub fn get(&self, name: &str) -> Option<&AcpAgentConfig> {
+        self.agents.iter().find(|a| a.name == name)
+    }
+
+    /// Get a mutable agent by name.
+    pub fn get_mut(&mut self, name: &str) -> Option<&mut AcpAgentConfig> {
+        self.agents.iter_mut().find(|a| a.name == name)
+    }
+
+    /// Add or update an agent configuration.
+    pub fn upsert(&mut self, config: AcpAgentConfig) {
+        if let Some(existing) = self.get_mut(&config.name) {
+            *existing = config;
+        } else {
+            self.agents.push(config);
+        }
+    }
+
+    /// Remove an agent by name.
+    pub fn remove(&mut self, name: &str) -> bool {
+        let len_before = self.agents.len();
+        self.agents.retain(|a| a.name != name);
+        self.agents.len() < len_before
+    }
+
+    /// Get all enabled agents.
+    pub fn enabled_agents(&self) -> impl Iterator<Item = &AcpAgentConfig> {
+        self.agents.iter().filter(|a| a.enabled)
+    }
+}
+
+/// Error type for ACP configuration operations.
+#[derive(Debug, thiserror::Error)]
+pub enum AcpConfigError {
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Invalid configuration: {reason}")]
+    InvalidConfig { reason: String },
+
+    #[error("Agent not found: {name}")]
+    AgentNotFound { name: String },
+
+    #[error("Agent is disabled: {name}")]
+    AgentDisabled { name: String },
+}
+
+// ==================== Disk persistence ====================
+
+/// Get the default ACP agents configuration path.
+pub fn default_config_path() -> PathBuf {
+    ironclaw_base_dir().join("acp-agents.json")
+}
+
+/// Load ACP agent configurations from the default location.
+pub async fn load_acp_agents() -> Result<AcpAgentsFile, AcpConfigError> {
+    load_acp_agents_from(default_config_path()).await
+}
+
+/// Load ACP agent configurations from a specific path.
+pub async fn load_acp_agents_from(path: impl AsRef<Path>) -> Result<AcpAgentsFile, AcpConfigError> {
+    let path = path.as_ref();
+
+    let content = match fs::read_to_string(path).await {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(AcpAgentsFile::default());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let config: AcpAgentsFile = serde_json::from_str(&content)?;
+
+    for agent in &config.agents {
+        agent
+            .validate()
+            .map_err(|e| AcpConfigError::InvalidConfig {
+                reason: format!("Agent '{}': {}", agent.name, e),
+            })?;
+    }
+
+    Ok(config)
+}
+
+/// Save ACP agent configurations to the default location.
+pub async fn save_acp_agents(config: &AcpAgentsFile) -> Result<(), AcpConfigError> {
+    save_acp_agents_to(config, default_config_path()).await
+}
+
+/// Save ACP agent configurations to a specific path.
+pub async fn save_acp_agents_to(
+    config: &AcpAgentsFile,
+    path: impl AsRef<Path>,
+) -> Result<(), AcpConfigError> {
+    let path = path.as_ref();
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await?;
+    }
+
+    let content = serde_json::to_string_pretty(config)?;
+
+    // Atomic write via temp file to avoid corruption on crash.
+    let tmp_path = path.with_extension("json.tmp");
+    fs::write(&tmp_path, content).await?;
+    fs::rename(&tmp_path, path).await?;
+
+    Ok(())
+}
+
+/// Add a new ACP agent configuration (disk-backed).
+pub async fn add_acp_agent(config: AcpAgentConfig) -> Result<(), AcpConfigError> {
+    config.validate()?;
+
+    let mut agents = load_acp_agents().await?;
+    agents.upsert(config);
+    save_acp_agents(&agents).await?;
+
+    Ok(())
+}
+
+/// Remove an ACP agent by name (disk-backed).
+pub async fn remove_acp_agent(name: &str) -> Result<(), AcpConfigError> {
+    let mut agents = load_acp_agents().await?;
+
+    if !agents.remove(name) {
+        return Err(AcpConfigError::AgentNotFound {
+            name: name.to_string(),
+        });
+    }
+
+    save_acp_agents(&agents).await?;
+
+    Ok(())
+}
+
+/// Get a specific ACP agent configuration (disk-backed).
+pub async fn get_acp_agent(name: &str) -> Result<AcpAgentConfig, AcpConfigError> {
+    let agents = load_acp_agents().await?;
+
+    agents
+        .get(name)
+        .cloned()
+        .ok_or_else(|| AcpConfigError::AgentNotFound {
+            name: name.to_string(),
+        })
+}
+
+// ==================== Database-backed persistence ====================
+
+/// Load ACP agent configurations from the database settings table.
+///
+/// Falls back to the disk file only if DB has no entry.
+pub async fn load_acp_agents_from_db(
+    store: &dyn crate::db::Database,
+    user_id: &str,
+) -> Result<AcpAgentsFile, AcpConfigError> {
+    match store.get_setting(user_id, "acp_agents").await {
+        Ok(Some(value)) => {
+            let config: AcpAgentsFile = serde_json::from_value(value)?;
+            for agent in &config.agents {
+                agent
+                    .validate()
+                    .map_err(|e| AcpConfigError::InvalidConfig {
+                        reason: format!("Agent '{}': {}", agent.name, e),
+                    })?;
+            }
+            Ok(config)
+        }
+        Ok(None) => load_acp_agents().await,
+        Err(e) => Err(AcpConfigError::Database(e.to_string())),
+    }
+}
+
+/// Load ACP agent configurations from the active persistence backend.
+pub async fn load_acp_agents_for_user(
+    store: Option<&dyn crate::db::Database>,
+    user_id: &str,
+) -> Result<AcpAgentsFile, AcpConfigError> {
+    match store {
+        Some(store) => load_acp_agents_from_db(store, user_id).await,
+        None => load_acp_agents().await,
+    }
+}
+
+/// Save ACP agent configurations to the database settings table.
+pub async fn save_acp_agents_to_db(
+    store: &dyn crate::db::Database,
+    user_id: &str,
+    config: &AcpAgentsFile,
+) -> Result<(), AcpConfigError> {
+    let value = serde_json::to_value(config)?;
+    store
+        .set_setting(user_id, "acp_agents", &value)
+        .await
+        .map_err(std::io::Error::other)?;
+    Ok(())
+}
+
+/// Save ACP agent configurations to the active persistence backend.
+pub async fn save_acp_agents_for_user(
+    store: Option<&dyn crate::db::Database>,
+    user_id: &str,
+    config: &AcpAgentsFile,
+) -> Result<(), AcpConfigError> {
+    match store {
+        Some(store) => save_acp_agents_to_db(store, user_id, config).await,
+        None => save_acp_agents(config).await,
+    }
+}
+
+/// Add a new ACP agent configuration (DB-backed).
+pub async fn add_acp_agent_db(
+    store: &dyn crate::db::Database,
+    user_id: &str,
+    config: AcpAgentConfig,
+) -> Result<(), AcpConfigError> {
+    config.validate()?;
+
+    let mut agents = load_acp_agents_from_db(store, user_id).await?;
+    agents.upsert(config);
+    save_acp_agents_to_db(store, user_id, &agents).await?;
+
+    Ok(())
+}
+
+/// Remove an ACP agent by name (DB-backed).
+pub async fn remove_acp_agent_db(
+    store: &dyn crate::db::Database,
+    user_id: &str,
+    name: &str,
+) -> Result<(), AcpConfigError> {
+    let mut agents = load_acp_agents_from_db(store, user_id).await?;
+
+    if !agents.remove(name) {
+        return Err(AcpConfigError::AgentNotFound {
+            name: name.to_string(),
+        });
+    }
+
+    save_acp_agents_to_db(store, user_id, &agents).await?;
+    Ok(())
+}
+
+/// Load a single ACP agent from the active persistence backend.
+pub async fn get_acp_agent_for_user(
+    store: Option<&dyn crate::db::Database>,
+    user_id: &str,
+    name: &str,
+) -> Result<AcpAgentConfig, AcpConfigError> {
+    let agents = load_acp_agents_for_user(store, user_id).await?;
+    agents
+        .get(name)
+        .cloned()
+        .ok_or_else(|| AcpConfigError::AgentNotFound {
+            name: name.to_string(),
+        })
+}
+
+/// Load a single ACP agent and ensure it is enabled.
+pub async fn get_enabled_acp_agent_for_user(
+    store: Option<&dyn crate::db::Database>,
+    user_id: &str,
+    name: &str,
+) -> Result<AcpAgentConfig, AcpConfigError> {
+    let agent = get_acp_agent_for_user(store, user_id, name).await?;
+    if !agent.enabled {
+        return Err(AcpConfigError::AgentDisabled {
+            name: name.to_string(),
+        });
+    }
+    Ok(agent)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_agent_config_new() {
+        let agent = AcpAgentConfig::new("goose", "goose", vec!["--stdio".into()], HashMap::new());
+        assert_eq!(agent.name, "goose");
+        assert_eq!(agent.command, "goose");
+        assert_eq!(agent.args, vec!["--stdio"]);
+        assert!(agent.enabled);
+        assert!(agent.description.is_none());
+    }
+
+    #[test]
+    fn test_agent_config_with_description() {
+        let agent = AcpAgentConfig::new("goose", "goose", vec![], HashMap::new())
+            .with_description("Goose coding agent");
+        assert_eq!(agent.description.as_deref(), Some("Goose coding agent"));
+    }
+
+    #[test]
+    fn test_validate_empty_name() {
+        let agent = AcpAgentConfig::new("", "goose", vec![], HashMap::new());
+        assert!(agent.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_empty_command() {
+        let agent = AcpAgentConfig::new("goose", "", vec![], HashMap::new());
+        assert!(agent.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_ok() {
+        let agent = AcpAgentConfig::new("goose", "goose", vec!["--stdio".into()], HashMap::new());
+        assert!(agent.validate().is_ok());
+    }
+
+    #[test]
+    fn test_agents_file_default() {
+        let file = AcpAgentsFile::default();
+        assert!(file.agents.is_empty());
+        assert_eq!(file.schema_version, 1);
+    }
+
+    #[test]
+    fn test_agents_file_get() {
+        let mut file = AcpAgentsFile::default();
+        file.agents.push(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec![],
+            HashMap::new(),
+        ));
+        assert!(file.get("goose").is_some());
+        assert!(file.get("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_agents_file_upsert_new() {
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec![],
+            HashMap::new(),
+        ));
+        assert_eq!(file.agents.len(), 1);
+    }
+
+    #[test]
+    fn test_agents_file_upsert_existing() {
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec![],
+            HashMap::new(),
+        ));
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose-v2",
+            vec!["--stdio".into()],
+            HashMap::new(),
+        ));
+        assert_eq!(file.agents.len(), 1);
+        assert_eq!(file.agents[0].command, "goose-v2");
+    }
+
+    #[test]
+    fn test_agents_file_remove() {
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec![],
+            HashMap::new(),
+        ));
+        assert!(file.remove("goose"));
+        assert!(file.agents.is_empty());
+        assert!(!file.remove("goose")); // already removed
+    }
+
+    #[test]
+    fn test_agents_file_enabled_agents() {
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec![],
+            HashMap::new(),
+        ));
+        let mut disabled = AcpAgentConfig::new("codex", "codex", vec![], HashMap::new());
+        disabled.enabled = false;
+        file.upsert(disabled);
+
+        let enabled: Vec<_> = file.enabled_agents().collect();
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].name, "goose");
+    }
+
+    #[test]
+    fn test_agents_file_serde_roundtrip() {
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec!["--stdio".into()],
+            HashMap::from([("GOOSE_TOKEN".to_string(), "secret".to_string())]),
+        ));
+
+        let json = serde_json::to_string_pretty(&file).unwrap();
+        let parsed: AcpAgentsFile = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.agents.len(), 1);
+        assert_eq!(parsed.agents[0].name, "goose");
+        assert_eq!(parsed.agents[0].command, "goose");
+        assert_eq!(parsed.agents[0].args, vec!["--stdio"]);
+        assert!(parsed.agents[0].env.contains_key("GOOSE_TOKEN"));
+    }
+
+    #[test]
+    fn test_default_config_path() {
+        let path = default_config_path();
+        assert!(path.ends_with("acp-agents.json"));
+    }
+
+    #[tokio::test]
+    async fn test_load_nonexistent_returns_empty() {
+        let path = std::env::temp_dir().join("ironclaw-test-nonexistent-acp.json");
+        let _ = std::fs::remove_file(&path); // ensure clean
+        let file = load_acp_agents_from(&path).await.unwrap();
+        assert!(file.agents.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_save_and_load_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acp-agents.json");
+
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec!["--stdio".into()],
+            HashMap::new(),
+        ));
+
+        save_acp_agents_to(&file, &path).await.unwrap();
+        let loaded = load_acp_agents_from(&path).await.unwrap();
+        assert_eq!(loaded.agents.len(), 1);
+        assert_eq!(loaded.agents[0].name, "goose");
+    }
+
+    #[tokio::test]
+    async fn test_load_rejects_invalid() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("acp-agents.json");
+        tokio::fs::write(
+            &path,
+            r#"{"agents":[{"name":"","command":"goose","args":[]}]}"#,
+        )
+        .await
+        .unwrap();
+
+        let result = load_acp_agents_from(&path).await;
+        assert!(result.is_err());
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_load_and_save_acp_agents_for_non_default_owner_scope() {
+        let (db, _tmp) = crate::testing::test_db().await;
+
+        let mut file = AcpAgentsFile::default();
+        file.upsert(AcpAgentConfig::new(
+            "goose",
+            "goose",
+            vec!["--stdio".into()],
+            HashMap::new(),
+        ));
+
+        save_acp_agents_for_user(Some(db.as_ref()), "owner-123", &file)
+            .await
+            .unwrap();
+
+        let loaded = load_acp_agents_for_user(Some(db.as_ref()), "owner-123")
+            .await
+            .unwrap();
+        assert_eq!(
+            loaded.get("goose").map(|agent| agent.command.as_str()),
+            Some("goose")
+        );
+
+        let default_scope = load_acp_agents_for_user(Some(db.as_ref()), "default")
+            .await
+            .unwrap();
+        assert!(default_scope.get("goose").is_none());
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_get_enabled_agent_rejects_disabled_agent() {
+        let (db, _tmp) = crate::testing::test_db().await;
+
+        let mut file = AcpAgentsFile::default();
+        let mut agent = AcpAgentConfig::new("codex", "codex", vec!["acp".into()], HashMap::new());
+        agent.enabled = false;
+        file.upsert(agent);
+
+        save_acp_agents_for_user(Some(db.as_ref()), "owner-123", &file)
+            .await
+            .unwrap();
+
+        let err = get_enabled_acp_agent_for_user(Some(db.as_ref()), "owner-123", "codex")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AcpConfigError::AgentDisabled { .. }));
+    }
+}

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use crate::config::helpers::{parse_bool_env, parse_option_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, parse_bool_env, parse_option_env,
+};
 use crate::error::ConfigError;
 use crate::settings::Settings;
 
@@ -73,49 +75,65 @@ impl AgentConfig {
     }
 
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::AgentSettings::default();
+
         Ok(Self {
-            name: parse_optional_env("AGENT_NAME", settings.agent.name.clone())?,
-            max_parallel_jobs: parse_optional_env(
+            name: db_first_or_default(&settings.agent.name, &defaults.name, "AGENT_NAME")?,
+            // Settings stores u32, config uses usize — cast for comparison.
+            max_parallel_jobs: db_first_or_default(
+                &(settings.agent.max_parallel_jobs as usize),
+                &(defaults.max_parallel_jobs as usize),
                 "AGENT_MAX_PARALLEL_JOBS",
-                settings.agent.max_parallel_jobs as usize,
             )?,
-            job_timeout: Duration::from_secs(parse_optional_env(
+            job_timeout: Duration::from_secs(db_first_or_default(
+                &settings.agent.job_timeout_secs,
+                &defaults.job_timeout_secs,
                 "AGENT_JOB_TIMEOUT_SECS",
-                settings.agent.job_timeout_secs,
             )?),
-            stuck_threshold: Duration::from_secs(parse_optional_env(
+            stuck_threshold: Duration::from_secs(db_first_or_default(
+                &settings.agent.stuck_threshold_secs,
+                &defaults.stuck_threshold_secs,
                 "AGENT_STUCK_THRESHOLD_SECS",
-                settings.agent.stuck_threshold_secs,
             )?),
-            repair_check_interval: Duration::from_secs(parse_optional_env(
+            repair_check_interval: Duration::from_secs(db_first_or_default(
+                &settings.agent.repair_check_interval_secs,
+                &defaults.repair_check_interval_secs,
                 "SELF_REPAIR_CHECK_INTERVAL_SECS",
-                settings.agent.repair_check_interval_secs,
             )?),
-            max_repair_attempts: parse_optional_env(
+            max_repair_attempts: db_first_or_default(
+                &settings.agent.max_repair_attempts,
+                &defaults.max_repair_attempts,
                 "SELF_REPAIR_MAX_ATTEMPTS",
-                settings.agent.max_repair_attempts,
             )?,
-            use_planning: parse_bool_env("AGENT_USE_PLANNING", settings.agent.use_planning)?,
-            session_idle_timeout: Duration::from_secs(parse_optional_env(
+            use_planning: db_first_bool(
+                settings.agent.use_planning,
+                defaults.use_planning,
+                "AGENT_USE_PLANNING",
+            )?,
+            session_idle_timeout: Duration::from_secs(db_first_or_default(
+                &settings.agent.session_idle_timeout_secs,
+                &defaults.session_idle_timeout_secs,
                 "SESSION_IDLE_TIMEOUT_SECS",
-                settings.agent.session_idle_timeout_secs,
             )?),
             allow_local_tools: parse_bool_env("ALLOW_LOCAL_TOOLS", false)?,
             max_cost_per_day_cents: parse_option_env("MAX_COST_PER_DAY_CENTS")?,
             max_actions_per_hour: parse_option_env("MAX_ACTIONS_PER_HOUR")?,
             max_cost_per_user_per_day_cents: parse_option_env("MAX_COST_PER_USER_PER_DAY_CENTS")?,
-            max_tool_iterations: parse_optional_env(
+            max_tool_iterations: db_first_or_default(
+                &settings.agent.max_tool_iterations,
+                &defaults.max_tool_iterations,
                 "AGENT_MAX_TOOL_ITERATIONS",
-                settings.agent.max_tool_iterations,
             )?,
-            auto_approve_tools: parse_bool_env(
-                "AGENT_AUTO_APPROVE_TOOLS",
+            auto_approve_tools: db_first_bool(
                 settings.agent.auto_approve_tools,
+                defaults.auto_approve_tools,
+                "AGENT_AUTO_APPROVE_TOOLS",
             )?,
             default_timezone: {
-                let tz: String = parse_optional_env(
+                let tz: String = db_first_or_default(
+                    &settings.agent.default_timezone,
+                    &defaults.default_timezone,
                     "DEFAULT_TIMEZONE",
-                    settings.agent.default_timezone.clone(),
                 )?;
                 if crate::timezone::parse_timezone(&tz).is_none() {
                     return Err(ConfigError::InvalidValue {
@@ -126,9 +144,10 @@ impl AgentConfig {
                 tz
             },
             max_jobs_per_user: parse_option_env("MAX_JOBS_PER_USER")?,
-            max_tokens_per_job: parse_optional_env(
+            max_tokens_per_job: db_first_or_default(
+                &settings.agent.max_tokens_per_job,
+                &defaults.max_tokens_per_job,
                 "AGENT_MAX_TOKENS_PER_JOB",
-                settings.agent.max_tokens_per_job,
             )?,
             multi_tenant: parse_bool_env("AGENT_MULTI_TENANT", false)?,
             max_llm_concurrent_per_user: parse_option_env("TENANT_MAX_LLM_CONCURRENT")?,

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default, optional_env};
 use crate::error::ConfigError;
 
 /// Builder mode configuration.
@@ -34,14 +34,29 @@ impl Default for BuilderModeConfig {
 impl BuilderModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let bs = &settings.builder;
+        let defaults = crate::settings::BuilderSettings::default();
         Ok(Self {
-            enabled: parse_bool_env("BUILDER_ENABLED", bs.enabled)?,
-            build_dir: optional_env("BUILDER_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| bs.build_dir.clone()),
-            max_iterations: parse_optional_env("BUILDER_MAX_ITERATIONS", bs.max_iterations)?,
-            timeout_secs: parse_optional_env("BUILDER_TIMEOUT_SECS", bs.timeout_secs)?,
-            auto_register: parse_bool_env("BUILDER_AUTO_REGISTER", bs.auto_register)?,
+            enabled: db_first_bool(bs.enabled, defaults.enabled, "BUILDER_ENABLED")?,
+            build_dir: if let Some(ref dir) = bs.build_dir {
+                Some(dir.clone())
+            } else {
+                optional_env("BUILDER_DIR")?.map(PathBuf::from)
+            },
+            max_iterations: db_first_or_default(
+                &bs.max_iterations,
+                &defaults.max_iterations,
+                "BUILDER_MAX_ITERATIONS",
+            )?,
+            timeout_secs: db_first_or_default(
+                &bs.timeout_secs,
+                &defaults.timeout_secs,
+                "BUILDER_TIMEOUT_SECS",
+            )?,
+            auto_register: db_first_bool(
+                bs.auto_register,
+                defaults.auto_register,
+                "BUILDER_AUTO_REGISTER",
+            )?,
         })
     }
 
@@ -79,7 +94,7 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
         settings.builder.timeout_secs = 123;
@@ -89,6 +104,22 @@ mod tests {
         let cfg = BuilderModeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("BUILDER_TIMEOUT_SECS") };
 
-        assert_eq!(cfg.timeout_secs, 3);
+        assert_eq!(cfg.timeout_secs, 123, "DB setting should win over env");
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("BUILDER_TIMEOUT_SECS", "42") };
+        let cfg = BuilderModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("BUILDER_TIMEOUT_SECS") };
+
+        assert_eq!(
+            cfg.timeout_secs, 42,
+            "env should be used when DB has the default value"
+        );
     }
 }

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_optional_string, db_first_or_default, optional_env, parse_bool_env,
+    parse_optional_env,
+};
 use crate::error::ConfigError;
-use crate::settings::Settings;
+use crate::settings::{ChannelSettings, Settings};
 use secrecy::SecretString;
 
 /// Channel configurations.
@@ -120,15 +123,24 @@ pub struct SignalConfig {
 impl ChannelsConfig {
     pub(crate) fn resolve(settings: &Settings, owner_id: &str) -> Result<Self, ConfigError> {
         let cs = &settings.channels;
+        let defaults = ChannelSettings::default();
 
         let http_enabled_by_env =
             optional_env("HTTP_PORT")?.is_some() || optional_env("HTTP_HOST")?.is_some();
-        let http = if http_enabled_by_env || cs.http_enabled {
+        let http_enabled_by_db =
+            db_first_bool(cs.http_enabled, defaults.http_enabled, "HTTP_ENABLED")?;
+        let http = if http_enabled_by_env || http_enabled_by_db {
             Some(HttpConfig {
-                host: optional_env("HTTP_HOST")?
-                    .or_else(|| cs.http_host.clone())
+                host: db_first_optional_string(&cs.http_host, "HTTP_HOST")?
                     .unwrap_or_else(|| "0.0.0.0".to_string()),
-                port: parse_optional_env("HTTP_PORT", cs.http_port.unwrap_or(8080))?,
+                port: {
+                    // defaults.http_port is None, so any Some(..) is an explicit DB override.
+                    if let Some(ref db_port) = cs.http_port {
+                        db_first_or_default(db_port, &8080, "HTTP_PORT")?
+                    } else {
+                        parse_optional_env("HTTP_PORT", 8080)?
+                    }
+                },
                 webhook_secret: optional_env("HTTP_WEBHOOK_SECRET")?.map(SecretString::from),
                 user_id: owner_id.to_string(),
             })
@@ -136,7 +148,11 @@ impl ChannelsConfig {
             None
         };
 
-        let gateway_enabled = parse_bool_env("GATEWAY_ENABLED", cs.gateway_enabled)?;
+        let gateway_enabled = db_first_bool(
+            cs.gateway_enabled,
+            defaults.gateway_enabled,
+            "GATEWAY_ENABLED",
+        )?;
         let gateway = if gateway_enabled {
             let memory_layers: Vec<crate::workspace::layer::MemoryLayer> =
                 match optional_env("MEMORY_LAYERS")? {
@@ -234,15 +250,26 @@ impl ChannelsConfig {
             };
 
             Some(GatewayConfig {
-                host: optional_env("GATEWAY_HOST")?
-                    .or_else(|| cs.gateway_host.clone())
+                host: db_first_optional_string(&cs.gateway_host, "GATEWAY_HOST")?
                     .unwrap_or_else(|| "127.0.0.1".to_string()),
-                port: parse_optional_env(
-                    "GATEWAY_PORT",
-                    cs.gateway_port.unwrap_or(DEFAULT_GATEWAY_PORT),
-                )?,
-                auth_token: optional_env("GATEWAY_AUTH_TOKEN")?
-                    .or_else(|| cs.gateway_auth_token.clone()),
+                port: {
+                    // defaults.gateway_port is None, so any Some(..) is an explicit DB override.
+                    if let Some(ref db_port) = cs.gateway_port {
+                        db_first_or_default(db_port, &DEFAULT_GATEWAY_PORT, "GATEWAY_PORT")?
+                    } else {
+                        parse_optional_env("GATEWAY_PORT", DEFAULT_GATEWAY_PORT)?
+                    }
+                },
+                // Security: auth token is env-only — never read from DB settings.
+                auth_token: {
+                    if cs.gateway_auth_token.is_some() {
+                        tracing::warn!(
+                            "gateway_auth_token is set in DB/TOML but is now env-only \
+                             (GATEWAY_AUTH_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("GATEWAY_AUTH_TOKEN")?
+                },
                 workspace_read_scopes,
                 memory_layers,
                 oidc,
@@ -251,16 +278,24 @@ impl ChannelsConfig {
             None
         };
 
-        let signal_url = optional_env("SIGNAL_HTTP_URL")?.or_else(|| cs.signal_http_url.clone());
-        let signal = if let Some(http_url) = signal_url {
-            let account = optional_env("SIGNAL_ACCOUNT")?
-                .or_else(|| cs.signal_account.clone())
-                .ok_or(ConfigError::InvalidValue {
+        let signal_enabled =
+            db_first_bool(cs.signal_enabled, defaults.signal_enabled, "SIGNAL_ENABLED")?;
+        let signal_url = db_first_optional_string(&cs.signal_http_url, "SIGNAL_HTTP_URL")?;
+        let signal = if signal_enabled || signal_url.is_some() {
+            let http_url = signal_url.ok_or(ConfigError::InvalidValue {
+                key: "SIGNAL_HTTP_URL".to_string(),
+                message: "SIGNAL_HTTP_URL is required when signal_enabled is set in DB/TOML \
+                         or SIGNAL_ENABLED env var is true"
+                    .to_string(),
+            })?;
+            let account = db_first_optional_string(&cs.signal_account, "SIGNAL_ACCOUNT")?.ok_or(
+                ConfigError::InvalidValue {
                     key: "SIGNAL_ACCOUNT".to_string(),
                     message: "SIGNAL_ACCOUNT is required when SIGNAL_HTTP_URL is set".to_string(),
-                })?;
+                },
+            )?;
             let allow_from =
-                match optional_env("SIGNAL_ALLOW_FROM")?.or_else(|| cs.signal_allow_from.clone()) {
+                match db_first_optional_string(&cs.signal_allow_from, "SIGNAL_ALLOW_FROM")? {
                     None => vec![account.clone()],
                     Some(s) => s
                         .split(',')
@@ -268,36 +303,39 @@ impl ChannelsConfig {
                         .filter(|s| !s.is_empty())
                         .collect(),
                 };
-            let dm_policy = optional_env("SIGNAL_DM_POLICY")?
-                .or_else(|| cs.signal_dm_policy.clone())
+            let dm_policy = db_first_optional_string(&cs.signal_dm_policy, "SIGNAL_DM_POLICY")?
                 .unwrap_or_else(|| "pairing".to_string());
-            let group_policy = optional_env("SIGNAL_GROUP_POLICY")?
-                .or_else(|| cs.signal_group_policy.clone())
-                .unwrap_or_else(|| "allowlist".to_string());
+            let group_policy =
+                db_first_optional_string(&cs.signal_group_policy, "SIGNAL_GROUP_POLICY")?
+                    .unwrap_or_else(|| "allowlist".to_string());
             Some(SignalConfig {
                 http_url,
                 account,
                 allow_from,
-                allow_from_groups: optional_env("SIGNAL_ALLOW_FROM_GROUPS")?
-                    .or_else(|| cs.signal_allow_from_groups.clone())
-                    .map(|s| {
-                        s.split(',')
-                            .map(|e| e.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                allow_from_groups: db_first_optional_string(
+                    &cs.signal_allow_from_groups,
+                    "SIGNAL_ALLOW_FROM_GROUPS",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
                 dm_policy,
                 group_policy,
-                group_allow_from: optional_env("SIGNAL_GROUP_ALLOW_FROM")?
-                    .or_else(|| cs.signal_group_allow_from.clone())
-                    .map(|s| {
-                        s.split(',')
-                            .map(|e| e.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                group_allow_from: db_first_optional_string(
+                    &cs.signal_group_allow_from,
+                    "SIGNAL_GROUP_ALLOW_FROM",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
                 ignore_attachments: optional_env("SIGNAL_IGNORE_ATTACHMENTS")?
                     .map(|s| s.to_lowercase() == "true" || s == "1")
                     .unwrap_or(false),
@@ -309,7 +347,7 @@ impl ChannelsConfig {
             None
         };
 
-        let cli_enabled = parse_bool_env("CLI_ENABLED", cs.cli_enabled)?;
+        let cli_enabled = db_first_bool(cs.cli_enabled, defaults.cli_enabled, "CLI_ENABLED")?;
 
         Ok(Self {
             cli: CliConfig {
@@ -318,13 +356,21 @@ impl ChannelsConfig {
             http,
             gateway,
             signal,
-            wasm_channels_dir: optional_env("WASM_CHANNELS_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| cs.wasm_channels_dir.clone())
-                .unwrap_or_else(default_channels_dir),
-            wasm_channels_enabled: parse_bool_env(
-                "WASM_CHANNELS_ENABLED",
+            wasm_channels_dir: {
+                // DB-first: use settings if explicitly set, else env, else default.
+                // defaults.wasm_channels_dir is None, so any Some(..) is an explicit DB override.
+                if let Some(ref db_dir) = cs.wasm_channels_dir {
+                    db_dir.clone()
+                } else {
+                    optional_env("WASM_CHANNELS_DIR")?
+                        .map(PathBuf::from)
+                        .unwrap_or_else(default_channels_dir)
+                }
+            },
+            wasm_channels_enabled: db_first_bool(
                 cs.wasm_channels_enabled,
+                defaults.wasm_channels_enabled,
+                "WASM_CHANNELS_ENABLED",
             )?,
             wasm_channel_owner_ids: {
                 let mut ids = cs.wasm_channel_owner_ids.clone();
@@ -526,7 +572,9 @@ mod tests {
         settings.channels.gateway_enabled = true;
         settings.channels.gateway_host = Some("127.0.0.3".to_string());
         settings.channels.gateway_port = Some(9191);
-        settings.channels.gateway_auth_token = Some("tok".to_string());
+        // auth_token is env-only (security), set via env var
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var("GATEWAY_AUTH_TOKEN", "tok") };
         settings.channels.signal_http_url = Some("http://127.0.0.1:8080".to_string());
         settings.channels.signal_account = Some("+15551234567".to_string());
         settings.channels.signal_allow_from = Some("+15551234567,+15557654321".to_string());
@@ -554,5 +602,8 @@ mod tests {
             PathBuf::from("/tmp/settings-channels")
         );
         assert!(!cfg.wasm_channels_enabled);
+
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::remove_var("GATEWAY_AUTH_TOKEN") };
     }
 }

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env, validate_base_url};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_optional_env, validate_base_url,
+};
 use crate::error::ConfigError;
 use crate::llm::SessionManager;
 use crate::settings::Settings;
@@ -71,22 +73,44 @@ pub(crate) fn default_dimension_for_model(model: &str) -> usize {
 
 impl EmbeddingsConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::EmbeddingsSettings::default();
+
         let openai_api_key = optional_env("OPENAI_API_KEY")?.map(SecretString::from);
 
-        let provider = optional_env("EMBEDDING_PROVIDER")?
-            .unwrap_or_else(|| settings.embeddings.provider.clone());
+        let provider = db_first_or_default(
+            &settings.embeddings.provider,
+            &defaults.provider,
+            "EMBEDDING_PROVIDER",
+        )?;
 
-        let model =
-            optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| settings.embeddings.model.clone());
+        let model = db_first_or_default(
+            &settings.embeddings.model,
+            &defaults.model,
+            "EMBEDDING_MODEL",
+        )?;
 
-        let ollama_base_url = optional_env("OLLAMA_BASE_URL")?
-            .or_else(|| settings.ollama_base_url.clone())
-            .unwrap_or_else(|| "http://localhost:11434".to_string());
+        // ollama_base_url lives on the top-level Settings, not the embeddings
+        // sub-struct. Use a manual DB > env > default chain.
+        let default_ollama_url = "http://localhost:11434".to_string();
+        let ollama_base_url = match settings
+            .ollama_base_url
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned()
+        {
+            Some(url) => url,
+            None => optional_env("OLLAMA_BASE_URL")?.unwrap_or(default_ollama_url),
+        };
 
+        // Dimension depends on the resolved model, not on a DB setting — env-only.
         let dimension =
             parse_optional_env("EMBEDDING_DIMENSION", default_dimension_for_model(&model))?;
 
-        let enabled = parse_bool_env("EMBEDDING_ENABLED", settings.embeddings.enabled)?;
+        let enabled = db_first_bool(
+            settings.embeddings.enabled,
+            defaults.enabled,
+            "EMBEDDING_ENABLED",
+        )?;
 
         let openai_base_url = optional_env("EMBEDDING_BASE_URL")?;
 
@@ -207,9 +231,11 @@ mod tests {
             std::env::remove_var("EMBEDDING_ENABLED");
             std::env::remove_var("EMBEDDING_PROVIDER");
             std::env::remove_var("EMBEDDING_MODEL");
+            std::env::remove_var("EMBEDDING_DIMENSION");
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("EMBEDDING_BASE_URL");
             std::env::remove_var("EMBEDDING_CACHE_SIZE");
+            std::env::remove_var("OLLAMA_BASE_URL");
         }
     }
 
@@ -264,18 +290,21 @@ mod tests {
     }
 
     #[test]
-    fn embeddings_env_override_takes_precedence() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         clear_embedding_env();
         // SAFETY: Under ENV_MUTEX.
         unsafe {
-            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_ENABLED", "false");
+            std::env::set_var("EMBEDDING_PROVIDER", "ollama");
+            std::env::set_var("EMBEDDING_MODEL", "all-minilm");
         }
 
         let settings = Settings {
             embeddings: EmbeddingsSettings {
-                enabled: false,
-                ..Default::default()
+                enabled: true,
+                provider: "openai".to_string(),
+                model: "text-embedding-3-large".to_string(),
             },
             ..Default::default()
         };
@@ -283,12 +312,55 @@ mod tests {
         let config = EmbeddingsConfig::resolve(&settings).expect("resolve should succeed");
         assert!(
             config.enabled,
-            "EMBEDDING_ENABLED=true env var should override settings"
+            "DB enabled=true should win over env EMBEDDING_ENABLED=false"
+        );
+        assert_eq!(config.provider, "openai", "DB provider should win over env");
+        assert_eq!(
+            config.model, "text-embedding-3-large",
+            "DB model should win over env"
         );
 
         // SAFETY: Under ENV_MUTEX.
         unsafe {
             std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_MODEL");
+        }
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_PROVIDER", "ollama");
+            std::env::set_var("EMBEDDING_MODEL", "nomic-embed-text");
+        }
+
+        // Settings left at defaults — no explicit DB/TOML override
+        let settings = Settings::default();
+
+        let config = EmbeddingsConfig::resolve(&settings).expect("resolve should succeed");
+        assert!(
+            config.enabled,
+            "env EMBEDDING_ENABLED should be used when settings at default"
+        );
+        assert_eq!(
+            config.provider, "ollama",
+            "env EMBEDDING_PROVIDER should be used when settings at default"
+        );
+        assert_eq!(
+            config.model, "nomic-embed-text",
+            "env EMBEDDING_MODEL should be used when settings at default"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_MODEL");
         }
     }
 

--- a/src/config/heartbeat.rs
+++ b/src/config/heartbeat.rs
@@ -1,4 +1,7 @@
-use crate::config::helpers::{optional_env, parse_bool_env, parse_option_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_option, db_first_optional_string, db_first_or_default, optional_env,
+    parse_bool_env,
+};
 use crate::error::ConfigError;
 use crate::settings::Settings;
 
@@ -44,8 +47,11 @@ impl Default for HeartbeatConfig {
 
 impl HeartbeatConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::HeartbeatSettings::default();
+
+        // fire_at: DB > env, then parse into NaiveTime
         let fire_at_str =
-            optional_env("HEARTBEAT_FIRE_AT")?.or_else(|| settings.heartbeat.fire_at.clone());
+            db_first_optional_string(&settings.heartbeat.fire_at, "HEARTBEAT_FIRE_AT")?;
         let fire_at = fire_at_str
             .map(|s| {
                 chrono::NaiveTime::parse_from_str(&s, "%H:%M").map_err(|e| {
@@ -57,31 +63,24 @@ impl HeartbeatConfig {
             })
             .transpose()?;
 
-        Ok(Self {
-            enabled: parse_bool_env("HEARTBEAT_ENABLED", settings.heartbeat.enabled)?,
-            interval_secs: parse_optional_env(
-                "HEARTBEAT_INTERVAL_SECS",
-                settings.heartbeat.interval_secs,
-            )?,
-            notify_channel: optional_env("HEARTBEAT_NOTIFY_CHANNEL")?
-                .or_else(|| settings.heartbeat.notify_channel.clone()),
-            notify_user: optional_env("HEARTBEAT_NOTIFY_USER")?
-                .or_else(|| settings.heartbeat.notify_user.clone()),
-            fire_at,
-            quiet_hours_start: parse_option_env::<u32>("HEARTBEAT_QUIET_START")?
-                .or(settings.heartbeat.quiet_hours_start)
-                .map(|h| {
-                    if h > 23 {
-                        return Err(ConfigError::InvalidValue {
-                            key: "HEARTBEAT_QUIET_START".into(),
-                            message: "must be 0-23".into(),
-                        });
-                    }
-                    Ok(h)
-                })
-                .transpose()?,
-            quiet_hours_end: parse_option_env::<u32>("HEARTBEAT_QUIET_END")?
-                .or(settings.heartbeat.quiet_hours_end)
+        // quiet_hours: DB > env (using db_first_option for shadow warnings)
+        let quiet_hours_start = db_first_option(
+            &settings.heartbeat.quiet_hours_start,
+            "HEARTBEAT_QUIET_START",
+        )?
+        .map(|h| {
+            if h > 23 {
+                return Err(ConfigError::InvalidValue {
+                    key: "HEARTBEAT_QUIET_START".into(),
+                    message: "must be 0-23".into(),
+                });
+            }
+            Ok(h)
+        })
+        .transpose()?;
+
+        let quiet_hours_end =
+            db_first_option(&settings.heartbeat.quiet_hours_end, "HEARTBEAT_QUIET_END")?
                 .map(|h| {
                     if h > 23 {
                         return Err(ConfigError::InvalidValue {
@@ -91,10 +90,33 @@ impl HeartbeatConfig {
                     }
                     Ok(h)
                 })
-                .transpose()?,
+                .transpose()?;
+
+        Ok(Self {
+            enabled: db_first_bool(
+                settings.heartbeat.enabled,
+                defaults.enabled,
+                "HEARTBEAT_ENABLED",
+            )?,
+            interval_secs: db_first_or_default(
+                &settings.heartbeat.interval_secs,
+                &defaults.interval_secs,
+                "HEARTBEAT_INTERVAL_SECS",
+            )?,
+            notify_channel: db_first_optional_string(
+                &settings.heartbeat.notify_channel,
+                "HEARTBEAT_NOTIFY_CHANNEL",
+            )?,
+            notify_user: db_first_optional_string(
+                &settings.heartbeat.notify_user,
+                "HEARTBEAT_NOTIFY_USER",
+            )?,
+            fire_at,
+            quiet_hours_start,
+            quiet_hours_end,
             timezone: {
-                let tz = optional_env("HEARTBEAT_TIMEZONE")?
-                    .or_else(|| settings.heartbeat.timezone.clone());
+                let tz =
+                    db_first_optional_string(&settings.heartbeat.timezone, "HEARTBEAT_TIMEZONE")?;
                 if let Some(ref tz_str) = tz
                     && crate::timezone::parse_timezone(tz_str).is_none()
                 {
@@ -105,7 +127,12 @@ impl HeartbeatConfig {
                 }
                 tz
             },
-            multi_tenant: parse_bool_env("HEARTBEAT_MULTI_TENANT", false)?,
+            // Auto-detect multi-tenant mode from GATEWAY_USER_TOKENS presence,
+            // or allow explicit override via HEARTBEAT_MULTI_TENANT. Stays env-only.
+            multi_tenant: parse_bool_env(
+                "HEARTBEAT_MULTI_TENANT",
+                optional_env("GATEWAY_USER_TOKENS")?.is_some(),
+            )?,
         })
     }
 }
@@ -113,10 +140,11 @@ impl HeartbeatConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::helpers::lock_env;
 
     #[test]
-    fn test_quiet_hours_settings_fallback() {
-        // When env vars are not set, settings values should be used
+    fn test_quiet_hours_settings_have_priority() {
+        // DB/settings values should take priority over env
         let mut settings = Settings::default();
         settings.heartbeat.quiet_hours_start = Some(22);
         settings.heartbeat.quiet_hours_end = Some(6);
@@ -162,5 +190,117 @@ mod tests {
 
         let config = HeartbeatConfig::resolve(&settings).expect("resolve");
         assert_eq!(config.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn test_db_first_enabled_beats_env() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var("HEARTBEAT_ENABLED", "false") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.enabled = true; // DB says enabled
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert!(config.enabled, "DB value (true) should beat env (false)");
+
+        unsafe { std::env::remove_var("HEARTBEAT_ENABLED") };
+    }
+
+    #[test]
+    fn test_db_first_interval_beats_env() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_INTERVAL_SECS", "999") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.interval_secs = 600; // DB says 600
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(config.interval_secs, 600, "DB value should beat env");
+
+        unsafe { std::env::remove_var("HEARTBEAT_INTERVAL_SECS") };
+    }
+
+    #[test]
+    fn test_db_first_notify_channel_beats_env() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_NOTIFY_CHANNEL", "env-channel") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.notify_channel = Some("db-channel".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.notify_channel.as_deref(),
+            Some("db-channel"),
+            "DB value should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_NOTIFY_CHANNEL") };
+    }
+
+    #[test]
+    fn test_env_fallback_when_db_at_default() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_INTERVAL_SECS", "999") };
+
+        // Settings at default => env should win
+        let settings = Settings::default();
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.interval_secs, 999,
+            "env should win when DB at default"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_INTERVAL_SECS") };
+    }
+
+    #[test]
+    fn test_fire_at_db_first() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_FIRE_AT", "08:00") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.fire_at = Some("14:30".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.fire_at,
+            Some(chrono::NaiveTime::from_hms_opt(14, 30, 0).unwrap()),
+            "DB fire_at should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_FIRE_AT") };
+    }
+
+    #[test]
+    fn test_timezone_db_first() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_TIMEZONE", "UTC") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.timezone = Some("America/New_York".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.timezone.as_deref(),
+            Some("America/New_York"),
+            "DB timezone should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_TIMEZONE") };
+    }
+
+    #[test]
+    fn test_multi_tenant_stays_env_only() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_MULTI_TENANT", "true") };
+
+        let settings = Settings::default();
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert!(config.multi_tenant, "multi_tenant should read from env");
+
+        unsafe { std::env::remove_var("HEARTBEAT_MULTI_TENANT") };
     }
 }

--- a/src/config/helpers.rs
+++ b/src/config/helpers.rs
@@ -331,6 +331,99 @@ pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), Confi
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// DB-first resolution helpers (DB > env > default)
+// ---------------------------------------------------------------------------
+
+/// Log a warning when a DB/TOML setting shadows a set env var.
+///
+/// Only checks real env vars (`std::env::var`), not runtime overrides or
+/// injected vars — those are internal and don't warrant operator warnings.
+/// Values are intentionally NOT logged to avoid leaking sensitive data.
+fn warn_if_db_shadows_env(env_key: &str) {
+    if std::env::var(env_key).is_ok_and(|v| !v.is_empty()) {
+        tracing::warn!(
+            env_key = %env_key,
+            "{env_key} env var is set but a DB or TOML setting takes priority. \
+             Remove the setting from DB/TOML to use the env var."
+        );
+    }
+}
+
+/// Resolve with DB > env > default priority for concrete settings fields.
+///
+/// If `settings_val != default_val`, the settings value wins (it was explicitly
+/// set in DB or TOML). Otherwise falls back to `optional_env(env_key)`, then
+/// `default_val`.
+///
+/// **Limitation:** Uses `settings_val != default_val` as a heuristic for
+/// "was this field explicitly set." If a user deliberately sets a DB value
+/// equal to the default, it's indistinguishable from "unset" and the env
+/// var will win. This matches `merge_from()` semantics and is acceptable
+/// since setting a value to its default is effectively a no-op.
+pub(crate) fn db_first_or_default<T>(
+    settings_val: &T,
+    default_val: &T,
+    env_key: &str,
+) -> Result<T, ConfigError>
+where
+    T: std::str::FromStr + Clone + PartialEq + std::fmt::Display,
+    T::Err: std::fmt::Display,
+{
+    if settings_val != default_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(settings_val.clone());
+    }
+    parse_optional_env(env_key, default_val.clone())
+}
+
+/// Resolve a bool with DB > env > default priority.
+pub(crate) fn db_first_bool(
+    settings_val: bool,
+    default_val: bool,
+    env_key: &str,
+) -> Result<bool, ConfigError> {
+    if settings_val != default_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(settings_val);
+    }
+    parse_bool_env(env_key, default_val)
+}
+
+/// Resolve an `Option<String>` with DB > env priority (no hardcoded default).
+///
+/// Non-empty `Some` means DB set it; `None` or empty falls back to env.
+pub(crate) fn db_first_optional_string(
+    settings_val: &Option<String>,
+    env_key: &str,
+) -> Result<Option<String>, ConfigError> {
+    if let Some(val) = settings_val
+        && !val.is_empty()
+    {
+        warn_if_db_shadows_env(env_key);
+        return Ok(Some(val.clone()));
+    }
+    optional_env(env_key)
+}
+
+/// Resolve an `Option<T>` with DB > env priority (no hardcoded default).
+///
+/// `Some(v)` means DB set it; `None` falls back to env.
+pub(crate) fn db_first_option<T>(
+    settings_val: &Option<T>,
+    env_key: &str,
+) -> Result<Option<T>, ConfigError>
+where
+    T: std::str::FromStr + Clone + std::fmt::Display,
+    T::Err: std::fmt::Display,
+{
+    if let Some(val) = settings_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(Some(val.clone()));
+    }
+    parse_option_env(env_key)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,5 +611,145 @@ mod tests {
             err.contains("failed to resolve"),
             "Expected DNS resolution failure, got: {err}"
         );
+    }
+
+    // --- db_first_* helper tests ---
+
+    #[test]
+    fn db_first_or_default_prefers_settings_over_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_1";
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let result: String =
+            db_first_or_default(&"from-db".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(result, "from-db", "DB value should win over env");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_or_default_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_2";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        // settings_val == default_val → treated as "unset"
+        let result: String =
+            db_first_or_default(&"default".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(
+            result, "from-env",
+            "env should win when settings at default"
+        );
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_or_default_uses_default_when_neither_set() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_3";
+        unsafe { std::env::remove_var(key) };
+
+        let result: String =
+            db_first_or_default(&"default".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(result, "default");
+    }
+
+    #[test]
+    fn db_first_bool_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_BOOL_1";
+        unsafe { std::env::set_var(key, "false") };
+
+        let result = db_first_bool(true, false, key).expect("should resolve");
+        assert!(result, "DB true should win over env false");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_bool_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_BOOL_2";
+        unsafe { std::env::set_var(key, "true") };
+
+        // settings == default → falls back to env
+        let result = db_first_bool(false, false, key).expect("should resolve");
+        assert!(result, "env should win when settings at default");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_1";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let val = Some("from-db".to_string());
+        let result = db_first_optional_string(&val, key).expect("should resolve");
+        assert_eq!(result, Some("from-db".to_string()));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_2";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let result = db_first_optional_string(&None, key).expect("should resolve");
+        assert_eq!(result, Some("from-env".to_string()));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_empty_treated_as_unset() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_3";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let val = Some(String::new());
+        let result = db_first_optional_string(&val, key).expect("should resolve");
+        assert_eq!(
+            result,
+            Some("from-env".to_string()),
+            "empty string should be treated as unset"
+        );
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_option_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_T_1";
+        unsafe { std::env::set_var(key, "99") };
+
+        let val: Option<u64> = Some(42);
+        let result = db_first_option(&val, key).expect("should resolve");
+        assert_eq!(result, Some(42));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_option_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_T_2";
+        unsafe { std::env::set_var(key, "99") };
+
+        let val: Option<u64> = None;
+        let result = db_first_option(&val, key).expect("should resolve");
+        assert_eq!(result, Some(99));
+
+        unsafe { std::env::remove_var(key) };
     }
 }

--- a/src/config/hygiene.rs
+++ b/src/config/hygiene.rs
@@ -11,10 +11,8 @@ use crate::settings::Settings;
 pub struct HygieneConfig {
     /// Whether hygiene is enabled. Env: `MEMORY_HYGIENE_ENABLED` (default: true).
     pub enabled: bool,
-    /// Days before `daily/` documents are deleted. Env: `MEMORY_HYGIENE_DAILY_RETENTION_DAYS` (default: 30).
-    pub daily_retention_days: u32,
-    /// Days before `conversations/` documents are deleted. Env: `MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS` (default: 7).
-    pub conversation_retention_days: u32,
+    /// Maximum versions to keep per document. Env: `MEMORY_HYGIENE_VERSION_KEEP_COUNT` (default: 50).
+    pub version_keep_count: u32,
     /// Minimum hours between hygiene passes. Env: `MEMORY_HYGIENE_CADENCE_HOURS` (default: 12).
     pub cadence_hours: u32,
 }
@@ -23,8 +21,7 @@ impl Default for HygieneConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            daily_retention_days: 30,
-            conversation_retention_days: 7,
+            version_keep_count: 50,
             cadence_hours: 12,
         }
     }
@@ -37,15 +34,10 @@ impl HygieneConfig {
 
         Ok(Self {
             enabled: db_first_bool(hs.enabled, defaults.enabled, "MEMORY_HYGIENE_ENABLED")?,
-            daily_retention_days: db_first_or_default(
-                &hs.daily_retention_days,
-                &defaults.daily_retention_days,
-                "MEMORY_HYGIENE_DAILY_RETENTION_DAYS",
-            )?,
-            conversation_retention_days: db_first_or_default(
-                &hs.conversation_retention_days,
-                &defaults.conversation_retention_days,
-                "MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS",
+            version_keep_count: db_first_or_default(
+                &hs.version_keep_count,
+                &defaults.version_keep_count,
+                "MEMORY_HYGIENE_VERSION_KEEP_COUNT",
             )?,
             cadence_hours: db_first_or_default(
                 &hs.cadence_hours,
@@ -60,8 +52,7 @@ impl HygieneConfig {
     pub fn to_workspace_config(&self) -> crate::workspace::hygiene::HygieneConfig {
         crate::workspace::hygiene::HygieneConfig {
             enabled: self.enabled,
-            daily_retention_days: self.daily_retention_days,
-            conversation_retention_days: self.conversation_retention_days,
+            version_keep_count: self.version_keep_count,
             cadence_hours: self.cadence_hours,
             state_dir: ironclaw_base_dir(),
         }

--- a/src/config/hygiene.rs
+++ b/src/config/hygiene.rs
@@ -1,6 +1,7 @@
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Memory hygiene configuration.
 ///
@@ -30,15 +31,27 @@ impl Default for HygieneConfig {
 }
 
 impl HygieneConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::HygieneSettings::default();
+        let hs = &settings.hygiene;
+
         Ok(Self {
-            enabled: parse_bool_env("MEMORY_HYGIENE_ENABLED", true)?,
-            daily_retention_days: parse_optional_env("MEMORY_HYGIENE_DAILY_RETENTION_DAYS", 30)?,
-            conversation_retention_days: parse_optional_env(
-                "MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS",
-                7,
+            enabled: db_first_bool(hs.enabled, defaults.enabled, "MEMORY_HYGIENE_ENABLED")?,
+            daily_retention_days: db_first_or_default(
+                &hs.daily_retention_days,
+                &defaults.daily_retention_days,
+                "MEMORY_HYGIENE_DAILY_RETENTION_DAYS",
             )?,
-            cadence_hours: parse_optional_env("MEMORY_HYGIENE_CADENCE_HOURS", 12)?,
+            conversation_retention_days: db_first_or_default(
+                &hs.conversation_retention_days,
+                &defaults.conversation_retention_days,
+                "MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS",
+            )?,
+            cadence_hours: db_first_or_default(
+                &hs.cadence_hours,
+                &defaults.cadence_hours,
+                "MEMORY_HYGIENE_CADENCE_HOURS",
+            )?,
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -28,6 +28,7 @@ mod heartbeat;
 pub(crate) mod helpers;
 mod hygiene;
 pub(crate) mod llm;
+pub mod oauth;
 pub mod relay;
 mod routines;
 mod safety;
@@ -58,6 +59,7 @@ pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
 pub use self::heartbeat::HeartbeatConfig;
 pub use self::hygiene::HygieneConfig;
 pub use self::llm::default_session_path;
+pub use self::oauth::OAuthConfig;
 pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
 pub use self::safety::SafetyConfig;
@@ -118,6 +120,8 @@ pub struct Config {
     pub search: WorkspaceSearchConfig,
     pub workspace: WorkspaceConfig,
     pub observability: crate::observability::ObservabilityConfig,
+    /// OAuth/social login configuration (Google, GitHub, etc.).
+    pub oauth: OAuthConfig,
     /// Channel-relay integration (Slack via external relay service).
     /// Present only when both `CHANNEL_RELAY_URL` and `CHANNEL_RELAY_API_KEY` are set.
     pub relay: Option<RelayConfig>,
@@ -197,6 +201,7 @@ impl Config {
             search: WorkspaceSearchConfig::default(),
             workspace: WorkspaceConfig::default(),
             observability: crate::observability::ObservabilityConfig::default(),
+            oauth: OAuthConfig::default(),
             relay: None,
         }
     }
@@ -389,6 +394,7 @@ impl Config {
             observability: crate::observability::ObservabilityConfig {
                 backend: std::env::var("OBSERVABILITY_BACKEND").unwrap_or_else(|_| "none".into()),
             },
+            oauth: OAuthConfig::resolve()?,
             relay: RelayConfig::from_env(),
         })
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -18,6 +18,7 @@
 //! `DATABASE_URL` lives in `~/.ironclaw/.env` (loaded via dotenvy early
 //! in startup).
 
+pub mod acp;
 mod agent;
 mod builder;
 mod channels;
@@ -61,7 +62,7 @@ pub use self::relay::RelayConfig;
 pub use self::routines::RoutineConfig;
 pub use self::safety::SafetyConfig;
 use self::safety::resolve_safety_config;
-pub use self::sandbox::{ClaudeCodeConfig, SandboxModeConfig};
+pub use self::sandbox::{AcpModeConfig, ClaudeCodeConfig, SandboxModeConfig};
 pub use self::search::WorkspaceSearchConfig;
 pub use self::secrets::SecretsConfig;
 pub use self::skills::SkillsConfig;
@@ -111,6 +112,7 @@ pub struct Config {
     pub routines: RoutineConfig,
     pub sandbox: SandboxModeConfig,
     pub claude_code: ClaudeCodeConfig,
+    pub acp: AcpModeConfig,
     pub skills: SkillsConfig,
     pub transcription: TranscriptionConfig,
     pub search: WorkspaceSearchConfig,
@@ -184,6 +186,7 @@ impl Config {
                 ..SandboxModeConfig::default()
             },
             claude_code: ClaudeCodeConfig::default(),
+            acp: AcpModeConfig::default(),
             skills: SkillsConfig {
                 enabled: true,
                 local_dir: skills_dir,
@@ -378,6 +381,7 @@ impl Config {
             routines: RoutineConfig::resolve(settings)?,
             sandbox: SandboxModeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
+            acp: AcpModeConfig::resolve(settings)?,
             skills: SkillsConfig::resolve(settings)?,
             transcription: TranscriptionConfig::resolve(settings)?,
             search: WorkspaceSearchConfig::resolve(settings)?,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,10 +1,19 @@
 //! Configuration for IronClaw.
 //!
-//! Settings are loaded from env vars, the DB settings table, TOML config,
-//! and built-in defaults. Priority varies by subsystem:
+//! Settings are loaded with priority: **DB/TOML > env > default**.
 //!
-//! - **LLM settings** (backend, model, api_key, base_url): DB > env > default
-//! - **Most other settings** (agent, channels, tunnel, …): env > DB > default
+//! DB and TOML are merged into a single `Settings` struct before
+//! resolution (DB wins over TOML when both set the same field).
+//! Resolvers then check settings before env vars.
+//!
+//! For concrete (non-`Option`) fields, a settings value equal to the
+//! built-in default is treated as "unset" and falls through to env.
+//!
+//! Exceptions:
+//! - Bootstrap configs (database, secrets): env-only (DB not yet available)
+//! - Security-sensitive fields (allow_local_tools, allow_full_access,
+//!   cost limits, auth tokens): env-only
+//! - API keys: env/secrets store only
 //!
 //! `DATABASE_URL` lives in `~/.ironclaw/.env` (loaded via dotenvy early
 //! in startup).
@@ -191,9 +200,9 @@ impl Config {
 
     /// Load configuration from environment variables and the database.
     ///
-    /// TOML is loaded first as a base, then DB values are merged on top
-    /// (DB wins over TOML). Individual subsystem resolvers then apply
-    /// their own env-vs-DB priority — see module docs for details.
+    /// Priority: DB/TOML > env > default. TOML is loaded first as a
+    /// base, then DB values are merged on top. Subsystem resolvers check
+    /// the merged settings before env vars (except bootstrap/security fields).
     pub async fn from_db(
         store: &(dyn crate::db::SettingsStore + Sync),
         user_id: &str,
@@ -203,9 +212,8 @@ impl Config {
 
     /// Load from DB with an optional TOML config file overlay.
     ///
-    /// TOML is loaded first as a base, then DB values are merged on top
-    /// (DB wins over TOML). Per-subsystem resolvers then decide whether
-    /// env vars or DB values take final precedence — see module docs.
+    /// Priority: DB/TOML > env > default. TOML is loaded as the base,
+    /// then DB values are merged on top. See module docs for exceptions.
     pub async fn from_db_with_toml(
         store: &(dyn crate::db::SettingsStore + Sync),
         user_id: &str,
@@ -366,13 +374,13 @@ impl Config {
             secrets: SecretsConfig::resolve().await?,
             builder: BuilderModeConfig::resolve(settings)?,
             heartbeat: HeartbeatConfig::resolve(settings)?,
-            hygiene: HygieneConfig::resolve()?,
-            routines: RoutineConfig::resolve()?,
+            hygiene: HygieneConfig::resolve(settings)?,
+            routines: RoutineConfig::resolve(settings)?,
             sandbox: SandboxModeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
-            skills: SkillsConfig::resolve()?,
+            skills: SkillsConfig::resolve(settings)?,
             transcription: TranscriptionConfig::resolve(settings)?,
-            search: WorkspaceSearchConfig::resolve()?,
+            search: WorkspaceSearchConfig::resolve(settings)?,
             workspace,
             observability: crate::observability::ObservabilityConfig {
                 backend: std::env::var("OBSERVABILITY_BACKEND").unwrap_or_else(|_| "none".into()),

--- a/src/config/oauth.rs
+++ b/src/config/oauth.rs
@@ -1,0 +1,182 @@
+//! OAuth provider configuration for direct social login.
+
+use secrecy::SecretString;
+
+use crate::config::helpers::{optional_env, parse_bool_env};
+use crate::error::ConfigError;
+
+/// OAuth/social login configuration.
+///
+/// Disabled by default. When enabled, the gateway exposes `/auth/*` routes
+/// for login flows. Each provider is independently configured via env vars:
+/// Google/GitHub require `CLIENT_ID` + `CLIENT_SECRET`, Apple requires
+/// `CLIENT_ID` + `TEAM_ID` + `KEY_ID` + private key, NEAR requires
+/// `NEAR_AUTH_ENABLED=true`.
+#[derive(Debug, Clone, Default)]
+pub struct OAuthConfig {
+    /// Whether OAuth social login is enabled.
+    pub enabled: bool,
+    /// Base URL for constructing OAuth callback URLs
+    /// (e.g. `https://myapp.example.com`).
+    /// Falls back to `http://localhost:{gateway_port}` if unset.
+    pub base_url: Option<String>,
+    /// Restrict OAuth login to users with verified emails from these domains.
+    /// Empty means allow all domains. Applied to all OAuth providers and OIDC.
+    /// Parsed from `OAUTH_ALLOWED_DOMAINS` (comma-separated, e.g. `company.com,partner.org`).
+    pub allowed_domains: Vec<String>,
+    /// Google OAuth configuration (OIDC).
+    pub google: Option<GoogleOAuthConfig>,
+    /// GitHub OAuth configuration.
+    pub github: Option<GitHubOAuthConfig>,
+    /// Apple Sign In configuration.
+    pub apple: Option<AppleOAuthConfig>,
+    /// NEAR wallet authentication (signature-based, not OAuth).
+    pub near: Option<NearAuthConfig>,
+}
+
+/// Google OAuth 2.0 / OIDC configuration.
+#[derive(Debug, Clone)]
+pub struct GoogleOAuthConfig {
+    pub client_id: String,
+    pub client_secret: SecretString,
+    /// Restrict to a specific Google Workspace (G Suite) hosted domain.
+    /// Sets the `hd` parameter in the authorization URL so Google only
+    /// shows accounts from this domain. Also validated server-side after
+    /// code exchange. Parsed from `GOOGLE_ALLOWED_HD`.
+    pub allowed_hd: Option<String>,
+}
+
+/// GitHub OAuth 2.0 configuration.
+#[derive(Debug, Clone)]
+pub struct GitHubOAuthConfig {
+    pub client_id: String,
+    pub client_secret: SecretString,
+}
+
+/// Apple Sign In configuration.
+///
+/// Apple uses OIDC but requires a JWT `client_secret` signed with an ES256
+/// private key from the Apple Developer portal.
+#[derive(Debug, Clone)]
+pub struct AppleOAuthConfig {
+    /// Services ID (e.g. `com.example.myapp`).
+    pub client_id: String,
+    /// Apple Developer Team ID (10-character string).
+    pub team_id: String,
+    /// Key ID from the Apple Developer portal.
+    pub key_id: String,
+    /// ES256 private key in PEM format (contents of the `.p8` file).
+    pub private_key_pem: SecretString,
+}
+
+/// NEAR wallet authentication configuration.
+///
+/// Uses NEP-413 signature verification instead of OAuth. The server generates
+/// a challenge nonce, the client signs it with a NEAR wallet, and the server
+/// verifies the Ed25519 signature and confirms the public key belongs to the
+/// claimed account via NEAR RPC.
+#[derive(Debug, Clone)]
+pub struct NearAuthConfig {
+    /// NEAR network: `mainnet` or `testnet`.
+    pub network: String,
+    /// NEAR RPC endpoint URL.
+    pub rpc_url: String,
+}
+
+impl OAuthConfig {
+    pub fn resolve() -> Result<Self, ConfigError> {
+        let enabled = parse_bool_env("OAUTH_ENABLED", false)?;
+        if !enabled {
+            return Ok(Self::default());
+        }
+
+        let base_url = optional_env("OAUTH_BASE_URL")?;
+
+        let allowed_domains: Vec<String> = optional_env("OAUTH_ALLOWED_DOMAINS")?
+            .map(|s| {
+                s.split(',')
+                    .map(|d| d.trim().to_ascii_lowercase())
+                    .filter(|d| !d.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let google = match (
+            optional_env("GOOGLE_CLIENT_ID")?,
+            optional_env("GOOGLE_CLIENT_SECRET")?,
+        ) {
+            (Some(id), Some(secret)) => Some(GoogleOAuthConfig {
+                client_id: id,
+                client_secret: SecretString::from(secret),
+                allowed_hd: optional_env("GOOGLE_ALLOWED_HD")?,
+            }),
+            _ => None,
+        };
+
+        let github = match (
+            optional_env("GITHUB_CLIENT_ID")?,
+            optional_env("GITHUB_CLIENT_SECRET")?,
+        ) {
+            (Some(id), Some(secret)) => Some(GitHubOAuthConfig {
+                client_id: id,
+                client_secret: SecretString::from(secret),
+            }),
+            _ => None,
+        };
+
+        let apple = match (
+            optional_env("APPLE_CLIENT_ID")?,
+            optional_env("APPLE_TEAM_ID")?,
+            optional_env("APPLE_KEY_ID")?,
+        ) {
+            (Some(client_id), Some(team_id), Some(key_id)) => {
+                // Read the private key from a file path or directly from env.
+                let pem = if let Some(path) = optional_env("APPLE_PRIVATE_KEY_PATH")? {
+                    std::fs::read_to_string(&path).map_err(|e| ConfigError::InvalidValue {
+                        key: "APPLE_PRIVATE_KEY_PATH".to_string(),
+                        message: format!("failed to read Apple private key from '{path}': {e}"),
+                    })?
+                } else if let Some(pem) = optional_env("APPLE_PRIVATE_KEY_PEM")? {
+                    pem
+                } else {
+                    return Err(ConfigError::InvalidValue {
+                        key: "APPLE_PRIVATE_KEY_PATH".to_string(),
+                        message: "either APPLE_PRIVATE_KEY_PATH or APPLE_PRIVATE_KEY_PEM is \
+                                  required when APPLE_CLIENT_ID is set"
+                            .to_string(),
+                    });
+                };
+                Some(AppleOAuthConfig {
+                    client_id,
+                    team_id,
+                    key_id,
+                    private_key_pem: SecretString::from(pem),
+                })
+            }
+            _ => None,
+        };
+
+        let near = if parse_bool_env("NEAR_AUTH_ENABLED", false)? {
+            let network =
+                optional_env("NEAR_AUTH_NETWORK")?.unwrap_or_else(|| "mainnet".to_string());
+            let rpc_url =
+                optional_env("NEAR_AUTH_RPC_URL")?.unwrap_or_else(|| match network.as_str() {
+                    "testnet" => "https://rpc.testnet.near.org".to_string(),
+                    _ => "https://rpc.mainnet.near.org".to_string(),
+                });
+            Some(NearAuthConfig { network, rpc_url })
+        } else {
+            None
+        };
+
+        Ok(Self {
+            enabled,
+            base_url,
+            allowed_domains,
+            google,
+            github,
+            apple,
+            near,
+        })
+    }
+}

--- a/src/config/routines.rs
+++ b/src/config/routines.rs
@@ -1,5 +1,6 @@
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Routines configuration.
 #[derive(Debug, Clone)]
@@ -35,15 +36,42 @@ impl Default for RoutineConfig {
 }
 
 impl RoutineConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
-        let max_iterations: u32 = parse_optional_env("ROUTINES_LIGHTWEIGHT_MAX_ITERATIONS", 3)?;
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::RoutineSettings::default();
+        let rs = &settings.routines;
+
+        let max_iterations: u32 = db_first_or_default(
+            &rs.lightweight_max_iterations,
+            &defaults.lightweight_max_iterations,
+            "ROUTINES_LIGHTWEIGHT_MAX_ITERATIONS",
+        )?;
         Ok(Self {
-            enabled: parse_bool_env("ROUTINES_ENABLED", true)?,
-            cron_check_interval_secs: parse_optional_env("ROUTINES_CRON_INTERVAL", 15)?,
-            max_concurrent_routines: parse_optional_env("ROUTINES_MAX_CONCURRENT", 10)?,
-            default_cooldown_secs: parse_optional_env("ROUTINES_DEFAULT_COOLDOWN", 300)?,
-            max_lightweight_tokens: parse_optional_env("ROUTINES_MAX_TOKENS", 4096)?,
-            lightweight_tools_enabled: parse_bool_env("ROUTINES_LIGHTWEIGHT_TOOLS", true)?,
+            enabled: db_first_bool(rs.enabled, defaults.enabled, "ROUTINES_ENABLED")?,
+            cron_check_interval_secs: db_first_or_default(
+                &rs.cron_check_interval_secs,
+                &defaults.cron_check_interval_secs,
+                "ROUTINES_CRON_INTERVAL",
+            )?,
+            max_concurrent_routines: db_first_or_default(
+                &rs.max_concurrent_routines,
+                &defaults.max_concurrent_routines,
+                "ROUTINES_MAX_CONCURRENT",
+            )?,
+            default_cooldown_secs: db_first_or_default(
+                &rs.default_cooldown_secs,
+                &defaults.default_cooldown_secs,
+                "ROUTINES_DEFAULT_COOLDOWN",
+            )?,
+            max_lightweight_tokens: db_first_or_default(
+                &rs.max_lightweight_tokens,
+                &defaults.max_lightweight_tokens,
+                "ROUTINES_MAX_TOKENS",
+            )?,
+            lightweight_tools_enabled: db_first_bool(
+                rs.lightweight_tools_enabled,
+                defaults.lightweight_tools_enabled,
+                "ROUTINES_LIGHTWEIGHT_TOOLS",
+            )?,
             lightweight_max_iterations: max_iterations.min(5), // cap at 5
         })
     }

--- a/src/config/safety.rs
+++ b/src/config/safety.rs
@@ -1,4 +1,4 @@
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
 
 pub use ironclaw_safety::SafetyConfig;
@@ -7,11 +7,17 @@ pub(crate) fn resolve_safety_config(
     settings: &crate::settings::Settings,
 ) -> Result<SafetyConfig, ConfigError> {
     let ss = &settings.safety;
+    let defaults = crate::settings::SafetySettings::default();
     Ok(SafetyConfig {
-        max_output_length: parse_optional_env("SAFETY_MAX_OUTPUT_LENGTH", ss.max_output_length)?,
-        injection_check_enabled: parse_bool_env(
-            "SAFETY_INJECTION_CHECK_ENABLED",
+        max_output_length: db_first_or_default(
+            &ss.max_output_length,
+            &defaults.max_output_length,
+            "SAFETY_MAX_OUTPUT_LENGTH",
+        )?,
+        injection_check_enabled: db_first_bool(
             ss.injection_check_enabled,
+            defaults.injection_check_enabled,
+            "SAFETY_INJECTION_CHECK_ENABLED",
         )?,
     })
 }
@@ -35,9 +41,10 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
+        // Non-default value simulates an explicit DB/TOML setting
         settings.safety.max_output_length = 42;
 
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
@@ -45,6 +52,25 @@ mod tests {
         let cfg = resolve_safety_config(&settings).expect("resolve");
         unsafe { std::env::remove_var("SAFETY_MAX_OUTPUT_LENGTH") };
 
+        // DB value (42) wins over env value (7)
+        assert_eq!(cfg.max_output_length, 42);
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        // Settings left at defaults — no explicit DB/TOML override
+        let settings = Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SAFETY_MAX_OUTPUT_LENGTH", "7") };
+        unsafe { std::env::set_var("SAFETY_INJECTION_CHECK_ENABLED", "false") };
+        let cfg = resolve_safety_config(&settings).expect("resolve");
+        unsafe { std::env::remove_var("SAFETY_MAX_OUTPUT_LENGTH") };
+        unsafe { std::env::remove_var("SAFETY_INJECTION_CHECK_ENABLED") };
+
+        // Env values win when settings are at their defaults
         assert_eq!(cfg.max_output_length, 7);
+        assert!(!cfg.injection_check_enabled);
     }
 }

--- a/src/config/sandbox.rs
+++ b/src/config/sandbox.rs
@@ -1,4 +1,7 @@
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env, parse_string_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_bool_env, parse_optional_env,
+    parse_string_env,
+};
 use crate::error::ConfigError;
 
 /// Docker sandbox configuration.
@@ -54,16 +57,16 @@ impl Default for SandboxModeConfig {
 impl SandboxModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ss = &settings.sandbox;
+        let defaults = crate::settings::SandboxSettings::default();
 
-        let extra_domains = optional_env("SANDBOX_EXTRA_DOMAINS")?
-            .map(|s| s.split(',').map(|d| d.trim().to_string()).collect())
-            .unwrap_or_else(|| {
-                if ss.extra_allowed_domains.is_empty() {
-                    Vec::new()
-                } else {
-                    ss.extra_allowed_domains.clone()
-                }
-            });
+        // extra_allowed_domains: DB wins if non-empty, otherwise env, otherwise empty.
+        let extra_domains = if !ss.extra_allowed_domains.is_empty() {
+            ss.extra_allowed_domains.clone()
+        } else {
+            optional_env("SANDBOX_EXTRA_DOMAINS")?
+                .map(|s| s.split(',').map(|d| d.trim().to_string()).collect())
+                .unwrap_or_default()
+        };
 
         // reaper/orphan fields have no Settings counterpart — env > default only.
         let reaper_interval_secs: u64 = parse_optional_env("SANDBOX_REAPER_INTERVAL_SECS", 300)?;
@@ -85,15 +88,31 @@ impl SandboxModeConfig {
         }
 
         Ok(Self {
-            enabled: parse_bool_env("SANDBOX_ENABLED", ss.enabled)?,
-            policy: parse_string_env("SANDBOX_POLICY", ss.policy.clone())?,
-            // allow_full_access has no Settings counterpart — env > default only.
+            enabled: db_first_bool(ss.enabled, defaults.enabled, "SANDBOX_ENABLED")?,
+            policy: db_first_or_default(&ss.policy, &defaults.policy, "SANDBOX_POLICY")?,
+            // allow_full_access has no Settings counterpart — env > default only (security).
             allow_full_access: parse_bool_env("SANDBOX_ALLOW_FULL_ACCESS", false)?,
-            timeout_secs: parse_optional_env("SANDBOX_TIMEOUT_SECS", ss.timeout_secs)?,
-            memory_limit_mb: parse_optional_env("SANDBOX_MEMORY_LIMIT_MB", ss.memory_limit_mb)?,
-            cpu_shares: parse_optional_env("SANDBOX_CPU_SHARES", ss.cpu_shares)?,
-            image: parse_string_env("SANDBOX_IMAGE", ss.image.clone())?,
-            auto_pull_image: parse_bool_env("SANDBOX_AUTO_PULL", ss.auto_pull_image)?,
+            timeout_secs: db_first_or_default(
+                &ss.timeout_secs,
+                &defaults.timeout_secs,
+                "SANDBOX_TIMEOUT_SECS",
+            )?,
+            memory_limit_mb: db_first_or_default(
+                &ss.memory_limit_mb,
+                &defaults.memory_limit_mb,
+                "SANDBOX_MEMORY_LIMIT_MB",
+            )?,
+            cpu_shares: db_first_or_default(
+                &ss.cpu_shares,
+                &defaults.cpu_shares,
+                "SANDBOX_CPU_SHARES",
+            )?,
+            image: db_first_or_default(&ss.image, &defaults.image, "SANDBOX_IMAGE")?,
+            auto_pull_image: db_first_bool(
+                ss.auto_pull_image,
+                defaults.auto_pull_image,
+                "SANDBOX_AUTO_PULL",
+            )?,
             extra_allowed_domains: extra_domains,
             reaper_interval_secs,
             orphan_threshold_secs,
@@ -264,19 +283,28 @@ impl ClaudeCodeConfig {
     }
 
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
+        let ss = &settings.sandbox;
         let defaults = Self::default();
         Ok(Self {
-            // Use settings.sandbox.claude_code_enabled as fallback (written by setup wizard).
-            enabled: parse_bool_env("CLAUDE_CODE_ENABLED", settings.sandbox.claude_code_enabled)?,
+            enabled: db_first_bool(
+                ss.claude_code_enabled,
+                defaults.enabled,
+                "CLAUDE_CODE_ENABLED",
+            )?,
+            // config_dir has no Settings counterpart — env > default only.
             config_dir: optional_env("CLAUDE_CONFIG_DIR")?
                 .map(std::path::PathBuf::from)
                 .unwrap_or(defaults.config_dir),
+            // model has no Settings counterpart — env > default only.
             model: parse_string_env("CLAUDE_CODE_MODEL", defaults.model)?,
+            // max_turns has no Settings counterpart — env > default only.
             max_turns: parse_optional_env("CLAUDE_CODE_MAX_TURNS", defaults.max_turns)?,
+            // memory_limit_mb has no Settings counterpart — env > default only.
             memory_limit_mb: parse_optional_env(
                 "CLAUDE_CODE_MEMORY_LIMIT_MB",
                 defaults.memory_limit_mb,
             )?,
+            // allowed_tools has no Settings counterpart — env > default only.
             allowed_tools: optional_env("CLAUDE_CODE_ALLOWED_TOOLS")?
                 .map(|s| {
                     s.split(',')
@@ -607,7 +635,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_env_overrides_settings() {
+    fn sandbox_db_settings_override_env() {
         let _guard = crate::config::helpers::lock_env();
         let mut settings = crate::settings::Settings::default();
         settings.sandbox.timeout_secs = 999;
@@ -617,7 +645,26 @@ mod tests {
         let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("SANDBOX_TIMEOUT_SECS") };
 
-        assert_eq!(cfg.timeout_secs, 5);
+        // DB value (999) wins over env (5) under DB-first priority.
+        assert_eq!(cfg.timeout_secs, 999);
+    }
+
+    #[test]
+    fn sandbox_env_used_when_no_db_setting() {
+        let _guard = crate::config::helpers::lock_env();
+        // Default settings — all fields at their defaults, so DB is "unset".
+        let settings = crate::settings::Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SANDBOX_TIMEOUT_SECS", "42") };
+        unsafe { std::env::set_var("SANDBOX_MEMORY_LIMIT_MB", "512") };
+        let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("SANDBOX_TIMEOUT_SECS") };
+        unsafe { std::env::remove_var("SANDBOX_MEMORY_LIMIT_MB") };
+
+        // Env values win when settings are at their defaults.
+        assert_eq!(cfg.timeout_secs, 42);
+        assert_eq!(cfg.memory_limit_mb, 512);
     }
 
     // ── ClaudeCodeConfig settings fallback tests ────────────────────
@@ -641,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_code_env_overrides_settings() {
+    fn claude_code_db_settings_override_env() {
         let _guard = crate::config::helpers::lock_env();
         let mut settings = crate::settings::Settings::default();
         settings.sandbox.claude_code_enabled = true;
@@ -651,7 +698,8 @@ mod tests {
         let cfg = ClaudeCodeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("CLAUDE_CODE_ENABLED") };
 
-        assert!(!cfg.enabled);
+        // DB value (true) wins over env (false) under DB-first priority.
+        assert!(cfg.enabled);
     }
 
     #[test]

--- a/src/config/sandbox.rs
+++ b/src/config/sandbox.rs
@@ -357,6 +357,62 @@ fn parse_oauth_access_token(json: &str) -> Option<String> {
     Some(token.to_string())
 }
 
+/// ACP (Agent Client Protocol) mode configuration.
+///
+/// Controls whether ACP agent delegation is available. Agent definitions
+/// are stored separately in a DB blob (key `"acp_agents"`) or disk file
+/// (`~/.ironclaw/acp-agents.json`), following the MCP server pattern.
+#[derive(Debug, Clone)]
+pub struct AcpModeConfig {
+    /// Whether ACP agent mode is available.
+    pub enabled: bool,
+    /// Memory limit in MB for ACP containers.
+    pub memory_limit_mb: u64,
+    /// Maximum timeout for an ACP session in seconds.
+    pub timeout_secs: u64,
+}
+
+impl Default for AcpModeConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            memory_limit_mb: 4096,
+            timeout_secs: 1800,
+        }
+    }
+}
+
+impl AcpModeConfig {
+    /// Load from environment variables only (used inside containers).
+    pub fn from_env() -> Self {
+        match Self::resolve_env_only() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!("Failed to resolve AcpModeConfig: {e}, using defaults");
+                Self::default()
+            }
+        }
+    }
+
+    pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
+        let defaults = Self::default();
+        Ok(Self {
+            enabled: parse_bool_env("ACP_ENABLED", settings.sandbox.acp_enabled)?,
+            memory_limit_mb: parse_optional_env("ACP_MEMORY_LIMIT_MB", defaults.memory_limit_mb)?,
+            timeout_secs: parse_optional_env("ACP_TIMEOUT_SECS", defaults.timeout_secs)?,
+        })
+    }
+
+    fn resolve_env_only() -> Result<Self, ConfigError> {
+        let defaults = Self::default();
+        Ok(Self {
+            enabled: parse_bool_env("ACP_ENABLED", defaults.enabled)?,
+            memory_limit_mb: parse_optional_env("ACP_MEMORY_LIMIT_MB", defaults.memory_limit_mb)?,
+            timeout_secs: parse_optional_env("ACP_TIMEOUT_SECS", defaults.timeout_secs)?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::config::sandbox::*;
@@ -711,5 +767,45 @@ mod tests {
         };
         let sandbox = config.to_sandbox_config();
         assert_eq!(sandbox.policy, crate::sandbox::SandboxPolicy::ReadOnly);
+    }
+
+    // ── AcpModeConfig defaults ──────────────────────────────────
+
+    #[test]
+    fn acp_mode_config_default_values() {
+        let cfg = AcpModeConfig::default();
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.memory_limit_mb, 4096);
+        assert_eq!(cfg.timeout_secs, 1800);
+    }
+
+    #[test]
+    fn acp_mode_config_resolve_uses_settings() {
+        let _guard = crate::config::helpers::lock_env();
+        let mut settings = crate::settings::Settings::default();
+        settings.sandbox.acp_enabled = true;
+
+        let cfg = AcpModeConfig::resolve(&settings).expect("resolve");
+        assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn acp_mode_config_env_overrides_settings() {
+        let _guard = crate::config::helpers::lock_env();
+        let mut settings = crate::settings::Settings::default();
+        settings.sandbox.acp_enabled = true;
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("ACP_ENABLED", "false") };
+        unsafe { std::env::set_var("ACP_MEMORY_LIMIT_MB", "8192") };
+        unsafe { std::env::set_var("ACP_TIMEOUT_SECS", "3600") };
+        let cfg = AcpModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("ACP_ENABLED") };
+        unsafe { std::env::remove_var("ACP_MEMORY_LIMIT_MB") };
+        unsafe { std::env::remove_var("ACP_TIMEOUT_SECS") };
+
+        assert!(!cfg.enabled);
+        assert_eq!(cfg.memory_limit_mb, 8192);
+        assert_eq!(cfg.timeout_secs, 3600);
     }
 }

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -1,5 +1,6 @@
-use crate::config::helpers::{optional_env, parse_optional_env};
+use crate::config::helpers::{db_first_option, db_first_or_default, parse_optional_env};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 use crate::workspace::FusionStrategy;
 
 /// Workspace search configuration resolved from environment variables.
@@ -33,30 +34,41 @@ impl Default for WorkspaceSearchConfig {
 }
 
 impl WorkspaceSearchConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
-        let fusion_strategy = match optional_env("SEARCH_FUSION_STRATEGY")? {
-            Some(s) => match s.to_lowercase().as_str() {
-                "rrf" => FusionStrategy::Rrf,
-                "weighted" => FusionStrategy::WeightedScore,
-                other => {
-                    return Err(ConfigError::InvalidValue {
-                        key: "SEARCH_FUSION_STRATEGY".to_string(),
-                        message: format!("must be 'rrf' or 'weighted', got '{other}'"),
-                    });
-                }
-            },
-            None => FusionStrategy::default(),
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::SearchSettings::default();
+        let ss = &settings.search;
+
+        // Resolve fusion_strategy string via DB-first, then parse into enum.
+        let strategy_str = db_first_or_default(
+            &ss.fusion_strategy,
+            &defaults.fusion_strategy,
+            "SEARCH_FUSION_STRATEGY",
+        )?;
+        let fusion_strategy = match strategy_str.to_lowercase().as_str() {
+            "rrf" => FusionStrategy::Rrf,
+            "weighted" => FusionStrategy::WeightedScore,
+            other => {
+                return Err(ConfigError::InvalidValue {
+                    key: "SEARCH_FUSION_STRATEGY".to_string(),
+                    message: format!("must be 'rrf' or 'weighted', got '{other}'"),
+                });
+            }
         };
 
-        let rrf_k = parse_optional_env("SEARCH_RRF_K", 60u32)?;
+        let rrf_k = db_first_or_default(&ss.rrf_k, &defaults.rrf_k, "SEARCH_RRF_K")?;
 
         // Per-strategy weight defaults: RRF uses 0.5/0.5, weighted uses 0.3/0.7 (vector-biased).
         let (default_fts, default_vec) = match fusion_strategy {
             FusionStrategy::Rrf => (0.5f32, 0.5f32),
             FusionStrategy::WeightedScore => (0.3f32, 0.7f32),
         };
-        let fts_weight = parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?;
-        let vector_weight = parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?;
+
+        // Weights: DB (Some) > env > per-strategy default.
+        // Uses db_first_option for shadow warnings when DB overrides env.
+        let fts_weight = db_first_option(&ss.fts_weight, "SEARCH_FTS_WEIGHT")?
+            .unwrap_or(parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?);
+        let vector_weight = db_first_option(&ss.vector_weight, "SEARCH_VECTOR_WEIGHT")?
+            .unwrap_or(parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?);
 
         if !fts_weight.is_finite() || fts_weight < 0.0 {
             return Err(ConfigError::InvalidValue {
@@ -109,7 +121,8 @@ mod tests {
         let _guard = lock_env();
         clear_search_env();
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
         assert_eq!(config.rrf_k, 60);
         assert!((config.fts_weight - 0.5).abs() < 0.001);
@@ -117,7 +130,35 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides() {
+    fn db_settings_override_env() {
+        let _guard = lock_env();
+        clear_search_env();
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("SEARCH_FUSION_STRATEGY", "rrf");
+            std::env::set_var("SEARCH_RRF_K", "30");
+            std::env::set_var("SEARCH_FTS_WEIGHT", "0.9");
+            std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.1");
+        }
+
+        let mut settings = Settings::default();
+        settings.search.fusion_strategy = "weighted".to_string();
+        settings.search.rrf_k = 42;
+        settings.search.fts_weight = Some(0.4);
+        settings.search.vector_weight = Some(0.6);
+
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
+        assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
+        assert_eq!(config.rrf_k, 42);
+        assert!((config.fts_weight - 0.4).abs() < 0.001);
+        assert!((config.vector_weight - 0.6).abs() < 0.001);
+
+        clear_search_env();
+    }
+
+    #[test]
+    fn env_fallback_when_settings_at_default() {
         let _guard = lock_env();
         clear_search_env();
 
@@ -129,7 +170,8 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.1");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         assert_eq!(config.rrf_k, 30);
         assert!((config.fts_weight - 0.9).abs() < 0.001);
@@ -148,7 +190,8 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "bm25");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let settings = Settings::default();
+        let result = WorkspaceSearchConfig::resolve(&settings);
         assert!(result.is_err());
 
         clear_search_env();
@@ -164,7 +207,8 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "weighted");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         // Weighted mode should default to 0.3 FTS / 0.7 vector
         assert!((config.fts_weight - 0.3).abs() < 0.001);
@@ -185,7 +229,8 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.0");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let settings = Settings::default();
+        let result = WorkspaceSearchConfig::resolve(&settings);
         assert!(result.is_err());
 
         clear_search_env();
@@ -203,7 +248,8 @@ mod tests {
         }
 
         // RRF ignores weights, so both=0 is fine
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
 
         clear_search_env();

--- a/src/config/skills.rs
+++ b/src/config/skills.rs
@@ -1,8 +1,11 @@
 use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_optional_env,
+};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Skills system configuration.
 #[derive(Debug, Clone)]
@@ -48,17 +51,29 @@ fn default_installed_skills_dir() -> PathBuf {
 }
 
 impl SkillsConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::SkillsSettings::default();
+        let ss = &settings.skills;
+
         Ok(Self {
-            enabled: parse_bool_env("SKILLS_ENABLED", true)?,
+            enabled: db_first_bool(ss.enabled, defaults.enabled, "SKILLS_ENABLED")?,
+            // local_dir and installed_dir are env-only (filesystem paths, no settings counterpart)
             local_dir: optional_env("SKILLS_DIR")?
                 .map(PathBuf::from)
                 .unwrap_or_else(default_skills_dir),
             installed_dir: optional_env("SKILLS_INSTALLED_DIR")?
                 .map(PathBuf::from)
                 .unwrap_or_else(default_installed_skills_dir),
-            max_active_skills: parse_optional_env("SKILLS_MAX_ACTIVE", 3)?,
-            max_context_tokens: parse_optional_env("SKILLS_MAX_CONTEXT_TOKENS", 4000)?,
+            max_active_skills: db_first_or_default(
+                &ss.max_active_skills,
+                &defaults.max_active_skills,
+                "SKILLS_MAX_ACTIVE",
+            )?,
+            max_context_tokens: db_first_or_default(
+                &ss.max_context_tokens,
+                &defaults.max_context_tokens,
+                "SKILLS_MAX_CONTEXT_TOKENS",
+            )?,
             max_scan_depth: parse_optional_env("SKILLS_MAX_SCAN_DEPTH", 3)?,
         })
     }

--- a/src/config/transcription.rs
+++ b/src/config/transcription.rs
@@ -39,10 +39,11 @@ impl Default for TranscriptionConfig {
 
 impl TranscriptionConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
-        let enabled = parse_bool_env(
-            "TRANSCRIPTION_ENABLED",
-            settings.transcription.as_ref().is_some_and(|t| t.enabled),
-        )?;
+        // Tri-state: Some(true/false) = explicit DB value, None = unset (fall back to env).
+        let enabled = match settings.transcription.as_ref().map(|t| t.enabled) {
+            Some(db_enabled) => db_enabled,
+            None => parse_bool_env("TRANSCRIPTION_ENABLED", false)?,
+        };
 
         let provider =
             optional_env("TRANSCRIPTION_PROVIDER")?.unwrap_or_else(|| "openai".to_string());

--- a/src/config/tunnel.rs
+++ b/src/config/tunnel.rs
@@ -1,11 +1,13 @@
-use crate::config::helpers::optional_env;
+use crate::config::helpers::{db_first_bool, db_first_optional_string, optional_env};
 use crate::error::ConfigError;
-use crate::settings::Settings;
+use crate::settings::{Settings, TunnelSettings};
 
 /// Tunnel configuration for exposing the agent to the internet.
 ///
 /// Used by channels and tools that need public webhook endpoints.
 /// The tunnel URL is shared across all channels (Telegram, Slack, etc.).
+///
+/// Resolution priority: DB/settings > env var > default.
 ///
 /// Two modes:
 /// - **Static URL** (`TUNNEL_URL`): set the public URL directly (manual tunnel)
@@ -25,8 +27,10 @@ pub struct TunnelConfig {
 
 impl TunnelConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
-        let public_url = optional_env("TUNNEL_URL")?
-            .or_else(|| settings.tunnel.public_url.clone().filter(|s| !s.is_empty()));
+        let defaults = TunnelSettings::default();
+
+        // Priority: DB/settings > env > default.
+        let public_url = db_first_optional_string(&settings.tunnel.public_url, "TUNNEL_URL")?;
 
         if let Some(ref url) = public_url
             && !url.starts_with("https://")
@@ -38,9 +42,8 @@ impl TunnelConfig {
         }
 
         // Resolve managed tunnel provider config.
-        // Priority: env var > settings > default (none).
-        let provider_name = optional_env("TUNNEL_PROVIDER")?
-            .or_else(|| settings.tunnel.provider.clone())
+        // Priority: DB/settings > env > default (none).
+        let provider_name = db_first_optional_string(&settings.tunnel.provider, "TUNNEL_PROVIDER")?
             .unwrap_or_default();
 
         let provider = if provider_name.is_empty() || provider_name == "none" {
@@ -48,38 +51,64 @@ impl TunnelConfig {
         } else {
             Some(crate::tunnel::TunnelProviderConfig {
                 provider: provider_name.clone(),
-                cloudflare: optional_env("TUNNEL_CF_TOKEN")?
-                    .or_else(|| settings.tunnel.cf_token.clone())
-                    .map(|token| crate::tunnel::CloudflareTunnelConfig { token }),
+                // Security: tunnel auth tokens are env-only (sensitive credentials).
+                cloudflare: {
+                    if settings.tunnel.cf_token.is_some() {
+                        tracing::warn!(
+                            "tunnel.cf_token is set in DB/TOML but is now env-only \
+                             (TUNNEL_CF_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("TUNNEL_CF_TOKEN")?
+                        .map(|token| crate::tunnel::CloudflareTunnelConfig { token })
+                },
                 tailscale: Some(crate::tunnel::TailscaleTunnelConfig {
-                    funnel: optional_env("TUNNEL_TS_FUNNEL")?
-                        .map(|s| s == "true" || s == "1")
-                        .unwrap_or(settings.tunnel.ts_funnel),
-                    hostname: optional_env("TUNNEL_TS_HOSTNAME")?
-                        .or_else(|| settings.tunnel.ts_hostname.clone()),
+                    funnel: db_first_bool(
+                        settings.tunnel.ts_funnel,
+                        defaults.ts_funnel,
+                        "TUNNEL_TS_FUNNEL",
+                    )?,
+                    hostname: db_first_optional_string(
+                        &settings.tunnel.ts_hostname,
+                        "TUNNEL_TS_HOSTNAME",
+                    )?,
                 }),
                 ngrok: {
-                    let ngrok_domain = optional_env("TUNNEL_NGROK_DOMAIN")?
-                        .or_else(|| settings.tunnel.ngrok_domain.clone());
-                    optional_env("TUNNEL_NGROK_TOKEN")?
-                        .or_else(|| settings.tunnel.ngrok_token.clone())
-                        .map(|auth_token| crate::tunnel::NgrokTunnelConfig {
+                    let ngrok_domain = db_first_optional_string(
+                        &settings.tunnel.ngrok_domain,
+                        "TUNNEL_NGROK_DOMAIN",
+                    )?;
+                    if settings.tunnel.ngrok_token.is_some() {
+                        tracing::warn!(
+                            "tunnel.ngrok_token is set in DB/TOML but is now env-only \
+                             (TUNNEL_NGROK_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("TUNNEL_NGROK_TOKEN")?.map(|auth_token| {
+                        crate::tunnel::NgrokTunnelConfig {
                             auth_token,
                             domain: ngrok_domain,
-                        })
+                        }
+                    })
                 },
                 custom: {
-                    let health_url = optional_env("TUNNEL_CUSTOM_HEALTH_URL")?
-                        .or_else(|| settings.tunnel.custom_health_url.clone());
-                    let url_pattern = optional_env("TUNNEL_CUSTOM_URL_PATTERN")?
-                        .or_else(|| settings.tunnel.custom_url_pattern.clone());
-                    optional_env("TUNNEL_CUSTOM_COMMAND")?
-                        .or_else(|| settings.tunnel.custom_command.clone())
-                        .map(|start_command| crate::tunnel::CustomTunnelConfig {
-                            start_command,
-                            health_url,
-                            url_pattern,
-                        })
+                    let health_url = db_first_optional_string(
+                        &settings.tunnel.custom_health_url,
+                        "TUNNEL_CUSTOM_HEALTH_URL",
+                    )?;
+                    let url_pattern = db_first_optional_string(
+                        &settings.tunnel.custom_url_pattern,
+                        "TUNNEL_CUSTOM_URL_PATTERN",
+                    )?;
+                    db_first_optional_string(
+                        &settings.tunnel.custom_command,
+                        "TUNNEL_CUSTOM_COMMAND",
+                    )?
+                    .map(|start_command| crate::tunnel::CustomTunnelConfig {
+                        start_command,
+                        health_url,
+                        url_pattern,
+                    })
                 },
             })
         };

--- a/src/config/wasm.rs
+++ b/src/config/wasm.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default, optional_env};
 use crate::error::ConfigError;
 
 /// WASM sandbox configuration.
@@ -46,28 +46,41 @@ fn default_tools_dir() -> PathBuf {
 impl WasmConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ws = &settings.wasm;
+        let defaults = crate::settings::WasmSettings::default();
         Ok(Self {
-            enabled: parse_bool_env("WASM_ENABLED", ws.enabled)?,
-            tools_dir: optional_env("WASM_TOOLS_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| ws.tools_dir.clone())
-                .unwrap_or_else(default_tools_dir),
-            default_memory_limit: parse_optional_env(
+            enabled: db_first_bool(ws.enabled, defaults.enabled, "WASM_ENABLED")?,
+            tools_dir: if let Some(ref dir) = ws.tools_dir {
+                dir.clone()
+            } else {
+                optional_env("WASM_TOOLS_DIR")?
+                    .map(PathBuf::from)
+                    .unwrap_or_else(default_tools_dir)
+            },
+            default_memory_limit: db_first_or_default(
+                &ws.default_memory_limit,
+                &defaults.default_memory_limit,
                 "WASM_DEFAULT_MEMORY_LIMIT",
-                ws.default_memory_limit,
             )?,
-            default_timeout_secs: parse_optional_env(
+            default_timeout_secs: db_first_or_default(
+                &ws.default_timeout_secs,
+                &defaults.default_timeout_secs,
                 "WASM_DEFAULT_TIMEOUT_SECS",
-                ws.default_timeout_secs,
             )?,
-            default_fuel_limit: parse_optional_env(
+            default_fuel_limit: db_first_or_default(
+                &ws.default_fuel_limit,
+                &defaults.default_fuel_limit,
                 "WASM_DEFAULT_FUEL_LIMIT",
-                ws.default_fuel_limit,
             )?,
-            cache_compiled: parse_bool_env("WASM_CACHE_COMPILED", ws.cache_compiled)?,
-            cache_dir: optional_env("WASM_CACHE_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| ws.cache_dir.clone()),
+            cache_compiled: db_first_bool(
+                ws.cache_compiled,
+                defaults.cache_compiled,
+                "WASM_CACHE_COMPILED",
+            )?,
+            cache_dir: if let Some(ref dir) = ws.cache_dir {
+                Some(dir.clone())
+            } else {
+                optional_env("WASM_CACHE_DIR")?.map(PathBuf::from)
+            },
         })
     }
 
@@ -111,10 +124,23 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
         settings.wasm.default_fuel_limit = 42;
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("WASM_DEFAULT_FUEL_LIMIT", "7") };
+        let cfg = WasmConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("WASM_DEFAULT_FUEL_LIMIT") };
+
+        assert_eq!(cfg.default_fuel_limit, 42);
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        let settings = Settings::default();
 
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
         unsafe { std::env::set_var("WASM_DEFAULT_FUEL_LIMIT", "7") };

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::llm::recording::HttpInterceptor;
+use crate::tools::ApprovalContext;
 
 /// Error returned when a job exceeds its token budget.
 #[derive(Debug, thiserror::Error)]
@@ -199,6 +200,12 @@ pub struct JobContext {
     pub tool_output_stash: Arc<tokio::sync::RwLock<HashMap<String, String>>>,
     /// User's preferred timezone (IANA name, e.g. "America/New_York"). Defaults to "UTC".
     pub user_timezone: String,
+    /// Approval context for tool execution in this job.
+    ///
+    /// When set, tools check this context before executing to determine
+    /// if they're allowed to run in autonomous/non-interactive contexts.
+    #[serde(skip)]
+    pub approval_context: Option<ApprovalContext>,
 }
 
 impl JobContext {
@@ -240,6 +247,7 @@ impl JobContext {
             metadata: serde_json::Value::Null,
             tool_output_stash: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             user_timezone: "UTC".to_string(),
+            approval_context: None,
         }
     }
 
@@ -252,6 +260,12 @@ impl JobContext {
     /// Set the channel-specific requester/actor ID.
     pub fn with_requester_id(mut self, requester_id: impl Into<String>) -> Self {
         self.requester_id = Some(requester_id.into());
+        self
+    }
+
+    /// Set the approval context on this context.
+    pub fn with_approval_context(mut self, ctx: ApprovalContext) -> Self {
+        self.approval_context = Some(ctx);
         self
     }
 
@@ -366,6 +380,9 @@ impl JobContext {
 
 impl Default for JobContext {
     fn default() -> Self {
+        // Default has no approval_context - safer default that requires explicit
+        // opt-in for autonomous execution. Code that creates JobContext directly
+        // must use with_approval_context() to enable autonomous tool use.
         Self::with_user("default", "Untitled", "No description")
     }
 }

--- a/src/db/CLAUDE.md
+++ b/src/db/CLAUDE.md
@@ -63,7 +63,8 @@ The `Database` supertrait is composed of seven sub-traits. Leaf consumers can de
 4. Implement in `libsql/<module>.rs` (SQLite-dialect SQL, use `self.connect().await?` per operation)
 5. Add migration if needed:
    - PostgreSQL: new `migrations/VN__description.sql`
-   - libSQL: add `CREATE TABLE IF NOT EXISTS` to `libsql_migrations.rs`
+   - libSQL: add entry to `INCREMENTAL_MIGRATIONS` in `libsql_migrations.rs`
+   - **Version numbering**: always base your migration number on what is already in `staging`/`main`, not your local branch. Migrations that have reached staging may already be deployed to production. Your new migration must come *after* the highest version on staging. Check with `git ls-tree origin/staging migrations/` (PG) and grep `INCREMENTAL_MIGRATIONS` on staging (libSQL). Never reuse or insert before an existing version number.
 
 ## SQL Dialect Differences
 

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -61,6 +61,33 @@ impl ConversationStore for LibSqlBackend {
         Ok(id)
     }
 
+    async fn add_conversation_message_if_empty(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+    ) -> Result<bool, DatabaseError> {
+        let conn = self.connect().await?;
+        let id = Uuid::new_v4();
+        let now = fmt_ts(&Utc::now());
+        let conv_str = conversation_id.to_string();
+        let result = conn
+            .execute(
+                "INSERT INTO conversation_messages (id, conversation_id, role, content, created_at) \
+                 SELECT ?1, ?2, ?3, ?4, ?5 \
+                 WHERE NOT EXISTS ( \
+                     SELECT 1 FROM conversation_messages WHERE conversation_id = ?2 \
+                 )",
+                params![id.to_string(), conv_str, role, content, now],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        if result > 0 {
+            self.touch_conversation(conversation_id).await?;
+        }
+        Ok(result > 0)
+    }
+
     async fn ensure_conversation(
         &self,
         id: Uuid,

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -67,19 +67,20 @@ impl ConversationStore for LibSqlBackend {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         let conn = self.connect().await?;
         let now = fmt_ts(&Utc::now());
         let affected = conn
             .execute(
             r#"
-                INSERT INTO conversations (id, channel, user_id, thread_id, started_at, last_activity)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                INSERT INTO conversations (id, channel, user_id, thread_id, source_channel, started_at, last_activity)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
                 ON CONFLICT (id) DO UPDATE SET last_activity = excluded.last_activity
                 WHERE conversations.user_id = excluded.user_id
                   AND conversations.channel = excluded.channel
                 "#,
-            params![id.to_string(), channel, user_id, opt_text(thread_id), now],
+            params![id.to_string(), channel, user_id, opt_text(thread_id), opt_text(source_channel), now],
         )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -600,6 +601,28 @@ impl ConversationStore for LibSqlBackend {
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(found.is_some())
     }
+
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT source_channel FROM conversations WHERE id = ?1",
+                params![conversation_id.to_string()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(row) => Ok(get_opt_text(&row, 0)),
+            None => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -723,6 +746,113 @@ mod tests {
         assert_eq!(
             id1, id2,
             "Expected same heartbeat conversation on repeated calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-src-chan";
+
+        // Create conversation with a source_channel
+        let created = backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("telegram"))
+            .await
+            .unwrap();
+        assert!(created, "first ensure should create");
+
+        // Read it back
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            source.as_deref(),
+            Some("telegram"),
+            "source_channel should round-trip through DB"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_none_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_none.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-no-src";
+
+        // Create conversation without source_channel
+        backend
+            .ensure_conversation(conv_id, "http", user_id, None, None)
+            .await
+            .unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert!(
+            source.is_none(),
+            "None source_channel should persist as NULL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_404.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(Uuid::new_v4())
+            .await
+            .unwrap();
+        assert!(
+            source.is_none(),
+            "non-existent conversation should return None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_not_overwritten_on_upsert() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_upsert.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-upsert";
+
+        // First insert with source_channel = "telegram"
+        backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("telegram"))
+            .await
+            .unwrap();
+
+        // Upsert same conversation (same user/channel) — source_channel should
+        // NOT be overwritten because the ON CONFLICT clause only updates
+        // last_activity.
+        backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("different"))
+            .await
+            .unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            source.as_deref(),
+            Some("telegram"),
+            "upsert should not overwrite original source_channel"
         );
     }
 }

--- a/src/db/libsql/identities.rs
+++ b/src/db/libsql/identities.rs
@@ -1,0 +1,418 @@
+//! IdentityStore implementation for LibSqlBackend.
+
+use async_trait::async_trait;
+use libsql::params;
+use uuid::Uuid;
+
+use super::{fmt_opt_ts, fmt_ts, get_opt_text, get_text, get_ts, opt_text};
+use crate::db::libsql::LibSqlBackend;
+use crate::db::{DatabaseError, IdentityStore, UserIdentityRecord, UserRecord};
+
+fn row_to_identity(row: &libsql::Row) -> Result<UserIdentityRecord, DatabaseError> {
+    let id_str = get_text(row, 0);
+    let id: Uuid = id_str
+        .parse()
+        .map_err(|e| DatabaseError::Serialization(format!("invalid UUID: {e}")))?;
+    let raw_str = get_text(row, 8);
+    let raw_profile: serde_json::Value =
+        serde_json::from_str(&raw_str).map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+    let email_verified_i: i64 = row
+        .get::<i64>(5)
+        .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+    Ok(UserIdentityRecord {
+        id,
+        user_id: get_text(row, 1),
+        provider: get_text(row, 2),
+        provider_user_id: get_text(row, 3),
+        email: get_opt_text(row, 4),
+        email_verified: email_verified_i != 0,
+        display_name: get_opt_text(row, 6),
+        avatar_url: get_opt_text(row, 7),
+        raw_profile,
+        created_at: get_ts(row, 9),
+        updated_at: get_ts(row, 10),
+    })
+}
+
+#[async_trait]
+impl IdentityStore for LibSqlBackend {
+    async fn get_identity_by_provider(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE provider = ?1 AND provider_user_id = ?2",
+                params![provider, provider_user_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows.next().await {
+            Ok(Some(row)) => Ok(Some(row_to_identity(&row)?)),
+            Ok(None) => Ok(None),
+            Err(e) => Err(DatabaseError::Query(e.to_string())),
+        }
+    }
+
+    async fn list_identities_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserIdentityRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE user_id = ?1 ORDER BY created_at",
+                params![user_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let mut result = Vec::new();
+        loop {
+            match rows.next().await {
+                Ok(Some(row)) => result.push(row_to_identity(&row)?),
+                Ok(None) => break,
+                Err(e) => return Err(DatabaseError::Query(e.to_string())),
+            }
+        }
+        Ok(result)
+    }
+
+    async fn create_identity(&self, identity: &UserIdentityRecord) -> Result<(), DatabaseError> {
+        let conn = self.connect().await?;
+        let raw = serde_json::to_string(&identity.raw_profile)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        conn.execute(
+            "INSERT INTO user_identities \
+             (id, user_id, provider, provider_user_id, email, email_verified, \
+              display_name, avatar_url, raw_profile, created_at, updated_at) \
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+            params![
+                identity.id.to_string(),
+                identity.user_id.as_str(),
+                identity.provider.as_str(),
+                identity.provider_user_id.as_str(),
+                opt_text(identity.email.as_deref()),
+                if identity.email_verified { 1i64 } else { 0i64 },
+                opt_text(identity.display_name.as_deref()),
+                opt_text(identity.avatar_url.as_deref()),
+                raw,
+                fmt_ts(&identity.created_at),
+                fmt_ts(&identity.updated_at),
+            ],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn update_identity_profile(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+        display_name: Option<&str>,
+        avatar_url: Option<&str>,
+    ) -> Result<(), DatabaseError> {
+        let conn = self.connect().await?;
+        conn.execute(
+            "UPDATE user_identities SET \
+             display_name = COALESCE(?3, display_name), \
+             avatar_url = COALESCE(?4, avatar_url), \
+             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now') \
+             WHERE provider = ?1 AND provider_user_id = ?2",
+            params![
+                provider,
+                provider_user_id,
+                opt_text(display_name),
+                opt_text(avatar_url),
+            ],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn find_identity_by_verified_email(
+        &self,
+        email: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE LOWER(email) = LOWER(?1) AND email_verified = 1 LIMIT 1",
+                params![email],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows.next().await {
+            Ok(Some(row)) => Ok(Some(row_to_identity(&row)?)),
+            Ok(None) => Ok(None),
+            Err(e) => Err(DatabaseError::Query(e.to_string())),
+        }
+    }
+
+    async fn create_user_with_identity(
+        &self,
+        user: &UserRecord,
+        identity: &UserIdentityRecord,
+    ) -> Result<(), DatabaseError> {
+        let conn = self.connect().await?;
+
+        let metadata_str = serde_json::to_string(&user.metadata)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        let raw_profile_str = serde_json::to_string(&identity.raw_profile)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+
+        conn.execute("BEGIN", ())
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        // Insert user
+        let user_result = conn
+            .execute(
+                "INSERT INTO users (id, email, display_name, status, role, created_at, \
+                 updated_at, last_login_at, created_by, metadata) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
+                params![
+                    user.id.as_str(),
+                    opt_text(user.email.as_deref()),
+                    user.display_name.as_str(),
+                    user.status.as_str(),
+                    user.role.as_str(),
+                    fmt_ts(&user.created_at),
+                    fmt_ts(&user.updated_at),
+                    fmt_opt_ts(&user.last_login_at),
+                    opt_text(user.created_by.as_deref()),
+                    metadata_str,
+                ],
+            )
+            .await;
+
+        if let Err(e) = user_result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(DatabaseError::Query(e.to_string()));
+        }
+
+        // Insert identity
+        let identity_result = conn
+            .execute(
+                "INSERT INTO user_identities \
+                 (id, user_id, provider, provider_user_id, email, email_verified, \
+                  display_name, avatar_url, raw_profile, created_at, updated_at) \
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)",
+                params![
+                    identity.id.to_string(),
+                    identity.user_id.as_str(),
+                    identity.provider.as_str(),
+                    identity.provider_user_id.as_str(),
+                    opt_text(identity.email.as_deref()),
+                    if identity.email_verified { 1i64 } else { 0i64 },
+                    opt_text(identity.display_name.as_deref()),
+                    opt_text(identity.avatar_url.as_deref()),
+                    raw_profile_str,
+                    fmt_ts(&identity.created_at),
+                    fmt_ts(&identity.updated_at),
+                ],
+            )
+            .await;
+
+        if let Err(e) = identity_result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(DatabaseError::Query(e.to_string()));
+        }
+
+        // Atomically promote to admin if this is the only user in the table.
+        // This prevents the TOCTOU race where two concurrent first logins both
+        // see an empty users table and both get role=admin.
+        let promote_result = conn
+            .execute(
+                "UPDATE users SET role = 'admin' \
+                 WHERE id = ?1 AND (SELECT COUNT(*) FROM users) = 1",
+                params![user.id.as_str()],
+            )
+            .await;
+
+        if let Err(e) = promote_result {
+            let _ = conn.execute("ROLLBACK", ()).await;
+            return Err(DatabaseError::Query(e.to_string()));
+        }
+
+        conn.execute("COMMIT", ())
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::{Database, IdentityStore, UserStore};
+
+    async fn test_backend() -> (LibSqlBackend, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_identities.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+        (backend, dir)
+    }
+
+    #[tokio::test]
+    async fn test_identity_crud() {
+        let (db, _dir) = test_backend().await;
+        let now = chrono::Utc::now();
+
+        // Create a user first
+        let user = UserRecord {
+            id: "user-1".to_string(),
+            email: Some("alice@example.com".to_string()),
+            display_name: "Alice".to_string(),
+            status: "active".to_string(),
+            role: "member".to_string(),
+            created_at: now,
+            updated_at: now,
+            last_login_at: None,
+            created_by: None,
+            metadata: serde_json::json!({}),
+        };
+        db.create_user(&user).await.unwrap();
+
+        let identity = UserIdentityRecord {
+            id: Uuid::new_v4(),
+            user_id: "user-1".to_string(),
+            provider: "google".to_string(),
+            provider_user_id: "google-sub-123".to_string(),
+            email: Some("alice@example.com".to_string()),
+            email_verified: true,
+            display_name: Some("Alice G".to_string()),
+            avatar_url: Some("https://example.com/photo.jpg".to_string()),
+            raw_profile: serde_json::json!({"sub": "google-sub-123"}),
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_identity(&identity).await.unwrap();
+
+        // Get by provider
+        let found = db
+            .get_identity_by_provider("google", "google-sub-123")
+            .await
+            .unwrap();
+        assert!(found.is_some());
+        let found = found.unwrap();
+        assert_eq!(found.user_id, "user-1");
+        assert_eq!(found.provider, "google");
+        assert!(found.email_verified);
+
+        // Not found for wrong provider
+        let not_found = db
+            .get_identity_by_provider("github", "google-sub-123")
+            .await
+            .unwrap();
+        assert!(not_found.is_none());
+
+        // List for user
+        let list = db.list_identities_for_user("user-1").await.unwrap();
+        assert_eq!(list.len(), 1);
+
+        // Find by verified email
+        let by_email = db
+            .find_identity_by_verified_email("alice@example.com")
+            .await
+            .unwrap();
+        assert!(by_email.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_find_by_verified_email_ignores_unverified() {
+        let (db, _dir) = test_backend().await;
+        let now = chrono::Utc::now();
+
+        let user = UserRecord {
+            id: "user-2".to_string(),
+            email: None,
+            display_name: "Bob".to_string(),
+            status: "active".to_string(),
+            role: "member".to_string(),
+            created_at: now,
+            updated_at: now,
+            last_login_at: None,
+            created_by: None,
+            metadata: serde_json::json!({}),
+        };
+        db.create_user(&user).await.unwrap();
+
+        let identity = UserIdentityRecord {
+            id: Uuid::new_v4(),
+            user_id: "user-2".to_string(),
+            provider: "github".to_string(),
+            provider_user_id: "gh-456".to_string(),
+            email: Some("bob@example.com".to_string()),
+            email_verified: false,
+            display_name: None,
+            avatar_url: None,
+            raw_profile: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_identity(&identity).await.unwrap();
+
+        let result = db
+            .find_identity_by_verified_email("bob@example.com")
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_create_user_with_identity() {
+        let (db, _dir) = test_backend().await;
+        let now = chrono::Utc::now();
+
+        let user = UserRecord {
+            id: "user-3".to_string(),
+            email: Some("carol@example.com".to_string()),
+            display_name: "Carol".to_string(),
+            status: "active".to_string(),
+            role: "member".to_string(),
+            created_at: now,
+            updated_at: now,
+            last_login_at: None,
+            created_by: None,
+            metadata: serde_json::json!({}),
+        };
+        let identity = UserIdentityRecord {
+            id: Uuid::new_v4(),
+            user_id: "user-3".to_string(),
+            provider: "google".to_string(),
+            provider_user_id: "google-sub-789".to_string(),
+            email: Some("carol@example.com".to_string()),
+            email_verified: true,
+            display_name: Some("Carol".to_string()),
+            avatar_url: None,
+            raw_profile: serde_json::json!({}),
+            created_at: now,
+            updated_at: now,
+        };
+        db.create_user_with_identity(&user, &identity)
+            .await
+            .unwrap();
+
+        // Verify both records exist
+        let found_user = db.get_user("user-3").await.unwrap();
+        assert!(found_user.is_some());
+
+        let found_identity = db
+            .get_identity_by_provider("google", "google-sub-789")
+            .await
+            .unwrap();
+        assert!(found_identity.is_some());
+    }
+}

--- a/src/db/libsql/jobs.rs
+++ b/src/db/libsql/jobs.rs
@@ -134,6 +134,10 @@ impl JobStore for LibSqlBackend {
                     // TODO(#661): persist user_timezone in agent_jobs table so
                     // background/routine jobs retain the session's timezone context.
                     user_timezone: "UTC".to_string(),
+                    // TODO(#1125): approval_context is #[serde(skip)] so it's lost on
+                    // DB restore. Tools that were allowed before restart will be blocked
+                    // until the scheduler re-sets the context on the next dispatch.
+                    approval_context: None,
                 }))
             }
             None => Ok(None),

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -7,6 +7,7 @@
 //! - In-memory (for testing)
 
 mod conversations;
+mod identities;
 mod jobs;
 mod routines;
 mod sandbox;

--- a/src/db/libsql/users.rs
+++ b/src/db/libsql/users.rs
@@ -105,7 +105,7 @@ impl UserStore for LibSqlBackend {
                 r#"
                 SELECT id, email, display_name, status, role, created_at, updated_at,
                        last_login_at, created_by, metadata
-                FROM users WHERE email = ?1
+                FROM users WHERE LOWER(email) = LOWER(?1)
                 "#,
                 params![email],
             )

--- a/src/db/libsql/workspace.rs
+++ b/src/db/libsql/workspace.rs
@@ -13,8 +13,8 @@ use super::{
 use crate::db::WorkspaceStore;
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::workspace::{
-    MemoryChunk, MemoryDocument, RankedResult, SearchConfig, SearchResult, WorkspaceEntry,
-    fuse_results,
+    DocumentVersion, MemoryChunk, MemoryDocument, RankedResult, SearchConfig, SearchResult,
+    VersionSummary, WorkspaceEntry, fuse_results,
 };
 
 use chrono::Utc;
@@ -839,6 +839,341 @@ impl WorkspaceStore for LibSqlBackend {
         }
 
         Ok(fuse_results(fts_results, vector_results, config))
+    }
+
+    // ==================== Metadata ====================
+
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let now = fmt_ts(&Utc::now());
+        let meta_str =
+            serde_json::to_string(metadata).map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to serialize metadata: {e}"),
+            })?;
+        conn.execute(
+            "UPDATE memory_documents SET metadata = ?2, updated_at = ?3 WHERE id = ?1",
+            params![id.to_string(), meta_str, now],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Failed to update metadata: {e}"),
+        })?;
+        Ok(())
+    }
+
+    async fn find_config_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let agent_str = agent_id.map(|a| a.to_string());
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, agent_id, path, content,
+                       created_at, updated_at, metadata
+                FROM memory_documents
+                WHERE user_id = ?1 AND agent_id IS ?2
+                  AND (path LIKE '%/.config' OR path = '.config')
+                ORDER BY path
+                "#,
+                params![user_id, agent_str],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to find config documents: {e}"),
+            })?;
+
+        let mut docs = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to read config document row: {e}"),
+            })?
+        {
+            docs.push(row_to_memory_document(&row));
+        }
+        Ok(docs)
+    }
+
+    // ==================== Versioning ====================
+
+    async fn save_version(
+        &self,
+        document_id: Uuid,
+        content: &str,
+        content_hash: &str,
+        changed_by: Option<&str>,
+    ) -> Result<i32, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let id = Uuid::new_v4().to_string();
+        let doc_id = document_id.to_string();
+        let now = fmt_ts(&Utc::now());
+
+        // BEGIN IMMEDIATE acquires a write lock upfront, serializing
+        // concurrent writers so two callers cannot both read the same
+        // MAX(version) before either inserts.
+        conn.execute("BEGIN IMMEDIATE", params![])
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to start transaction: {e}"),
+            })?;
+
+        let result: Result<i32, WorkspaceError> = async {
+            let mut rows = conn
+                .query(
+                    "SELECT COALESCE(MAX(version), 0) + 1 FROM memory_document_versions WHERE document_id = ?1",
+                    params![doc_id.clone()],
+                )
+                .await
+                .map_err(|e| WorkspaceError::SearchFailed {
+                    reason: format!("Failed to get next version number: {e}"),
+                })?;
+
+            let next_version = if let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| WorkspaceError::SearchFailed {
+                    reason: format!("Failed to read version number: {e}"),
+                })? {
+                get_i64(&row, 0) as i32
+            } else {
+                1
+            };
+            drop(rows);
+
+            conn.execute(
+                r#"
+                INSERT INTO memory_document_versions
+                    (id, document_id, version, content, content_hash, created_at, changed_by)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+                "#,
+                params![
+                    id,
+                    doc_id,
+                    next_version as i64,
+                    content,
+                    content_hash,
+                    now,
+                    changed_by
+                ],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to save version: {e}"),
+            })?;
+
+            Ok(next_version)
+        }
+        .await;
+
+        match &result {
+            Ok(_) => {
+                conn.execute("COMMIT", params![]).await.map_err(|e| {
+                    WorkspaceError::SearchFailed {
+                        reason: format!("Failed to commit version: {e}"),
+                    }
+                })?;
+            }
+            Err(_) => {
+                let _ = conn.execute("ROLLBACK", params![]).await;
+            }
+        }
+
+        result
+    }
+
+    async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<DocumentVersion, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id, document_id, version, content, content_hash,
+                       created_at, changed_by
+                FROM memory_document_versions
+                WHERE document_id = ?1 AND version = ?2
+                "#,
+                params![document_id.to_string(), version as i64],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to get version: {e}"),
+            })?;
+
+        let row = rows
+            .next()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to read version row: {e}"),
+            })?
+            .ok_or(WorkspaceError::VersionNotFound {
+                document_id,
+                version,
+            })?;
+
+        Ok(DocumentVersion {
+            id: get_text(&row, 0)
+                .parse()
+                .map_err(|e| WorkspaceError::SearchFailed {
+                    reason: format!("Invalid version UUID: {e}"),
+                })?,
+            document_id: get_text(&row, 1)
+                .parse()
+                .map_err(|e| WorkspaceError::SearchFailed {
+                    reason: format!("Invalid document UUID: {e}"),
+                })?,
+            version: get_i64(&row, 2) as i32,
+            content: get_text(&row, 3),
+            content_hash: get_text(&row, 4),
+            created_at: get_ts(&row, 5),
+            changed_by: get_opt_text(&row, 6),
+        })
+    }
+
+    async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<VersionSummary>, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT version, content_hash, created_at, changed_by
+                FROM memory_document_versions
+                WHERE document_id = ?1
+                ORDER BY version DESC
+                LIMIT ?2
+                "#,
+                params![document_id.to_string(), limit],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to list versions: {e}"),
+            })?;
+
+        let mut versions = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to read version row: {e}"),
+            })?
+        {
+            versions.push(VersionSummary {
+                version: get_i64(&row, 0) as i32,
+                content_hash: get_text(&row, 1),
+                created_at: get_ts(&row, 2),
+                changed_by: get_opt_text(&row, 3),
+            });
+        }
+        Ok(versions)
+    }
+
+    async fn get_latest_version_number(
+        &self,
+        document_id: Uuid,
+    ) -> Result<Option<i32>, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let mut rows = conn
+            .query(
+                "SELECT MAX(version) FROM memory_document_versions WHERE document_id = ?1",
+                params![document_id.to_string()],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to get latest version number: {e}"),
+            })?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to read version number: {e}"),
+            })?
+        {
+            // MAX returns NULL if no rows — libsql returns Null for the value
+            let val = row.get::<libsql::Value>(0).ok();
+            match val {
+                Some(libsql::Value::Integer(v)) => Ok(Some(v as i32)),
+                _ => Ok(None),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: e.to_string(),
+            })?;
+        let doc_id = document_id.to_string();
+        let result = conn
+            .execute(
+                r#"
+                DELETE FROM memory_document_versions
+                WHERE document_id = ?1
+                  AND version NOT IN (
+                      SELECT version FROM memory_document_versions
+                      WHERE document_id = ?1
+                      ORDER BY version DESC
+                      LIMIT ?2
+                  )
+                "#,
+                params![doc_id, keep_count as i64],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to prune versions: {e}"),
+            })?;
+        Ok(result)
     }
 }
 

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -798,6 +798,25 @@ CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
 ALTER TABLE conversations ADD COLUMN source_channel TEXT;
 "#,
     ),
+    (
+        17,
+        "document_versions",
+        r#"
+CREATE TABLE IF NOT EXISTS memory_document_versions (
+    id TEXT PRIMARY KEY,
+    document_id TEXT NOT NULL REFERENCES memory_documents(id) ON DELETE CASCADE,
+    version INTEGER NOT NULL,
+    content TEXT NOT NULL,
+    content_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    changed_by TEXT,
+    UNIQUE(document_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS idx_doc_versions_lookup
+    ON memory_document_versions(document_id, version DESC);
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -787,7 +787,45 @@ CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
 "#,
     ),
+    (
+        16,
+        "conversation_source_channel",
+        // Add source_channel to conversations for cross-channel approval authorization.
+        // Marked as idempotent (see IDEMPOTENT_ADD_COLUMN_MIGRATIONS below)
+        // because SQLite does not support IF NOT EXISTS for ADD COLUMN.
+        // The runner checks pragma_table_info before executing the ALTER.
+        r#"
+ALTER TABLE conversations ADD COLUMN source_channel TEXT;
+"#,
+    ),
 ];
+
+/// Migrations whose ADD COLUMN should be skipped when the column already
+/// exists (e.g. because the base SCHEMA was updated to include it).
+/// Each entry is `(version, table_name, column_name)`.
+const IDEMPOTENT_ADD_COLUMN_MIGRATIONS: &[(i64, &str, &str)] =
+    &[(16, "conversations", "source_channel")];
+
+/// Check whether `table` already contains `column` via `pragma_table_info`.
+async fn column_exists(
+    conn: &libsql::Connection,
+    table: &str,
+    column: &str,
+) -> Result<bool, crate::error::DatabaseError> {
+    use crate::error::DatabaseError;
+
+    let sql = format!(
+        "SELECT 1 FROM pragma_table_info('{}') WHERE name = ?1",
+        table
+    );
+    let mut rows = conn
+        .query(&sql, libsql::params![column])
+        .await
+        .map_err(|e| {
+            DatabaseError::Migration(format!("Failed to check column {table}.{column}: {e}"))
+        })?;
+    Ok(rows.next().await.ok().flatten().is_some())
+}
 
 /// Run incremental migrations that haven't been applied yet.
 ///
@@ -813,6 +851,18 @@ pub async fn run_incremental(conn: &libsql::Connection) -> Result<(), crate::err
             continue; // Already applied
         }
 
+        // For ADD COLUMN migrations, skip the ALTER if the column already
+        // exists (e.g. because the base SCHEMA was updated to include it)
+        // and just record the migration as applied.
+        let skip_sql = if let Some(&(_, table, column)) = IDEMPOTENT_ADD_COLUMN_MIGRATIONS
+            .iter()
+            .find(|(v, _, _)| *v == version)
+        {
+            column_exists(conn, table, column).await?
+        } else {
+            false
+        };
+
         // Wrap migration + recording in a transaction for atomicity.
         // If the process crashes mid-migration, the transaction rolls back
         // and the migration will be retried on next startup.
@@ -822,9 +872,19 @@ pub async fn run_incremental(conn: &libsql::Connection) -> Result<(), crate::err
             ))
         })?;
 
-        tx.execute_batch(sql).await.map_err(|e| {
-            DatabaseError::Migration(format!("libSQL migration V{version} ({name}) failed: {e}"))
-        })?;
+        if skip_sql {
+            tracing::debug!(
+                version,
+                name,
+                "libSQL: column already exists, recording migration as applied"
+            );
+        } else {
+            tx.execute_batch(sql).await.map_err(|e| {
+                DatabaseError::Migration(format!(
+                    "libSQL migration V{version} ({name}) failed: {e}"
+                ))
+            })?;
+        }
 
         // Record as applied (inside the same transaction)
         tx.execute(

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -788,6 +788,28 @@ CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
 "#,
     ),
     (
+        15,
+        "user_identities",
+        r#"
+CREATE TABLE IF NOT EXISTS user_identities (
+    id TEXT PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    provider TEXT NOT NULL,
+    provider_user_id TEXT NOT NULL,
+    email TEXT,
+    email_verified INTEGER NOT NULL DEFAULT 0,
+    display_name TEXT,
+    avatar_url TEXT,
+    raw_profile TEXT NOT NULL DEFAULT '{}',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    UNIQUE (provider, provider_user_id)
+);
+CREATE INDEX IF NOT EXISTS idx_user_identities_user ON user_identities(user_id);
+CREATE INDEX IF NOT EXISTS idx_user_identities_email ON user_identities(email) WHERE email IS NOT NULL;
+"#,
+    ),
+    (
         16,
         "conversation_source_channel",
         // Add source_channel to conversations for cross-channel approval authorization.

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -346,6 +346,27 @@ pub struct ApiTokenRecord {
     pub revoked_at: Option<DateTime<Utc>>,
 }
 
+// ==================== User identity record types ====================
+
+/// A linked external identity from an OAuth/social login provider.
+#[derive(Debug, Clone)]
+pub struct UserIdentityRecord {
+    pub id: Uuid,
+    pub user_id: String,
+    /// Provider name (e.g. `google`, `github`, `apple`, `near`, `email`).
+    pub provider: String,
+    /// Provider-specific unique user identifier (Google `sub`, GitHub user ID, etc.).
+    pub provider_user_id: String,
+    pub email: Option<String>,
+    pub email_verified: bool,
+    pub display_name: Option<String>,
+    pub avatar_url: Option<String>,
+    /// Raw JSON profile payload from the provider for debugging/auditing.
+    pub raw_profile: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 // ==================== Sub-traits ====================
 //
 // Each sub-trait groups related persistence methods. The `Database` supertrait
@@ -367,6 +388,14 @@ pub trait ConversationStore: Send + Sync {
         role: &str,
         content: &str,
     ) -> Result<Uuid, DatabaseError>;
+    /// Insert a message only if the conversation has zero messages.
+    /// Returns `Ok(true)` if the message was inserted, `Ok(false)` if skipped.
+    async fn add_conversation_message_if_empty(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+    ) -> Result<bool, DatabaseError>;
     async fn ensure_conversation(
         &self,
         id: Uuid,
@@ -1006,6 +1035,48 @@ pub struct UserSummaryStats {
     pub last_active_at: Option<DateTime<Utc>>,
 }
 
+/// Persistence for linked external identities (OAuth/social login providers).
+#[async_trait]
+pub trait IdentityStore: Send + Sync {
+    /// Find a user identity by provider and provider-specific user ID.
+    async fn get_identity_by_provider(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError>;
+
+    /// Find all identities linked to a user.
+    async fn list_identities_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserIdentityRecord>, DatabaseError>;
+
+    /// Create a new identity link.
+    async fn create_identity(&self, identity: &UserIdentityRecord) -> Result<(), DatabaseError>;
+
+    /// Update display_name and avatar_url on an existing identity (e.g. on re-login).
+    async fn update_identity_profile(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+        display_name: Option<&str>,
+        avatar_url: Option<&str>,
+    ) -> Result<(), DatabaseError>;
+
+    /// Find identities with a given verified email (for automatic account linking).
+    async fn find_identity_by_verified_email(
+        &self,
+        email: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError>;
+
+    /// Create a new user and link an identity atomically.
+    async fn create_user_with_identity(
+        &self,
+        user: &UserRecord,
+        identity: &UserIdentityRecord,
+    ) -> Result<(), DatabaseError>;
+}
+
 /// Backend-agnostic database supertrait.
 ///
 /// Combines all sub-traits into one. Existing `Arc<dyn Database>` consumers
@@ -1020,6 +1091,7 @@ pub trait Database:
     + SettingsStore
     + WorkspaceStore
     + UserStore
+    + IdentityStore
     + Send
     + Sync
 {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -373,6 +373,7 @@ pub trait ConversationStore: Send + Sync {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError>;
     async fn list_conversations_with_preview(
         &self,
@@ -438,6 +439,11 @@ pub trait ConversationStore: Send + Sync {
         conversation_id: Uuid,
         user_id: &str,
     ) -> Result<bool, DatabaseError>;
+    /// Get the source_channel for a conversation (the channel that created it).
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError>;
 }
 
 #[async_trait]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -713,6 +713,94 @@ pub trait WorkspaceStore: Send + Sync {
         config: &SearchConfig,
     ) -> Result<Vec<SearchResult>, WorkspaceError>;
 
+    // ==================== Metadata ====================
+    //
+    // **Trust boundary:** methods in this section accept bare document/version
+    // UUIDs without a `user_id` guard. They trust the caller (`Workspace`) to
+    // have obtained the UUID through a user-scoped query (e.g.
+    // `get_document_by_path` or `get_or_create_document_by_path`). Do NOT call
+    // these with an unverified UUID from external input.
+
+    /// Update the metadata JSON field on a document (full replacement).
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `id` via a user-scoped lookup.
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError>;
+
+    /// Find all `.config` documents in the workspace.
+    ///
+    /// Returns documents whose path ends with `/.config` or equals `.config`.
+    /// Used by the hygiene system to discover metadata-driven cleanup targets.
+    async fn find_config_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError>;
+
+    // ==================== Versioning ====================
+    //
+    // **Trust boundary:** same as metadata — these accept bare `document_id`
+    // UUIDs and trust the caller to have verified ownership first.
+
+    /// Save the current content of a document as a new version.
+    ///
+    /// Returns the new version number (1-based, monotonically increasing).
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `document_id`.
+    async fn save_version(
+        &self,
+        document_id: Uuid,
+        content: &str,
+        content_hash: &str,
+        changed_by: Option<&str>,
+    ) -> Result<i32, WorkspaceError>;
+
+    /// Get a specific version of a document.
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `document_id`.
+    async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<crate::workspace::DocumentVersion, WorkspaceError>;
+
+    /// List versions of a document (newest first).
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `document_id`.
+    async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<crate::workspace::VersionSummary>, WorkspaceError>;
+
+    /// Get the latest version number for a document, or `None` if no versions exist.
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `document_id`.
+    async fn get_latest_version_number(
+        &self,
+        document_id: Uuid,
+    ) -> Result<Option<i32>, WorkspaceError>;
+
+    /// Delete old versions, keeping only the most recent `keep_count`.
+    ///
+    /// Returns the number of versions deleted.
+    ///
+    /// # Trust
+    /// Caller must have verified ownership of `document_id`.
+    async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError>;
+
     // ==================== Multi-scope read methods ====================
     //
     // Default implementations loop over user_ids calling single-scope methods,

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -16,8 +16,9 @@ use crate::agent::routine::{Routine, RoutineRun, RunStatus};
 use crate::config::DatabaseConfig;
 use crate::context::{ActionRecord, JobContext, JobState};
 use crate::db::{
-    ApiTokenRecord, ConversationStore, Database, JobStore, RoutineStore, SandboxStore,
-    SettingsStore, ToolFailureStore, UserRecord, UserStore, WorkspaceStore,
+    ApiTokenRecord, ConversationStore, Database, IdentityStore, JobStore, RoutineStore,
+    SandboxStore, SettingsStore, ToolFailureStore, UserIdentityRecord, UserRecord, UserStore,
+    WorkspaceStore,
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
@@ -92,6 +93,30 @@ impl ConversationStore for PgBackend {
         self.store
             .add_conversation_message(conversation_id, role, content)
             .await
+    }
+
+    async fn add_conversation_message_if_empty(
+        &self,
+        conversation_id: Uuid,
+        role: &str,
+        content: &str,
+    ) -> Result<bool, DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        let id = Uuid::new_v4();
+        let result = conn
+            .execute(
+                "INSERT INTO conversation_messages (id, conversation_id, role, content) \
+                 SELECT $1, $2, $3, $4 \
+                 WHERE NOT EXISTS ( \
+                     SELECT 1 FROM conversation_messages WHERE conversation_id = $2 \
+                 )",
+                &[&id, &conversation_id, &role, &content],
+            )
+            .await?;
+        if result > 0 {
+            self.store.touch_conversation(conversation_id).await?;
+        }
+        Ok(result > 0)
     }
 
     async fn ensure_conversation(
@@ -980,5 +1005,186 @@ impl UserStore for PgBackend {
         self.store
             .create_user_with_token(user, token_name, token_hash, token_prefix, expires_at)
             .await
+    }
+}
+
+// ==================== IdentityStore ====================
+
+fn row_to_identity(row: &tokio_postgres::Row) -> UserIdentityRecord {
+    UserIdentityRecord {
+        id: row.get("id"),
+        user_id: row.get("user_id"),
+        provider: row.get("provider"),
+        provider_user_id: row.get("provider_user_id"),
+        email: row.get("email"),
+        email_verified: row.get("email_verified"),
+        display_name: row.get("display_name"),
+        avatar_url: row.get("avatar_url"),
+        raw_profile: row.get("raw_profile"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+#[async_trait]
+impl IdentityStore for PgBackend {
+    async fn get_identity_by_provider(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        let row = conn
+            .query_opt(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE provider = $1 AND provider_user_id = $2",
+                &[&provider, &provider_user_id],
+            )
+            .await?;
+        Ok(row.as_ref().map(row_to_identity))
+    }
+
+    async fn list_identities_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<UserIdentityRecord>, DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        let rows = conn
+            .query(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE user_id = $1 ORDER BY created_at",
+                &[&user_id],
+            )
+            .await?;
+        Ok(rows.iter().map(row_to_identity).collect())
+    }
+
+    async fn create_identity(&self, identity: &UserIdentityRecord) -> Result<(), DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        conn.execute(
+            "INSERT INTO user_identities \
+             (id, user_id, provider, provider_user_id, email, email_verified, \
+              display_name, avatar_url, raw_profile, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            &[
+                &identity.id,
+                &identity.user_id,
+                &identity.provider,
+                &identity.provider_user_id,
+                &identity.email,
+                &identity.email_verified,
+                &identity.display_name,
+                &identity.avatar_url,
+                &identity.raw_profile,
+                &identity.created_at,
+                &identity.updated_at,
+            ],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn update_identity_profile(
+        &self,
+        provider: &str,
+        provider_user_id: &str,
+        display_name: Option<&str>,
+        avatar_url: Option<&str>,
+    ) -> Result<(), DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        conn.execute(
+            "UPDATE user_identities SET display_name = COALESCE($3, display_name), \
+             avatar_url = COALESCE($4, avatar_url), updated_at = NOW() \
+             WHERE provider = $1 AND provider_user_id = $2",
+            &[&provider, &provider_user_id, &display_name, &avatar_url],
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn find_identity_by_verified_email(
+        &self,
+        email: &str,
+    ) -> Result<Option<UserIdentityRecord>, DatabaseError> {
+        let conn = self.store.pool().get().await?;
+        let row = conn
+            .query_opt(
+                "SELECT id, user_id, provider, provider_user_id, email, email_verified, \
+                 display_name, avatar_url, raw_profile, created_at, updated_at \
+                 FROM user_identities WHERE LOWER(email) = LOWER($1) AND email_verified = true LIMIT 1",
+                &[&email],
+            )
+            .await?;
+        Ok(row.as_ref().map(row_to_identity))
+    }
+
+    async fn create_user_with_identity(
+        &self,
+        user: &UserRecord,
+        identity: &UserIdentityRecord,
+    ) -> Result<(), DatabaseError> {
+        let mut conn = self.store.pool().get().await?;
+        let tx = conn.transaction().await?;
+
+        tx.execute(
+            "INSERT INTO users (id, email, display_name, status, role, created_at, \
+             updated_at, last_login_at, created_by, metadata) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
+            &[
+                &user.id,
+                &user.email,
+                &user.display_name,
+                &user.status,
+                &user.role,
+                &user.created_at,
+                &user.updated_at,
+                &user.last_login_at,
+                &user.created_by,
+                &user.metadata,
+            ],
+        )
+        .await?;
+
+        tx.execute(
+            "INSERT INTO user_identities \
+             (id, user_id, provider, provider_user_id, email, email_verified, \
+              display_name, avatar_url, raw_profile, created_at, updated_at) \
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)",
+            &[
+                &identity.id,
+                &identity.user_id,
+                &identity.provider,
+                &identity.provider_user_id,
+                &identity.email,
+                &identity.email_verified,
+                &identity.display_name,
+                &identity.avatar_url,
+                &identity.raw_profile,
+                &identity.created_at,
+                &identity.updated_at,
+            ],
+        )
+        .await?;
+
+        // Atomically promote to admin if this is the only user in the table.
+        // Under READ COMMITTED, two concurrent transactions could both see
+        // COUNT(*)=1 (each sees its own uncommitted insert). Use an advisory
+        // lock to serialize the first-user election across transactions.
+        tx.execute(
+            "SELECT pg_advisory_xact_lock(hashtext('first_user_admin_election'))",
+            &[],
+        )
+        .await?;
+        tx.execute(
+            "UPDATE users SET role = 'admin' \
+             WHERE id = $1 AND (SELECT COUNT(*) FROM users) = 1",
+            &[&user.id],
+        )
+        .await?;
+
+        tx.commit().await?;
+        Ok(())
     }
 }

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -25,7 +25,8 @@ use crate::history::{
     LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow, Store,
 };
 use crate::workspace::{
-    MemoryChunk, MemoryDocument, Repository, SearchConfig, SearchResult, WorkspaceEntry,
+    DocumentVersion, MemoryChunk, MemoryDocument, Repository, SearchConfig, SearchResult,
+    VersionSummary, WorkspaceEntry,
 };
 
 /// PostgreSQL database backend.
@@ -804,6 +805,69 @@ impl WorkspaceStore for PgBackend {
         self.repo
             .list_directory_multi(user_ids, agent_id, directory)
             .await
+    }
+
+    // ==================== Metadata ====================
+
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        self.repo.update_document_metadata(id, metadata).await
+    }
+
+    async fn find_config_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        self.repo.find_config_documents(user_id, agent_id).await
+    }
+
+    // ==================== Versioning ====================
+
+    async fn save_version(
+        &self,
+        document_id: Uuid,
+        content: &str,
+        content_hash: &str,
+        changed_by: Option<&str>,
+    ) -> Result<i32, WorkspaceError> {
+        self.repo
+            .save_version(document_id, content, content_hash, changed_by)
+            .await
+    }
+
+    async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<DocumentVersion, WorkspaceError> {
+        self.repo.get_version(document_id, version).await
+    }
+
+    async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<VersionSummary>, WorkspaceError> {
+        self.repo.list_versions(document_id, limit).await
+    }
+
+    async fn get_latest_version_number(
+        &self,
+        document_id: Uuid,
+    ) -> Result<Option<i32>, WorkspaceError> {
+        self.repo.get_latest_version_number(document_id).await
+    }
+
+    async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError> {
+        self.repo.prune_versions(document_id, keep_count).await
     }
 }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -99,9 +99,10 @@ impl ConversationStore for PgBackend {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         self.store
-            .ensure_conversation(id, channel, user_id, thread_id)
+            .ensure_conversation(id, channel, user_id, thread_id, source_channel)
             .await
     }
 
@@ -220,6 +221,15 @@ impl ConversationStore for PgBackend {
     ) -> Result<bool, DatabaseError> {
         self.store
             .conversation_belongs_to_user(conversation_id, user_id)
+            .await
+    }
+
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        self.store
+            .get_conversation_source_channel(conversation_id)
             .await
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -283,6 +283,9 @@ pub enum WorkspaceError {
     #[error("Document not found: {doc_type} for user {user_id}")]
     DocumentNotFound { doc_type: String, user_id: String },
 
+    // TODO: SearchFailed is used as a catch-all for metadata, versioning, and
+    // connection errors across both backends. A cleanup pass should introduce
+    // more specific variants (e.g. MetadataError, VersioningError).
     #[error("Search failed: {reason}")]
     SearchFailed { reason: String },
 
@@ -315,6 +318,12 @@ pub enum WorkspaceError {
 
     #[error("Write rejected for '{path}': prompt injection detected ({reason})")]
     InjectionRejected { path: String, reason: String },
+
+    #[error("Version not found: document {document_id} version {version}")]
+    VersionNotFound { document_id: Uuid, version: i32 },
+
+    #[error("Patch failed for '{path}': {reason}")]
+    PatchFailed { path: String, reason: String },
 }
 
 /// Orchestrator errors (internal API, container management).

--- a/src/error.rs
+++ b/src/error.rs
@@ -404,16 +404,49 @@ pub enum RoutineError {
     Database { reason: String },
 
     #[error("LLM call failed: {reason}")]
-    LlmFailed { reason: String },
+    LlmFailed {
+        reason: String,
+        /// Partial token count consumed before the failure (if any).
+        /// Used to accumulate usage across retry attempts.
+        partial_tokens: Option<i32>,
+        /// Whether the underlying LLM error was classified as retryable.
+        /// Set at the `LlmError` → `RoutineError` conversion site using
+        /// `crate::llm::retry::is_retryable()`, avoiding fragile substring
+        /// matching on the stringified reason.
+        retryable: bool,
+    },
 
     #[error("Failed to dispatch full job: {reason}")]
     JobDispatchFailed { reason: String },
 
     #[error("LLM returned empty content")]
-    EmptyResponse,
+    EmptyResponse {
+        /// Tokens consumed by the call that produced the empty response.
+        partial_tokens: Option<i32>,
+    },
 
     #[error("LLM response truncated (finish_reason=length) with no content")]
-    TruncatedResponse,
+    TruncatedResponse {
+        /// Tokens consumed by the call that produced the truncated response.
+        partial_tokens: Option<i32>,
+    },
+}
+
+impl RoutineError {
+    /// Whether this error is transient and worth retrying with backoff.
+    ///
+    /// Retryable: LLM failures where the underlying `LlmError` was classified
+    /// as retryable by `crate::llm::retry::is_retryable()`, empty responses,
+    /// and truncated responses.
+    /// Non-retryable: configuration errors, authorization, resource limits,
+    /// DB errors, and LLM failures caused by auth/content-policy/context-length.
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            RoutineError::LlmFailed { retryable, .. } => *retryable,
+            RoutineError::EmptyResponse { .. } | RoutineError::TruncatedResponse { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 /// Result type alias for the agent.
@@ -521,6 +554,99 @@ mod tests {
         };
         let msg = err.to_string();
         assert!(msg.contains("bad format"), "Should mention reason: {msg}");
+    }
+
+    #[test]
+    fn routine_error_retryable_classification() {
+        // Transient errors should be retryable
+        assert!(
+            RoutineError::LlmFailed {
+                reason: "timeout".into(),
+                partial_tokens: None,
+                retryable: true,
+            }
+            .is_retryable()
+        );
+        // Non-retryable LLM error
+        assert!(
+            !RoutineError::LlmFailed {
+                reason: "timeout".into(),
+                partial_tokens: None,
+                retryable: false,
+            }
+            .is_retryable()
+        );
+        assert!(
+            RoutineError::EmptyResponse {
+                partial_tokens: None
+            }
+            .is_retryable()
+        );
+        assert!(
+            RoutineError::TruncatedResponse {
+                partial_tokens: None
+            }
+            .is_retryable()
+        );
+
+        // Hard failures should NOT be retryable
+        assert!(
+            !RoutineError::Disabled {
+                name: "test".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::JobDispatchFailed {
+                reason: "no docker".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::Database {
+                reason: "conn refused".into()
+            }
+            .is_retryable()
+        );
+        assert!(!RoutineError::NotFound { id: Uuid::new_v4() }.is_retryable());
+        assert!(!RoutineError::NotAuthorized { id: Uuid::new_v4() }.is_retryable());
+        assert!(
+            !RoutineError::MaxConcurrent {
+                name: "test".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownTriggerType {
+                trigger_type: "x".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownActionType {
+                action_type: "x".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::MissingField {
+                context: "c".into(),
+                field: "f".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::InvalidCron {
+                reason: "bad".into()
+            }
+            .is_retryable()
+        );
+        assert!(
+            !RoutineError::UnknownRunStatus {
+                status: "bad".into()
+            }
+            .is_retryable()
+        );
     }
 
     #[test]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1324,6 +1324,10 @@ impl ExtensionManager {
                         "Channel relay extensions cannot be installed by URL".to_string(),
                     ))
                 }
+                ExtensionKind::AcpAgent => Err(ExtensionError::InstallFailed(
+                    "ACP agents are configured via 'ironclaw acp add', not the extension manager"
+                        .to_string(),
+                )),
             }
             .map_err(|e| {
                 let sanitized = sanitize_url_for_logging(url);
@@ -1356,6 +1360,11 @@ impl ExtensionManager {
             ExtensionKind::WasmTool => self.auth_wasm_tool(name, user_id).await,
             ExtensionKind::WasmChannel => self.auth_wasm_channel_status(name, user_id).await,
             ExtensionKind::ChannelRelay => self.auth_channel_relay(name, user_id).await,
+            ExtensionKind::AcpAgent => Ok(AuthResult {
+                name: name.to_string(),
+                kind: ExtensionKind::AcpAgent,
+                status: crate::extensions::AuthStatus::NoAuthRequired,
+            }),
         }
     }
 
@@ -1373,6 +1382,15 @@ impl ExtensionManager {
             ExtensionKind::WasmTool => self.activate_wasm_tool(name, user_id).await,
             ExtensionKind::WasmChannel => self.activate_wasm_channel(name, user_id).await,
             ExtensionKind::ChannelRelay => self.activate_channel_relay(name, user_id).await,
+            ExtensionKind::AcpAgent => Ok(ActivateResult {
+                name: name.to_string(),
+                kind: ExtensionKind::AcpAgent,
+                tools_loaded: Vec::new(),
+                message: format!(
+                    "ACP agent '{}' is managed via 'ironclaw acp' commands",
+                    name
+                ),
+            }),
         }
     }
 
@@ -1813,6 +1831,13 @@ impl ExtensionManager {
 
                 Ok(format!("Removed channel relay '{}'", name))
             }
+            ExtensionKind::AcpAgent => {
+                // ACP agents are managed via `ironclaw acp remove`
+                Ok(format!(
+                    "ACP agent '{}' should be removed via 'ironclaw acp remove {}'",
+                    name, name
+                ))
+            }
         }
     }
 
@@ -1904,7 +1929,7 @@ impl ExtensionManager {
                 &self.wasm_channels_dir,
                 crate::tools::wasm::WIT_CHANNEL_VERSION,
             ),
-            ExtensionKind::McpServer | ExtensionKind::ChannelRelay => {
+            ExtensionKind::McpServer | ExtensionKind::ChannelRelay | ExtensionKind::AcpAgent => {
                 return UpgradeOutcome {
                     name: name.to_string(),
                     kind,
@@ -1930,7 +1955,9 @@ impl ExtensionManager {
                                 .ok()
                                 .and_then(|c| c.wit_version)
                         }
-                        ExtensionKind::McpServer | ExtensionKind::ChannelRelay => None,
+                        ExtensionKind::McpServer
+                        | ExtensionKind::ChannelRelay
+                        | ExtensionKind::AcpAgent => None,
                     };
                     wit
                 }
@@ -2099,6 +2126,13 @@ impl ExtensionManager {
                     "name": name,
                     "kind": "channel_relay",
                     "active": self.active_channel_names.read().await.contains(name),
+                });
+                Ok(info)
+            }
+            ExtensionKind::AcpAgent => {
+                let info = serde_json::json!({
+                    "name": name,
+                    "kind": "acp_agent",
                 });
                 Ok(info)
             }
@@ -2291,6 +2325,9 @@ impl ExtensionManager {
                     ),
                 })
             }
+            ExtensionKind::AcpAgent => Err(ExtensionError::InstallFailed(
+                "ACP agents are configured via 'ironclaw acp add', not the registry".to_string(),
+            )),
         }
     }
 
@@ -2652,6 +2689,7 @@ impl ExtensionManager {
             ExtensionKind::WasmChannel => "WASM channel",
             ExtensionKind::McpServer => "MCP server",
             ExtensionKind::ChannelRelay => "channel relay",
+            ExtensionKind::AcpAgent => "ACP agent",
         };
 
         tracing::info!(
@@ -3133,7 +3171,7 @@ impl ExtensionManager {
                     oauth_scopes_secret_name(&token_secret_name),
                 );
             }
-            ExtensionKind::ChannelRelay => {}
+            ExtensionKind::ChannelRelay | ExtensionKind::AcpAgent => {}
         }
 
         Ok(plan)
@@ -5652,6 +5690,11 @@ impl ExtensionManager {
                 }];
                 (std::collections::HashSet::new(), relay_fields)
             }
+            ExtensionKind::AcpAgent => {
+                return Err(ExtensionError::Other(
+                    "ACP agents do not require setup through the extension manager".to_string(),
+                ));
+            }
         };
 
         let allowed_fields: std::collections::HashSet<String> =
@@ -5937,7 +5980,7 @@ impl ExtensionManager {
             ExtensionKind::WasmChannel => self.activate_wasm_channel(name, user_id).await,
             ExtensionKind::McpServer => self.activate_mcp(name, user_id).await,
             ExtensionKind::ChannelRelay => self.activate_channel_relay(name, user_id).await,
-            ExtensionKind::WasmTool => {
+            ExtensionKind::WasmTool | ExtensionKind::AcpAgent => {
                 return Ok(ConfigureResult {
                     message: format!("Configuration saved for '{}'.", name),
                     activated: false,
@@ -6099,6 +6142,11 @@ impl ExtensionManager {
             }
             ExtensionKind::ChannelRelay => {
                 return Err(ExtensionError::AuthRequired);
+            }
+            ExtensionKind::AcpAgent => {
+                return Err(ExtensionError::Other(
+                    "ACP agents do not use token-based authentication".to_string(),
+                ));
             }
         };
 

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -40,6 +40,8 @@ pub enum ExtensionKind {
     WasmChannel,
     /// External channel via channel-relay service (Slack, etc.).
     ChannelRelay,
+    /// ACP-compliant coding agent (Goose, Codex, Gemini CLI, etc.).
+    AcpAgent,
 }
 
 impl std::fmt::Display for ExtensionKind {
@@ -49,6 +51,7 @@ impl std::fmt::Display for ExtensionKind {
             ExtensionKind::WasmTool => write!(f, "wasm_tool"),
             ExtensionKind::WasmChannel => write!(f, "wasm_channel"),
             ExtensionKind::ChannelRelay => write!(f, "channel_relay"),
+            ExtensionKind::AcpAgent => write!(f, "acp_agent"),
         }
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1585,19 +1585,20 @@ impl Store {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         let conn = self.conn().await?;
         let affected = conn
             .execute(
                 r#"
-            INSERT INTO conversations (id, channel, user_id, thread_id)
-            VALUES ($1, $2, $3, $4)
+            INSERT INTO conversations (id, channel, user_id, thread_id, source_channel)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (id) DO UPDATE
             SET last_activity = NOW()
             WHERE conversations.user_id = EXCLUDED.user_id
               AND conversations.channel = EXCLUDED.channel
             "#,
-                &[&id, &channel, &user_id, &thread_id],
+                &[&id, &channel, &user_id, &thread_id, &source_channel],
             )
             .await?;
         Ok(affected > 0)
@@ -1915,6 +1916,21 @@ impl Store {
             )
             .await?;
         Ok(row.is_some())
+    }
+
+    /// Get the source_channel for a conversation.
+    pub async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                "SELECT source_channel FROM conversations WHERE id = $1",
+                &[&conversation_id],
+            )
+            .await?;
+        Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
     }
 
     /// Load messages for a conversation with cursor-based pagination.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -258,6 +258,10 @@ impl Store {
                     // TODO(#661): persist user_timezone in agent_jobs table so
                     // background/routine jobs retain the session's timezone context.
                     user_timezone: "UTC".to_string(),
+                    // TODO(#1125): approval_context is #[serde(skip)] so it's lost on
+                    // DB restore. Tools that were allowed before restart will be blocked
+                    // until the scheduler re-sets the context on the next dispatch.
+                    approval_context: None,
                 }))
             }
             None => Ok(None),

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -2368,7 +2368,7 @@ impl Store {
     ) -> Result<Option<UserRecord>, DatabaseError> {
         let conn = self.conn().await?;
         let row = conn
-            .query_opt("SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE email = $1", &[&email])
+            .query_opt("SELECT id, email, display_name, status, role, created_at, updated_at, last_login_at, created_by, metadata FROM users WHERE LOWER(email) = LOWER($1)", &[&email])
             .await?;
         Ok(row.map(|r| row_to_user(&r)))
     }

--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -921,7 +922,14 @@ pub struct GeminiOauthProvider {
     http_client: Client,
     /// Latest response metadata (updated after each request).
     last_response_meta: std::sync::Mutex<GeminiResponseMeta>,
+    /// Captured thought signatures keyed by tool-call ID. Gemini 3.x models
+    /// require these echoed back on `functionCall` parts when replaying history.
+    /// Populated from responses, consumed when building the next request.
+    thought_signatures: std::sync::Mutex<HashMap<String, String>>,
 }
+
+/// Parsed Gemini response: (completion, tool_calls, thought_signatures_by_call_id).
+type GeminiParsedResponse = (CompletionResponse, Vec<ToolCall>, HashMap<String, String>);
 
 impl GeminiOauthProvider {
     pub fn new(config: GeminiOauthConfig) -> Result<Self, LlmError> {
@@ -939,6 +947,7 @@ impl GeminiOauthProvider {
             cred_manager,
             http_client,
             last_response_meta: std::sync::Mutex::new(GeminiResponseMeta::default()),
+            thought_signatures: std::sync::Mutex::new(HashMap::new()),
         })
     }
 
@@ -1062,8 +1071,21 @@ impl GeminiOauthProvider {
 
     /// Count tokens for the given messages using the Gemini countTokens API.
     pub async fn count_tokens(&self, messages: &[ChatMessage]) -> Result<u32, LlmError> {
-        let req =
-            Self::to_gemini_request(messages, None, None, None, None, None, &self.config.model);
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let req = Self::to_gemini_request(
+            messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &self.config.model,
+            &sigs,
+        );
         let contents = req
             .get("contents")
             .cloned()
@@ -1589,6 +1611,7 @@ impl GeminiOauthProvider {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn to_gemini_request(
         messages: &[ChatMessage],
         tools: Option<&[ToolDefinition]>,
@@ -1597,6 +1620,7 @@ impl GeminiOauthProvider {
         stop_sequences: Option<&[String]>,
         tool_choice: Option<&str>,
         model: &str,
+        thought_sigs: &HashMap<String, String>,
     ) -> serde_json::Value {
         let mut contents = Vec::new();
 
@@ -1621,12 +1645,24 @@ impl GeminiOauthProvider {
                     }
                     if let Some(ref calls) = msg.tool_calls {
                         for call in calls {
-                            parts.push(serde_json::json!({
+                            let mut part = serde_json::json!({
                                 "functionCall": {
                                     "name": call.name,
                                     "args": call.arguments
                                 }
-                            }));
+                            });
+                            // Echo back the real thoughtSignature if captured from a
+                            // prior Gemini response. ensure_thought_signatures() will
+                            // fill in synthetic placeholders for any gaps.
+                            if let Some(sig) = thought_sigs.get(&call.id)
+                                && let Some(obj) = part.as_object_mut()
+                            {
+                                obj.insert(
+                                    "thoughtSignature".to_string(),
+                                    serde_json::Value::String(sig.clone()),
+                                );
+                            }
+                            parts.push(part);
                         }
                     }
                     // Fallback: if no parts at all, add empty text to avoid
@@ -1855,9 +1891,8 @@ impl GeminiOauthProvider {
         req
     }
 
-    fn from_gemini_response(
-        body: serde_json::Value,
-    ) -> Result<(CompletionResponse, Vec<ToolCall>), LlmError> {
+    /// Parsed Gemini response: (completion, tool_calls, thought_signatures_by_call_id).
+    fn from_gemini_response(body: serde_json::Value) -> Result<GeminiParsedResponse, LlmError> {
         let candidate = body
             .get("candidates")
             .and_then(|c| c.as_array())
@@ -1874,6 +1909,7 @@ impl GeminiOauthProvider {
 
         let mut text_content = String::new();
         let mut tool_calls = Vec::new();
+        let mut thought_sigs = HashMap::new();
 
         if let Some(parts) = parts {
             for part in parts {
@@ -1892,6 +1928,11 @@ impl GeminiOauthProvider {
                         .and_then(|i| i.as_str())
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                    // Capture thoughtSignature (sibling of functionCall in the part)
+                    // so it can be echoed back when replaying history.
+                    if let Some(sig) = part.get("thoughtSignature").and_then(|s| s.as_str()) {
+                        thought_sigs.insert(id.clone(), sig.to_string());
+                    }
 
                     tool_calls.push(ToolCall {
                         id,
@@ -2003,6 +2044,7 @@ impl GeminiOauthProvider {
                 cache_creation_input_tokens: 0,
             },
             tool_calls,
+            thought_sigs,
         ))
     }
 }
@@ -2041,6 +2083,11 @@ impl LlmProvider for GeminiOauthProvider {
     }
 
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let req_json = Self::to_gemini_request(
             &request.messages,
             None,
@@ -2049,9 +2096,10 @@ impl LlmProvider for GeminiOauthProvider {
             request.stop_sequences.as_deref(),
             None,
             &self.config.model,
+            &sigs,
         );
         let resp_json = self.send_request(&req_json).await?;
-        let (response, _tool_calls) = Self::from_gemini_response(resp_json)?;
+        let (response, _tool_calls, _new_sigs) = Self::from_gemini_response(resp_json)?;
         Ok(response)
     }
 
@@ -2065,6 +2113,11 @@ impl LlmProvider for GeminiOauthProvider {
             Some(request.tools.as_slice())
         };
 
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let req_json = Self::to_gemini_request(
             &request.messages,
             tool_defs,
@@ -2073,9 +2126,29 @@ impl LlmProvider for GeminiOauthProvider {
             request.stop_sequences.as_deref(),
             request.tool_choice.as_deref(),
             &self.config.model,
+            &sigs,
         );
         let resp_json = self.send_request(&req_json).await?;
-        let (response, tool_calls) = Self::from_gemini_response(resp_json)?;
+        let (response, tool_calls, new_sigs) = Self::from_gemini_response(resp_json)?;
+        // Store captured thought signatures, pruning stale entries to prevent
+        // unbounded growth over long-running processes. Only keep IDs that
+        // appear in the conversation history or the just-received response.
+        {
+            let mut sigs = self
+                .thought_signatures
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            sigs.extend(new_sigs);
+            let live_ids: std::collections::HashSet<&str> = request
+                .messages
+                .iter()
+                .filter_map(|m| m.tool_calls.as_ref())
+                .flatten()
+                .map(|tc| tc.id.as_str())
+                .chain(tool_calls.iter().map(|tc| tc.id.as_str()))
+                .collect();
+            sigs.retain(|id, _| live_ids.contains(id.as_str()));
+        }
 
         Ok(crate::llm::provider::ToolCompletionResponse {
             content: if response.content.is_empty() {
@@ -2218,6 +2291,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let decls = &req["tools"][0]["functionDeclarations"];
@@ -2240,6 +2314,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let contents = req["contents"].as_array().unwrap();
@@ -2265,7 +2340,7 @@ mod tests {
             }
         });
 
-        let (resp, tool_calls) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        let (resp, tool_calls, _sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
 
         assert_eq!(resp.content, "Hello world");
         assert_eq!(resp.input_tokens, 10);
@@ -2293,7 +2368,7 @@ mod tests {
             }
         });
 
-        let (resp, tool_calls) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        let (resp, tool_calls, _sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
 
         assert!(resp.content.is_empty());
         assert_eq!(tool_calls.len(), 1);
@@ -2313,6 +2388,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let gen_cfg = &req["generationConfig"];
@@ -2333,6 +2409,7 @@ mod tests {
             None,
             None,
             "gemini-3-flash-preview",
+            &HashMap::new(),
         );
 
         let thinking = &req["generationConfig"]["thinkingConfig"];
@@ -2353,6 +2430,7 @@ mod tests {
             None,
             None,
             "gemini-2.5-flash-thinking",
+            &HashMap::new(),
         );
 
         let thinking = &req["generationConfig"]["thinkingConfig"];
@@ -2376,6 +2454,7 @@ mod tests {
             Some(&stops),
             None,
             "gemini-2.5-flash",
+            &HashMap::new(),
         );
 
         let gen_cfg = &req["generationConfig"];
@@ -2403,6 +2482,7 @@ mod tests {
             None,
             Some("auto"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_auto["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2417,6 +2497,7 @@ mod tests {
             None,
             Some("required"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_req["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2431,6 +2512,7 @@ mod tests {
             None,
             Some("none"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_none["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2500,6 +2582,7 @@ mod tests {
             None,
             None,
             "gemini-1.5-flash",
+            &HashMap::new(),
         );
 
         let system_instruction = req
@@ -2613,5 +2696,134 @@ mod tests {
             .count();
 
         assert_eq!(signed_calls, 2); // safety: test-only assertion
+    }
+
+    #[test]
+    fn test_from_gemini_response_captures_thought_signature() {
+        let body = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "thoughtSignature": "abc123sig",
+                        "functionCall": {
+                            "name": "read_file",
+                            "args": { "path": "/tmp/test.txt" }
+                        }
+                    }]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5
+            }
+        });
+
+        let (_resp, tool_calls, sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            sigs.get(&tool_calls[0].id).map(|s| s.as_str()),
+            Some("abc123sig")
+        );
+    }
+
+    #[test]
+    fn test_from_gemini_response_no_thought_signature_yields_none() {
+        let body = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "functionCall": {
+                            "name": "echo",
+                            "args": {}
+                        }
+                    }]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 5,
+                "candidatesTokenCount": 3
+            }
+        });
+
+        let (_resp, tool_calls, sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert!(!sigs.contains_key(&tool_calls[0].id));
+    }
+
+    #[test]
+    fn test_to_gemini_request_echoes_thought_signature_on_function_call() {
+        let messages = vec![
+            ChatMessage::user("call a tool"),
+            ChatMessage::assistant_with_tool_calls(
+                None,
+                vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({"path": "/tmp/x"}),
+                    reasoning: None,
+                }],
+            ),
+            ChatMessage::tool_result("call_1", "read_file", r#"{"output":"hello"}"#),
+        ];
+
+        let mut sigs = HashMap::new();
+        sigs.insert("call_1".to_string(), "sig_from_gemini".to_string());
+
+        let req = GeminiOauthProvider::to_gemini_request(
+            &messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "gemini-3-flash-preview",
+            &sigs,
+        );
+
+        let contents = req["contents"].as_array().unwrap();
+        // The model turn (index 1) should have the thoughtSignature on its functionCall part.
+        let model_turn = &contents[1];
+        assert_eq!(model_turn["role"], "model");
+        let fc_part = &model_turn["parts"][0];
+        assert!(fc_part.get("functionCall").is_some());
+        assert_eq!(fc_part["thoughtSignature"], "sig_from_gemini");
+    }
+
+    #[test]
+    fn test_to_gemini_request_omits_thought_signature_when_none() {
+        let messages = vec![
+            ChatMessage::user("call a tool"),
+            ChatMessage::assistant_with_tool_calls(
+                None,
+                vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "echo".to_string(),
+                    arguments: serde_json::json!({}),
+                    reasoning: None,
+                }],
+            ),
+            ChatMessage::tool_result("call_1", "echo", r#"{"output":"ok"}"#),
+        ];
+
+        let empty_sigs = HashMap::new();
+        let req = GeminiOauthProvider::to_gemini_request(
+            &messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "gemini-2.0-flash",
+            &empty_sigs,
+        );
+
+        let contents = req["contents"].as_array().unwrap();
+        let model_turn = &contents[1];
+        let fc_part = &model_turn["parts"][0];
+        assert!(fc_part.get("functionCall").is_some());
+        // No thoughtSignature should be present when there is no captured signature for this call ID.
+        assert!(fc_part.get("thoughtSignature").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,6 +165,10 @@ async fn async_main() -> anyhow::Result<()> {
             let config = ironclaw::config::Config::from_env().await?;
             return ironclaw::cli::run_import_command(import_cmd, &config).await;
         }
+        Some(Command::Acp(acp_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_acp_command(acp_cmd.clone()).await;
+        }
         Some(Command::Worker {
             job_id,
             orchestrator_url,
@@ -187,6 +191,13 @@ async fn async_main() -> anyhow::Result<()> {
                 model,
             )
             .await;
+        }
+        Some(Command::AcpBridge {
+            job_id,
+            orchestrator_url,
+        }) => {
+            init_worker_tracing();
+            return ironclaw::worker::run_acp_bridge(*job_id, orchestrator_url).await;
         }
         Some(Command::Login { openai_codex }) => {
             init_cli_tracing();
@@ -799,6 +810,7 @@ async fn async_main() -> anyhow::Result<()> {
             sandbox_enabled: config.sandbox.enabled,
             docker_status,
             claude_code_enabled: config.claude_code.enabled,
+            acp_enabled: config.acp.enabled,
             routines_enabled: config.routines.enabled,
             skills_enabled: config.skills.enabled,
             channels: channel_names,

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,6 +449,7 @@ async fn async_main() -> anyhow::Result<()> {
             &components.secrets_store,
             components.extension_manager.as_ref(),
             components.db.as_ref(),
+            &channel_names,
         )
         .await;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -706,6 +706,7 @@ async fn async_main() -> anyhow::Result<()> {
             gw = gw.with_skill_catalog(Arc::clone(sc));
         }
         gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+        gw = gw.with_oauth(config.oauth.clone(), gw_config.port);
         {
             let active_model = components.llm.model_name().to_string();
             let mut enabled = channel_names.clone();

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -16,6 +16,11 @@ use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
 use crate::sandbox::connect_docker;
 
+/// Path to the master worker MCP config on the host.
+const WORKER_MCP_CONFIG_PATH: &str = "/opt/ironclaw/config/worker/mcp-servers.json";
+
+use ironclaw_common::MAX_WORKER_ITERATIONS;
+
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JobMode {
@@ -38,6 +43,19 @@ impl std::fmt::Display for JobMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
     }
+}
+
+/// Parameters for creating a container job, bundled to avoid positional
+/// argument proliferation on `create_job` / `execute_sandbox`.
+#[derive(Debug, Clone, Default)]
+pub struct JobCreationParams {
+    /// Credential grants for the worker (served via `/credentials`).
+    pub credential_grants: Vec<CredentialGrant>,
+    /// Optional filter: which MCP servers to mount into the container.
+    /// `None` = full master config, `Some([])` = no MCP, `Some(["name"])` = filtered.
+    pub mcp_servers: Option<Vec<String>>,
+    /// Optional cap on worker agent loop iterations (clamped to 1..=500 server-side).
+    pub max_iterations: Option<u32>,
 }
 
 /// Configuration for the container job manager.
@@ -66,6 +84,9 @@ pub struct ContainerJobConfig {
     pub claude_code_memory_limit_mb: u64,
     /// Allowed tool patterns for Claude Code (passed as CLAUDE_CODE_ALLOWED_TOOLS env var).
     pub claude_code_allowed_tools: Vec<String>,
+    /// Whether per-job MCP server filtering is enabled.
+    /// When false, `mcp_servers` param on `create_job` is ignored.
+    pub mcp_per_job_enabled: bool,
 }
 
 impl Default for ContainerJobConfig {
@@ -81,6 +102,7 @@ impl Default for ContainerJobConfig {
             claude_code_max_turns: 50,
             claude_code_memory_limit_mb: 4096,
             claude_code_allowed_tools: crate::config::ClaudeCodeConfig::default().allowed_tools,
+            mcp_per_job_enabled: false,
         }
     }
 }
@@ -254,14 +276,14 @@ impl ContainerJobManager {
         task: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
+        params: JobCreationParams,
     ) -> Result<String, OrchestratorError> {
         // Generate auth token (stored in TokenStore, never logged)
         let token = self.token_store.create_token(job_id).await;
 
         // Store credential grants (revoked automatically when the token is revoked)
         self.token_store
-            .store_grants(job_id, credential_grants)
+            .store_grants(job_id, params.credential_grants)
             .await;
 
         // Record the handle
@@ -282,7 +304,14 @@ impl ContainerJobManager {
         // Run the actual container creation. On any failure, revoke the token
         // and remove the handle so we don't leak resources.
         match self
-            .create_job_inner(job_id, &token, project_dir, mode)
+            .create_job_inner(
+                job_id,
+                &token,
+                project_dir,
+                mode,
+                params.mcp_servers,
+                params.max_iterations,
+            )
             .await
         {
             Ok(()) => Ok(token),
@@ -301,6 +330,8 @@ impl ContainerJobManager {
         token: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
+        mcp_servers: Option<Vec<String>>,
+        max_iterations: Option<u32>,
     ) -> Result<(), OrchestratorError> {
         // Connect to Docker (reuses cached connection)
         let docker = self.docker().await?;
@@ -329,6 +360,42 @@ impl ContainerJobManager {
             let canonical = validate_bind_mount_path(dir, job_id)?;
             binds.push(format!("{}:/workspace:rw", canonical.display()));
             env_vec.push("IRONCLAW_WORKSPACE=/workspace".to_string());
+        }
+
+        // Inject max_iterations if specified (only for Worker mode — ClaudeCode uses max_turns).
+        // Server-side clamp ensures the cap is enforced even if the tool parsing
+        // layer is bypassed (e.g., direct API call via the web restart handler).
+        if let Some(iters) = max_iterations
+            && mode == JobMode::Worker
+        {
+            let capped = iters.clamp(1, MAX_WORKER_ITERATIONS);
+            env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", capped));
+        }
+
+        // Mount per-job MCP config when the feature is enabled.
+        if self.config.mcp_per_job_enabled {
+            let mcp_config_host = std::path::Path::new(WORKER_MCP_CONFIG_PATH);
+            match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)
+                .await?
+            {
+                Some(config_path) => {
+                    binds.push(format!(
+                        "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
+                        config_path.display()
+                    ));
+                    tracing::debug!(
+                        job_id = %job_id,
+                        filtered = mcp_servers.is_some(),
+                        "Mounted MCP config into container"
+                    );
+                }
+                None => {
+                    tracing::debug!(
+                        job_id = %job_id,
+                        "No MCP config to mount (master missing or empty filter list)"
+                    );
+                }
+            }
         }
 
         // Claude Code mode: auth + tool allowlist.
@@ -579,6 +646,23 @@ impl ContainerJobManager {
 
     /// Remove a completed job handle from memory (called after result is read).
     pub async fn cleanup_job(&self, job_id: Uuid) {
+        // Clean up per-job MCP config temp file if one was written.
+        // Use remove_file directly — avoids TOCTOU race with exists() check.
+        let tmp_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // No temp file — normal
+            Err(e) => {
+                tracing::warn!(
+                    job_id = %job_id,
+                    error = %e,
+                    "Failed to remove per-job MCP config temp file"
+                );
+            }
+        }
+
         self.containers.write().await.remove(&job_id);
     }
 
@@ -608,6 +692,132 @@ impl ContainerJobManager {
     /// Get a reference to the token store.
     pub fn token_store(&self) -> &TokenStore {
         &self.token_store
+    }
+}
+
+/// Generate a per-job MCP config file, optionally filtering to specific servers.
+///
+/// - `None` → mount the full master config as-is
+/// - `Some([])` → no MCP config (no mount)
+/// - `Some(["serpstat"])` → filtered config with only matching servers
+///
+/// Temp files are written to `<temp_dir>/ironclaw-mcp-configs/` and cleaned up
+/// in `cleanup_job`.
+async fn generate_worker_mcp_config(
+    master_path: &std::path::Path,
+    server_names: Option<&[String]>,
+    job_id: Uuid,
+) -> Result<Option<std::path::PathBuf>, OrchestratorError> {
+    if !tokio::fs::try_exists(master_path).await.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    match server_names {
+        // No filter → use master config as-is
+        None => Ok(Some(master_path.to_path_buf())),
+
+        // Empty list → no MCP
+        Some([]) => Ok(None),
+
+        // Filter to specific servers
+        Some(names) => {
+            // Validate server names: reject path separators, null bytes, and
+            // excessively long names to prevent misuse if names are ever used
+            // in file paths or shell commands.
+            for name in names {
+                if name.len() > 128
+                    || name.contains('/')
+                    || name.contains('\\')
+                    || name.contains('\0')
+                {
+                    return Err(OrchestratorError::ContainerCreationFailed {
+                        job_id,
+                        reason: format!("invalid MCP server name: {:?}", name),
+                    });
+                }
+            }
+
+            let content = tokio::fs::read_to_string(master_path).await.map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to read master MCP config: {e}"),
+                }
+            })?;
+
+            let master: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to parse master MCP config: {e}"),
+                }
+            })?;
+
+            let servers = master["servers"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|s| {
+                    let name_matches = s["name"]
+                        .as_str()
+                        .map(|n| names.iter().any(|req| req.eq_ignore_ascii_case(n)))
+                        .unwrap_or(false);
+                    let is_enabled = s["enabled"].as_bool().unwrap_or(true);
+                    name_matches && is_enabled
+                })
+                .collect::<Vec<_>>();
+
+            if servers.is_empty() {
+                tracing::warn!(
+                    job_id = %job_id,
+                    requested = ?names,
+                    "No matching MCP servers found in master config; skipping MCP mount"
+                );
+                return Ok(None);
+            }
+
+            let schema_version = master
+                .get("schema_version")
+                .cloned()
+                .unwrap_or(serde_json::json!(1));
+            let filtered = serde_json::json!({
+                "servers": servers,
+                "schema_version": schema_version
+            });
+
+            let tmp_dir = std::env::temp_dir().join("ironclaw-mcp-configs");
+            tokio::fs::create_dir_all(&tmp_dir).await.map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to create MCP config temp dir: {e}"),
+                }
+            })?;
+
+            // Restrict directory permissions to owner-only (0o700) to prevent
+            // other users on the host from reading filtered MCP configs.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    tokio::fs::set_permissions(&tmp_dir, std::fs::Permissions::from_mode(0o700))
+                        .await;
+            }
+
+            let tmp_path = tmp_dir.join(format!("{}.json", job_id));
+            let config_json = serde_json::to_string_pretty(&filtered).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to serialize filtered MCP config: {e}"),
+                }
+            })?;
+            tokio::fs::write(&tmp_path, config_json)
+                .await
+                .map_err(|e| OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to write per-job MCP config: {e}"),
+                })?;
+
+            Ok(Some(tmp_path))
+        }
     }
 }
 
@@ -704,5 +914,309 @@ mod tests {
         let handle = mgr.get_handle(job_id).await.unwrap();
         assert_eq!(handle.worker_iteration, 3);
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 3"));
+    }
+
+    // ── generate_worker_mcp_config tests ────────────────────────────
+
+    #[tokio::test]
+    async fn test_mcp_config_none_filter_returns_master_path() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), None, Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), Some(tmp.path().to_path_buf()));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_empty_filter_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), Some(&[]), Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_missing_master_returns_none() {
+        let result = generate_worker_mcp_config(
+            std::path::Path::new("/nonexistent/mcp.json"),
+            None,
+            Uuid::new_v4(),
+        )
+        .await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_filters_to_named_servers() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":1,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"disabled","enabled":false,"url":"http://localhost:9999"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string(), "disabled".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        // "disabled" should be excluded because enabled=false
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert_eq!(content["schema_version"], 1);
+
+        // cleanup
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_no_match_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["nonexistent".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_case_insensitive_match() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"Serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("case-insensitive match should work");
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn test_max_iterations_env_var_injected() {
+        // Verify the IRONCLAW_MAX_ITERATIONS env var name matches what the
+        // worker CLI reads via clap's `env` attribute.
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        // We can't test actual container creation without Docker, but we can
+        // verify the env var name matches the clap definition.
+        // The clap definition uses: #[arg(long, env = "IRONCLAW_MAX_ITERATIONS")]
+        // The create_job_inner injects: format!("IRONCLAW_MAX_ITERATIONS={}", iters)
+        // This test ensures the constant isn't accidentally changed in either place.
+        let env_var_in_job = "IRONCLAW_MAX_ITERATIONS";
+        let source = include_str!("../cli/mod.rs");
+        assert!(
+            source.contains(&format!("env = \"{}\"", env_var_in_job)),
+            "cli/mod.rs must have env = \"IRONCLAW_MAX_ITERATIONS\" on the max_iterations arg"
+        );
+        drop(mgr);
+    }
+
+    #[test]
+    fn test_max_iterations_not_injected_for_claude_code() {
+        // ClaudeCode mode uses its own `max_turns`, not IRONCLAW_MAX_ITERATIONS.
+        // Verify the gate in create_job_inner only injects for Worker mode.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("mode == JobMode::Worker"),
+            "create_job_inner must gate IRONCLAW_MAX_ITERATIONS on JobMode::Worker \
+             (ClaudeCode has its own max_turns)"
+        );
+    }
+
+    #[test]
+    fn test_server_side_max_iterations_clamp() {
+        // Verify the server-side clamp uses the same constant as worker/job.rs
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("iters.clamp(1, MAX_WORKER_ITERATIONS)"),
+            "create_job_inner must clamp max_iterations server-side using MAX_WORKER_ITERATIONS"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_server_name_validation_rejects_path_separators() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        // Path separator should be rejected
+        let names = vec!["../../etc/passwd".to_string()];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Null byte should be rejected
+        let names = vec!["test\0evil".to_string()];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Excessively long name should be rejected
+        let names = vec!["a".repeat(129)];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Valid name should pass
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        assert!(result.is_ok());
+    }
+
+    // ── Regression tests (CI-required) ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_filtered_config_contains_only_requested_server() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":2,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"archon","enabled":true,"url":"http://localhost:8064"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        assert_eq!(servers.len(), 1, "only serpstat should be present");
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert!(
+            !servers.iter().any(|s| s["name"] == "notion"),
+            "notion must not leak into filtered config"
+        );
+        assert!(
+            !servers.iter().any(|s| s["name"] == "archon"),
+            "archon must not leak into filtered config"
+        );
+        assert_eq!(
+            content["schema_version"], 2,
+            "schema_version must be preserved"
+        );
+
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[tokio::test]
+    async fn test_feature_flag_disabled_skips_mcp_filtering() {
+        // When MCP_PER_JOB_ENABLED is false (the default), the mcp_servers
+        // parameter should be ignored and no filtered config should be created.
+        let config = ContainerJobConfig::default();
+        assert!(
+            !config.mcp_per_job_enabled,
+            "mcp_per_job_enabled must default to false"
+        );
+
+        // Verify the gate in create_job_inner: the mcp_per_job_enabled field
+        // controls whether generate_worker_mcp_config is called at all.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("if self.config.mcp_per_job_enabled"),
+            "create_job_inner must gate MCP filtering on config.mcp_per_job_enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_temp_file_cleanup_removes_per_job_config() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+        assert!(
+            out_path.exists(),
+            "temp config file should exist after creation"
+        );
+
+        // Simulate what cleanup_job does
+        let expected_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
+        assert_eq!(
+            out_path, expected_path,
+            "temp path must match cleanup expectation"
+        );
+        std::fs::remove_file(&out_path).unwrap();
+        assert!(!out_path.exists(), "temp file should be gone after cleanup");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_job_is_idempotent() {
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        let job_id = Uuid::new_v4();
+
+        // cleanup_job should not panic or error when called for a job
+        // that has no temp file and no container handle.
+        mgr.cleanup_job(job_id).await;
+        // Second call should also be fine (idempotent).
+        mgr.cleanup_job(job_id).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_temp_dir_has_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let dir_path = out_path.parent().unwrap();
+        let mode = std::fs::metadata(dir_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "ironclaw-mcp-configs dir must be 0700, got {:o}",
+            mode
+        );
+
+        let _ = std::fs::remove_file(&out_path);
     }
 }

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -28,6 +28,8 @@ pub enum JobMode {
     Worker,
     /// Claude Code bridge that spawns the `claude` CLI directly.
     ClaudeCode,
+    /// ACP (Agent Client Protocol) bridge that spawns any ACP-compliant agent.
+    Acp,
 }
 
 impl JobMode {
@@ -35,6 +37,7 @@ impl JobMode {
         match self {
             Self::Worker => "worker",
             Self::ClaudeCode => "claude_code",
+            Self::Acp => "acp",
         }
     }
 }
@@ -56,6 +59,8 @@ pub struct JobCreationParams {
     pub mcp_servers: Option<Vec<String>>,
     /// Optional cap on worker agent loop iterations (clamped to 1..=500 server-side).
     pub max_iterations: Option<u32>,
+    /// ACP agent definition to inject into ACP-mode containers.
+    pub acp_agent: Option<crate::config::acp::AcpAgentConfig>,
 }
 
 /// Configuration for the container job manager.
@@ -84,6 +89,10 @@ pub struct ContainerJobConfig {
     pub claude_code_memory_limit_mb: u64,
     /// Allowed tool patterns for Claude Code (passed as CLAUDE_CODE_ALLOWED_TOOLS env var).
     pub claude_code_allowed_tools: Vec<String>,
+    /// Memory limit for ACP containers.
+    pub acp_memory_limit_mb: u64,
+    /// Maximum runtime for ACP bridge sessions in seconds.
+    pub acp_timeout_secs: u64,
     /// Whether per-job MCP server filtering is enabled.
     /// When false, `mcp_servers` param on `create_job` is ignored.
     pub mcp_per_job_enabled: bool,
@@ -102,6 +111,8 @@ impl Default for ContainerJobConfig {
             claude_code_max_turns: 50,
             claude_code_memory_limit_mb: 4096,
             claude_code_allowed_tools: crate::config::ClaudeCodeConfig::default().allowed_tools,
+            acp_memory_limit_mb: 4096,
+            acp_timeout_secs: 1800,
             mcp_per_job_enabled: false,
         }
     }
@@ -247,6 +258,28 @@ impl ContainerJobManager {
         }
     }
 
+    fn extend_acp_env(
+        &self,
+        env_vec: &mut Vec<String>,
+        acp_agent: Option<&crate::config::acp::AcpAgentConfig>,
+    ) {
+        env_vec.push(format!("ACP_TIMEOUT_SECS={}", self.config.acp_timeout_secs));
+
+        if let Some(agent) = acp_agent {
+            env_vec.push(format!("ACP_AGENT_COMMAND={}", agent.command));
+            if !agent.args.is_empty()
+                && let Ok(json) = serde_json::to_string(&agent.args)
+            {
+                env_vec.push(format!("ACP_AGENT_ARGS={}", json));
+            }
+            if !agent.env.is_empty()
+                && let Ok(json) = serde_json::to_string(&agent.env)
+            {
+                env_vec.push(format!("ACP_AGENT_ENV={}", json));
+            }
+        }
+    }
+
     /// Get or create a Docker connection.
     async fn docker(&self) -> Result<bollard::Docker, OrchestratorError> {
         {
@@ -282,8 +315,15 @@ impl ContainerJobManager {
         let token = self.token_store.create_token(job_id).await;
 
         // Store credential grants (revoked automatically when the token is revoked)
+        let JobCreationParams {
+            credential_grants,
+            mcp_servers,
+            max_iterations,
+            acp_agent,
+        } = params;
+
         self.token_store
-            .store_grants(job_id, params.credential_grants)
+            .store_grants(job_id, credential_grants)
             .await;
 
         // Record the handle
@@ -309,8 +349,9 @@ impl ContainerJobManager {
                 &token,
                 project_dir,
                 mode,
-                params.mcp_servers,
-                params.max_iterations,
+                mcp_servers,
+                max_iterations,
+                acp_agent,
             )
             .await
         {
@@ -324,6 +365,7 @@ impl ContainerJobManager {
     }
 
     /// Inner implementation of container creation (separated for cleanup).
+    #[allow(clippy::too_many_arguments)]
     async fn create_job_inner(
         &self,
         job_id: Uuid,
@@ -332,16 +374,15 @@ impl ContainerJobManager {
         mode: JobMode,
         mcp_servers: Option<Vec<String>>,
         max_iterations: Option<u32>,
+        acp_agent: Option<crate::config::acp::AcpAgentConfig>,
     ) -> Result<(), OrchestratorError> {
         // Connect to Docker (reuses cached connection)
         let docker = self.docker().await?;
 
         // Build container configuration
-        let orchestrator_host = if cfg!(target_os = "linux") {
-            "172.17.0.1"
-        } else {
-            "host.docker.internal"
-        };
+        // Use host.docker.internal on all platforms — the extra_hosts mapping
+        // below resolves it to the actual host IP via Docker's host-gateway.
+        let orchestrator_host = "host.docker.internal";
 
         let orchestrator_url = format!(
             "http://{}:{}",
@@ -418,9 +459,15 @@ impl ContainerJobManager {
             }
         }
 
-        // Memory limit: Claude Code gets more memory
+        // ACP mode: inject runtime timeout plus per-job agent command/args/env.
+        if mode == JobMode::Acp {
+            self.extend_acp_env(&mut env_vec, acp_agent.as_ref());
+        }
+
+        // Memory limit per mode
         let memory_mb = match mode {
             JobMode::ClaudeCode => self.config.claude_code_memory_limit_mb,
+            JobMode::Acp => self.config.acp_memory_limit_mb,
             JobMode::Worker => self.config.memory_limit_mb,
         };
 
@@ -465,6 +512,13 @@ impl ContainerJobManager {
                 "--model".to_string(),
                 self.config.claude_code_model.clone(),
             ],
+            JobMode::Acp => vec![
+                "acp-bridge".to_string(),
+                "--job-id".to_string(),
+                job_id.to_string(),
+                "--orchestrator-url".to_string(),
+                orchestrator_url,
+            ],
         };
 
         // Add Docker labels for reaper identification and orphan detection
@@ -489,6 +543,7 @@ impl ContainerJobManager {
         let container_name = match mode {
             JobMode::Worker => format!("ironclaw-worker-{}", job_id),
             JobMode::ClaudeCode => format!("ironclaw-claude-{}", job_id),
+            JobMode::Acp => format!("ironclaw-acp-{}", job_id),
         };
         let options = CreateContainerOptions {
             name: container_name,
@@ -916,6 +971,58 @@ mod tests {
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 3"));
     }
 
+    #[test]
+    fn test_job_mode_acp_as_str() {
+        assert_eq!(JobMode::Acp.as_str(), "acp");
+    }
+
+    #[test]
+    fn test_job_mode_acp_display() {
+        assert_eq!(format!("{}", JobMode::Acp), "acp");
+    }
+
+    #[test]
+    fn test_container_job_config_acp_memory_default() {
+        let config = ContainerJobConfig::default();
+        assert_eq!(config.acp_memory_limit_mb, 4096);
+    }
+
+    #[test]
+    fn test_container_job_config_acp_timeout_default() {
+        let config = ContainerJobConfig::default();
+        assert_eq!(config.acp_timeout_secs, 1800);
+    }
+
+    #[test]
+    fn test_extend_acp_env_includes_timeout_and_agent_details() {
+        let config = ContainerJobConfig {
+            acp_timeout_secs: 45,
+            ..Default::default()
+        };
+        let manager = ContainerJobManager::new(config, TokenStore::new());
+
+        let agent = crate::config::acp::AcpAgentConfig::new(
+            "codex",
+            "codex",
+            vec!["acp".into()],
+            HashMap::from([("FOO".to_string(), "bar".to_string())]),
+        );
+        let mut env_vec = Vec::new();
+        manager.extend_acp_env(&mut env_vec, Some(&agent));
+
+        assert!(env_vec.contains(&"ACP_TIMEOUT_SECS=45".to_string()));
+        assert!(env_vec.contains(&"ACP_AGENT_COMMAND=codex".to_string()));
+        assert!(
+            env_vec
+                .iter()
+                .any(|entry| entry.starts_with("ACP_AGENT_ARGS="))
+        );
+        assert!(
+            env_vec
+                .iter()
+                .any(|entry| entry.starts_with("ACP_AGENT_ENV="))
+        );
+    }
     // ── generate_worker_mcp_config tests ────────────────────────────
 
     #[tokio::test]

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -122,6 +122,9 @@ pub async fn setup_orchestrator(
             claude_code_max_turns: config.claude_code.max_turns,
             claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
             claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
+            mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
         };
         let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
 

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -122,6 +122,8 @@ pub async fn setup_orchestrator(
             claude_code_max_turns: config.claude_code.max_turns,
             claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
             claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
+            acp_memory_limit_mb: config.acp.memory_limit_mb,
+            acp_timeout_secs: config.acp.timeout_secs,
             mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
                 .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
                 .unwrap_or(false),
@@ -152,6 +154,9 @@ pub async fn setup_orchestrator(
                 config.claude_code.model,
                 config.claude_code.max_turns
             );
+        }
+        if config.acp.enabled {
+            tracing::info!("ACP agent sandbox mode available");
         }
         (job_event_tx, Some(jm))
     } else {

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -98,6 +98,18 @@ impl ContainerRunner {
         }
     }
 
+    /// Create a runner for image-only operations (exists / pull / build).
+    ///
+    /// `proxy_port` is unused for image operations, so this avoids requiring
+    /// a real port number when the caller only needs to check or build images.
+    pub fn for_image_ops(docker: Docker, image: String) -> Self {
+        Self {
+            docker,
+            image,
+            proxy_port: 0,
+        }
+    }
+
     /// Check if the Docker daemon is available.
     pub async fn is_available(&self) -> bool {
         self.docker.ping().await.is_ok()
@@ -137,6 +149,141 @@ impl ContainerRunner {
         }
 
         tracing::info!("Successfully pulled image: {}", self.image);
+        Ok(())
+    }
+
+    /// Build the sandbox image from a Dockerfile.
+    ///
+    /// This is used when the image is not available from a registry and needs
+    /// to be built locally from source.
+    ///
+    /// # Security
+    ///
+    /// The `dockerfile_path` MUST point to a trusted Dockerfile. Docker builds
+    /// execute arbitrary `RUN` commands from the Dockerfile, which is a code
+    /// execution vector. Callers must ensure the path is not user-controlled
+    /// and points to a known, safe Dockerfile (e.g., bundled with the application).
+    pub async fn build_image(&self, dockerfile_path: &Path) -> Result<()> {
+        use tokio::io::AsyncBufReadExt;
+        use tokio::process::Command;
+
+        const MAX_STDERR_CAPTURE: usize = 4096;
+
+        // Canonicalize so the -f path is absolute and context_dir is its parent.
+        // This avoids the bug where a relative path like "docker/sandbox.Dockerfile"
+        // would be resolved twice (once for context_dir, once by docker -f).
+        let canonical =
+            dockerfile_path
+                .canonicalize()
+                .map_err(|e| SandboxError::ContainerCreationFailed {
+                    reason: format!(
+                        "cannot resolve Dockerfile path '{}': {}",
+                        dockerfile_path.display(),
+                        e
+                    ),
+                })?;
+
+        let context_dir =
+            canonical
+                .parent()
+                .ok_or_else(|| SandboxError::ContainerCreationFailed {
+                    reason: format!(
+                        "Dockerfile path '{}' has no parent directory",
+                        canonical.display()
+                    ),
+                })?;
+
+        tracing::info!(
+            "Building sandbox image from {}: {}",
+            canonical.display(),
+            self.image
+        );
+
+        let mut child = Command::new("docker")
+            .arg("build")
+            .arg("-f")
+            .arg(&canonical)
+            .arg("-t")
+            .arg(&self.image)
+            .arg(".")
+            .current_dir(context_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| SandboxError::ContainerCreationFailed {
+                reason: format!("failed to run docker build: {}", e),
+            })?;
+
+        // Both streams are piped above, so take() returns Some.
+        let mut stdout_lines = tokio::io::BufReader::new(child.stdout.take().ok_or_else(|| {
+            SandboxError::ContainerCreationFailed {
+                reason: "stdout pipe missing".to_string(),
+            }
+        })?)
+        .lines();
+        let mut stderr_lines = tokio::io::BufReader::new(child.stderr.take().ok_or_else(|| {
+            SandboxError::ContainerCreationFailed {
+                reason: "stderr pipe missing".to_string(),
+            }
+        })?)
+        .lines();
+
+        let mut stderr_capture = String::new();
+        let mut stdout_done = false;
+        let mut stderr_done = false;
+
+        while !stdout_done || !stderr_done {
+            tokio::select! {
+                line = stdout_lines.next_line(), if !stdout_done => {
+                    match line {
+                        Ok(Some(line)) => tracing::info!("[docker build] {}", line),
+                        Ok(None) => stdout_done = true,
+                        Err(e) => {
+                            tracing::warn!("Error reading docker build stdout: {}", e);
+                            stdout_done = true;
+                        }
+                    }
+                },
+                line = stderr_lines.next_line(), if !stderr_done => {
+                    match line {
+                        Ok(Some(line)) => {
+                            tracing::info!("[docker build] {}", line);
+                            if stderr_capture.len() < MAX_STDERR_CAPTURE {
+                                stderr_capture.push_str(&line);
+                                stderr_capture.push('\n');
+                            }
+                        }
+                        Ok(None) => stderr_done = true,
+                        Err(e) => {
+                            tracing::warn!("Error reading docker build stderr: {}", e);
+                            stderr_done = true;
+                        }
+                    }
+                },
+            }
+        }
+
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| SandboxError::ContainerCreationFailed {
+                reason: format!("docker build wait failed: {}", e),
+            })?;
+
+        if !status.success() {
+            let code = status
+                .code()
+                .map_or("unknown".to_string(), |c| c.to_string());
+            return Err(SandboxError::ContainerCreationFailed {
+                reason: format!(
+                    "docker build failed (exit {}): {}",
+                    code,
+                    stderr_capture.trim_end()
+                ),
+            });
+        }
+
+        tracing::info!("Successfully built image: {}", self.image);
         Ok(())
     }
 
@@ -615,6 +762,22 @@ mod tests {
         assert!(candidates.contains(&PathBuf::from("/home/tester/.colima/default/docker.sock")));
         assert!(candidates.contains(&PathBuf::from("/home/tester/.rd/docker.sock")));
         assert!(candidates.contains(&PathBuf::from("/run/user/1000/docker.sock")));
+    }
+
+    #[tokio::test]
+    async fn build_image_rejects_nonexistent_dockerfile() {
+        // The behavior under test (Dockerfile path canonicalization) happens
+        // before any Docker daemon call, so we don't need a reachable daemon.
+        let docker = Docker::connect_with_http_defaults().unwrap();
+        let runner = ContainerRunner::for_image_ops(docker, "test-nonexistent:latest".to_string());
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("definitely-does-not-exist.Dockerfile");
+        let err = runner.build_image(&bad_path).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot resolve Dockerfile path"),
+            "expected path resolution error, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -914,13 +914,19 @@ pub struct HygieneSettings {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
-    /// Days before `daily/` documents are deleted.
+    /// Deprecated: retention is now per-folder via `.config` metadata.
+    /// Kept for backward compatibility with existing DB settings rows.
     #[serde(default = "default_hygiene_daily_retention")]
     pub daily_retention_days: u32,
 
-    /// Days before `conversations/` documents are deleted.
+    /// Deprecated: retention is now per-folder via `.config` metadata.
+    /// Kept for backward compatibility with existing DB settings rows.
     #[serde(default = "default_hygiene_conversation_retention")]
     pub conversation_retention_days: u32,
+
+    /// Maximum versions to keep per document during hygiene passes.
+    #[serde(default = "default_hygiene_version_keep_count")]
+    pub version_keep_count: u32,
 
     /// Minimum hours between hygiene passes.
     #[serde(default = "default_hygiene_cadence_hours")]
@@ -935,6 +941,10 @@ fn default_hygiene_conversation_retention() -> u32 {
     7
 }
 
+fn default_hygiene_version_keep_count() -> u32 {
+    50
+}
+
 fn default_hygiene_cadence_hours() -> u32 {
     12
 }
@@ -945,6 +955,7 @@ impl Default for HygieneSettings {
             enabled: true,
             daily_retention_days: default_hygiene_daily_retention(),
             conversation_retention_days: default_hygiene_conversation_retention(),
+            version_keep_count: default_hygiene_version_keep_count(),
             cadence_hours: default_hygiene_cadence_hours(),
         }
     }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -700,6 +700,10 @@ pub struct SandboxSettings {
     /// Whether Claude Code sandbox mode is enabled.
     #[serde(default)]
     pub claude_code_enabled: bool,
+
+    /// Whether ACP (Agent Client Protocol) agent mode is enabled.
+    #[serde(default)]
+    pub acp_enabled: bool,
 }
 
 fn default_sandbox_policy() -> String {
@@ -734,6 +738,7 @@ impl Default for SandboxSettings {
             auto_pull_image: true,
             extra_allowed_domains: Vec::new(),
             claude_code_enabled: false,
+            acp_enabled: false,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,6 +201,22 @@ pub struct Settings {
     #[serde(default)]
     pub builder: BuilderSettings,
 
+    /// Routine scheduling and execution configuration.
+    #[serde(default)]
+    pub routines: RoutineSettings,
+
+    /// Skills system configuration.
+    #[serde(default)]
+    pub skills: SkillsSettings,
+
+    /// Memory hygiene configuration.
+    #[serde(default)]
+    pub hygiene: HygieneSettings,
+
+    /// Workspace search fusion configuration.
+    #[serde(default)]
+    pub search: SearchSettings,
+
     /// Transcription configuration.
     #[serde(default)]
     pub transcription: Option<TranscriptionSettings>,
@@ -791,6 +807,188 @@ impl Default for BuilderSettings {
     }
 }
 
+/// Routine scheduling and execution configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutineSettings {
+    /// Whether the routines system is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// How often (seconds) to poll for cron routines that need firing.
+    #[serde(default = "default_routine_cron_interval")]
+    pub cron_check_interval_secs: u64,
+
+    /// Max routines executing concurrently.
+    #[serde(default = "default_routine_max_concurrent")]
+    pub max_concurrent_routines: usize,
+
+    /// Default cooldown between fires (seconds).
+    #[serde(default = "default_routine_cooldown")]
+    pub default_cooldown_secs: u64,
+
+    /// Max output tokens for lightweight routine LLM calls.
+    #[serde(default = "default_routine_max_tokens")]
+    pub max_lightweight_tokens: u32,
+
+    /// Enable tool execution in lightweight routines.
+    #[serde(default = "default_true")]
+    pub lightweight_tools_enabled: bool,
+
+    /// Max tool iterations for lightweight routines.
+    #[serde(default = "default_routine_max_iterations")]
+    pub lightweight_max_iterations: u32,
+}
+
+fn default_routine_cron_interval() -> u64 {
+    15
+}
+
+fn default_routine_max_concurrent() -> usize {
+    10
+}
+
+fn default_routine_cooldown() -> u64 {
+    300
+}
+
+fn default_routine_max_tokens() -> u32 {
+    4096
+}
+
+fn default_routine_max_iterations() -> u32 {
+    3
+}
+
+impl Default for RoutineSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cron_check_interval_secs: default_routine_cron_interval(),
+            max_concurrent_routines: default_routine_max_concurrent(),
+            default_cooldown_secs: default_routine_cooldown(),
+            max_lightweight_tokens: default_routine_max_tokens(),
+            lightweight_tools_enabled: true,
+            lightweight_max_iterations: default_routine_max_iterations(),
+        }
+    }
+}
+
+/// Skills system configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillsSettings {
+    /// Whether the skills system is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Maximum number of skills that can be active simultaneously.
+    #[serde(default = "default_skills_max_active")]
+    pub max_active_skills: usize,
+
+    /// Maximum total context tokens allocated to skill prompts.
+    #[serde(default = "default_skills_max_context_tokens")]
+    pub max_context_tokens: usize,
+}
+
+fn default_skills_max_active() -> usize {
+    3
+}
+
+fn default_skills_max_context_tokens() -> usize {
+    4000
+}
+
+impl Default for SkillsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_active_skills: default_skills_max_active(),
+            max_context_tokens: default_skills_max_context_tokens(),
+        }
+    }
+}
+
+/// Memory hygiene configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HygieneSettings {
+    /// Whether hygiene is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Days before `daily/` documents are deleted.
+    #[serde(default = "default_hygiene_daily_retention")]
+    pub daily_retention_days: u32,
+
+    /// Days before `conversations/` documents are deleted.
+    #[serde(default = "default_hygiene_conversation_retention")]
+    pub conversation_retention_days: u32,
+
+    /// Minimum hours between hygiene passes.
+    #[serde(default = "default_hygiene_cadence_hours")]
+    pub cadence_hours: u32,
+}
+
+fn default_hygiene_daily_retention() -> u32 {
+    30
+}
+
+fn default_hygiene_conversation_retention() -> u32 {
+    7
+}
+
+fn default_hygiene_cadence_hours() -> u32 {
+    12
+}
+
+impl Default for HygieneSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            daily_retention_days: default_hygiene_daily_retention(),
+            conversation_retention_days: default_hygiene_conversation_retention(),
+            cadence_hours: default_hygiene_cadence_hours(),
+        }
+    }
+}
+
+/// Workspace search fusion configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchSettings {
+    /// Fusion strategy: "rrf" or "weighted".
+    #[serde(default = "default_search_fusion_strategy")]
+    pub fusion_strategy: String,
+
+    /// RRF constant k.
+    #[serde(default = "default_search_rrf_k")]
+    pub rrf_k: u32,
+
+    /// FTS weight for fusion. `None` = use per-strategy default.
+    #[serde(default)]
+    pub fts_weight: Option<f32>,
+
+    /// Vector weight for fusion. `None` = use per-strategy default.
+    #[serde(default)]
+    pub vector_weight: Option<f32>,
+}
+
+fn default_search_fusion_strategy() -> String {
+    "rrf".to_string()
+}
+
+fn default_search_rrf_k() -> u32 {
+    60
+}
+
+impl Default for SearchSettings {
+    fn default() -> Self {
+        Self {
+            fusion_strategy: default_search_fusion_strategy(),
+            rrf_k: default_search_rrf_k(),
+            fts_weight: None,
+            vector_weight: None,
+        }
+    }
+}
+
 /// Transcription pipeline settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionSettings {
@@ -907,8 +1105,9 @@ impl Settings {
         let content = format!(
             "# IronClaw configuration file.\n\
              #\n\
-             # Priority varies by subsystem. LLM: DB > env > this file > defaults.\n\
-             # Most others: env > DB > this file > defaults.\n\
+             # Priority: DB settings > env vars > this file > defaults.\n\
+             # A DB value equal to the built-in default is treated as unset.\n\
+             # Exceptions: bootstrap and security-sensitive fields are env-only.\n\
              # Uncomment and edit values to override defaults.\n\
              # Run `ironclaw config init` to regenerate this file.\n\
              #\n\

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -349,7 +349,7 @@ key first, then falls back to the standard env var.
 **Telegram special case** (`setup_telegram`):
 - Validates bot token via Telegram `getMe` API
 - Owner binding: polls `getUpdates` for 120s to capture sender's user ID
-- Optional webhook secret generation
+- Optional webhook secret auto-generation for webhook mode
 
 **SecretsContext creation** (`init_secrets_context`):
 1. Check `self.secrets_crypto` (set in Step 2) → use if available

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -65,6 +65,9 @@ pub enum SetupError {
 
     #[error("User cancelled")]
     Cancelled,
+
+    #[error("Sandbox error: {0}")]
+    Sandbox(#[from] crate::sandbox::error::SandboxError),
 }
 
 impl From<crate::setup::channels::ChannelSetupError> for SetupError {
@@ -2859,6 +2862,9 @@ impl SetupWizard {
             crate::sandbox::detect::DockerStatus::Available => {
                 self.settings.sandbox.enabled = true;
                 print_success("Docker is installed and running. Sandbox enabled.");
+
+                // Check if the worker image exists
+                self.ensure_worker_image().await?;
             }
             crate::sandbox::detect::DockerStatus::NotInstalled
             | crate::sandbox::detect::DockerStatus::NotRunning => {
@@ -2888,6 +2894,8 @@ impl SetupWizard {
                         } else {
                             "Docker is now running. Sandbox enabled."
                         });
+                        // Check if the worker image exists
+                        self.ensure_worker_image().await?;
                     } else {
                         self.settings.sandbox.enabled = false;
                         print_info(if not_installed {
@@ -2969,6 +2977,113 @@ impl SetupWizard {
                 self.settings.sandbox.claude_code_enabled = false;
                 print_info("Claude Code disabled. Enable with CLAUDE_CODE_ENABLED=true later.");
             }
+        }
+
+        Ok(())
+    }
+
+    /// Ensure the sandbox worker Docker image exists, building it if necessary.
+    async fn ensure_worker_image(&mut self) -> Result<(), SetupError> {
+        use crate::sandbox::container::{ContainerRunner, connect_docker};
+
+        let image_name = self.settings.sandbox.image.clone();
+        let docker = match connect_docker().await {
+            Ok(d) => d,
+            Err(e) => {
+                // check_docker() may report Available (via CLI fallback) even when
+                // connect_docker() fails (e.g. on Windows). Don't hard-fail setup.
+                print_info(&format!(
+                    "Could not connect to Docker API to verify image: {}",
+                    e
+                ));
+                print_info("Image check skipped. The image will be pulled at first job run.");
+                return Ok(());
+            }
+        };
+        let runner = ContainerRunner::for_image_ops(docker, image_name.clone());
+
+        if runner.image_exists().await {
+            print_success(&format!("Worker image '{}' found.", image_name));
+            return Ok(());
+        }
+
+        println!();
+        print_info(&format!("Worker image '{}' not found.", image_name));
+        print_info("This image is required for sandboxed job execution.");
+        println!();
+
+        // Images that contain '/' look like registry references (e.g.
+        // "ghcr.io/nearai/ironclaw-worker:v1"). For those, or when
+        // auto_pull_image is enabled, attempt a pull before offering a
+        // local build — the runtime would do the same thing via
+        // SandboxManager::ensure_ready().
+        let is_registry_image = image_name.contains('/');
+        if is_registry_image || self.settings.sandbox.auto_pull_image {
+            print_info(&format!("Attempting to pull '{}'...", image_name));
+            match runner.pull_image().await {
+                Ok(()) => {
+                    print_success(&format!("Successfully pulled image '{}'.", image_name));
+                    return Ok(());
+                }
+                Err(e) => {
+                    if is_registry_image {
+                        // Registry image that can't be pulled — don't offer local build.
+                        print_error(&format!("Failed to pull image: {}", e));
+                        print_info("Ensure the image is published and accessible, or set");
+                        print_info("SANDBOX_IMAGE to a local image name and try again.");
+                        return Ok(());
+                    }
+                    print_info(&format!(
+                        "Pull failed ({}). Checking for local Dockerfile...",
+                        e
+                    ));
+                }
+            }
+        }
+
+        // Only offer local build for default-style local images.
+        let dockerfile_path = std::path::PathBuf::from("Dockerfile.worker");
+
+        if dockerfile_path.exists() {
+            print_info(&format!(
+                "Found Dockerfile at: {}",
+                dockerfile_path.display()
+            ));
+            if confirm(
+                "Build the worker image now? (this may take a few minutes)",
+                true,
+            )
+            .map_err(SetupError::Io)?
+            {
+                print_info("Building worker image... This may take a few minutes.");
+                match runner.build_image(&dockerfile_path).await {
+                    Ok(()) => {
+                        print_success(&format!("Successfully built image '{}'.", image_name));
+                    }
+                    Err(e) => {
+                        print_error(&format!("Failed to build image: {}", e));
+                        print_info("You can build it manually later with:");
+                        print_info(&format!(
+                            "  docker build -f Dockerfile.worker -t {} .",
+                            image_name
+                        ));
+                    }
+                }
+            } else {
+                print_info("Skipped image build. Build it manually with:");
+                print_info(&format!(
+                    "  docker build -f Dockerfile.worker -t {} .",
+                    image_name
+                ));
+            }
+        } else {
+            print_info("No Dockerfile.worker found in current directory.");
+            print_info("To use Docker sandbox, build the worker image manually:");
+            print_info(&format!(
+                "  docker build -f Dockerfile.worker -t {} .",
+                image_name
+            ));
+            print_info("or clone the IronClaw repository and build from source.");
         }
 
         Ok(())

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -278,7 +278,7 @@ impl TenantScope {
         thread_id: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         self.inner
-            .ensure_conversation(id, channel, &self.user_id, thread_id)
+            .ensure_conversation(id, channel, &self.user_id, thread_id, Some(channel))
             .await
     }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -753,7 +753,7 @@ mod tests {
 
         // ensure_conversation should create the row.
         assert!(
-            db.ensure_conversation(conv_id, "web", "carol", None)
+            db.ensure_conversation(conv_id, "web", "carol", None, Some("web"))
                 .await
                 .expect("ensure first"),
             "first ensure_conversation should create the row"
@@ -761,7 +761,7 @@ mod tests {
 
         // Calling again with the same ID should not error.
         assert!(
-            db.ensure_conversation(conv_id, "web", "carol", None)
+            db.ensure_conversation(conv_id, "web", "carol", None, Some("web"))
                 .await
                 .expect("ensure second (idempotent)"),
             "second ensure_conversation should touch owned row"
@@ -806,7 +806,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
 
         assert!(
-            !db.ensure_conversation(conv_id, "web", "mallory", None)
+            !db.ensure_conversation(conv_id, "web", "mallory", None, None)
                 .await
                 .expect("foreign ensure should not error"),
             "foreign ensure_conversation should report not ensured"

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -48,6 +48,75 @@ use crate::tools::tool::{
 };
 use crate::tools::{ToolRegistry, prepare_tool_params};
 
+/// Deserialize `dependencies` from either a list of strings, a list of objects,
+/// or a flat object map.  LLMs often produce TOML-style inline tables
+/// (`{"ureq": {"version": "2"}}`) instead of simple strings (`"ureq = \"2\""`);
+/// this normalises all variants to `Vec<"name = \"version\"">`  strings.
+fn deserialize_dependencies<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    use serde_json::Value;
+
+    let val = Value::deserialize(deserializer)?;
+    match val {
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::String(s) => out.push(s),
+                    Value::Object(map) => {
+                        for (name, spec) in map {
+                            if let Some(dep) = flatten_dep(&name, &spec) {
+                                out.push(dep);
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(de::Error::custom(format!(
+                            "expected string or object in dependencies array, got {other}"
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Value::Object(map) => {
+            let out: Vec<String> = map
+                .into_iter()
+                .filter_map(|(name, spec)| flatten_dep(&name, &spec))
+                .collect();
+            Ok(out)
+        }
+        Value::Null => Ok(Vec::new()),
+        other => Err(de::Error::custom(format!(
+            "expected array or object for dependencies, got {other}"
+        ))),
+    }
+}
+
+/// Flatten a dependency entry like `("ureq", "2")` or `("serde", {"version":"1","features":["derive"]})`
+/// into a TOML-compatible string like `ureq = "2"` or `serde = { version = "1", features = ["derive"] }`.
+/// Returns `None` for values that cannot produce valid TOML (null, bool, array, number).
+fn flatten_dep(name: &str, spec: &serde_json::Value) -> Option<String> {
+    match spec {
+        serde_json::Value::String(version) => Some(format!("{name} = \"{version}\"")),
+        serde_json::Value::Object(map) => {
+            let parts: Vec<String> = map.iter().map(|(k, v)| format!("{k} = {v}")).collect();
+            Some(format!("{name} = {{ {} }}", parts.join(", ")))
+        }
+        _ => {
+            tracing::warn!(
+                name,
+                ?spec,
+                "Skipping dependency with unsupported value type"
+            );
+            None
+        }
+    }
+}
+
 fn process_builder_tool_result(
     tool_name: &str,
     tool_call_id: &str,
@@ -80,6 +149,7 @@ pub struct BuildRequirement {
     /// Expected output format.
     pub output_spec: Option<String>,
     /// External dependencies needed.
+    #[serde(default, deserialize_with = "deserialize_dependencies")]
     pub dependencies: Vec<String>,
     /// Security/capability requirements (for WASM tools).
     pub capabilities: Vec<String>,
@@ -1234,6 +1304,59 @@ mod tests {
         assert!(deserialized.output_spec.is_none());
         assert!(deserialized.dependencies.is_empty());
         assert!(deserialized.capabilities.is_empty());
+    }
+
+    /// Regression test for #1640: LLM returns dependencies as inline tables
+    /// (`{"ureq": {"version": "2"}}`) instead of simple strings.
+    #[test]
+    fn test_build_requirement_deserialize_inline_table_deps() {
+        let json = r#"{
+            "name": "gh-search",
+            "description": "Search GitHub repos",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": [
+                {"ureq": {"version": "2"}},
+                {"serde": {"version": "1", "features": ["derive"]}}
+            ],
+            "capabilities": ["http"]
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies[0].starts_with("ureq = "));
+        assert!(req.dependencies[1].starts_with("serde = "));
+    }
+
+    /// Dependencies as a flat object map (`{"ureq": "2", "serde_json": "1"}`).
+    #[test]
+    fn test_build_requirement_deserialize_object_map_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": {"ureq": "2", "serde_json": "1"},
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies.iter().any(|d| d.contains("ureq")));
+        assert!(req.dependencies.iter().any(|d| d.contains("serde_json")));
+    }
+
+    /// Null or missing dependencies should deserialize to empty vec.
+    #[test]
+    fn test_build_requirement_deserialize_null_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "script",
+            "language": "bash",
+            "dependencies": null,
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert!(req.dependencies.is_empty());
     }
 
     #[test]

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -43,7 +43,9 @@ use crate::error::ToolError as AgentToolError;
 use crate::llm::{
     ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondResult, ToolDefinition,
 };
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+use crate::tools::tool::{
+    ApprovalContext, ApprovalRequirement, Tool, ToolError, ToolOutput, check_approval_in_context,
+};
 use crate::tools::{ToolRegistry, prepare_tool_params};
 
 fn process_builder_tool_result(
@@ -793,8 +795,22 @@ Create alongside the .wasm file to grant capabilities:
             })?;
         let normalized_params = prepare_tool_params(tool.as_ref(), params);
 
-        // Execute with a dummy context (build tools don't need job context)
-        let ctx = JobContext::default();
+        // Create context with build-specific approval permissions.
+        // Note: shell commands (cargo, npm, pip, etc.) handle network access
+        // for dependency fetching, so we don't need to grant direct http tool access.
+        let ctx =
+            JobContext::default().with_approval_context(ApprovalContext::autonomous_with_tools([
+                "shell".into(),
+                "read_file".into(),
+                "write_file".into(),
+                "list_dir".into(),
+                "apply_patch".into(),
+            ]));
+
+        // Check approval before executing (bypasses worker check, so we do it here)
+        let requirement = tool.requires_approval(&normalized_params);
+        check_approval_in_context(&ctx, tool_name, requirement)?;
+
         tool.execute(normalized_params, &ctx).await
     }
 

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -21,7 +21,7 @@ use crate::context::{ContextManager, JobContext, JobState};
 use crate::db::Database;
 use crate::history::SandboxJobRecord;
 use crate::orchestrator::auth::CredentialGrant;
-use crate::orchestrator::job_manager::{ContainerJobManager, JobMode};
+use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
 use crate::secrets::SecretsStore;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 use ironclaw_common::AppEvent;
@@ -361,7 +361,7 @@ impl CreateJobTool {
         explicit_dir: Option<PathBuf>,
         wait: bool,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
+        params: JobCreationParams,
         ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
@@ -376,7 +376,7 @@ impl CreateJobTool {
         let project_dir_str = project_dir.display().to_string();
 
         // Serialize credential grants so restarts can reload them.
-        let credential_grants_json = match serde_json::to_string(&credential_grants) {
+        let credential_grants_json = match serde_json::to_string(&params.credential_grants) {
             Ok(json) => json,
             Err(e) => {
                 tracing::warn!(
@@ -431,7 +431,7 @@ impl CreateJobTool {
 
         // Create the container job with the pre-determined job_id.
         let _token = jm
-            .create_job(job_id, task, Some(project_dir), mode, credential_grants)
+            .create_job(job_id, task, Some(project_dir), mode, params)
             .await
             .map_err(|e| {
                 self.update_status(
@@ -849,6 +849,18 @@ impl Tool for CreateJobTool {
                                         secrets store (via 'ironclaw tool auth' or web UI). Example: \
                                         {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
                         "additionalProperties": { "type": "string" }
+                    },
+                    "mcp_servers": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of MCP server names to make available in the container. \
+                                        If omitted, the full master config is mounted. If empty, no MCP servers \
+                                        are available. Only effective when MCP_PER_JOB_ENABLED=true."
+                    },
+                    "max_iterations": {
+                        "type": "integer",
+                        "description": "Maximum number of agent loop iterations for the worker. \
+                                        Defaults to 50, capped at 500. Use lower values for simple tasks."
                     }
                 },
                 "required": ["title", "description"]
@@ -909,10 +921,44 @@ impl Tool for CreateJobTool {
             // Parse and validate credential grants
             let credential_grants = self.parse_credentials(&params, &ctx.user_id).await?;
 
+            // Parse optional MCP server filter and iteration cap.
+            // Validate types: warn if present but wrong type so callers know why it was ignored.
+            let mcp_servers: Option<Vec<String>> = match params.get("mcp_servers") {
+                Some(v) if v.is_array() => v.as_array().map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                }),
+                Some(_) => {
+                    tracing::warn!("mcp_servers parameter is not an array — ignoring");
+                    None
+                }
+                None => None,
+            };
+            let max_iterations: Option<u32> = match params.get("max_iterations") {
+                Some(v) if v.is_u64() || v.is_i64() => v.as_u64().map(|n| n.clamp(1, 500) as u32),
+                Some(_) => {
+                    tracing::warn!("max_iterations parameter is not a number — ignoring");
+                    None
+                }
+                None => None,
+            };
+
             // Combine title and description into the task prompt for the sub-agent.
             let task = format!("{}\n\n{}", title, description);
-            self.execute_sandbox(&task, explicit_dir, wait, mode, credential_grants, ctx)
-                .await
+            self.execute_sandbox(
+                &task,
+                explicit_dir,
+                wait,
+                mode,
+                JobCreationParams {
+                    credential_grants,
+                    mcp_servers,
+                    max_iterations,
+                },
+                ctx,
+            )
+            .await
         } else {
             self.execute_local(title, description, ctx).await
         }
@@ -1568,7 +1614,7 @@ mod tests {
                 None,
                 false,
                 JobMode::Worker,
-                vec![],
+                JobCreationParams::default(),
                 &JobContext::default(),
             )
             .await;

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -355,6 +355,7 @@ impl CreateJobTool {
     }
 
     /// Execute via sandboxed Docker container.
+    #[allow(clippy::too_many_arguments)]
     async fn execute_sandbox(
         &self,
         task: &str,
@@ -414,16 +415,21 @@ impl CreateJobTool {
             credential_grants_json,
         });
 
-        // Persist the job mode to DB
-        if mode == JobMode::ClaudeCode
+        // Persist the job mode to DB (for non-default modes).
+        // For ACP, store "acp:<agent_name>" so restarts know which agent to use.
+        if mode != JobMode::Worker
             && let Some(store) = self.store.clone()
         {
             let job_id_copy = job_id;
+            let mode_str = if mode == JobMode::Acp
+                && let Some(ref agent) = params.acp_agent
+            {
+                format!("acp:{}", agent.name)
+            } else {
+                mode.as_str().to_string()
+            };
             tokio::spawn(async move {
-                if let Err(e) = store
-                    .update_sandbox_job_mode(job_id_copy, "claude_code")
-                    .await
-                {
+                if let Err(e) = store.update_sandbox_job_mode(job_id_copy, &mode_str).await {
                     tracing::warn!(job_id = %job_id_copy, "Failed to set job mode: {}", e);
                 }
             });
@@ -834,9 +840,15 @@ impl Tool for CreateJobTool {
                     },
                     "mode": {
                         "type": "string",
-                        "enum": ["worker", "claude_code"],
+                        "enum": ["worker", "claude_code", "acp"],
                         "description": "Execution mode. 'worker' (default) uses the IronClaw sub-agent. \
-                                        'claude_code' uses Claude Code CLI for full agentic software engineering."
+                                        'claude_code' uses Claude Code CLI. \
+                                        'acp' uses an ACP-compliant agent (Goose, Codex, Gemini CLI)."
+                    },
+                    "agent_name": {
+                        "type": "string",
+                        "description": "Name of the ACP agent to use (from 'ironclaw acp list'). \
+                                        Required when mode is 'acp'."
                     },
                     "project_dir": {
                         "type": "string",
@@ -910,7 +922,33 @@ impl Tool for CreateJobTool {
 
             let mode = match params.get("mode").and_then(|v| v.as_str()) {
                 Some("claude_code") => JobMode::ClaudeCode,
+                Some("acp") => JobMode::Acp,
                 _ => JobMode::Worker,
+            };
+
+            // Resolve ACP agent config when mode is ACP.
+            let acp_agent = if mode == JobMode::Acp {
+                let agent_name = require_str(&params, "agent_name")?;
+                Some(
+                    crate::config::acp::get_enabled_acp_agent_for_user(
+                        self.store.as_deref(),
+                        &ctx.user_id,
+                        agent_name,
+                    )
+                    .await
+                    .map_err(|e| match e {
+                        crate::config::acp::AcpConfigError::AgentNotFound { .. }
+                        | crate::config::acp::AcpConfigError::AgentDisabled { .. } => {
+                            ToolError::InvalidParameters(e.to_string())
+                        }
+                        _ => ToolError::ExecutionFailed(format!(
+                            "failed to load ACP agent '{}': {}",
+                            agent_name, e
+                        )),
+                    })?,
+                )
+            } else {
+                None
             };
 
             let explicit_dir = params
@@ -955,6 +993,7 @@ impl Tool for CreateJobTool {
                     credential_grants,
                     mcp_servers,
                     max_iterations,
+                    acp_agent,
                 },
                 ctx,
             )
@@ -2309,5 +2348,70 @@ mod tests {
         let cm = ContextManager::new(5);
         let result = resolve_job_id("not-hex-at-all!", &cm).await;
         assert!(result.is_err()); // safety: test
+    }
+
+    // ── ACP mode tests ──────────────────────────────────────────
+
+    #[test]
+    fn test_sandbox_schema_includes_acp_mode() {
+        let manager = Arc::new(ContextManager::new(5));
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig::default(),
+            crate::orchestrator::TokenStore::new(),
+        ));
+        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+        let schema = tool.parameters_schema();
+        let mode_enum = schema["properties"]["mode"]["enum"].as_array().unwrap(); // safety: test
+        let modes: Vec<&str> = mode_enum.iter().map(|v| v.as_str().unwrap()).collect(); // safety: test
+        assert!(modes.contains(&"acp"), "mode enum must include 'acp'");
+        assert!(modes.contains(&"worker"));
+        assert!(modes.contains(&"claude_code"));
+    }
+
+    #[test]
+    fn test_sandbox_schema_includes_agent_name() {
+        let manager = Arc::new(ContextManager::new(5));
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig::default(),
+            crate::orchestrator::TokenStore::new(),
+        ));
+        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+        let schema = tool.parameters_schema();
+        let props = schema.get("properties").unwrap().as_object().unwrap(); // safety: test
+        assert!(
+            /* safety: test */
+            props.contains_key("agent_name"),
+            "sandbox schema must expose agent_name for ACP mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_acp_mode_requires_agent_name() {
+        let manager = Arc::new(ContextManager::new(5));
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig::default(),
+            crate::orchestrator::TokenStore::new(),
+        ));
+        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+
+        let params = serde_json::json!({
+            "title": "Test ACP job",
+            "description": "Test task",
+            "mode": "acp"
+            // no agent_name — should fail
+        });
+        let result = tool.execute(params, &JobContext::default()).await;
+        assert!(result.is_err()); // safety: test
+        let err = result.unwrap_err().to_string(); // safety: test
+        assert!(
+            err.contains("agent_name"),
+            "error should mention missing agent_name, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_job_mode_acp_as_str() {
+        assert_eq!(JobMode::Acp.as_str(), "acp");
+        assert_eq!(JobMode::Acp.to_string(), "acp");
     }
 }

--- a/src/tools/builtin/memory.rs
+++ b/src/tools/builtin/memory.rs
@@ -246,9 +246,26 @@ impl Tool for MemoryWriteTool {
                     "type": "boolean",
                     "description": "Skip privacy classification and write directly to the specified layer without redirect. Use when you're certain the content belongs in the target layer.",
                     "default": false
+                },
+                "metadata": {
+                    "type": "object",
+                    "description": "Optional metadata to set on the document (e.g., {\"skip_indexing\": true, \"hygiene\": {\"enabled\": true, \"retention_days\": 7}})"
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "When present, switches to patch mode: finds and replaces this exact string in the document. Works with any target including 'memory' and custom paths."
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "Replacement string (required when old_string is present)."
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": "If true, replace all occurrences of old_string. Default: false.",
+                    "default": false
                 }
             },
-            "required": ["content"]
+            "required": []
         })
     }
 
@@ -259,7 +276,18 @@ impl Tool for MemoryWriteTool {
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
 
-        let content = require_str(&params, "content")?;
+        // At least one mode must be provided: content for write/append, or old_string for patch.
+        let is_patch_mode = params.get("old_string").and_then(|v| v.as_str()).is_some();
+        let has_content = params
+            .get("content")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.trim().is_empty());
+        if !is_patch_mode && !has_content {
+            return Err(ToolError::InvalidParameters(
+                "Either 'content' (for write/append) or 'old_string'+'new_string' (for patch) is required".to_string(),
+            ));
+        }
+        let content = params.get("content").and_then(|v| v.as_str()).unwrap_or("");
 
         let target = params
             .get("target")
@@ -299,12 +327,6 @@ impl Tool for MemoryWriteTool {
             return Ok(ToolOutput::success(output, start.elapsed()));
         }
 
-        if content.trim().is_empty() {
-            return Err(ToolError::InvalidParameters(
-                "content cannot be empty".to_string(),
-            ));
-        }
-
         let append = params
             .get("append")
             .and_then(|v| v.as_bool())
@@ -329,6 +351,85 @@ impl Tool for MemoryWriteTool {
             "heartbeat" => paths::HEARTBEAT.to_string(),
             path => path.to_string(),
         };
+
+        // Apply metadata BEFORE the write/patch so that metadata-driven flags
+        // (skip_indexing, skip_versioning) take effect for this operation,
+        // not just subsequent ones.
+        //
+        // Merge incoming metadata with existing to avoid silently dropping
+        // previously-set keys (e.g. skip_versioning lost when hygiene is added).
+        //
+        // Skip when a layer is specified — get_or_create targets the primary
+        // scope, not the layer's scope.
+        //
+        // In patch mode, use read() instead of get_or_create() so we don't
+        // create a ghost empty document when the target doesn't exist.
+        let metadata_param = params.get("metadata").filter(|m| m.is_object());
+        if let Some(meta) = metadata_param
+            && layer.is_none()
+        {
+            let doc = if is_patch_mode {
+                // read_primary() ensures we target the same scope that patch()
+                // operates on, avoiding cross-scope metadata mutation in
+                // multi-scope mode. Returns an error if the doc doesn't exist —
+                // the patch call below will produce a clear "not found" error.
+                workspace.read_primary(&resolved_path).await.ok()
+            } else {
+                Some(
+                    workspace
+                        .get_or_create(&resolved_path)
+                        .await
+                        .map_err(map_write_err)?,
+                )
+            };
+            if let Some(doc) = doc {
+                let merged = crate::workspace::DocumentMetadata::merge(&doc.metadata, meta);
+                workspace
+                    .update_metadata(doc.id, &merged)
+                    .await
+                    .map_err(map_write_err)?;
+            }
+        }
+
+        // Patch mode: if old_string is provided, do search-and-replace instead of write/append.
+        let old_string = params.get("old_string").and_then(|v| v.as_str());
+        if let Some(old_str) = old_string {
+            if old_str.is_empty() {
+                return Err(ToolError::InvalidParameters(
+                    "old_string cannot be empty".to_string(),
+                ));
+            }
+            if layer.is_some() {
+                return Err(ToolError::InvalidParameters(
+                    "patch mode (old_string/new_string) cannot be combined with layer".to_string(),
+                ));
+            }
+            let new_str = params
+                .get("new_string")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| {
+                    ToolError::InvalidParameters(
+                        "new_string is required when old_string is provided".to_string(),
+                    )
+                })?;
+            let replace_all = params
+                .get("replace_all")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+
+            let result = workspace
+                .patch(&resolved_path, old_str, new_str, replace_all)
+                .await
+                .map_err(map_write_err)?;
+
+            let output = serde_json::json!({
+                "status": "patched",
+                "path": resolved_path,
+                "replacements": result.replacements,
+                "content_length": result.document.content.len(),
+            });
+            return Ok(ToolOutput::success(output, start.elapsed()));
+        }
 
         // When a layer is specified, route through layer-aware methods for ALL targets.
         // Otherwise, use default workspace methods (which include injection scanning).
@@ -433,6 +534,9 @@ impl Tool for MemoryWriteTool {
             }
         }
 
+        // Metadata was already applied before the write (see above), so
+        // skip_indexing/skip_versioning took effect for this operation.
+
         let mut output = serde_json::json!({
             "status": "written",
             "path": resolved_path,
@@ -501,6 +605,15 @@ impl Tool for MemoryReadTool {
                 "path": {
                     "type": "string",
                     "description": "Path to the file (e.g., 'MEMORY.md', 'daily/2024-01-15.md', 'projects/alpha/notes.md')"
+                },
+                "version": {
+                    "type": "integer",
+                    "description": "Read a specific historical version of the document (omit for current content)"
+                },
+                "list_versions": {
+                    "type": "boolean",
+                    "description": "If true, return version history instead of file content",
+                    "default": false
                 }
             },
             "required": ["path"]
@@ -525,11 +638,72 @@ impl Tool for MemoryReadTool {
         }
 
         let workspace = self.resolver.resolve(&ctx.user_id).await;
+
+        let list_versions = params
+            .get("list_versions")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        let version = match params.get("version").and_then(|v| v.as_i64()) {
+            _ if list_versions && params.get("version").is_some() => {
+                return Err(ToolError::InvalidParameters(
+                    "list_versions and version are mutually exclusive".to_string(),
+                ));
+            }
+            Some(v) if v < 1 || v > i64::from(i32::MAX) => {
+                return Err(ToolError::InvalidParameters(format!(
+                    "version must be between 1 and {}, got {v}",
+                    i32::MAX
+                )));
+            }
+            Some(v) => Some(v as i32),
+            None => None,
+        };
+
+        // Read the document first (needed for document_id in all version operations)
         let doc = workspace
             .read(path)
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("Read failed: {}", e)))?;
 
+        // List versions mode
+        if list_versions {
+            let versions = workspace
+                .list_versions(doc.id, 50)
+                .await
+                .map_err(|e| ToolError::ExecutionFailed(format!("List versions failed: {}", e)))?;
+
+            let output = serde_json::json!({
+                "path": doc.path,
+                "versions": versions.iter().map(|v| serde_json::json!({
+                    "version": v.version,
+                    "content_hash": v.content_hash,
+                    "created_at": v.created_at.to_rfc3339(),
+                    "changed_by": v.changed_by,
+                })).collect::<Vec<_>>(),
+                "version_count": versions.len(),
+            });
+            return Ok(ToolOutput::success(output, start.elapsed()));
+        }
+
+        // Specific version mode
+        if let Some(ver) = version {
+            let version_doc = workspace
+                .get_version(doc.id, ver)
+                .await
+                .map_err(|e| ToolError::ExecutionFailed(format!("Get version failed: {}", e)))?;
+
+            let output = serde_json::json!({
+                "path": doc.path,
+                "version": version_doc.version,
+                "content": version_doc.content,
+                "content_hash": version_doc.content_hash,
+                "created_at": version_doc.created_at.to_rfc3339(),
+                "changed_by": version_doc.changed_by,
+            });
+            return Ok(ToolOutput::success(output, start.elapsed()));
+        }
+
+        // Normal read
         let output = serde_json::json!({
             "path": doc.path,
             "content": doc.content,
@@ -742,6 +916,21 @@ mod tests {
             assert!(schema["properties"]["content"].is_object());
             assert!(schema["properties"]["target"].is_object());
             assert!(schema["properties"]["append"].is_object());
+
+            // Patch mode parameters
+            assert!(schema["properties"]["old_string"].is_object());
+            assert!(schema["properties"]["new_string"].is_object());
+            assert!(schema["properties"]["replace_all"].is_object());
+
+            // Metadata parameter
+            assert!(schema["properties"]["metadata"].is_object());
+
+            // Content is not required (patch mode doesn't need it)
+            let required = schema["required"].as_array().unwrap();
+            assert!(
+                !required.contains(&"content".into()),
+                "content should not be required (patch mode)"
+            );
         }
 
         #[test]
@@ -759,6 +948,10 @@ mod tests {
                     .unwrap()
                     .contains(&"path".into())
             );
+
+            // Version parameters
+            assert!(schema["properties"]["version"].is_object());
+            assert!(schema["properties"]["list_versions"].is_object());
         }
 
         #[test]

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -205,11 +205,11 @@ impl Tool for MessageTool {
                 },
                 "channel": {
                     "type": "string",
-                    "description": "Target channel (defaults to current channel if omitted)"
+                    "description": "Transport/integration name: 'slack-relay', 'telegram', 'signal', 'gateway'. This is NOT a Slack channel ID — use target for that. Defaults to current channel if omitted."
                 },
                 "target": {
                     "type": "string",
-                    "description": "Recipient: E.164 phone, group ID, chat ID (defaults to current sender/group if omitted)"
+                    "description": "Recipient within the transport. Slack: channel ID (C0...), user ID (U0...), or #channel-name. Telegram: chat ID. Signal: E.164 phone or group ID. Defaults to current conversation target if omitted."
                 },
                 "attachments": {
                     "type": "array",

--- a/src/tools/builtin/routine.rs
+++ b/src/tools/builtin/routine.rs
@@ -1178,8 +1178,22 @@ impl Tool for RoutineCreateTool {
                 dedup_window: None,
             },
             notify: NotifyConfig {
-                channel: normalized.delivery.channel.clone(),
-                user: normalized.delivery.user.clone(),
+                // Fall back to the current conversation's channel/target when
+                // the LLM omits delivery params, so routines created from
+                // e.g. a Slack channel know where to send results.
+                channel: normalized.delivery.channel.clone().or_else(|| {
+                    ctx.metadata
+                        .get("notify_channel")
+                        .and_then(|v| v.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                user: normalized.delivery.user.clone().or_else(|| {
+                    ctx.metadata
+                        .get("notify_user")
+                        .and_then(|v| v.as_str())
+                        .filter(|v| *v != "default")
+                        .map(ToOwned::to_owned)
+                }),
                 ..NotifyConfig::default()
             },
             last_run_at: None,
@@ -2611,6 +2625,28 @@ mod tests {
         assert!(
             schema_property(&schema, "source").is_object(),
             "event_emit discovery schema should keep source alias",
+        );
+    }
+
+    /// Regression: routine_create must fall back to ctx.metadata for delivery
+    /// config when the LLM omits delivery.channel/user. This verifies the
+    /// parsing layer returns None so the execute path triggers the fallback.
+    #[test]
+    fn routine_create_omitted_delivery_enables_context_fallback() {
+        let params = serde_json::json!({
+            "name": "ping-every-5",
+            "prompt": "Send Ping in this channel.",
+            "request": { "kind": "cron", "schedule": "*/5 * * * *" }
+        });
+
+        let parsed = parse_routine_create_request(&params).expect("parse");
+        assert!(
+            parsed.delivery.channel.is_none(),
+            "omitted delivery.channel should be None so execute() falls back to ctx.metadata",
+        );
+        assert!(
+            parsed.delivery.user.is_none(),
+            "omitted delivery.user should be None so execute() falls back to ctx.metadata",
         );
     }
 

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -855,7 +855,8 @@ impl Tool for ShellTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (optional, default 120)"
+                    "description": "Timeout in seconds (optional, default 120)",
+                    "minimum": 1
                 }
             },
             "required": ["command"]
@@ -869,8 +870,41 @@ impl Tool for ShellTool {
     ) -> Result<ToolOutput, ToolError> {
         let command = require_str(&params, "command")?;
 
-        let workdir = params.get("workdir").and_then(|v| v.as_str());
-        let timeout = params.get("timeout").and_then(|v| v.as_u64());
+        let workdir = match params.get("workdir") {
+            None => None,
+            Some(v) if v.is_null() => None,
+            Some(v) => {
+                let s = v.as_str().ok_or_else(|| {
+                    ToolError::InvalidParameters("workdir must be a string".to_string())
+                })?;
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }
+        };
+
+        let timeout = match params.get("timeout") {
+            None => None,
+            Some(v) if v.is_null() => None,
+            Some(v) => {
+                let n = v.as_u64().ok_or_else(|| {
+                    ToolError::InvalidParameters(
+                        "timeout must be a positive integer number of seconds".to_string(),
+                    )
+                })?;
+
+                if n == 0 {
+                    return Err(ToolError::InvalidParameters(
+                        "timeout must be greater than 0".to_string(),
+                    ));
+                }
+
+                Some(n)
+            }
+        };
 
         let start = std::time::Instant::now();
         let (output, exit_code) = self
@@ -952,16 +986,159 @@ fn truncate_for_error(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    async fn execute_shell(
+        tool: &ShellTool,
+        params: serde_json::Value,
+    ) -> Result<ToolOutput, ToolError> {
+        tool.execute(params, &JobContext::default()).await
+    }
+
+    fn assert_invalid_parameters(result: Result<ToolOutput, ToolError>, expected_message: &str) {
+        match result {
+            Err(ToolError::InvalidParameters(message)) => {
+                assert_eq!(message, expected_message);
+            }
+            Err(other) => panic!("expected InvalidParameters, got {other:?}"),
+            Ok(output) => panic!("expected InvalidParameters, got success: {output:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn test_echo_command() {
         let tool = ShellTool::new();
-        let ctx = JobContext::default();
-
-        let result = tool
-            .execute(serde_json::json!({"command": "echo hello"}), &ctx)
+        let result = execute_shell(&tool, serde_json::json!({"command": "echo hello"}))
             .await
             .unwrap();
+
+        let output = result.result.get("output").unwrap().as_str().unwrap();
+        assert!(output.contains("hello"));
+        assert_eq!(result.result.get("exit_code").unwrap().as_i64().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_treats_blank_workdir_as_none() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = ShellTool::new().with_working_dir(temp_dir.path().to_path_buf());
+
+        for workdir in ["", "   "] {
+            let result = execute_shell(
+                &tool,
+                serde_json::json!({
+                    "command": "pwd",
+                    "workdir": workdir
+                }),
+            )
+            .await
+            .unwrap();
+
+            let output = result
+                .result
+                .get("output")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .trim();
+            let output_path = PathBuf::from(output).canonicalize().unwrap();
+            let expected_path = temp_dir.path().canonicalize().unwrap();
+            assert_eq!(output_path, expected_path);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_non_string_workdir() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "pwd",
+                "workdir": 42
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(result, "workdir must be a string");
+    }
+
+    #[tokio::test]
+    async fn test_execute_treats_missing_or_null_timeout_as_none() {
+        let tool = ShellTool::new();
+
+        for params in [
+            serde_json::json!({"command": "echo hello"}),
+            serde_json::json!({"command": "echo hello", "timeout": null}),
+        ] {
+            let result = execute_shell(&tool, params).await.unwrap();
+            let output = result.result.get("output").unwrap().as_str().unwrap();
+            assert!(output.contains("hello"));
+            assert_eq!(result.result.get("exit_code").unwrap().as_i64().unwrap(), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_non_numeric_timeout_string() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": "abc"
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(
+            result,
+            "timeout must be a positive integer number of seconds",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_zero_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 0
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(result, "timeout must be greater than 0");
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_float_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 3.5
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(
+            result,
+            "timeout must be a positive integer number of seconds",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_accepts_valid_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 30
+            }),
+        )
+        .await
+        .unwrap();
 
         let output = result.result.get("output").unwrap().as_str().unwrap();
         assert!(output.contains("hello"));

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -35,5 +35,5 @@ pub use rate_limiter::RateLimiter;
 pub use registry::ToolRegistry;
 pub use tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput,
-    ToolRateLimitConfig, redact_params, validate_tool_schema,
+    ToolRateLimitConfig, check_approval_in_context, redact_params, validate_tool_schema,
 };

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -32,7 +32,7 @@ pub use builder::{
 };
 pub(crate) use coercion::prepare_tool_params;
 pub use rate_limiter::RateLimiter;
-pub use registry::ToolRegistry;
+pub use registry::{ToolRegistry, is_protected_tool_name};
 pub use tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput,
     ToolRateLimitConfig, check_approval_in_context, redact_params, validate_tool_schema,

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -25,7 +25,7 @@ use crate::tools::builtin::{
     ToolUpgradeTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain};
+use crate::tools::tool::{ApprovalRequirement, Tool, ToolDiscoverySummary, ToolDomain};
 use crate::tools::wasm::{
     Capabilities, OAuthRefreshConfig, ResourceLimits, SharedCredentialRegistry, WasmError,
     WasmStorageError, WasmToolRuntime, WasmToolStore, WasmToolWrapper,
@@ -674,6 +674,9 @@ impl ToolRegistry {
         if let Some(s) = reg.schema {
             wrapper = wrapper.with_schema(s);
         }
+        if let Some(summary) = reg.discovery_summary {
+            wrapper = wrapper.with_discovery_summary(summary);
+        }
         if let Some(store) = reg.secrets_store {
             wrapper = wrapper.with_secrets_store(store);
         }
@@ -748,6 +751,7 @@ impl ToolRegistry {
             limits: None,
             description: Some(&tool_with_binary.tool.description),
             schema: Some(tool_with_binary.tool.parameters_schema.clone()),
+            discovery_summary: None,
             secrets_store: self.secrets_store.clone(),
             oauth_refresh: None,
         })
@@ -791,6 +795,8 @@ pub struct WasmToolRegistration<'a> {
     pub description: Option<&'a str>,
     /// Optional parameter schema override.
     pub schema: Option<serde_json::Value>,
+    /// Optional curated discovery guidance for `tool_info(detail: "summary")`.
+    pub discovery_summary: Option<ToolDiscoverySummary>,
     /// Secrets store for credential injection at request time.
     pub secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
     /// OAuth refresh configuration for auto-refreshing expired tokens.

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -32,27 +32,42 @@ use crate::tools::wasm::{
 };
 use crate::workspace::Workspace;
 
-/// Names of built-in tools that cannot be shadowed by dynamic registrations.
-/// This prevents a dynamically built or installed tool from replacing a
-/// security-critical built-in like "shell" or "memory_write".
+/// Names of built-in tools that cannot be shadowed by dynamic registrations
+/// and should not be rebuilt by the self-repair system. Protected tools are
+/// authored as part of the ironclaw binary — errors on them are caller-side
+/// issues (bad LLM parameters), not tool defects.
+///
+/// Keep this list in sync with all `fn name() -> &str` implementations in
+/// `src/tools/builtin/` and `src/tools/builder/` (for `build_software`).
+/// Aliases like `web_fetch` are included for completeness. When adding a
+/// new built-in tool, add its name here too.
 const PROTECTED_TOOL_NAMES: &[&str] = &[
+    // Core tools
     "echo",
     "time",
     "json",
     "http",
     "shell",
+    "restart",
+    "message",
+    // File tools
     "read_file",
     "write_file",
     "list_dir",
     "apply_patch",
+    // Memory tools
     "memory_search",
     "memory_write",
     "memory_read",
     "memory_tree",
+    // Job tools
     "create_job",
     "list_jobs",
     "job_status",
+    "job_events",
+    "job_prompt",
     "cancel_job",
+    // Extension/tool management
     "build_software",
     "tool_search",
     "tool_install",
@@ -60,6 +75,10 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "tool_activate",
     "tool_list",
     "tool_remove",
+    "tool_upgrade",
+    "tool_info",
+    "extension_info",
+    // Routine tools
     "routine_create",
     "routine_list",
     "routine_update",
@@ -67,18 +86,29 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "routine_fire",
     "routine_history",
     "event_emit",
+    // Skill tools
     "skill_list",
     "skill_search",
     "skill_install",
     "skill_remove",
-    "message",
-    "web_fetch",
-    "restart",
+    // Secret tools
+    "secret_list",
+    "secret_delete",
+    // Image tools
     "image_generate",
     "image_edit",
     "image_analyze",
-    "tool_info",
+    // Aliases (web_fetch is an alias for http in some contexts)
+    "web_fetch",
 ];
+
+/// Check if a tool name is a protected built-in that should not be rebuilt
+/// by the self-repair system. Protected tools are authored as part of the
+/// ironclaw binary; errors in these tools are caller-side issues (bad
+/// parameters from the LLM), not tool defects.
+pub fn is_protected_tool_name(name: &str) -> bool {
+    PROTECTED_TOOL_NAMES.contains(&name)
+}
 
 /// Registry of available tools.
 pub struct ToolRegistry {

--- a/src/tools/tool.rs
+++ b/src/tools/tool.rs
@@ -59,9 +59,18 @@ impl ApprovalContext {
     }
 
     /// Check whether a tool invocation is blocked in this context.
-    pub fn is_blocked(&self, tool_name: &str, _requirement: ApprovalRequirement) -> bool {
+    ///
+    /// - `Never` tools are always allowed (no approval needed).
+    /// - `UnlessAutoApproved` tools are allowed in autonomous contexts
+    ///   (autonomous execution implies auto-approve).
+    /// - `Always` tools are only allowed if explicitly listed in `allowed_tools`.
+    pub fn is_blocked(&self, tool_name: &str, requirement: ApprovalRequirement) -> bool {
         match self {
-            Self::Autonomous { allowed_tools } => !allowed_tools.contains(tool_name),
+            Self::Autonomous { allowed_tools } => match requirement {
+                ApprovalRequirement::Never => false,
+                ApprovalRequirement::UnlessAutoApproved => false,
+                ApprovalRequirement::Always => !allowed_tools.contains(tool_name),
+            },
         }
     }
 
@@ -445,6 +454,53 @@ pub fn require_param<'a>(
     params
         .get(name)
         .ok_or_else(|| ToolError::InvalidParameters(format!("missing '{}' parameter", name)))
+}
+
+/// Check if a tool invocation is allowed based on the job's approval context.
+///
+/// This helper function should be called by tools that execute sub-tools
+/// (like the builder) to ensure proper approval checking is done even when
+/// bypassing the worker's normal approval flow.
+///
+/// Returns `Ok(())` if the tool is allowed, `Err(ToolError::NotAuthorized)` if blocked.
+///
+/// # Security semantics
+///
+/// When `approval_context` is `None`, this function uses **legacy blocking behavior**:
+/// - `Never` tools: allowed
+/// - `UnlessAutoApproved` tools: blocked (require interactive approval)
+/// - `Always` tools: blocked (require explicit approval)
+///
+/// This matches the worker-level `ApprovalContext::is_blocked_or_default()` semantics
+/// to prevent privilege escalation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use ironclaw::context::JobContext;
+/// # use ironclaw::tools::{Tool, ToolError, ToolOutput, check_approval_in_context};
+/// # use serde_json::Value;
+/// async fn execute(&self, params: Value, ctx: &JobContext) -> Result<ToolOutput, ToolError> {
+///     // If this tool executes sub-tools, check their approval first
+///     check_approval_in_context(ctx, "sub_tool_name", self.requires_approval(&params))?;
+///
+///     // ... rest of implementation
+///     # todo!()
+/// }
+/// ```
+pub fn check_approval_in_context(
+    ctx: &crate::context::JobContext,
+    tool_name: &str,
+    requirement: ApprovalRequirement,
+) -> Result<(), ToolError> {
+    // Match worker-level approval semantics exactly to prevent inconsistency
+    if ApprovalContext::is_blocked_or_default(&ctx.approval_context, tool_name, requirement) {
+        return Err(ToolError::NotAuthorized(format!(
+            "Tool '{}' requires approval in this context",
+            tool_name
+        )));
+    }
+    Ok(())
 }
 
 /// Replace sensitive parameter values with `"[REDACTED]"`.
@@ -1006,10 +1062,12 @@ mod tests {
     }
 
     #[test]
-    fn test_approval_context_autonomous_blocks_tools_not_in_scope() {
+    fn test_approval_context_autonomous_blocks_always_but_allows_soft() {
         let ctx = ApprovalContext::autonomous();
-        assert!(ctx.is_blocked("shell", ApprovalRequirement::Never));
-        assert!(ctx.is_blocked("shell", ApprovalRequirement::UnlessAutoApproved));
+        // Never and UnlessAutoApproved are always allowed in autonomous context
+        assert!(!ctx.is_blocked("shell", ApprovalRequirement::Never));
+        assert!(!ctx.is_blocked("shell", ApprovalRequirement::UnlessAutoApproved));
+        // Always tools are blocked unless explicitly listed
         assert!(ctx.is_blocked("shell", ApprovalRequirement::Always));
     }
 
@@ -1024,9 +1082,12 @@ mod tests {
     }
 
     #[test]
-    fn test_approval_context_blocks_never_when_not_in_scope() {
+    fn test_approval_context_never_always_passes() {
         let ctx = ApprovalContext::autonomous();
-        assert!(ctx.is_blocked("any_tool", ApprovalRequirement::Never));
+        assert!(
+            !ctx.is_blocked("any_tool", ApprovalRequirement::Never),
+            "Never tools should always be allowed regardless of allowlist"
+        );
     }
 
     #[test]
@@ -1064,7 +1125,8 @@ mod tests {
             "other",
             ApprovalRequirement::Always
         ));
-        assert!(ApprovalContext::is_blocked_or_default(
+        // UnlessAutoApproved is allowed in autonomous context (auto-approved)
+        assert!(!ApprovalContext::is_blocked_or_default(
             &ctx,
             "any",
             ApprovalRequirement::UnlessAutoApproved

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::secrets::{CredentialLocation, CredentialMapping};
+use crate::tools::tool::ToolDiscoverySummary;
 use crate::tools::wasm::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
     ToolInvokeCapability, WebhookCapability, WorkspaceCapability,
@@ -46,6 +47,10 @@ pub struct CapabilitiesFile {
     /// If omitted, a generic fallback is used (with a warning).
     #[serde(default)]
     pub description: Option<String>,
+
+    /// Optional curated guidance surfaced by `tool_info(detail: "summary")`.
+    #[serde(default)]
+    pub discovery_summary: Option<ToolDiscoverySummary>,
 
     /// Extension version (semver).
     #[serde(default)]
@@ -154,6 +159,7 @@ impl CapabilitiesFile {
         if let Some(inner) = self.capabilities.take() {
             let inner = inner.resolve_nested_inner(depth + 1);
             self.description = self.description.or(inner.description);
+            self.discovery_summary = self.discovery_summary.or(inner.discovery_summary);
             self.http = self.http.or(inner.http);
             self.secrets = self.secrets.or(inner.secrets);
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);
@@ -1528,6 +1534,28 @@ mod tests {
             caps.description.as_deref(),
             Some("Outer description wins"),
             "Outer description should take precedence over inner"
+        );
+    }
+
+    #[test]
+    fn test_discovery_summary_promoted_from_nested_capabilities() {
+        let json = r#"{
+            "capabilities": {
+                "discovery_summary": {
+                    "always_required": ["action"],
+                    "notes": ["Use tool_info for full schema"]
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let summary = caps
+            .discovery_summary
+            .expect("discovery summary should be promoted");
+        assert_eq!(summary.always_required, vec!["action".to_string()]);
+        assert_eq!(
+            summary.notes,
+            vec!["Use tool_info for full schema".to_string()]
         );
     }
 

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -128,48 +128,50 @@ impl WasmToolLoader {
         // capabilities file — it is auto-derived from the WASM module's
         // schema() export at prepare time (see WasmToolSchemas::compact_schema),
         // so no schema override is needed here.
-        let (capabilities, oauth_refresh, description) = if let Some(cap_path) = capabilities_path {
-            if cap_path.exists() {
-                let cap_bytes = fs::read(cap_path).await?;
-                let cap_file = CapabilitiesFile::from_bytes(&cap_bytes)
-                    .map_err(|e| WasmLoadError::InvalidCapabilities(e.to_string()))?;
-                cap_file.validate(name);
+        let (capabilities, oauth_refresh, description, discovery_summary) =
+            if let Some(cap_path) = capabilities_path {
+                if cap_path.exists() {
+                    let cap_bytes = fs::read(cap_path).await?;
+                    let cap_file = CapabilitiesFile::from_bytes(&cap_bytes)
+                        .map_err(|e| WasmLoadError::InvalidCapabilities(e.to_string()))?;
+                    cap_file.validate(name);
 
-                // Check WIT version compatibility
-                check_wit_version_compat(
-                    name,
-                    cap_file.wit_version.as_deref(),
-                    crate::tools::wasm::WIT_TOOL_VERSION,
-                )?;
+                    // Check WIT version compatibility
+                    check_wit_version_compat(
+                        name,
+                        cap_file.wit_version.as_deref(),
+                        crate::tools::wasm::WIT_TOOL_VERSION,
+                    )?;
 
-                let caps = cap_file.to_capabilities();
-                let oauth = resolve_oauth_refresh_config(&cap_file);
-                let desc = cap_file.description.clone();
-                if desc.is_none() {
+                    let caps = cap_file.to_capabilities();
+                    let oauth = resolve_oauth_refresh_config(&cap_file);
+                    let desc = cap_file.description.clone();
+                    let summary = cap_file.discovery_summary.clone();
+                    if desc.is_none() {
+                        tracing::warn!(
+                            tool = name,
+                            path = %cap_path.display(),
+                            "Capabilities file missing \"description\" field; \
+                             tool will use generic fallback description"
+                        );
+                    }
+                    (caps, oauth, desc, summary)
+                } else {
                     tracing::warn!(
                         tool = name,
                         path = %cap_path.display(),
-                        "Capabilities file missing \"description\" field; \
-                         tool will use generic fallback description"
+                        "Capabilities file not found, using default (no permissions)"
                     );
+                    (Capabilities::default(), None, None, None)
                 }
-                (caps, oauth, desc)
             } else {
                 tracing::warn!(
                     tool = name,
-                    path = %cap_path.display(),
-                    "Capabilities file not found, using default (no permissions)"
-                );
-                (Capabilities::default(), None, None)
-            }
-        } else {
-            tracing::warn!(
-                tool = name,
-                "No capabilities file for WASM tool; \
+                    "No capabilities file for WASM tool; \
                      tool will use generic fallback description"
-            );
-            (Capabilities::default(), None, None)
-        };
+                );
+                (Capabilities::default(), None, None, None)
+            };
 
         // Register the tool
         self.registry
@@ -181,6 +183,7 @@ impl WasmToolLoader {
                 limits: None,
                 description: description.as_deref(),
                 schema: None,
+                discovery_summary,
                 secrets_store: self.secrets_store.clone(),
                 oauth_refresh,
             })

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -20,7 +20,7 @@ use crate::context::JobContext;
 use crate::llm::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 use crate::safety::LeakDetector;
 use crate::secrets::{DecryptedSecret, SecretsStore};
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use crate::tools::tool::{Tool, ToolDiscoverySummary, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
 use crate::tools::wasm::credential_injector::{
     InjectedCredentials, host_matches_pattern, inject_credential,
@@ -585,6 +585,8 @@ pub struct WasmToolWrapper {
     description: String,
     /// Compact and discovery schemas for this tool.
     schemas: WasmToolSchemas,
+    /// Optional curated discovery guidance surfaced by `tool_info`.
+    discovery_summary: Option<ToolDiscoverySummary>,
     /// Injected credentials for HTTP requests (e.g., OAuth tokens).
     /// Keys are placeholder names like "GOOGLE_ACCESS_TOKEN".
     credentials: HashMap<String, String>,
@@ -836,6 +838,7 @@ impl WasmToolWrapper {
         Self {
             description: prepared.description.clone(),
             schemas: WasmToolSchemas::new(prepared.schema.clone()),
+            discovery_summary: None,
             runtime,
             prepared,
             capabilities,
@@ -879,6 +882,12 @@ impl WasmToolWrapper {
         } else {
             self.schemas = self.schemas.with_override(schema);
         }
+        self
+    }
+
+    /// Override the curated discovery summary.
+    pub fn with_discovery_summary(mut self, summary: ToolDiscoverySummary) -> Self {
+        self.discovery_summary = Some(summary);
         self
     }
 
@@ -1098,6 +1107,10 @@ impl Tool for WasmToolWrapper {
         self.schemas.discovery()
     }
 
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        self.discovery_summary.clone()
+    }
+
     /// Compose the tool schema for LLM function calling.
     ///
     /// When the advertised schema is permissive (no typed properties), appends
@@ -1149,6 +1162,7 @@ impl Tool for WasmToolWrapper {
         let capabilities = self.capabilities.clone();
         let description = self.description.clone();
         let schemas = self.schemas.clone();
+        let discovery_summary = self.discovery_summary.clone();
         let credentials = self.credentials.clone();
 
         // Execute in blocking task with timeout
@@ -1159,6 +1173,7 @@ impl Tool for WasmToolWrapper {
                 capabilities,
                 description,
                 schemas,
+                discovery_summary,
                 credentials,
                 secrets_store: None, // Not needed in blocking task
                 oauth_refresh: None, // Already used above for pre-refresh
@@ -3056,6 +3071,27 @@ mod tests {
             })
         );
         assert_eq!(wrapper.discovery_schema(), typed_schema); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_wrapper_returns_curated_discovery_summary() {
+        let runtime = Arc::new(WasmToolRuntime::new(WasmRuntimeConfig::for_testing()).unwrap()); // safety: test-only setup
+        let prepared = runtime
+            .prepare("github", b"\0asm\x0d\0\x01\0", None)
+            .await
+            .unwrap(); // safety: test-only setup
+
+        let summary = crate::tools::tool::ToolDiscoverySummary {
+            always_required: vec!["action".into()],
+            notes: vec!["Use tool_info for the full schema".into()],
+            ..crate::tools::tool::ToolDiscoverySummary::default()
+        };
+
+        let wrapper =
+            super::WasmToolWrapper::new(Arc::clone(&runtime), prepared, Capabilities::default())
+                .with_discovery_summary(summary.clone());
+
+        assert_eq!(wrapper.discovery_summary(), Some(summary));
     }
 
     #[test]

--- a/src/worker/acp_bridge.rs
+++ b/src/worker/acp_bridge.rs
@@ -1,0 +1,629 @@
+//! ACP (Agent Client Protocol) bridge for sandboxed execution.
+//!
+//! Spawns any ACP-compliant agent (Goose, Codex, Gemini CLI, etc.) as a
+//! subprocess inside a Docker container and communicates via the standard
+//! ACP protocol (JSON-RPC over stdio). Agent output is translated into
+//! IronClaw's `JobEventPayload` stream and posted to the orchestrator.
+//!
+//! Security model: the Docker container is the primary security boundary
+//! (cap-drop ALL, non-root user, memory limits, network isolation).
+//! Agent permissions are auto-approved since the container is isolated.
+//!
+//! ```text
+//! ┌──────────────────────────────────────────────┐
+//! │ Docker Container                              │
+//! │                                               │
+//! │  ironclaw acp-bridge --job-id <uuid>          │
+//! │    └─ spawns ACP agent subprocess             │
+//! │    └─ ACP handshake (initialize + session)    │
+//! │    └─ sends job description via prompt()      │
+//! │    └─ translates ACP events → JobEventPayload │
+//! │    └─ POSTs events to orchestrator            │
+//! │    └─ polls for follow-up prompts             │
+//! └──────────────────────────────────────────────┘
+//! ```
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use agent_client_protocol::{self as acp, Agent as _};
+use serde_json::json;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
+use uuid::Uuid;
+
+use crate::error::WorkerError;
+use crate::worker::api::{CompletionReport, JobEventPayload, WorkerHttpClient};
+
+/// Configuration for the ACP bridge runtime.
+pub struct AcpBridgeConfig {
+    pub job_id: Uuid,
+    pub orchestrator_url: String,
+    pub timeout: Duration,
+    /// Command to spawn the ACP agent.
+    pub agent_command: String,
+    /// Arguments for the agent command.
+    pub agent_args: Vec<String>,
+    /// Extra environment variables for the agent process.
+    pub agent_env: HashMap<String, String>,
+}
+
+/// The ACP bridge runtime.
+pub struct AcpBridgeRuntime {
+    config: AcpBridgeConfig,
+    client: Arc<WorkerHttpClient>,
+}
+
+impl AcpBridgeRuntime {
+    /// Create a new bridge runtime.
+    ///
+    /// Reads `IRONCLAW_WORKER_TOKEN` from the environment for auth.
+    pub fn new(config: AcpBridgeConfig) -> Result<Self, WorkerError> {
+        let client = Arc::new(WorkerHttpClient::from_env(
+            config.orchestrator_url.clone(),
+            config.job_id,
+        )?);
+
+        Ok(Self { config, client })
+    }
+
+    /// Run the bridge: fetch job, spawn ACP agent, stream events, handle follow-ups.
+    pub async fn run(&self) -> Result<(), WorkerError> {
+        // Fetch the job description from the orchestrator
+        let job = self.client.get_job().await?;
+
+        tracing::info!(
+            job_id = %self.config.job_id,
+            "Starting ACP bridge for: {}",
+            truncate(&job.description, 100)
+        );
+
+        // Fetch credentials for injection into the spawned Command
+        let credentials = self.client.fetch_credentials().await?;
+        let mut extra_env = self.config.agent_env.clone();
+        for cred in &credentials {
+            extra_env.insert(cred.env_var.clone(), cred.value.clone());
+        }
+        if !credentials.is_empty() {
+            tracing::info!(
+                job_id = %self.config.job_id,
+                "Fetched {} credential(s) for child process injection",
+                credentials.len()
+            );
+        }
+
+        // Report that we're running
+        self.client
+            .report_status(&crate::worker::api::StatusUpdate {
+                state: "running".to_string(),
+                message: Some(format!("Spawning ACP agent: {}", self.config.agent_command)),
+                iteration: 0,
+            })
+            .await?;
+
+        // Run the ACP session
+        match self.run_acp_session(&job.description, &extra_env).await {
+            Ok(()) => {
+                self.client
+                    .report_complete(&CompletionReport {
+                        success: true,
+                        message: Some("ACP agent session completed".to_string()),
+                        iterations: 1,
+                    })
+                    .await?;
+            }
+            Err(e) => {
+                tracing::error!(job_id = %self.config.job_id, "ACP session failed: {}", e);
+                self.client
+                    .report_complete(&CompletionReport {
+                        success: false,
+                        message: Some(format!("ACP agent failed: {}", e)),
+                        iterations: 1,
+                    })
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Spawn the ACP agent and run the protocol lifecycle.
+    async fn run_acp_session(
+        &self,
+        prompt: &str,
+        extra_env: &HashMap<String, String>,
+    ) -> Result<(), WorkerError> {
+        let mut cmd = Command::new(&self.config.agent_command);
+        cmd.args(&self.config.agent_args);
+        cmd.envs(extra_env);
+        cmd.current_dir("/workspace")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+
+        let mut child = cmd.spawn().map_err(|e| WorkerError::ExecutionFailed {
+            reason: format!(
+                "failed to spawn ACP agent '{}': {}",
+                self.config.agent_command, e
+            ),
+        })?;
+
+        let child_stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| WorkerError::ExecutionFailed {
+                reason: "failed to capture ACP agent stdin".to_string(),
+            })?;
+        let child_stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| WorkerError::ExecutionFailed {
+                reason: "failed to capture ACP agent stdout".to_string(),
+            })?;
+        let child_stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| WorkerError::ExecutionFailed {
+                reason: "failed to capture ACP agent stderr".to_string(),
+            })?;
+
+        // Spawn stderr reader that forwards lines as status events
+        let client_for_stderr = Arc::clone(&self.client);
+        let job_id = self.config.job_id;
+        let stderr_handle = tokio::spawn(async move {
+            let reader = BufReader::new(child_stderr);
+            let mut lines = reader.lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                tracing::debug!(job_id = %job_id, "acp agent stderr: {}", line);
+                let payload = JobEventPayload {
+                    event_type: "status".to_string(),
+                    data: json!({ "message": line }),
+                };
+                client_for_stderr.post_event(&payload).await;
+            }
+        });
+
+        // Run the ACP protocol inside a LocalSet (SDK futures are !Send)
+        let client_for_acp = Arc::clone(&self.client);
+        let prompt_owned = prompt.to_string();
+        let job_id = self.config.job_id;
+        let timeout = self.config.timeout;
+
+        // Clone client for follow-up loop
+        let client_for_followup = Arc::clone(&self.client);
+
+        // Monitor the child process so the follow-up loop can exit if the agent dies.
+        // The oneshot is Send, so it crosses the LocalSet boundary cleanly.
+        let (child_exit_tx, child_exit_rx) = tokio::sync::oneshot::channel::<Option<i32>>();
+        tokio::spawn(async move {
+            let exit_code = match child.wait().await {
+                Ok(status) => status.code(),
+                Err(_) => None,
+            };
+            let _ = child_exit_tx.send(exit_code);
+        });
+
+        let local_set = tokio::task::LocalSet::new();
+        let acp_result = local_set
+            .run_until(async move {
+                let outgoing = child_stdin.compat_write();
+                let incoming = child_stdout.compat();
+
+                // Create ACP connection
+                let ironclaw_client = IronClawAcpClient::new(Arc::clone(&client_for_acp));
+
+                let (conn, handle_io) =
+                    acp::ClientSideConnection::new(ironclaw_client, outgoing, incoming, |fut| {
+                        tokio::task::spawn_local(fut);
+                    });
+                tokio::task::spawn_local(handle_io);
+
+                conn.initialize(ironclaw_init_request())
+                    .await
+                    .map_err(|e| WorkerError::ExecutionFailed {
+                        reason: format!("ACP initialize failed: {}", e),
+                    })?;
+
+                tracing::info!(job_id = %job_id, "ACP handshake complete");
+
+                // Create a new session
+                let workspace = std::env::current_dir().unwrap_or_else(|_| "/workspace".into());
+                let session_response = conn
+                    .new_session(acp::NewSessionRequest::new(workspace))
+                    .await
+                    .map_err(|e| WorkerError::ExecutionFailed {
+                        reason: format!("ACP new_session failed: {}", e),
+                    })?;
+
+                let session_id = session_response.session_id.clone();
+                tracing::info!(job_id = %job_id, session_id = %session_id, "ACP session created");
+
+                // Send the job description as a prompt
+                let prompt_result = tokio::time::timeout(timeout, async {
+                    conn.prompt(acp::PromptRequest::new(
+                        session_id.clone(),
+                        vec![prompt_owned.into()],
+                    ))
+                    .await
+                })
+                .await;
+
+                let prompt_response = match prompt_result {
+                    Ok(Ok(resp)) => resp,
+                    Ok(Err(e)) => {
+                        return Err(WorkerError::ExecutionFailed {
+                            reason: format!("ACP prompt failed: {}", e),
+                        });
+                    }
+                    Err(_) => {
+                        return Err(WorkerError::ExecutionFailed {
+                            reason: "ACP prompt timed out".to_string(),
+                        });
+                    }
+                };
+
+                // Report prompt result
+                let result_payload =
+                    stop_reason_to_result(&prompt_response.stop_reason, &session_id.to_string());
+                client_for_acp.post_event(&result_payload).await;
+
+                // Follow-up loop: poll for prompts, send additional prompt() calls.
+                // Exits when: orchestrator sends done, or agent process exits.
+                let mut child_exit_rx = child_exit_rx;
+                loop {
+                    match client_for_followup.poll_prompt().await {
+                        Ok(Some(follow_up)) => {
+                            if follow_up.done {
+                                tracing::info!(job_id = %job_id, "Orchestrator signaled done");
+                                break;
+                            }
+                            tracing::info!(job_id = %job_id, "Got follow-up prompt");
+
+                            let follow_result = conn
+                                .prompt(acp::PromptRequest::new(
+                                    session_id.clone(),
+                                    vec![follow_up.content.into()],
+                                ))
+                                .await;
+
+                            match follow_result {
+                                Ok(resp) => {
+                                    let payload = stop_reason_to_result(
+                                        &resp.stop_reason,
+                                        &session_id.to_string(),
+                                    );
+                                    client_for_followup.post_event(&payload).await;
+                                }
+                                Err(e) => {
+                                    tracing::error!(
+                                        job_id = %job_id,
+                                        "Follow-up prompt failed: {}", e
+                                    );
+                                    client_for_followup
+                                        .post_event(&JobEventPayload {
+                                            event_type: "status".to_string(),
+                                            data: json!({
+                                                "message": format!("Follow-up failed: {}", e),
+                                            }),
+                                        })
+                                        .await;
+                                }
+                            }
+                        }
+                        Ok(None) => {
+                            // No prompt available — wait, but also watch for agent exit.
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+                                exit_code = &mut child_exit_rx => {
+                                    let code = exit_code.ok().flatten();
+                                    tracing::info!(
+                                        job_id = %job_id,
+                                        exit_code = ?code,
+                                        "ACP agent process exited, ending follow-up loop"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                        Err(e) => {
+                            tracing::warn!(job_id = %job_id, "Prompt polling error: {}", e);
+                            tokio::select! {
+                                _ = tokio::time::sleep(Duration::from_secs(5)) => {}
+                                exit_code = &mut child_exit_rx => {
+                                    let code = exit_code.ok().flatten();
+                                    tracing::info!(
+                                        job_id = %job_id,
+                                        exit_code = ?code,
+                                        "ACP agent process exited, ending follow-up loop"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                Ok::<(), WorkerError>(())
+            })
+            .await;
+
+        // Wait for stderr reader to finish
+        let _ = stderr_handle.await;
+
+        acp_result
+    }
+}
+
+// ==================== ACP Client trait implementation ====================
+
+/// Sink for ACP events translated from session notifications.
+///
+/// The bridge posts events to the orchestrator via HTTP; the CLI test
+/// command prints them to stdout. Both share the same `IronClawAcpClient`.
+pub(crate) trait AcpEventSink: 'static {
+    fn emit_event(&self, payload: &JobEventPayload) -> impl std::future::Future<Output = ()>;
+}
+
+impl AcpEventSink for Arc<WorkerHttpClient> {
+    async fn emit_event(&self, payload: &JobEventPayload) {
+        self.post_event(payload).await;
+    }
+}
+
+/// IronClaw's implementation of the ACP Client trait.
+///
+/// Handles callbacks from the agent: session notifications (streaming output)
+/// and permission requests (auto-approved). Generic over the event sink so
+/// both the container bridge and CLI test command can reuse it.
+pub(crate) struct IronClawAcpClient<S: AcpEventSink> {
+    sink: S,
+}
+
+impl<S: AcpEventSink> IronClawAcpClient<S> {
+    pub(crate) fn new(sink: S) -> Self {
+        Self { sink }
+    }
+}
+
+#[async_trait::async_trait(?Send)]
+impl<S: AcpEventSink> acp::Client for IronClawAcpClient<S> {
+    async fn request_permission(
+        &self,
+        args: acp::RequestPermissionRequest,
+    ) -> acp::Result<acp::RequestPermissionResponse> {
+        // Auto-approve by selecting the first option — Docker container is the
+        // security boundary, so we trust the agent to operate freely.
+        let Some(first_option) = args.options.first() else {
+            return Err(acp::Error::invalid_params());
+        };
+        let option_id = first_option.option_id.clone();
+        Ok(acp::RequestPermissionResponse::new(
+            acp::RequestPermissionOutcome::Selected(acp::SelectedPermissionOutcome::new(option_id)),
+        ))
+    }
+
+    async fn session_notification(&self, args: acp::SessionNotification) -> acp::Result<()> {
+        if let Some(payload) = session_update_to_payload(&args.update) {
+            self.sink.emit_event(&payload).await;
+        }
+        Ok(())
+    }
+}
+
+/// Build the standard IronClaw ACP initialization request.
+pub(crate) fn ironclaw_init_request() -> acp::InitializeRequest {
+    acp::InitializeRequest::new(acp::ProtocolVersion::V1).client_info(
+        acp::Implementation::new("ironclaw", env!("CARGO_PKG_VERSION")).title("IronClaw"),
+    )
+}
+
+// ==================== Event translation ====================
+
+/// Convert an ACP `SessionUpdate` into an IronClaw `JobEventPayload`.
+fn session_update_to_payload(update: &acp::SessionUpdate) -> Option<JobEventPayload> {
+    match update {
+        acp::SessionUpdate::AgentMessageChunk(chunk) => text_from_content_block(&chunk.content)
+            .map(|text| JobEventPayload {
+                event_type: "message".to_string(),
+                data: json!({
+                    "role": "assistant",
+                    "content": text,
+                }),
+            }),
+        acp::SessionUpdate::AgentThoughtChunk(chunk) => text_from_content_block(&chunk.content)
+            .map(|text| JobEventPayload {
+                event_type: "status".to_string(),
+                data: json!({
+                    "message": text,
+                    "type": "thought",
+                }),
+            }),
+        acp::SessionUpdate::ToolCall(tool_call) => Some(JobEventPayload {
+            event_type: "tool_use".to_string(),
+            data: json!({
+                "tool_name": tool_call.title,
+                "tool_use_id": tool_call.tool_call_id.to_string(),
+            }),
+        }),
+        acp::SessionUpdate::ToolCallUpdate(update) => Some(JobEventPayload {
+            event_type: "tool_result".to_string(),
+            data: json!({
+                "tool_use_id": update.tool_call_id.to_string(),
+            }),
+        }),
+        _ => Some(JobEventPayload {
+            event_type: "status".to_string(),
+            data: json!({ "message": "ACP session update" }),
+        }),
+    }
+}
+
+/// Extract text from a `ContentBlock`, returning `None` for non-text blocks.
+fn text_from_content_block(block: &acp::ContentBlock) -> Option<&str> {
+    match block {
+        acp::ContentBlock::Text(text_content) => Some(&text_content.text),
+        _ => None,
+    }
+}
+
+/// Convert an ACP `StopReason` into a "result" `JobEventPayload`.
+fn stop_reason_to_result(reason: &acp::StopReason, session_id: &str) -> JobEventPayload {
+    let (status, message) = match reason {
+        acp::StopReason::EndTurn => ("completed", "Agent completed successfully"),
+        acp::StopReason::MaxTokens => ("error", "Agent reached max tokens"),
+        acp::StopReason::MaxTurnRequests => ("error", "Agent reached max turn requests"),
+        acp::StopReason::Refusal => ("error", "Agent refused to continue"),
+        acp::StopReason::Cancelled => ("cancelled", "Agent was cancelled"),
+        _ => ("completed", "Agent finished"),
+    };
+    JobEventPayload {
+        event_type: "result".to_string(),
+        data: json!({
+            "status": status,
+            "session_id": session_id,
+            "message": message,
+        }),
+    }
+}
+
+fn truncate(s: &str, max_len: usize) -> &str {
+    if s.len() <= max_len {
+        s
+    } else {
+        let mut end = max_len;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        &s[..end]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_session_update_agent_message_text() {
+        let update = acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+            acp::ContentBlock::Text(acp::TextContent::new("Hello world")),
+        ));
+        let payload = session_update_to_payload(&update).unwrap();
+        assert_eq!(payload.event_type, "message");
+        assert_eq!(payload.data["role"], "assistant");
+        assert_eq!(payload.data["content"], "Hello world");
+    }
+
+    #[test]
+    fn test_session_update_agent_thought_text() {
+        let update = acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(
+            acp::ContentBlock::Text(acp::TextContent::new("Thinking...")),
+        ));
+        let payload = session_update_to_payload(&update).unwrap();
+        assert_eq!(payload.event_type, "status");
+        assert_eq!(payload.data["type"], "thought");
+        assert_eq!(payload.data["message"], "Thinking...");
+    }
+
+    #[test]
+    fn test_session_update_agent_message_image_ignored() {
+        let update = acp::SessionUpdate::AgentMessageChunk(acp::ContentChunk::new(
+            acp::ContentBlock::Image(acp::ImageContent::new("base64data", "image/png")),
+        ));
+        assert!(session_update_to_payload(&update).is_none());
+    }
+
+    #[test]
+    fn test_stop_reason_end_turn() {
+        let payload = stop_reason_to_result(&acp::StopReason::EndTurn, "sid-1");
+        assert_eq!(payload.event_type, "result");
+        assert_eq!(payload.data["status"], "completed");
+    }
+
+    #[test]
+    fn test_stop_reason_max_tokens() {
+        let payload = stop_reason_to_result(&acp::StopReason::MaxTokens, "sid-1");
+        assert_eq!(payload.data["status"], "error");
+    }
+
+    #[test]
+    fn test_stop_reason_cancelled() {
+        let payload = stop_reason_to_result(&acp::StopReason::Cancelled, "sid-1");
+        assert_eq!(payload.data["status"], "cancelled");
+    }
+
+    #[test]
+    fn test_stop_reason_refusal() {
+        let payload = stop_reason_to_result(&acp::StopReason::Refusal, "sid-1");
+        assert_eq!(payload.data["status"], "error");
+        assert_eq!(payload.data["message"], "Agent refused to continue");
+    }
+
+    #[test]
+    fn test_session_update_tool_call() {
+        let update = acp::SessionUpdate::ToolCall(acp::ToolCall::new("tc-1", "Running tests"));
+        let payload = session_update_to_payload(&update).unwrap();
+        assert_eq!(payload.event_type, "tool_use");
+        assert_eq!(payload.data["tool_name"], "Running tests");
+        assert_eq!(payload.data["tool_use_id"], "tc-1");
+    }
+
+    #[test]
+    fn test_session_update_tool_call_update() {
+        let fields = acp::ToolCallUpdateFields::new();
+        let update = acp::SessionUpdate::ToolCallUpdate(acp::ToolCallUpdate::new("tc-1", fields));
+        let payload = session_update_to_payload(&update).unwrap();
+        assert_eq!(payload.event_type, "tool_result");
+        assert_eq!(payload.data["tool_use_id"], "tc-1");
+    }
+
+    #[test]
+    fn test_session_update_thought_image_ignored() {
+        let update = acp::SessionUpdate::AgentThoughtChunk(acp::ContentChunk::new(
+            acp::ContentBlock::Image(acp::ImageContent::new("data", "image/png")),
+        ));
+        assert!(session_update_to_payload(&update).is_none());
+    }
+
+    #[test]
+    fn test_stop_reason_max_turn_requests() {
+        let payload = stop_reason_to_result(&acp::StopReason::MaxTurnRequests, "sid-1");
+        assert_eq!(payload.data["status"], "error");
+        assert_eq!(payload.data["message"], "Agent reached max turn requests");
+    }
+
+    #[test]
+    fn test_stop_reason_includes_session_id() {
+        let payload = stop_reason_to_result(&acp::StopReason::EndTurn, "my-session-42");
+        assert_eq!(payload.data["session_id"], "my-session-42");
+    }
+
+    #[test]
+    fn test_text_from_content_block_text() {
+        let block = acp::ContentBlock::Text(acp::TextContent::new("hello"));
+        assert_eq!(text_from_content_block(&block), Some("hello"));
+    }
+
+    #[test]
+    fn test_text_from_content_block_image_returns_none() {
+        let block = acp::ContentBlock::Image(acp::ImageContent::new("data", "image/png"));
+        assert!(text_from_content_block(&block).is_none());
+    }
+
+    #[test]
+    fn test_truncate() {
+        assert_eq!(truncate("hello", 10), "hello");
+        assert_eq!(truncate("hello world", 5), "hello");
+        assert_eq!(truncate("", 5), "");
+    }
+
+    #[test]
+    fn test_truncate_multibyte_safe() {
+        // 2-byte UTF-8 char: "é" is 0xC3 0xA9
+        let s = "café";
+        assert_eq!(truncate(s, 3), "caf"); // doesn't split the é
+        assert_eq!(truncate(s, 5), "café"); // includes full char
+    }
+}

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -30,9 +30,7 @@ use crate::safety::SafetyLayer;
 use crate::tenant::AdminScope;
 use crate::tools::execute::process_tool_result;
 use crate::tools::rate_limiter::RateLimitResult;
-use crate::tools::{
-    ApprovalContext, ToolRegistry, autonomous_unavailable_error, prepare_tool_params, redact_params,
-};
+use crate::tools::{ApprovalContext, ToolRegistry, prepare_tool_params, redact_params};
 use crate::worker::autonomous_recovery::{
     AutonomousRecoveryAction, AutonomousRecoveryState, EMPTY_TOOL_COMPLETION_FAILURE,
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
@@ -511,20 +509,52 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         let normalized_params = prepare_tool_params(tool.as_ref(), params);
 
-        // Fetch job context early so we have the real user_id for approval, hooks,
-        // and rate limiting decisions.
+        // Fetch job context early for approval checking and other needs
         let mut job_ctx = deps.context_manager.get_context(job_id).await?;
+
+        // Check approval: additive semantics - BOTH job-level AND worker-level must approve
+        let requirement = tool.requires_approval(&normalized_params);
+
+        // Check job-level approval context (if set by tools like the builder)
+        let job_level_blocked = job_ctx
+            .approval_context
+            .as_ref()
+            .map(|ctx| ctx.is_blocked(tool_name, requirement))
+            .unwrap_or(false);
+
+        // Check worker-level approval context (set by scheduler for autonomous jobs)
+        let worker_level_blocked =
+            ApprovalContext::is_blocked_or_default(&deps.approval_context, tool_name, requirement);
+
+        // Tool is blocked if EITHER level blocks it (additive/intersection semantics)
+        // This maintains defense in depth: job-level cannot bypass worker-level restrictions
+        if job_level_blocked || worker_level_blocked {
+            let reason = if job_level_blocked && worker_level_blocked {
+                format!(
+                    "Tool '{}' is blocked by both job-level and worker-level approval context",
+                    tool_name
+                )
+            } else if job_level_blocked {
+                format!(
+                    "Tool '{}' is not in the job-level allowed tools list",
+                    tool_name
+                )
+            } else {
+                format!(
+                    "Tool '{}' is not available for autonomous execution",
+                    tool_name
+                )
+            };
+            return Err(crate::error::ToolError::AutonomousUnavailable {
+                name: tool_name.to_string(),
+                reason,
+            }
+            .into());
+        }
+
         // Propagate http_interceptor for trace recording/replay
         if job_ctx.http_interceptor.is_none() {
             job_ctx.http_interceptor = deps.http_interceptor.clone();
-        }
-
-        // Check approval: use context-aware check if available, else block all non-Never tools
-        let requirement = tool.requires_approval(&normalized_params);
-        let blocked =
-            ApprovalContext::is_blocked_or_default(&deps.approval_context, tool_name, requirement);
-        if blocked {
-            return Err(autonomous_unavailable_error(tool_name, &job_ctx.user_id).into());
         }
 
         // Check per-tool rate limit before running hooks or executing (cheaper check first)
@@ -2171,6 +2201,105 @@ mod tests {
             Err(Error::Tool(crate::error::ToolError::AutonomousUnavailable { name, .. }))
                 if name == "always_approval"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_semantics_both_levels_must_approve() {
+        // Test additive semantics: BOTH job-level AND worker-level must approve
+        // If either blocks, the tool is blocked (defense in depth)
+
+        // Scenario 1: Worker-level allows, job-level blocks → BLOCKED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level allows the tool
+            Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                "always_approval".to_string(),
+            ])),
+        )
+        .await;
+
+        // Set job-level context to block the tool (by not listing it)
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context = Some(crate::tools::ApprovalContext::autonomous());
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_err(),
+            "Tool should be blocked when job-level doesn't allow it, \
+             even if worker-level does (additive semantics)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_worker_block_overrides_job_allow() {
+        // Scenario 2: Job-level allows, worker-level blocks → BLOCKED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level does NOT allow the tool
+            Some(crate::tools::ApprovalContext::autonomous()),
+        )
+        .await;
+
+        // Set job-level context to allow the tool
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context =
+                    Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                        "always_approval".to_string(),
+                    ]));
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_err(),
+            "Tool should be blocked when worker-level doesn't allow it, \
+             even if job-level does (additive semantics)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_both_levels_allow() {
+        // Scenario 3: Both levels allow → ALLOWED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level allows
+            Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                "always_approval".to_string(),
+            ])),
+        )
+        .await;
+
+        // Job-level also allows
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context =
+                    Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                        "always_approval".to_string(),
+                    ]));
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_ok(),
+            "Tool should be allowed when both job-level and worker-level allow it"
+        );
     }
 
     #[tokio::test]

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -316,7 +316,6 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         reasoning: &Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
-        const MAX_WORKER_ITERATIONS: usize = 500;
         let max_iterations = self
             .context_manager()
             .get_context(self.job_id)
@@ -324,7 +323,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .ok()
             .and_then(|ctx| ctx.metadata.get("max_iterations").and_then(|v| v.as_u64()))
             .unwrap_or(50) as usize;
-        let max_iterations = max_iterations.min(MAX_WORKER_ITERATIONS);
+        let max_iterations = max_iterations.min(ironclaw_common::MAX_WORKER_ITERATIONS as usize);
 
         // Initial tool definitions for planning (will be refreshed in loop)
         reason_ctx.available_tools = self.tools().tool_definitions().await;

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -24,6 +24,7 @@
 //! └────────────────────────────────┘
 //! ```
 
+pub mod acp_bridge;
 pub mod api;
 mod autonomous_recovery;
 pub mod claude_bridge;
@@ -31,11 +32,16 @@ pub mod container;
 pub mod job;
 pub mod proxy_llm;
 
+pub use acp_bridge::AcpBridgeRuntime;
 pub use api::WorkerHttpClient;
 pub use claude_bridge::ClaudeBridgeRuntime;
 pub use container::WorkerRuntime;
 pub use job::{Worker, WorkerDeps};
 pub use proxy_llm::ProxyLlmProvider;
+
+fn acp_bridge_timeout() -> std::time::Duration {
+    std::time::Duration::from_secs(crate::config::AcpModeConfig::from_env().timeout_secs)
+}
 
 /// Run the Worker subcommand (inside Docker containers).
 pub async fn run_worker(
@@ -62,6 +68,54 @@ pub async fn run_worker(
     rt.run()
         .await
         .map_err(|e| anyhow::anyhow!("Worker failed: {}", e))
+}
+
+/// Run the ACP bridge subcommand (inside Docker containers).
+pub async fn run_acp_bridge(job_id: uuid::Uuid, orchestrator_url: &str) -> anyhow::Result<()> {
+    let agent_command = std::env::var("ACP_AGENT_COMMAND").map_err(|_| {
+        anyhow::anyhow!("ACP_AGENT_COMMAND not set — cannot determine which agent to spawn")
+    })?;
+
+    let agent_args: Vec<String> = match std::env::var("ACP_AGENT_ARGS") {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
+            tracing::warn!("Failed to parse ACP_AGENT_ARGS as JSON: {e}, using empty args");
+            Vec::new()
+        }),
+        Err(_) => Vec::new(),
+    };
+
+    let agent_env: std::collections::HashMap<String, String> = match std::env::var("ACP_AGENT_ENV")
+    {
+        Ok(s) => serde_json::from_str(&s).unwrap_or_else(|e| {
+            tracing::warn!("Failed to parse ACP_AGENT_ENV as JSON: {e}, using empty env");
+            std::collections::HashMap::new()
+        }),
+        Err(_) => std::collections::HashMap::new(),
+    };
+
+    tracing::info!(
+        "Starting ACP bridge for job {} (orchestrator: {}, agent: {} {})",
+        job_id,
+        orchestrator_url,
+        agent_command,
+        agent_args.join(" ")
+    );
+
+    let config = acp_bridge::AcpBridgeConfig {
+        job_id,
+        orchestrator_url: orchestrator_url.to_string(),
+        timeout: acp_bridge_timeout(),
+        agent_command,
+        agent_args,
+        agent_env,
+    };
+
+    let rt = AcpBridgeRuntime::new(config)
+        .map_err(|e| anyhow::anyhow!("ACP bridge init failed: {}", e))?;
+
+    rt.run()
+        .await
+        .map_err(|e| anyhow::anyhow!("ACP bridge failed: {}", e))
 }
 
 /// Run the Claude Code bridge subcommand (inside Docker containers).
@@ -93,4 +147,27 @@ pub async fn run_claude_bridge(
     rt.run()
         .await
         .map_err(|e| anyhow::anyhow!("Claude bridge failed: {}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn acp_bridge_timeout_defaults_to_1800_seconds() {
+        let _guard = crate::config::helpers::lock_env();
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::remove_var("ACP_TIMEOUT_SECS") };
+        assert_eq!(acp_bridge_timeout(), std::time::Duration::from_secs(1800));
+    }
+
+    #[test]
+    fn acp_bridge_timeout_respects_env_override() {
+        let _guard = crate::config::helpers::lock_env();
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("ACP_TIMEOUT_SECS", "45") };
+        assert_eq!(acp_bridge_timeout(), std::time::Duration::from_secs(45));
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::remove_var("ACP_TIMEOUT_SECS") };
+    }
 }

--- a/src/workspace/document.rs
+++ b/src/workspace/document.rs
@@ -2,6 +2,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 /// Well-known document paths.
@@ -35,6 +36,153 @@ pub mod paths {
     pub const PROFILE: &str = "context/profile.json";
     /// Assistant behavioral directives (derived from profile).
     pub const ASSISTANT_DIRECTIVES: &str = "context/assistant-directives.md";
+}
+
+/// Name of the folder-level configuration document.
+///
+/// A document at `{directory}/.config` carries metadata flags that apply
+/// as defaults to all documents in that directory (e.g., `skip_indexing`,
+/// `hygiene` settings). Individual document metadata overrides folder defaults.
+pub const CONFIG_FILE_NAME: &str = ".config";
+
+/// Typed overlay for the `metadata` JSON field on [`MemoryDocument`].
+///
+/// Fields use `Option` so that only explicitly set flags participate in
+/// the merge chain (document metadata → folder `.config` → system defaults).
+/// Unknown fields are preserved via `serde(flatten)`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+pub struct DocumentMetadata {
+    /// When `true`, skip chunking and embedding for this document/folder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_indexing: Option<bool>,
+
+    /// When `true`, skip automatic versioning for this document/folder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skip_versioning: Option<bool>,
+
+    /// Hygiene (auto-cleanup) configuration for this folder.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hygiene: Option<HygieneMetadata>,
+
+    /// Preserve unknown fields for forward compatibility.
+    #[serde(flatten)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+impl DocumentMetadata {
+    /// Parse from a raw JSON [`serde_json::Value`].
+    ///
+    /// Returns [`Default`] if the value is not an object or cannot be parsed.
+    pub fn from_value(value: &serde_json::Value) -> Self {
+        serde_json::from_value(value.clone()).unwrap_or_default()
+    }
+
+    /// Convert to a JSON [`serde_json::Value`].
+    pub fn to_value(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::json!({}))
+    }
+
+    /// Merge two metadata values: `overlay` keys win over `base` keys.
+    ///
+    /// This is a shallow merge at the top-level keys — nested objects are
+    /// replaced wholesale, not recursively merged. This keeps the semantics
+    /// simple and predictable across both PostgreSQL and libSQL.
+    pub fn merge(base: &serde_json::Value, overlay: &serde_json::Value) -> serde_json::Value {
+        let mut merged = match base {
+            serde_json::Value::Object(map) => map.clone(),
+            _ => serde_json::Map::new(),
+        };
+        if let serde_json::Value::Object(over) = overlay {
+            for (k, v) in over {
+                merged.insert(k.clone(), v.clone());
+            }
+        }
+        serde_json::Value::Object(merged)
+    }
+}
+
+/// Minimum allowed `retention_days` to prevent accidental mass-deletion.
+const MIN_RETENTION_DAYS: u32 = 1;
+
+/// Hygiene (auto-cleanup) settings for a folder.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct HygieneMetadata {
+    /// Whether this folder is a hygiene target.
+    pub enabled: bool,
+
+    /// Delete documents older than this many days (minimum: 1).
+    #[serde(
+        default = "default_retention_days",
+        deserialize_with = "deserialize_retention_days"
+    )]
+    pub retention_days: u32,
+}
+
+fn default_retention_days() -> u32 {
+    30
+}
+
+fn deserialize_retention_days<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u32::deserialize(deserializer)?;
+    Ok(value.max(MIN_RETENTION_DAYS))
+}
+
+/// A historical version of a workspace document.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DocumentVersion {
+    /// Version record ID.
+    pub id: Uuid,
+    /// Parent document ID.
+    pub document_id: Uuid,
+    /// Version number (1-based, monotonically increasing per document).
+    pub version: i32,
+    /// Full document content at this version.
+    pub content: String,
+    /// SHA-256 hash of `content` (hex-encoded, prefixed with `sha256:`).
+    pub content_hash: String,
+    /// When this version was created.
+    pub created_at: DateTime<Utc>,
+    /// Who/what created this version (e.g. `"agent"`, `"user:alice"`).
+    pub changed_by: Option<String>,
+}
+
+/// Summary of a document version (without full content).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VersionSummary {
+    /// Version number.
+    pub version: i32,
+    /// SHA-256 hash of the version's content.
+    pub content_hash: String,
+    /// When this version was created.
+    pub created_at: DateTime<Utc>,
+    /// Who/what created this version.
+    pub changed_by: Option<String>,
+}
+
+/// Result of a workspace patch operation.
+#[derive(Debug, Clone)]
+pub struct PatchResult {
+    /// The updated document.
+    pub document: MemoryDocument,
+    /// Number of replacements made.
+    pub replacements: usize,
+}
+
+/// Compute a SHA-256 hash of content, returned as `"sha256:{hex}"`.
+pub fn content_sha256(content: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let result = hasher.finalize();
+    format!("sha256:{:x}", result)
+}
+
+/// Check if a path refers to a `.config` document.
+pub fn is_config_path(path: &str) -> bool {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    file_name == CONFIG_FILE_NAME
 }
 
 /// Paths treated as identity documents for multi-scope isolation.
@@ -358,6 +506,205 @@ mod tests {
         let result = merge_workspace_entries(entries);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].updated_at, Some(ts));
+    }
+
+    #[test]
+    fn test_document_metadata_default_is_empty() {
+        let meta = DocumentMetadata::default();
+        assert_eq!(meta.skip_indexing, None);
+        assert_eq!(meta.skip_versioning, None);
+        assert_eq!(meta.hygiene, None);
+        assert!(meta.extra.is_empty());
+    }
+
+    #[test]
+    fn test_document_metadata_from_value_full() {
+        let value = serde_json::json!({
+            "skip_indexing": true,
+            "skip_versioning": false,
+            "hygiene": { "enabled": true, "retention_days": 7 }
+        });
+        let meta = DocumentMetadata::from_value(&value);
+        assert_eq!(meta.skip_indexing, Some(true));
+        assert_eq!(meta.skip_versioning, Some(false));
+        let hygiene = meta.hygiene.unwrap();
+        assert!(hygiene.enabled);
+        assert_eq!(hygiene.retention_days, 7);
+    }
+
+    #[test]
+    fn test_document_metadata_from_value_partial() {
+        let value = serde_json::json!({"skip_indexing": true});
+        let meta = DocumentMetadata::from_value(&value);
+        assert_eq!(meta.skip_indexing, Some(true));
+        assert_eq!(meta.hygiene, None);
+    }
+
+    #[test]
+    fn test_document_metadata_from_value_invalid() {
+        let meta = DocumentMetadata::from_value(&serde_json::json!("not an object"));
+        assert_eq!(meta, DocumentMetadata::default());
+    }
+
+    #[test]
+    fn test_document_metadata_preserves_unknown_fields() {
+        let value = serde_json::json!({
+            "skip_indexing": true,
+            "custom_field": "hello"
+        });
+        let meta = DocumentMetadata::from_value(&value);
+        assert_eq!(meta.skip_indexing, Some(true));
+        assert_eq!(
+            meta.extra.get("custom_field").and_then(|v| v.as_str()),
+            Some("hello")
+        );
+
+        // Round-trip preserves the field
+        let back = meta.to_value();
+        assert_eq!(
+            back.get("custom_field").and_then(|v| v.as_str()),
+            Some("hello")
+        );
+    }
+
+    #[test]
+    fn test_document_metadata_merge() {
+        let base = serde_json::json!({"skip_indexing": false, "hygiene": {"enabled": true, "retention_days": 30}});
+        let overlay = serde_json::json!({"skip_indexing": true, "skip_versioning": true});
+        let merged = DocumentMetadata::merge(&base, &overlay);
+        let meta = DocumentMetadata::from_value(&merged);
+        // Overlay wins
+        assert_eq!(meta.skip_indexing, Some(true));
+        assert_eq!(meta.skip_versioning, Some(true));
+        // Base preserved when not overridden
+        assert!(meta.hygiene.is_some());
+    }
+
+    #[test]
+    fn test_document_metadata_merge_empty_base() {
+        let base = serde_json::json!({});
+        let overlay = serde_json::json!({"skip_indexing": true});
+        let merged = DocumentMetadata::merge(&base, &overlay);
+        let meta = DocumentMetadata::from_value(&merged);
+        assert_eq!(meta.skip_indexing, Some(true));
+    }
+
+    #[test]
+    fn test_hygiene_metadata_default_retention() {
+        let value = serde_json::json!({"enabled": true});
+        let hygiene: HygieneMetadata = serde_json::from_value(value).unwrap();
+        assert!(hygiene.enabled);
+        assert_eq!(hygiene.retention_days, 30);
+    }
+
+    #[test]
+    fn test_hygiene_metadata_retention_days_clamped_to_minimum() {
+        // retention_days: 0 should be clamped to 1 to prevent mass-deletion.
+        let hygiene: HygieneMetadata =
+            serde_json::from_value(serde_json::json!({"enabled": true, "retention_days": 0}))
+                .unwrap();
+        assert_eq!(hygiene.retention_days, MIN_RETENTION_DAYS);
+
+        // retention_days: 1 is the minimum and should pass through unchanged.
+        let hygiene: HygieneMetadata =
+            serde_json::from_value(serde_json::json!({"enabled": true, "retention_days": 1}))
+                .unwrap();
+        assert_eq!(hygiene.retention_days, 1);
+    }
+
+    #[test]
+    fn test_content_sha256_deterministic() {
+        let hash1 = content_sha256("hello world");
+        let hash2 = content_sha256("hello world");
+        assert_eq!(hash1, hash2);
+        assert!(hash1.starts_with("sha256:"));
+    }
+
+    #[test]
+    fn test_content_sha256_different_content() {
+        let hash1 = content_sha256("hello");
+        let hash2 = content_sha256("world");
+        assert_ne!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_is_config_path() {
+        assert!(is_config_path(".config"));
+        assert!(is_config_path("daily/.config"));
+        assert!(is_config_path("frontend/widgets/.config"));
+        assert!(!is_config_path("daily/2024-01-15.md"));
+        assert!(!is_config_path("MEMORY.md"));
+        assert!(!is_config_path(".config.bak"));
+    }
+
+    #[test]
+    fn test_is_config_path_edge_cases() {
+        assert!(!is_config_path("foo.config"));
+        assert!(!is_config_path(""));
+        // ".config/bar" — the filename component is "bar", not ".config"
+        assert!(!is_config_path(".config/bar"));
+    }
+
+    #[test]
+    fn test_content_sha256_empty_string() {
+        let hash = content_sha256("");
+        assert!(hash.starts_with("sha256:"));
+        // SHA-256 of "" is a known constant
+        assert_eq!(
+            hash,
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn test_content_sha256_unicode() {
+        let hash1 = content_sha256("Hello 🌍");
+        let hash2 = content_sha256("Hello 🌍");
+        assert_eq!(hash1, hash2);
+        // Different unicode content produces different hashes
+        let hash3 = content_sha256("Hello 🌎");
+        assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_document_metadata_merge_null_overlay_value() {
+        // Overlay with null values should overwrite base values
+        let base = serde_json::json!({"skip_indexing": true});
+        let overlay = serde_json::json!({"skip_indexing": null});
+        let merged = DocumentMetadata::merge(&base, &overlay);
+        // null wins over true (shallow merge replaces entire key)
+        assert_eq!(merged.get("skip_indexing"), Some(&serde_json::Value::Null));
+    }
+
+    #[test]
+    fn test_document_metadata_merge_nested_hygiene_replaced_wholesale() {
+        // Nested objects are replaced entirely, not recursively merged
+        let base = serde_json::json!({
+            "hygiene": {"enabled": true, "retention_days": 30}
+        });
+        let overlay = serde_json::json!({
+            "hygiene": {"enabled": false}
+        });
+        let merged = DocumentMetadata::merge(&base, &overlay);
+        let meta = DocumentMetadata::from_value(&merged);
+        let hygiene = meta.hygiene.unwrap();
+        // Overlay replaced the entire hygiene object — retention_days falls back to default
+        assert!(!hygiene.enabled);
+        assert_eq!(hygiene.retention_days, 30); // serde default kicks in
+    }
+
+    #[test]
+    fn test_document_metadata_merge_both_empty() {
+        let merged = DocumentMetadata::merge(&serde_json::json!({}), &serde_json::json!({}));
+        assert_eq!(merged, serde_json::json!({}));
+    }
+
+    #[test]
+    fn test_document_metadata_merge_non_object_base() {
+        // Non-object base is treated as empty
+        let merged =
+            DocumentMetadata::merge(&serde_json::json!("string"), &serde_json::json!({"a": 1}));
+        assert_eq!(merged, serde_json::json!({"a": 1}));
     }
 
     #[test]

--- a/src/workspace/hygiene.rs
+++ b/src/workspace/hygiene.rs
@@ -1,8 +1,10 @@
 //! Memory hygiene: automatic cleanup of stale workspace documents.
 //!
-//! Runs on a configurable cadence and deletes daily log entries and conversation
-//! documents older than their respective retention periods. Identity files
-//! (`IDENTITY.md`, `SOUL.md`, etc.) are never touched.
+//! Runs on a configurable cadence and discovers which directories have hygiene
+//! enabled by reading `.config` metadata documents. This is a **metadata-driven**
+//! approach: instead of hardcoding `daily/` and `conversations/`, the system
+//! respects `hygiene.enabled` and `hygiene.retention_days` set on each folder's
+//! `.config` document.
 //!
 //! A global [`AtomicBool`] guard prevents concurrent hygiene passes, which
 //! avoids TOCTOU races on the state file and Windows file-locking errors
@@ -10,18 +12,16 @@
 //! pass completes.
 //!
 //! ```text
-//! ┌─────────────────────────────────────────────┐
-//! │               Hygiene Pass                   │
-//! │                                              │
-//! │  0. Acquire RUNNING guard (skip if held)     │
-//! │  1. Check cadence (skip if ran recently)     │
-//! │  2. Save state (claim the cadence window)    │
-//! │  3. List daily/ documents                    │
-//! │  4. Delete those older than daily_retention  │
-//! │  5. List conversations/ documents            │
-//! │  6. Delete those older than conversation_ret │
-//! │  7. Log summary                              │
-//! └─────────────────────────────────────────────┘
+//! ┌──────────────────────────────────────────────────┐
+//! │               Hygiene Pass                        │
+//! │                                                   │
+//! │  0. Acquire RUNNING guard (skip if held)          │
+//! │  1. Check cadence (skip if ran recently)          │
+//! │  2. Save state (claim the cadence window)         │
+//! │  3. Discover .config docs with hygiene.enabled    │
+//! │  4. For each: cleanup_directory(parent, retention)│
+//! │  5. Log summary                                   │
+//! └──────────────────────────────────────────────────┘
 //! ```
 
 use std::path::PathBuf;
@@ -31,46 +31,19 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::workspace::Workspace;
+use crate::workspace::{DocumentMetadata, IDENTITY_PATHS, Workspace, is_config_path, paths};
 
 /// Global guard preventing concurrent hygiene passes.
 static RUNNING: AtomicBool = AtomicBool::new(false);
-
-/// Paths that must never be deleted by hygiene, regardless of age.
-const IDENTITY_PATHS: &[&str] = &[
-    crate::workspace::document::paths::MEMORY,
-    crate::workspace::document::paths::IDENTITY,
-    crate::workspace::document::paths::SOUL,
-    crate::workspace::document::paths::AGENTS,
-    crate::workspace::document::paths::USER,
-    crate::workspace::document::paths::HEARTBEAT,
-    crate::workspace::document::paths::README,
-    crate::workspace::document::paths::TOOLS,
-    crate::workspace::document::paths::BOOTSTRAP,
-];
-
-/// Check if a document path is an identity document that must never be deleted.
-///
-/// Performs case-insensitive comparison to handle case-insensitive filesystems
-/// (Windows, macOS) and prevent accidental deletion of identity docs with
-/// different casing (e.g., memory.md, MEMORY.MD, Memory.md).
-fn is_identity_path(path: &str) -> bool {
-    let file_name = path.rsplit('/').next().unwrap_or(path);
-    let file_name_lower = file_name.to_lowercase();
-    IDENTITY_PATHS
-        .iter()
-        .any(|&p| p.to_lowercase() == file_name_lower)
-}
 
 /// Configuration for workspace hygiene.
 #[derive(Debug, Clone)]
 pub struct HygieneConfig {
     /// Whether hygiene is enabled at all.
     pub enabled: bool,
-    /// Documents in `daily/` older than this many days are deleted.
-    pub daily_retention_days: u32,
-    /// Documents in `conversations/` older than this many days are deleted.
-    pub conversation_retention_days: u32,
+    /// Maximum number of versions to keep per document.
+    /// Enforced during hygiene passes for documents in cleaned directories.
+    pub version_keep_count: u32,
     /// Minimum hours between hygiene passes.
     pub cadence_hours: u32,
     /// Directory to store state file (default: `~/.ironclaw`).
@@ -81,8 +54,7 @@ impl Default for HygieneConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            daily_retention_days: 30,
-            conversation_retention_days: 7,
+            version_keep_count: 50,
             cadence_hours: 12,
             state_dir: ironclaw_base_dir(),
         }
@@ -98,10 +70,10 @@ struct HygieneState {
 /// Summary of what a hygiene pass cleaned up.
 #[derive(Debug, Default)]
 pub struct HygieneReport {
-    /// Number of daily log documents deleted.
-    pub daily_logs_deleted: u32,
-    /// Number of conversation documents deleted.
-    pub conversation_docs_deleted: u32,
+    /// Per-directory cleanup results: `(directory_path, deleted_count)`.
+    pub directories_cleaned: Vec<(String, u32)>,
+    /// Number of document versions pruned across all documents.
+    pub versions_pruned: u64,
     /// Whether the run was skipped (cadence not yet elapsed).
     pub skipped: bool,
 }
@@ -109,7 +81,7 @@ pub struct HygieneReport {
 impl HygieneReport {
     /// True if any cleanup work was done.
     pub fn had_work(&self) -> bool {
-        self.daily_logs_deleted > 0 || self.conversation_docs_deleted > 0
+        self.directories_cleaned.iter().any(|(_, n)| *n > 0) || self.versions_pruned > 0
     }
 }
 
@@ -168,30 +140,88 @@ pub async fn run_if_due(workspace: &Workspace, config: &HygieneConfig) -> Hygien
     // TOCTOU races where another task reads stale state.
     save_state(&state_file);
 
-    tracing::info!(
-        daily_retention_days = config.daily_retention_days,
-        conversation_retention_days = config.conversation_retention_days,
-        "memory hygiene: starting cleanup pass"
-    );
+    tracing::info!("memory hygiene: starting cleanup pass");
 
     let mut report = HygieneReport::default();
 
-    // Delete old daily logs
-    match cleanup_daily_logs(workspace, config.daily_retention_days).await {
-        Ok(count) => report.daily_logs_deleted = count,
-        Err(e) => tracing::warn!("memory hygiene: failed to clean daily logs: {e}"),
+    // Discover directories that have hygiene enabled via .config metadata.
+    let config_docs = match workspace.find_config_documents().await {
+        Ok(docs) => docs,
+        Err(e) => {
+            tracing::warn!("memory hygiene: failed to discover .config documents: {e}");
+            return report;
+        }
+    };
+
+    for doc in &config_docs {
+        let meta = DocumentMetadata::from_value(&doc.metadata);
+        let Some(hygiene) = meta.hygiene else {
+            continue;
+        };
+        if !hygiene.enabled {
+            continue;
+        }
+
+        // Derive the parent directory from the .config path.
+        let directory = match doc.path.rsplit_once('/') {
+            Some((dir, _)) => format!("{dir}/"),
+            None => continue, // root-level .config — skip
+        };
+
+        match cleanup_directory(workspace, &directory, hygiene.retention_days).await {
+            Ok(deleted) => {
+                if deleted > 0 {
+                    tracing::info!(directory, deleted, "memory hygiene: cleaned directory");
+                }
+                report.directories_cleaned.push((directory, deleted));
+            }
+            Err(e) => {
+                tracing::warn!(directory, "memory hygiene: failed to clean directory: {e}");
+            }
+        }
     }
 
-    // Delete old conversation documents
-    match cleanup_conversation_docs(workspace, config.conversation_retention_days).await {
-        Ok(count) => report.conversation_docs_deleted = count,
-        Err(e) => tracing::warn!("memory hygiene: failed to clean conversation docs: {e}"),
+    // Prune old document versions if configured.
+    // NOTE: O(n) reads — does workspace.read() per document to get doc.id for
+    // prune_versions. A bulk prune query would be more efficient but is fine
+    // for typical directory sizes.
+    if config.version_keep_count > 0 {
+        // Prune versions for documents in directories that were just cleaned.
+        // This avoids iterating ALL documents — we only prune where hygiene ran.
+        for (directory, _) in &report.directories_cleaned {
+            if let Ok(entries) = workspace.list(directory).await {
+                for entry in entries {
+                    if entry.is_directory || is_config_path(&entry.path) {
+                        continue;
+                    }
+                    let path = if entry.path.starts_with(directory.as_str()) {
+                        entry.path.clone()
+                    } else {
+                        format!("{}{}", directory, entry.path)
+                    };
+                    if let Ok(doc) = workspace.read(&path).await {
+                        match workspace
+                            .prune_versions(
+                                doc.id,
+                                config.version_keep_count.min(i32::MAX as u32) as i32,
+                            )
+                            .await
+                        {
+                            Ok(pruned) => report.versions_pruned += pruned,
+                            Err(e) => {
+                                tracing::debug!(path, "version prune failed: {e}");
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     if report.had_work() {
         tracing::info!(
-            daily_logs_deleted = report.daily_logs_deleted,
-            conversation_docs_deleted = report.conversation_docs_deleted,
+            directories_cleaned = ?report.directories_cleaned,
+            versions_pruned = report.versions_pruned,
             "memory hygiene: cleanup complete"
         );
     } else {
@@ -210,88 +240,84 @@ impl Drop for RunningGuard {
     }
 }
 
-/// Delete daily log documents older than `retention_days`.
-async fn cleanup_daily_logs(
+/// Paths that must never be deleted by hygiene, regardless of directory.
+///
+/// This is a superset of `IDENTITY_PATHS` (which is for multi-scope isolation)
+/// and includes additional files like MEMORY.md, HEARTBEAT.md, README.md that
+/// are critical to workspace operation.
+const HYGIENE_PROTECTED_PATHS: &[&str] = &[
+    paths::MEMORY,
+    paths::IDENTITY,
+    paths::SOUL,
+    paths::AGENTS,
+    paths::USER,
+    paths::HEARTBEAT,
+    paths::README,
+    paths::TOOLS,
+    paths::BOOTSTRAP,
+];
+
+/// Check if a document path is a protected file that must never be deleted.
+///
+/// Performs case-insensitive filename comparison to handle case-insensitive
+/// filesystems (Windows, macOS). Also checks against `IDENTITY_PATHS` for
+/// any future additions there that aren't in the hygiene list.
+fn is_protected_document(path: &str) -> bool {
+    let file_name = path.rsplit('/').next().unwrap_or(path);
+    let file_name_lower = file_name.to_lowercase();
+    HYGIENE_PROTECTED_PATHS
+        .iter()
+        .chain(IDENTITY_PATHS.iter())
+        .any(|&p| p.to_lowercase() == file_name_lower)
+}
+
+/// Delete documents in `directory` that are older than `retention_days`.
+///
+/// Skips directories, `.config` files, and identity documents (`MEMORY.md`,
+/// `SOUL.md`, `IDENTITY.md`, etc.) which must never be deleted by hygiene
+/// regardless of which directory they appear in.
+async fn cleanup_directory(
     workspace: &Workspace,
+    directory: &str,
     retention_days: u32,
 ) -> Result<u32, anyhow::Error> {
     let cutoff = Utc::now() - chrono::Duration::days(i64::from(retention_days));
-    let entries = workspace.list("daily/").await?;
-
+    // NOTE: workspace.list() merges entries from secondary read scopes in
+    // multi-scope mode, but workspace.delete() only targets the primary scope.
+    // Entries from secondary scopes will fail silently at the delete call
+    // (caught by the `if let Err` below). This is harmless but may produce
+    // unexpected log noise. A list_primary_only() variant could avoid this.
+    let entries = workspace.list(directory).await?;
     let mut deleted = 0u32;
     for entry in entries {
         if entry.is_directory {
             continue;
         }
-
-        // Never delete identity documents
-        if is_identity_path(&entry.path) {
+        if is_config_path(&entry.path) {
             continue;
         }
-
-        // Check if the document is old enough to delete
+        // Safety net: never delete identity documents regardless of directory.
+        // This protects MEMORY.md, SOUL.md, IDENTITY.md, etc. even if a
+        // misconfigured .config enables hygiene on a directory containing them.
+        if is_protected_document(&entry.path) {
+            continue;
+        }
         if let Some(updated_at) = entry.updated_at
             && updated_at < cutoff
         {
-            let path = if entry.path.starts_with("daily/") {
+            let path = if entry.path.starts_with(directory) {
                 entry.path.clone()
             } else {
-                format!("daily/{}", entry.path)
+                format!("{}{}", directory, entry.path)
             };
-
             if let Err(e) = workspace.delete(&path).await {
                 tracing::warn!(path, "memory hygiene: failed to delete: {e}");
             } else {
-                tracing::debug!(path, "memory hygiene: deleted old daily log");
+                tracing::debug!(path, "memory hygiene: deleted stale document");
                 deleted += 1;
             }
         }
     }
-
-    Ok(deleted)
-}
-
-/// Delete conversation documents older than `retention_days`.
-async fn cleanup_conversation_docs(
-    workspace: &Workspace,
-    retention_days: u32,
-) -> Result<u32, anyhow::Error> {
-    let cutoff = Utc::now() - chrono::Duration::days(i64::from(retention_days));
-    let entries = workspace.list("conversations/").await?;
-
-    let mut deleted = 0u32;
-    for entry in entries {
-        if entry.is_directory {
-            continue;
-        }
-
-        // Never delete identity documents
-        if is_identity_path(&entry.path) {
-            continue;
-        }
-
-        // Check if the document is old enough to delete
-        if let Some(updated_at) = entry.updated_at
-            && updated_at < cutoff
-        {
-            let path = if entry.path.starts_with("conversations/") {
-                entry.path.clone()
-            } else {
-                format!("conversations/{}", entry.path)
-            };
-
-            if let Err(e) = workspace.delete(&path).await {
-                tracing::warn!(
-                    path,
-                    "memory hygiene: failed to delete conversation doc: {e}"
-                );
-            } else {
-                tracing::debug!(path, "memory hygiene: deleted old conversation doc");
-                deleted += 1;
-            }
-        }
-    }
-
     Ok(deleted)
 }
 
@@ -349,8 +375,7 @@ mod tests {
     fn default_config_is_reasonable() {
         let cfg = HygieneConfig::default();
         assert!(cfg.enabled);
-        assert_eq!(cfg.daily_retention_days, 30);
-        assert_eq!(cfg.conversation_retention_days, 7);
+        assert_eq!(cfg.version_keep_count, 50);
         assert_eq!(cfg.cadence_hours, 12);
     }
 
@@ -362,84 +387,33 @@ mod tests {
     }
 
     #[test]
-    fn report_had_work_when_deleted() {
+    fn report_had_work_when_directories_cleaned() {
         let report = HygieneReport {
-            daily_logs_deleted: 3,
-            conversation_docs_deleted: 0,
+            directories_cleaned: vec![("daily/".to_string(), 3)],
+            versions_pruned: 0,
             skipped: false,
         };
         assert!(report.had_work());
     }
 
     #[test]
-    fn report_had_work_when_conversation_deleted() {
+    fn report_had_work_when_versions_pruned() {
         let report = HygieneReport {
-            daily_logs_deleted: 0,
-            conversation_docs_deleted: 2,
+            directories_cleaned: vec![],
+            versions_pruned: 5,
             skipped: false,
         };
         assert!(report.had_work());
     }
 
     #[test]
-    fn is_identity_path_excludes_sacred_docs() {
-        for name in [
-            "MEMORY.md",
-            "IDENTITY.md",
-            "SOUL.md",
-            "AGENTS.md",
-            "USER.md",
-            "HEARTBEAT.md",
-            "README.md",
-            "TOOLS.md",
-            "BOOTSTRAP.md",
-        ] {
-            assert!(is_identity_path(name), "{name} should be excluded");
-            assert!(
-                is_identity_path(&format!("conversations/{name}")),
-                "conversations/{name} should be excluded via path"
-            );
-        }
-    }
-
-    #[test]
-    fn is_identity_path_case_insensitive() {
-        // Verify case-insensitive matching for case-insensitive filesystems
-        assert!(
-            is_identity_path("memory.md"),
-            "lowercase memory.md should be excluded"
-        );
-        assert!(
-            is_identity_path("Memory.md"),
-            "mixed case Memory.md should be excluded"
-        );
-        assert!(
-            is_identity_path("MEMORY.MD"),
-            "uppercase MEMORY.MD should be excluded"
-        );
-        assert!(
-            is_identity_path("identity.md"),
-            "lowercase identity.md should be excluded"
-        );
-        assert!(
-            is_identity_path("conversations/soul.md"),
-            "conversations/soul.md should be excluded"
-        );
-        assert!(
-            is_identity_path("conversations/SOUL.MD"),
-            "conversations/SOUL.MD should be excluded"
-        );
-    }
-
-    #[test]
-    fn is_identity_path_allows_normal_docs() {
-        for path in [
-            "daily/2024-01-01.md",
-            "conversations/chat-abc.md",
-            "notes.md",
-        ] {
-            assert!(!is_identity_path(path), "{path} should not be excluded");
-        }
+    fn report_no_work_when_zero_deletions() {
+        let report = HygieneReport {
+            directories_cleaned: vec![("daily/".to_string(), 0)],
+            versions_pruned: 0,
+            skipped: false,
+        };
+        assert!(!report.had_work());
     }
 
     #[test]
@@ -552,87 +526,134 @@ mod tests {
             Arc::new(Workspace::new_with_db("default", db.clone()))
         }
 
-        #[tokio::test]
-        async fn cleanup_daily_logs_preserves_identity_documents() {
-            let (db, _tmp) = create_test_db().await;
-            let ws = create_workspace(&db);
-
-            // Write several regular documents (non-identity)
-            ws.write("daily/2024-01-15.md", "Old log")
+        /// Helper to seed a .config document with hygiene metadata on a directory.
+        async fn seed_hygiene_config(workspace: &Workspace, directory: &str, retention_days: u32) {
+            let config_path = format!("{}.config", directory);
+            // Create the .config document with empty content
+            workspace
+                .write(&config_path, "")
                 .await
-                .expect("write log 1");
-            ws.write("daily/2024-01-20.md", "Another log")
+                .expect("write .config");
+            // Read back to get the document ID
+            let doc = workspace
+                .read(&config_path)
                 .await
-                .expect("write log 2");
-
-            // Write an identity document
-            ws.write("MEMORY.md", "Long-term curated memory")
+                .expect("read .config doc");
+            // Set hygiene metadata
+            workspace
+                .update_metadata(
+                    doc.id,
+                    &serde_json::json!({
+                        "hygiene": {"enabled": true, "retention_days": retention_days},
+                        "skip_versioning": true
+                    }),
+                )
                 .await
-                .expect("write identity");
-
-            // List before cleanup
-            let before = ws.list("daily/").await.expect("list before");
-            let daily_count_before = before.iter().filter(|e| !e.is_directory).count();
-            assert!(daily_count_before >= 2, "should have at least 2 daily logs");
-
-            // Run cleanup with 0-day retention (deletes everything old)
-            // This tests that even with aggressive cleanup, identity docs survive
-            let deleted = cleanup_daily_logs(&ws, 0)
-                .await
-                .expect("cleanup_daily_logs");
-
-            // Should have deleted some documents (the daily logs)
-            assert!(deleted > 0, "should have deleted old daily documents");
-
-            // Verify identity doc still exists
-            let identity = db
-                .get_document_by_path("default", None, "MEMORY.md")
-                .await
-                .expect("get identity doc");
-            assert_eq!(identity.path, "MEMORY.md");
-            assert_eq!(identity.content, "Long-term curated memory");
+                .expect("set metadata");
         }
 
         #[tokio::test]
-        async fn cleanup_conversation_docs_handles_empty_directory() {
+        async fn cleanup_directory_skips_config_files() {
             let (db, _tmp) = create_test_db().await;
             let ws = create_workspace(&db);
 
-            // Run cleanup on an empty directory (conversations/ doesn't exist)
-            let deleted = cleanup_conversation_docs(&ws, 7)
+            // Write documents including a .config
+            ws.write("daily/2024-01-15.md", "Old log")
                 .await
-                .expect("cleanup_conversation_docs");
+                .expect("write log");
+            ws.write("daily/.config", "").await.expect("write config");
 
-            // Should delete 0 (nothing to delete)
+            // Run cleanup with 0-day retention (deletes everything old)
+            let deleted = cleanup_directory(&ws, "daily/", 0)
+                .await
+                .expect("cleanup_directory");
+
+            // Should have deleted the log but not the .config
+            assert!(deleted > 0, "should have deleted old daily documents");
+
+            // Verify .config still exists
+            let config_doc = db
+                .get_document_by_path("default", None, "daily/.config")
+                .await
+                .expect("get .config doc");
+            assert_eq!(config_doc.path, "daily/.config");
+        }
+
+        #[tokio::test]
+        async fn cleanup_directory_handles_empty_directory() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            // Run cleanup on an empty directory
+            let deleted = cleanup_directory(&ws, "conversations/", 7)
+                .await
+                .expect("cleanup_directory");
+
             assert_eq!(deleted, 0, "should delete 0 from empty directory");
         }
 
         #[tokio::test]
-        async fn cleanup_respects_cadence_prevents_concurrent_runs() {
+        async fn metadata_driven_cleanup_discovers_directories() {
             let (db, _tmp) = create_test_db().await;
             let ws = create_workspace(&db);
 
-            let config = HygieneConfig {
-                enabled: true,
-                daily_retention_days: 30,
-                conversation_retention_days: 7,
-                cadence_hours: 12,
-                state_dir: _tmp.path().to_path_buf(),
-            };
+            // Seed .config with hygiene enabled on daily/ (0-day retention = delete everything)
+            seed_hygiene_config(&ws, "daily/", 0).await;
 
-            // First run should succeed
-            let report1 = run_if_due(&ws, &config).await;
-            assert!(!report1.skipped, "first run should not be skipped");
+            // Write some documents
+            ws.write("daily/log1.md", "content 1")
+                .await
+                .expect("write doc 1");
+            ws.write("daily/log2.md", "content 2")
+                .await
+                .expect("write doc 2");
 
-            // Second run immediately should be skipped (cadence not elapsed)
-            let report2 = run_if_due(&ws, &config).await;
-            assert!(report2.skipped, "second run should be skipped by cadence");
+            // Use find_config_documents + cleanup_directory directly to avoid
+            // global AtomicBool contention with concurrent tests.
+            let configs = ws
+                .find_config_documents()
+                .await
+                .expect("find_config_documents");
+            assert!(!configs.is_empty(), "should find .config documents");
 
-            // Report structure should be correct
-            assert_eq!(
-                report1.daily_logs_deleted + report1.conversation_docs_deleted,
-                0,
-                "first run should have clean counts"
+            let meta = DocumentMetadata::from_value(&configs[0].metadata);
+            assert!(
+                meta.hygiene.as_ref().is_some_and(|h| h.enabled),
+                "hygiene should be enabled"
+            );
+
+            let deleted = cleanup_directory(&ws, "daily/", 0)
+                .await
+                .expect("cleanup_directory");
+            assert!(deleted > 0, "should have cleaned documents");
+        }
+
+        #[test]
+        fn cleanup_respects_cadence_via_state_file() {
+            // Test cadence logic without run_if_due (which uses a global
+            // AtomicBool that causes flakiness with concurrent tests).
+            let dir = tempfile::tempdir().expect("tempdir");
+            let state_file = dir.path().join("memory_hygiene_state.json");
+
+            // No state file → cadence not elapsed (first run should proceed)
+            assert!(
+                load_state(&state_file).is_none(),
+                "no state file should exist initially"
+            );
+
+            // Save state (simulates a completed run)
+            save_state(&state_file);
+
+            // State exists with recent timestamp → cadence check should block
+            let state = load_state(&state_file).expect("state should be loadable");
+            let elapsed = Utc::now().signed_duration_since(state.last_run);
+            assert!(elapsed.num_seconds() < 5, "state should be very recent");
+
+            // With 12-hour cadence, a run just saved should cause skip
+            let cadence = chrono::Duration::hours(12);
+            assert!(
+                elapsed < cadence,
+                "elapsed time should be less than cadence"
             );
         }
 
@@ -640,6 +661,10 @@ mod tests {
         async fn cleanup_reports_deletion_counts_correctly() {
             let (db, _tmp) = create_test_db().await;
             let ws = create_workspace(&db);
+
+            // Seed hygiene on both directories
+            seed_hygiene_config(&ws, "daily/", 0).await;
+            seed_hygiene_config(&ws, "conversations/", 0).await;
 
             // Write some documents
             ws.write("daily/log1.md", "content 1")
@@ -652,38 +677,212 @@ mod tests {
                 .await
                 .expect("write doc 3");
 
-            // Run with 0-day retention to delete everything non-identity
-            let deleted_daily = cleanup_daily_logs(&ws, 0).await.expect("cleanup daily");
-            let deleted_conv = cleanup_conversation_docs(&ws, 0)
+            // Run with 0-day retention via direct cleanup_directory calls
+            let deleted_daily = cleanup_directory(&ws, "daily/", 0)
+                .await
+                .expect("cleanup daily");
+            let deleted_conv = cleanup_directory(&ws, "conversations/", 0)
                 .await
                 .expect("cleanup conversations");
 
-            // Both should report deletions
             assert!(deleted_daily > 0, "should report deleted daily logs");
             assert_eq!(deleted_conv, 1, "should report 1 deleted conversation doc");
 
-            // Create a HygieneReport and verify aggregation works
+            // Verify HygieneReport aggregation
             let report = HygieneReport {
-                daily_logs_deleted: deleted_daily,
-                conversation_docs_deleted: deleted_conv,
+                directories_cleaned: vec![
+                    ("daily/".to_string(), deleted_daily),
+                    ("conversations/".to_string(), deleted_conv),
+                ],
+                versions_pruned: 0,
                 skipped: false,
             };
 
-            // Verify HygieneReport structure
             assert!(!report.skipped, "should not be skipped");
             assert!(report.had_work(), "report should indicate work was done");
-            assert!(
-                report.daily_logs_deleted > 0 || report.conversation_docs_deleted > 0,
-                "report should have at least one deletion count > 0"
-            );
 
-            // Verify had_work() correctly combines both counts
+            // Verify had_work() correctly checks directory counts
             let no_work = HygieneReport {
-                daily_logs_deleted: 0,
-                conversation_docs_deleted: 0,
+                directories_cleaned: vec![],
+                versions_pruned: 0,
                 skipped: false,
             };
             assert!(!no_work.had_work(), "empty report should indicate no work");
+        }
+
+        #[tokio::test]
+        async fn no_config_documents_means_no_cleanup() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            // Write documents to custom/ but do NOT create a .config
+            ws.write("custom/note1.md", "some content")
+                .await
+                .expect("write note1");
+            ws.write("custom/note2.md", "other content")
+                .await
+                .expect("write note2");
+
+            // Without .config documents, find_config_documents returns empty,
+            // so no directories are discovered for cleanup.
+            let config_docs = ws
+                .find_config_documents()
+                .await
+                .expect("find_config_documents");
+            assert!(config_docs.is_empty(), "no .config documents should exist");
+
+            // Documents should still exist (no cleanup occurred)
+            assert!(ws.read("custom/note1.md").await.is_ok());
+            assert!(ws.read("custom/note2.md").await.is_ok());
+        }
+
+        #[tokio::test]
+        async fn config_with_hygiene_disabled_skips_directory() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            // Create a .config with hygiene disabled
+            let config_doc = ws.write("test/.config", "").await.expect("write .config");
+            ws.update_metadata(
+                config_doc.id,
+                &serde_json::json!({
+                    "hygiene": {"enabled": false, "retention_days": 1},
+                    "skip_versioning": true
+                }),
+            )
+            .await
+            .expect("set metadata");
+
+            // Write a document
+            ws.write("test/data.md", "should survive")
+                .await
+                .expect("write data");
+
+            // Verify that the .config document is found but has hygiene disabled.
+            // The run_if_due loop skips directories where hygiene.enabled is false.
+            let config_docs = ws
+                .find_config_documents()
+                .await
+                .expect("find_config_documents");
+            assert_eq!(config_docs.len(), 1, "should find 1 .config document");
+            let meta = DocumentMetadata::from_value(&config_docs[0].metadata);
+            assert!(
+                meta.hygiene.is_some() && !meta.hygiene.as_ref().is_none_or(|h| h.enabled),
+                "hygiene should be present but disabled"
+            );
+
+            // Even with 0-day retention, cleanup_directory should not delete
+            // the doc — but the key point is that run_if_due would never call
+            // cleanup_directory for this directory at all (enabled=false).
+            // Document should still exist.
+            let doc = ws.read("test/data.md").await.expect("data.md should exist");
+            assert_eq!(doc.content, "should survive");
+        }
+
+        #[tokio::test]
+        async fn multiple_directories_with_different_retention() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            // fast/ has 0-day retention (everything gets deleted)
+            seed_hygiene_config(&ws, "fast/", 0).await;
+            // slow/ has 9999-day retention (nothing gets deleted)
+            seed_hygiene_config(&ws, "slow/", 9999).await;
+
+            ws.write("fast/ephemeral.md", "gone soon")
+                .await
+                .expect("write fast doc");
+            ws.write("slow/durable.md", "here to stay")
+                .await
+                .expect("write slow doc");
+
+            // Use cleanup_directory directly to avoid global AtomicBool
+            // contention with concurrent tests.
+            let fast_deleted = cleanup_directory(&ws, "fast/", 0)
+                .await
+                .expect("cleanup fast");
+            let slow_deleted = cleanup_directory(&ws, "slow/", 9999)
+                .await
+                .expect("cleanup slow");
+
+            assert!(fast_deleted > 0, "fast/ docs should be deleted");
+            assert_eq!(slow_deleted, 0, "slow/ docs should be preserved");
+
+            // Verify slow doc still readable
+            let doc = ws
+                .read("slow/durable.md")
+                .await
+                .expect("slow doc should still exist");
+            assert_eq!(doc.content, "here to stay");
+        }
+
+        #[tokio::test]
+        async fn documents_newer_than_retention_not_deleted() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            ws.write("test/recent.md", "just created")
+                .await
+                .expect("write recent doc");
+
+            // Use cleanup_directory directly to avoid global AtomicBool contention
+            // with other concurrent tests that call run_if_due.
+            let deleted = cleanup_directory(&ws, "test/", 9999)
+                .await
+                .expect("cleanup_directory");
+
+            assert_eq!(
+                deleted, 0,
+                "recent docs should not be deleted with 9999-day retention"
+            );
+
+            let doc = ws
+                .read("test/recent.md")
+                .await
+                .expect("recent doc should still exist");
+            assert_eq!(doc.content, "just created");
+        }
+
+        #[tokio::test]
+        async fn version_pruning_during_hygiene() {
+            let (db, _tmp) = create_test_db().await;
+            let ws = create_workspace(&db);
+
+            // Write multiple times to create versions
+            let doc = ws
+                .write("daily/evolving.md", "version 1")
+                .await
+                .expect("write v1");
+            let doc_id = doc.id;
+            ws.write("daily/evolving.md", "version 2")
+                .await
+                .expect("write v2");
+            ws.write("daily/evolving.md", "version 3")
+                .await
+                .expect("write v3");
+            ws.write("daily/evolving.md", "version 4")
+                .await
+                .expect("write v4");
+
+            // Verify we have multiple versions before pruning
+            let versions_before = ws.list_versions(doc_id, 100).await.expect("list versions");
+            assert!(
+                versions_before.len() >= 3,
+                "should have at least 3 versions before pruning, got {}",
+                versions_before.len()
+            );
+
+            // Prune directly (avoids global AtomicBool contention with concurrent tests)
+            let pruned = ws.prune_versions(doc_id, 2).await.expect("prune_versions");
+            assert!(pruned > 0, "should have pruned some versions");
+
+            // After pruning, at most 2 versions should remain
+            let versions_after = ws.list_versions(doc_id, 100).await.expect("list versions");
+            assert!(
+                versions_after.len() <= 2,
+                "should have at most 2 versions after pruning, got {}",
+                versions_after.len()
+            );
         }
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2112,7 +2112,7 @@ impl Workspace {
         }
 
         if count > 0 {
-            tracing::info!("Seeded {} workspace files", count);
+            tracing::debug!("Seeded {} workspace files", count);
         }
         Ok(count)
     }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -53,8 +53,9 @@ mod search;
 
 pub use chunker::{ChunkConfig, chunk_document};
 pub use document::{
-    IDENTITY_PATHS, MemoryChunk, MemoryDocument, WorkspaceEntry, is_identity_path,
-    merge_workspace_entries, paths,
+    CONFIG_FILE_NAME, DocumentMetadata, DocumentVersion, HygieneMetadata, IDENTITY_PATHS,
+    MemoryChunk, MemoryDocument, PatchResult, VersionSummary, WorkspaceEntry, content_sha256,
+    is_config_path, is_identity_path, merge_workspace_entries, paths,
 };
 pub use embedding_cache::{CachedEmbeddingProvider, EmbeddingCacheConfig};
 pub use embeddings::{
@@ -364,6 +365,102 @@ impl WorkspaceStorage {
                 db.get_document_by_path_multi(user_ids, agent_id, path)
                     .await
             }
+        }
+    }
+
+    // ==================== Metadata ====================
+
+    async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.update_document_metadata(id, metadata).await,
+            Self::Db(db) => db.update_document_metadata(id, metadata).await,
+        }
+    }
+
+    async fn find_config_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.find_config_documents(user_id, agent_id).await,
+            Self::Db(db) => db.find_config_documents(user_id, agent_id).await,
+        }
+    }
+
+    // ==================== Versioning ====================
+
+    async fn save_version(
+        &self,
+        document_id: Uuid,
+        content: &str,
+        content_hash: &str,
+        changed_by: Option<&str>,
+    ) -> Result<i32, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => {
+                repo.save_version(document_id, content, content_hash, changed_by)
+                    .await
+            }
+            Self::Db(db) => {
+                db.save_version(document_id, content, content_hash, changed_by)
+                    .await
+            }
+        }
+    }
+
+    async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<DocumentVersion, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.get_version(document_id, version).await,
+            Self::Db(db) => db.get_version(document_id, version).await,
+        }
+    }
+
+    async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<VersionSummary>, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.list_versions(document_id, limit).await,
+            Self::Db(db) => db.list_versions(document_id, limit).await,
+        }
+    }
+
+    #[allow(dead_code)] // Part of WorkspaceStore trait; used by DB backends directly
+    async fn get_latest_version_number(
+        &self,
+        document_id: Uuid,
+    ) -> Result<Option<i32>, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.get_latest_version_number(document_id).await,
+            Self::Db(db) => db.get_latest_version_number(document_id).await,
+        }
+    }
+
+    async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError> {
+        match self {
+            #[cfg(feature = "postgres")]
+            Self::Repo(repo) => repo.prune_versions(document_id, keep_count).await,
+            Self::Db(db) => db.prune_versions(document_id, keep_count).await,
         }
     }
 }
@@ -696,10 +793,211 @@ impl Workspace {
             .await
     }
 
+    /// Get or create a document at the given path.
+    ///
+    /// Creates the document with empty content if it doesn't exist.
+    /// Does not trigger reindexing or versioning.
+    pub async fn get_or_create(&self, path: &str) -> Result<MemoryDocument, WorkspaceError> {
+        let path = normalize_path(path);
+        self.storage
+            .get_or_create_document_by_path(&self.user_id, self.agent_id, &path)
+            .await
+    }
+
+    // ==================== Metadata ====================
+
+    /// Update the metadata JSON on a document by ID (full replacement).
+    pub async fn update_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        self.storage.update_document_metadata(id, metadata).await
+    }
+
+    /// Prune old versions for a document, keeping only the most recent `keep_count`.
+    ///
+    /// Returns the number of versions deleted.
+    pub async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError> {
+        self.storage.prune_versions(document_id, keep_count).await
+    }
+
+    /// Find all `.config` documents in this workspace scope.
+    pub async fn find_config_documents(&self) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        self.storage
+            .find_config_documents(&self.user_id, self.agent_id)
+            .await
+    }
+
+    /// Resolve effective metadata for a document path.
+    ///
+    /// Resolution chain: document's own metadata → nearest ancestor `.config` → defaults.
+    ///
+    /// Uses a single `find_config_documents` query to fetch all `.config` docs,
+    /// then finds the nearest ancestor in-memory — O(1) DB queries instead of
+    /// O(depth) serial queries walking up the directory tree.
+    pub async fn resolve_metadata(&self, path: &str) -> DocumentMetadata {
+        let path = normalize_path(path);
+
+        // 1. Document's own metadata
+        let doc_meta = self
+            .storage
+            .get_document_by_path(&self.user_id, self.agent_id, &path)
+            .await
+            .ok()
+            .map(|d| d.metadata);
+
+        // 2. Find nearest ancestor .config using a single query + in-memory match
+        let config_meta = self
+            .storage
+            .find_config_documents(&self.user_id, self.agent_id)
+            .await
+            .ok()
+            .and_then(|configs| find_nearest_config(&path, &configs));
+
+        // 3. Merge: config as base, document metadata as overlay
+        let base = config_meta.unwrap_or(serde_json::json!({}));
+        let overlay = doc_meta.unwrap_or(serde_json::json!({}));
+        let merged = DocumentMetadata::merge(&base, &overlay);
+        DocumentMetadata::from_value(&merged)
+    }
+
+    // ==================== Versioning ====================
+
+    /// List versions of a document (newest first).
+    pub async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<VersionSummary>, WorkspaceError> {
+        self.storage.list_versions(document_id, limit).await
+    }
+
+    /// Get a specific version of a document.
+    pub async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<DocumentVersion, WorkspaceError> {
+        self.storage.get_version(document_id, version).await
+    }
+
+    /// Save the current content as a version if it differs from the latest.
+    ///
+    /// Returns the new version number, or `None` if skipped (empty content,
+    /// identical hash, or versioning disabled via metadata).
+    ///
+    /// Accepts pre-resolved metadata to avoid redundant DB queries when the
+    /// caller (e.g., `write()`) will also pass metadata to `reindex_document()`.
+    async fn maybe_save_version(
+        &self,
+        document_id: Uuid,
+        current_content: &str,
+        metadata: &DocumentMetadata,
+        changed_by: Option<&str>,
+    ) -> Result<Option<i32>, WorkspaceError> {
+        // Don't version empty documents
+        if current_content.is_empty() {
+            return Ok(None);
+        }
+
+        // Check metadata for skip_versioning flag
+        if metadata.skip_versioning == Some(true) {
+            return Ok(None);
+        }
+
+        let hash = content_sha256(current_content);
+
+        // Check if latest version already has this hash (skip duplicate saves).
+        // Uses a single query instead of get_version + get_latest_version_number.
+        if let Ok(versions) = self.storage.list_versions(document_id, 1).await
+            && let Some(latest) = versions.first()
+            && latest.content_hash == hash
+        {
+            return Ok(None);
+        }
+
+        let version = self
+            .storage
+            .save_version(document_id, current_content, &hash, changed_by)
+            .await?;
+        Ok(Some(version))
+    }
+
+    // ==================== Patch ====================
+
+    /// Apply a search-and-replace patch to a workspace document.
+    ///
+    /// Finds `old_string` in the document and replaces it with `new_string`.
+    /// If `replace_all` is true, replaces all occurrences; otherwise only the first.
+    /// Auto-versions before applying the patch.
+    pub async fn patch(
+        &self,
+        path: &str,
+        old_string: &str,
+        new_string: &str,
+        replace_all: bool,
+    ) -> Result<PatchResult, WorkspaceError> {
+        if old_string.is_empty() {
+            return Err(WorkspaceError::PatchFailed {
+                path: path.to_string(),
+                reason: "old_string cannot be empty".to_string(),
+            });
+        }
+        let path = normalize_path(path);
+        let doc = self
+            .storage
+            .get_document_by_path(&self.user_id, self.agent_id, &path)
+            .await?;
+
+        if !doc.content.contains(old_string) {
+            return Err(WorkspaceError::PatchFailed {
+                path,
+                reason: "old_string not found in document".to_string(),
+            });
+        }
+
+        let (new_content, count) = if replace_all {
+            let count = doc.content.matches(old_string).count();
+            (doc.content.replace(old_string, new_string), count)
+        } else {
+            (doc.content.replacen(old_string, new_string, 1), 1)
+        };
+
+        // Injection scan for system prompt files
+        if is_system_prompt_file(&path) && !new_content.is_empty() {
+            reject_if_injected(&path, &new_content)?;
+        }
+
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(&path).await;
+
+        // Auto-version before updating.
+        // Fail-open: versioning failures must not block writes.
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
+        self.storage.update_document(doc.id, &new_content).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
+
+        let updated = self.storage.get_document_by_id(doc.id).await?;
+        Ok(PatchResult {
+            document: updated,
+            replacements: count,
+        })
+    }
+
     /// Write (create or update) a file.
     ///
     /// Creates parent directories implicitly (they're virtual in the DB).
     /// Re-indexes the document for search after writing.
+    /// Auto-versions the previous content before overwriting.
     ///
     /// # Example
     /// ```ignore
@@ -715,8 +1013,30 @@ impl Workspace {
             .storage
             .get_or_create_document_by_path(&self.user_id, self.agent_id, &path)
             .await?;
+
+        // Short-circuit when content is unchanged: skip versioning and update,
+        // but still reindex so metadata-driven flags (e.g. skip_indexing toggled
+        // via the memory_write metadata param) take effect immediately.
+        if doc.content == content {
+            let metadata = self.resolve_metadata(&path).await;
+            let _ = self
+                .reindex_document_with_metadata(doc.id, Some(&metadata))
+                .await;
+            return Ok(doc);
+        }
+
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(&path).await;
+
+        // Auto-version previous content before overwriting.
+        // Fail-open: versioning failures must not block writes.
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
         self.storage.update_document(doc.id, content).await?;
-        self.reindex_document(doc.id).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
 
         // Return updated doc
         self.storage.get_document_by_id(doc.id).await
@@ -754,8 +1074,18 @@ impl Workspace {
             reject_if_injected(&path, &new_content)?;
         }
 
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(&path).await;
+
+        // Auto-version previous content before appending.
+        // Fail-open: versioning failures must not block writes.
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
         self.storage.update_document(doc.id, &new_content).await?;
-        self.reindex_document(doc.id).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
         Ok(())
     }
 
@@ -840,8 +1170,16 @@ impl Workspace {
             .storage
             .get_or_create_document_by_path(&scope, self.agent_id, &path)
             .await?;
+
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(&path).await;
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
         self.storage.update_document(doc.id, content).await?;
-        self.reindex_document(doc.id).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
         let document = self.storage.get_document_by_id(doc.id).await?;
         Ok(WriteResult {
             document,
@@ -884,8 +1222,16 @@ impl Workspace {
         } else {
             format!("{}\n\n{}", doc.content, content)
         };
+
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(&path).await;
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
         self.storage.update_document(doc.id, &new_content).await?;
-        self.reindex_document(doc.id).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
         let document = self.storage.get_document_by_id(doc.id).await?;
         Ok(WriteResult {
             document,
@@ -1090,8 +1436,16 @@ impl Workspace {
         } else {
             format!("{}\n\n{}", doc.content, entry)
         };
+
+        // Resolve metadata once — shared by versioning and indexing.
+        let metadata = self.resolve_metadata(paths::MEMORY).await;
+        let _ = self
+            .maybe_save_version(doc.id, &doc.content, &metadata, Some(&self.user_id))
+            .await;
+
         self.storage.update_document(doc.id, &new_content).await?;
-        self.reindex_document(doc.id).await?;
+        self.reindex_document_with_metadata(doc.id, Some(&metadata))
+            .await?;
         Ok(())
     }
 
@@ -1581,9 +1935,31 @@ impl Workspace {
     // ==================== Indexing ====================
 
     /// Re-index a document (chunk and generate embeddings).
-    async fn reindex_document(&self, document_id: Uuid) -> Result<(), WorkspaceError> {
+    ///
+    /// Accepts optional pre-resolved metadata to skip a redundant `resolve_metadata`
+    /// call when the caller already has it (e.g., the `write()` path).
+    async fn reindex_document_with_metadata(
+        &self,
+        document_id: Uuid,
+        metadata: Option<&DocumentMetadata>,
+    ) -> Result<(), WorkspaceError> {
         // Get the document
         let doc = self.storage.get_document_by_id(document_id).await?;
+
+        // Check metadata for skip_indexing flag
+        let resolved;
+        let metadata = match metadata {
+            Some(m) => m,
+            None => {
+                resolved = self.resolve_metadata(&doc.path).await;
+                &resolved
+            }
+        };
+        if metadata.skip_indexing == Some(true) {
+            // Delete any existing chunks and skip indexing
+            self.storage.delete_chunks(document_id).await?;
+            return Ok(());
+        }
 
         // Chunk the content
         let chunks = chunk_document(&doc.content, ChunkConfig::default());
@@ -1667,6 +2043,51 @@ impl Workspace {
                 tracing::debug!("Failed to seed {}: {}", path, e);
             } else {
                 count += 1;
+            }
+        }
+
+        // Seed folder-level .config documents for hygiene defaults.
+        let config_seeds: &[(&str, serde_json::Value)] = &[
+            (
+                "daily/.config",
+                serde_json::json!({
+                    "hygiene": {"enabled": true, "retention_days": 30},
+                    "skip_versioning": true
+                }),
+            ),
+            (
+                "conversations/.config",
+                serde_json::json!({
+                    "hygiene": {"enabled": true, "retention_days": 7},
+                    "skip_versioning": true
+                }),
+            ),
+        ];
+
+        for (config_path, metadata_value) in config_seeds {
+            match self.read_primary(config_path).await {
+                Ok(_) => continue, // Already exists, don't overwrite
+                Err(WorkspaceError::DocumentNotFound { .. }) => {}
+                Err(e) => {
+                    tracing::debug!("Failed to check {}: {}", config_path, e);
+                    continue;
+                }
+            }
+            // Create empty document with metadata
+            if let Ok(doc) = self
+                .storage
+                .get_or_create_document_by_path(&self.user_id, self.agent_id, config_path)
+                .await
+            {
+                if let Err(e) = self
+                    .storage
+                    .update_document_metadata(doc.id, metadata_value)
+                    .await
+                {
+                    tracing::debug!("Failed to set metadata on {}: {}", config_path, e);
+                } else {
+                    count += 1;
+                }
             }
         }
 
@@ -1819,6 +2240,33 @@ impl Workspace {
 
         Ok(count)
     }
+}
+
+/// Find the nearest ancestor `.config` document for a given path.
+///
+/// Given a pre-fetched list of all `.config` documents (from `find_config_documents`),
+/// walks up the path components to find the most specific (nearest parent) config.
+/// Returns the metadata of the matching `.config`, or `None` if no ancestor has one.
+fn find_nearest_config(path: &str, configs: &[MemoryDocument]) -> Option<serde_json::Value> {
+    // Build a set of config paths → metadata for O(1) lookup
+    let config_map: std::collections::HashMap<&str, &serde_json::Value> = configs
+        .iter()
+        .map(|doc| (doc.path.as_str(), &doc.metadata))
+        .collect();
+
+    // Walk up the path looking for the nearest ancestor .config
+    let mut current = path;
+    while let Some(slash_pos) = current.rfind('/') {
+        let parent = &current[..slash_pos];
+        let config_path = format!("{}/{CONFIG_FILE_NAME}", parent);
+        if let Some(meta) = config_map.get(config_path.as_str()) {
+            return Some((*meta).clone());
+        }
+        current = parent;
+    }
+
+    // Check root-level .config
+    config_map.get(CONFIG_FILE_NAME).map(|m| (*m).clone())
 }
 
 /// Normalize a file path (remove leading/trailing slashes, collapse //).
@@ -2169,5 +2617,245 @@ mod seed_tests {
 
         // Multi scope: is multi
         assert!(multi_count > 1);
+    }
+}
+
+#[cfg(all(test, feature = "libsql"))]
+mod versioning_tests {
+    use super::*;
+    use std::sync::Arc;
+
+    async fn create_test_workspace() -> (Workspace, tempfile::TempDir) {
+        use crate::db::libsql::LibSqlBackend;
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("version_test.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        <LibSqlBackend as crate::db::Database>::run_migrations(&backend)
+            .await
+            .expect("migrations");
+        let db: Arc<dyn crate::db::Database> = Arc::new(backend);
+        let ws = Workspace::new_with_db("test_version", db);
+        (ws, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn write_creates_version() {
+        let (ws, _dir) = create_test_workspace().await;
+        let doc = ws.write("test.md", "v1").await.unwrap();
+        ws.write("test.md", "v2").await.unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        assert_eq!(
+            versions.len(),
+            1,
+            "should have 1 version (the pre-v2 content)"
+        );
+        assert!(versions[0].content_hash.starts_with("sha256:"));
+
+        let v = ws.get_version(doc.id, versions[0].version).await.unwrap();
+        assert_eq!(v.content, "v1");
+        assert_eq!(v.changed_by.as_deref(), Some("test_version"));
+    }
+
+    #[tokio::test]
+    async fn write_deduplicates_identical_content() {
+        let (ws, _dir) = create_test_workspace().await;
+        let doc = ws.write("test.md", "same").await.unwrap();
+        ws.write("test.md", "same").await.unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        // First write creates the doc (empty → "same"), second write is "same" → "same"
+        // The hash check should deduplicate the second write
+        assert!(
+            versions.len() <= 1,
+            "identical writes should not create duplicate versions"
+        );
+    }
+
+    #[tokio::test]
+    async fn append_versions_pre_append_content() {
+        let (ws, _dir) = create_test_workspace().await;
+        let doc = ws.write("test.md", "line1").await.unwrap();
+        ws.append("test.md", "line2").await.unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        assert!(!versions.is_empty(), "append should create a version");
+
+        let v = ws.get_version(doc.id, versions[0].version).await.unwrap();
+        assert_eq!(
+            v.content, "line1",
+            "version should contain pre-append content"
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_single_replacement() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("test.md", "hello world hello").await.unwrap();
+        let result = ws.patch("test.md", "hello", "hi", false).await.unwrap();
+
+        assert_eq!(result.replacements, 1);
+        assert_eq!(result.document.content, "hi world hello");
+    }
+
+    #[tokio::test]
+    async fn patch_replace_all() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("test.md", "hello world hello").await.unwrap();
+        let result = ws.patch("test.md", "hello", "hi", true).await.unwrap();
+
+        assert_eq!(result.replacements, 2);
+        assert_eq!(result.document.content, "hi world hi");
+    }
+
+    #[tokio::test]
+    async fn patch_not_found_error() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("test.md", "hello").await.unwrap();
+        let err = ws.patch("test.md", "xyz", "abc", false).await;
+
+        assert!(err.is_err());
+        match err.unwrap_err() {
+            WorkspaceError::PatchFailed { path, .. } => {
+                assert_eq!(path, "test.md");
+            }
+            other => panic!("expected PatchFailed, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn patch_creates_version() {
+        let (ws, _dir) = create_test_workspace().await;
+        let doc = ws.write("test.md", "original").await.unwrap();
+        ws.patch("test.md", "original", "modified", false)
+            .await
+            .unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        assert!(!versions.is_empty(), "patch should create a version");
+        let v = ws.get_version(doc.id, versions[0].version).await.unwrap();
+        assert_eq!(
+            v.content, "original",
+            "version should contain pre-patch content"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_no_config() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("notes.md", "content").await.unwrap();
+
+        let meta = ws.resolve_metadata("notes.md").await;
+        assert_eq!(meta.skip_indexing, None);
+        assert_eq!(meta.skip_versioning, None);
+        assert!(meta.hygiene.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_inherits_from_folder_config() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        // Create folder .config
+        let config_doc = ws.write("projects/.config", "").await.unwrap();
+        ws.update_metadata(config_doc.id, &serde_json::json!({"skip_indexing": true}))
+            .await
+            .unwrap();
+
+        // File in that folder inherits
+        let meta = ws.resolve_metadata("projects/notes.md").await;
+        assert_eq!(meta.skip_indexing, Some(true));
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_document_overrides_config() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        // Folder says skip_indexing: true
+        let config_doc = ws.write("projects/.config", "").await.unwrap();
+        ws.update_metadata(config_doc.id, &serde_json::json!({"skip_indexing": true}))
+            .await
+            .unwrap();
+
+        // Document says skip_indexing: false (override)
+        let doc = ws.write("projects/important.md", "content").await.unwrap();
+        ws.update_metadata(doc.id, &serde_json::json!({"skip_indexing": false}))
+            .await
+            .unwrap();
+
+        let meta = ws.resolve_metadata("projects/important.md").await;
+        assert_eq!(
+            meta.skip_indexing,
+            Some(false),
+            "document metadata should override .config"
+        );
+    }
+
+    #[tokio::test]
+    async fn resolve_metadata_nearest_ancestor_wins() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        // Root says skip_indexing: true
+        let root_config = ws.write(".config", "").await.unwrap();
+        ws.update_metadata(root_config.id, &serde_json::json!({"skip_indexing": true}))
+            .await
+            .unwrap();
+
+        // projects/ says skip_indexing: false
+        let proj_config = ws.write("projects/.config", "").await.unwrap();
+        ws.update_metadata(proj_config.id, &serde_json::json!({"skip_indexing": false}))
+            .await
+            .unwrap();
+
+        // Nearest parent (projects/.config) wins over root
+        let meta = ws.resolve_metadata("projects/alpha/notes.md").await;
+        assert_eq!(
+            meta.skip_indexing,
+            Some(false),
+            "nearest ancestor .config should win"
+        );
+    }
+
+    #[tokio::test]
+    async fn skip_versioning_via_config() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        // Set skip_versioning on ephemeral/ directory
+        let config_doc = ws.write("ephemeral/.config", "").await.unwrap();
+        ws.update_metadata(config_doc.id, &serde_json::json!({"skip_versioning": true}))
+            .await
+            .unwrap();
+
+        // Write multiple times — no versions should be created
+        let doc = ws.write("ephemeral/data.md", "v1").await.unwrap();
+        ws.write("ephemeral/data.md", "v2").await.unwrap();
+        ws.write("ephemeral/data.md", "v3").await.unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        assert_eq!(
+            versions.len(),
+            0,
+            "skip_versioning should prevent version creation"
+        );
+    }
+
+    #[tokio::test]
+    async fn patch_with_unicode() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("test.md", "Hello 🌍 World 🌍").await.unwrap();
+        let result = ws.patch("test.md", "🌍", "🌎", false).await.unwrap();
+
+        assert_eq!(result.replacements, 1);
+        assert_eq!(result.document.content, "Hello 🌎 World 🌍");
+    }
+
+    #[tokio::test]
+    async fn patch_empty_replacement() {
+        let (ws, _dir) = create_test_workspace().await;
+        ws.write("test.md", "hello cruel world").await.unwrap();
+        let result = ws.patch("test.md", " cruel", "", false).await.unwrap();
+
+        assert_eq!(result.document.content, "hello world");
     }
 }

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -11,7 +11,9 @@ use uuid::Uuid;
 
 use crate::error::WorkspaceError;
 
-use crate::workspace::document::{MemoryChunk, MemoryDocument, WorkspaceEntry};
+use crate::workspace::document::{
+    DocumentVersion, MemoryChunk, MemoryDocument, VersionSummary, WorkspaceEntry,
+};
 use crate::workspace::search::{RankedResult, SearchConfig, SearchResult, fuse_results};
 
 /// Database repository for workspace operations.
@@ -701,5 +703,234 @@ impl Repository {
             all_entries.extend(self.list_directory(uid, agent_id, directory).await?);
         }
         Ok(crate::workspace::merge_workspace_entries(all_entries))
+    }
+
+    // ==================== Metadata ====================
+
+    pub async fn update_document_metadata(
+        &self,
+        id: Uuid,
+        metadata: &serde_json::Value,
+    ) -> Result<(), WorkspaceError> {
+        let conn = self.conn().await?;
+        conn.execute(
+            "UPDATE memory_documents SET metadata = $2, updated_at = NOW() WHERE id = $1",
+            &[&id, &metadata],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Failed to update metadata: {e}"),
+        })?;
+        Ok(())
+    }
+
+    pub async fn find_config_documents(
+        &self,
+        user_id: &str,
+        agent_id: Option<Uuid>,
+    ) -> Result<Vec<MemoryDocument>, WorkspaceError> {
+        let conn = self.conn().await?;
+        let rows = conn
+            .query(
+                r#"
+                SELECT id, user_id, agent_id, path, content,
+                       created_at, updated_at, metadata
+                FROM memory_documents
+                WHERE user_id = $1 AND agent_id IS NOT DISTINCT FROM $2
+                  AND (path LIKE '%/.config' OR path = '.config')
+                ORDER BY path
+                "#,
+                &[&user_id, &agent_id],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to find config documents: {e}"),
+            })?;
+        Ok(rows.iter().map(|r| self.row_to_document(r)).collect())
+    }
+
+    // ==================== Versioning ====================
+
+    pub async fn save_version(
+        &self,
+        document_id: Uuid,
+        content: &str,
+        content_hash: &str,
+        changed_by: Option<&str>,
+    ) -> Result<i32, WorkspaceError> {
+        let mut conn = self.conn().await?;
+
+        // Use a transaction to prevent concurrent writers from allocating
+        // the same version number. The SELECT FOR UPDATE locks the existing
+        // version rows for this document, serializing concurrent inserts.
+        let tx = conn
+            .transaction()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to start transaction: {e}"),
+            })?;
+
+        // Lock the parent document row to serialize concurrent version writes.
+        // We lock memory_documents (which always exists) instead of
+        // memory_document_versions (which may have no rows yet — FOR UPDATE
+        // on an empty result set locks nothing).
+        tx.execute(
+            "SELECT 1 FROM memory_documents WHERE id = $1 FOR UPDATE",
+            &[&document_id],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Failed to lock document for versioning: {e}"),
+        })?;
+
+        let row = tx
+            .query_one(
+                "SELECT COALESCE(MAX(version), 0) + 1 AS next_version \
+                 FROM memory_document_versions WHERE document_id = $1",
+                &[&document_id],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to get next version number: {e}"),
+            })?;
+        let next_version: i32 = row.get(0);
+
+        tx.execute(
+            r#"
+            INSERT INTO memory_document_versions
+                (id, document_id, version, content, content_hash, changed_by)
+            VALUES (gen_random_uuid(), $1, $2, $3, $4, $5)
+            "#,
+            &[
+                &document_id,
+                &next_version,
+                &content,
+                &content_hash,
+                &changed_by,
+            ],
+        )
+        .await
+        .map_err(|e| WorkspaceError::SearchFailed {
+            reason: format!("Failed to save version: {e}"),
+        })?;
+
+        tx.commit()
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to commit version: {e}"),
+            })?;
+
+        Ok(next_version)
+    }
+
+    pub async fn get_version(
+        &self,
+        document_id: Uuid,
+        version: i32,
+    ) -> Result<DocumentVersion, WorkspaceError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                r#"
+                SELECT id, document_id, version, content, content_hash,
+                       created_at, changed_by
+                FROM memory_document_versions
+                WHERE document_id = $1 AND version = $2
+                "#,
+                &[&document_id, &version],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to get version: {e}"),
+            })?
+            .ok_or(WorkspaceError::VersionNotFound {
+                document_id,
+                version,
+            })?;
+        Ok(DocumentVersion {
+            id: row.get(0),
+            document_id: row.get(1),
+            version: row.get(2),
+            content: row.get(3),
+            content_hash: row.get(4),
+            created_at: row.get(5),
+            changed_by: row.get(6),
+        })
+    }
+
+    pub async fn list_versions(
+        &self,
+        document_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<VersionSummary>, WorkspaceError> {
+        let conn = self.conn().await?;
+        let rows = conn
+            .query(
+                r#"
+                SELECT version, content_hash, created_at, changed_by
+                FROM memory_document_versions
+                WHERE document_id = $1
+                ORDER BY version DESC
+                LIMIT $2
+                "#,
+                &[&document_id, &limit],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to list versions: {e}"),
+            })?;
+        Ok(rows
+            .iter()
+            .map(|row| VersionSummary {
+                version: row.get(0),
+                content_hash: row.get(1),
+                created_at: row.get(2),
+                changed_by: row.get(3),
+            })
+            .collect())
+    }
+
+    pub async fn get_latest_version_number(
+        &self,
+        document_id: Uuid,
+    ) -> Result<Option<i32>, WorkspaceError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_one(
+                "SELECT MAX(version) FROM memory_document_versions WHERE document_id = $1",
+                &[&document_id],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to get latest version number: {e}"),
+            })?;
+        Ok(row.get(0))
+    }
+
+    pub async fn prune_versions(
+        &self,
+        document_id: Uuid,
+        keep_count: i32,
+    ) -> Result<u64, WorkspaceError> {
+        let conn = self.conn().await?;
+        let result = conn
+            .execute(
+                r#"
+                DELETE FROM memory_document_versions
+                WHERE document_id = $1
+                  AND version NOT IN (
+                      SELECT version FROM memory_document_versions
+                      WHERE document_id = $1
+                      ORDER BY version DESC
+                      LIMIT $2
+                  )
+                "#,
+                &[&document_id, &(keep_count as i64)],
+            )
+            .await
+            .map_err(|e| WorkspaceError::SearchFailed {
+                reason: format!("Failed to prune versions: {e}"),
+            })?;
+        Ok(result)
     }
 }

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -444,6 +444,200 @@ async def hosted_oauth_refresh_server(
 
 
 @pytest.fixture(scope="session")
+async def loop_limited_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance with a low tool-iteration limit."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "openai_compatible",
+            "LLM_BASE_URL": mock_llm_server,
+            "LLM_MODEL": "mock-model",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "loop-limited.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+            "AGENT_MAX_TOOL_ITERATIONS": "2",
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"loop-limited ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
+async def length_preserving_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance using the NearAI provider path."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "nearai",
+            "NEARAI_BASE_URL": mock_llm_server,
+            "NEARAI_MODEL": "mock-model",
+            "NEARAI_API_KEY": "mock-nearai-key",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "length-preserving.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"length-preserving ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
 async def extension_cleanup_server(
     ironclaw_binary,
     mock_llm_server,
@@ -672,6 +866,28 @@ async def page(ironclaw_server, browser):
     pg = await context.new_page()
     await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
     # Wait for the app to initialize (auth screen hidden, SSE connected)
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def loop_limited_page(loop_limited_server, browser):
+    """Fresh Playwright page bound to the low-iteration gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{loop_limited_server}/?token={AUTH_TOKEN}")
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def length_preserving_page(length_preserving_server, browser):
+    """Fresh Playwright page bound to the length-preserving gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{length_preserving_server}/?token={AUTH_TOKEN}")
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     yield pg
     await context.close()

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -26,6 +26,7 @@ SEL = {
     "chat_messages": "#chat-messages",
     "message_user": "#chat-messages .message.user",
     "message_assistant": "#chat-messages .message.assistant",
+    "message_system": "#chat-messages .message.system",
     # Skills
     "skill_search_input": "#skill-search-input",
     "skill_search_results": "#skill-search-results",
@@ -180,6 +181,75 @@ async def api_post(base_url: str, path: str, **kwargs) -> httpx.Response:
             timeout=kwargs.pop("timeout", 10),
             **kwargs,
         )
+
+
+async def send_chat_and_wait_for_terminal_message(
+    page,
+    message: str,
+    *,
+    timeout: int = 30000,
+) -> dict[str, str]:
+    """Send a chat message and wait for the next terminal visible outcome.
+
+    Returns a dict with:
+    - ``role``: ``assistant`` or ``system``
+    - ``text``: rendered text of the newest terminal message
+    """
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    assistant_sel = SEL["message_assistant"]
+    system_sel = SEL["message_system"]
+    before_assistant = await page.locator(assistant_sel).count()
+    before_system = await page.locator(system_sel).count()
+
+    await chat_input.fill(message)
+    await chat_input.press("Enter")
+
+    handle = await page.wait_for_function(
+        """({
+            assistantSelector,
+            systemSelector,
+            chatInputSelector,
+            assistantCount,
+            systemCount,
+        }) => {
+            const input = document.querySelector(chatInputSelector);
+            const systems = document.querySelectorAll(systemSelector);
+            if (systems.length > systemCount) {
+                const last = systems[systems.length - 1];
+                const content = last.querySelector('.message-content');
+                return {
+                    role: 'system',
+                    text: ((content && content.innerText) || last.innerText || '').trim(),
+                };
+            }
+
+            const assistants = document.querySelectorAll(assistantSelector);
+            if (assistants.length > assistantCount && input && !input.disabled) {
+                const last = assistants[assistants.length - 1];
+                const content = last.querySelector('.message-content');
+                const text = ((content && content.innerText) || last.innerText || '').trim();
+                if (text.length > 0 && !last.hasAttribute('data-streaming')) {
+                    return {
+                        role: 'assistant',
+                        text,
+                    };
+                }
+            }
+
+            return null;
+        }""",
+        arg={
+            "assistantSelector": assistant_sel,
+            "systemSelector": system_sel,
+            "chatInputSelector": SEL["chat_input"],
+            "assistantCount": before_assistant,
+            "systemCount": before_system,
+        },
+        timeout=timeout,
+    )
+    return await handle.json_value()
 
 
 def signed_http_webhook_headers(body: bytes) -> dict[str, str]:

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -14,6 +14,7 @@ import uuid
 from aiohttp import web
 
 CANNED_RESPONSES = [
+    (re.compile(r"empty routine response", re.IGNORECASE), ""),
     (re.compile(r"hello|hi|hey", re.IGNORECASE), "Hello! How can I help you today?"),
     (re.compile(r"2\s*\+\s*2|two plus two", re.IGNORECASE), "The answer is 4."),
     (re.compile(r"skill|install", re.IGNORECASE), "I can help you with skills management."),
@@ -25,6 +26,11 @@ DEFAULT_RESPONSE = "I understand your request."
 
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
+    (
+        re.compile(r"loop until cap", re.IGNORECASE),
+        "echo",
+        lambda _: {"message": "loop-until-cap"},
+    ),
     (
         re.compile(r"make approval post (?P<label>[a-z0-9_-]+)", re.IGNORECASE),
         "http",
@@ -66,6 +72,21 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create failing lightweight owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Failing lightweight routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Empty routine response for {m.group('name')}.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
             re.IGNORECASE,
         ),
@@ -80,8 +101,41 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create looping full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Looping full-job routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Loop until cap for {m.group('name')}.",
+            "action_type": "full_job",
+            "max_iterations": 1,
+        },
+    ),
+    (
+        re.compile(
+            r"create cron owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Cron routine {m.group('name')}",
+            "trigger_type": "cron",
+            "schedule": "0 */5 * * * *",
+            "timezone": "UTC",
+            "prompt": f"Confirm that cron routine {m.group('name')} executed.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create event routine (?P<name>[a-z0-9][a-z0-9_-]*) "
-            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)",
+            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)"
+            r"(?: cooldown (?P<cooldown>\d+))?",
             re.IGNORECASE,
         ),
         "routine_create",
@@ -94,7 +148,7 @@ TOOL_CALL_PATTERNS = [
             "prompt": f"Acknowledge that {m.group('name')} fired.",
             "action_type": "lightweight",
             "use_tools": False,
-            "cooldown_secs": 0,
+            "cooldown_secs": int(m.group("cooldown") or 0),
         },
     ),
     (
@@ -126,6 +180,21 @@ def _last_user_content(messages: list[dict]) -> str:
     return ""
 
 
+def _job_contains_marker(messages: list[dict], marker: str) -> bool:
+    marker_lower = marker.lower()
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                p.get("text", "") for p in content if p.get("type") == "text"
+            )
+        if marker_lower in str(content).lower():
+            return True
+    return False
+
+
 def _is_job_mode(messages: list[dict]) -> bool:
     """Detect if this conversation is a background job (not chat)."""
     for msg in messages:
@@ -152,6 +221,25 @@ def match_job_response(messages: list[dict], has_tools: bool) -> dict | None:
 
     last_user = _last_user_content(messages)
     tool_result_count = _count_tool_results(messages)
+    loop_until_cap = _job_contains_marker(messages, "loop until cap")
+
+    if loop_until_cap and "create a plan" in last_user.lower():
+        return {"text": json.dumps({
+            "goal": "Keep iterating until the worker hits the iteration cap",
+            "actions": [],
+            "estimated_cost": 0.001,
+            "estimated_time_secs": 5,
+            "confidence": 0.8,
+        })}
+
+    if loop_until_cap and "all planned actions have been executed" in last_user.lower():
+        return {"text": "loop until cap still requires more work"}
+
+    if loop_until_cap and has_tools:
+        return {"tool_call": {
+            "tool_name": "echo",
+            "arguments": {"message": "loop-until-cap"},
+        }}
 
     # Planning call (no tools available = complete() not complete_with_tools())
     if "create a plan" in last_user.lower():

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -24,6 +24,14 @@ CANNED_RESPONSES = [
 ]
 DEFAULT_RESPONSE = "I understand your request."
 
+TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
+TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
+    r"issue 1780 truncated tool call",
+    re.IGNORECASE,
+)
+EMPTY_REPLY_TRIGGER = re.compile(r"issue 1780 empty reply", re.IGNORECASE)
+LOOP_FOREVER_TRIGGER = re.compile(r"issue 1780 loop forever", re.IGNORECASE)
+
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
     (
@@ -168,16 +176,26 @@ def _new_oauth_state() -> dict:
     }
 
 
+def _message_text(msg: dict) -> str:
+    content = msg.get("content") or ""
+    if isinstance(content, list):
+        content = " ".join(
+            p.get("text") or "" for p in content if p.get("type") == "text"
+        )
+    return content
+
+
 def _last_user_content(messages: list[dict]) -> str:
     for msg in reversed(messages):
         if msg.get("role") == "user":
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                content = " ".join(
-                    p.get("text", "") for p in content if p.get("type") == "text"
-                )
-            return content
+            return _message_text(msg)
     return ""
+
+def _conversation_has_user_trigger(messages: list[dict], pattern: re.Pattern[str]) -> bool:
+    for msg in messages:
+        if msg.get("role") == "user" and pattern.search(_message_text(msg)):
+            return True
+    return False
 
 
 def _job_contains_marker(messages: list[dict], marker: str) -> bool:
@@ -185,12 +203,7 @@ def _job_contains_marker(messages: list[dict], marker: str) -> bool:
     for msg in messages:
         if msg.get("role") != "user":
             continue
-        content = msg.get("content", "")
-        if isinstance(content, list):
-            content = " ".join(
-                p.get("text", "") for p in content if p.get("type") == "text"
-            )
-        if marker_lower in str(content).lower():
+        if marker_lower in _message_text(msg).lower():
             return True
     return False
 
@@ -347,6 +360,82 @@ async def _send_sse(resp: web.StreamResponse, data: dict):
     await resp.write(f"data: {json.dumps(data)}\n\n".encode())
 
 
+def match_special_response(messages: list[dict], has_tools: bool) -> dict | None:
+    """Deterministic issue-specific responses for agent-loop recovery tests."""
+    last_user = _last_user_content(messages)
+
+    if _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        if has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "echo",
+                    "arguments": {"message": "loop-iteration"},
+                },
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after hitting the tool iteration limit.",
+        }
+
+    if _conversation_has_user_trigger(messages, TRUNCATED_TOOL_CALL_TRIGGER):
+        if TRUNCATED_TOOL_CALL_TRIGGER.search(last_user) and has_tools:
+            return {
+                "type": "truncated_tool_call",
+                "tool_call": {
+                    "tool_name": "time",
+                    "arguments": {},
+                },
+                "content": "Attempting a tool call but the response was truncated.",
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after discarding a truncated tool call.",
+        }
+
+    if TOOL_FAILURE_TRIGGER.search(last_user) and has_tools:
+        return {
+            "type": "tool_call",
+            "tool_call": {
+                "tool_name": "time",
+                "arguments": {"operation": "broken-operation"},
+            },
+        }
+
+    if EMPTY_REPLY_TRIGGER.search(last_user):
+        return {"type": "empty_text"}
+
+    return None
+
+
+async def _dispatch_special_response(
+    request: web.Request,
+    cid: str,
+    stream: bool,
+    special: dict,
+) -> web.StreamResponse | web.Response:
+    if special["type"] == "tool_call":
+        tc = special["tool_call"]
+        if not stream:
+            return _tool_call_response(cid, tc)
+        return await _stream_tool_call(request, cid, tc)
+    if special["type"] == "truncated_tool_call":
+        tc = special["tool_call"]
+        content = special["content"]
+        if not stream:
+            return _truncated_tool_call_response(cid, tc, content)
+        return await _stream_truncated_tool_call(request, cid, tc, content)
+    if special["type"] == "empty_text":
+        if not stream:
+            return _text_response(cid, "")
+        return await _stream_text(request, cid, "")
+
+    text = special["text"]
+    if not stream:
+        return _text_response(cid, text)
+    return await _stream_text(request, cid, text)
+
+
 async def chat_completions(request: web.Request) -> web.StreamResponse:
     """Handle POST /v1/chat/completions and /chat/completions."""
     body = await request.json()
@@ -368,6 +457,12 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
 
+    # Special chat-loop recovery cases that intentionally override the normal
+    # tool-result summary path (for example, the looping case).
+    special = match_special_response(messages, has_tools)
+    if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        return await _dispatch_special_response(request, cid, stream, special)
+
     # Tool result in messages -> text summary
     tr = _find_tool_result(messages)
     if tr:
@@ -375,6 +470,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if not stream:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
+
+    if special:
+        return await _dispatch_special_response(request, cid, stream, special)
 
     # Tool-call pattern match
     tc = match_tool_call(messages, has_tools)
@@ -410,6 +508,28 @@ def _tool_call_response(cid: str, tc: dict) -> web.Response:
                             "function": {"name": tc["tool_name"],
                                          "arguments": json.dumps(tc["arguments"])}}],
         }, "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    })
+
+
+def _truncated_tool_call_response(cid: str, tc: dict, content: str) -> web.Response:
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+    return web.json_response({
+        "id": cid,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "mock-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": f"{content}\n<tool_call>{tool_tag}</tool_call>",
+            },
+            "finish_reason": "length",
+        }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     })
 
@@ -452,6 +572,39 @@ async def _stream_tool_call(request: web.Request, cid: str, tc: dict) -> web.Str
     # Final chunk: finish reason
     chunk["choices"][0]["delta"] = {}
     chunk["choices"][0]["finish_reason"] = "tool_calls"
+    await _send_sse(resp, chunk)
+    await resp.write(b"data: [DONE]\n\n")
+    return resp
+
+
+async def _stream_truncated_tool_call(
+    request: web.Request,
+    cid: str,
+    tc: dict,
+    content: str,
+) -> web.StreamResponse:
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type": "text/event-stream", "Cache-Control": "no-cache"})
+    await resp.prepare(request)
+    base = _make_base(cid)
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+
+    chunk = {**base, "choices": [{"index": 0, "delta": {
+        "role": "assistant",
+        "content": content,
+    }, "finish_reason": None}]}
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {
+        "content": f"\n<tool_call>{tool_tag}</tool_call>",
+    }
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {}
+    chunk["choices"][0]["finish_reason"] = "length"
     await _send_sse(resp, chunk)
     await resp.write(b"data: [DONE]\n\n")
     return resp

--- a/tests/e2e/scenarios/test_agent_loop_recovery.py
+++ b/tests/e2e/scenarios/test_agent_loop_recovery.py
@@ -1,0 +1,77 @@
+"""Agent-loop recovery regressions for issue #1780."""
+
+from helpers import SEL, send_chat_and_wait_for_terminal_message
+
+
+async def _create_new_thread(page) -> None:
+    previous_thread = await page.evaluate("() => currentThreadId")
+    await page.evaluate("createNewThread()")
+    await page.wait_for_function(
+        """(prevThread) => {
+            return !!currentThreadId
+                && currentThreadId !== prevThread
+                && document.querySelectorAll('#chat-messages .message').length === 0;
+        }""",
+        arg=previous_thread,
+        timeout=10000,
+    )
+
+
+async def test_tool_failure_recovery_shows_final_response(page):
+    """A failed tool call should surface a final assistant response and not hang."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 tool failure",
+    )
+
+    assert result["role"] == "assistant", result
+    text = result["text"].lower()
+    assert "time tool returned" in text, result
+    assert (
+        "unknown operation" in text
+        or "broken-operation" in text
+        or "error" in text
+    ), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_truncated_tool_call_is_discarded_gracefully(length_preserving_page):
+    """A length-truncated tool call should be ignored and the turn should recover."""
+    await _create_new_thread(length_preserving_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        length_preserving_page,
+        "issue 1780 truncated tool call",
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after discarding a truncated tool call" in result["text"].lower(), result
+    assert await length_preserving_page.locator(SEL["approval_card"]).count() == 0
+    assert await length_preserving_page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_empty_reply_uses_chat_fallback(page):
+    """An empty LLM reply should terminate visibly instead of hanging."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 empty reply",
+    )
+
+    assert "error:" in result["text"].lower(), result
+    assert "empty" in result["text"].lower(), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_looping_tool_calls_terminate_under_low_iteration_limit(loop_limited_page):
+    """A looping tool-call pattern should terminate once force-text kicks in."""
+    await _create_new_thread(loop_limited_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        loop_limited_page,
+        "issue 1780 loop forever",
+        timeout=20000,
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after hitting the tool iteration limit" in result["text"].lower(), result
+    assert await loop_limited_page.locator(SEL["chat_input"]).is_enabled()

--- a/tests/e2e/scenarios/test_routine_event_batch.py
+++ b/tests/e2e/scenarios/test_routine_event_batch.py
@@ -7,7 +7,7 @@ import uuid
 import httpx
 import pytest
 
-from helpers import AUTH_TOKEN, SEL, signed_http_webhook_headers
+from helpers import AUTH_TOKEN, SEL, api_post, signed_http_webhook_headers
 
 
 async def _send_chat_message(page, message: str) -> None:
@@ -39,11 +39,15 @@ async def _create_event_routine(
     name: str,
     pattern: str,
     channel: str = "http",
+    cooldown_secs: int | None = None,
 ) -> dict:
     """Create an event routine through chat and return its API record."""
+    message = f"create event routine {name} channel {channel} pattern {pattern}"
+    if cooldown_secs is not None:
+        message += f" cooldown {cooldown_secs}"
     await _send_chat_message(
         page,
-        f"create event routine {name} channel {channel} pattern {pattern}",
+        message,
     )
     return await _wait_for_routine(base_url, name)
 
@@ -54,13 +58,14 @@ async def _post_http_message(
     content: str,
     sender_id: str | None = None,
     thread_id: str | None = None,
+    wait_for_response: bool = True,
 ) -> dict:
     """Send a signed HTTP-channel message and return the JSON body."""
     payload = {
         "user_id": sender_id or f"sender-{uuid.uuid4().hex[:8]}",
         "thread_id": thread_id or f"thread-{uuid.uuid4().hex[:8]}",
         "content": content,
-        "wait_for_response": True,
+        "wait_for_response": wait_for_response,
     }
     body = json.dumps(payload).encode("utf-8")
 
@@ -75,7 +80,10 @@ async def _post_http_message(
     assert response.status_code == 200, (
         f"HTTP webhook failed: {response.status_code} {response.text[:400]}"
     )
-    return response.json()
+    data = response.json()
+    if wait_for_response:
+        assert data.get("response"), f"Expected synchronous response body, got: {data}"
+    return data
 
 
 async def _wait_for_routine(base_url: str, name: str, timeout: float = 20.0) -> dict:
@@ -138,6 +146,17 @@ async def _wait_for_completed_run(
             return runs[0]
         await asyncio.sleep(0.5)
     raise AssertionError(f"Routine '{routine_id}' did not complete within {timeout}s")
+
+
+async def _toggle_routine(base_url: str, routine_id: str, enabled: bool) -> dict:
+    """Toggle a routine through the routines API."""
+    response = await api_post(
+        base_url,
+        f"/api/routines/{routine_id}/toggle",
+        json={"enabled": enabled},
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 @pytest.mark.asyncio
@@ -314,4 +333,85 @@ async def test_routine_execution_history_is_available(
 
     assert completed_run["id"]
     assert completed_run["started_at"]
+    assert completed_run["status"].lower() == "attention"
+
+
+@pytest.mark.asyncio
+async def test_event_trigger_respects_cooldown(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Rapid matching events should not re-fire a routine within cooldown."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="alert",
+        cooldown_secs=30,
+    )
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: primary incident",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    first_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert first_run["status"].lower() == "attention"
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: follow-up incident",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+
+    runs = await _get_routine_runs(ironclaw_server, routine["id"])
+    assert len(runs) == 1, f"Cooldown should suppress duplicate fire, got runs={runs}"
+
+
+@pytest.mark.asyncio
+async def test_event_routine_can_be_paused_and_resumed(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Disabled routines should not fire until they are re-enabled."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="resume",
+    )
+
+    disabled = await _toggle_routine(ironclaw_server, routine["id"], False)
+    assert disabled["status"] == "disabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+    assert await _get_routine_runs(ironclaw_server, routine["id"]) == []
+
+    enabled = await _toggle_routine(ironclaw_server, routine["id"], True)
+    assert enabled["status"] == "enabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
     assert completed_run["status"].lower() == "attention"

--- a/tests/e2e/scenarios/test_routine_full_job.py
+++ b/tests/e2e/scenarios/test_routine_full_job.py
@@ -25,15 +25,61 @@ async def _send_chat_message(page, message: str) -> None:
     await chat_input.fill(message)
     await chat_input.press("Enter")
 
-    await page.wait_for_function(
-        """({ selector, expectedCount }) => {
-            return document.querySelectorAll(selector).length >= expectedCount;
-        }""",
-        arg={
-            "selector": SEL["message_assistant"],
-            "expectedCount": before_count + 1,
-        },
-        timeout=30000,
+    wait_args = {
+        "selector": SEL["message_assistant"],
+        "expectedCount": before_count + 1,
+    }
+
+    async def _wait_for_assistant() -> None:
+        await page.wait_for_function(
+            """({ selector, expectedCount }) => {
+                return document.querySelectorAll(selector).length >= expectedCount;
+            }""",
+            arg=wait_args,
+            timeout=30000,
+        )
+
+    async def _wait_for_approval():
+        approval_card = page.locator(SEL["approval_card"]).last
+        await approval_card.wait_for(
+            state="visible",
+            timeout=30000,
+        )
+        return approval_card
+
+    assistant_task = asyncio.create_task(_wait_for_assistant())
+    approval_task = asyncio.create_task(_wait_for_approval())
+
+    done, pending = await asyncio.wait(
+        {assistant_task, approval_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    if assistant_task in done and assistant_task.exception() is None:
+        await assistant_task
+        return
+
+    if approval_task not in done or approval_task.exception() is not None:
+        await assistant_task
+        return
+
+    approval_card = await approval_task
+    await approval_card.locator("button.approve").click()
+    await _wait_for_assistant()
+
+
+async def _open_tab(page, tab: str) -> None:
+    """Switch to a visible top-level tab."""
+    button = page.locator(SEL["tab_button"].format(tab=tab))
+    await button.click()
+    await page.locator(SEL["tab_panel"].format(tab=tab)).wait_for(
+        state="visible",
+        timeout=5000,
     )
 
 
@@ -131,3 +177,65 @@ async def test_full_job_routine_completes_with_tools(page, ironclaw_server):
         assert job["state"].lower() in success_states, (
             f"Expected job state in {success_states}, got '{job['state']}'"
         )
+
+
+async def test_cron_routine_appears_and_can_be_manually_triggered(page, ironclaw_server):
+    """Cron routines should expose schedule metadata and support manual trigger."""
+    name = f"cron-{uuid.uuid4().hex[:8]}"
+
+    await _send_chat_message(page, f"create cron owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    assert routine["trigger_type"] == "cron"
+    assert routine["trigger_raw"] == "0 */5 * * * * *"
+    assert routine["next_fire_at"], f"Expected next_fire_at on cron routine: {routine}"
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    trigger_cell_text = await row.locator("td").nth(1).inner_text()
+    assert trigger_cell_text.strip() == routine["trigger_summary"]
+
+    resp = await api_post(ironclaw_server, f"/api/routines/{routine['id']}/trigger")
+    resp.raise_for_status()
+    assert resp.json()["status"] == "triggered"
+
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert completed_run["trigger_type"] == "manual"
+    assert completed_run["status"].lower() == "attention"
+
+
+async def test_failed_routine_is_visible_in_ui(page, ironclaw_server):
+    """A failed routine should surface failed state and error text in the UI."""
+    name = f"fail-{uuid.uuid4().hex[:8]}"
+    failure_reason = "Response contained no message or tool call"
+
+    await _send_chat_message(page, f"create failing lightweight owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    trigger_response = await api_post(
+        ironclaw_server,
+        f"/api/routines/{routine['id']}/trigger",
+    )
+    trigger_response.raise_for_status()
+    assert trigger_response.json()["status"] == "triggered"
+
+    failed_run = await _wait_for_completed_run(ironclaw_server, routine["id"], timeout=60)
+    assert failed_run["status"].lower() == "failed", failed_run
+    assert failure_reason in failed_run["result_summary"]
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    await row.click()
+
+    detail = page.locator("#routine-detail")
+    await detail.wait_for(state="visible", timeout=10000)
+    await detail.locator(".badge.failed").first.wait_for(state="visible", timeout=10000)
+    assert "failing" in (await detail.locator(".badge.failed").first.inner_text()).lower()
+
+    recent_run_row = detail.locator("table.routines-table tbody tr").first
+    await recent_run_row.wait_for(state="visible", timeout=10000)
+    recent_run_text = await recent_run_row.inner_text()
+    assert "failed" in recent_run_text.lower()
+    assert failure_reason in recent_run_text

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -1,7 +1,8 @@
 """Scenario 6: Tool approval overlay UI behavior."""
 
-import pytest
-from helpers import SEL
+import asyncio
+
+from helpers import SEL, api_get, api_post
 
 
 INJECT_APPROVAL_JS = """
@@ -10,6 +11,60 @@ INJECT_APPROVAL_JS = """
     showApproval(data);
 }
 """
+
+
+async def _create_thread(base_url: str) -> str:
+    response = await api_post(base_url, "/api/chat/thread/new", timeout=15)
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def _send_chat_message(base_url: str, thread_id: str, content: str) -> None:
+    response = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={"content": content, "thread_id": thread_id},
+        timeout=30,
+    )
+    assert response.status_code == 202, response.text
+
+
+async def _wait_for_history(
+    base_url: str,
+    thread_id: str,
+    *,
+    expect_pending: bool | None = None,
+    response_fragment: str | None = None,
+    turn_count_at_least: int | None = None,
+    timeout: float = 20.0,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        response = await api_get(
+            base_url,
+            f"/api/chat/history?thread_id={thread_id}",
+            timeout=10,
+        )
+        assert response.status_code == 200, response.text
+        history = response.json()
+        pending = history.get("pending_approval")
+        turns = history.get("turns", [])
+        latest_response = turns[-1].get("response") if turns else None
+
+        pending_ok = expect_pending is None or bool(pending) == expect_pending
+        response_ok = response_fragment is None or (
+            latest_response is not None and response_fragment in latest_response
+        )
+        turns_ok = turn_count_at_least is None or len(turns) >= turn_count_at_least
+        if pending_ok and response_ok and turns_ok:
+            return history
+
+        await asyncio.sleep(0.25)
+
+    raise AssertionError(
+        f"Timed out waiting for history state: expect_pending={expect_pending}, "
+        f"response_fragment={response_fragment!r}"
+    )
 
 
 async def test_approval_card_appears(page):
@@ -186,3 +241,73 @@ async def test_waiting_for_approval_message_no_error_prefix(page):
     assert "HTTP requests to external APIs" in msg_text, (
         f"Expected tool description in message. Got: {msg_text!r}"
     )
+
+
+async def test_chat_reply_approve_resumes_pending_tool(ironclaw_server):
+    """A plain chat reply of 'approve' should resume the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-chat")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "approve")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    assert history.get("pending_approval") is None
+    assert history["turns"][-1]["response"] is not None
+
+
+async def test_chat_reply_deny_rejects_pending_tool(ironclaw_server):
+    """A plain chat reply of 'deny' should reject the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-denied")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "deny")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="was rejected",
+        turn_count_at_least=1,
+    )
+
+    response_text = history["turns"][-1]["response"]
+    assert response_text is not None
+    assert "Tool 'http' was rejected" in response_text
+
+
+async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
+    """A plain chat reply of 'always' should auto-approve the same tool next time."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-a")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "always")
+    await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-b")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=2,
+    )
+
+    assert history.get("pending_approval") is None
+    assert len(history["turns"]) >= 2

--- a/tests/e2e_advanced_traces.rs
+++ b/tests/e2e_advanced_traces.rs
@@ -816,33 +816,57 @@ mod advanced {
     }
 
     // -----------------------------------------------------------------------
-    // 10. Bootstrap greeting fires on fresh workspace
+    // 10. Bootstrap greeting is seeded into assistant conversation
     // -----------------------------------------------------------------------
 
-    /// Verifies that a fresh workspace triggers a static bootstrap greeting
-    /// before the user sends any message (no LLM call needed).
+    /// Verifies that the bootstrap greeting is seeded into the assistant
+    /// conversation in the DB when the thread is first created (via
+    /// `add_conversation_message_if_empty`). The greeting is no longer
+    /// broadcast via SSE — it is inserted on the first `/api/chat/threads`
+    /// call.
     #[tokio::test]
     async fn bootstrap_greeting_fires() {
         let rig = TestRigBuilder::new().with_bootstrap().build().await;
 
-        // The static bootstrap greeting should arrive without us sending any
-        // message and without an LLM call.
-        let responses = rig.wait_for_responses(1, TIMEOUT).await;
-        assert!(
-            !responses.is_empty(),
-            "bootstrap greeting should produce a response"
+        // Simulate what chat_threads_handler does: get-or-create the
+        // assistant conversation and seed the greeting if empty.
+        let db = rig.database();
+        let conv_id = db
+            .get_or_create_assistant_conversation("default", "gateway")
+            .await
+            .expect("create assistant conversation");
+
+        static GREETING: &str = include_str!("../src/workspace/seeds/GREETING.md");
+        let inserted = db
+            .add_conversation_message_if_empty(conv_id, "assistant", GREETING)
+            .await
+            .expect("seed greeting");
+        assert!(inserted, "greeting should be inserted into empty thread");
+
+        // Verify the greeting is in the DB.
+        let (messages, _) = db
+            .list_conversation_messages_paginated(conv_id, None, 10)
+            .await
+            .expect("list messages");
+        assert_eq!(
+            messages.len(),
+            1,
+            "should have exactly one greeting message"
         );
-        let greeting = &responses[0].content;
         assert!(
-            greeting.contains("chief of staff"),
-            "bootstrap greeting should contain the static text, got: {greeting}"
+            messages[0].content.contains("chief of staff"),
+            "bootstrap greeting should contain the static text, got: {}",
+            messages[0].content
         );
 
-        // The bootstrap greeting must carry a thread_id so the gateway can
-        // route it to the correct assistant conversation.
+        // Second call should not duplicate.
+        let inserted2 = db
+            .add_conversation_message_if_empty(conv_id, "assistant", GREETING)
+            .await
+            .expect("seed greeting again");
         assert!(
-            responses[0].thread_id.is_some(),
-            "bootstrap greeting response should have a thread_id set"
+            !inserted2,
+            "second call should not insert a duplicate greeting"
         );
 
         rig.shutdown();
@@ -852,8 +876,8 @@ mod advanced {
     // 11. Bootstrap onboarding completes and clears BOOTSTRAP.md
     // -----------------------------------------------------------------------
 
-    /// Exercises the full onboarding flow: bootstrap greeting fires, user
-    /// converses for 3 turns, agent writes profile + memory + identity,
+    /// Exercises the full onboarding flow: bootstrap greeting is seeded in DB,
+    /// user converses for 3 turns, agent writes profile + memory + identity,
     /// clears BOOTSTRAP.md, and the workspace reflects all writes.
     #[tokio::test]
     async fn bootstrap_onboarding_clears_bootstrap() {
@@ -866,17 +890,18 @@ mod advanced {
             .build()
             .await;
 
-        // 1. Wait for the static bootstrap greeting (no user message needed).
-        let greeting_responses = rig.wait_for_responses(1, TIMEOUT).await;
-        assert!(
-            !greeting_responses.is_empty(),
-            "bootstrap greeting should arrive"
-        );
-        assert!(
-            greeting_responses[0].content.contains("chief of staff"),
-            "expected bootstrap greeting, got: {}",
-            greeting_responses[0].content
-        );
+        // 1. Seed the greeting via the DB (simulates chat_threads_handler).
+        let db = rig.database();
+        let conv_id = db
+            .get_or_create_assistant_conversation("default", "gateway")
+            .await
+            .expect("create assistant conversation");
+        static GREETING: &str = include_str!("../src/workspace/seeds/GREETING.md");
+        let inserted = db
+            .add_conversation_message_if_empty(conv_id, "assistant", GREETING)
+            .await
+            .expect("seed greeting");
+        assert!(inserted, "bootstrap greeting should be inserted");
 
         // 2. BOOTSTRAP.md should exist (non-empty) before onboarding completes.
         let ws = rig.workspace().expect("workspace should exist");
@@ -888,7 +913,7 @@ mod advanced {
 
         // 3. Run the 3-turn conversation. The trace has the agent write
         //    profile, memory, identity, and then clear bootstrap.
-        let mut total = 1; // already have the greeting
+        let mut total = 0;
         for turn in &trace.turns {
             rig.send_message(&turn.user_input).await;
             total += 1;

--- a/tests/e2e_routine_heartbeat.rs
+++ b/tests/e2e_routine_heartbeat.rs
@@ -989,8 +989,7 @@ mod tests {
 
         let hygiene_config = HygieneConfig {
             enabled: false,
-            daily_retention_days: 30,
-            conversation_retention_days: 7,
+            version_keep_count: 50,
             cadence_hours: 24,
             state_dir: _tmp.path().to_path_buf(),
         };
@@ -1036,8 +1035,7 @@ mod tests {
 
         let hygiene_config = HygieneConfig {
             enabled: false,
-            daily_retention_days: 30,
-            conversation_retention_days: 7,
+            version_keep_count: 50,
             cadence_hours: 24,
             state_dir: _tmp.path().to_path_buf(),
         };

--- a/tests/e2e_thread_id_isolation.rs
+++ b/tests/e2e_thread_id_isolation.rs
@@ -48,7 +48,13 @@ mod tests {
         let store = rig.database();
         assert!(
             store
-                .ensure_conversation(foreign_thread_id, "gateway", "victim-user", None)
+                .ensure_conversation(
+                    foreign_thread_id,
+                    "gateway",
+                    "victim-user",
+                    None,
+                    Some("gateway")
+                )
                 .await
                 .expect("failed to create victim conversation"),
             "test setup failed: victim conversation was not created"

--- a/tests/e2e_wasm_github_coercion.rs
+++ b/tests/e2e_wasm_github_coercion.rs
@@ -46,6 +46,37 @@ mod tests {
         }
     }
 
+    fn github_exchange(
+        method: &str,
+        url: &str,
+        body: Option<String>,
+        response_body: &str,
+    ) -> HttpExchange {
+        HttpExchange {
+            request: HttpExchangeRequest {
+                method: method.to_string(),
+                url: url.to_string(),
+                headers: vec![],
+                body,
+            },
+            response: github_ok(response_body),
+        }
+    }
+
+    async fn run_trace(trace: LlmTrace, prompt: &str) {
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
+            .build()
+            .await;
+
+        rig.send_message(prompt).await;
+        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
+        rig.verify_trace_expects(&trace, &responses);
+
+        rig.shutdown();
+    }
+
     /// LLM sends `limit: "50"` (string) to `list_issues`. Coercion converts it
     /// to integer, and the WASM tool must call `GET /repos/.../issues?...&per_page=50`.
     #[tokio::test]
@@ -110,18 +141,7 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
-
-        rig.send_message("List issues in nearai/ironclaw with limit 50")
-            .await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
-
-        rig.shutdown();
+        run_trace(trace, "List issues in nearai/ironclaw with limit 50").await;
     }
 
     /// LLM sends `issue_number: "42"` (string) to `get_issue`. Coercion converts
@@ -186,17 +206,7 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
-
-        rig.send_message("Get issue 42 from nearai/ironclaw").await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
-
-        rig.shutdown();
+        run_trace(trace, "Get issue 42 from nearai/ironclaw").await;
     }
 
     /// LLM sends `limit: "25"` (string) to `list_pull_requests`. URL must
@@ -262,16 +272,449 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
+        run_trace(trace, "List PRs in nearai/ironclaw").await;
+    }
 
-        rig.send_message("List PRs in nearai/ironclaw").await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
+    /// LLM sends pagination as strings to `search_code`. Coercion converts them
+    /// to integers, and the tool must construct the expected search query.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_search_code_coerces_string_pagination() {
+        let expected_url = "https://api.github.com/search/code?q=repo%3Anearai%2Fironclaw%20path%3Asrc%20Tool&per_page=10&page=2&sort=indexed&order=desc";
 
-        rig.shutdown();
+        let trace = LlmTrace {
+            model_name: "test-wasm-coercion-search-code".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Search code in nearai/ironclaw".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_4".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "search_code",
+                                    "query": "repo:nearai/ironclaw path:src Tool",
+                                    "limit": "10",
+                                    "page": "2",
+                                    "sort": "indexed",
+                                    "order": "desc"
+                                }),
+                            }],
+                            input_tokens: 120,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Found matching code results.".to_string(),
+                            input_tokens: 180,
+                            output_tokens: 12,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "GET",
+                expected_url,
+                None,
+                r#"{"total_count":1,"items":[{"name":"lib.rs","path":"src/lib.rs"}]}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Search code in nearai/ironclaw").await;
+    }
+
+    /// `create_repo` must target the org repos endpoint and send the expected
+    /// JSON body for repository creation.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_repo_posts_expected_payload() {
+        let expected_url = "https://api.github.com/orgs/nearai/repos";
+        let expected_body = json!({
+            "name": "github-tool-replay",
+            "private": true,
+            "auto_init": true,
+            "description": "Replay-created repo",
+            "gitignore_template": "Rust",
+            "license_template": "mit"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-repo".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a private repo for nearai".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_5".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_repo",
+                                    "name": "github-tool-replay",
+                                    "description": "Replay-created repo",
+                                    "private": true,
+                                    "auto_init": true,
+                                    "gitignore_template": "Rust",
+                                    "license_template": "mit",
+                                    "org": "nearai"
+                                }),
+                            }],
+                            input_tokens: 110,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Repository created.".to_string(),
+                            input_tokens: 150,
+                            output_tokens: 12,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "POST",
+                expected_url,
+                Some(expected_body),
+                r#"{"name":"github-tool-replay","private":true}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a private repo for nearai").await;
+    }
+
+    /// `create_branch` should fetch the source ref SHA and then create the new
+    /// branch ref in a second request.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_branch_replays_two_step_ref_flow() {
+        let source_ref_url = "https://api.github.com/repos/nearai/ironclaw/git/ref/heads/main";
+        let create_ref_url = "https://api.github.com/repos/nearai/ironclaw/git/refs";
+        let create_ref_body = json!({
+            "ref": "refs/heads/feature/replay-test",
+            "sha": "abc123def4567890abc123def4567890abc123de"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-branch".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a replay branch from main".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_6".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_branch",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "branch": "feature/replay-test",
+                                    "from_ref": "main"
+                                }),
+                            }],
+                            input_tokens: 100,
+                            output_tokens: 35,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Branch created.".to_string(),
+                            input_tokens: 145,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![
+                github_exchange(
+                    "GET",
+                    source_ref_url,
+                    None,
+                    r#"{"ref":"refs/heads/main","object":{"sha":"abc123def4567890abc123def4567890abc123de"}}"#,
+                ),
+                github_exchange(
+                    "POST",
+                    create_ref_url,
+                    Some(create_ref_body),
+                    r#"{"ref":"refs/heads/feature/replay-test"}"#,
+                ),
+            ],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a replay branch from main").await;
+    }
+
+    /// `create_or_update_file` must target the contents API and send base64
+    /// encoded file contents in the request body.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_or_update_file_puts_contents_payload() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/contents/docs/replay.md";
+        let expected_body = json!({
+            "message": "Add replay doc",
+            "content": "IyBSZXBsYXkgZG9jCg==",
+            "branch": "feature/replay-test",
+            "committer": {
+                "name": "IronClaw Bot",
+                "email": "bot@example.com"
+            }
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-or-update-file".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Write docs/replay.md".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_7".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_or_update_file",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "path": "docs/replay.md",
+                                    "message": "Add replay doc",
+                                    "content": "# Replay doc\n",
+                                    "branch": "feature/replay-test",
+                                    "committer": {
+                                        "name": "IronClaw Bot",
+                                        "email": "bot@example.com"
+                                    }
+                                }),
+                            }],
+                            input_tokens: 120,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "File written.".to_string(),
+                            input_tokens: 160,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "PUT",
+                expected_url,
+                Some(expected_body),
+                r#"{"content":{"path":"docs/replay.md"},"commit":{"sha":"deadbeef"}}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Write docs/replay.md").await;
+    }
+
+    /// `delete_file` must call DELETE on the contents endpoint with the blob SHA
+    /// and commit metadata in the request body.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_delete_file_deletes_contents_with_sha() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/contents/docs/replay.md";
+        let expected_body = json!({
+            "message": "Remove replay doc",
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "branch": "feature/replay-test"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-delete-file".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Delete docs/replay.md".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_8".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "delete_file",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "path": "docs/replay.md",
+                                    "message": "Remove replay doc",
+                                    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                                    "branch": "feature/replay-test"
+                                }),
+                            }],
+                            input_tokens: 110,
+                            output_tokens: 36,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "File deleted.".to_string(),
+                            input_tokens: 150,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "DELETE",
+                expected_url,
+                Some(expected_body),
+                r#"{"commit":{"sha":"feedface"}}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Delete docs/replay.md").await;
+    }
+
+    /// `create_release` should post release metadata to the releases endpoint.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_release_posts_expected_payload() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/releases";
+        let expected_body = json!({
+            "tag_name": "v1.2.3",
+            "draft": false,
+            "prerelease": true,
+            "generate_release_notes": true,
+            "target_commitish": "main",
+            "name": "Replay Release",
+            "body": "Generated during replay testing"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-release".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a prerelease".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_9".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_release",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "tag_name": "v1.2.3",
+                                    "target_commitish": "main",
+                                    "name": "Replay Release",
+                                    "body": "Generated during replay testing",
+                                    "draft": false,
+                                    "prerelease": true,
+                                    "generate_release_notes": true
+                                }),
+                            }],
+                            input_tokens: 125,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Release created.".to_string(),
+                            input_tokens: 170,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "POST",
+                expected_url,
+                Some(expected_body),
+                r#"{"id":1,"tag_name":"v1.2.3"}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a prerelease").await;
     }
 }

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -70,6 +70,10 @@ mod tests {
                         "event_source": "github",
                         "event_type": "issue.opened",
                         "event_filters": {"repository": "nearai/ironclaw"},
+                        // This test fires the same routine via event_emit and then the
+                        // webhook endpoint back-to-back, so cooldown must not suppress
+                        // the second path.
+                        "cooldown_secs": 0,
                         "action_type": "lightweight",
                         "prompt": "Summarize webhook and report issue number"
                     }),

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -11,19 +11,49 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use chrono::Utc;
     use ironclaw::agent::routine::{
         NotifyConfig, Routine, RoutineAction, RoutineGuardrails, Trigger,
         reset_routine_verification_state, routine_verification_fingerprint,
     };
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{Tool, ToolError, ToolOutput};
     use uuid::Uuid;
 
     use crate::support::gateway_workflow_harness::GatewayWorkflowHarness;
     use crate::support::mock_openai_server::{
         MockOpenAiResponse, MockOpenAiRule, MockOpenAiServerBuilder, MockToolCall,
     };
+
+    struct BlockingTool;
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "block_once"
+        }
+
+        fn description(&self) -> &str {
+            "Sleeps long enough for cancellation-path integration tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object"})
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(ToolOutput::text("block complete", Duration::from_secs(30)))
+        }
+    }
 
     #[tokio::test]
     async fn gateway_workflow_harness_chat_and_webhook() {
@@ -551,6 +581,166 @@ mod tests {
         assert_eq!(
             after_count, before_count,
             "run count should not increase for disabled routine"
+        );
+
+        harness.shutdown().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_running_full_job_routine_finalizes_run() {
+        let mock = MockOpenAiServerBuilder::new()
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "create blocking routine",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_create_blocking_1",
+                    "routine_create",
+                    serde_json::json!({
+                        "name": "wf-cancel-full-job",
+                        "description": "Full-job cancellation regression test",
+                        "trigger_type": "manual",
+                        "action_type": "full_job",
+                        "prompt": "Use block_once then finish.",
+                        "max_iterations": 10
+                    }),
+                )]),
+            ))
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "use block_once then finish",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_block_once_1",
+                    "block_once",
+                    serde_json::json!({}),
+                )]),
+            ))
+            .with_default_response(MockOpenAiResponse::Text("ack".to_string()))
+            .start()
+            .await;
+
+        let harness =
+            GatewayWorkflowHarness::start_openai_compatible(&mock.openai_base_url(), "mock-model")
+                .await;
+        harness.register_tool(Arc::new(BlockingTool)).await;
+
+        let thread_id = harness.create_thread().await;
+        harness
+            .send_chat(&thread_id, "create blocking routine")
+            .await;
+        harness
+            .wait_for_turns(&thread_id, 1, Duration::from_secs(10))
+            .await;
+
+        let routine = harness
+            .routine_by_name("wf-cancel-full-job")
+            .await
+            .expect("blocking full-job routine should exist");
+        let routine_id = routine["id"].as_str().expect("routine id missing");
+
+        let trigger = harness
+            .client
+            .post(format!(
+                "{}/api/routines/{routine_id}/trigger",
+                harness.base_url()
+            ))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("trigger request failed")
+            .error_for_status()
+            .expect("trigger non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid trigger response");
+        assert_eq!(trigger["status"].as_str(), Some("triggered"));
+
+        let mut job_id = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            if let Some(found_job_id) = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .and_then(|run| run["job_id"].as_str())
+            {
+                job_id = Some(found_job_id.to_string());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let job_id = job_id.expect("routine run should be linked to a job");
+
+        let mut saw_job_execution_request = false;
+        for _ in 0..50 {
+            if mock.requests().await.len() >= 2 {
+                saw_job_execution_request = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            saw_job_execution_request,
+            "job should issue an execution LLM request before cancellation"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let cancel_response = harness
+            .client
+            .post(format!("{}/api/jobs/{job_id}/cancel", harness.base_url()))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("cancel request failed")
+            .error_for_status()
+            .expect("cancel non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid cancel response");
+        assert_eq!(cancel_response["status"].as_str(), Some("cancelled"));
+
+        let mut final_job = None;
+        for _ in 0..100 {
+            let job = harness
+                .client
+                .get(format!("{}/api/jobs/{job_id}", harness.base_url()))
+                .bearer_auth(&harness.auth_token)
+                .send()
+                .await
+                .expect("final job detail request failed")
+                .error_for_status()
+                .expect("final job detail non-2xx")
+                .json::<serde_json::Value>()
+                .await
+                .expect("invalid final job detail");
+            if job["state"].as_str() == Some("cancelled") {
+                final_job = Some(job);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_job = final_job.expect("job should reach cancelled state");
+        assert_eq!(final_job["state"].as_str(), Some("cancelled"));
+
+        let mut final_run = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            let run = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .cloned()
+                .expect("routine run should exist");
+            if run["status"].as_str() != Some("running") {
+                final_run = Some(run);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_run = final_run.expect("routine run should reach terminal state");
+        assert_eq!(final_run["status"].as_str(), Some("failed"));
+        assert_eq!(final_run["job_id"].as_str(), Some(job_id.as_str()));
+        assert!(
+            final_run["result_summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("finished (failed)")),
+            "expected failed routine summary, got {final_run}"
         );
 
         harness.shutdown().await;

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -553,7 +553,7 @@ fn gateway_state_has_multi_tenant_fields() {
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: PerUserRateLimiter::new(30, 60), // Multi-tenant: per-user
-        oauth_rate_limiter: RateLimiter::new(10, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
         routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
@@ -562,6 +562,14 @@ fn gateway_state_has_multi_tenant_fields() {
         active_config: Default::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     };
 
     assert_eq!(state.owner_id, "fallback");
@@ -629,7 +637,7 @@ async fn start_owner_scoped_sender_server() -> (
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: RateLimiter::new(10, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
         webhook_rate_limiter: RateLimiter::new(10, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
@@ -638,6 +646,14 @@ async fn start_owner_scoped_sender_server() -> (
         active_config: Default::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     });
 
     let auth = MultiAuthState::multi(tokens).into();
@@ -1015,7 +1031,7 @@ async fn start_multi_user_server_with_db() -> (
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: RateLimiter::new(10, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
         routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
@@ -1024,6 +1040,14 @@ async fn start_multi_user_server_with_db() -> (
         active_config: Default::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     });
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();

--- a/tests/oauth_greeting_integration.rs
+++ b/tests/oauth_greeting_integration.rs
@@ -1,0 +1,320 @@
+//! Integration tests for the bootstrap greeting and cookie-based auth.
+//!
+//! Verifies:
+//! - Bootstrap greeting is inserted exactly once for new users
+//! - Subsequent calls to /api/chat/threads do NOT re-insert the greeting
+//! - Concurrent requests don't duplicate the greeting
+//! - Multiple users each get their own greeting
+//! - Cookie-based session auth works for protected endpoints
+//! - Pre-existing conversations are not overwritten with the greeting
+
+#[cfg(feature = "libsql")]
+mod tests {
+    use std::sync::Arc;
+
+    use ironclaw::agent::SessionManager;
+    use ironclaw::channels::web::auth::{MultiAuthState, UserIdentity};
+    use ironclaw::channels::web::server::{
+        GatewayState, PerUserRateLimiter, RateLimiter, start_server,
+    };
+    use ironclaw::channels::web::sse::SseManager;
+    use ironclaw::channels::web::ws::WsConnectionTracker;
+    use ironclaw::db::Database;
+
+    const ALICE_TOKEN: &str = "tok-alice-greeting-test";
+    const BOB_TOKEN: &str = "tok-bob-greeting-test";
+
+    async fn create_test_db() -> (Arc<dyn Database>, tempfile::TempDir) {
+        use ironclaw::db::libsql::LibSqlBackend;
+
+        let temp_dir = tempfile::tempdir().expect("tempdir");
+        let db_path = temp_dir.path().join("greeting_test.db");
+        let backend = LibSqlBackend::new_local(&db_path)
+            .await
+            .expect("LibSqlBackend");
+        backend.run_migrations().await.expect("migrations");
+        (Arc::new(backend) as Arc<dyn Database>, temp_dir)
+    }
+
+    fn auth_state(tokens: Vec<(&str, &str)>) -> MultiAuthState {
+        let mut map = std::collections::HashMap::new();
+        for (token, user_id) in tokens {
+            map.insert(
+                token.to_string(),
+                UserIdentity {
+                    user_id: user_id.to_string(),
+                    role: "admin".to_string(),
+                    workspace_read_scopes: Vec::new(),
+                },
+            );
+        }
+        MultiAuthState::multi(map)
+    }
+
+    async fn start_test_server(
+        db: Arc<dyn Database>,
+        auth: MultiAuthState,
+    ) -> std::net::SocketAddr {
+        let (agent_tx, _agent_rx) = tokio::sync::mpsc::channel(64);
+        let session_manager = Arc::new(SessionManager::new());
+
+        let state = Arc::new(GatewayState {
+            msg_tx: tokio::sync::RwLock::new(Some(agent_tx)),
+            sse: Arc::new(SseManager::new()),
+            workspace: None,
+            workspace_pool: None,
+            session_manager: Some(session_manager),
+            log_broadcaster: None,
+            log_level_handle: None,
+            extension_manager: None,
+            tool_registry: None,
+            store: Some(db),
+            job_manager: None,
+            prompt_queue: None,
+            scheduler: None,
+            owner_id: "test-owner".to_string(),
+            shutdown_tx: tokio::sync::RwLock::new(None),
+            ws_tracker: Some(Arc::new(WsConnectionTracker::new())),
+            llm_provider: None,
+            skill_registry: None,
+            skill_catalog: None,
+            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+            webhook_rate_limiter: RateLimiter::new(10, 60),
+            registry_entries: Vec::new(),
+            cost_guard: None,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            startup_time: std::time::Instant::now(),
+            active_config: Default::default(),
+            secrets_store: None,
+            db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
+        });
+
+        let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
+        start_server(addr, state, auth.into())
+            .await
+            .expect("start server")
+    }
+
+    fn client() -> reqwest::Client {
+        reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap()
+    }
+
+    /// Helper: call /api/chat/threads and return the JSON response.
+    async fn get_threads(
+        client: &reqwest::Client,
+        addr: std::net::SocketAddr,
+        token: &str,
+    ) -> serde_json::Value {
+        let resp = client
+            .get(format!("http://{addr}/api/chat/threads"))
+            .bearer_auth(token)
+            .send()
+            .await
+            .expect("threads request");
+        assert_eq!(resp.status(), 200);
+        resp.json().await.expect("parse threads JSON")
+    }
+
+    /// Helper: get messages for a conversation via /api/chat/history.
+    async fn get_history(
+        client: &reqwest::Client,
+        addr: std::net::SocketAddr,
+        token: &str,
+        thread_id: &str,
+    ) -> serde_json::Value {
+        let resp = client
+            .get(format!(
+                "http://{addr}/api/chat/history?thread_id={thread_id}"
+            ))
+            .bearer_auth(token)
+            .send()
+            .await
+            .expect("history request");
+        assert_eq!(resp.status(), 200);
+        resp.json().await.expect("parse history JSON")
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_greeting_inserted_once_for_new_user() {
+        let (db, _dir) = create_test_db().await;
+        let auth = auth_state(vec![(ALICE_TOKEN, "alice")]);
+        let addr = start_test_server(db, auth).await;
+        let c = client();
+
+        // First call — should create assistant thread with greeting.
+        let threads1 = get_threads(&c, addr, ALICE_TOKEN).await;
+        let assistant1 = threads1["assistant_thread"]
+            .as_object()
+            .expect("assistant thread");
+        let thread_id = assistant1["id"].as_str().expect("thread id");
+
+        // Verify history has exactly one turn (the greeting as a standalone assistant msg).
+        let history = get_history(&c, addr, ALICE_TOKEN, thread_id).await;
+        let turns = history["turns"].as_array().expect("turns array");
+        assert_eq!(turns.len(), 1, "should have exactly one greeting turn");
+        let response = turns[0]["response"].as_str().unwrap_or("");
+        assert!(
+            response.contains("excited to be your new assistant"),
+            "greeting content mismatch: {response}"
+        );
+
+        // Second call — should NOT insert another greeting.
+        let _threads2 = get_threads(&c, addr, ALICE_TOKEN).await;
+        let history2 = get_history(&c, addr, ALICE_TOKEN, thread_id).await;
+        let turns2 = history2["turns"].as_array().expect("turns array");
+        assert_eq!(turns2.len(), 1, "second call should not duplicate greeting");
+    }
+
+    #[tokio::test]
+    async fn test_greeting_not_duplicated_on_rapid_calls() {
+        let (db, _dir) = create_test_db().await;
+        let auth = auth_state(vec![(ALICE_TOKEN, "alice-rapid")]);
+        let addr = start_test_server(db, auth).await;
+        let c = client();
+
+        // Fire 5 concurrent requests.
+        let mut handles = Vec::new();
+        for _ in 0..5 {
+            let c2 = c.clone();
+            let addr2 = addr;
+            handles.push(tokio::spawn(async move {
+                get_threads(&c2, addr2, ALICE_TOKEN).await
+            }));
+        }
+        for h in handles {
+            h.await.expect("join");
+        }
+
+        // Check that the assistant thread has exactly 1 message.
+        let threads = get_threads(&c, addr, ALICE_TOKEN).await;
+        let thread_id = threads["assistant_thread"]["id"]
+            .as_str()
+            .expect("thread id");
+        let history = get_history(&c, addr, ALICE_TOKEN, thread_id).await;
+        let turns = history["turns"].as_array().expect("turns");
+        assert_eq!(
+            turns.len(),
+            1,
+            "concurrent calls should not duplicate the greeting"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_each_user_gets_own_greeting() {
+        let (db, _dir) = create_test_db().await;
+        let auth = auth_state(vec![(ALICE_TOKEN, "alice-multi"), (BOB_TOKEN, "bob-multi")]);
+        let addr = start_test_server(db, auth).await;
+        let c = client();
+
+        // Alice's first request.
+        let alice_threads = get_threads(&c, addr, ALICE_TOKEN).await;
+        let alice_id = alice_threads["assistant_thread"]["id"]
+            .as_str()
+            .expect("alice thread id");
+
+        // Bob's first request.
+        let bob_threads = get_threads(&c, addr, BOB_TOKEN).await;
+        let bob_id = bob_threads["assistant_thread"]["id"]
+            .as_str()
+            .expect("bob thread id");
+
+        // Different thread IDs.
+        assert_ne!(
+            alice_id, bob_id,
+            "each user should have their own assistant thread"
+        );
+
+        // Both have the greeting.
+        let alice_history = get_history(&c, addr, ALICE_TOKEN, alice_id).await;
+        let bob_history = get_history(&c, addr, BOB_TOKEN, bob_id).await;
+
+        assert_eq!(
+            alice_history["turns"].as_array().unwrap().len(),
+            1,
+            "alice should have greeting"
+        );
+        assert_eq!(
+            bob_history["turns"].as_array().unwrap().len(),
+            1,
+            "bob should have greeting"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cookie_auth_works_for_threads() {
+        let (db, _dir) = create_test_db().await;
+        let auth = auth_state(vec![(ALICE_TOKEN, "alice-cookie")]);
+        let addr = start_test_server(db, auth).await;
+
+        // Use a cookie instead of Bearer token.
+        let c = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .unwrap();
+
+        let resp = c
+            .get(format!("http://{addr}/api/chat/threads"))
+            .header("Cookie", format!("ironclaw_session={ALICE_TOKEN}"))
+            .send()
+            .await
+            .expect("cookie auth request");
+
+        assert_eq!(resp.status(), 200);
+        let body: serde_json::Value = resp.json().await.expect("parse");
+        assert!(
+            body["assistant_thread"].is_object(),
+            "should have assistant thread via cookie auth"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_existing_conversation_no_greeting() {
+        let (db, _dir) = create_test_db().await;
+        let auth = auth_state(vec![(ALICE_TOKEN, "alice-existing")]);
+        let addr = start_test_server(Arc::clone(&db), auth).await;
+        let c = client();
+
+        // Pre-populate the assistant conversation with a user message.
+        let conv_id = db
+            .get_or_create_assistant_conversation("alice-existing", "gateway")
+            .await
+            .expect("create conv");
+        db.add_conversation_message(conv_id, "user", "Hello!")
+            .await
+            .expect("add message");
+
+        // Now call /api/chat/threads — should NOT insert greeting (conv not empty).
+        let threads = get_threads(&c, addr, ALICE_TOKEN).await;
+        let thread_id = threads["assistant_thread"]["id"]
+            .as_str()
+            .expect("thread id");
+
+        let history = get_history(&c, addr, ALICE_TOKEN, thread_id).await;
+        let turns = history["turns"].as_array().expect("turns");
+        assert_eq!(
+            turns.len(),
+            1,
+            "should have only the pre-existing message, no greeting"
+        );
+        // A standalone user message with no assistant response shows as user_input.
+        let user_input = turns[0]["user_input"].as_str().unwrap_or("");
+        assert_eq!(
+            user_input, "Hello!",
+            "should be the original message, not the greeting"
+        );
+    }
+}

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -211,7 +211,7 @@ async fn start_test_server_with_provider(
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
+        oauth_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(20, 60),
         webhook_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
@@ -220,6 +220,14 @@ async fn start_test_server_with_provider(
         active_config: ironclaw::channels::web::server::ActiveConfigSnapshot::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(
@@ -711,7 +719,7 @@ async fn test_no_llm_provider_returns_503() {
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
+        oauth_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(20, 60),
         webhook_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
@@ -720,6 +728,14 @@ async fn test_no_llm_provider_returns_503() {
         active_config: ironclaw::channels::web::server::ActiveConfigSnapshot::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -233,7 +233,7 @@ impl GatewayWorkflowHarness {
             skill_registry: components.skill_registry.clone(),
             skill_catalog: components.skill_catalog.clone(),
             chat_rate_limiter: PerUserRateLimiter::new(120, 60),
-            oauth_rate_limiter: RateLimiter::new(10, 60),
+            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
             webhook_rate_limiter: RateLimiter::new(10, 60),
             registry_entries: Vec::new(),
             cost_guard: Some(Arc::clone(&components.cost_guard)),
@@ -242,6 +242,14 @@ impl GatewayWorkflowHarness {
             active_config: ironclaw::channels::web::server::ActiveConfigSnapshot::default(),
             secrets_store: None,
             db_auth: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
         });
 
         let mut agent = Agent::new(

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -488,6 +488,15 @@ impl GatewayWorkflowHarness {
             .expect("invalid routine runs response")
     }
 
+    pub async fn register_tool(&self, tool: Arc<dyn Tool>) {
+        let registry = self
+            .gateway_state
+            .tool_registry
+            .as_ref()
+            .expect("tool registry should be available");
+        registry.register(tool).await;
+    }
+
     pub async fn github_webhook(
         &self,
         event: &str,

--- a/tests/tool_approval_context.rs
+++ b/tests/tool_approval_context.rs
@@ -1,0 +1,287 @@
+//! Tests for tool approval context propagation.
+//!
+//! Verifies that:
+//! - JobContext carries approval_context through the execution chain
+//! - Builder sub-tools use proper approval checks
+//! - Worker checks job-level approval context
+
+use ironclaw::context::JobContext;
+use ironclaw::tools::{
+    ApprovalContext, ApprovalRequirement, Tool, ToolError, ToolOutput, check_approval_in_context,
+};
+
+/// A simple test tool that requires approval.
+#[derive(Debug)]
+struct TestTool {
+    approval_req: ApprovalRequirement,
+}
+
+#[async_trait::async_trait]
+impl Tool for TestTool {
+    fn name(&self) -> &str {
+        "test_tool"
+    }
+
+    fn description(&self) -> &str {
+        "A test tool for approval checking"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+        })
+    }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolOutput::text("ok", std::time::Duration::from_millis(1)))
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        self.approval_req
+    }
+}
+
+#[test]
+fn test_job_context_default_has_no_approval_context() {
+    let ctx = JobContext::default();
+    assert!(
+        ctx.approval_context.is_none(),
+        "JobContext::default() should NOT have approval_context set for security"
+    );
+}
+
+#[test]
+fn test_job_context_with_approval_context() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    assert!(ctx.approval_context.is_some());
+}
+
+#[test]
+fn test_approval_context_autonomous_allows_unless_auto_approved() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::UnlessAutoApproved,
+    };
+
+    // Check should pass for UnlessAutoApproved in autonomous context
+    check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("UnlessAutoApproved should be allowed in autonomous context");
+}
+
+#[test]
+fn test_approval_context_autonomous_blocks_always() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // Check should fail for Always in autonomous context without explicit allow
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "Always should be blocked in autonomous context"
+    );
+    assert!(matches!(result, Err(ToolError::NotAuthorized(_))));
+}
+
+#[test]
+fn test_approval_context_autonomous_with_tools_allows_specific() {
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools(["shell".to_string(), "read_file".to_string()]),
+    );
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // shell should be allowed (explicitly listed)
+    check_approval_in_context(
+        &ctx,
+        "shell",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Listed tool should be allowed");
+
+    // read_file should be allowed (explicitly listed)
+    check_approval_in_context(
+        &ctx,
+        "read_file",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Listed tool should be allowed");
+
+    // write_file should be blocked (not listed)
+    let result = check_approval_in_context(
+        &ctx,
+        "write_file",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(result.is_err(), "Non-listed Always tool should be blocked");
+}
+
+#[test]
+fn test_builder_tools_approval_context() {
+    // Verify the builder creates the correct approval context
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools([
+            "shell".into(),
+            "read_file".into(),
+            "write_file".into(),
+            "list_dir".into(),
+            "apply_patch".into(),
+        ]),
+    );
+
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // All build tools should be allowed
+    for tool_name in &[
+        "shell",
+        "read_file",
+        "write_file",
+        "list_dir",
+        "apply_patch",
+    ] {
+        check_approval_in_context(
+            &ctx,
+            tool_name,
+            tool.requires_approval(&serde_json::json!({})),
+        )
+        .unwrap_or_else(|e| panic!("Builder tool '{}' should be allowed, got: {}", tool_name, e));
+    }
+
+    // Non-build tools should be blocked
+    let result = check_approval_in_context(
+        &ctx,
+        "create_job",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(result.is_err(), "Non-build Always tool should be blocked");
+}
+
+#[test]
+fn test_default_context_blocks_non_never_tools() {
+    // JobContext::default() has no approval_context, which should block
+    // all non-Never tools (secure default)
+    let ctx = JobContext::default();
+
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::UnlessAutoApproved,
+    };
+
+    // UnlessAutoApproved should be blocked with no approval_context
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "UnlessAutoApproved should be blocked with no approval_context"
+    );
+
+    let always_tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        always_tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "Always should be blocked with no approval_context"
+    );
+
+    // Never should still be allowed
+    let never_tool = TestTool {
+        approval_req: ApprovalRequirement::Never,
+    };
+    check_approval_in_context(
+        &ctx,
+        "test_tool",
+        never_tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Never should be allowed even with no approval_context");
+}
+
+#[test]
+fn test_never_tools_allowed_in_additive_model() {
+    // Never tools (echo, time, etc.) should always be allowed regardless of
+    // approval context configuration - they don't need to be in the allowlist.
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools(["shell".to_string()]),
+    );
+
+    // A Never tool not in the allowlist should still be allowed
+    check_approval_in_context(&ctx, "echo", ApprovalRequirement::Never)
+        .expect("Never tools should pass without being in the allowlist");
+
+    // And of course a Never tool in the allowlist should also be allowed
+    check_approval_in_context(&ctx, "shell", ApprovalRequirement::Never)
+        .expect("Never tools in the allowlist should also pass");
+
+    // But an Always tool not in the allowlist should be blocked
+    let result = check_approval_in_context(&ctx, "echo", ApprovalRequirement::Always);
+    assert!(
+        result.is_err(),
+        "Always tools NOT in allowlist should be blocked"
+    );
+}
+
+#[test]
+fn test_builder_execute_build_tool_blocks_unlisted_tool() {
+    // The builder creates a context with specific allowed tools.
+    // Tools NOT in the builder's allowlist should be blocked.
+    let builder_ctx = JobContext::new("Build", "Building software").with_approval_context(
+        ApprovalContext::autonomous_with_tools([
+            "shell".into(),
+            "read_file".into(),
+            "write_file".into(),
+            "list_dir".into(),
+            "apply_patch".into(),
+        ]),
+    );
+
+    // Builder-allowed tools should pass
+    for tool_name in &[
+        "shell",
+        "read_file",
+        "write_file",
+        "list_dir",
+        "apply_patch",
+    ] {
+        check_approval_in_context(&builder_ctx, tool_name, ApprovalRequirement::Always)
+            .unwrap_or_else(|e| {
+                panic!("Builder tool '{}' should be allowed, got: {}", tool_name, e)
+            });
+    }
+
+    // Tools NOT in builder's allowlist should be blocked (e.g., http, create_job, message)
+    for tool_name in &["http", "create_job", "message", "secret_save"] {
+        let result =
+            check_approval_in_context(&builder_ctx, tool_name, ApprovalRequirement::Always);
+        assert!(
+            result.is_err(),
+            "Tool '{}' should be blocked by builder context (not in allowlist)",
+            tool_name
+        );
+    }
+}

--- a/tests/ws_gateway_integration.rs
+++ b/tests/ws_gateway_integration.rs
@@ -58,7 +58,7 @@ async fn start_test_server() -> (
         skill_registry: None,
         skill_catalog: None,
         chat_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(30, 60),
-        oauth_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
+        oauth_rate_limiter: ironclaw::channels::web::server::PerUserRateLimiter::new(20, 60),
         webhook_rate_limiter: ironclaw::channels::web::server::RateLimiter::new(10, 60),
         registry_entries: Vec::new(),
         cost_guard: None,
@@ -67,6 +67,14 @@ async fn start_test_server() -> (
         active_config: ironclaw::channels::web::server::ActiveConfigSnapshot::default(),
         secrets_store: None,
         db_auth: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
     });
 
     let auth = ironclaw::channels::web::auth::MultiAuthState::single(

--- a/tools-src/github/Cargo.toml
+++ b/tools-src/github/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "github-tool"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "GitHub integration tool for IronClaw (WASM component)"
 license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
+base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.41.0"

--- a/tools-src/github/README.md
+++ b/tools-src/github/README.md
@@ -1,13 +1,17 @@
 # GitHub Tool for IronClaw
 
-WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
+WASM tool for GitHub integration. It covers repositories, issues, pull requests,
+search, branches, file reads and writes, releases, and workflows.
 
 ## Features
 
-- **Repository Info** - Get repo details, list user repos
+- **Repositories** - Get repo details, list user repos, create repositories
+- **Search** - Search repositories, code, and issues/PRs
+- **Branches** - List branches and create new branches from an existing ref
 - **Issues** - List/create/get issues, list/add issue comments
 - **Pull Requests** - List/create/get PRs, review files, create reviews, list/reply review comments, merge PRs
-- **File Content** - Read files from repos
+- **File Content** - Read files and create/update/delete repository files
+- **Releases** - List releases and create new releases
 - **Workflows** - Trigger GitHub Actions, check run status
 
 ## Setup
@@ -29,6 +33,18 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "action": "get_repo",
   "owner": "nearai",
   "repo": "ironclaw"
+}
+```
+
+### Create Repository
+
+```json
+{
+  "action": "create_repo",
+  "name": "infra-playground",
+  "description": "Scratch repo for release automation",
+  "private": true,
+  "auto_init": true
 }
 ```
 
@@ -66,6 +82,26 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "repo": "ironclaw",
   "state": "open",
   "limit": 5
+}
+```
+
+### Search Code
+
+```json
+{
+  "action": "search_code",
+  "query": "repo:nearai/ironclaw tool_info",
+  "limit": 5
+}
+```
+
+### Search Issues and Pull Requests
+
+```json
+{
+  "action": "search_issues_pull_requests",
+  "query": "repo:nearai/ironclaw is:pr label:bug",
+  "limit": 10
 }
 ```
 
@@ -187,6 +223,81 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "repo": "ironclaw",
   "path": "README.md",
   "ref": "main"
+}
+```
+
+### Create or Update a File
+
+```json
+{
+  "action": "create_or_update_file",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "path": "docs/example.txt",
+  "message": "docs: add example",
+  "content": "Hello from IronClaw"
+}
+```
+
+When updating an existing file, include the current blob `sha`.
+
+### Delete a File
+
+```json
+{
+  "action": "delete_file",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "path": "docs/example.txt",
+  "message": "docs: remove example",
+  "sha": "0123456789abcdef0123456789abcdef01234567"
+}
+```
+
+### List Branches
+
+```json
+{
+  "action": "list_branches",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "limit": 20
+}
+```
+
+### Create Branch
+
+```json
+{
+  "action": "create_branch",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "branch": "feature/github-tool-audit",
+  "from_ref": "main"
+}
+```
+
+### List Releases
+
+```json
+{
+  "action": "list_releases",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "limit": 10
+}
+```
+
+### Create Release
+
+```json
+{
+  "action": "create_release",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "tag_name": "v1.2.3",
+  "name": "v1.2.3",
+  "generate_release_notes": true
 }
 ```
 

--- a/tools-src/github/github-tool.capabilities.json
+++ b/tools-src/github/github-tool.capabilities.json
@@ -1,7 +1,45 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
-  "description": "Manage GitHub repositories, issues, pull requests, reviews, and workflows. Supports listing, creating, commenting, merging PRs, and triggering GitHub Actions.",
+  "description": "Manage GitHub repositories, issues, pull requests, search, branches, file reads and writes, releases, and workflows.",
+  "discovery_summary": {
+    "always_required": [
+      "action"
+    ],
+    "conditional_requirements": [
+      "Repository-scoped actions require `owner` and `repo`.",
+      "Search actions require `query`.",
+      "File write actions require `path` and `message`; updates additionally need `sha`.",
+      "Workflow dispatch requires `workflow_id` and `ref`.",
+      "Branch creation requires `branch` and `from_ref`."
+    ],
+    "notes": [
+      "Use `tool_info(name: \"github\", detail: \"schema\")` for the full action schema before guessing fields.",
+      "Supported families: repositories, issues, pull requests, reviews/comments, search, branches, code reads, file writes, releases, workflow dispatch/runs, and webhook normalization.",
+      "Not supported yet: forks, labels, milestones, projects, org/team admin, GraphQL, release asset uploads, and repository deletion."
+    ],
+    "examples": [
+      {
+        "action": "create_repo",
+        "name": "infra-playground",
+        "private": true,
+        "auto_init": true
+      },
+      {
+        "action": "search_code",
+        "query": "repo:nearai/ironclaw tool_info",
+        "limit": 5
+      },
+      {
+        "action": "create_or_update_file",
+        "owner": "nearai",
+        "repo": "ironclaw",
+        "path": "docs/example.txt",
+        "message": "docs: add example",
+        "content": "Hello from IronClaw"
+      }
+    ]
+  },
   "capabilities": {
     "webhook": {
       "hmac_secret_name": "github_webhook_secret",
@@ -16,7 +54,8 @@
           "methods": [
             "GET",
             "POST",
-            "PUT"
+            "PUT",
+            "DELETE"
           ]
         }
       ],

--- a/tools-src/github/src/lib.rs
+++ b/tools-src/github/src/lib.rs
@@ -20,6 +20,8 @@ wit_bindgen::generate!({
 
 use std::collections::HashMap;
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 const MAX_TEXT_LENGTH: usize = 65536;
@@ -63,7 +65,129 @@ fn url_encode_query(s: &str) -> String {
 /// Validate that a path segment doesn't contain dangerous characters.
 /// Returns true if the segment is safe to use.
 fn validate_path_segment(s: &str) -> bool {
-    !s.is_empty() && !s.contains('/') && !s.contains("..") && !s.contains('?') && !s.contains('#')
+    !s.is_empty()
+        && !s.contains('/')
+        && !s.contains("..")
+        && !s.contains('?')
+        && !s.contains('#')
+        && !s.chars().any(|c| c.is_control() || c.is_whitespace())
+}
+
+fn validate_repo_path(path: &str) -> Result<(), String> {
+    validate_input_length(path, "path")?;
+    for segment in path.split('/') {
+        if segment == ".." {
+            return Err("Invalid path: path traversal not allowed".into());
+        }
+        if segment.is_empty() {
+            return Err("Invalid path: empty segment not allowed".into());
+        }
+    }
+    Ok(())
+}
+
+fn encode_repo_path(path: &str) -> String {
+    path.split('/')
+        .map(url_encode_path)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn validate_git_ref(ref_name: &str, field_name: &str) -> Result<(), String> {
+    if ref_name.is_empty() {
+        return Err(format!("Invalid {field_name}: cannot be empty"));
+    }
+    if ref_name.contains("..")
+        || ref_name.contains(':')
+        || ref_name.contains('?')
+        || ref_name.contains('[')
+        || ref_name.contains('\\')
+        || ref_name.contains('^')
+        || ref_name.contains('~')
+        || ref_name.contains("@{")
+        || ref_name.contains("//")
+        || ref_name.starts_with('/')
+        || ref_name.ends_with('/')
+        || ref_name.starts_with('.')
+        || ref_name.ends_with('.')
+        || ref_name.ends_with(".lock")
+        || ref_name.chars().any(|c| c.is_control() || c == ' ')
+    {
+        return Err(format!(
+            "Invalid {field_name}: must be a valid branch, tag, or ref name"
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_ref_lookup(ref_name: &str) -> Result<String, String> {
+    validate_git_ref(ref_name, "from_ref")?;
+    if let Some(stripped) = ref_name.strip_prefix("refs/heads/") {
+        return Ok(format!("heads/{stripped}"));
+    }
+    if let Some(stripped) = ref_name.strip_prefix("refs/tags/") {
+        return Ok(format!("tags/{stripped}"));
+    }
+    if ref_name.starts_with("refs/") {
+        return Err(
+            "Unsupported from_ref: only refs/heads/* and refs/tags/* are supported".to_string(),
+        );
+    }
+    if ref_name.starts_with("heads/") || ref_name.starts_with("tags/") {
+        return Ok(ref_name.to_string());
+    }
+    Ok(format!("heads/{ref_name}"))
+}
+
+fn normalize_branch_ref(branch: &str) -> Result<String, String> {
+    validate_git_ref(branch, "branch")?;
+    if branch.starts_with("refs/heads/") {
+        return Ok(branch.to_string());
+    }
+    if branch.starts_with("refs/") {
+        return Err("Invalid branch ref: only refs/heads/* is allowed".to_string());
+    }
+    let branch = branch.strip_prefix("heads/").unwrap_or(branch);
+    if branch.starts_with("tags/") {
+        return Err("Invalid branch ref: tags/* is not a branch".to_string());
+    }
+    Ok(format!("refs/heads/{branch}"))
+}
+
+fn append_search_params(
+    path: &mut String,
+    page: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<(), String> {
+    if let Some(p) = page {
+        path.push_str(&format!("&page={p}"));
+    }
+    if let Some(sort) = sort {
+        validate_input_length(sort, "sort")?;
+        path.push_str("&sort=");
+        path.push_str(&url_encode_query(sort));
+    }
+    if let Some(order) = order {
+        if !matches!(order, "asc" | "desc") {
+            return Err("Invalid order: must be 'asc' or 'desc'".into());
+        }
+        path.push_str("&order=");
+        path.push_str(order);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct GitCommitIdentity {
+    name: String,
+    email: String,
+}
+
+fn validate_commit_identity(identity: &GitCommitIdentity, field_name: &str) -> Result<(), String> {
+    validate_input_length(&identity.name, &format!("{field_name}.name"))?;
+    validate_input_length(&identity.email, &format!("{field_name}.email"))?;
+    Ok(())
 }
 
 struct GitHubTool;
@@ -73,6 +197,16 @@ struct GitHubTool;
 enum GitHubAction {
     #[serde(rename = "get_repo")]
     GetRepo { owner: String, repo: String },
+    #[serde(rename = "create_repo")]
+    CreateRepo {
+        name: String,
+        description: Option<String>,
+        private: Option<bool>,
+        auto_init: Option<bool>,
+        gitignore_template: Option<String>,
+        license_template: Option<String>,
+        org: Option<String>,
+    },
     #[serde(rename = "list_issues")]
     ListIssues {
         owner: String,
@@ -192,12 +326,93 @@ enum GitHubAction {
         page: Option<u32>,
         limit: Option<u32>,
     },
+    #[serde(rename = "search_repositories")]
+    SearchRepositories {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "search_code")]
+    SearchCode {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "search_issues_pull_requests")]
+    SearchIssuesPullRequests {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "list_branches")]
+    ListBranches {
+        owner: String,
+        repo: String,
+        protected: Option<bool>,
+        page: Option<u32>,
+        limit: Option<u32>,
+    },
+    #[serde(rename = "create_branch")]
+    CreateBranch {
+        owner: String,
+        repo: String,
+        branch: String,
+        from_ref: String,
+    },
     #[serde(rename = "get_file_content")]
     GetFileContent {
         owner: String,
         repo: String,
         path: String,
         r#ref: Option<String>,
+    },
+    #[serde(rename = "create_or_update_file")]
+    CreateOrUpdateFile {
+        owner: String,
+        repo: String,
+        path: String,
+        message: String,
+        content: String,
+        sha: Option<String>,
+        branch: Option<String>,
+        committer: Option<GitCommitIdentity>,
+        author: Option<GitCommitIdentity>,
+    },
+    #[serde(rename = "delete_file")]
+    DeleteFile {
+        owner: String,
+        repo: String,
+        path: String,
+        message: String,
+        sha: String,
+        branch: Option<String>,
+        committer: Option<GitCommitIdentity>,
+        author: Option<GitCommitIdentity>,
+    },
+    #[serde(rename = "list_releases")]
+    ListReleases {
+        owner: String,
+        repo: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+    },
+    #[serde(rename = "create_release")]
+    CreateRelease {
+        owner: String,
+        repo: String,
+        tag_name: String,
+        target_commitish: Option<String>,
+        name: Option<String>,
+        body: Option<String>,
+        draft: Option<bool>,
+        prerelease: Option<bool>,
+        generate_release_notes: Option<bool>,
     },
     #[serde(rename = "trigger_workflow")]
     TriggerWorkflow {
@@ -259,9 +474,8 @@ impl exports::near::agent::tool::Guest for GitHubTool {
     }
 
     fn description() -> String {
-        "GitHub integration for managing repositories, issues, pull requests, \
-         and workflows. Supports reading repo info, listing/creating issues, \
-         reviewing PRs, and triggering GitHub Actions. \
+        "GitHub integration for repositories, issues, pull requests, search, \
+         branches, file reads and writes, releases, and workflows. \
          Authentication is handled via the 'github_token' secret injected by the host."
             .to_string()
     }
@@ -277,6 +491,23 @@ fn execute_inner(params: &str) -> Result<String, String> {
 
     match action {
         GitHubAction::GetRepo { owner, repo } => get_repo(&owner, &repo),
+        GitHubAction::CreateRepo {
+            name,
+            description,
+            private,
+            auto_init,
+            gitignore_template,
+            license_template,
+            org,
+        } => create_repo(
+            &name,
+            description.as_deref(),
+            private.unwrap_or(false),
+            auto_init.unwrap_or(false),
+            gitignore_template.as_deref(),
+            license_template.as_deref(),
+            org.as_deref(),
+        ),
         GitHubAction::ListIssues {
             owner,
             repo,
@@ -393,12 +624,113 @@ fn execute_inner(params: &str) -> Result<String, String> {
             page,
             limit,
         } => list_repos(&username, page, limit),
+        GitHubAction::SearchRepositories {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_repositories(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::SearchCode {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_code(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::SearchIssuesPullRequests {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_issues_pull_requests(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::ListBranches {
+            owner,
+            repo,
+            protected,
+            page,
+            limit,
+        } => list_branches(&owner, &repo, protected, page, limit),
+        GitHubAction::CreateBranch {
+            owner,
+            repo,
+            branch,
+            from_ref,
+        } => create_branch(&owner, &repo, &branch, &from_ref),
         GitHubAction::GetFileContent {
             owner,
             repo,
             path,
             r#ref,
         } => get_file_content(&owner, &repo, &path, r#ref.as_deref()),
+        GitHubAction::CreateOrUpdateFile {
+            owner,
+            repo,
+            path,
+            message,
+            content,
+            sha,
+            branch,
+            committer,
+            author,
+        } => create_or_update_file(
+            &owner,
+            &repo,
+            &path,
+            &message,
+            &content,
+            sha.as_deref(),
+            branch.as_deref(),
+            committer,
+            author,
+        ),
+        GitHubAction::DeleteFile {
+            owner,
+            repo,
+            path,
+            message,
+            sha,
+            branch,
+            committer,
+            author,
+        } => delete_file(
+            &owner,
+            &repo,
+            &path,
+            &message,
+            &sha,
+            branch.as_deref(),
+            committer,
+            author,
+        ),
+        GitHubAction::ListReleases {
+            owner,
+            repo,
+            page,
+            limit,
+        } => list_releases(&owner, &repo, page, limit),
+        GitHubAction::CreateRelease {
+            owner,
+            repo,
+            tag_name,
+            target_commitish,
+            name,
+            body,
+            draft,
+            prerelease,
+            generate_release_notes,
+        } => create_release(
+            &owner,
+            &repo,
+            &tag_name,
+            target_commitish.as_deref(),
+            name.as_deref(),
+            body.as_deref(),
+            draft.unwrap_or(false),
+            prerelease.unwrap_or(false),
+            generate_release_notes.unwrap_or(false),
+        ),
         GitHubAction::TriggerWorkflow {
             owner,
             repo,
@@ -435,7 +767,7 @@ fn github_request(method: &str, path: &str, body: Option<String>) -> Result<Stri
     // via the `http-wrapper` proxy based on the `github_token` secret.
     let headers = serde_json::json!({
         "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        "X-GitHub-Api-Version": "2026-03-10",
         "User-Agent": "IronClaw-GitHub-Tool"
     });
 
@@ -533,6 +865,58 @@ fn get_repo(owner: &str, repo: &str) -> Result<String, String> {
         &format!("/repos/{}/{}", encoded_owner, encoded_repo),
         None,
     )
+}
+
+fn create_repo(
+    name: &str,
+    description: Option<&str>,
+    private: bool,
+    auto_init: bool,
+    gitignore_template: Option<&str>,
+    license_template: Option<&str>,
+    org: Option<&str>,
+) -> Result<String, String> {
+    if !validate_path_segment(name) {
+        return Err("Invalid repository name".into());
+    }
+    validate_input_length(name, "name")?;
+    if let Some(description) = description {
+        validate_input_length(description, "description")?;
+    }
+    if let Some(template) = gitignore_template {
+        validate_input_length(template, "gitignore_template")?;
+    }
+    if let Some(template) = license_template {
+        validate_input_length(template, "license_template")?;
+    }
+    if let Some(org) = org {
+        if !validate_path_segment(org) {
+            return Err("Invalid org name".into());
+        }
+    }
+
+    let path = if let Some(org) = org {
+        format!("/orgs/{}/repos", url_encode_path(org))
+    } else {
+        "/user/repos".to_string()
+    };
+
+    let mut req_body = serde_json::json!({
+        "name": name,
+        "private": private,
+        "auto_init": auto_init,
+    });
+    if let Some(description) = description {
+        req_body["description"] = serde_json::json!(description);
+    }
+    if let Some(template) = gitignore_template {
+        req_body["gitignore_template"] = serde_json::json!(template);
+    }
+    if let Some(template) = license_template {
+        req_body["license_template"] = serde_json::json!(template);
+    }
+
+    github_request("POST", &path, Some(req_body.to_string()))
 }
 
 fn list_issues(
@@ -916,6 +1300,119 @@ fn list_repos(username: &str, page: Option<u32>, limit: Option<u32>) -> Result<S
     github_request("GET", &path, None)
 }
 
+fn search_repositories(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/repositories?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn search_code(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/code?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn search_issues_pull_requests(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/issues?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn list_branches(
+    owner: &str,
+    repo: &str,
+    protected: Option<bool>,
+    page: Option<u32>,
+    limit: Option<u32>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/repos/{}/{}/branches?per_page={}",
+        encoded_owner, encoded_repo, limit
+    );
+    if let Some(protected) = protected {
+        path.push_str("&protected=");
+        path.push_str(if protected { "true" } else { "false" });
+    }
+    if let Some(page) = page {
+        path.push_str(&format!("&page={page}"));
+    }
+    github_request("GET", &path, None)
+}
+
+fn create_branch(owner: &str, repo: &str, branch: &str, from_ref: &str) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_input_length(branch, "branch")?;
+    validate_input_length(from_ref, "from_ref")?;
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let source_ref = normalize_ref_lookup(from_ref)?;
+    let source_path = format!(
+        "/repos/{}/{}/git/ref/{}",
+        encoded_owner,
+        encoded_repo,
+        encode_repo_path(&source_ref)
+    );
+    let source_ref_resp = github_request("GET", &source_path, None)?;
+    let source_ref_json: serde_json::Value = serde_json::from_str(&source_ref_resp)
+        .map_err(|e| format!("Invalid GitHub response for source ref: {e}"))?;
+    let sha = source_ref_json
+        .pointer("/object/sha")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Source ref response missing object.sha".to_string())?;
+
+    let req_body = serde_json::json!({
+        "ref": normalize_branch_ref(branch)?,
+        "sha": sha,
+    });
+    let path = format!("/repos/{}/{}/git/refs", encoded_owner, encoded_repo);
+    github_request("POST", &path, Some(req_body.to_string()))
+}
+
 fn get_file_content(
     owner: &str,
     repo: &str,
@@ -925,29 +1422,14 @@ fn get_file_content(
     if !validate_path_segment(owner) || !validate_path_segment(repo) {
         return Err("Invalid owner or repo name".into());
     }
-    // Validate path segments - reject path traversal attempts and empty segments
-    for segment in path.split('/') {
-        if segment == ".." {
-            return Err("Invalid path: path traversal not allowed".into());
-        }
-        if segment.is_empty() {
-            return Err("Invalid path: empty segment not allowed".into());
-        }
-    }
+    validate_repo_path(path)?;
     // Validate ref if provided
     if let Some(r#ref) = r#ref {
-        if r#ref.contains("..") || r#ref.contains(':') {
-            return Err("Invalid ref: must be a valid branch, tag, or commit SHA".into());
-        }
+        validate_git_ref(r#ref, "ref")?;
     }
     let encoded_owner = url_encode_path(owner);
     let encoded_repo = url_encode_path(repo);
-    // Path can contain slashes, so we encode each segment separately
-    let encoded_path = path
-        .split('/')
-        .map(url_encode_path)
-        .collect::<Vec<_>>()
-        .join("/");
+    let encoded_path = encode_repo_path(path);
 
     let url_path = if let Some(r#ref) = r#ref {
         let encoded_ref = url_encode_query(r#ref);
@@ -962,6 +1444,186 @@ fn get_file_content(
         )
     };
     github_request("GET", &url_path, None)
+}
+
+fn create_or_update_file(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    message: &str,
+    content: &str,
+    sha: Option<&str>,
+    branch: Option<&str>,
+    committer: Option<GitCommitIdentity>,
+    author: Option<GitCommitIdentity>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_repo_path(path)?;
+    validate_input_length(message, "message")?;
+    validate_input_length(content, "content")?;
+    if let Some(branch) = branch {
+        validate_git_ref(branch, "branch")?;
+    }
+    if let Some(sha) = sha {
+        validate_input_length(sha, "sha")?;
+    }
+    if let Some(committer) = &committer {
+        validate_commit_identity(committer, "committer")?;
+    }
+    if let Some(author) = &author {
+        validate_commit_identity(author, "author")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let encoded_path = encode_repo_path(path);
+    let mut req_body = serde_json::json!({
+        "message": message,
+        "content": BASE64_STANDARD.encode(content.as_bytes()),
+    });
+    if let Some(sha) = sha {
+        req_body["sha"] = serde_json::json!(sha);
+    }
+    if let Some(branch) = branch {
+        req_body["branch"] = serde_json::json!(branch);
+    }
+    if let Some(committer) = committer {
+        req_body["committer"] =
+            serde_json::to_value(committer).map_err(|e| format!("Invalid committer: {e}"))?;
+    }
+    if let Some(author) = author {
+        req_body["author"] =
+            serde_json::to_value(author).map_err(|e| format!("Invalid author: {e}"))?;
+    }
+
+    let path = format!(
+        "/repos/{}/{}/contents/{}",
+        encoded_owner, encoded_repo, encoded_path
+    );
+    github_request("PUT", &path, Some(req_body.to_string()))
+}
+
+fn delete_file(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    message: &str,
+    sha: &str,
+    branch: Option<&str>,
+    committer: Option<GitCommitIdentity>,
+    author: Option<GitCommitIdentity>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_repo_path(path)?;
+    validate_input_length(message, "message")?;
+    validate_input_length(sha, "sha")?;
+    if let Some(branch) = branch {
+        validate_git_ref(branch, "branch")?;
+    }
+    if let Some(committer) = &committer {
+        validate_commit_identity(committer, "committer")?;
+    }
+    if let Some(author) = &author {
+        validate_commit_identity(author, "author")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let encoded_path = encode_repo_path(path);
+    let mut req_body = serde_json::json!({
+        "message": message,
+        "sha": sha,
+    });
+    if let Some(branch) = branch {
+        req_body["branch"] = serde_json::json!(branch);
+    }
+    if let Some(committer) = committer {
+        req_body["committer"] =
+            serde_json::to_value(committer).map_err(|e| format!("Invalid committer: {e}"))?;
+    }
+    if let Some(author) = author {
+        req_body["author"] =
+            serde_json::to_value(author).map_err(|e| format!("Invalid author: {e}"))?;
+    }
+
+    let path = format!(
+        "/repos/{}/{}/contents/{}",
+        encoded_owner, encoded_repo, encoded_path
+    );
+    github_request("DELETE", &path, Some(req_body.to_string()))
+}
+
+fn list_releases(
+    owner: &str,
+    repo: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/repos/{}/{}/releases?per_page={}",
+        encoded_owner, encoded_repo, limit
+    );
+    if let Some(page) = page {
+        path.push_str(&format!("&page={page}"));
+    }
+    github_request("GET", &path, None)
+}
+
+fn create_release(
+    owner: &str,
+    repo: &str,
+    tag_name: &str,
+    target_commitish: Option<&str>,
+    name: Option<&str>,
+    body: Option<&str>,
+    draft: bool,
+    prerelease: bool,
+    generate_release_notes: bool,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_git_ref(tag_name, "tag_name")?;
+    if let Some(target_commitish) = target_commitish {
+        validate_git_ref(target_commitish, "target_commitish")?;
+    }
+    if let Some(name) = name {
+        validate_input_length(name, "name")?;
+    }
+    if let Some(body) = body {
+        validate_input_length(body, "body")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let path = format!("/repos/{}/{}/releases", encoded_owner, encoded_repo);
+    let mut req_body = serde_json::json!({
+        "tag_name": tag_name,
+        "draft": draft,
+        "prerelease": prerelease,
+        "generate_release_notes": generate_release_notes,
+    });
+    if let Some(target_commitish) = target_commitish {
+        req_body["target_commitish"] = serde_json::json!(target_commitish);
+    }
+    if let Some(name) = name {
+        req_body["name"] = serde_json::json!(name);
+    }
+    if let Some(body) = body {
+        req_body["body"] = serde_json::json!(body);
+    }
+
+    github_request("POST", &path, Some(req_body.to_string()))
 }
 
 fn trigger_workflow(
@@ -1288,6 +1950,19 @@ const SCHEMA: &str = r#"{
         },
         {
             "properties": {
+                "action": { "const": "create_repo" },
+                "name": { "type": "string", "description": "New repository name" },
+                "description": { "type": "string" },
+                "private": { "type": "boolean", "default": false },
+                "auto_init": { "type": "boolean", "default": false },
+                "gitignore_template": { "type": "string" },
+                "license_template": { "type": "string" },
+                "org": { "type": "string", "description": "Optional organization name; omit to create under the authenticated user" }
+            },
+            "required": ["action", "name"]
+        },
+        {
+            "properties": {
                 "action": { "const": "list_issues" },
                 "owner": { "type": "string" },
                 "repo": { "type": "string" },
@@ -1446,9 +2121,64 @@ const SCHEMA: &str = r#"{
             "properties": {
                 "action": { "const": "list_repos" },
                 "username": { "type": "string" },
+                "page": { "type": "integer" },
                 "limit": { "type": "integer", "default": 30 }
             },
             "required": ["action", "username"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_repositories" },
+                "query": { "type": "string", "description": "GitHub repository search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_code" },
+                "query": { "type": "string", "description": "GitHub code search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_issues_pull_requests" },
+                "query": { "type": "string", "description": "GitHub issue/PR search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_branches" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "protected": { "type": "boolean" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 }
+            },
+            "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_branch" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "branch": { "type": "string", "description": "New branch name" },
+                "from_ref": { "type": "string", "description": "Source branch or tag to branch from" }
+            },
+            "required": ["action", "owner", "repo", "branch", "from_ref"]
         },
         {
             "properties": {
@@ -1459,6 +2189,88 @@ const SCHEMA: &str = r#"{
                 "ref": { "type": "string", "description": "Branch/commit (default: default branch)" }
             },
             "required": ["action", "owner", "repo", "path"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_or_update_file" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "path": { "type": "string", "description": "File path in repo" },
+                "message": { "type": "string", "description": "Commit message" },
+                "content": { "type": "string", "description": "Raw UTF-8 file content; the tool base64-encodes it for GitHub" },
+                "sha": { "type": "string", "description": "Required when updating an existing file" },
+                "branch": { "type": "string" },
+                "committer": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                },
+                "author": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                }
+            },
+            "required": ["action", "owner", "repo", "path", "message", "content"]
+        },
+        {
+            "properties": {
+                "action": { "const": "delete_file" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "path": { "type": "string", "description": "File path in repo" },
+                "message": { "type": "string", "description": "Commit message" },
+                "sha": { "type": "string", "description": "Blob SHA of the file to delete" },
+                "branch": { "type": "string" },
+                "committer": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                },
+                "author": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                }
+            },
+            "required": ["action", "owner", "repo", "path", "message", "sha"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_releases" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 }
+            },
+            "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_release" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "tag_name": { "type": "string" },
+                "target_commitish": { "type": "string" },
+                "name": { "type": "string" },
+                "body": { "type": "string" },
+                "draft": { "type": "boolean", "default": false },
+                "prerelease": { "type": "boolean", "default": false },
+                "generate_release_notes": { "type": "boolean", "default": false }
+            },
+            "required": ["action", "owner", "repo", "tag_name"]
         },
         {
             "properties": {
@@ -1480,6 +2292,26 @@ const SCHEMA: &str = r#"{
                 "limit": { "type": "integer", "default": 30 }
             },
             "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "handle_webhook" },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "headers": {
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        },
+                        "body_json": {
+                            "type": "object",
+                            "description": "Parsed GitHub webhook JSON payload"
+                        }
+                    },
+                    "required": ["headers", "body_json"]
+                }
+            },
+            "required": ["action", "webhook"]
         }
     ]
 }"#;
@@ -1489,6 +2321,61 @@ export!(GitHubTool);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn schema_actions() -> std::collections::HashSet<String> {
+        let schema: serde_json::Value =
+            serde_json::from_str(SCHEMA).expect("schema should be valid JSON");
+        schema["oneOf"]
+            .as_array()
+            .expect("schema.oneOf should be an array")
+            .iter()
+            .filter_map(|variant| {
+                variant
+                    .pointer("/properties/action/const")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect()
+    }
+
+    fn supported_actions() -> std::collections::HashSet<String> {
+        [
+            "get_repo",
+            "create_repo",
+            "list_issues",
+            "create_issue",
+            "get_issue",
+            "list_issue_comments",
+            "create_issue_comment",
+            "list_pull_requests",
+            "create_pull_request",
+            "get_pull_request",
+            "get_pull_request_files",
+            "create_pr_review",
+            "list_pull_request_comments",
+            "reply_pull_request_comment",
+            "get_pull_request_reviews",
+            "get_combined_status",
+            "merge_pull_request",
+            "list_repos",
+            "search_repositories",
+            "search_code",
+            "search_issues_pull_requests",
+            "list_branches",
+            "create_branch",
+            "get_file_content",
+            "create_or_update_file",
+            "delete_file",
+            "list_releases",
+            "create_release",
+            "trigger_workflow",
+            "get_workflow_runs",
+            "handle_webhook",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
 
     #[test]
     fn test_url_encode_path() {
@@ -1500,10 +2387,12 @@ mod tests {
     #[test]
     fn test_validate_path_segment() {
         assert!(validate_path_segment("foo"));
+        assert!(validate_path_segment("foo-bar_123.baz"));
         assert!(!validate_path_segment(""));
         assert!(!validate_path_segment("foo/bar"));
         assert!(!validate_path_segment(".."));
-        // Empty segments are handled in get_file_content logic, not here
+        assert!(!validate_path_segment("foo bar"));
+        assert!(!validate_path_segment("foo\nbar"));
     }
 
     #[test]
@@ -1654,5 +2543,151 @@ mod tests {
                 .and_then(|v| v.as_i64()),
             Some(42)
         );
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_bad_names() {
+        assert!(validate_git_ref("feature/test", "branch").is_ok());
+        assert!(validate_git_ref("release/v1.2.3", "branch").is_ok());
+        assert!(validate_git_ref("bad ref", "branch").is_err());
+        assert!(validate_git_ref("../main", "branch").is_err());
+        assert!(validate_git_ref("refs/heads/main.lock", "branch").is_err());
+    }
+
+    #[test]
+    fn test_normalize_ref_lookup_and_branch_ref() {
+        assert_eq!(
+            normalize_ref_lookup("main").expect("main should normalize"),
+            "heads/main"
+        );
+        assert_eq!(
+            normalize_ref_lookup("refs/tags/v1.0.0").expect("tag ref should normalize"),
+            "tags/v1.0.0"
+        );
+        assert_eq!(
+            normalize_branch_ref("feature/github-tool-audit").expect("branch ref should normalize"),
+            "refs/heads/feature/github-tool-audit"
+        );
+        assert_eq!(
+            normalize_branch_ref("refs/heads/main").expect("qualified branch ref should pass"),
+            "refs/heads/main"
+        );
+        assert!(normalize_ref_lookup("refs/pull/123/head").is_err());
+        assert!(normalize_branch_ref("refs/tags/v1.0.0").is_err());
+        assert!(normalize_branch_ref("tags/v1.0.0").is_err());
+    }
+
+    #[test]
+    fn test_validate_repo_path_enforces_length_limit() {
+        let long_path = format!("dir/{}", "a".repeat(MAX_TEXT_LENGTH));
+        assert!(validate_repo_path("docs/readme.md").is_ok());
+        assert!(validate_repo_path(&long_path).is_err());
+    }
+
+    #[test]
+    fn test_validate_commit_identity_enforces_length_limit() {
+        let identity = GitCommitIdentity {
+            name: "IronClaw Bot".to_string(),
+            email: "bot@example.com".to_string(),
+        };
+        assert!(validate_commit_identity(&identity, "committer").is_ok());
+
+        let too_long = GitCommitIdentity {
+            name: "a".repeat(MAX_TEXT_LENGTH + 1),
+            email: "bot@example.com".to_string(),
+        };
+        assert!(validate_commit_identity(&too_long, "committer").is_err());
+    }
+
+    #[test]
+    fn test_schema_includes_new_core_actions() {
+        let actions = schema_actions();
+        for action in [
+            "create_repo",
+            "search_repositories",
+            "search_code",
+            "search_issues_pull_requests",
+            "list_branches",
+            "create_branch",
+            "create_or_update_file",
+            "delete_file",
+            "list_releases",
+            "create_release",
+        ] {
+            assert!(
+                actions.contains(action),
+                "schema should include action {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_matches_supported_action_set() {
+        assert_eq!(schema_actions(), supported_actions());
+    }
+
+    #[test]
+    fn test_readme_examples_only_reference_supported_actions() {
+        let actions = schema_actions();
+        let readme = include_str!("../README.md");
+        let mut referenced = Vec::new();
+
+        for line in readme.lines() {
+            let Some((_, rhs)) = line.split_once("\"action\":") else {
+                continue;
+            };
+            let rhs = rhs.trim();
+            let Some(rest) = rhs.strip_prefix('"') else {
+                continue;
+            };
+            let Some(action) = rest.split('"').next() else {
+                continue;
+            };
+            referenced.push(action.to_string());
+        }
+
+        assert!(
+            !referenced.is_empty(),
+            "README should contain action examples"
+        );
+        for action in referenced {
+            assert!(
+                actions.contains(&action),
+                "README references unsupported action {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_registry_description_claims_are_supported() {
+        let actions = schema_actions();
+        let manifest: serde_json::Value =
+            serde_json::from_str(include_str!("../../../registry/tools/github.json"))
+                .expect("registry manifest should parse");
+        let description = manifest["description"]
+            .as_str()
+            .expect("registry manifest should have a description")
+            .to_ascii_lowercase();
+
+        if description.contains("search") {
+            assert!(
+                actions.contains("search_repositories")
+                    && actions.contains("search_code")
+                    && actions.contains("search_issues_pull_requests"),
+                "registry search claim should map to implemented search actions"
+            );
+        }
+        if description.contains("releases") {
+            assert!(
+                actions.contains("list_releases") && actions.contains("create_release"),
+                "registry releases claim should map to implemented release actions"
+            );
+        }
+        if description.contains("file writes") {
+            assert!(
+                actions.contains("create_or_update_file") && actions.contains("delete_file"),
+                "registry file write claim should map to implemented content actions"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- **Problem**: The self-repair system was attempting to rebuild built-in tools (http, shell, json, etc.) when they accumulated failure counts. Built-in tools are part of the ironclaw binary — errors on them are caller-side issues (bad LLM parameters), not tool defects. This wasted LLM tokens and spammed users with repair notifications.
- **Fix**: Filter built-in tools out of the repair pipeline at two levels:
  1. **Detection** (`detect_broken_tools`): filters protected names before returning results
  2. **Repair** (`repair_broken_tool`): defense-in-depth guard rejects protected names even if detection missed them
- Adds `PROTECTED_TOOL_NAMES` list (47+ entries) covering all built-in tools, with public `is_protected_tool_name()` function
- Documents the `SelfRepair` trait contract about built-in tool exclusion

## Test plan

- [x] `detect_broken_tools_filters_out_builtins` — seeds real libSQL DB with failures for both a built-in ("http") and dynamic tool, verifies only the dynamic tool is returned
- [x] `repair_broken_tool_skips_builtin` — verifies defense-in-depth guard rejects built-in without invoking the builder (uses mock builder to confirm zero invocations)
- [x] `is_protected_tool_name_covers_common_builtins` — spot-checks the lookup function against known built-in names
- [x] All 15 self_repair tests pass
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)