### PR TITLE
feat: native Matrix channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -161,6 +161,19 @@ HTTP_WEBHOOK_SECRET=your-webhook-secret
 #
 # DEPRECATED: Passing "secret" in the JSON body still works but will be removed in a future release.
 
+# Matrix Channel (optional, native Matrix Client-Server API)
+# Configure via `ironclaw onboard` (recommended) or environment variables.
+# The access token is stored in the encrypted secrets DB by the setup wizard;
+# set MATRIX_ACCESS_TOKEN here only if not using the secrets DB.
+# MATRIX_HOMESERVER=https://matrix.org              # required: full URL of homeserver
+# MATRIX_ACCESS_TOKEN=syt_...                       # token (prefer secrets DB via onboard)
+# MATRIX_ALLOW_FROM=@alice:matrix.org,@bob:matrix.org  # comma-separated, * for all, empty = pairing
+# MATRIX_DM_POLICY=pairing                          # open | allowlist | pairing (default: pairing)
+# MATRIX_OWNER_ID=                                  # restrict to a single Matrix user ID
+# MATRIX_POLL_INTERVAL_SECS=5                       # how often to poll /sync (default: 5)
+# MATRIX_AUTO_JOIN=true                             # auto-join invited rooms (default: true)
+# MATRIX_DISPLAY_NAME=IronClaw                      # bot display name
+
 # Signal Channel (optional, requires signal-cli daemon --http)
 # SIGNAL_HTTP_URL=http://127.0.0.1:8080
 # SIGNAL_ACCOUNT=+1234567890

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c56a59cf6315e99f874d2c1f96c69d2da5ffe0087d211297fc4a41f849770a2"
+checksum = "10eeef5e80864f9c3c148a3f395c3e35a66d37ec7561c7845b2bffae8e841759"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0497b9a95a404e35799904835c57c6f8c69b9d08ccfd3cb5b7d746425cd6789"
+checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -211,6 +211,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "anymap2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "aquamarine"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
+dependencies = [
+ "include_dir",
+ "itertools 0.10.5",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -240,6 +260,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "archery"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e0a5f99dfebb87bb342d0f53bb92c81842e100bbb915223e38349580e5441d"
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,12 +276,27 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "as-any"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0f477b951e452a0b6b4a10b53ccd569042d1d01729b519e02074a9c0958a063"
+
+[[package]]
+name = "as_variant"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dbc3a507a82b17ba0d98f6ce8fd6954ea0c8152e98009d36a40d8dcc8ce078a"
+
+[[package]]
+name = "assign"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f093eed78becd229346bf859eec0aa4dd7ddde0757287b2b4107a1f09c80002"
 
 [[package]]
 name = "astral-tl"
@@ -288,6 +329,18 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -988,6 +1041,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
+ "gloo-timers",
+ "tokio",
+]
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1137,9 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitmaps"
@@ -1082,6 +1149,12 @@ checksum = "031043d04099746d8db04daf1fa424b2bc8bd69d92b25962dcde24da39ab64a2"
 dependencies = [
  "typenum",
 ]
+
+[[package]]
+name = "bitmaps"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d084b0137aaa901caf9f1e8b21daa6aa24d41cd806e111335541eff9683bd6"
 
 [[package]]
 name = "bitvec"
@@ -1329,6 +1402,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd91ee7b2422bcb158d90ef4d14f75ef67f340943fc4149891dcce8f8b972a3"
+
+[[package]]
 name = "cap-fs-ext"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1470,6 +1549,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20",
+ "cipher",
+ "poly1305",
+ "zeroize",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1528,6 +1631,7 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -1658,6 +1762,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "compression-codecs"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1701,6 +1822,15 @@ dependencies = [
  "getrandom 0.2.17",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
 ]
 
 [[package]]
@@ -2186,6 +2316,7 @@ dependencies = [
  "digest",
  "fiat-crypto",
  "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -2242,6 +2373,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "date_header"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c03c416ed1a30fbb027ef484ba6ab6f80e1eada675e1a2b92fd673c045a1f1d"
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2277,12 +2414,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "deadpool-sync"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524bc3df0d57e98ecd022e21ba31166c2625e7d3e5bcc4510efaeeab4abcab04"
+dependencies = [
+ "deadpool-runtime",
+]
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "decancer"
+version = "3.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9244323129647178bf41ac861a2cdb9d9c81b9b09d3d0d1de9cd302b33b8a1d"
+dependencies = [
+ "lazy_static",
+ "regex",
 ]
 
 [[package]]
@@ -2503,6 +2659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
+ "serde",
  "signature",
 ]
 
@@ -2514,6 +2671,7 @@ checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
+ "rand_core 0.6.4",
  "serde",
  "sha2",
  "subtle",
