### PR TITLE
fix(tools): gate claude_code and acp modes behind enabled flags

### DIFF
--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -14,6 +14,7 @@ use uuid::Uuid;
 use crate::channels::web::auth::{AuthenticatedUser, ownership_identity};
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
+use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
 use crate::ownership::{OwnerId, can_act_on};
 
 fn db_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
@@ -28,22 +29,17 @@ async fn resolve_sandbox_restart_mode(
     store: &dyn crate::db::Database,
     stored_mode: &str,
     user_id: &str,
-) -> Result<
-    (
-        crate::orchestrator::job_manager::JobMode,
-        Option<crate::config::acp::AcpAgentConfig>,
-    ),
-    crate::config::acp::AcpConfigError,
-> {
+) -> Result<(JobMode, Option<crate::config::acp::AcpAgentConfig>), crate::config::acp::AcpConfigError>
+{
     if stored_mode == "claude_code" {
-        return Ok((crate::orchestrator::job_manager::JobMode::ClaudeCode, None));
+        return Ok((JobMode::ClaudeCode, None));
     }
 
     if let Some(agent_name) = stored_mode.strip_prefix("acp:") {
         let agent =
             crate::config::acp::get_enabled_acp_agent_for_user(Some(store), user_id, agent_name)
                 .await?;
-        return Ok((crate::orchestrator::job_manager::JobMode::Acp, Some(agent)));
+        return Ok((JobMode::Acp, Some(agent)));
     }
 
     if stored_mode == "acp" {
@@ -52,7 +48,24 @@ async fn resolve_sandbox_restart_mode(
         });
     }
 
