### PR TITLE
fix(tools) raw tool-call output in routine Telegram notifications

### DIFF
--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -1630,6 +1630,11 @@ fn build_lightweight_prompt(
             "Do not claim you lack messaging integrations or ask the user to set one up when \
              a plain reply is sufficient.\n",
         );
+        full_prompt.push_str(
+            "Return the final user-facing notification as normal assistant text. Do not use the \
+             `message` tool for the routine's primary delivery unless the task explicitly requires \
+             an extra follow-up or attachment; even then, still return a concise human-readable summary.\n",
+        );
     }
 
     if !use_tools {
@@ -1717,6 +1722,7 @@ fn handle_text_response(
     total_input_tokens: u32,
     total_output_tokens: u32,
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
+    let content = strip_internal_tool_call_text(content);
     let content = content.trim();
 
     // Empty content guard — carry consumed tokens so the retry loop can
@@ -1746,6 +1752,34 @@ fn handle_text_response(
         Some(content.to_string()),
         total_tokens,
     ))
+}
+
+/// Strip internal `[Called tool ...]` and `[Tool ... returned: ...]` markers
+/// from routine summaries before they are persisted or delivered to channels.
+fn strip_internal_tool_call_text(text: &str) -> String {
+    let result = text
+        .lines()
+        .filter(|line| {
+            let trimmed = line.trim();
+            !((trimmed.starts_with("[Called tool ") && trimmed.ends_with(']'))
+                || (trimmed.starts_with("[Tool ")
+                    && trimmed.contains(" returned:")
+                    && trimmed.ends_with(']')))
+        })
+        .fold(String::new(), |mut acc, s| {
+            if !acc.is_empty() {
+                acc.push('\n');
+            }
+            acc.push_str(s);
+            acc
+        });
+
+    let result = result.trim();
+    if result.is_empty() {
+        "I wasn't able to produce a user-facing routine summary.".to_string()
+    } else {
+        result.to_string()
+    }
 }
 
 /// Execute a lightweight routine with tool execution support (agentic loop).
@@ -2311,6 +2345,10 @@ mod tests {
             "delivery guidance should suppress fake setup chatter: {prompt}",
         );
         assert!(
+            prompt.contains("Do not use the `message` tool for the routine's primary delivery"),
+            "delivery guidance should reserve message tool for non-primary delivery: {prompt}",
+        );
+        assert!(
             prompt.contains("Tools are disabled for this routine run"),
             "prompt should explain that tools are disabled: {prompt}",
         );
@@ -2538,6 +2576,39 @@ mod tests {
         );
         assert_eq!(finish_reason_length, crate::llm::FinishReason::Length);
         assert_eq!(finish_reason_stop, crate::llm::FinishReason::Stop);
+    }
+
+    #[test]
+    fn test_handle_text_response_strips_internal_tool_markers() {
+        let result = super::handle_text_response(
+            "Here is the report.\n[Called tool `http` with arguments: {\"url\":\"https://example.com\"}]",
+            crate::llm::FinishReason::Stop,
+            10,
+            5,
+        )
+        .expect("tool marker text should sanitize");
+
+        assert_eq!(result.0, RunStatus::Attention);
+        assert_eq!(result.1.as_deref(), Some("Here is the report."));
+        assert_eq!(result.2, Some(15));
+    }
+
+    #[test]
+    fn test_handle_text_response_replaces_marker_only_text() {
+        let result = super::handle_text_response(
+            "[Called tool `http` with arguments: {\"url\":\"https://example.com\"}]",
+            crate::llm::FinishReason::Stop,
+            4,
+            3,
+        )
+        .expect("marker-only text should fall back to a user-facing summary");
+
+        assert_eq!(result.0, RunStatus::Attention);
+        assert_eq!(
+            result.1.as_deref(),
+            Some("I wasn't able to produce a user-facing routine summary.")
+        );
+        assert_eq!(result.2, Some(7));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- strip leaked internal tool-call markers from lightweight routine summaries before persistence and notification delivery
- steer lightweight routine prompts to return the primary notification as assistant text instead of using the `message` tool by default
- add regression tests for both the prompt guidance and marker-only summary fallback

Closes #1995

## Testing
- cargo fmt --all -- --check
- cargo test build_lightweight_prompt_explains_delivery_and_disabled_tools
- cargo test handle_text_response_strips_internal_tool_markers
- cargo test handle_text_response_replaces_marker_only_text