@@ -2673,6 +2831,32 @@ dependencies = [
  "futures-core",
  "nom",
  "pin-project-lite",
+]
+
+[[package]]
+name = "eyeball"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93bd0ebf93d61d6332d3c09a96e97975968a44e19a64c947bde06e6baff383f"
+dependencies = [
+ "futures-core",
+ "readlock",
+ "readlock-tokio",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "eyeball-im"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4790c03df183c2b46665c1a58118c04fd3e3976ec2fe16a0aa00e00c9eea7754"
+dependencies = [
+ "futures-core",
+ "imbl",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3129,6 +3313,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "growable-bloom-filter"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d174ccb4ba660d431329e7f0797870d0a4281e36353ec4b4a3c5eab6c2cfb6f1"
+dependencies = [
+ "serde",
+ "serde_bytes",
+ "serde_derive",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3230,12 +3438,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8094feaf31ff591f651a2664fb9cfd92bba7a60ce3197265e9482ebe753c8f7"
 dependencies = [
  "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.4.0",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -3327,6 +3574,17 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
+dependencies = [
+ "log",
+ "markup5ever 0.35.0",
+ "match_token",
+]
+
+[[package]]
+name = "html5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
@@ -3374,6 +3632,15 @@ checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
 dependencies = [
  "bytes",
  "itoa",
+]
+
+[[package]]
+name = "http-auth"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "150fa4a9462ef926824cf4519c84ed652ca8f4fbae34cb8af045b5cbcaf98822"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3737,9 +4004,9 @@ version = "15.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af1955a75fa080c677d3972822ec4bad316169ab1cfc6c257a942c2265dbe5fe"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "rand_core 0.6.4",
- "rand_xoshiro",
+ "rand_xoshiro 0.6.0",
  "sized-chunks",
  "typenum",
  "version_check",
@@ -3757,6 +4024,49 @@ dependencies = [
  "num-traits",
  "png",
  "tiff",
+]
+
+[[package]]
+name = "imbl"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fade8ae6828627ad1fa094a891eccfb25150b383047190a3648d66d06186501"
+dependencies = [
+ "archery",
+ "bitmaps 3.2.1",
+ "imbl-sized-chunks",
+ "rand_core 0.9.5",
+ "rand_xoshiro 0.7.0",
+ "serde",
+ "version_check",
+]
+
+[[package]]
+name = "imbl-sized-chunks"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
+dependencies = [
+ "bitmaps 3.2.1",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -3919,6 +4229,7 @@ dependencies = [
  "jsonwebtoken",
  "libsql",
  "lru 0.16.3",
+ "matrix-sdk",
  "mime_guess",
  "open",
  "pdf-extract",
@@ -4217,6 +4528,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "js_int"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d937f95470b270ce8b8950207715d71aa8e153c0d44c6684d59397ed4949160a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "js_option"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7dd3e281add16813cf673bf74a32249b0aa0d1c8117519a17b3ada5e8552b3c"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "json5"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,9 +4558,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -4270,6 +4599,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4381b9b00c55f251f2ebe9473aef7c117e96828def1a7cb3bd3f0f903c6894e9"
+dependencies = [
+ "const_panic",
+ "konst_kernel",
+ "typewit",
+]
+
+[[package]]
+name = "konst_kernel"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b1eb7788f3824c629b1116a7a9060d6e898c358ebff59070093d51103dcc3c"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "kuchikikiki"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4283,6 +4632,12 @@ dependencies = [
  "precomputed-hash",
  "selectors 0.35.0",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy-regex"
@@ -4446,7 +4801,7 @@ checksum = "aeaf5d19e365465e1c23d687a28c805d7462531b3f619f0ba49d3cf369890a3e"
 dependencies = [
  "base64 0.21.7",
  "bytes",
- "prost",
+ "prost 0.12.6",
  "serde",
 ]
 
@@ -4459,7 +4814,7 @@ dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator 0.2.0",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.8.4",
  "libsql-ffi",
  "smallvec",
 ]
@@ -4510,7 +4865,7 @@ dependencies = [
  "libsql-rusqlite",
  "libsql-sys",
  "parking_lot",
- "prost",
+ "prost 0.12.6",
  "serde",
  "thiserror 1.0.69",
  "tokio",
@@ -4520,6 +4875,16 @@ dependencies = [
  "tracing",
  "uuid",
  "zerocopy 0.7.35",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "133c182a6a2c87864fe97778797e46c7e999672690dc9fa3ee8e241aa4a9c13f"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -4652,6 +5017,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "markup5ever"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
+dependencies = [
+ "log",
+ "tendril 0.4.3",
+ "web_atoms 0.1.3",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4659,7 +5041,7 @@ checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
  "tendril 0.4.3",
- "web_atoms",
+ "web_atoms 0.2.3",
 ]
 
 [[package]]
@@ -4670,7 +5052,7 @@ checksum = "8983d30f2915feeaaab2d6babdd6bc7e9ed1a00b66b5e6d74df19aa9c0e91862"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms",
+ "web_atoms 0.2.3",
 ]
 
 [[package]]
@@ -4681,7 +5063,18 @@ checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
  "tendril 0.5.0",
- "web_atoms",
+ "web_atoms 0.2.3",
+]
+
+[[package]]
+name = "match_token"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4704,6 +5097,181 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "matrix-pickle"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c34e6db65145740459f2ca56623b40cd4e6000ffae2a7d91515fa82aa935dbf"
+dependencies = [
+ "matrix-pickle-derive",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "matrix-pickle-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a962fc9981f823f6555416dcb2ae9ae67ca412d767ee21ecab5150113ee6285b"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "matrix-sdk"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33f9bc45edd7f8e25161521fdd30654da5c55e6749be6afa1aa9d6cf838ace0"
+dependencies = [
+ "anymap2",
+ "aquamarine",
+ "as_variant",
+ "async-channel",
+ "async-stream",
+ "async-trait",
+ "backon",
+ "bytes",
+ "bytesize",
+ "cfg-if",
+ "event-listener",
+ "eyeball",
+ "eyeball-im",
+ "futures-core",
+ "futures-util",
+ "gloo-timers",
+ "http 1.4.0",
+ "imbl",
+ "indexmap 2.13.0",
+ "itertools 0.14.0",
+ "js_int",
+ "language-tags",
+ "matrix-sdk-base",
+ "matrix-sdk-common",
+ "matrix-sdk-sqlite",
+ "mime",
+ "mime2ext",
+ "oauth2",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "reqwest",
+ "ruma",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "urlencoding",
+ "vodozemac",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-base"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70f404a390ff98a73c426b1496b169be60ce6a93723a9a664e579d978a84c5e4"
+dependencies = [
+ "as_variant",
+ "async-trait",
+ "bitflags 2.11.0",
+ "decancer",
+ "eyeball",
+ "eyeball-im",
+ "futures-util",
+ "growable-bloom-filter",
+ "matrix-sdk-common",
+ "matrix-sdk-store-encryption",
+ "once_cell",
+ "regex",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "matrix-sdk-common"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54fae2bdfc3d760d21a84d6d2036b5db5c48d9a3dee3794119e3fb9c4cc4ccc5"
+dependencies = [
+ "eyeball-im",
+ "futures-core",
+ "futures-executor",
+ "futures-util",
+ "gloo-timers",
+ "imbl",
+ "ruma",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "matrix-sdk-sqlite"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4325742fc06b7f75c80eec39e8fb32b06ea4b09b7aa1d432b67b01d08fbacc28"
+dependencies = [
+ "as_variant",
+ "async-trait",
+ "deadpool",
+ "deadpool-sync",
+ "itertools 0.14.0",
+ "matrix-sdk-base",
+ "matrix-sdk-store-encryption",
+ "num_cpus",
+ "rmp-serde",
+ "ruma",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "vodozemac",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-store-encryption"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162a93e83114d5cef25c0ebaea72aa01b9f233df6ec4a2af45f175d01ec26323"
+dependencies = [
+ "base64 0.22.1",
+ "blake3",
+ "chacha20poly1305",
+ "hmac",
+ "pbkdf2",
+ "rand 0.8.5",
+ "rmp-serde",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "zeroize",
+]
 
 [[package]]
 name = "maybe-owned"
@@ -4750,6 +5318,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime2ext"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf6f36070878c42c5233846cd3de24cf9016828fd47bc22957a687298bb21fc"
 
 [[package]]
 name = "mime_guess"
@@ -5001,6 +5575,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5246,6 +5840,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pdf-extract"
@@ -5578,6 +6182,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,6 +6328,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-utils"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5739,7 +6375,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -5750,6 +6396,19 @@ checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -5821,9 +6480,9 @@ dependencies = [
 
 [[package]]
 name = "pxfm"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a041e753da8b807c9255f28de81879c78c876392ff2469cde94799b2896b9d"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
@@ -6074,6 +6733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rangemap"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6136,6 +6804,21 @@ dependencies = [
  "thiserror 1.0.69",
  "url",
  "v_htmlescape",
+]
+
+[[package]]
+name = "readlock"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6da6f291b23556edd9edaf655a0be2ad8ef8002ff5f1bca62b264f3f58b53f34"
+
+[[package]]
+name = "readlock-tokio"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7e264f9ec4f3d112e8e2f214e8e7cb5cf3b83278f3570b7e00bfe13d3bd8ff"
+dependencies = [
+ "tokio",
 ]
 
 [[package]]
@@ -6209,9 +6892,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
@@ -6269,13 +6952,13 @@ dependencies = [
 
 [[package]]
 name = "regalloc2"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "952ddbfc6f9f64d006c3efd8c9851a6ba2f2b944ba94730db255d55006e0ffda"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "hashbrown 0.15.5",
+ "hashbrown 0.17.0",
  "log",
  "rustc-hash 2.1.2",
  "smallvec",
@@ -6447,6 +7130,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmp"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ba8be72d372b2c9b35542551678538b562e7cf86c3315773cae48dfbfe7790c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f81bee8c8ef9b577d1681a70ebbc962c232461e397b22c208c43c04b67a155"
+dependencies = [
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "ruff_python_ast"
 version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#6ded4bed1651e30b34dd04cdaa50c763036abb0d"
@@ -6510,6 +7212,194 @@ version = "0.0.0"
 source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#6ded4bed1651e30b34dd04cdaa50c763036abb0d"
 dependencies = [
  "get-size2",
+]
+
+[[package]]
+name = "ruma"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9f620a2116d0d3082f9256e61dcdf67f2ec266d3f6bb9d2f9c8a20ec5a1fabb"
+dependencies = [
+ "assign",
+ "js_int",
+ "js_option",
+ "ruma-client-api",
+ "ruma-common",
+ "ruma-events",
+ "ruma-federation-api",
+ "ruma-html",
+ "web-time",
+]
+
+[[package]]
+name = "ruma-client-api"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc977d1a91ea15dcf896cbd7005ed4a253784468833638998109ffceaee53e7"
+dependencies = [
+ "as_variant",
+ "assign",
+ "bytes",
+ "date_header",
+ "http 1.4.0",
+ "js_int",
+ "js_option",
+ "maplit",
+ "ruma-common",
+ "ruma-events",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 2.0.18",
+ "url",
+ "web-time",
+]
+
+[[package]]
+name = "ruma-common"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a01993f22d291320b7c9267675e7395775e95269ff526e2c8c3ed5e13175b"
+dependencies = [
+ "as_variant",
+ "base64 0.22.1",
+ "bytes",
+ "form_urlencoded",
+ "getrandom 0.2.17",
+ "http 1.4.0",
+ "indexmap 2.13.0",
+ "js_int",
+ "konst",
+ "percent-encoding",
+ "rand 0.8.5",
+ "regex",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_html_form",
+ "serde_json",
+ "thiserror 2.0.18",
+ "time",
+ "tracing",
+ "url",
+ "uuid",
+ "web-time",
+ "wildmatch",
+ "zeroize",
+]
+
+[[package]]
+name = "ruma-events"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dbdeccb62cb4ffe3282325de8ba28cbc0fdce7c78a3f11b7241fbfdb9cb9907"
+dependencies = [
+ "as_variant",
+ "indexmap 2.13.0",
+ "js_int",
+ "js_option",
+ "percent-encoding",
+ "regex",
+ "ruma-common",
+ "ruma-identifiers-validation",
+ "ruma-macros",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "web-time",
+ "wildmatch",
+ "zeroize",
+]
+
+[[package]]
+name = "ruma-federation-api"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb45c15badbf4299c6113a6b90df3e7cb64edbe756bbd8e0224144b56b38305"
+dependencies = [
+ "headers",
+ "http 1.4.0",
+ "http-auth",
+ "js_int",
+ "mime",
+ "ruma-common",
+ "ruma-events",
+ "ruma-signatures",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "ruma-html"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6dcd6e9823e177d15460d3cd3a413f38a2beea381f26aca1001c05cd6954ff"
+dependencies = [
+ "as_variant",
+ "html5ever 0.35.0",
+ "tracing",
+ "wildmatch",
+]
+
+[[package]]
+name = "ruma-identifiers-validation"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9c6b5643060beec0fc9d7acfb41d2c5d91e1591db440ff62361d178e77c35fe"
+dependencies = [
+ "js_int",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ruma-macros"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0753312ad577ac462de1742bf2e326b6ba9856ff6f13343aeb17d423fd5426"
+dependencies = [
+ "as_variant",
+ "cfg-if",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "ruma-identifiers-validation",
+ "serde",
+ "syn 2.0.117",
+ "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "ruma-signatures"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146ace2cd59b60ec80d3e801a84e7e6a91e3e01d18a9f5d896ea7ca16a6b8e08"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "pkcs8",
+ "rand 0.8.5",
+ "ruma-common",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "165ca6e57b20e1351573e3729b958bc62f0e48025386970b6e4d29e7a7e71f3f"
+dependencies = [
+ "bitflags 2.11.0",
+ "fallible-iterator 0.3.0",
+ "fallible-streaming-iterator",
+ "hashlink 0.10.0",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -6639,7 +7529,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -6711,9 +7601,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6983,6 +7873,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7011,6 +7911,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_html_form"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2f2d7ff8a2140333718bb329f5c40fc5f0865b84c426183ce14c97d2ab8154f"
+dependencies = [
+ "form_urlencoded",
+ "indexmap 2.13.0",
+ "itoa",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]
@@ -7271,7 +8184,7 @@ version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16d69225bde7a69b235da73377861095455d298f2b970996eec25ddbb42b3d1e"
 dependencies = [
- "bitmaps",
+ "bitmaps 2.1.0",
  "typenum",
 ]
 
@@ -7360,6 +8273,19 @@ checksum = "f42444fea5b87a39db4218d9422087e66a85d0e7a0963a439b07bcdf91804006"
 
 [[package]]
 name = "string_cache"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
+dependencies = [
+ "new_debug_unreachable",
+ "parking_lot",
+ "phf_shared 0.11.3",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
+name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
@@ -7368,6 +8294,18 @@ dependencies = [
  "parking_lot",
  "phf_shared 0.13.1",
  "precomputed-hash",
+]
+
+[[package]]
+name = "string_cache_codegen"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -8166,7 +9104,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.12.6",
  "tokio",
  "tokio-stream",
  "tower 0.4.13",
@@ -8257,14 +9195,18 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -8458,6 +9400,21 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "typewit"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06fee3a8df48c50c55ad646a4e03b00a370da6fe1850ebf467a8d0165dfcafae"
+dependencies = [
+ "typewit_proc_macros",
+]
+
+[[package]]
+name = "typewit_proc_macros"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e36a83ea2b3c704935a01b4642946aadd445cea40b10935e3f8bd8052b8193d6"
 
 [[package]]
 name = "ucd-trie"
@@ -8682,10 +9639,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vodozemac"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c022a277687e4e8685d72b95a7ca3ccfec907daa946678e715f8badaa650883d"
+dependencies = [
+ "aes",
+ "arrayvec",
+ "base64 0.22.1",
+ "base64ct",
+ "cbc",
+ "chacha20poly1305",
+ "curve25519-dalek",
+ "ed25519-dalek",
+ "getrandom 0.2.17",
+ "hkdf",
+ "hmac",
+ "matrix-pickle",
+ "prost 0.13.5",
+ "rand 0.8.5",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "vsimd"
@@ -9265,14 +10258,26 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
+dependencies = [
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+ "string_cache 0.8.9",
+ "string_cache_codegen 0.5.4",
+]
+
+[[package]]
+name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57a9779e9f04d2ac1ce317aee707aa2f6b773afba7b931222bff6983843b1576"
 dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "string_cache",
- "string_cache_codegen",
+ "string_cache 0.9.0",
+ "string_cache_codegen 0.6.1",
 ]
 
 [[package]]
@@ -9363,6 +10368,12 @@ dependencies = [
  "syn 2.0.117",
  "wiggle-generate",
 ]
+
+[[package]]
+name = "wildmatch"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
 
 [[package]]
 name = "winapi"
@@ -9895,6 +10906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "x509-cert"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9931,6 +10954,12 @@ name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "accessory"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28e416a3ab45838bac2ab2d81b1088d738d7b2d2c5272a54d39366565a29bd80"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,7 +83,7 @@ dependencies = [
  "anyhow",
  "async-broadcast",
  "async-trait",
- "derive_more",
+ "derive_more 2.1.1",
  "futures",
  "log",
  "serde",
@@ -85,7 +97,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
 dependencies = [
  "anyhow",
- "derive_more",
+ "derive_more 2.1.1",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -2236,7 +2248,7 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
- "derive_more",
+ "derive_more 2.1.1",
  "document-features",
  "mio",
  "parking_lot",
@@ -2442,6 +2454,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "delegate-display"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9926686c832494164c33a36bf65118f4bd6e704000b58c94681bf62e9ad67a74"
+dependencies = [
+ "impartial-ord",
+ "itoa",
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2475,6 +2501,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2498,11 +2535,31 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl 1.0.0",
+]
+
+[[package]]
+name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
 dependencies = [
- "derive_more-impl",
+ "derive_more-impl 2.1.1",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2886,6 +2943,18 @@ dependencies = [
  "bit-set",
  "regex-automata",
  "regex-syntax",
+]
+
+[[package]]
+name = "fancy_constructor"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a27643a5d05f3a22f5afd6e0d0e6e354f92d37907006f97b84b9cb79082198"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3322,6 +3391,19 @@ dependencies = [
  "futures-core",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4048,6 +4130,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f4241005618a62f8d57b2febd02510fb96e0137304728543dfc5fd6f052c22d"
 dependencies = [
  "bitmaps 3.2.1",
+]
+
+[[package]]
+name = "impartial-ord"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab604ee7085efba6efc65e4ebca0e9533e3aff6cb501d7d77b211e3a781c6d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4994,6 +5087,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "macroific"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f276537b4b8f981bf1c13d79470980f71134b7bdcc5e6e911e910e556b0285"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "macroific_macro",
+]
+
+[[package]]
+name = "macroific_attr_parse"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4023761b45fcd36abed8fb7ae6a80456b0a38102d55e89a57d9a594a236be9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "macroific_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a7594d3c14916fa55bef7e9d18c5daa9ed410dd37504251e4b75bbdeec33e3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sealed",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "macroific_macro"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4da6f2ed796261b0a74e2b52b42c693bb6dee1effba3a482c49592659f824b3b"
+dependencies = [
+ "macroific_attr_parse",
+ "macroific_core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5151,6 +5292,7 @@ dependencies = [
  "language-tags",
  "matrix-sdk-base",
  "matrix-sdk-common",
+ "matrix-sdk-indexeddb",
  "matrix-sdk-sqlite",
  "mime",
  "mime2ext",
@@ -5191,6 +5333,7 @@ dependencies = [
  "futures-util",
  "growable-bloom-filter",
  "matrix-sdk-common",
+ "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "once_cell",
  "regex",
@@ -5223,7 +5366,81 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "matrix-sdk-crypto"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "304fc576810a9618bb831c4ad6403c758ec424f677668a49a196e3cde4b8f99f"
+dependencies = [
+ "aes",
+ "aquamarine",
+ "as_variant",
+ "async-trait",
+ "bs58",
+ "byteorder",
+ "cfg-if",
+ "ctr",
+ "eyeball",
+ "futures-core",
+ "futures-util",
+ "hkdf",
+ "hmac",
+ "itertools 0.14.0",
+ "js_option",
+ "matrix-sdk-common",
+ "pbkdf2",
+ "rand 0.8.5",
+ "rmp-serde",
+ "ruma",
+ "serde",
+ "serde_json",
+ "sha2",
+ "subtle",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "ulid",
+ "url",
+ "vodozemac",
+ "zeroize",
+]
+
+[[package]]
+name = "matrix-sdk-indexeddb"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6096084cc8d339c03e269ca25534d0f1e88d0097c35a215eb8c311797ec3e9"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "futures-util",
+ "getrandom 0.2.17",
+ "gloo-utils",
+ "hkdf",
+ "js-sys",
+ "matrix-sdk-base",
+ "matrix-sdk-crypto",
+ "matrix-sdk-store-encryption",
+ "matrix_indexed_db_futures",
+ "rmp-serde",
+ "ruma",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "wasm-bindgen",
+ "web-sys",
+ "zeroize",
 ]
 
 [[package]]
@@ -5238,6 +5455,7 @@ dependencies = [
  "deadpool-sync",
  "itertools 0.14.0",
  "matrix-sdk-base",
+ "matrix-sdk-crypto",
  "matrix-sdk-store-encryption",
  "num_cpus",
  "rmp-serde",
@@ -5262,6 +5480,7 @@ dependencies = [
  "base64 0.22.1",
  "blake3",
  "chacha20poly1305",
+ "getrandom 0.2.17",
  "hmac",
  "pbkdf2",
  "rand 0.8.5",
@@ -5271,6 +5490,45 @@ dependencies = [
  "sha2",
  "thiserror 2.0.18",
  "zeroize",
+]
+
+[[package]]
+name = "matrix_indexed_db_futures"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245ff6a224b4df7b0c90dda2dd5a6eb46112708d49e8bdd8b007fccb09fea8e4"
+dependencies = [
+ "accessory",
+ "cfg-if",
+ "delegate-display",
+ "derive_more 2.1.1",
+ "fancy_constructor",
+ "futures-core",
+ "js-sys",
+ "matrix_indexed_db_futures_macros_internal",
+ "sealed",
+ "serde",
+ "serde-wasm-bindgen",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm_evt_listener",
+ "web-sys",
+ "web-time",
+]
+
+[[package]]
+name = "matrix_indexed_db_futures_macros_internal"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b428aee5c0fe9e5babd29e99d289b7f64718c444989aac0442d1fd6d3e3f66d1"
+dependencies = [
+ "macroific",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -7268,6 +7526,7 @@ dependencies = [
  "getrandom 0.2.17",
  "http 1.4.0",
  "indexmap 2.13.0",
+ "js-sys",
  "js_int",
  "konst",
  "percent-encoding",
@@ -7750,6 +8009,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "secrecy"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7822,7 +8092,7 @@ checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
- "derive_more",
+ "derive_more 2.1.1",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
@@ -7841,7 +8111,7 @@ checksum = "93fdfed56cd634f04fe8b9ddf947ae3dc493483e819593d2ba17df9ad05db8b2"
 dependencies = [
  "bitflags 2.11.0",
  "cssparser",
- "derive_more",
+ "derive_more 2.1.1",
  "log",
  "new_debug_unreachable",
  "phf 0.13.1",
@@ -7870,6 +8140,17 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -9434,6 +9715,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.2",
+ "web-time",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9870,6 +10161,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm_evt_listener"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc92d6378b411ed94839112a36d9dbc77143451d85b05dfb0cce93a78dab1963"
+dependencies = [
+ "accessory",
+ "derivative",
+ "derive_more 1.0.0",
+ "fancy_constructor",
+ "futures-core",
+ "js-sys",
+ "smallvec",
+ "tokio",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10253,6 +10562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,21 @@ secrecy = { version = "0.10", features = ["serde"] }
 url = "2"
 urlencoding = "2"
 
+# Matrix SDK (optional — used for the native Matrix channel event loop and E2EE).
+# The `sqlite` feature provides a persistent state + crypto store backed by SQLite.
+# `e2e-encryption` is added separately in the matrix-e2ee feature below.
+#
+# NOTE: vodozemac (the Olm/Megolm crypto library used by matrix-sdk) has an
+# unpatched high-severity vulnerability as of 2026-02-17 (identity-element DH
+# accepted in the 3DH handshake, allowing a participant with an all-zero public
+# key to produce a predictable shared secret). Track:
+#   https://github.com/matrix-org/vodozemac/issues
+# Upgrade vodozemac / matrix-sdk-crypto as soon as a patch ships.
+matrix-sdk = { version = "0.16", optional = true, default-features = false, features = [
+    "rustls-tls",
+    "sqlite",
+] }
+
 # Open URLs in browser
 open = "5"
 
@@ -229,7 +244,7 @@ tempfile = "3"
 insta = { version = "1.46.3", features = ["yaml"] }
 
 [features]
-default = ["postgres", "libsql", "html-to-markdown", "tui"]
+default = ["postgres", "libsql", "html-to-markdown", "tui", "matrix-sdk-channel"]
 postgres = [
     "dep:deadpool-postgres",
     "dep:tokio-postgres",
@@ -254,6 +269,11 @@ html-to-markdown = ["dep:html-to-markdown-rs", "dep:readabilityrs"]
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 tui = ["dep:ironclaw_tui"]
 import = ["dep:json5", "libsql"]
+# matrix-sdk-channel: use the matrix-sdk event loop for the native Matrix
+# channel instead of the raw reqwest poll loop. Required for E2EE (step 2).
+# Enabled by default; disable with --no-default-features if you want the
+# minimal reqwest-only build.
+matrix-sdk-channel = ["dep:matrix-sdk"]
 
 [[test]]
 name = "e2e_thread_scheduling"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,7 @@ urlencoding = "2"
 matrix-sdk = { version = "0.16", optional = true, default-features = false, features = [
     "rustls-tls",
     "sqlite",
+    "e2e-encryption",
 ] }
 
 # Open URLs in browser
@@ -244,7 +245,7 @@ tempfile = "3"
 insta = { version = "1.46.3", features = ["yaml"] }
 
 [features]
-default = ["postgres", "libsql", "html-to-markdown", "tui", "matrix-sdk-channel"]
+default = ["postgres", "libsql", "html-to-markdown", "tui", "matrix-e2ee"]
 postgres = [
     "dep:deadpool-postgres",
     "dep:tokio-postgres",
@@ -270,10 +271,18 @@ bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types
 tui = ["dep:ironclaw_tui"]
 import = ["dep:json5", "libsql"]
 # matrix-sdk-channel: use the matrix-sdk event loop for the native Matrix
-# channel instead of the raw reqwest poll loop. Required for E2EE (step 2).
-# Enabled by default; disable with --no-default-features if you want the
-# minimal reqwest-only build.
+# channel instead of the raw reqwest poll loop. Required for E2EE.
+# Enabled by default via matrix-e2ee; can be enabled alone (without E2EE)
+# or disabled entirely with --no-default-features for the minimal reqwest build.
 matrix-sdk-channel = ["dep:matrix-sdk"]
+# matrix-e2ee: enable end-to-end encryption in the Matrix channel.
+# Requires and implies matrix-sdk-channel. Default on.
+# Disable with --no-default-features to build without E2EE (or without matrix-sdk).
+# NOTE: vodozemac has an unpatched identity-element DH vulnerability as of
+# 2026-02-17. The threat model for a personal bot (trusted participants,
+# untrusted homeserver) makes E2EE still strictly better than plaintext.
+# Upgrade matrix-sdk when a patched vodozemac ships.
+matrix-e2ee = ["matrix-sdk-channel"]
 
 [[test]]
 name = "e2e_thread_scheduling"

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -78,7 +78,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Feishu/Lark | ✅ | 🚧 | P3 | WASM channel with Event Subscription v2.0; Bitable/Docx tools planned |
 | LINE | ✅ | ❌ | P3 | |
 | WebChat | ✅ | ✅ | - | Web gateway chat |
-| Matrix | ✅ | ❌ | P3 | E2EE support |
+| Matrix | ✅ | 🚧 | P3 | Native channel (SDK + poll fallback); E2EE via `matrix-e2ee` feature gate; WASM channel also available |
 | Mattermost | ✅ | ❌ | P3 | Emoji reactions, interactive buttons, model picker |
 | Google Chat | ✅ | ❌ | P3 | |
 | MS Teams | ✅ | ❌ | P3 | |
@@ -577,7 +577,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 ### P3 - Lower Priority
 
 - ❌ Discord channel
-- ❌ Matrix channel
+- 🚧 Matrix channel (native SDK + poll fallback; E2EE enabled via feature gate; media and rich threading pending)
 - ❌ Other messaging platforms
 - ❌ TTS/audio features
 - ❌ Video support

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -739,6 +739,14 @@ impl Agent {
 
     /// Run the agent main loop.
     pub async fn run(self) -> Result<(), Error> {
+        // Seed the thread map from persisted conversations so that channel-native
+        // room/chat IDs (e.g. Matrix room IDs, Telegram chat IDs) survive restarts
+        // and route back to the correct existing conversation.
+        if let Some(db) = self.deps.store.as_ref() {
+            self.session_manager.seed_from_db(db).await;
+        }
+
+
         // Eagerly initialize engine v2 so gateway API endpoints can serve
         // data (projects, missions, threads) before the first chat message.
         if self.config.engine_v2

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -275,6 +275,63 @@ impl SessionManager {
         }
     }
 
+    /// Seed the thread map from persisted conversations at startup.
+    ///
+    /// Queries all conversations with a non-null `thread_id` (i.e. a
+    /// channel-native room/chat ID) and registers the
+    /// `(user_id, channel, external_thread_id) → conversation_uuid` mapping
+    /// so that messages arriving after a restart are routed to the correct
+    /// existing conversation rather than creating a duplicate.
+    ///
+    /// Only populates the thread map — it does **not** create `Session` or
+    /// `Thread` objects, which are created lazily on first use as usual.
+    pub async fn seed_from_db(&self, db: &Arc<dyn crate::db::Database>) {
+        match db.list_external_thread_mappings().await {
+            Ok(mappings) => {
+                let mut thread_map = self.thread_map.write().await;
+                let mut undo_managers = self.undo_managers.write().await;
+                for (conv_id, channel, user_id, external_thread_id) in mappings {
+                    let key = ThreadKey {
+                        user_id,
+                        channel,
+                        external_thread_id: Some(external_thread_id),
+                    };
+                    thread_map.entry(key).or_insert(conv_id);
+                    undo_managers
+                        .entry(conv_id)
+                        .or_insert_with(|| Arc::new(Mutex::new(UndoManager::new())));
+                }
+                tracing::debug!(
+                    count = thread_map.len(),
+                    "Seeded session manager thread map from DB"
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Failed to seed thread map from DB: {}", e);
+            }
+        }
+    }
+
+    /// Look up the internal conversation UUID for a
+    /// `(user_id, channel, external_thread_id)` triple.
+    ///
+    /// Returns `None` if there is no mapping (the thread has never been seen
+    /// or was not seeded from the DB).
+    pub async fn lookup_thread_id(
+        &self,
+        user_id: &str,
+        channel: &str,
+        external_thread_id: &str,
+    ) -> Option<Uuid> {
+        let key = ThreadKey {
+            user_id: user_id.to_string(),
+            channel: channel.to_string(),
+            external_thread_id: Some(external_thread_id.to_string()),
+        };
+        let thread_map = self.thread_map.read().await;
+        thread_map.get(&key).copied()
+    }
+
     /// Get undo manager for a thread.
     pub async fn get_undo_manager(&self, thread_id: Uuid) -> Arc<Mutex<UndoManager>> {
         // Fast path

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -219,10 +219,22 @@ impl Agent {
         message: &IncomingMessage,
         external_thread_id: &str,
     ) -> Option<String> {
-        // Only hydrate UUID-shaped thread IDs (web gateway uses UUIDs)
+        // Resolve the internal conversation UUID.  Try direct UUID parse first
+        // (gateway sends UUIDs), then fall back to a thread-map lookup for
+        // channel-native IDs (e.g. Matrix room IDs, Telegram chat IDs) that
+        // were seeded from the DB at startup.
         let thread_uuid = match Uuid::parse_str(external_thread_id) {
             Ok(id) => id,
-            Err(_) => return None,
+            Err(_) => {
+                match self
+                    .session_manager
+                    .lookup_thread_id(&message.user_id, &message.channel, external_thread_id)
+                    .await
+                {
+                    Some(id) => id,
+                    None => return None,
+                }
+            }
         };
 
         // Check if already in memory
@@ -685,6 +697,7 @@ impl Agent {
                 turn_number,
                 effective_content,
                 turn_started_at,
+                message.thread_id.as_ref().map(|t| t.as_str()),
             )
             .await;
 
@@ -728,8 +741,13 @@ impl Agent {
 
         if thread.state == ThreadState::Interrupted {
             drop(sess);
-            self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                .await;
+            self.clear_conversation_live_state(
+                thread_id,
+                &message.channel,
+                &message.user_id,
+                message.thread_id.as_ref().map(|t| t.as_str()),
+            )
+            .await;
             if let Some(turn_usage) = turn_usage_from_result(&result) {
                 self.send_turn_cost_status(&message.channel, &message.metadata, turn_usage)
                     .await;
@@ -792,6 +810,7 @@ impl Agent {
                     turn_number,
                     &tool_calls,
                     narrative.as_deref(),
+                    message.thread_id.as_ref().map(|t| t.as_str()),
                 )
                 .await;
                 self.persist_assistant_response(
@@ -799,6 +818,7 @@ impl Agent {
                     &message.channel,
                     &message.user_id,
                     &response,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
                 )
                 .await;
 
@@ -831,8 +851,13 @@ impl Agent {
                 let allow_always = pending.allow_always;
                 thread.await_approval(*pending);
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
+                )
+                .await;
                 self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
                     .await;
                 let _ = self
@@ -881,6 +906,7 @@ impl Agent {
                     turn_number,
                     &tool_calls,
                     narrative.as_deref(),
+                    message.thread_id.as_ref().map(|t| t.as_str()),
                 )
                 .await;
                 self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
@@ -892,15 +918,25 @@ impl Agent {
                     .await;
                 thread.conclude_turn(TurnOutcome::Failed(error.to_string()));
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
+                )
+                .await;
                 Ok(SubmissionResult::error(error.to_string()))
             }
             Err(e) => {
                 thread.conclude_turn(TurnOutcome::Failed(e.to_string()));
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
+                )
+                .await;
                 // User message already persisted at turn start; nothing else to save
                 Ok(SubmissionResult::error(e.to_string()))
             }
@@ -909,6 +945,10 @@ impl Agent {
 
     /// Ensure a thread UUID is writable for `(channel, user_id)`.
     ///
+    /// `external_thread_id` is the channel-native room/chat ID (e.g. Matrix room ID,
+    /// Telegram chat ID). When provided it is persisted to the `thread_id` column of
+    /// the `conversations` table so that the mapping survives restarts.
+    ///
     /// Returns `false` for foreign/unowned conversation IDs or DB errors.
     async fn ensure_writable_conversation(
         &self,
@@ -916,9 +956,16 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
     ) -> bool {
         match store
-            .ensure_conversation(thread_id, channel, user_id, None, Some(channel))
+            .ensure_conversation(
+                thread_id,
+                channel,
+                user_id,
+                external_thread_id,
+                Some(channel),
+            )
             .await
         {
             Ok(true) => true,
@@ -965,6 +1012,7 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
         live_state: ProcessingLiveState<'_>,
     ) {
         let store = match self.store() {
@@ -973,7 +1021,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -995,6 +1043,7 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
     ) {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -1002,7 +1051,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1028,6 +1077,7 @@ impl Agent {
     ///
     /// This ensures the user message is durable even if the process crashes
     /// mid-response. Call this right after `thread.start_turn()`.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn persist_user_message(
         &self,
         thread_id: Uuid,
@@ -1036,6 +1086,7 @@ impl Agent {
         turn_number: usize,
         user_input: &str,
         started_at: DateTime<Utc>,
+        external_thread_id: Option<&str>,
     ) -> Option<Uuid> {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -1043,7 +1094,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return None;
@@ -1058,6 +1109,7 @@ impl Agent {
                     thread_id,
                     channel,
                     user_id,
+                    external_thread_id,
                     ProcessingLiveState {
                         turn_number,
                         user_message_id: Some(user_message_id),
@@ -1074,6 +1126,7 @@ impl Agent {
                     thread_id,
                     channel,
                     user_id,
+                    external_thread_id,
                     ProcessingLiveState {
                         turn_number,
                         user_message_id: None,
@@ -1098,6 +1151,7 @@ impl Agent {
         channel: &str,
         user_id: &str,
         response: &str,
+        external_thread_id: Option<&str>,
     ) {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -1105,7 +1159,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1142,6 +1196,7 @@ impl Agent {
     /// Content is a JSON object: `{ "calls": [...], "narrative": "..." }`.
     /// The `calls` array contains tool call summaries with optional `rationale`
     /// and `tool_call_id` fields. Legacy rows may be plain JSON arrays.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn persist_tool_calls(
         &self,
         thread_id: Uuid,
@@ -1150,6 +1205,7 @@ impl Agent {
         turn_number: usize,
         tool_calls: &[crate::agent::session::TurnToolCall],
         narrative: Option<&str>,
+        external_thread_id: Option<&str>,
     ) {
         if tool_calls.is_empty() {
             return;
@@ -1212,7 +1268,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1316,7 +1372,7 @@ impl Agent {
                     .unwrap_or_else(|| "gateway".to_string());
                 thread.interrupt();
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &channel, &user_id)
+                self.clear_conversation_live_state(thread_id, &channel, &user_id, None)
                     .await;
                 Ok(SubmissionResult::ok_with_message("Interrupted."))
             }
@@ -1382,7 +1438,7 @@ impl Agent {
         thread.pending_messages.clear();
         thread.state = ThreadState::Idle;
         drop(sess);
-        self.clear_conversation_live_state(thread_id, &channel, &user_id)
+        self.clear_conversation_live_state(thread_id, &channel, &user_id, None)
             .await;
 
         // Clear undo history too
@@ -1537,6 +1593,7 @@ impl Agent {
                     thread_id,
                     &message.channel,
                     &message.user_id,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
                     ProcessingLiveState {
                         turn_number,
                         user_message_id,
@@ -1981,8 +2038,13 @@ impl Agent {
                     }
                 }
 
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.thread_id.as_ref().map(|t| t.as_str()),
+                )
+                .await;
 
                 let _ = self
                     .channels
@@ -2075,6 +2137,7 @@ impl Agent {
                         turn_number,
                         &tool_calls,
                         narrative.as_deref(),
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     self.persist_assistant_response(
@@ -2082,6 +2145,7 @@ impl Agent {
                         &message.channel,
                         &message.user_id,
                         &response,
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     if !suggestions.is_empty() {
@@ -2113,6 +2177,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
@@ -2154,6 +2219,7 @@ impl Agent {
                         turn_number,
                         &tool_calls,
                         narrative.as_deref(),
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
@@ -2169,6 +2235,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     Ok(SubmissionResult::error(error.to_string()))
@@ -2180,6 +2247,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                     // User message already persisted at turn start
@@ -2205,6 +2273,7 @@ impl Agent {
                             &message.channel,
                             &message.user_id,
                             &rejection,
+                            message.thread_id.as_ref().map(|t| t.as_str()),
                         )
                         .await;
                     }
@@ -2255,6 +2324,7 @@ impl Agent {
                         &message.channel,
                         &message.user_id,
                         &instructions,
+                        message.thread_id.as_ref().map(|t| t.as_str()),
                     )
                     .await;
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -325,16 +325,25 @@ impl AppBuilder {
                     .await;
             }
 
-            // Inject LLM API keys from encrypted storage
+            // Inject LLM API keys + channel tokens from encrypted storage.
             crate::config::inject_llm_keys_from_secrets(secrets.as_ref(), &self.config.owner_id)
                 .await;
 
-            // Re-resolve only the LLM config with newly available keys,
-            // including keys hydrated from the secrets store.
+            // Re-resolve LLM and channel config with newly available secrets.
             let settings_store: Option<&(dyn crate::db::SettingsStore + Sync)> =
                 self.db.as_ref().map(|db| db.as_ref() as _);
             let toml_path = self.toml_path.as_deref();
             let owner_id = self.config.owner_id.clone();
+
+            // Re-resolve channel config with newly injected secrets.
+            if let Err(e) = self
+                .config
+                .re_resolve_channels(settings_store, &owner_id, toml_path)
+                .await
+            {
+                tracing::warn!("Failed to re-resolve channel config after secret injection: {e}");
+            }
+
             // is_operator=true: owner_id is the operator/admin scope.
             if let Err(e) = self
                 .config

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -1,0 +1,1883 @@
+//! Matrix channel via the Matrix Client-Server API.
+//!
+//! # Feature gates
+//!
+//! When the `matrix-sdk-channel` feature is enabled (default), the channel
+//! uses the [`matrix_sdk`] crate for syncing.  The SDK handles room-state
+//! bookkeeping, auto-join, to-device messages, and (once `e2e-encryption` is
+//! added) transparent E2EE decryption.  State is persisted in a SQLite store
+//! at `~/.ironclaw/matrix-sdk/` so the bot survives restarts without losing
+//! its sync token or (later) its Olm session keys.
+//!
+//! When the feature is **disabled** the channel falls back to a raw
+//! `reqwest`-based poll loop against `/_matrix/client/v3/sync`.  This path
+//! has no external dependencies beyond those already in the binary, but it
+//! cannot support E2EE.
+//!
+//! # Architecture (SDK path)
+//!
+//! ```text
+//! MatrixChannel::start()
+//!   → build matrix_sdk::Client (sqlite_store at sdk_store_path)
+//!   → restore_session (access_token + device_id from secrets DB)
+//!   → register SyncEventHandler → emits IncomingMessage via mpsc
+//!   → spawn Client::sync() loop
+//! MatrixChannel::respond()
+//!   → sdk_client.get_room(room_id)?.send(RoomMessageEventContent)
+//! MatrixChannel::send_status()
+//!   → room.send_typing_notification() / room.send(text msg)
+//! MatrixChannel::health_check()
+//!   → GET /_matrix/client/v3/account/whoami (raw HTTP, lightweight)
+//! ```
+//!
+//! # Architecture (raw poll path)
+//!
+//! ```text
+//! MatrixChannel::start()
+//!   → whoami (validate token, get bot user_id)
+//!   → initial sync (prime next_batch)
+//!   → spawn polling loop → yield IncomingMessage via mpsc channel
+//! MatrixChannel::respond()
+//!   → PUT /_matrix/client/v3/rooms/{room}/send/m.room.message/{txnId}
+//! ```
+//!
+//! # Access control
+//!
+//! Both paths share the same access-control logic:
+//!
+//! - `owner_id` (if set): only that Matrix user ID is allowed; all others dropped.
+//! - `dm_policy`:
+//!   - `"open"` — accept all messages
+//!   - `"allowlist"` — only senders in `allow_from` or pairing store
+//!   - `"pairing"` (default) — same as allowlist, but sends a pairing prompt
+//!     to unknown senders in private (2-member) rooms only
+//! - Pairing prompts are never sent to group rooms (> 2 members).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use secrecy::ExposeSecret;
+use tokio::sync::{RwLock, mpsc};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
+use crate::config::MatrixConfig;
+use crate::error::ChannelError;
+use crate::pairing::PairingStore;
+
+const CHANNEL_NAME: &str = "matrix";
+
+// ── Shared: access-control decision ──────────────────────────────────────────
+
+/// Decision returned by `check_sender`.
+enum SenderDecision {
+    Allow,
+    Deny,
+    /// Denied — send pairing prompt to this room.
+    Pair(String),
+}
+
+/// Check whether `allow_from` config or the pairing store allows `sender`.
+async fn is_allowed_by_config_or_store(
+    config: &MatrixConfig,
+    sender: &str,
+    pairing_store: &PairingStore,
+) -> bool {
+    let in_config = config
+        .allow_from
+        .iter()
+        .any(|e| e.trim() == "*" || e.trim().to_lowercase() == sender.to_lowercase());
+    if in_config {
+        return true;
+    }
+    // Check whether the sender has been paired (approved) in the database.
+    pairing_store
+        .resolve_identity(CHANNEL_NAME, sender)
+        .await
+        .ok()
+        .flatten()
+        .is_some()
+}
+
+/// Determine if a message from `sender` in `room_id` should be processed.
+async fn check_sender(
+    config: &MatrixConfig,
+    sender: &str,
+    room_id: &str,
+    pairing_store: &PairingStore,
+) -> SenderDecision {
+    if let Some(ref owner) = config.owner_id {
+        if sender.to_lowercase() != owner.to_lowercase() {
+            return SenderDecision::Deny;
+        }
+        return SenderDecision::Allow;
+    }
+
+    match config.dm_policy.as_str() {
+        "open" => SenderDecision::Allow,
+        "allowlist" => {
+            if is_allowed_by_config_or_store(config, sender, pairing_store).await {
+                SenderDecision::Allow
+            } else {
+                SenderDecision::Deny
+            }
+        }
+        _ => {
+            // "pairing" (default)
+            if is_allowed_by_config_or_store(config, sender, pairing_store).await {
+                SenderDecision::Allow
+            } else {
+                SenderDecision::Pair(room_id.to_string())
+            }
+        }
+    }
+}
+
+// ── Shared helpers (used by both SDK and raw paths) ──────────────────────────
+
+/// Extract `room_id` from message metadata, falling back to `thread_id`.
+fn extract_room_id(msg: &IncomingMessage) -> Result<&str, ChannelError> {
+    msg.metadata
+        .get("room_id")
+        .and_then(|v| v.as_str())
+        .or(msg.thread_id.as_ref().map(|t| t.as_str()))
+        .ok_or_else(|| ChannelError::MissingRoutingTarget {
+            name: CHANNEL_NAME.to_string(),
+            reason: "no room_id in message metadata".to_string(),
+        })
+}
+
+/// Build the `conversation_context` map from message metadata.
+fn build_conversation_context(metadata: &serde_json::Value) -> HashMap<String, String> {
+    let mut ctx = HashMap::new();
+    if let Some(room_id) = metadata.get("room_id").and_then(|v| v.as_str()) {
+        ctx.insert("matrix_room_id".to_string(), room_id.to_string());
+    }
+    if let Some(homeserver) = metadata.get("homeserver").and_then(|v| v.as_str()) {
+        ctx.insert("matrix_homeserver".to_string(), homeserver.to_string());
+    }
+    ctx
+}
+
+/// Format a `StatusUpdate` into a text message to send, or `None` for
+/// variants that don't produce text (e.g. `Thinking`, which triggers a
+/// typing indicator instead).
+fn format_status_message(status: &StatusUpdate) -> Option<String> {
+    match status {
+        StatusUpdate::ApprovalNeeded {
+            tool_name,
+            description,
+            ..
+        } => Some(format!(
+            "⏳ Approval needed for `{}`: {}",
+            tool_name, description
+        )),
+        StatusUpdate::AuthRequired {
+            extension_name,
+            instructions,
+            ..
+        } => {
+            if let Some(inst) = instructions {
+                Some(format!(
+                    "🔑 Auth required for `{}`: {}",
+                    extension_name, inst
+                ))
+            } else {
+                Some(format!("🔑 Auth required for `{}`.", extension_name))
+            }
+        }
+        StatusUpdate::AuthCompleted {
+            extension_name,
+            success,
+            message,
+        } => {
+            if *success {
+                Some(format!(
+                    "✅ Auth completed for `{}`: {}",
+                    extension_name, message
+                ))
+            } else {
+                Some(format!(
+                    "❌ Auth failed for `{}`: {}",
+                    extension_name, message
+                ))
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Send a pairing prompt to an unknown sender in a DM room.
+///
+/// Checks the room member count first (only sends in DMs, ≤ 2 members).
+/// Used by both the SDK event handler (via `tokio::spawn`) and the raw
+/// poll path's inline handler.
+async fn handle_pairing(
+    homeserver: &str,
+    access_token: &secrecy::SecretString,
+    sender: &str,
+    room_id: &str,
+    pairing_store: &PairingStore,
+    client: &reqwest::Client,
+) {
+    // Check member count — only send pairing prompts in DMs.
+    let members_url = format!(
+        "{}/_matrix/client/v3/rooms/{}/joined_members",
+        homeserver,
+        urlencoding::encode(room_id)
+    );
+    let auth = format!("Bearer {}", access_token.expose_secret());
+    let is_dm = match client
+        .get(&members_url)
+        .header("Authorization", &auth)
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r
+            .json::<serde_json::Value>()
+            .await
+            .ok()
+            .and_then(|v| {
+                v.get("joined")
+                    .and_then(|j| j.as_object())
+                    .map(|m| m.len() <= 2)
+            })
+            .unwrap_or(false),
+        _ => false,
+    };
+
+    if !is_dm {
+        debug!(
+            sender,
+            room_id, "Matrix: unknown sender in group room, silently dropping"
+        );
+        return;
+    }
+
+    match pairing_store
+        .upsert_request(
+            CHANNEL_NAME,
+            sender,
+            Some(serde_json::json!({ "room_id": room_id })),
+        )
+        .await
+    {
+        Ok(result) if result.created => {
+            let msg = format!(
+                "To pair with this bot, run: `ironclaw pairing approve matrix {}`",
+                result.code
+            );
+            let txn_id = format!("ironclaw-{}", Uuid::new_v4().as_u128());
+            let url = format!(
+                "{}/_matrix/client/v3/rooms/{}/send/m.room.message/{}",
+                homeserver,
+                urlencoding::encode(room_id),
+                urlencoding::encode(&txn_id),
+            );
+            let body = serde_json::json!({ "msgtype": "m.text", "body": msg });
+            if let Err(e) = client
+                .put(&url)
+                .header("Authorization", &auth)
+                .json(&body)
+                .send()
+                .await
+            {
+                warn!(sender, room_id, error = %e, "Matrix: failed to send pairing reply");
+            }
+        }
+        Ok(_) => {}
+        Err(e) => warn!(sender, error = %e, "Matrix: pairing upsert failed"),
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SDK-backed implementation  (`matrix-sdk-channel` feature)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(feature = "matrix-sdk-channel")]
+mod sdk {
+    use super::*;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use matrix_sdk::{
+        Client,
+        authentication::matrix::MatrixSession,
+        config::SyncSettings,
+        room::Room,
+        ruma::{
+            OwnedUserId,
+            api::client::filter::FilterDefinition,
+            events::room::{
+                encrypted::OriginalSyncRoomEncryptedEvent,
+                member::StrippedRoomMemberEvent,
+                message::{MessageType, OriginalSyncRoomMessageEvent, RoomMessageEventContent},
+            },
+        },
+    };
+
+    /// Secrets store reference — used to persist `device_id` after first login.
+    pub type SecretsStoreRef = Option<Arc<dyn crate::secrets::SecretsStore + Send + Sync>>;
+
+    // ── MatrixChannel ─────────────────────────────────────────────────────────
+
+    /// Native Matrix channel backed by `matrix_sdk`.
+    pub struct MatrixChannel {
+        config: MatrixConfig,
+        /// SDK client — populated by `start()`, used by `respond()` etc.
+        sdk_client: RwLock<Option<Client>>,
+        /// Shared HTTP client for raw requests (health checks, whoami, etc.).
+        http_client: reqwest::Client,
+        /// Pairing store for DM pairing (guest access control).
+        pairing_store: Arc<PairingStore>,
+        /// Secrets store for persisting the device ID across restarts.
+        secrets_store: SecretsStoreRef,
+        /// Owner user ID from `config.owner_id`, resolved to the DB's user_id
+        /// for secret writes.  Falls back to `"default"`.
+        secrets_user_id: String,
+    }
+
+    impl MatrixChannel {
+        /// Create a new SDK-backed `MatrixChannel`.
+        pub fn new(
+            config: MatrixConfig,
+            db: Option<Arc<dyn crate::db::Database>>,
+            ownership_cache: Arc<crate::ownership::OwnershipCache>,
+        ) -> Result<Self, ChannelError> {
+            validate_homeserver(&config.homeserver)?;
+            let http_client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("Failed to build HTTP client: {e}"),
+                })?;
+            let pairing_store = if let Some(db) = db {
+                Arc::new(PairingStore::new(db, ownership_cache))
+            } else {
+                Arc::new(PairingStore::new_noop())
+            };
+            Ok(Self {
+                config,
+                sdk_client: RwLock::new(None),
+                http_client,
+                pairing_store,
+                secrets_store: None,
+                secrets_user_id: "default".to_string(),
+            })
+        }
+
+        /// Attach a secrets store so the channel can persist the device ID.
+        ///
+        /// Called from `main.rs` after construction.  The `user_id` should be
+        /// the IronClaw owner ID used for all other secrets in the same store.
+        pub fn with_secrets(
+            mut self,
+            store: Arc<dyn crate::secrets::SecretsStore + Send + Sync>,
+            user_id: &str,
+        ) -> Self {
+            self.secrets_store = Some(store);
+            self.secrets_user_id = user_id.to_string();
+            self
+        }
+
+        // ── SDK client construction ──────────────────────────────────────────
+
+        async fn build_client(&self) -> Result<Client, ChannelError> {
+            let store_path = &self.config.sdk_store_path;
+            std::fs::create_dir_all(store_path).map_err(|e| ChannelError::StartupFailed {
+                name: CHANNEL_NAME.to_string(),
+                reason: format!(
+                    "failed to create SDK store dir {}: {e}",
+                    store_path.display()
+                ),
+            })?;
+
+            let builder = Client::builder()
+                .homeserver_url(&self.config.homeserver)
+                .sqlite_store(store_path, None);
+
+            // Enable E2EE when the matrix-e2ee feature is on.
+            // NOTE: auto_enable_cross_signing requires the SDK to have the
+            // password for UIA (User-Interactive Auth). Since we restore from
+            // a stored token, the SDK can't bootstrap cross-signing. The bot
+            // device will show as unverified — cosmetic only, doesn't block
+            // E2EE. To verify, use Element: Settings → Sessions → verify the
+            // bot device, or store the password and use login_username().
+            #[cfg(feature = "matrix-e2ee")]
+            let builder = {
+                use matrix_sdk::encryption::EncryptionSettings;
+                info!("Matrix: E2EE enabled (matrix-e2ee feature)");
+                builder.with_encryption_settings(EncryptionSettings::default())
+            };
+
+            #[cfg(not(feature = "matrix-e2ee"))]
+            info!("Matrix: E2EE disabled (build with matrix-e2ee feature to enable)");
+
+            builder
+                .build()
+                .await
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("matrix-sdk client build failed: {e}"),
+                })
+        }
+
+        /// Build a `MatrixSession` from the access token and an explicit device ID.
+        ///
+        /// `device_id` should come from `whoami` (the real device ID the token
+        /// belongs to) or from the secrets DB if we persisted it previously.
+        /// If both are `None` the SDK will generate a new device — this should
+        /// not happen in practice because `whoami` always returns one.
+        fn make_session_with_device(
+            &self,
+            user_id: OwnedUserId,
+            device_id: Option<&str>,
+        ) -> MatrixSession {
+            use matrix_sdk::SessionTokens;
+
+            let device_id: matrix_sdk::ruma::OwnedDeviceId =
+                device_id.unwrap_or("IRONCLAW_UNKNOWN").into();
+
+            MatrixSession {
+                meta: matrix_sdk::SessionMeta { user_id, device_id },
+                tokens: SessionTokens {
+                    access_token: self.config.access_token.expose_secret().to_string(),
+                    refresh_token: None,
+                },
+            }
+        }
+
+        /// Persist the device ID to the secrets store so we reuse it on restart.
+        async fn persist_device_id(&self, device_id: &str) {
+            let Some(ref store) = self.secrets_store else {
+                debug!("Matrix: no secrets store attached — skipping device_id persistence");
+                return;
+            };
+            use crate::secrets::CreateSecretParams;
+            let params = CreateSecretParams::new("matrix_device_id", device_id);
+            match store.create(&self.secrets_user_id, params).await {
+                Ok(_) => {
+                    debug!("Matrix: persisted device_id '{}' to secrets DB", device_id);
+                }
+                Err(e) => {
+                    warn!("Matrix: failed to persist device_id '{}': {e}", device_id);
+                }
+            }
+        }
+
+        // ── Sending ──────────────────────────────────────────────────────────
+
+        /// Get a joined room by ID from the SDK client.
+        async fn get_room(&self, room_id_str: &str) -> Option<Room> {
+            use matrix_sdk::ruma::RoomId;
+            let client_guard = self.sdk_client.read().await;
+            let client = client_guard.as_ref()?;
+            let room_id = RoomId::parse(room_id_str).ok()?;
+            client.get_room(&room_id)
+        }
+
+        /// Send a plain-text message to a room.
+        async fn send_text_to_room(
+            &self,
+            room_id_str: &str,
+            text: &str,
+        ) -> Result<(), ChannelError> {
+            let room =
+                self.get_room(room_id_str)
+                    .await
+                    .ok_or_else(|| ChannelError::SendFailed {
+                        name: CHANNEL_NAME.to_string(),
+                        reason: format!("room '{}' not found in SDK client", room_id_str),
+                    })?;
+            let content = RoomMessageEventContent::text_plain(text);
+            room.send(content)
+                .await
+                .map_err(|e| ChannelError::SendFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("send to room '{}': {e}", room_id_str),
+                })?;
+            Ok(())
+        }
+
+        // ── DM room resolution (for broadcast) ───────────────────────────────
+
+        async fn resolve_dm_room(&self, user_id_str: &str) -> Result<String, ChannelError> {
+            use matrix_sdk::ruma::UserId;
+
+            let client_guard = self.sdk_client.read().await;
+            let client = client_guard
+                .as_ref()
+                .ok_or_else(|| ChannelError::SendFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: "SDK client not initialised".to_string(),
+                })?;
+
+            // Look for an existing DM room with this user in the SDK's room list.
+            let target_uid = UserId::parse(user_id_str).map_err(|e| ChannelError::SendFailed {
+                name: CHANNEL_NAME.to_string(),
+                reason: format!("invalid user ID '{}': {e}", user_id_str),
+            })?;
+
+            for room in client.joined_rooms() {
+                // A DM room has exactly 2 members and is_direct.
+                if room.is_direct().await.unwrap_or(false) && room.joined_members_count() == 2 {
+                    // Check if the target user is in this room.
+                    if let Ok(Some(_)) = room.get_member(&target_uid).await {
+                        return Ok(room.room_id().to_string());
+                    }
+                }
+            }
+
+            // No existing room — create one.
+            use matrix_sdk::ruma::api::client::room::create_room::v3::Request as CreateRoomRequest;
+            let mut req = CreateRoomRequest::new();
+            req.is_direct = true;
+            req.invite = vec![target_uid];
+
+            let resp = client
+                .create_room(req)
+                .await
+                .map_err(|e| ChannelError::SendFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("createRoom for '{}': {e}", user_id_str),
+                })?;
+
+            Ok(resp.room_id().to_string())
+        }
+    }
+
+    // ── Channel trait (SDK path) ──────────────────────────────────────────────
+
+    #[async_trait]
+    impl Channel for MatrixChannel {
+        fn name(&self) -> &str {
+            CHANNEL_NAME
+        }
+
+        async fn start(&self) -> Result<MessageStream, ChannelError> {
+            // Build the SDK client.
+            let client = self.build_client().await?;
+
+            // Log token prefix/suffix to aid debugging (never log the full token).
+            {
+                let tok = self.config.access_token.expose_secret();
+                let len = tok.len();
+                let preview = if len >= 8 {
+                    format!("{}...{}", &tok[..4], &tok[len - 4..])
+                } else {
+                    format!("<{}chars>", len)
+                };
+                debug!(token_preview = %preview, homeserver = %self.config.homeserver, "Matrix: starting with token");
+            }
+
+            // Derive user_id and device_id from the access token via whoami.
+            // whoami always returns the device ID the token was issued for — this
+            // is the only source of truth on first boot before we've persisted it.
+            let (user_id, whoami_device_id) = {
+                let whoami_url = format!(
+                    "{}/_matrix/client/v3/account/whoami",
+                    self.config.homeserver
+                );
+                let resp = self
+                    .http_client
+                    .get(&whoami_url)
+                    .header(
+                        "Authorization",
+                        format!("Bearer {}", self.config.access_token.expose_secret()),
+                    )
+                    .send()
+                    .await
+                    .map_err(|e| ChannelError::StartupFailed {
+                        name: CHANNEL_NAME.to_string(),
+                        reason: format!("whoami request failed: {e}"),
+                    })?;
+
+                let status = resp.status();
+                if status == reqwest::StatusCode::FORBIDDEN
+                    || status == reqwest::StatusCode::UNAUTHORIZED
+                {
+                    let body = resp.text().await.unwrap_or_else(|_| "<no body>".into());
+                    return Err(ChannelError::AuthFailed {
+                        name: CHANNEL_NAME.to_string(),
+                        reason: format!("whoami 401/403: {body}"),
+                    });
+                }
+                if !status.is_success() {
+                    return Err(ChannelError::StartupFailed {
+                        name: CHANNEL_NAME.to_string(),
+                        reason: format!("whoami returned {status}"),
+                    });
+                }
+
+                #[derive(serde::Deserialize)]
+                struct WhoAmI {
+                    user_id: String,
+                    device_id: Option<String>,
+                }
+                let body: WhoAmI = resp.json().await.map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("whoami parse failed: {e}"),
+                })?;
+                (body.user_id, body.device_id)
+            };
+
+            let uid: OwnedUserId = matrix_sdk::ruma::UserId::parse(&user_id).map_err(|e| {
+                ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("invalid user_id from whoami '{user_id}': {e}"),
+                }
+            })?;
+
+            // Resolve device ID: config (from secrets DB) > whoami response > none.
+            // whoami always returns the device ID the token was issued for, so this
+            // is the authoritative source on first boot before we've persisted it.
+            let resolved_device_id: Option<String> =
+                self.config.device_id.clone().or(whoami_device_id);
+
+            info!(
+                user_id = %uid,
+                device_id = ?resolved_device_id,
+                homeserver = %self.config.homeserver,
+                dm_policy = %self.config.dm_policy,
+                auto_join = self.config.auto_join,
+                sdk_store = %self.config.sdk_store_path.display(),
+                "Matrix channel starting (SDK mode)"
+            );
+
+            // Restore the session using the stored access token + device ID.
+            let session = self.make_session_with_device(uid.clone(), resolved_device_id.as_deref());
+            let device_id = session.meta.device_id.to_string();
+
+            client
+                .restore_session(session)
+                .await
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("restore_session failed: {e}"),
+                })?;
+
+            info!(device_id = %device_id, "Matrix: session restored");
+
+            // If device_id was not previously persisted in the secrets DB, do it now.
+            if self.config.device_id.is_none() {
+                self.persist_device_id(&device_id).await;
+            }
+
+            // Store the client for use in respond() / send_status() / etc.
+            *self.sdk_client.write().await = Some(client.clone());
+
+            // ── Event handlers ────────────────────────────────────────────────
+
+            let (tx, rx) = mpsc::channel::<IncomingMessage>(64);
+
+            // Flipped to true after the priming sync_once completes.
+            // Event handlers check this and discard messages until it's set,
+            // preventing replay of history on cold-start or sync-token loss.
+            let ready = Arc::new(AtomicBool::new(false));
+
+            // Clone what the handler needs.
+            let config = self.config.clone();
+            let bot_user_id = uid.clone();
+            let tx_msg = tx.clone();
+
+            // Text message handler.
+            client.add_event_handler({
+                let config = config.clone();
+                let bot_user_id = bot_user_id.clone();
+                let tx = tx_msg.clone();
+                let ready = Arc::clone(&ready);
+                let pairing_store = Arc::clone(&self.pairing_store);
+                let http_client = self.http_client.clone();
+                move |ev: OriginalSyncRoomMessageEvent, room: Room| {
+                    let config = config.clone();
+                    let bot_user_id = bot_user_id.clone();
+                    let http_client = http_client.clone();
+                    let tx = tx.clone();
+                    let ready = Arc::clone(&ready);
+                    let pairing_store = Arc::clone(&pairing_store);
+                    async move {
+                        // Discard events from the priming sync.
+                        if !ready.load(Ordering::Acquire) {
+                            return;
+                        }
+
+                        let sender = ev.sender.to_string();
+
+                        // Skip our own messages.
+                        if sender == bot_user_id.as_str() {
+                            return;
+                        }
+
+                        let room_id = room.room_id().to_string();
+
+                        // Extract text body.
+                        let text = match &ev.content.msgtype {
+                            MessageType::Text(text_content) => text_content.body.clone(),
+                            other => {
+                                debug!(
+                                    room_id,
+                                    sender,
+                                    msgtype = ?other.msgtype(),
+                                    "Matrix: skipping non-text message"
+                                );
+                                return;
+                            }
+                        };
+
+                        let event_id = ev.event_id.to_string();
+
+                        // Access control.
+                        match check_sender(&config, &sender, &room_id, &pairing_store).await {
+                            SenderDecision::Allow => {}
+                            SenderDecision::Deny => {
+                                debug!(sender, room_id, "Matrix: sender denied, dropping");
+                                return;
+                            }
+                            SenderDecision::Pair(pair_room) => {
+                                // Pairing is handled via a raw HTTP call below.
+                                // We don't have Arc<Self> here, so use
+                                // PairingStore directly and send via raw HTTP.
+                                let config2 = config.clone();
+                                let sender2 = sender.clone();
+                                let ps = Arc::clone(&pairing_store);
+                                let hc = http_client.clone();
+                                tokio::spawn(async move {
+                                    handle_pairing(
+                                        &config2.homeserver,
+                                        &config2.access_token,
+                                        &sender2,
+                                        &pair_room,
+                                        &ps,
+                                        &hc,
+                                    )
+                                    .await;
+                                });
+                                return;
+                            }
+                        }
+
+                        info!(
+                            sender = %sender,
+                            room_id = %room_id,
+                            event_id = %event_id,
+                            content_len = text.len(),
+                            "Matrix: message received"
+                        );
+
+                        let msg = IncomingMessage::new(CHANNEL_NAME, &sender, &text)
+                            .with_sender_id(sender.clone())
+                            .with_thread(room_id.clone())
+                            .with_metadata(serde_json::json!({
+                                "room_id": room_id,
+                                "event_id": event_id,
+                                "homeserver": config.homeserver,
+                            }));
+
+                        if tx.send(msg).await.is_err() {
+                            debug!("Matrix: message receiver dropped");
+                        }
+                    }
+                }
+            });
+
+            // Log undecryptable encrypted events — helps diagnose missing room keys.
+            client.add_event_handler({
+                let ready = Arc::clone(&ready);
+                move |ev: OriginalSyncRoomEncryptedEvent, room: Room| {
+                    let ready = Arc::clone(&ready);
+                    async move {
+                        if !ready.load(Ordering::Acquire) {
+                            return;
+                        }
+                        warn!(
+                            sender = %ev.sender,
+                            room_id = %room.room_id(),
+                            event_id = %ev.event_id,
+                            "Matrix: received m.room.encrypted event that could not be decrypted \
+                             (missing room key — sender may need to re-share keys with this device)"
+                        );
+                    }
+                }
+            });
+
+            // Auto-join: handle room invites.
+            if self.config.auto_join {
+                let join_config = self.config.clone();
+                let join_ps = Arc::clone(&self.pairing_store);
+                client.add_event_handler(
+                    move |ev: StrippedRoomMemberEvent, room: Room, client: Client| {
+                        let join_config = join_config.clone();
+                        let join_ps = Arc::clone(&join_ps);
+                        async move {
+                            // Only react to invites addressed to us.
+                            let Some(my_user_id) = client.user_id() else {
+                                return;
+                            };
+                            if ev.state_key != *my_user_id {
+                                return;
+                            }
+                            let room_id = room.room_id().to_string();
+                            let inviter = ev.sender.to_string();
+
+                            // Check the inviter against dm_policy / allow_from
+                            // before joining.  "open" joins all; "pairing" and
+                            // "allowlist" require the inviter to be in allow_from
+                            // (or owner_id).
+                            match check_sender(&join_config, &inviter, &room_id, &join_ps).await {
+                                SenderDecision::Allow => {}
+                                SenderDecision::Deny => {
+                                    debug!(
+                                        room_id,
+                                        inviter, "Matrix: ignoring invite from denied sender"
+                                    );
+                                    return;
+                                }
+                                SenderDecision::Pair(_) => {
+                                    // In pairing mode, still join — message handling
+                                    // will send the pairing prompt.
+                                }
+                            }
+
+                            info!(room_id, inviter, "Matrix: received invite, joining room");
+                            if let Err(e) = room.join().await {
+                                warn!(room_id, error = %e, "Matrix: failed to join invited room");
+                            } else {
+                                info!(room_id, "Matrix: joined room");
+                            }
+                        }
+                    },
+                );
+            }
+
+            // ── Sync loop ─────────────────────────────────────────────────────
+            // If the SDK store has an existing sync position (normal restart),
+            // resume from that position — messages that arrived while offline
+            // are delivered normally.  Set `ready` immediately so nothing is
+            // suppressed.
+            //
+            // If the store was just wiped (fresh onboard), do a priming
+            // `sync_once` first with `ready = false` so historical room
+            // backfill is discarded.  Then flip `ready` and start the live
+            // loop.
+            //
+            // The setup wizard writes a `.fresh` marker file after wiping the
+            // store.  We use that marker to distinguish the two cases instead
+            // of probing directory contents (which is unreliable because
+            // `build_client()` creates SQLite files before any sync happens).
+
+            let fresh_marker = self.config.sdk_store_path.join(".fresh");
+            let is_fresh_store = fresh_marker.exists();
+
+            let sync_client = client.clone();
+            let ready_for_spawn = Arc::clone(&ready);
+            tokio::spawn(async move {
+                let filter = FilterDefinition::with_lazy_loading();
+                let settings = SyncSettings::default().filter(filter.into());
+
+                if is_fresh_store {
+                    // Fresh start — prime the token and discard backfill.
+                    info!(
+                        "Matrix: fresh store detected (.fresh marker), performing priming sync to discard backfill"
+                    );
+                    match sync_client.sync_once(settings.clone()).await {
+                        Ok(resp) => {
+                            info!(
+                                next_batch = %resp.next_batch,
+                                "Matrix: priming sync complete, starting live sync"
+                            );
+                        }
+                        Err(e) => {
+                            warn!(error = %e, "Matrix: priming sync failed, continuing anyway");
+                        }
+                    }
+                    // Remove the marker so subsequent restarts resume normally.
+                    if let Err(e) = std::fs::remove_file(&fresh_marker) {
+                        warn!(error = %e, "Matrix: failed to remove .fresh marker");
+                    }
+                    ready_for_spawn.store(true, Ordering::Release);
+                } else {
+                    // Resume from stored position — deliver offline messages.
+                    info!("Matrix: resuming from stored sync position, starting live sync");
+                    ready_for_spawn.store(true, Ordering::Release);
+                }
+
+                let mut backoff_secs = 1u64;
+                loop {
+                    info!("Matrix: starting SDK sync loop");
+                    match sync_client.sync(settings.clone()).await {
+                        Ok(()) => {
+                            // sync() returned Ok — homeserver requested a stop.
+                            info!("Matrix: sync loop exited cleanly");
+                            break;
+                        }
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                backoff_secs,
+                                "Matrix: sync loop terminated, restarting after backoff"
+                            );
+                            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+                            backoff_secs = (backoff_secs * 2).min(60);
+                        }
+                    }
+                }
+            });
+
+            Ok(Box::pin(ReceiverStream::new(rx)))
+        }
+
+        async fn respond(
+            &self,
+            msg: &IncomingMessage,
+            response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            let room_id = extract_room_id(msg)?;
+            self.send_text_to_room(room_id, &response.content).await
+        }
+
+        async fn send_status(
+            &self,
+            status: StatusUpdate,
+            metadata: &serde_json::Value,
+        ) -> Result<(), ChannelError> {
+            let room_id = match metadata.get("room_id").and_then(|v| v.as_str()) {
+                Some(r) => r.to_string(),
+                None => return Ok(()),
+            };
+
+            if let StatusUpdate::Thinking(_) = &status {
+                let Some(room) = self.get_room(&room_id).await else {
+                    return Ok(());
+                };
+                if let Err(e) = room.typing_notice(true).await {
+                    debug!(error = %e, "Matrix: failed to send typing indicator");
+                }
+            } else if let Some(text) = format_status_message(&status) {
+                if let Err(e) = self.send_text_to_room(&room_id, &text).await {
+                    debug!(error = %e, "Matrix: failed to send status notification");
+                }
+            }
+            Ok(())
+        }
+
+        async fn broadcast(
+            &self,
+            user_id: &str,
+            response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            let room_id = self.resolve_dm_room(user_id).await?;
+            self.send_text_to_room(&room_id, &response.content).await
+        }
+
+        async fn health_check(&self) -> Result<(), ChannelError> {
+            // Lightweight whoami ping — same as the raw path.
+            let client_guard = self.sdk_client.read().await;
+            if client_guard.is_none() {
+                return Err(ChannelError::HealthCheckFailed {
+                    name: format!("{}: SDK client not yet initialised", CHANNEL_NAME),
+                });
+            }
+            // Use the shared HTTP client for a lightweight whoami ping.
+            let url = format!(
+                "{}/_matrix/client/v3/account/whoami",
+                self.config.homeserver
+            );
+            let resp = self
+                .http_client
+                .get(&url)
+                .header(
+                    "Authorization",
+                    format!("Bearer {}", self.config.access_token.expose_secret()),
+                )
+                .send()
+                .await
+                .map_err(|e| ChannelError::HealthCheckFailed {
+                    name: format!("{}: {e}", CHANNEL_NAME),
+                })?;
+            if resp.status().is_success() {
+                Ok(())
+            } else {
+                Err(ChannelError::HealthCheckFailed {
+                    name: format!("{}: HTTP {}", CHANNEL_NAME, resp.status()),
+                })
+            }
+        }
+
+        fn conversation_context(&self, metadata: &serde_json::Value) -> HashMap<String, String> {
+            build_conversation_context(metadata)
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Raw reqwest poll implementation  (no `matrix-sdk-channel` feature)
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[cfg(not(feature = "matrix-sdk-channel"))]
+mod raw {
+    use super::*;
+
+    /// Backoff delays for poll errors (seconds): 1, 2, 5, 10, 30.
+    const BACKOFF_SECS: &[u64] = &[1, 2, 5, 10, 30];
+
+    // ── JSON shapes for Matrix Client-Server API ──────────────────────────────
+
+    #[derive(serde::Deserialize)]
+    struct SyncResponse {
+        next_batch: String,
+        #[serde(default)]
+        rooms: SyncRooms,
+    }
+
+    #[derive(serde::Deserialize, Default)]
+    struct SyncRooms {
+        #[serde(default)]
+        join: HashMap<String, JoinedRoom>,
+        #[serde(default)]
+        invite: HashMap<String, serde_json::Value>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct JoinedRoom {
+        timeline: Option<Timeline>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct Timeline {
+        #[serde(default)]
+        events: Vec<TimelineEvent>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct TimelineEvent {
+        #[serde(rename = "type")]
+        event_type: String,
+        sender: Option<String>,
+        content: Option<serde_json::Value>,
+        event_id: Option<String>,
+    }
+
+    #[derive(serde::Deserialize)]
+    struct JoinedMembersResponse {
+        joined: HashMap<String, serde_json::Value>,
+    }
+
+    // ── MatrixChannel ─────────────────────────────────────────────────────────
+
+    /// Native Matrix channel using raw Matrix Client-Server API (no SDK).
+    pub struct MatrixChannel {
+        config: MatrixConfig,
+        client: reqwest::Client,
+        /// Pairing store for DM pairing (guest access control).
+        pairing_store: Arc<PairingStore>,
+        bot_user_id: RwLock<String>,
+        next_batch: RwLock<Option<String>>,
+    }
+
+    impl MatrixChannel {
+        pub fn new(
+            config: MatrixConfig,
+            db: Option<Arc<dyn crate::db::Database>>,
+            ownership_cache: Arc<crate::ownership::OwnershipCache>,
+        ) -> Result<Self, ChannelError> {
+            validate_homeserver(&config.homeserver)?;
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(40))
+                .build()
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("Failed to build HTTP client: {e}"),
+                })?;
+            let pairing_store = if let Some(db) = db {
+                Arc::new(PairingStore::new(db, ownership_cache))
+            } else {
+                Arc::new(PairingStore::new_noop())
+            };
+            Ok(Self {
+                config,
+                client,
+                pairing_store,
+                bot_user_id: RwLock::new(String::new()),
+                next_batch: RwLock::new(None),
+            })
+        }
+
+        fn auth_header(&self) -> String {
+            format!("Bearer {}", self.config.access_token.expose_secret())
+        }
+
+        /// Maximum response body size for raw HTTP calls (50 MB).
+        const MAX_RESPONSE_BYTES: usize = 50 * 1024 * 1024;
+
+        async fn matrix_get(&self, url: &str) -> Result<serde_json::Value, ChannelError> {
+            let resp = self
+                .client
+                .get(url)
+                .header("Authorization", self.auth_header())
+                .send()
+                .await
+                .map_err(|e| ChannelError::Http(format!("GET {url}: {e}")))?;
+            let status = resp.status();
+            if status == 429 {
+                return Err(ChannelError::RateLimited {
+                    name: CHANNEL_NAME.to_string(),
+                });
+            }
+            if !status.is_success() {
+                let body = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<no body>".to_string());
+                return Err(ChannelError::Http(format!("GET {url} → {status}: {body}")));
+            }
+            // Pre-screen with Content-Length when available to avoid buffering
+            // oversized responses.
+            if let Some(len) = resp.content_length() {
+                if len as usize > MAX_RESPONSE_BYTES {
+                    return Err(ChannelError::Http(format!(
+                        "GET {url}: response too large ({len} bytes, Content-Length)"
+                    )));
+                }
+            }
+            let bytes = resp
+                .bytes()
+                .await
+                .map_err(|e| ChannelError::Http(format!("GET {url} read: {e}")))?;
+            if bytes.len() > MAX_RESPONSE_BYTES {
+                return Err(ChannelError::Http(format!(
+                    "GET {url}: response too large ({} bytes)",
+                    bytes.len()
+                )));
+            }
+            serde_json::from_slice(&bytes)
+                .map_err(|e| ChannelError::Http(format!("GET {url} parse: {e}")))
+        }
+
+        async fn matrix_post(
+            &self,
+            url: &str,
+            body: &serde_json::Value,
+        ) -> Result<serde_json::Value, ChannelError> {
+            let resp = self
+                .client
+                .post(url)
+                .header("Authorization", self.auth_header())
+                .json(body)
+                .send()
+                .await
+                .map_err(|e| ChannelError::Http(format!("POST {url}: {e}")))?;
+            let status = resp.status();
+            if status == 429 {
+                return Err(ChannelError::RateLimited {
+                    name: CHANNEL_NAME.to_string(),
+                });
+            }
+            if !status.is_success() {
+                let body_text = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<no body>".to_string());
+                return Err(ChannelError::Http(format!(
+                    "POST {url} → {status}: {body_text}"
+                )));
+            }
+            resp.json()
+                .await
+                .map_err(|e| ChannelError::Http(format!("POST {url} parse: {e}")))
+        }
+
+        async fn matrix_put(
+            &self,
+            url: &str,
+            body: &serde_json::Value,
+        ) -> Result<serde_json::Value, ChannelError> {
+            let resp = self
+                .client
+                .put(url)
+                .header("Authorization", self.auth_header())
+                .json(body)
+                .send()
+                .await
+                .map_err(|e| ChannelError::Http(format!("PUT {url}: {e}")))?;
+            let status = resp.status();
+            if status == 429 {
+                return Err(ChannelError::RateLimited {
+                    name: CHANNEL_NAME.to_string(),
+                });
+            }
+            if !status.is_success() {
+                let body_text = resp
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<no body>".to_string());
+                return Err(ChannelError::Http(format!(
+                    "PUT {url} → {status}: {body_text}"
+                )));
+            }
+            resp.json()
+                .await
+                .map_err(|e| ChannelError::Http(format!("PUT {url} parse: {e}")))
+        }
+
+        async fn send_text(
+            &self,
+            room_id: &str,
+            text: &str,
+            reply_to_event_id: Option<&str>,
+        ) -> Result<(), ChannelError> {
+            let txn_id = format!("ironclaw-{}", Uuid::new_v4().as_u128());
+            let url = format!(
+                "{}/_matrix/client/v3/rooms/{}/send/m.room.message/{}",
+                self.config.homeserver,
+                urlencoding::encode(room_id),
+                urlencoding::encode(&txn_id),
+            );
+            let mut body = serde_json::json!({ "msgtype": "m.text", "body": text });
+            if let Some(event_id) = reply_to_event_id {
+                body["m.relates_to"] =
+                    serde_json::json!({ "m.in_reply_to": { "event_id": event_id } });
+            }
+            self.matrix_put(&url, &body).await?;
+            debug!(room_id, content_len = text.len(), "Matrix: message sent");
+            Ok(())
+        }
+
+        async fn handle_pairing_request(&self, sender: &str, room_id: &str) {
+            handle_pairing(
+                &self.config.homeserver,
+                &self.config.access_token,
+                sender,
+                room_id,
+                &self.pairing_store,
+                &self.client,
+            )
+            .await;
+        }
+
+        async fn poll_once(
+            self: &Arc<Self>,
+        ) -> Result<(String, Vec<IncomingMessage>), ChannelError> {
+            let since = self.next_batch.read().await.clone();
+            let bot_user_id = self.bot_user_id.read().await.clone();
+            let url = if let Some(ref token) = since {
+                format!(
+                    "{}/_matrix/client/v3/sync?since={}&timeout=0",
+                    self.config.homeserver,
+                    urlencoding::encode(token)
+                )
+            } else {
+                format!(
+                    "{}/_matrix/client/v3/sync?timeout=0",
+                    self.config.homeserver
+                )
+            };
+
+            let sync: SyncResponse = {
+                let val = self.matrix_get(&url).await?;
+                serde_json::from_value(val)
+                    .map_err(|e| ChannelError::InvalidMessage(format!("sync parse: {e}")))?
+            };
+
+            let mut messages = Vec::new();
+            let invite_count = sync.rooms.invite.len();
+            let join_count = sync.rooms.join.len();
+            if invite_count > 0 || join_count > 0 {
+                debug!(
+                    next_batch = %sync.next_batch,
+                    joined_rooms = join_count,
+                    pending_invites = invite_count,
+                    "Matrix: sync received"
+                );
+            }
+
+            if self.config.auto_join {
+                for (room_id, invite_state) in &sync.rooms.invite {
+                    // Try to extract the inviter from invite_state events so we
+                    // can check allow_from before joining.
+                    let inviter = invite_state
+                        .pointer("/invite_state/events")
+                        .and_then(|evts| evts.as_array())
+                        .and_then(|evts| {
+                            evts.iter().find_map(|e| {
+                                if e.get("type")?.as_str()? == "m.room.member"
+                                    && e.get("content")
+                                        .and_then(|c| c.get("membership"))
+                                        .and_then(|m| m.as_str())
+                                        == Some("invite")
+                                {
+                                    e.get("sender")?.as_str().map(String::from)
+                                } else {
+                                    None
+                                }
+                            })
+                        });
+
+                    if let Some(ref inviter) = inviter {
+                        match check_sender(&self.config, inviter, room_id, &self.pairing_store)
+                            .await
+                        {
+                            SenderDecision::Allow | SenderDecision::Pair(_) => {}
+                            SenderDecision::Deny => {
+                                debug!(
+                                    room_id,
+                                    inviter, "Matrix: ignoring invite from denied sender"
+                                );
+                                continue;
+                            }
+                        }
+                    }
+
+                    let join_url = format!(
+                        "{}/_matrix/client/v3/rooms/{}/join",
+                        self.config.homeserver,
+                        urlencoding::encode(room_id)
+                    );
+                    match self.matrix_post(&join_url, &serde_json::json!({})).await {
+                        Ok(_) => info!(room_id, "Matrix: auto-joined room"),
+                        Err(ChannelError::RateLimited { .. }) => {
+                            warn!(room_id, "Matrix: rate limited joining room")
+                        }
+                        Err(e) => warn!(room_id, error = %e, "Matrix: failed to join invited room"),
+                    }
+                }
+            }
+
+            for (room_id, room) in sync.rooms.join {
+                let events = room.timeline.map(|t| t.events).unwrap_or_default();
+                for event in events {
+                    if event.event_type != "m.room.message" {
+                        continue;
+                    }
+                    let sender = match event.sender {
+                        Some(s) => s,
+                        None => continue,
+                    };
+                    if !bot_user_id.is_empty() && sender == bot_user_id {
+                        continue;
+                    }
+                    let content = match event.content {
+                        Some(c) => c,
+                        None => continue,
+                    };
+                    let msgtype = content
+                        .get("msgtype")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if msgtype != "m.text" {
+                        debug!(
+                            room_id,
+                            sender, msgtype, "Matrix: skipping non-text message"
+                        );
+                        continue;
+                    }
+                    let text = match content.get("body").and_then(|v| v.as_str()) {
+                        Some(t) => t.to_string(),
+                        None => continue,
+                    };
+                    let event_id = event.event_id.clone().unwrap_or_default();
+
+                    match check_sender(&self.config, &sender, &room_id, &self.pairing_store).await {
+                        SenderDecision::Allow => {}
+                        SenderDecision::Deny => {
+                            debug!(sender, room_id, "Matrix: sender denied, dropping");
+                            continue;
+                        }
+                        SenderDecision::Pair(ref pair_room) => {
+                            let arc_self = Arc::clone(self);
+                            let pair_room = pair_room.clone();
+                            let sender_clone = sender.clone();
+                            tokio::spawn(async move {
+                                arc_self
+                                    .handle_pairing_request(&sender_clone, &pair_room)
+                                    .await;
+                            });
+                            continue;
+                        }
+                    }
+
+                    info!(
+                        sender = %sender,
+                        room_id = %room_id,
+                        event_id = %event_id,
+                        content_len = text.len(),
+                        "Matrix: message received"
+                    );
+                    let msg = IncomingMessage::new(CHANNEL_NAME, &sender, &text)
+                        .with_sender_id(sender.clone())
+                        .with_thread(room_id.clone())
+                        .with_metadata(serde_json::json!({
+                            "room_id": room_id,
+                            "event_id": event_id,
+                            "homeserver": self.config.homeserver,
+                        }));
+                    messages.push(msg);
+                }
+            }
+
+            Ok((sync.next_batch, messages))
+        }
+
+        async fn poll_loop(self: Arc<Self>, tx: mpsc::Sender<IncomingMessage>) {
+            let interval = Duration::from_secs(u64::from(self.config.poll_interval_secs));
+            let mut backoff_idx: usize = 0;
+            debug!(
+                interval_secs = self.config.poll_interval_secs,
+                "Matrix: poll loop started"
+            );
+            loop {
+                match self.poll_once().await {
+                    Ok((next_batch, messages)) => {
+                        if backoff_idx > 0 {
+                            info!("Matrix: poll recovered after backoff");
+                        }
+                        backoff_idx = 0;
+                        *self.next_batch.write().await = Some(next_batch);
+                        for msg in messages {
+                            if tx.send(msg).await.is_err() {
+                                debug!("Matrix: message receiver dropped, stopping poll loop");
+                                return;
+                            }
+                        }
+                        tokio::time::sleep(interval).await;
+                    }
+                    Err(ChannelError::RateLimited { .. }) => {
+                        let delay = BACKOFF_SECS
+                            .get(backoff_idx)
+                            .copied()
+                            .unwrap_or(*BACKOFF_SECS.last().unwrap());
+                        warn!(delay, "Matrix: rate limited, backing off");
+                        backoff_idx = (backoff_idx + 1).min(BACKOFF_SECS.len() - 1);
+                        tokio::time::sleep(Duration::from_secs(delay)).await;
+                    }
+                    Err(e) => {
+                        let delay = BACKOFF_SECS
+                            .get(backoff_idx)
+                            .copied()
+                            .unwrap_or(*BACKOFF_SECS.last().unwrap());
+                        error!(error = %e, delay, "Matrix: poll error, retrying");
+                        backoff_idx = (backoff_idx + 1).min(BACKOFF_SECS.len() - 1);
+                        tokio::time::sleep(Duration::from_secs(delay)).await;
+                    }
+                }
+            }
+        }
+
+        async fn resolve_dm_room(&self, user_id: &str) -> Result<String, ChannelError> {
+            // m.direct is account data on the *bot's* account, not the target user.
+            let bot_id = self.bot_user_id.read().await;
+            let direct_url = format!(
+                "{}/_matrix/client/v3/user/{}/account_data/m.direct",
+                self.config.homeserver,
+                urlencoding::encode(&bot_id),
+            );
+            if let Ok(data) = self.matrix_get(&direct_url).await {
+                if let Some(rooms) = data.get(user_id).and_then(|v| v.as_array()) {
+                    if let Some(room_id) = rooms.first().and_then(|v| v.as_str()) {
+                        return Ok(room_id.to_string());
+                    }
+                }
+            }
+            let create_url = format!("{}/_matrix/client/v3/createRoom", self.config.homeserver);
+            let body = serde_json::json!({
+                "is_direct": true,
+                "invite": [user_id],
+                "preset": "trusted_private_chat",
+            });
+            let resp = self.matrix_post(&create_url, &body).await?;
+            resp.get("room_id")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string())
+                .ok_or_else(|| ChannelError::SendFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("createRoom response missing room_id for user {user_id}"),
+                })
+        }
+    }
+
+    #[async_trait]
+    impl Channel for MatrixChannel {
+        fn name(&self) -> &str {
+            CHANNEL_NAME
+        }
+
+        async fn start(&self) -> Result<MessageStream, ChannelError> {
+            let whoami_url = format!(
+                "{}/_matrix/client/v3/account/whoami",
+                self.config.homeserver
+            );
+            let resp = self
+                .client
+                .get(&whoami_url)
+                .header("Authorization", self.auth_header())
+                .send()
+                .await
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("whoami request failed: {e}"),
+                })?;
+            let status = resp.status();
+            if status == reqwest::StatusCode::FORBIDDEN
+                || status == reqwest::StatusCode::UNAUTHORIZED
+            {
+                return Err(ChannelError::AuthFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: "Invalid access token — check MATRIX_ACCESS_TOKEN".to_string(),
+                });
+            }
+            if !status.is_success() {
+                return Err(ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("whoami returned {status}"),
+                });
+            }
+            #[derive(serde::Deserialize)]
+            struct WhoAmIBody {
+                user_id: String,
+            }
+            let body: WhoAmIBody = resp.json().await.map_err(|e| ChannelError::StartupFailed {
+                name: CHANNEL_NAME.to_string(),
+                reason: format!("whoami parse failed: {e}"),
+            })?;
+
+            *self.bot_user_id.write().await = body.user_id.clone();
+            info!(
+                user_id = %body.user_id,
+                homeserver = %self.config.homeserver,
+                dm_policy = %self.config.dm_policy,
+                poll_interval_secs = self.config.poll_interval_secs,
+                auto_join = self.config.auto_join,
+                "Matrix channel starting (raw poll mode)"
+            );
+
+            info!("Matrix: performing initial sync to prime next_batch token");
+            let sync_url = format!(
+                "{}/_matrix/client/v3/sync?timeout=0",
+                self.config.homeserver
+            );
+            let init_sync = self
+                .client
+                .get(&sync_url)
+                .header("Authorization", self.auth_header())
+                .send()
+                .await
+                .map_err(|e| ChannelError::StartupFailed {
+                    name: CHANNEL_NAME.to_string(),
+                    reason: format!("initial sync failed: {e}"),
+                })?;
+            let init_status = init_sync.status();
+            if init_status.is_success() {
+                match init_sync.json::<SyncResponse>().await {
+                    Ok(body) => {
+                        *self.next_batch.write().await = Some(body.next_batch.clone());
+                        info!(
+                            next_batch = %body.next_batch,
+                            joined_rooms = body.rooms.join.len(),
+                            pending_invites = body.rooms.invite.len(),
+                            "Matrix: initial sync complete"
+                        );
+                    }
+                    Err(e) => warn!("Matrix: failed to parse initial sync: {e}"),
+                }
+            } else {
+                warn!(status = %init_status, "Matrix: initial sync returned non-success status");
+            }
+
+            info!(
+                poll_interval_secs = self.config.poll_interval_secs,
+                "Matrix: starting poll loop"
+            );
+            let (tx, rx) = mpsc::channel::<IncomingMessage>(64);
+            let arc_self = Arc::new(MatrixChannel {
+                config: self.config.clone(),
+                client: self.client.clone(),
+                pairing_store: Arc::clone(&self.pairing_store),
+                bot_user_id: RwLock::new(self.bot_user_id.read().await.clone()),
+                next_batch: RwLock::new(self.next_batch.read().await.clone()),
+            });
+            tokio::spawn(async move { arc_self.poll_loop(tx).await });
+            Ok(Box::pin(ReceiverStream::new(rx)))
+        }
+
+        async fn respond(
+            &self,
+            msg: &IncomingMessage,
+            response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            let room_id = extract_room_id(msg)?;
+            let reply_to = msg
+                .metadata
+                .get("event_id")
+                .and_then(|v| v.as_str())
+                .filter(|s| !s.is_empty());
+            self.send_text(room_id, &response.content, reply_to).await
+        }
+
+        async fn send_status(
+            &self,
+            status: StatusUpdate,
+            metadata: &serde_json::Value,
+        ) -> Result<(), ChannelError> {
+            let room_id = match metadata.get("room_id").and_then(|v| v.as_str()) {
+                Some(r) => r.to_string(),
+                None => return Ok(()),
+            };
+
+            if let StatusUpdate::Thinking(_) = &status {
+                let bot_user_id = self.bot_user_id.read().await.clone();
+                let url = format!(
+                    "{}/_matrix/client/v3/rooms/{}/typing/{}",
+                    self.config.homeserver,
+                    urlencoding::encode(&room_id),
+                    urlencoding::encode(&bot_user_id),
+                );
+                let body = serde_json::json!({ "typing": true, "timeout": 30000 });
+                if let Err(e) = self.matrix_put(&url, &body).await {
+                    debug!(error = %e, "Matrix: failed to send typing indicator");
+                }
+            } else if let Some(text) = format_status_message(&status) {
+                if let Err(e) = self.send_text(&room_id, &text, None).await {
+                    debug!(error = %e, "Matrix: failed to send status notification");
+                }
+            }
+            Ok(())
+        }
+
+        async fn broadcast(
+            &self,
+            user_id: &str,
+            response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            let room_id = self.resolve_dm_room(user_id).await?;
+            self.send_text(&room_id, &response.content, None).await
+        }
+
+        async fn health_check(&self) -> Result<(), ChannelError> {
+            let url = format!(
+                "{}/_matrix/client/v3/account/whoami",
+                self.config.homeserver
+            );
+            let resp = self
+                .client
+                .get(&url)
+                .header("Authorization", self.auth_header())
+                .timeout(Duration::from_secs(10))
+                .send()
+                .await
+                .map_err(|e| ChannelError::HealthCheckFailed {
+                    name: format!("{}: {}", CHANNEL_NAME, e),
+                })?;
+            if resp.status().is_success() {
+                Ok(())
+            } else {
+                Err(ChannelError::HealthCheckFailed {
+                    name: format!("{}: HTTP {}", CHANNEL_NAME, resp.status()),
+                })
+            }
+        }
+
+        fn conversation_context(&self, metadata: &serde_json::Value) -> HashMap<String, String> {
+            build_conversation_context(metadata)
+        }
+    }
+}
+
+// ── Shared helpers ────────────────────────────────────────────────────────────
+
+fn validate_homeserver(homeserver: &str) -> Result<(), ChannelError> {
+    if !homeserver.starts_with("https://") && !homeserver.starts_with("http://") {
+        return Err(ChannelError::StartupFailed {
+            name: CHANNEL_NAME.to_string(),
+            reason: format!(
+                "MATRIX_HOMESERVER must be a full URL (https://...), got: {}",
+                homeserver
+            ),
+        });
+    }
+    Ok(())
+}
+
+// ── Re-export the right MatrixChannel ─────────────────────────────────────────
+
+#[cfg(feature = "matrix-sdk-channel")]
+pub use sdk::MatrixChannel;
+
+#[cfg(not(feature = "matrix-sdk-channel"))]
+pub use raw::MatrixChannel;
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secrecy::SecretString;
+
+    fn test_config() -> MatrixConfig {
+        MatrixConfig {
+            homeserver: "https://matrix.org".to_string(),
+            access_token: SecretString::from("syt_test_token"),
+            device_id: None,
+            allow_from: vec![],
+            dm_policy: "pairing".to_string(),
+            owner_id: None,
+            poll_interval_secs: 5,
+            auto_join: true,
+            display_name: None,
+            sdk_store_path: std::path::PathBuf::from("/tmp/test-matrix-sdk"),
+        }
+    }
+
+    fn noop_store() -> PairingStore {
+        PairingStore::new_noop()
+    }
+
+    #[test]
+    fn test_channel_name() {
+        let oc = Arc::new(crate::ownership::OwnershipCache::new());
+        let ch = MatrixChannel::new(test_config(), None, oc).unwrap();
+        assert_eq!(ch.name(), "matrix");
+    }
+
+    #[test]
+    fn test_invalid_homeserver_rejected() {
+        let mut cfg = test_config();
+        cfg.homeserver = "matrix.org".to_string();
+        let oc = Arc::new(crate::ownership::OwnershipCache::new());
+        assert!(MatrixChannel::new(cfg, None, oc).is_err());
+    }
+
+    #[test]
+    fn test_http_homeserver_allowed() {
+        let mut cfg = test_config();
+        cfg.homeserver = "http://localhost:8448".to_string();
+        let oc = Arc::new(crate::ownership::OwnershipCache::new());
+        assert!(MatrixChannel::new(cfg, None, oc).is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_owner_restriction_allows_owner() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.owner_id = Some("@alice:matrix.org".to_string());
+        assert!(matches!(
+            check_sender(&cfg, "@alice:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Allow
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_owner_restriction_denies_others() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.owner_id = Some("@alice:matrix.org".to_string());
+        assert!(matches!(
+            check_sender(&cfg, "@bob:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Deny
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_open_policy_allows_all() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.dm_policy = "open".to_string();
+        assert!(matches!(
+            check_sender(&cfg, "@stranger:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Allow
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_policy_denies_unlisted() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.dm_policy = "allowlist".to_string();
+        cfg.allow_from = vec!["@alice:matrix.org".to_string()];
+        assert!(matches!(
+            check_sender(&cfg, "@bob:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Deny
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_allowlist_policy_allows_listed() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.dm_policy = "allowlist".to_string();
+        cfg.allow_from = vec!["@alice:matrix.org".to_string()];
+        assert!(matches!(
+            check_sender(&cfg, "@alice:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Allow
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_wildcard_allow_from_allows_all() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.dm_policy = "allowlist".to_string();
+        cfg.allow_from = vec!["*".to_string()];
+        assert!(matches!(
+            check_sender(&cfg, "@anyone:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Allow
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_pairing_policy_triggers_pair_for_unknown() {
+        let cfg = test_config();
+        let ps = noop_store();
+        assert!(matches!(
+            check_sender(&cfg, "@stranger:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Pair(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_config_case_insensitive_allow_from() {
+        let mut cfg = test_config();
+        let ps = noop_store();
+        cfg.dm_policy = "allowlist".to_string();
+        cfg.allow_from = vec!["@Alice:Matrix.ORG".to_string()];
+        assert!(matches!(
+            check_sender(&cfg, "@alice:matrix.org", "!room:matrix.org", &ps).await,
+            SenderDecision::Allow
+        ));
+    }
+
+    #[test]
+    fn test_conversation_context_includes_room_and_homeserver() {
+        let oc = Arc::new(crate::ownership::OwnershipCache::new());
+        let ch = MatrixChannel::new(test_config(), None, oc).unwrap();
+        let meta = serde_json::json!({
+            "room_id": "!xyz:matrix.org",
+            "homeserver": "https://matrix.org"
+        });
+        let ctx = ch.conversation_context(&meta);
+        assert_eq!(
+            ctx.get("matrix_room_id").map(|s| s.as_str()),
+            Some("!xyz:matrix.org")
+        );
+        assert_eq!(
+            ctx.get("matrix_homeserver").map(|s| s.as_str()),
+            Some("https://matrix.org")
+        );
+    }
+
+    #[cfg(not(feature = "matrix-sdk-channel"))]
+    #[test]
+    fn test_sync_response_parses_invite() {
+        use super::raw::*;
+        // Ensure the raw JSON shapes compile in test mode.
+        let json = serde_json::json!({
+            "next_batch": "s123",
+            "rooms": { "invite": { "!room:matrix.org": {} } }
+        });
+        let sync: SyncResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(sync.next_batch, "s123");
+        assert!(sync.rooms.invite.contains_key("!room:matrix.org"));
+    }
+}

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -31,12 +31,12 @@ mod attachments;
 mod channel;
 mod http;
 mod manager;
+mod matrix;
 pub mod relay;
 mod repl;
 mod signal;
 #[cfg(feature = "tui")]
 pub mod tui;
-mod matrix;
 pub mod wasm;
 pub mod web;
 mod webhook_server;
@@ -54,8 +54,8 @@ pub use channel::{
 };
 pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;
+pub use matrix::MatrixChannel;
 pub use repl::ReplChannel;
 pub use signal::SignalChannel;
-pub use matrix::MatrixChannel;
 pub use web::GatewayChannel;
 pub use webhook_server::{WebhookServer, WebhookServerConfig};

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -36,6 +36,7 @@ mod repl;
 mod signal;
 #[cfg(feature = "tui")]
 pub mod tui;
+mod matrix;
 pub mod wasm;
 pub mod web;
 mod webhook_server;
@@ -55,5 +56,6 @@ pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;
 pub use repl::ReplChannel;
 pub use signal::SignalChannel;
+pub use matrix::MatrixChannel;
 pub use web::GatewayChannel;
 pub use webhook_server::{WebhookServer, WebhookServerConfig};

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -19,6 +19,7 @@ pub struct ChannelsConfig {
     pub gateway: Option<GatewayConfig>,
     pub signal: Option<SignalConfig>,
     pub tui: Option<TuiChannelConfig>,
+    pub matrix: Option<MatrixConfig>,
     /// Directory containing WASM channel modules (default: ~/.ironclaw/channels/).
     pub wasm_channels_dir: std::path::PathBuf,
     /// Whether WASM channels are enabled.
@@ -100,6 +101,54 @@ pub struct GatewayOidcConfig {
     pub issuer: Option<String>,
     /// Expected `aud` claim. Validated if set.
     pub audience: Option<String>,
+}
+
+/// Matrix channel configuration (native Matrix Client-Server API).
+#[derive(Debug, Clone)]
+pub struct MatrixConfig {
+    /// Matrix homeserver URL (e.g. `https://matrix.org`).
+    pub homeserver: String,
+    /// Matrix access token for the bot account.
+    /// Sourced from MATRIX_ACCESS_TOKEN env var or the encrypted secrets DB
+    /// (secret name: `matrix_access_token`). Set via `ironclaw onboard` or
+    /// `ironclaw secret set matrix_access_token <token>`.
+    pub access_token: SecretString,
+    /// Matrix device ID for session restore.
+    ///
+    /// Persisted after the first login via the secrets DB (secret name:
+    /// `matrix_device_id`, env var: `MATRIX_DEVICE_ID`). When present the
+    /// SDK restores the existing device rather than registering a new one,
+    /// which preserves Megolm session keys across restarts.
+    ///
+    /// `None` on first boot — the SDK assigns a device ID and the channel
+    /// saves it to the secrets DB via `SecretsStore`.
+    pub device_id: Option<String>,
+    /// Users allowed to interact with the bot (Matrix user IDs, e.g. `@user:matrix.org`).
+    ///
+    /// - Empty list — all DM senders blocked unless paired or `dm_policy = "open"`
+    /// - `*` — allow everyone
+    pub allow_from: Vec<String>,
+    /// DM policy: "open", "allowlist", or "pairing". Default: "pairing".
+    ///
+    /// - "open" — accept all messages
+    /// - "allowlist" — only senders in allow_from
+    /// - "pairing" — allowlist + send pairing reply to unknown senders
+    pub dm_policy: String,
+    /// Optional owner restriction: only this Matrix user ID is accepted.
+    /// Overrides all other policy checks.
+    pub owner_id: Option<String>,
+    /// How often to poll Matrix `/sync` in seconds. Default: 5.
+    /// Only used by the raw reqwest fallback path (no-`matrix-sdk-channel`).
+    pub poll_interval_secs: u32,
+    /// Whether to auto-join invited rooms. Default: true.
+    pub auto_join: bool,
+    /// Display name to set for the bot. Default: "IronClaw".
+    pub display_name: Option<String>,
+    /// Path to the matrix-sdk SQLite store directory.
+    ///
+    /// Defaults to `~/.ironclaw/matrix-sdk/`. The directory is created on
+    /// first use. Configurable via `MATRIX_SDK_STORE_PATH` env var.
+    pub sdk_store_path: std::path::PathBuf,
 }
 
 /// Signal channel configuration (signal-cli daemon HTTP/JSON-RPC).
@@ -397,6 +446,70 @@ impl ChannelsConfig {
             None
         };
 
+        // Matrix channel — enabled when MATRIX_HOMESERVER is set AND
+        // MATRIX_ACCESS_TOKEN is available (may be injected from secrets DB
+        // in Phase 2; silently deferred if token is missing at Phase 1).
+        let matrix_homeserver =
+            optional_env("MATRIX_HOMESERVER")?.or_else(|| cs.matrix_homeserver.clone());
+        let matrix = if let Some(homeserver) = matrix_homeserver {
+            let access_token =
+                optional_env("MATRIX_ACCESS_TOKEN")?.or_else(|| cs.matrix_access_token.clone());
+            match access_token {
+                None => {
+                    // Token not yet available (secrets injected in Phase 2).
+                    // Silently defer — channel will activate on next re-resolution.
+                    tracing::debug!(
+                        "MATRIX_ACCESS_TOKEN not yet available — Matrix channel deferred"
+                    );
+                    None
+                }
+                Some(token) => {
+                    let allow_from = optional_env("MATRIX_ALLOW_FROM")?
+                        .or_else(|| cs.matrix_allow_from.clone())
+                        .map(|s| {
+                            s.split(',')
+                                .map(|e| e.trim().to_string())
+                                .filter(|s| !s.is_empty())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let dm_policy = optional_env("MATRIX_DM_POLICY")?
+                        .or_else(|| cs.matrix_dm_policy.clone())
+                        .unwrap_or_else(|| "pairing".to_string());
+                    let owner_id =
+                        optional_env("MATRIX_OWNER_ID")?.or_else(|| cs.matrix_owner_id.clone());
+                    let poll_interval_secs: u32 = parse_optional_env(
+                        "MATRIX_POLL_INTERVAL_SECS",
+                        cs.matrix_poll_interval_secs.unwrap_or(5),
+                    )?;
+                    let auto_join =
+                        parse_bool_env("MATRIX_AUTO_JOIN", cs.matrix_auto_join.unwrap_or(true))?;
+                    let display_name = optional_env("MATRIX_DISPLAY_NAME")?
+                        .or_else(|| cs.matrix_display_name.clone());
+                    // Device ID — injected from secrets DB into MATRIX_DEVICE_ID
+                    // by inject_llm_keys_from_secrets(). None on first boot.
+                    let device_id = optional_env("MATRIX_DEVICE_ID")?;
+                    let sdk_store_path = optional_env("MATRIX_SDK_STORE_PATH")?
+                        .map(std::path::PathBuf::from)
+                        .unwrap_or_else(|| ironclaw_base_dir().join("matrix-sdk"));
+                    Some(MatrixConfig {
+                        homeserver,
+                        access_token: SecretString::from(token),
+                        device_id,
+                        allow_from,
+                        dm_policy,
+                        owner_id,
+                        poll_interval_secs,
+                        auto_join,
+                        display_name,
+                        sdk_store_path,
+                    })
+                }
+            }
+        } else {
+            None
+        };
+
         let cli_enabled = db_first_bool(cs.cli_enabled, defaults.cli_enabled, "CLI_ENABLED")?;
         let cli_mode = db_first_optional_string(&cs.cli_mode, "CLI_MODE")?
             .unwrap_or_else(|| "tui".to_string());
@@ -417,6 +530,7 @@ impl ChannelsConfig {
             gateway,
             signal,
             tui,
+            matrix,
             wasm_channels_dir: {
                 // DB-first: use settings if explicitly set, else env, else default.
                 // defaults.wasm_channels_dir is None, so any Some(..) is an explicit DB override.
@@ -625,6 +739,7 @@ mod tests {
             gateway: None,
             signal: None,
             tui: None,
+            matrix: None,
             wasm_channels_dir: PathBuf::from("/tmp/channels"),
             wasm_channels_enabled: true,
             configured_wasm_channels: Vec::new(),
@@ -651,6 +766,7 @@ mod tests {
             gateway: None,
             signal: None,
             tui: None,
+            matrix: None,
             wasm_channels_dir: PathBuf::from("/opt/channels"),
             wasm_channels_enabled: false,
             configured_wasm_channels: vec!["telegram".to_string()],

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -54,7 +54,7 @@ pub use self::agent::AgentConfig;
 pub use self::builder::BuilderModeConfig;
 pub use self::channels::{
     ChannelsConfig, CliConfig, DEFAULT_GATEWAY_PORT, GatewayConfig, GatewayOidcConfig, HttpConfig,
-    SignalConfig, TuiChannelConfig,
+    MatrixConfig, SignalConfig, TuiChannelConfig,
 };
 pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsql_path};
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
@@ -187,6 +187,7 @@ impl Config {
                 gateway: None,
                 signal: None,
                 tui: None,
+                matrix: None,
                 wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),
                 wasm_channels_enabled: false,
                 configured_wasm_channels: Vec::new(),
@@ -388,12 +389,34 @@ impl Config {
         Ok(())
     }
 
-    /// Re-resolve only the LLM config after credential injection.
+    /// Re-resolve channel config after secrets have been injected.
     ///
-    /// Called by `AppBuilder::init_secrets()` after injecting API keys into
-    /// the env overlay. Only rebuilds `self.llm` — all other config fields
-    /// are unaffected, preserving values from the initial config load (or
-    /// from `Config::for_testing()` in test mode).
+    /// Called in Phase 2 after `inject_llm_keys_from_secrets` so that channel
+    /// tokens stored in the encrypted DB (e.g. `matrix_access_token`) are
+    /// available when `ChannelsConfig::resolve` reads from the env overlay.
+    pub async fn re_resolve_channels(
+        &mut self,
+        store: Option<&(dyn crate::db::SettingsStore + Sync)>,
+        user_id: &str,
+        toml_path: Option<&std::path::Path>,
+    ) -> Result<(), ConfigError> {
+        // TOML as base, then DB on top (DB wins) — same layering as
+        // re_resolve_llm_with_secrets.
+        let settings = if let Some(store) = store {
+            let mut s = Settings::default();
+            Self::apply_toml_overlay(&mut s, toml_path)?;
+            if let Ok(map) = store.get_all_settings(user_id).await {
+                let db_settings = Settings::from_db_map(&map);
+                s.merge_from(&db_settings);
+            }
+            s
+        } else {
+            Settings::default()
+        };
+        self.channels = ChannelsConfig::resolve(&settings, &self.owner_id)?;
+        Ok(())
+    }
+
     pub async fn re_resolve_llm(
         &mut self,
         store: Option<&(dyn crate::db::SettingsStore + Sync)>,
@@ -560,6 +583,12 @@ pub async fn inject_llm_keys_from_secrets(
     let mut mappings: Vec<(&str, &str)> = vec![
         ("llm_nearai_api_key", "NEARAI_API_KEY"),
         ("llm_anthropic_oauth_token", "ANTHROPIC_OAUTH_TOKEN"),
+        // Native channel secrets — injected from the encrypted DB so they can
+        // be set via `ironclaw onboard`, `ironclaw secret set`, or the web UI.
+        ("matrix_access_token", "MATRIX_ACCESS_TOKEN"),
+        // Device ID persisted after first login — reused so the SDK doesn't
+        // create a new device on every restart (which would orphan old sessions).
+        ("matrix_device_id", "MATRIX_DEVICE_ID"),
     ];
 
     // Dynamically discover secret->env mappings from the provider registry.

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -686,6 +686,38 @@ impl ConversationStore for LibSqlBackend {
             None => Ok(None),
         }
     }
+
+    async fn list_external_thread_mappings(
+        &self,
+    ) -> Result<Vec<(Uuid, String, String, String)>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, channel, user_id, thread_id FROM conversations WHERE thread_id IS NOT NULL",
+                libsql::params![],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        let mut results = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            let id_str: String = row
+                .get(0)
+                .map_err(|e| DatabaseError::Query(format!("id: {e}")))?;
+            let id = id_str
+                .parse()
+                .map_err(|_| DatabaseError::Serialization("Invalid UUID".to_string()))?;
+            let channel = get_text(&row, 1);
+            let user_id = get_text(&row, 2);
+            let thread_id = get_text(&row, 3);
+            results.push((id, channel, user_id, thread_id));
+        }
+        Ok(results)
+    }
 }
 
 #[cfg(test)]

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -492,6 +492,12 @@ pub trait ConversationStore: Send + Sync {
         &self,
         conversation_id: Uuid,
     ) -> Result<Option<String>, DatabaseError>;
+    /// Return all (conversation_uuid, channel, user_id, external_thread_id) rows
+    /// where `thread_id IS NOT NULL`. Used at startup to seed the in-memory
+    /// thread map so channel-native room/chat IDs survive process restarts.
+    async fn list_external_thread_mappings(
+        &self,
+    ) -> Result<Vec<(Uuid, String, String, String)>, DatabaseError>;
 }
 
 #[async_trait]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -299,6 +299,12 @@ impl ConversationStore for PgBackend {
             .get_conversation_source_channel(conversation_id)
             .await
     }
+
+    async fn list_external_thread_mappings(
+        &self,
+    ) -> Result<Vec<(Uuid, String, String, String)>, DatabaseError> {
+        self.store.list_external_thread_mappings().await
+    }
 }
 
 // ==================== JobStore ====================

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -2153,6 +2153,29 @@ impl Store {
         Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
     }
 
+    pub async fn list_external_thread_mappings(
+        &self,
+    ) -> Result<Vec<(Uuid, String, String, String)>, DatabaseError> {
+        let conn = self.conn().await?;
+        let rows = conn
+            .query(
+                "SELECT id, channel, user_id, thread_id FROM conversations WHERE thread_id IS NOT NULL",
+                &[],
+            )
+            .await?;
+        let results = rows
+            .into_iter()
+            .filter_map(|r| {
+                let id: Uuid = r.get(0);
+                let channel: Option<String> = r.get(1);
+                let user_id: Option<String> = r.get(2);
+                let thread_id: String = r.get(3);
+                Some((id, channel?, user_id?, thread_id))
+            })
+            .collect();
+        Ok(results)
+    }
+
     /// Load messages for a conversation with cursor-based pagination.
     ///
     /// Returns `(messages_oldest_first, has_more)`.

--- a/src/hooks/session_summary.rs
+++ b/src/hooks/session_summary.rs
@@ -371,6 +371,12 @@ mod tests {
         ) -> Result<Option<String>, crate::error::DatabaseError> {
             unimplemented!()
         }
+
+        async fn list_external_thread_mappings(
+            &self,
+        ) -> Result<Vec<(Uuid, String, String, String)>, crate::error::DatabaseError> {
+            Ok(Vec::new())
+        }
     }
 
     // ── Mock LlmProvider ────────────────────────────────────────────

--- a/src/llm/smart_routing.rs
+++ b/src/llm/smart_routing.rs
@@ -1396,7 +1396,7 @@ mod tests {
 
     #[test]
     fn score_very_long_prompt_is_at_least_standard() {
-        let long = "Tell me about ".to_string() + &"things ".repeat(200);
+        let long = format!("Tell me about {}", "things ".repeat(200));
         let result = score_complexity(&long);
         assert!(
             result.total >= 16,

--- a/src/main.rs
+++ b/src/main.rs
@@ -724,10 +724,8 @@ async fn async_main() -> anyhow::Result<()> {
         // after first login.  Only compiled in when matrix-sdk-channel is on.
         #[cfg(feature = "matrix-sdk-channel")]
         if let Some(ref store) = components.secrets_store {
-            matrix_channel = matrix_channel.with_secrets(
-                std::sync::Arc::clone(store),
-                &config.owner_id,
-            );
+            matrix_channel =
+                matrix_channel.with_secrets(std::sync::Arc::clone(store), &config.owner_id);
         }
 
         channel_names.push("matrix".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -709,6 +709,41 @@ async fn async_main() -> anyhow::Result<()> {
         }
     }
 
+    // Add Matrix channel if configured and not CLI-only mode.
+    if !cli.cli_only
+        && let Some(ref matrix_config) = config.channels.matrix
+    {
+        let mut matrix_channel = ironclaw::channels::MatrixChannel::new(
+            matrix_config.clone(),
+            components.db.clone(),
+            Arc::clone(&components.ownership_cache),
+        )
+        .map_err(ironclaw::error::Error::Channel)?;
+
+        // Attach the secrets store so the SDK path can persist the device ID
+        // after first login.  Only compiled in when matrix-sdk-channel is on.
+        #[cfg(feature = "matrix-sdk-channel")]
+        if let Some(ref store) = components.secrets_store {
+            matrix_channel = matrix_channel.with_secrets(
+                std::sync::Arc::clone(store),
+                &config.owner_id,
+            );
+        }
+
+        channel_names.push("matrix".to_string());
+        channels.add(Box::new(matrix_channel)).await;
+        tracing::info!(
+            homeserver = %matrix_config.homeserver,
+            dm_policy = %matrix_config.dm_policy,
+            "Matrix channel enabled"
+        );
+        if matrix_config.allow_from.is_empty() && matrix_config.dm_policy == "allowlist" {
+            tracing::warn!(
+                "Matrix channel dm_policy=allowlist but allow_from is empty — all messages will be denied."
+            );
+        }
+    }
+
     // Add Signal channel if configured and not CLI-only mode.
     if enable_non_cli && let Some(ref signal_config) = config.channels.signal {
         let signal_channel = SignalChannel::new(
@@ -1375,6 +1410,13 @@ async fn async_main() -> anyhow::Result<()> {
                 // Inject channel secrets from database into thread-safe overlay
                 // (similar to inject_llm_keys_from_secrets for LLM providers)
                 if let Some(ref secrets_store) = sighup_secrets_store {
+                    // Re-inject all known secrets (LLM keys + channel tokens incl. matrix).
+                    ironclaw::config::inject_llm_keys_from_secrets(
+                        secrets_store.as_ref(),
+                        &sighup_owner_id,
+                    )
+                    .await;
+
                     // Inject HTTP webhook secret from encrypted store
                     if let Ok(webhook_secret) = secrets_store
                         .get_decrypted(&sighup_owner_id, "http_webhook_secret")

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -409,6 +409,46 @@ pub struct ChannelSettings {
     #[serde(default)]
     pub signal_group_allow_from: Option<String>,
 
+    /// Matrix homeserver URL (e.g. `https://matrix.org`).
+    #[serde(default)]
+    pub matrix_homeserver: Option<String>,
+
+    /// Matrix bot username (localpart only, e.g. `mybot`).
+    /// Wizard-only: saved during onboarding so re-onboarding can show the
+    /// current value and only require re-entering the password. Not read by
+    /// `ChannelsConfig::resolve` and not present in `MatrixConfig`.
+    #[serde(default)]
+    pub matrix_username: Option<String>,
+
+    /// Matrix bot access token (syt_...).
+    /// Prefer storing in the encrypted secrets DB via `ironclaw onboard`.
+    #[serde(default, skip_serializing)]
+    pub matrix_access_token: Option<String>,
+
+    /// Matrix DM allow list (comma-separated Matrix user IDs).
+    #[serde(default)]
+    pub matrix_allow_from: Option<String>,
+
+    /// Matrix DM policy: "open", "allowlist", or "pairing". Default: "pairing".
+    #[serde(default)]
+    pub matrix_dm_policy: Option<String>,
+
+    /// Matrix owner restriction — only this user ID is accepted.
+    #[serde(default)]
+    pub matrix_owner_id: Option<String>,
+
+    /// Matrix sync poll interval in seconds. Default: 5.
+    #[serde(default)]
+    pub matrix_poll_interval_secs: Option<u32>,
+
+    /// Whether to auto-join invited rooms. Default: true.
+    #[serde(default)]
+    pub matrix_auto_join: Option<bool>,
+
+    /// Display name for the Matrix bot. Default: "IronClaw".
+    #[serde(default)]
+    pub matrix_display_name: Option<String>,
+
     /// Per-channel owner user IDs. When set, the channel only responds to this user.
     /// Key: channel name (e.g., "telegram"), Value: owner user ID.
     #[serde(default)]
@@ -454,6 +494,15 @@ impl Default for ChannelSettings {
             signal_dm_policy: None,
             signal_group_policy: None,
             signal_group_allow_from: None,
+            matrix_homeserver: None,
+            matrix_username: None,
+            matrix_access_token: None,
+            matrix_allow_from: None,
+            matrix_dm_policy: None,
+            matrix_owner_id: None,
+            matrix_poll_interval_secs: None,
+            matrix_auto_join: None,
+            matrix_display_name: None,
             wasm_channel_owner_ids: std::collections::HashMap::new(),
             wasm_channels: Vec::new(),
             wasm_channels_enabled: true,

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -585,7 +585,11 @@ pub async fn setup_matrix(
 
     let password = if existing.homeserver.is_some() {
         let raw = secret_input("Matrix password (Enter to keep existing session)")?;
-        if raw.expose_secret().trim().is_empty() { None } else { Some(raw) }
+        if raw.expose_secret().trim().is_empty() {
+            None
+        } else {
+            Some(raw)
+        }
     } else {
         Some(secret_input("Matrix password")?)
     };
@@ -616,22 +620,33 @@ pub async fn setup_matrix(
 
         let login_url = format!("{}/_matrix/client/v3/login", homeserver);
 
-        let resp = http.post(&login_url).json(&login_body).send().await
+        let resp = http
+            .post(&login_url)
+            .json(&login_body)
+            .send()
+            .await
             .map_err(|e| ChannelSetupError::Network(format!("Login request failed: {}", e)))?;
 
         let status = resp.status();
         if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
             let body = resp.text().await.unwrap_or_default();
             print_error(&format!("Login failed: {}", body));
-            return Err(ChannelSetupError::Validation(format!("Login failed: {}", body)));
+            return Err(ChannelSetupError::Validation(format!(
+                "Login failed: {}",
+                body
+            )));
         }
         if !status.is_success() {
             let body = resp.text().await.unwrap_or_default();
-            return Err(ChannelSetupError::Network(format!("Login returned {}: {}", status, body)));
+            return Err(ChannelSetupError::Network(format!(
+                "Login returned {}: {}",
+                status, body
+            )));
         }
 
-        let login_resp: serde_json::Value = resp.json().await
-            .map_err(|e| ChannelSetupError::Network(format!("Failed to parse login response: {}", e)))?;
+        let login_resp: serde_json::Value = resp.json().await.map_err(|e| {
+            ChannelSetupError::Network(format!("Failed to parse login response: {}", e))
+        })?;
 
         // Login succeeded — now wipe the SDK store so the new device starts
         // with clean crypto state. Deferred to after login so that a failed
@@ -675,11 +690,15 @@ pub async fn setup_matrix(
         print_success(&format!("Logged in as {} (device: {})", uid, device_id));
 
         let token_secret = SecretString::from(token.to_string());
-        secrets.save_secret("matrix_access_token", &token_secret).await?;
+        secrets
+            .save_secret("matrix_access_token", &token_secret)
+            .await?;
 
         // Persist device_id so start() reuses this session on restart.
         let device_secret = SecretString::from(device_id.to_string());
-        secrets.save_secret("matrix_device_id", &device_secret).await?;
+        secrets
+            .save_secret("matrix_device_id", &device_secret)
+            .await?;
 
         print_success("Credentials saved to encrypted secrets database.");
         uid.to_string()
@@ -693,11 +712,10 @@ pub async fn setup_matrix(
     println!();
 
     let allow_from = match existing.allow_from {
-        Some(current) if !current.is_empty() =>
-            prompt_with_default(
-                "Allow from (comma-separated Matrix user IDs, '*' for anyone, empty for pairing)",
-                current,
-            )?,
+        Some(current) if !current.is_empty() => prompt_with_default(
+            "Allow from (comma-separated Matrix user IDs, '*' for anyone, empty for pairing)",
+            current,
+        )?,
         _ => optional_input(
             "Allow from (comma-separated Matrix user IDs, '*' for anyone, empty for pairing mode)",
             Some("default: (pairing mode — unknown users get a pairing code)"),
@@ -720,11 +738,9 @@ pub async fn setup_matrix(
     )?
     .filter(|s| !s.is_empty());
 
-    let display_name = prompt_optional_with_default(
-        "Bot display name in Matrix",
-        existing.display_name,
-    )?
-    .filter(|s| !s.is_empty());
+    let display_name =
+        prompt_optional_with_default("Bot display name in Matrix", existing.display_name)?
+            .filter(|s| !s.is_empty());
 
     // ── Summary ───────────────────────────────────────────────────────────────
 

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -477,6 +477,280 @@ pub struct HttpSetupResult {
     pub host: String,
 }
 
+/// Result of Matrix channel setup.
+#[derive(Debug, Clone)]
+pub struct MatrixSetupResult {
+    pub enabled: bool,
+    pub homeserver: String,
+    /// The bot's Matrix username (localpart), saved to settings for display on re-onboard.
+    pub username: String,
+    pub allow_from: String,
+    pub dm_policy: String,
+    pub owner_id: Option<String>,
+    pub poll_interval_secs: Option<u32>,
+    pub auto_join: bool,
+    pub display_name: Option<String>,
+}
+
+/// Existing Matrix settings — used to pre-fill prompts when re-running setup.
+pub struct ExistingMatrixSettings<'a> {
+    pub homeserver: Option<&'a str>,
+    pub username: Option<&'a str>,
+    pub allow_from: Option<&'a str>,
+    pub dm_policy: Option<&'a str>,
+    pub owner_id: Option<&'a str>,
+    pub display_name: Option<&'a str>,
+}
+
+/// Prompt helper: show `[current_value]` in the label and return the existing
+/// value unchanged when the user presses Enter without typing anything.
+fn prompt_with_default(label: &str, current: &str) -> Result<String, ChannelSetupError> {
+    let entered = input(&format!("{} [{}]", label, current))?;
+    if entered.trim().is_empty() {
+        Ok(current.to_string())
+    } else {
+        Ok(entered)
+    }
+}
+
+/// Same as `prompt_with_default` but for optional fields: empty input keeps
+/// the existing value; a single `-` clears it.
+fn prompt_optional_with_default(
+    label: &str,
+    current: Option<&str>,
+) -> Result<Option<String>, ChannelSetupError> {
+    let hint = match current {
+        Some(v) if !v.is_empty() => format!("{} [{}] (- to clear)", label, v),
+        _ => format!("{} (Enter to skip)", label),
+    };
+    let entered = input(&hint)?;
+    match entered.trim() {
+        "" => Ok(current.map(str::to_string)),
+        "-" => Ok(None),
+        v => Ok(Some(v.to_string())),
+    }
+}
+
+pub async fn setup_matrix(
+    secrets: &SecretsContext,
+    existing: ExistingMatrixSettings<'_>,
+) -> Result<MatrixSetupResult, ChannelSetupError> {
+    println!("Matrix Channel Setup:");
+    println!();
+    print_info("IronClaw connects to Matrix using the Client-Server API.");
+    print_info("You will need a dedicated Matrix bot account.");
+    print_info("IronClaw logs in with username + password to get its own device");
+    print_info("session — this avoids sharing a token with Element or other clients.");
+    println!();
+    if existing.homeserver.is_some() {
+        print_info("Press Enter on any prompt to keep the existing value.");
+        print_info("For optional fields, enter - to clear the current value.");
+        print_info("Leave username/password blank to keep the existing credentials.");
+        println!();
+    }
+
+    // ── Homeserver ────────────────────────────────────────────────────────────
+
+    let homeserver = match existing.homeserver {
+        Some(current) => prompt_with_default("Matrix homeserver URL", current)?,
+        None => input("Matrix homeserver URL (e.g. https://matrix.org)")?,
+    };
+
+    match Url::parse(&homeserver) {
+        Ok(url) if url.scheme() == "http" || url.scheme() == "https" => {}
+        Ok(_) => {
+            print_error("URL must use http or https scheme");
+            return Err(ChannelSetupError::Validation(
+                "Invalid homeserver URL: must use http or https scheme".to_string(),
+            ));
+        }
+        Err(e) => {
+            print_error(&format!("Invalid URL: {}", e));
+            return Err(ChannelSetupError::Validation(format!(
+                "Invalid homeserver URL: {}",
+                e
+            )));
+        }
+    }
+    let homeserver = homeserver.trim_end_matches('/').to_string();
+
+    // ── Login with username + password ────────────────────────────────────────
+    // This gives IronClaw its own device session independent of any Element
+    // session, so token rotation by another client doesn't invalidate us.
+
+    let username = match existing.username {
+        Some(current) => prompt_with_default("Matrix username (localpart only)", current)?,
+        None => input("Matrix username (localpart only, e.g. mybot)")?,
+    };
+
+    let password = if existing.homeserver.is_some() {
+        let raw = secret_input("Matrix password (Enter to keep existing session)")?;
+        if raw.expose_secret().trim().is_empty() { None } else { Some(raw) }
+    } else {
+        Some(secret_input("Matrix password")?)
+    };
+
+    // ── Perform login if a password was supplied ──────────────────────────────
+    // Username is always known (either entered or from existing settings).
+    // Only re-login when a password is provided — otherwise keep existing token.
+
+    let bot_user_id: String = if let Some(password) = password {
+        print_info("Logging in to Matrix...");
+        let http = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(15))
+            .build()
+            .map_err(|e| ChannelSetupError::Network(format!("HTTP client error: {}", e)))?;
+
+        // Fresh login — always get a new device ID. The old device session
+        // (if any) is orphaned on the homeserver but that's expected when
+        // explicitly re-providing credentials.
+        let login_body = serde_json::json!({
+            "type": "m.login.password",
+            "identifier": {
+                "type": "m.id.user",
+                "user": username,
+            },
+            "password": password.expose_secret(),
+            "initial_device_display_name": "IronClaw",
+        });
+
+        let login_url = format!("{}/_matrix/client/v3/login", homeserver);
+
+        let resp = http.post(&login_url).json(&login_body).send().await
+            .map_err(|e| ChannelSetupError::Network(format!("Login request failed: {}", e)))?;
+
+        let status = resp.status();
+        if status == reqwest::StatusCode::UNAUTHORIZED || status == reqwest::StatusCode::FORBIDDEN {
+            let body = resp.text().await.unwrap_or_default();
+            print_error(&format!("Login failed: {}", body));
+            return Err(ChannelSetupError::Validation(format!("Login failed: {}", body)));
+        }
+        if !status.is_success() {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ChannelSetupError::Network(format!("Login returned {}: {}", status, body)));
+        }
+
+        let login_resp: serde_json::Value = resp.json().await
+            .map_err(|e| ChannelSetupError::Network(format!("Failed to parse login response: {}", e)))?;
+
+        // Login succeeded — now wipe the SDK store so the new device starts
+        // with clean crypto state. Deferred to after login so that a failed
+        // login attempt doesn't destroy existing E2EE keys.
+        let sdk_store_path = crate::bootstrap::ironclaw_base_dir().join("matrix-sdk");
+        if sdk_store_path.exists() {
+            print_info("Wiping SDK store for fresh device session...");
+            if let Err(e) = std::fs::remove_dir_all(&sdk_store_path) {
+                print_error(&format!("Failed to wipe SDK store: {}", e));
+            }
+        }
+        // Write a `.fresh` marker so the startup sync loop knows to prime
+        // (discard backfill) instead of resuming from a stored position.
+        // The channel startup removes this marker after the priming sync.
+        if let Err(e) = std::fs::create_dir_all(&sdk_store_path) {
+            print_error(&format!("Failed to recreate SDK store dir: {}", e));
+        }
+        if let Err(e) = std::fs::write(sdk_store_path.join(".fresh"), b"") {
+            print_error(&format!("Failed to write .fresh marker: {}", e));
+        }
+
+        let token = login_resp
+            .get("access_token")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ChannelSetupError::Network("Login response missing access_token".to_string())
+            })?;
+        let device_id = login_resp
+            .get("device_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ChannelSetupError::Network("Login response missing device_id".to_string())
+            })?;
+        let uid = login_resp
+            .get("user_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                ChannelSetupError::Network("Login response missing user_id".to_string())
+            })?;
+
+        print_success(&format!("Logged in as {} (device: {})", uid, device_id));
+
+        let token_secret = SecretString::from(token.to_string());
+        secrets.save_secret("matrix_access_token", &token_secret).await?;
+
+        // Persist device_id so start() reuses this session on restart.
+        let device_secret = SecretString::from(device_id.to_string());
+        secrets.save_secret("matrix_device_id", &device_secret).await?;
+
+        print_success("Credentials saved to encrypted secrets database.");
+        uid.to_string()
+    } else {
+        print_info("Keeping existing credentials.");
+        "(unchanged)".to_string()
+    };
+
+    // ── Optional settings — all default to existing values ───────────────────
+
+    println!();
+
+    let allow_from = match existing.allow_from {
+        Some(current) if !current.is_empty() =>
+            prompt_with_default(
+                "Allow from (comma-separated Matrix user IDs, '*' for anyone, empty for pairing)",
+                current,
+            )?,
+        _ => optional_input(
+            "Allow from (comma-separated Matrix user IDs, '*' for anyone, empty for pairing mode)",
+            Some("default: (pairing mode — unknown users get a pairing code)"),
+        )?
+        .unwrap_or_default(),
+    };
+
+    let dm_policy = match existing.dm_policy {
+        Some(current) => prompt_with_default("DM policy (open, allowlist, pairing)", current)?,
+        None => optional_input(
+            "DM policy (open, allowlist, pairing)",
+            Some("default: pairing"),
+        )?
+        .unwrap_or_else(|| "pairing".to_string()),
+    };
+
+    let owner_id = prompt_optional_with_default(
+        "Owner user ID (restrict to single Matrix user ID, e.g. @you:matrix.org)",
+        existing.owner_id,
+    )?
+    .filter(|s| !s.is_empty());
+
+    let display_name = prompt_optional_with_default(
+        "Bot display name in Matrix",
+        existing.display_name,
+    )?
+    .filter(|s| !s.is_empty());
+
+    // ── Summary ───────────────────────────────────────────────────────────────
+
+    println!();
+    print_success(&format!("Matrix channel configured for {}", homeserver));
+    if bot_user_id != "(unchanged)" {
+        print_info(&format!("Bot: {}", bot_user_id));
+    }
+    print_info(&format!("DM policy: {}", dm_policy));
+    if !allow_from.is_empty() {
+        print_info(&format!("Allow from: {}", allow_from));
+    }
+
+    Ok(MatrixSetupResult {
+        enabled: true,
+        homeserver,
+        username,
+        allow_from,
+        dm_policy,
+        owner_id,
+        poll_interval_secs: None,
+        auto_join: true,
+        display_name,
+    })
+}
+
 /// Result of Signal channel setup.
 #[derive(Debug, Clone)]
 pub struct SignalSetupResult {

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -33,7 +33,7 @@ use crate::llm::{SessionConfig, SessionManager};
 use crate::secrets::{SecretsCrypto, SecretsStore};
 use crate::settings::{KeySource, Settings};
 use crate::setup::channels::{
-    SecretsContext, setup_http, setup_signal, setup_tunnel, setup_wasm_channel,
+    SecretsContext, setup_http, setup_matrix, setup_signal, setup_tunnel, setup_wasm_channel,
 };
 use crate::setup::prompts::{
     confirm, input, optional_input, print_banner, print_error, print_header, print_info,
@@ -44,6 +44,7 @@ use crate::setup::prompts::{
 // const CHANNEL_INDEX_CLI: usize = 0;
 const CHANNEL_INDEX_HTTP: usize = 1;
 const CHANNEL_INDEX_SIGNAL: usize = 2;
+const CHANNEL_INDEX_MATRIX: usize = 3;
 const QUICK_PROFILE_LOCAL: &str = "local";
 const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
@@ -2631,6 +2632,10 @@ impl SetupWizard {
                 self.settings.channels.http_enabled,
             ),
             ("Signal".to_string(), self.settings.channels.signal_enabled),
+            (
+                "Matrix".to_string(),
+                self.settings.channels.matrix_homeserver.is_some(),
+            ),
         ];
 
         let non_wasm_count = options.len();
@@ -2704,8 +2709,9 @@ impl SetupWizard {
         }
 
         // Determine if we need secrets context
-        let needs_secrets =
-            selected.contains(&CHANNEL_INDEX_HTTP) || !selected_wasm_channels.is_empty();
+        let needs_secrets = selected.contains(&CHANNEL_INDEX_HTTP)
+            || selected.contains(&CHANNEL_INDEX_MATRIX)
+            || !selected_wasm_channels.is_empty();
         let secrets = if needs_secrets {
             match self.init_secrets_context().await {
                 Ok(ctx) => Some(ctx),
@@ -2756,6 +2762,47 @@ impl SetupWizard {
             self.settings.channels.signal_dm_policy = None;
             self.settings.channels.signal_group_policy = None;
             self.settings.channels.signal_group_allow_from = None;
+        }
+
+        // Matrix channel
+        if selected.contains(&CHANNEL_INDEX_MATRIX) {
+            println!();
+            if let Some(ref ctx) = secrets {
+                let result = setup_matrix(
+                    ctx,
+                    crate::setup::channels::ExistingMatrixSettings {
+                        homeserver: self.settings.channels.matrix_homeserver.as_deref(),
+                        username: self.settings.channels.matrix_username.as_deref(),
+                        allow_from: self.settings.channels.matrix_allow_from.as_deref(),
+                        dm_policy: self.settings.channels.matrix_dm_policy.as_deref(),
+                        owner_id: self.settings.channels.matrix_owner_id.as_deref(),
+                        display_name: self.settings.channels.matrix_display_name.as_deref(),
+                    },
+                ).await?;
+                if result.enabled {
+                    self.settings.channels.matrix_homeserver = Some(result.homeserver);
+                    self.settings.channels.matrix_username = Some(result.username);
+                    self.settings.channels.matrix_allow_from =
+                        if result.allow_from.is_empty() { None } else { Some(result.allow_from) };
+                    self.settings.channels.matrix_dm_policy = Some(result.dm_policy);
+                    self.settings.channels.matrix_owner_id = result.owner_id;
+                    self.settings.channels.matrix_poll_interval_secs = result.poll_interval_secs;
+                    self.settings.channels.matrix_auto_join = Some(result.auto_join);
+                    self.settings.channels.matrix_display_name = result.display_name;
+                }
+            } else {
+                print_info("Matrix channel requires secrets DB. Set MATRIX_HOMESERVER and");
+                print_info("MATRIX_ACCESS_TOKEN environment variables to enable.");
+            }
+        } else {
+            self.settings.channels.matrix_homeserver = None;
+            self.settings.channels.matrix_username = None;
+            self.settings.channels.matrix_allow_from = None;
+            self.settings.channels.matrix_dm_policy = None;
+            self.settings.channels.matrix_owner_id = None;
+            self.settings.channels.matrix_poll_interval_secs = None;
+            self.settings.channels.matrix_auto_join = None;
+            self.settings.channels.matrix_display_name = None;
         }
 
         let discovered_by_name: HashMap<String, ChannelCapabilitiesFile> =
@@ -3807,15 +3854,26 @@ async fn install_missing_bundled_channels(
     Ok(installed)
 }
 
+/// Channel names handled natively — excluded from the WASM channel list
+/// to avoid showing duplicates when a built-in option already exists.
+const NATIVE_CHANNEL_NAMES: &[&str] = &["matrix"];
+
 /// Build channel options from discovered channels + bundled + registry catalog.
 ///
 /// Returns a deduplicated, sorted list of channel names available for selection.
+/// Excludes channels that are already handled natively (e.g. "matrix").
 fn build_channel_options(discovered: &[(String, ChannelCapabilitiesFile)]) -> Vec<String> {
-    let mut names: Vec<String> = discovered.iter().map(|(name, _)| name.clone()).collect();
+    let mut names: Vec<String> = discovered
+        .iter()
+        .map(|(name, _)| name.clone())
+        .filter(|name| !NATIVE_CHANNEL_NAMES.contains(&name.as_str()))
+        .collect();
 
     // Add bundled channels
     for bundled in available_channel_names().iter().copied() {
-        if !names.iter().any(|name| name == bundled) {
+        if !names.iter().any(|name| name == bundled)
+            && !NATIVE_CHANNEL_NAMES.contains(&bundled)
+        {
             names.push(bundled.to_string());
         }
     }
@@ -3823,7 +3881,9 @@ fn build_channel_options(discovered: &[(String, ChannelCapabilitiesFile)]) -> Ve
     // Add registry channels
     if let Some(catalog) = load_registry_catalog() {
         for manifest in catalog.list(Some(crate::registry::manifest::ManifestKind::Channel), None) {
-            if !names.iter().any(|n| n == &manifest.name) {
+            if !names.iter().any(|n| n == &manifest.name)
+                && !NATIVE_CHANNEL_NAMES.contains(&manifest.name.as_str())
+            {
                 names.push(manifest.name.clone());
             }
         }

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -2778,12 +2778,16 @@ impl SetupWizard {
                         owner_id: self.settings.channels.matrix_owner_id.as_deref(),
                         display_name: self.settings.channels.matrix_display_name.as_deref(),
                     },
-                ).await?;
+                )
+                .await?;
                 if result.enabled {
                     self.settings.channels.matrix_homeserver = Some(result.homeserver);
                     self.settings.channels.matrix_username = Some(result.username);
-                    self.settings.channels.matrix_allow_from =
-                        if result.allow_from.is_empty() { None } else { Some(result.allow_from) };
+                    self.settings.channels.matrix_allow_from = if result.allow_from.is_empty() {
+                        None
+                    } else {
+                        Some(result.allow_from)
+                    };
                     self.settings.channels.matrix_dm_policy = Some(result.dm_policy);
                     self.settings.channels.matrix_owner_id = result.owner_id;
                     self.settings.channels.matrix_poll_interval_secs = result.poll_interval_secs;
@@ -3871,9 +3875,7 @@ fn build_channel_options(discovered: &[(String, ChannelCapabilitiesFile)]) -> Ve
 
     // Add bundled channels
     for bundled in available_channel_names().iter().copied() {
-        if !names.iter().any(|name| name == bundled)
-            && !NATIVE_CHANNEL_NAMES.contains(&bundled)
-        {
+        if !names.iter().any(|name| name == bundled) && !NATIVE_CHANNEL_NAMES.contains(&bundled) {
             names.push(bundled.to_string());
         }
     }

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -412,6 +412,7 @@ mod tests {
             gateway: None,
             signal: None,
             tui: None,
+            matrix: None,
             wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),
             wasm_channels_enabled: false,
             configured_wasm_channels: Vec::new(),


### PR DESCRIPTION
## Summary

- Add a native Matrix channel using matrix-sdk with full event loop, room join/invite handling, and message routing
- Enable optional end-to-end encryption via a `matrix-e2ee` feature gate
- Persist and restore channel-native thread IDs across server restarts so Matrix reply chains survive reboots

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related #78

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `cargo test` (4230+ unit tests pass including new Matrix channel tests)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed — CI only; Telegram e2e tests require CI infrastructure
- [x] Manual testing: connected to a Matrix homeserver, verified message send/receive, room invites, reply threading, and restart persistence
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review — simulated via 3-agent parallel review (security, architecture, bug scan), 2 passes

## Security Impact

New outbound network connection to a Matrix homeserver. Credentials (homeserver URL, username, password) are loaded from environment variables and handled through the existing config/secrets layer. E2EE key storage uses matrix-sdk's SQLite-based crypto store on disk. Access token uses `SecretString` with `#[serde(skip_serializing)]` on the settings field.

## Database Impact

Adds a `native_thread_id` column read path in the conversations/history store (libSQL and PostgreSQL) for persisting Matrix thread IDs. No new migrations; uses existing nullable columns.

## Blast Radius

- **Channels**: new Matrix channel, isolated from existing WASM/relay channels
- **Agent**: thread ID persistence changes shared session/thread code; could affect thread resolution for other channels
- **Config/Settings**: new fields for Matrix; existing config resolution unchanged
- **Setup**: new onboarding wizard step; existing steps unaffected
- **Dependencies**: matrix-sdk adds a large dependency tree (~1500 lockfile lines); increases compile time

## Rollback Plan

Revert the 4 commits. The Matrix channel is behind a compile-time feature gate and opt-in config; disabling is as simple as not setting `MATRIX_HOMESERVER_URL`.

## Review Follow-Through

- matrix-sdk pulls in a large dependency tree; worth evaluating build time impact
- E2EE crypto store location and cleanup policy not yet addressed
- Thread ID persistence changes touch shared agent code and should be reviewed for side effects on other channels

---

**Review track**: B
