### PR TITLE
fix: unblock bootstrap ownership on dynamic_tools

### DIFF
--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -357,13 +357,15 @@ impl Database for LibSqlBackend {
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
 
         let result = async {
+            // Only tables with a real `user_id` column participate in the legacy
+            // 'default' -> owner rewrite. `dynamic_tools` is intentionally excluded:
+            // it is ownerless today and scoped by `scope`, not `user_id`.
             let tables = [
                 "conversations",
                 "memory_documents",
                 "heartbeat_state",
                 "secrets",
                 "wasm_tools",
-                "dynamic_tools",
                 "routines",
                 "settings",
                 "agent_jobs",

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -74,13 +74,15 @@ impl Database for PgBackend {
             .transaction()
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        // Only tables with a real `user_id` column participate in the legacy
+        // 'default' -> owner rewrite. `dynamic_tools` is intentionally excluded:
+        // it is ownerless today and scoped by `scope`, not `user_id`.
         let tables = [
             "conversations",
             "memory_documents",
             "heartbeat_state",
             "secrets",
             "wasm_tools",
-            "dynamic_tools",
             "routines",
             "settings",
             "agent_jobs",

--- a/tests/ownership_integration.rs
+++ b/tests/ownership_integration.rs
@@ -113,7 +113,9 @@ mod tests {
         create_user(&db, "henry", "admin").await;
 
         // Run migrate_default_owner
-        db.migrate_default_owner("henry").await.unwrap();
+        db.migrate_default_owner("owner-bootstrap-test")
+            .await
+            .unwrap();
 
         // The settings row should now be under 'henry'
         let conn = db.connect().await.unwrap();
@@ -152,6 +154,16 @@ mod tests {
         create_user(&db, "henry", "admin").await;
 
         // No 'default' rows to migrate — should succeed without error
+        db.migrate_default_owner("henry").await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_migrate_default_owner_succeeds_on_fresh_migrated_db() {
+        let (db, _dir) = setup_db().await;
+
+        // Fresh installs include ownerless tables like `dynamic_tools`; the
+        // bootstrap rewrite should still succeed without assuming every table
+        // in the schema carries a `user_id` column.
         db.migrate_default_owner("henry").await.unwrap();
     }
 

--- a/tests/ownership_integration.rs
+++ b/tests/ownership_integration.rs
@@ -113,9 +113,7 @@ mod tests {
         create_user(&db, "henry", "admin").await;
 
         // Run migrate_default_owner
-        db.migrate_default_owner("owner-bootstrap-test")
-            .await
-            .unwrap();
+        db.migrate_default_owner("henry").await.unwrap();
 
         // The settings row should now be under 'henry'
         let conn = db.connect().await.unwrap();
@@ -140,7 +138,9 @@ mod tests {
         create_user(&db, "henry", "admin").await;
 
         // Run twice — should not error
-        db.migrate_default_owner("henry").await.unwrap();
+        db.migrate_default_owner("owner-bootstrap-test")
+            .await
+            .unwrap();
         db.migrate_default_owner("henry").await.unwrap();
 
         // Still exactly one henry row


### PR DESCRIPTION
## Summary
- remove `dynamic_tools` from `migrate_default_owner()` in both backends
- document that only tables with a real `user_id` column belong in the legacy default-owner rewrite
- add a fresh-migrated-db regression for the bootstrap failure mode

## Why
`bootstrap_ownership()` currently calls `migrate_default_owner()`, which was trying to run `UPDATE dynamic_tools SET user_id = ...` even though `dynamic_tools` has no `user_id` column. That aborts startup after schema migrations have already run.

## Validation
- `cargo test --test ownership_integration --no-default-features --features libsql`
- `cargo fmt --check`

## Notes
- No schema or migration changes in this follow-up
- Python ownership E2E smoke was not run in this checkout because no local `pytest` environment is present here