-    Ok((crate::orchestrator::job_manager::JobMode::Worker, None))
+    Ok((JobMode::Worker, None))
+}
+
+/// Reject restart requests for modes disabled since the job was created.
+fn check_mode_enabled(mode: JobMode, jm: &ContainerJobManager) -> Result<(), (StatusCode, String)> {
+    if jm.is_mode_enabled(mode) {
+        Ok(())
+    } else {
+        let env_hint = match mode {
+            JobMode::ClaudeCode => " Set CLAUDE_CODE_ENABLED=true to re-enable.",
+            JobMode::Acp => " Set ACP_ENABLED=true to re-enable.",
+            JobMode::Worker => "", // Worker is always enabled; unreachable in practice.
+        };
+        Err((
+            StatusCode::CONFLICT,
+            format!("{mode} mode is no longer enabled.{env_hint}"),
+        ))
+    }
 }
 
 pub async fn jobs_list_handler(
@@ -462,6 +475,9 @@ pub async fn jobs_restart_handler(
                 resolve_sandbox_restart_mode(store.as_ref(), &stored_mode, &old_job.user_id)
                     .await
                     .map_err(|e| (StatusCode::CONFLICT, format!("Cannot restart job: {}", e)))?;
+
+            check_mode_enabled(mode, jm.as_ref())?;
+
             let record = crate::history::SandboxJobRecord {
                 id: new_job_id,
                 task: task.clone(),
@@ -480,8 +496,8 @@ pub async fn jobs_restart_handler(
                 .await
                 .map_err(|e| db_error("jobs_restart_handler", e))?;
 
-            if mode != crate::orchestrator::job_manager::JobMode::Worker {
-                let mode_str = if mode == crate::orchestrator::job_manager::JobMode::Acp {
+            if mode != JobMode::Worker {
+                let mode_str = if mode == JobMode::Acp {
                     format!(
                         "acp:{}",
                         acp_agent
@@ -516,7 +532,7 @@ pub async fn jobs_restart_handler(
                     &task,
                     Some(project_dir),
                     mode,
-                    crate::orchestrator::job_manager::JobCreationParams {
+                    JobCreationParams {
                         credential_grants,
                         acp_agent,
                         ..Default::default()
@@ -914,6 +930,9 @@ pub async fn job_files_read_handler(
 mod tests {
     use super::*;
 
+    use crate::orchestrator::TokenStore;
+    use crate::orchestrator::job_manager::ContainerJobConfig;
+
     #[cfg(feature = "libsql")]
     #[tokio::test]
     async fn sandbox_restart_mode_uses_original_job_owner_scope() {
@@ -934,7 +953,7 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(mode, crate::orchestrator::job_manager::JobMode::Acp);
+        assert_eq!(mode, JobMode::Acp);
         assert_eq!(
             agent.as_ref().map(|agent| agent.name.as_str()),
             Some("codex")
@@ -975,5 +994,47 @@ mod tests {
         assert_eq!(body, "Internal database error");
         assert!(!body.contains("relation"));
         assert!(!body.contains("does not exist"));
+    }
+
+    fn make_job_manager(claude_code: bool, acp: bool) -> ContainerJobManager {
+        ContainerJobManager::new(
+            ContainerJobConfig {
+                claude_code_enabled: claude_code,
+                acp_enabled: acp,
+                ..Default::default()
+            },
+            TokenStore::new(),
+        )
+    }
+
+    #[test]
+    fn test_check_mode_rejects_disabled_claude_code() {
+        let jm = make_job_manager(false, false);
+        let result = check_mode_enabled(JobMode::ClaudeCode, &jm);
+        let (status, body) = result.unwrap_err(); // safety: test
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            body.contains("claude_code"),
+            "error should mention claude_code, got: {body}"
+        );
+    }
+
+    #[test]
+    fn test_check_mode_rejects_disabled_acp() {
+        let jm = make_job_manager(false, false);
+        let result = check_mode_enabled(JobMode::Acp, &jm);
+        let (status, body) = result.unwrap_err(); // safety: test
+        assert_eq!(status, StatusCode::CONFLICT);
+        assert!(
+            body.contains("acp"),
+            "error should mention acp, got: {body}"
+        );
+    }
+
+    #[test]
+    fn test_check_mode_allows_worker_always() {
+        let jm = make_job_manager(false, false);
+        let result = check_mode_enabled(JobMode::Worker, &jm);
+        assert!(result.is_ok(), "worker mode should always be allowed");
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -343,6 +343,9 @@ pub enum OrchestratorError {
 
     #[error("Docker error: {reason}")]
     Docker { reason: String },
+
+    #[error("{mode} mode is not enabled")]
+    ModeDisabled { mode: String },
 }
 
 /// Worker errors (container-side execution).

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -336,6 +336,12 @@ impl ContainerJobManager {
         mode: JobMode,
         params: JobCreationParams,
     ) -> Result<String, OrchestratorError> {
+        if !self.is_mode_enabled(mode) {
+            return Err(OrchestratorError::ModeDisabled {
+                mode: mode.to_string(),
+            });
+        }
+
         // Generate auth token (stored in TokenStore, never logged)
         let token = self.token_store.create_token(job_id).await;
 
@@ -1043,6 +1049,32 @@ mod tests {
         assert!(manager.is_mode_enabled(JobMode::Worker));
         assert!(manager.is_mode_enabled(JobMode::ClaudeCode));
         assert!(!manager.is_mode_enabled(JobMode::Acp));
+    }
+
+    #[tokio::test]
+    async fn test_create_job_rejects_disabled_mode() {
+        let manager = ContainerJobManager::new(
+            ContainerJobConfig {
+                claude_code_enabled: false,
+                acp_enabled: false,
+                ..Default::default()
+            },
+            TokenStore::new(),
+        );
+        let result = manager
+            .create_job(
+                Uuid::new_v4(),
+                "test task",
+                None,
+                JobMode::ClaudeCode,
+                JobCreationParams::default(),
+            )
+            .await;
+        let err = result.unwrap_err().to_string(); // safety: test
+        assert!(
+            err.contains("not enabled"),
+            "expected mode-disabled error, got: {err}"
+        );
     }
 
     #[test]

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -274,6 +274,15 @@ impl ContainerJobManager {
         self.config.acp_enabled
     }
 
+    /// Whether the given job mode is allowed by the current configuration.
+    pub fn is_mode_enabled(&self, mode: JobMode) -> bool {
+        match mode {
+            JobMode::Worker => true,
+            JobMode::ClaudeCode => self.config.claude_code_enabled,
+            JobMode::Acp => self.config.acp_enabled,
+        }
+    }
+
     fn extend_acp_env(
         &self,
         env_vec: &mut Vec<String>,
@@ -1022,23 +1031,18 @@ mod tests {
     }
 
     #[test]
-    fn test_container_job_manager_claude_code_enabled_accessor() {
-        let config = ContainerJobConfig {
-            claude_code_enabled: true,
-            ..Default::default()
-        };
-        let manager = ContainerJobManager::new(config, TokenStore::new());
-        assert!(manager.claude_code_enabled());
-    }
-
-    #[test]
-    fn test_container_job_manager_acp_enabled_accessor() {
-        let config = ContainerJobConfig {
-            acp_enabled: true,
-            ..Default::default()
-        };
-        let manager = ContainerJobManager::new(config, TokenStore::new());
-        assert!(manager.acp_enabled());
+    fn test_is_mode_enabled_matches_individual_accessors() {
+        let manager = ContainerJobManager::new(
+            ContainerJobConfig {
+                claude_code_enabled: true,
+                acp_enabled: false,
+                ..Default::default()
+            },
+            TokenStore::new(),
+        );
+        assert!(manager.is_mode_enabled(JobMode::Worker));
+        assert!(manager.is_mode_enabled(JobMode::ClaudeCode));
+        assert!(!manager.is_mode_enabled(JobMode::Acp));
     }
 
     #[test]

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -96,6 +96,10 @@ pub struct ContainerJobConfig {
     /// Whether per-job MCP server filtering is enabled.
     /// When false, `mcp_servers` param on `create_job` is ignored.
     pub mcp_per_job_enabled: bool,
+    /// Whether Claude Code sandbox mode is available (from CLAUDE_CODE_ENABLED).
+    pub claude_code_enabled: bool,
+    /// Whether ACP agent mode is available (from ACP_ENABLED).
+    pub acp_enabled: bool,
 }
 
 impl Default for ContainerJobConfig {
@@ -114,6 +118,8 @@ impl Default for ContainerJobConfig {
             acp_memory_limit_mb: 4096,
             acp_timeout_secs: 1800,
             mcp_per_job_enabled: false,
+            claude_code_enabled: false,
+            acp_enabled: false,
         }
     }
 }
@@ -256,6 +262,16 @@ impl ContainerJobManager {
             containers: Arc::new(RwLock::new(HashMap::new())),
             docker: Arc::new(RwLock::new(None)),
         }
+    }
+
+    /// Whether Claude Code mode is enabled for job creation.
+    pub fn claude_code_enabled(&self) -> bool {
+        self.config.claude_code_enabled
+    }
+
+    /// Whether ACP agent mode is enabled for job creation.
+    pub fn acp_enabled(&self) -> bool {
+        self.config.acp_enabled
     }
 
     fn extend_acp_env(
@@ -991,6 +1007,38 @@ mod tests {
     fn test_container_job_config_acp_timeout_default() {
         let config = ContainerJobConfig::default();
         assert_eq!(config.acp_timeout_secs, 1800);
+    }
+
+    #[test]
+    fn test_container_job_config_claude_code_disabled_by_default() {
+        let config = ContainerJobConfig::default();
+        assert!(!config.claude_code_enabled);
+    }
+
+    #[test]
+    fn test_container_job_config_acp_disabled_by_default() {
+        let config = ContainerJobConfig::default();
+        assert!(!config.acp_enabled);
+    }
+
+    #[test]
+    fn test_container_job_manager_claude_code_enabled_accessor() {
+        let config = ContainerJobConfig {
+            claude_code_enabled: true,
+            ..Default::default()
+        };
+        let manager = ContainerJobManager::new(config, TokenStore::new());
+        assert!(manager.claude_code_enabled());
+    }
+
+    #[test]
+    fn test_container_job_manager_acp_enabled_accessor() {
+        let config = ContainerJobConfig {
+            acp_enabled: true,
+            ..Default::default()
+        };
+        let manager = ContainerJobManager::new(config, TokenStore::new());
+        assert!(manager.acp_enabled());
     }
 
     #[test]

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -127,6 +127,8 @@ pub async fn setup_orchestrator(
             mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
                 .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
                 .unwrap_or(false),
+            claude_code_enabled: config.claude_code.enabled,
+            acp_enabled: config.acp.enabled,
         };
         let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
 

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -452,10 +452,10 @@ impl CreateJobTool {
 
         // Persist the job mode to DB (for non-default modes).
         // For ACP, store "acp:<agent_name>" so restarts know which agent to use.
+        // Done synchronously so mode is available if the job needs restarting.
         if mode != JobMode::Worker
-            && let Some(store) = self.store.clone()
+            && let Some(ref store) = self.store
         {
-            let job_id_copy = job_id;
             let mode_str = if mode == JobMode::Acp
                 && let Some(ref agent) = params.acp_agent
             {
@@ -463,11 +463,9 @@ impl CreateJobTool {
             } else {
                 mode.as_str().to_string()
             };
-            tokio::spawn(async move {
-                if let Err(e) = store.update_sandbox_job_mode(job_id_copy, &mode_str).await {
-                    tracing::warn!(job_id = %job_id_copy, "Failed to set job mode: {}", e);
-                }
-            });
+            if let Err(e) = store.update_sandbox_job_mode(job_id, &mode_str).await {
+                tracing::warn!(job_id = %job_id, "Failed to set job mode: {}", e);
+            }
         }
 
         // Create the container job with the pre-determined job_id.
@@ -856,67 +854,70 @@ impl Tool for CreateJobTool {
 
     fn parameters_schema(&self) -> serde_json::Value {
         if self.sandbox_enabled() {
-            let mut props = serde_json::json!({
-                "title": {
+            let mut props = serde_json::Map::new();
+            props.insert(
+                "title".into(),
+                serde_json::json!({
                     "type": "string",
                     "description": "Clear description of what to accomplish"
-                },
-                "description": {
+                }),
+            );
+            props.insert(
+                "description".into(),
+                serde_json::json!({
                     "type": "string",
                     "description": "Full description of what needs to be done"
-                },
-                "wait": {
-                    "type": "boolean",
-                    "description": "If true (default), wait for the container to complete and return results. \
-                                    If false, start the container and return the job_id immediately."
-                },
-                "project_dir": {
-                    "type": "string",
-                    "description": "Path to an existing project directory to mount into the container. \
-                                    Must be under ~/.ironclaw/projects/. If omitted, a fresh directory is created."
-                },
-                "credentials": {
-                    "type": "object",
-                    "description": "Map of secret names to env var names. Each secret must exist in the \
-                                    secrets store (via 'ironclaw tool auth' or web UI). Example: \
-                                    {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
-                    "additionalProperties": { "type": "string" }
-                },
-                "mcp_servers": {
-                    "type": "array",
-                    "items": { "type": "string" },
-                    "description": "Optional list of MCP server names to make available in the container. \
-                                    If omitted, the full master config is mounted. If empty, no MCP servers \
-                                    are available. Only effective when MCP_PER_JOB_ENABLED=true."
-                },
-                "max_iterations": {
-                    "type": "integer",
-                    "description": "Maximum number of agent loop iterations for the worker. \
-                                    Defaults to 50, capped at 500. Use lower values for simple tasks."
-                }
-            });
+                }),
+            );
+            props.insert("wait".into(), serde_json::json!({
+                "type": "boolean",
+                "description": "If true (default), wait for the container to complete and return results. \
+                                If false, start the container and return the job_id immediately."
+            }));
+            props.insert("project_dir".into(), serde_json::json!({
+                "type": "string",
+                "description": "Path to an existing project directory to mount into the container. \
+                                Must be under ~/.ironclaw/projects/. If omitted, a fresh directory is created."
+            }));
+            props.insert("credentials".into(), serde_json::json!({
+                "type": "object",
+                "description": "Map of secret names to env var names. Each secret must exist in the \
+                                secrets store (via 'ironclaw tool auth' or web UI). Example: \
+                                {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
+                "additionalProperties": { "type": "string" }
+            }));
+            props.insert("mcp_servers".into(), serde_json::json!({
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Optional list of MCP server names to make available in the container. \
+                                If omitted, the full master config is mounted. If empty, no MCP servers \
+                                are available. Only effective when MCP_PER_JOB_ENABLED=true."
+            }));
+            props.insert("max_iterations".into(), serde_json::json!({
+                "type": "integer",
+                "description": "Maximum number of agent loop iterations for the worker. \
+                                Defaults to 50, capped at 500. Use lower values for simple tasks."
+            }));
             let modes = self.available_modes();
-            if let Some(map) = props.as_object_mut() {
-                if modes.len() > 1 {
-                    map.insert(
-                        "mode".to_string(),
-                        serde_json::json!({
-                            "type": "string",
-                            "enum": modes,
-                            "description": self.mode_description(),
-                        }),
-                    );
-                }
-                if self.acp_enabled() {
-                    map.insert(
-                        "agent_name".to_string(),
-                        serde_json::json!({
-                            "type": "string",
-                            "description": "Name of the ACP agent to use (from 'ironclaw acp list'). \
-                                            Required when mode is 'acp'."
-                        }),
-                    );
-                }
+            if modes.len() > 1 {
+                props.insert(
+                    "mode".into(),
+                    serde_json::json!({
+                        "type": "string",
+                        "enum": modes,
+                        "description": self.mode_description(),
+                    }),
+                );
+            }
+            if self.acp_enabled() {
+                props.insert(
+                    "agent_name".into(),
+                    serde_json::json!({
+                        "type": "string",
+                        "description": "Name of the ACP agent to use (from 'ironclaw acp list'). \
+                                        Required when mode is 'acp'."
+                    }),
+                );
             }
             serde_json::json!({
                 "type": "object",

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -169,7 +169,9 @@ impl CreateJobTool {
         let mut desc =
             String::from("Execution mode. 'worker' (default) uses the IronClaw sub-agent.");
         if self.claude_code_enabled() {
-            desc.push_str(" 'claude_code' uses Claude Code CLI.");
+            desc.push_str(
+                " 'claude_code' uses Claude Code CLI — prefer this for complex software engineering tasks.",
+            );
         }
         if self.acp_enabled() {
             desc.push_str(" 'acp' uses an ACP-compliant agent (Goose, Codex, Gemini CLI).");
@@ -845,8 +847,7 @@ impl Tool for CreateJobTool {
              sub-agent that has shell, file read/write, list_dir, and apply_patch tools. Use this \
              whenever the user asks you to build, create, or work on something. The task \
              description should be detailed enough for the sub-agent to work independently. \
-             Set wait=false to start immediately while continuing the conversation. Set mode \
-             to 'claude_code' for complex software engineering tasks."
+             Set wait=false to start immediately while continuing the conversation."
         } else {
             "Create a new job or task for the agent to work on. Use this when the user wants \
              you to do something substantial that should be tracked as a separate job."
@@ -2558,6 +2559,16 @@ mod tests {
         assert!(
             err.contains("acp mode is not enabled"),
             "expected acp disabled error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_description_omits_mode_guidance() {
+        let tool = sandbox_tool(false, false);
+        let desc = tool.description();
+        assert!(
+            !desc.contains("claude_code"),
+            "description should not mention claude_code when mode is disabled, got: {desc}"
         );
     }
 }

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -144,6 +144,39 @@ impl CreateJobTool {
         self.job_manager.is_some()
     }
 
+    fn claude_code_enabled(&self) -> bool {
+        self.job_manager
+            .as_ref()
+            .is_some_and(|jm| jm.claude_code_enabled())
+    }
+
+    fn acp_enabled(&self) -> bool {
+        self.job_manager.as_ref().is_some_and(|jm| jm.acp_enabled())
+    }
+
+    fn available_modes(&self) -> Vec<&'static str> {
+        let mut modes = vec!["worker"];
+        if self.claude_code_enabled() {
+            modes.push("claude_code");
+        }
+        if self.acp_enabled() {
+            modes.push("acp");
+        }
+        modes
+    }
+
+    fn mode_description(&self) -> String {
+        let mut desc =
+            String::from("Execution mode. 'worker' (default) uses the IronClaw sub-agent.");
+        if self.claude_code_enabled() {
+            desc.push_str(" 'claude_code' uses Claude Code CLI.");
+        }
+        if self.acp_enabled() {
+            desc.push_str(" 'acp' uses an ACP-compliant agent (Goose, Codex, Gemini CLI).");
+        }
+        desc
+    }
+
     /// Parse and validate the `credentials` parameter.
     ///
     /// Each key is a secret name (must exist in SecretsStore), each value is the
@@ -822,59 +855,71 @@ impl Tool for CreateJobTool {
 
     fn parameters_schema(&self) -> serde_json::Value {
         if self.sandbox_enabled() {
+            let mut props = serde_json::json!({
+                "title": {
+                    "type": "string",
+                    "description": "Clear description of what to accomplish"
+                },
+                "description": {
+                    "type": "string",
+                    "description": "Full description of what needs to be done"
+                },
+                "wait": {
+                    "type": "boolean",
+                    "description": "If true (default), wait for the container to complete and return results. \
+                                    If false, start the container and return the job_id immediately."
+                },
+                "project_dir": {
+                    "type": "string",
+                    "description": "Path to an existing project directory to mount into the container. \
+                                    Must be under ~/.ironclaw/projects/. If omitted, a fresh directory is created."
+                },
+                "credentials": {
+                    "type": "object",
+                    "description": "Map of secret names to env var names. Each secret must exist in the \
+                                    secrets store (via 'ironclaw tool auth' or web UI). Example: \
+                                    {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
+                    "additionalProperties": { "type": "string" }
+                },
+                "mcp_servers": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Optional list of MCP server names to make available in the container. \
+                                    If omitted, the full master config is mounted. If empty, no MCP servers \
+                                    are available. Only effective when MCP_PER_JOB_ENABLED=true."
+                },
+                "max_iterations": {
+                    "type": "integer",
+                    "description": "Maximum number of agent loop iterations for the worker. \
+                                    Defaults to 50, capped at 500. Use lower values for simple tasks."
+                }
+            });
+            let modes = self.available_modes();
+            if let Some(map) = props.as_object_mut() {
+                if modes.len() > 1 {
+                    map.insert(
+                        "mode".to_string(),
+                        serde_json::json!({
+                            "type": "string",
+                            "enum": modes,
+                            "description": self.mode_description(),
+                        }),
+                    );
+                }
+                if self.acp_enabled() {
+                    map.insert(
+                        "agent_name".to_string(),
+                        serde_json::json!({
+                            "type": "string",
+                            "description": "Name of the ACP agent to use (from 'ironclaw acp list'). \
+                                            Required when mode is 'acp'."
+                        }),
+                    );
+                }
+            }
             serde_json::json!({
                 "type": "object",
-                "properties": {
-                    "title": {
-                        "type": "string",
-                        "description": "Clear description of what to accomplish"
-                    },
-                    "description": {
-                        "type": "string",
-                        "description": "Full description of what needs to be done"
-                    },
-                    "wait": {
-                        "type": "boolean",
-                        "description": "If true (default), wait for the container to complete and return results. \
-                                        If false, start the container and return the job_id immediately."
-                    },
-                    "mode": {
-                        "type": "string",
-                        "enum": ["worker", "claude_code", "acp"],
-                        "description": "Execution mode. 'worker' (default) uses the IronClaw sub-agent. \
-                                        'claude_code' uses Claude Code CLI. \
-                                        'acp' uses an ACP-compliant agent (Goose, Codex, Gemini CLI)."
-                    },
-                    "agent_name": {
-                        "type": "string",
-                        "description": "Name of the ACP agent to use (from 'ironclaw acp list'). \
-                                        Required when mode is 'acp'."
-                    },
-                    "project_dir": {
-                        "type": "string",
-                        "description": "Path to an existing project directory to mount into the container. \
-                                        Must be under ~/.ironclaw/projects/. If omitted, a fresh directory is created."
-                    },
-                    "credentials": {
-                        "type": "object",
-                        "description": "Map of secret names to env var names. Each secret must exist in the \
-                                        secrets store (via 'ironclaw tool auth' or web UI). Example: \
-                                        {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
-                        "additionalProperties": { "type": "string" }
-                    },
-                    "mcp_servers": {
-                        "type": "array",
-                        "items": { "type": "string" },
-                        "description": "Optional list of MCP server names to make available in the container. \
-                                        If omitted, the full master config is mounted. If empty, no MCP servers \
-                                        are available. Only effective when MCP_PER_JOB_ENABLED=true."
-                    },
-                    "max_iterations": {
-                        "type": "integer",
-                        "description": "Maximum number of agent loop iterations for the worker. \
-                                        Defaults to 50, capped at 500. Use lower values for simple tasks."
-                    }
-                },
+                "properties": props,
                 "required": ["title", "description"]
             })
         } else {
@@ -920,7 +965,18 @@ impl Tool for CreateJobTool {
         if self.sandbox_enabled() {
             let wait = params.get("wait").and_then(|v| v.as_bool()).unwrap_or(true);
 
-            let mode = match params.get("mode").and_then(|v| v.as_str()) {
+            let mode_str = params.get("mode").and_then(|v| v.as_str());
+            if mode_str == Some("claude_code") && !self.claude_code_enabled() {
+                return Err(ToolError::InvalidParameters(
+                    "claude_code mode is not enabled. Set CLAUDE_CODE_ENABLED=true.".into(),
+                ));
+            }
+            if mode_str == Some("acp") && !self.acp_enabled() {
+                return Err(ToolError::InvalidParameters(
+                    "acp mode is not enabled. Set ACP_ENABLED=true.".into(),
+                ));
+            }
+            let mode = match mode_str {
                 Some("claude_code") => JobMode::ClaudeCode,
                 Some("acp") => JobMode::Acp,
                 _ => JobMode::Worker,
@@ -2360,16 +2416,24 @@ mod tests {
         assert!(result.is_err()); // safety: test
     }
 
-    // ── ACP mode tests ──────────────────────────────────────────
+    // ── ACP / mode-gating tests ─────────────────────────────────
+
+    fn sandbox_tool(claude_code: bool, acp: bool) -> CreateJobTool {
+        let manager = Arc::new(ContextManager::new(5));
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig {
+                claude_code_enabled: claude_code,
+                acp_enabled: acp,
+                ..Default::default()
+            },
+            crate::orchestrator::TokenStore::new(),
+        ));
+        CreateJobTool::new(manager).with_sandbox(jm, None)
+    }
 
     #[test]
     fn test_sandbox_schema_includes_acp_mode() {
-        let manager = Arc::new(ContextManager::new(5));
-        let jm = Arc::new(ContainerJobManager::new(
-            crate::orchestrator::job_manager::ContainerJobConfig::default(),
-            crate::orchestrator::TokenStore::new(),
-        ));
-        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+        let tool = sandbox_tool(true, true);
         let schema = tool.parameters_schema();
         let mode_enum = schema["properties"]["mode"]["enum"].as_array().unwrap(); // safety: test
         let modes: Vec<&str> = mode_enum.iter().map(|v| v.as_str().unwrap()).collect(); // safety: test
@@ -2380,29 +2444,19 @@ mod tests {
 
     #[test]
     fn test_sandbox_schema_includes_agent_name() {
-        let manager = Arc::new(ContextManager::new(5));
-        let jm = Arc::new(ContainerJobManager::new(
-            crate::orchestrator::job_manager::ContainerJobConfig::default(),
-            crate::orchestrator::TokenStore::new(),
-        ));
-        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+        let tool = sandbox_tool(false, true);
         let schema = tool.parameters_schema();
         let props = schema.get("properties").unwrap().as_object().unwrap(); // safety: test
         assert!(
             /* safety: test */
             props.contains_key("agent_name"),
-            "sandbox schema must expose agent_name for ACP mode"
+            "sandbox schema must expose agent_name when ACP is enabled"
         );
     }
 
     #[tokio::test]
     async fn test_acp_mode_requires_agent_name() {
-        let manager = Arc::new(ContextManager::new(5));
-        let jm = Arc::new(ContainerJobManager::new(
-            crate::orchestrator::job_manager::ContainerJobConfig::default(),
-            crate::orchestrator::TokenStore::new(),
-        ));
-        let tool = CreateJobTool::new(manager).with_sandbox(jm, None);
+        let tool = sandbox_tool(false, true);
 
         let params = serde_json::json!({
             "title": "Test ACP job",
@@ -2423,5 +2477,87 @@ mod tests {
     fn test_job_mode_acp_as_str() {
         assert_eq!(JobMode::Acp.as_str(), "acp");
         assert_eq!(JobMode::Acp.to_string(), "acp");
+    }
+
+    #[test]
+    fn test_schema_excludes_mode_and_agent_name_when_only_worker() {
+        let tool = sandbox_tool(false, false);
+        let schema = tool.parameters_schema();
+        let props = schema["properties"].as_object().unwrap(); // safety: test
+        assert!(
+            !props.contains_key("mode"),
+            "mode field should be omitted when only worker is available"
+        );
+        assert!(
+            !props.contains_key("agent_name"),
+            "agent_name field should be omitted when ACP is disabled"
+        );
+    }
+
+    #[test]
+    fn test_schema_includes_claude_code_when_enabled() {
+        let tool = sandbox_tool(true, false);
+        let schema = tool.parameters_schema();
+        let mode_enum = schema["properties"]["mode"]["enum"].as_array().unwrap(); // safety: test
+        let modes: Vec<&str> = mode_enum
+            .iter()
+            .map(|v| v.as_str().unwrap()) // safety: test
+            .collect();
+        assert!(modes.contains(&"claude_code"));
+        assert!(!modes.contains(&"acp"));
+        let props = schema["properties"].as_object().unwrap(); // safety: test
+        assert!(
+            !props.contains_key("agent_name"),
+            "agent_name should be absent when ACP is disabled"
+        );
+    }
+
+    #[test]
+    fn test_schema_includes_acp_when_enabled() {
+        let tool = sandbox_tool(false, true);
+        let schema = tool.parameters_schema();
+        let mode_enum = schema["properties"]["mode"]["enum"].as_array().unwrap(); // safety: test
+        let modes: Vec<&str> = mode_enum
+            .iter()
+            .map(|v| v.as_str().unwrap()) // safety: test
+            .collect();
+        assert!(modes.contains(&"acp"));
+        assert!(!modes.contains(&"claude_code"));
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_claude_code_when_disabled() {
+        let tool = sandbox_tool(false, false);
+
+        let params = serde_json::json!({
+            "title": "Test job",
+            "description": "Test task",
+            "mode": "claude_code"
+        });
+        let result = tool.execute(params, &JobContext::default()).await;
+        assert!(result.is_err()); // safety: test
+        let err = result.unwrap_err().to_string(); // safety: test
+        assert!(
+            err.contains("claude_code mode is not enabled"),
+            "expected claude_code disabled error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_acp_when_disabled() {
+        let tool = sandbox_tool(false, false);
+
+        let params = serde_json::json!({
+            "title": "Test job",
+            "description": "Test task",
+            "mode": "acp"
+        });
+        let result = tool.execute(params, &JobContext::default()).await;
+        assert!(result.is_err()); // safety: test
+        let err = result.unwrap_err().to_string(); // safety: test
+        assert!(
+            err.contains("acp mode is not enabled"),
+            "expected acp disabled error, got: {err}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1987. `CreateJobTool` always offered `claude_code` and `acp` as valid modes in its JSON schema and accepted them at runtime, even when `CLAUDE_CODE_ENABLED=false` / `ACP_ENABLED=false`. This caused the LLM to select disabled modes, spawning containers that fail at startup.

- Add `claude_code_enabled` and `acp_enabled` to `ContainerJobConfig` (follows existing `mcp_per_job_enabled` pattern), with `ContainerJobManager` accessors
- `parameters_schema()` dynamically builds the mode enum — disabled modes are hidden; `mode` field omitted when only `worker` is available; `agent_name` field omitted when ACP is disabled
- `execute()` rejects disabled modes with `ToolError::InvalidParameters` as defense-in-depth
- No changes to `register_job_tools()` signature or any call sites — flags flow through the already-injected `job_manager`

## Test plan

- [x] 10 new regression tests (schema gating, runtime rejection, accessor delegation, defaults)
- [x] 3 existing tests updated to explicitly enable the modes they exercise
- [x] `cargo fmt` — no changes
- [x] `cargo clippy` — zero warnings
- [x] `cargo test --lib` — 4193 passed, 0 failed