### PR TITLE
[codex] Fix ENGINE_V2 auto-approve tool behavior

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -315,6 +315,10 @@ impl Agent {
         &self.deps.llm
     }
 
+    pub(crate) fn config(&self) -> &AgentConfig {
+        &self.config
+    }
+
     /// Get the cheap/fast LLM provider, falling back to the main one.
     pub(crate) fn cheap_llm(&self) -> &Arc<dyn LlmProvider> {
         self.deps.cheap_llm.as_ref().unwrap_or(&self.deps.llm)

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -34,6 +34,8 @@ pub struct EffectBridgeAdapter {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     hooks: Arc<HookRegistry>,
+    /// Global auto-approve mode from agent config/env.
+    auto_approve_tools: bool,
     /// Tools the user has approved with "always" (persists within session).
     auto_approved: RwLock<HashSet<String>>,
     /// Per-step tool call counter (reset externally between steps).
@@ -56,12 +58,19 @@ impl EffectBridgeAdapter {
             tools,
             safety,
             hooks,
+            auto_approve_tools: false,
             auto_approved: RwLock::new(HashSet::new()),
             call_count: std::sync::atomic::AtomicU32::new(0),
             rate_limiter: RateLimiter::new(),
             mission_manager: RwLock::new(None),
             auth_manager: RwLock::new(None),
         }
+    }
+
+    /// Mirror the v1 dispatcher behavior for globally auto-approved tools.
+    pub fn with_global_auto_approve(mut self, enabled: bool) -> Self {
+        self.auto_approve_tools = enabled;
+        self
     }
 
     /// Mark a tool as auto-approved (user said "always").
@@ -460,7 +469,8 @@ impl EffectBridgeAdapter {
                     });
                 }
                 ApprovalRequirement::UnlessAutoApproved => {
-                    let is_approved = self.auto_approved.read().await.contains(lookup_name);
+                    let is_approved = self.auto_approve_tools
+                        || self.auto_approved.read().await.contains(lookup_name);
                     if !is_approved && !approval_already_granted {
                         // Credential presence alone does NOT bypass approval.
                         // Credentials indicate the call *can* be authenticated,
@@ -915,7 +925,74 @@ mod tests {
         assert!(adapter.auto_approved.read().await.contains("shell"));
     }
 
+    #[tokio::test]
+    async fn global_auto_approve_skips_unless_auto_approved_gates() {
+        use ironclaw_safety::SafetyConfig;
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(ApprovalTestTool)).await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let result = adapter
+            .execute_action(
+                "approval_test",
+                serde_json::json!({"value": "x"}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_global_auto_approve"),
+                ),
+            )
+            .await
+            .expect("global auto-approve should bypass approval gate");
+
+        assert!(!result.is_error);
+    }
+
+    #[tokio::test]
+    async fn global_auto_approve_does_not_bypass_always_gates() {
+        use ironclaw_safety::SafetyConfig;
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(AlwaysApprovalTestTool)).await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        )
+        .with_global_auto_approve(true);
+
+        let result = adapter
+            .execute_action(
+                "always_approval_test",
+                serde_json::json!({"value": "x"}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_global_auto_approve_always"),
+                ),
+            )
+            .await;
+
+        assert!(matches!(result, Err(EngineError::LeaseDenied { .. })));
+    }
+
     struct ApprovalTestTool;
+
+    struct AlwaysApprovalTestTool;
 
     #[async_trait]
     impl Tool for ApprovalTestTool {
@@ -949,6 +1026,41 @@ mod tests {
 
         fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
             ApprovalRequirement::UnlessAutoApproved
+        }
+    }
+
+    #[async_trait]
+    impl Tool for AlwaysApprovalTestTool {
+        fn name(&self) -> &str {
+            "always_approval_test"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that always requires explicit approval"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                }
+            })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                serde_json::json!({ "echo": params }),
+                std::time::Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::Always
         }
     }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -476,11 +476,14 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         Some(agent.cheap_llm().clone()),
     ));
 
-    let effect_adapter = Arc::new(EffectBridgeAdapter::new(
-        agent.tools().clone(),
-        agent.safety().clone(),
-        agent.hooks().clone(),
-    ));
+    let effect_adapter = Arc::new(
+        EffectBridgeAdapter::new(
+            agent.tools().clone(),
+            agent.safety().clone(),
+            agent.hooks().clone(),
+        )
+        .with_global_auto_approve(agent.config().auto_approve_tools),
+    );
 
     // Build centralized auth manager for pre-flight credential checks.
     let has_secrets = agent.tools().secrets_store().is_some();

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -12,13 +12,16 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod engine_v2_tests {
+    use async_trait::async_trait;
     use std::sync::OnceLock;
     use std::time::Duration;
 
     use tokio::sync::Mutex;
 
     use crate::support::test_rig::TestRigBuilder;
-    use crate::support::trace_llm::LlmTrace;
+    use crate::support::trace_llm::{LlmTrace, TraceResponse, TraceStep, TraceToolCall};
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
 
     fn engine_v2_test_lock() -> &'static Mutex<()> {
         static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
@@ -42,6 +45,47 @@ mod engine_v2_tests {
         "/tests/fixtures/llm_traces/engine_v2"
     );
     const TIMEOUT: Duration = Duration::from_secs(15);
+
+    struct ApprovalProbeTool;
+
+    #[async_trait]
+    impl Tool for ApprovalProbeTool {
+        fn name(&self) -> &str {
+            "approval_probe"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that should be auto-approved in engine v2"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "required": ["value"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                serde_json::json!({
+                    "ok": true,
+                    "echo": params.get("value").cloned().unwrap_or(serde_json::Value::Null),
+                }),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::UnlessAutoApproved
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Phase 1: Core scenarios — prove the v2 path works
@@ -174,6 +218,73 @@ mod engine_v2_tests {
         assert!(
             !completed.is_empty(),
             "should have ToolCompleted status events"
+        );
+        rig.shutdown();
+    }
+
+    /// Regression: engine v2 must honor the global auto-approve setting for
+    /// `UnlessAutoApproved` tools, matching the legacy dispatcher.
+    #[tokio::test]
+    async fn v2_honors_global_auto_approve_for_unless_auto_approved_tools() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::single_turn(
+            "test-v2-auto-approve",
+            "Run the approval probe tool",
+            vec![
+                TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::ToolCalls {
+                        tool_calls: vec![TraceToolCall {
+                            id: "call_approval_probe_1".into(),
+                            name: "approval_probe".into(),
+                            arguments: serde_json::json!({ "value": "engine-v2" }),
+                        }],
+                        input_tokens: 10,
+                        output_tokens: 5,
+                    },
+                    expected_tool_results: Vec::new(),
+                },
+                TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::Text {
+                        content: "approval probe completed".into(),
+                        input_tokens: 10,
+                        output_tokens: 5,
+                    },
+                    expected_tool_results: Vec::new(),
+                },
+            ],
+        );
+        let rig = TestRigBuilder::new()
+            .with_engine_v2()
+            .with_auto_approve_tools(true)
+            .with_trace(trace)
+            .with_extra_tools(vec![std::sync::Arc::new(ApprovalProbeTool)])
+            .build()
+            .await;
+
+        rig.send_message("Run the approval probe tool").await;
+        let responses = rig.wait_for_responses(1, Duration::from_secs(5)).await;
+
+        assert_eq!(
+            responses.len(),
+            1,
+            "expected a final response, got {responses:?}"
+        );
+        assert!(
+            responses[0].content.contains("approval probe completed"),
+            "unexpected response: {:?}",
+            responses[0]
+        );
+        assert_v2_tool_used(&rig.tool_calls_started(), "approval_probe");
+        assert!(
+            !rig.captured_status_events().iter().any(|status| {
+                matches!(
+                    status,
+                    ironclaw::channels::StatusUpdate::ApprovalNeeded { .. }
+                )
+            }),
+            "engine v2 should not emit ApprovalNeeded when global auto-approve is enabled"
         );
         rig.shutdown();
     }


### PR DESCRIPTION
## Summary
- make the engine v2 effect bridge honor `agent.auto_approve_tools` for `UnlessAutoApproved` tools
- keep `Always`-gated tools blocked even when global auto-approve is enabled
- add bridge-level and engine-v2 regression coverage for the approval behavior

## Root Cause
`ENGINE_V2=true` routed tool execution through the bridge adapter, but that adapter only tracked per-tool `always approve` decisions and never received the global `AGENT_AUTO_APPROVE_TOOLS` setting. As a result, the v1 dispatcher respected the flag while the v2 path still paused on standard approval-gated tools.

## Impact
This restores parity between the legacy dispatcher and engine v2 for tool approval behavior. Deployments using `AGENT_AUTO_APPROVE_TOOLS=true` will no longer get unexpected approval pauses in v2 for standard tools, while destructive `Always` approvals remain protected.

## Validation
- `cargo test global_auto_approve_ --lib --features libsql -- --nocapture`
- `cargo test need_approval_preserves_current_call_id --lib --features libsql -- --nocapture`
- `cargo test --test e2e_engine_v2 v2_honors_global_auto_approve_for_unless_auto_approved_tools --features libsql -- --nocapture`
- `cargo fmt --all --check`

Closes #2010