### PR TITLE
feat(routines): agent review — inject routine results into agentic loop (v2 rebase)

### DIFF
--- a/migrations/V21__routine_agent_review.sql
+++ b/migrations/V21__routine_agent_review.sql
@@ -1,0 +1,7 @@
+-- Add agent review columns to routines table.
+-- When enabled per-routine + globally, completed routine results are injected
+-- into the agent loop so the agent can interpret and relay them to the user.
+
+ALTER TABLE routines ADD COLUMN agent_review_on_success BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE routines ADD COLUMN agent_review_on_failure BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE routines ADD COLUMN agent_review_on_attention BOOLEAN NOT NULL DEFAULT false;

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1694,6 +1694,10 @@ impl Agent {
 
         // Set message tool context to the routine's notify channel/user so the
         // `message` tool targets the right destination (not a stale previous context).
+        // KNOWN LIMITATION: `set_message_tool_context` mutates shared Tools state and is
+        // inherently racy when multiple routine reviews run concurrently. This is a
+        // pre-existing design limitation, not introduced by this PR. A proper fix would
+        // require per-invocation tool context scoping.
         let notify_ch = message
             .metadata
             .get("notify_channel")
@@ -1703,10 +1707,29 @@ impl Agent {
             .set_message_tool_context(notify_ch.map(String::from), notify_user.map(String::from))
             .await;
 
+        // Clone thread_id as a String before process_user_input consumes it.
+        let thread_id_str = thread_id.to_string();
+
         // Enter the agentic loop for routine review processing.
         let result = self
             .process_user_input(message, tenant, session, thread_id, &message.content)
             .await;
+
+        // Extract metadata fields before the match so they're available in all arms.
+        let routine_name = message
+            .metadata
+            .get("routine_name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("unknown");
+        let notify_channel = message
+            .metadata
+            .get("notify_channel")
+            .and_then(|v| v.as_str());
+        let notify_user = message
+            .metadata
+            .get("notify_user")
+            .and_then(|v| v.as_str())
+            .unwrap_or(&message.user_id);
 
         match result {
             Ok(SubmissionResult::Response { content }) => {
@@ -1714,43 +1737,41 @@ impl Agent {
                     return Ok(Some(String::new()));
                 }
 
-                // Run BeforeOutbound hooks
-                let hooked_content = match self
+                // Run BeforeOutbound hooks.
+                // Use the resolved thread_id (not message.thread_id, which is None for
+                // injected routine-review messages).
+                let hook_result = self
                     .hooks()
                     .run(&crate::hooks::HookEvent::Outbound {
                         user_id: message.user_id.clone(),
                         channel: message.channel.clone(),
                         content: content.clone(),
-                        thread_id: message.thread_id.clone(),
+                        thread_id: Some(thread_id_str.clone()),
                     })
-                    .await
-                {
+                    .await;
+
+                // If the hook explicitly rejects the outbound, suppress broadcast.
+                if let Err(crate::hooks::HookError::Rejected { reason }) = &hook_result {
+                    tracing::warn!(
+                        routine = routine_name,
+                        reason = %reason,
+                        "BeforeOutbound hook rejected routine review response — suppressing broadcast"
+                    );
+                    return Ok(Some(String::new()));
+                }
+
+                let hooked_content = match hook_result {
                     Ok(crate::hooks::HookOutcome::Continue {
                         modified: Some(new_content),
                     }) => new_content,
                     _ => content,
                 };
 
-                // Broadcast the response via notify_channel from metadata.
-                let notify_channel = message
-                    .metadata
-                    .get("notify_channel")
-                    .and_then(|v| v.as_str());
-                let notify_user = message
-                    .metadata
-                    .get("notify_user")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or(&message.user_id);
-
-                let routine_name = message
-                    .metadata
-                    .get("routine_name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("unknown");
-
                 let response = OutgoingResponse {
                     content: hooked_content.clone(),
-                    thread_id: message.thread_id.clone(),
+                    // Use the resolved thread_id, not message.thread_id which is None
+                    // for injected routine-review messages.
+                    thread_id: Some(thread_id_str.clone()),
                     attachments: Vec::new(),
                     metadata: serde_json::json!({
                         "source": "routine_review",
@@ -1772,7 +1793,8 @@ impl Agent {
                             "Failed to broadcast routine review response: {e}"
                         );
                         // Fallback: broadcast to all channels
-                        let fallback = OutgoingResponse::text(&hooked_content);
+                        let fallback = OutgoingResponse::text(&hooked_content)
+                            .in_thread(thread_id_str.clone());
                         let results = self.channels.broadcast_all(notify_user, fallback).await;
                         for (ch, res) in &results {
                             if let Err(e2) = res {
@@ -1789,7 +1811,8 @@ impl Agent {
                         routine = routine_name,
                         "No notify_channel in routine review metadata; using broadcast_all"
                     );
-                    let fallback = OutgoingResponse::text(&hooked_content);
+                    let fallback =
+                        OutgoingResponse::text(&hooked_content).in_thread(thread_id_str.clone());
                     let results = self.channels.broadcast_all(notify_user, fallback).await;
                     for (ch, res) in &results {
                         if let Err(e) = res {

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1101,18 +1101,28 @@ impl Agent {
             "Message details"
         );
 
-        // Internal messages (e.g. job-monitor notifications) are already
-        // rendered text and should be forwarded directly to the user without
-        // entering the normal user-input pipeline (LLM/tool loop).
-        // The `is_internal` field and `into_internal()` setter are pub(crate),
-        // so external channels cannot spoof this flag.
-        if message.is_internal {
-            tracing::debug!(
-                message_id = %message.id,
-                channel = %message.channel,
-                "Forwarding internal message"
-            );
-            return Ok(Some(message.content.clone()));
+        // Dispatch based on message source.
+        // Internal messages bypass the pipeline; RoutineReview enters the
+        // agentic loop but skips submission parsing, hooks, and event triggers.
+        use crate::channels::MessageSource;
+        match message.source {
+            MessageSource::Internal => {
+                tracing::debug!(
+                    message_id = %message.id,
+                    channel = %message.channel,
+                    "Forwarding internal message"
+                );
+                return Ok(Some(message.content.clone()));
+            }
+            MessageSource::RoutineReview => {
+                tracing::debug!(
+                    message_id = %message.id,
+                    channel = %message.channel,
+                    "Processing routine review message"
+                );
+                return self.handle_routine_review(message).await;
+            }
+            MessageSource::User => { /* fall through to normal pipeline */ }
         }
 
         // Set message tool context for this turn (current channel and target)
@@ -1368,7 +1378,7 @@ impl Agent {
             message.content.len()
         );
 
-        if !message.is_internal
+        if message.source == MessageSource::User
             && let Submission::UserInput { ref content } = submission
             && let Some(engine) = self.routine_engine().await
         {
@@ -1652,6 +1662,144 @@ impl Agent {
                 // returning this result. Empty string signals the caller to skip
                 // respond() (no duplicate text).
                 Ok(Some(String::new()))
+            }
+        }
+    }
+
+    /// Handle a routine-review message by entering the agentic loop
+    /// directly, skipping submission parsing, hooks, and event triggers.
+    ///
+    /// Responses are broadcast via the notify_channel from metadata
+    /// instead of using `channels.respond()` (routine-review isn't a
+    /// real channel).
+    async fn handle_routine_review(
+        &self,
+        message: &IncomingMessage,
+    ) -> Result<Option<String>, Error> {
+        // Resolve session and thread using the routine-review channel
+        // with conversation_scope for per-routine thread isolation.
+        let (session, thread_id) = self
+            .session_manager
+            .resolve_thread(
+                &message.user_id,
+                &message.channel,
+                message.conversation_scope(),
+            )
+            .await;
+
+        let tenant = self.tenant_ctx(&message.user_id).await;
+
+        // Run BeforeOutbound hooks on the response and broadcast it.
+        let result = self
+            .process_user_input(message, tenant, session, thread_id, &message.content)
+            .await;
+
+        match result {
+            Ok(SubmissionResult::Response { content }) => {
+                if content.is_empty() {
+                    return Ok(Some(String::new()));
+                }
+
+                // Run BeforeOutbound hooks
+                let hooked_content = match self
+                    .hooks()
+                    .run(&crate::hooks::HookEvent::Outbound {
+                        user_id: message.user_id.clone(),
+                        channel: message.channel.clone(),
+                        content: content.clone(),
+                        thread_id: message.thread_id.clone(),
+                    })
+                    .await
+                {
+                    Ok(crate::hooks::HookOutcome::Continue {
+                        modified: Some(new_content),
+                    }) => new_content,
+                    _ => content,
+                };
+
+                // Broadcast the response via notify_channel from metadata.
+                let notify_channel = message
+                    .metadata
+                    .get("notify_channel")
+                    .and_then(|v| v.as_str());
+                let notify_user = message
+                    .metadata
+                    .get("notify_user")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or(&message.user_id);
+
+                let routine_name = message
+                    .metadata
+                    .get("routine_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+
+                let response = OutgoingResponse {
+                    content: hooked_content.clone(),
+                    thread_id: message.thread_id.clone(),
+                    attachments: Vec::new(),
+                    metadata: serde_json::json!({
+                        "source": "routine_review",
+                        "routine_name": routine_name,
+                        "notify_channel": notify_channel,
+                        "notify_user": notify_user,
+                    }),
+                };
+
+                if let Some(channel_name) = notify_channel {
+                    if let Err(e) = self
+                        .channels
+                        .broadcast(channel_name, notify_user, response)
+                        .await
+                    {
+                        tracing::warn!(
+                            routine = routine_name,
+                            channel = channel_name,
+                            "Failed to broadcast routine review response: {e}"
+                        );
+                        // Fallback: broadcast to all channels
+                        let fallback = OutgoingResponse::text(&hooked_content);
+                        let results = self.channels.broadcast_all(notify_user, fallback).await;
+                        for (ch, res) in &results {
+                            if let Err(e2) = res {
+                                tracing::error!(
+                                    routine = routine_name,
+                                    channel = %ch,
+                                    "Fallback broadcast failed: {e2}"
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    tracing::warn!(
+                        routine = routine_name,
+                        "No notify_channel in routine review metadata; using broadcast_all"
+                    );
+                    let fallback = OutgoingResponse::text(&hooked_content);
+                    let results = self.channels.broadcast_all(notify_user, fallback).await;
+                    for (ch, res) in &results {
+                        if let Err(e) = res {
+                            tracing::error!(
+                                routine = routine_name,
+                                channel = %ch,
+                                "broadcast_all failed for routine review: {e}"
+                            );
+                        }
+                    }
+                }
+
+                Ok(Some(String::new()))
+            }
+            Ok(other) => {
+                tracing::debug!(
+                    "Routine review got non-Response result: {:?}",
+                    std::any::type_name_of_val(&other)
+                );
+                Ok(Some(String::new()))
+            }
+            Err(e) => {
+                tracing::error!("Routine review processing failed: {e}");
+                Err(e)
             }
         }
     }

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1692,7 +1692,18 @@ impl Agent {
 
         let tenant = self.tenant_ctx(&message.user_id).await;
 
-        // Run BeforeOutbound hooks on the response and broadcast it.
+        // Set message tool context to the routine's notify channel/user so the
+        // `message` tool targets the right destination (not a stale previous context).
+        let notify_ch = message
+            .metadata
+            .get("notify_channel")
+            .and_then(|v| v.as_str());
+        let notify_user = message.metadata.get("notify_user").and_then(|v| v.as_str());
+        self.tools()
+            .set_message_tool_context(notify_ch.map(String::from), notify_user.map(String::from))
+            .await;
+
+        // Enter the agentic loop for routine review processing.
         let result = self
             .process_user_input(message, tenant, session, thread_id, &message.content)
             .await;
@@ -1791,6 +1802,15 @@ impl Agent {
                     }
                 }
 
+                Ok(Some(String::new()))
+            }
+            Ok(SubmissionResult::NeedApproval { tool_name, .. }) => {
+                // Approval-requiring tools should not fire during routine review
+                // (there's no user to approve). Log and return empty.
+                tracing::warn!(
+                    tool = %tool_name,
+                    "Routine review triggered tool approval request — auto-denied (no interactive user)"
+                );
                 Ok(Some(String::new()))
             }
             Ok(other) => {

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -772,7 +772,7 @@ impl Agent {
                     let (notify_tx, mut notify_rx) =
                         tokio::sync::mpsc::channel::<OutgoingResponse>(32);
 
-                    let engine = Arc::new(RoutineEngine::new(
+                    let mut engine = RoutineEngine::new(
                         rt_config.clone(),
                         crate::tenant::SystemScope::new(Arc::clone(store)),
                         self.llm().clone(),
@@ -783,7 +783,10 @@ impl Agent {
                         self.tools().clone(),
                         self.safety().clone(),
                         self.deps.sandbox_readiness,
-                    ));
+                    );
+                    // Wire up agent-loop injection for routine review.
+                    engine.set_inject_tx(self.channels.inject_sender());
+                    let engine = Arc::new(engine);
 
                     // Register routine tools
                     self.deps

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -238,6 +238,7 @@ impl Agent {
             user_tz,
             turn_usage: std::sync::Mutex::new(TurnUsageSummary::default()),
             cached_tool_permissions: std::sync::Mutex::new(None),
+            message_source: message.source,
         };
 
         // If /skill-name mentions were expanded, rewrite the last user message
@@ -350,6 +351,8 @@ struct ChatDelegate<'a> {
     turn_usage: std::sync::Mutex<TurnUsageSummary>,
     cached_tool_permissions:
         std::sync::Mutex<Option<std::collections::HashMap<String, PermissionState>>>,
+    /// Message source — used to restrict tool access for RoutineReview.
+    message_source: crate::channels::MessageSource,
 }
 
 impl ChatDelegate<'_> {
@@ -509,6 +512,18 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 sess.auto_approve_tool(name);
             }
         }
+
+        // For RoutineReview messages, filter tools through the autonomous
+        // denylist so the agent cannot use interactive or dangerous tools
+        // when reviewing routine results.
+        let tool_defs = if self.message_source == crate::channels::MessageSource::RoutineReview {
+            tool_defs
+                .into_iter()
+                .filter(|def| !crate::tools::is_autonomous_tool_denylisted(&def.name))
+                .collect()
+        } else {
+            tool_defs
+        };
 
         // Update context for this iteration
         reason_ctx.available_tools = tool_defs;

--- a/src/agent/job_monitor.rs
+++ b/src/agent/job_monitor.rs
@@ -257,7 +257,10 @@ mod tests {
         assert_eq!(msg.user_id, "user-1");
         assert_eq!(msg.thread_id, Some("thread-1".to_string()));
         assert!(msg.content.contains("I found a bug"));
-        assert!(msg.is_internal, "monitor messages must be marked internal");
+        assert!(
+            msg.is_internal(),
+            "monitor messages must be marked internal"
+        );
     }
 
     #[tokio::test]
@@ -371,9 +374,9 @@ mod tests {
     }
 
     /// Regression test: external channels must not be able to spoof the
-    /// `is_internal` flag via metadata keys. A message created through
+    /// `source` field via metadata keys. A message created through
     /// the normal `IncomingMessage::new` + `with_metadata` path must
-    /// always have `is_internal == false`, regardless of metadata content.
+    /// always have `source == User`, regardless of metadata content.
     #[test]
     fn test_external_metadata_cannot_spoof_internal_flag() {
         let msg = IncomingMessage::new("wasm_channel", "attacker", "pwned").with_metadata(
@@ -383,15 +386,15 @@ mod tests {
             }),
         );
         assert!(
-            !msg.is_internal,
-            "with_metadata must not set is_internal — only into_internal() can"
+            !msg.is_internal(),
+            "with_metadata must not set source — only into_internal() can"
         );
     }
 
     #[test]
     fn test_into_internal_sets_flag() {
         let msg = IncomingMessage::new("monitor", "system", "test").into_internal();
-        assert!(msg.is_internal);
+        assert!(msg.is_internal());
     }
 
     // === Regression: fire-and-forget sandbox jobs must transition out of InProgress ===

--- a/src/agent/routine.rs
+++ b/src/agent/routine.rs
@@ -487,6 +487,15 @@ pub struct NotifyConfig {
     pub on_failure: bool,
     /// Notify when routine runs with no findings.
     pub on_success: bool,
+    /// Inject result into agent loop for review on success.
+    #[serde(default)]
+    pub agent_review_on_success: bool,
+    /// Inject result into agent loop for review on attention.
+    #[serde(default)]
+    pub agent_review_on_attention: bool,
+    /// Inject result into agent loop for review on failure.
+    #[serde(default)]
+    pub agent_review_on_failure: bool,
 }
 
 impl Default for NotifyConfig {
@@ -497,6 +506,9 @@ impl Default for NotifyConfig {
             on_attention: true,
             on_failure: true,
             on_success: false,
+            agent_review_on_success: false,
+            agent_review_on_attention: false,
+            agent_review_on_failure: false,
         }
     }
 }

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -127,6 +127,10 @@ pub struct RoutineEngine {
     /// `sync_dispatched_runs` to distinguish orphaned runs (from a previous
     /// process) from actively-watched runs (from this process).
     boot_time: chrono::DateTime<Utc>,
+    /// Sender for injecting messages into the agent loop (routine review).
+    inject_tx: Option<mpsc::Sender<IncomingMessage>>,
+    /// Agent review rate limiter: (window_start, count_in_window).
+    agent_review_rate: Arc<RwLock<(chrono::DateTime<Utc>, u32)>>,
 }
 
 impl RoutineEngine {
@@ -157,7 +161,14 @@ impl RoutineEngine {
             safety,
             sandbox_readiness,
             boot_time: Utc::now(),
+            inject_tx: None,
+            agent_review_rate: Arc::new(RwLock::new((Utc::now(), 0))),
         }
+    }
+
+    /// Set the agent-loop injection channel for routine review.
+    pub fn set_inject_tx(&mut self, tx: mpsc::Sender<IncomingMessage>) {
+        self.inject_tx = Some(tx);
     }
 
     /// Expose the running count for integration tests.
@@ -829,6 +840,8 @@ impl RoutineEngine {
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
             event_cache: Arc::clone(&self.event_cache),
+            inject_tx: self.inject_tx.clone(),
+            agent_review_rate: Arc::clone(&self.agent_review_rate),
         };
 
         tokio::spawn(async move {
@@ -915,6 +928,8 @@ impl RoutineEngine {
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
             event_cache: Arc::clone(&self.event_cache),
+            inject_tx: self.inject_tx.clone(),
+            agent_review_rate: Arc::clone(&self.agent_review_rate),
         };
 
         tokio::spawn(async move {
@@ -967,6 +982,8 @@ impl RoutineEngine {
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
             event_cache: Arc::clone(&self.event_cache),
+            inject_tx: self.inject_tx.clone(),
+            agent_review_rate: Arc::clone(&self.agent_review_rate),
         };
 
         // Record the run in DB, then spawn execution
@@ -1106,6 +1123,8 @@ struct EngineContext {
     safety: Arc<SafetyLayer>,
     sandbox_readiness: SandboxReadiness,
     event_cache: Arc<RwLock<Vec<EventMatcher>>>,
+    inject_tx: Option<mpsc::Sender<IncomingMessage>>,
+    agent_review_rate: Arc<RwLock<(chrono::DateTime<Utc>, u32)>>,
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
@@ -1359,6 +1378,9 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         thread_id.as_deref(),
     )
     .await;
+
+    // Optionally inject result into agent loop for review
+    inject_agent_review(&ctx, &routine, status, summary.as_deref()).await;
 }
 
 async fn update_cached_event_runtime(
@@ -2078,6 +2100,140 @@ async fn send_notification(
 
     if let Err(e) = tx.send(response).await {
         tracing::error!(routine = %routine_name, "Failed to send notification: {}", e);
+    }
+}
+
+/// Circuit breaker threshold: disable agent review after N consecutive failures.
+const AGENT_REVIEW_CIRCUIT_BREAKER_THRESHOLD: u32 = 3;
+
+/// Inject a routine result into the agent loop for review.
+///
+/// Checks:
+/// 1. Per-routine `agent_review_on_*` matches the status
+/// 2. Global `config.agent_review_enabled` is true
+/// 3. Circuit breaker: skip if `consecutive_failures >= 3` (reset on successful Ok run)
+/// 4. Rate limit: tumbling hourly window, `max_agent_reviews_per_hour`
+/// 5. `inject_tx` is available
+///
+/// Sanitizes the summary through the safety layer before injection.
+async fn inject_agent_review(
+    ctx: &EngineContext,
+    routine: &Routine,
+    status: RunStatus,
+    summary: Option<&str>,
+) {
+    // 1. Check per-routine config
+    let should_review = match status {
+        RunStatus::Ok => routine.notify.agent_review_on_success,
+        RunStatus::Attention => routine.notify.agent_review_on_attention,
+        RunStatus::Failed => routine.notify.agent_review_on_failure,
+        RunStatus::Running => false,
+    };
+    if !should_review {
+        return;
+    }
+
+    // 2. Check global config
+    if !ctx.config.agent_review_enabled {
+        tracing::debug!(
+            routine = %routine.name,
+            "Agent review skipped: globally disabled"
+        );
+        return;
+    }
+
+    // 3. Circuit breaker: skip if too many consecutive failures
+    // The circuit breaker checks the routine's consecutive_failures count.
+    // This resets automatically when a routine run succeeds (Ok status)
+    // without agent review — the normal execute_routine path resets
+    // consecutive_failures to 0 on success.
+    if routine.consecutive_failures >= AGENT_REVIEW_CIRCUIT_BREAKER_THRESHOLD {
+        tracing::debug!(
+            routine = %routine.name,
+            consecutive_failures = routine.consecutive_failures,
+            "Agent review skipped: circuit breaker open ({} consecutive failures)",
+            routine.consecutive_failures
+        );
+        return;
+    }
+
+    // 4. Rate limit: tumbling hourly window
+    {
+        let mut rate = ctx.agent_review_rate.write().await;
+        let now = Utc::now();
+        let window_duration = chrono::Duration::hours(1);
+        if now.signed_duration_since(rate.0) >= window_duration {
+            // Reset window
+            *rate = (now, 0);
+        }
+        if rate.1 >= ctx.config.max_agent_reviews_per_hour {
+            tracing::debug!(
+                routine = %routine.name,
+                count = rate.1,
+                max = ctx.config.max_agent_reviews_per_hour,
+                "Agent review skipped: hourly rate limit reached"
+            );
+            return;
+        }
+        rate.1 += 1;
+    }
+
+    // 5. Check inject_tx is available
+    let inject_tx = match &ctx.inject_tx {
+        Some(tx) => tx,
+        None => {
+            tracing::debug!(
+                routine = %routine.name,
+                "Agent review skipped: no inject_tx available"
+            );
+            return;
+        }
+    };
+
+    // Sanitize the summary through the safety layer
+    let raw_summary = summary.unwrap_or("(no summary)");
+    let sanitized = ctx
+        .safety
+        .sanitize_tool_output("routine_result", raw_summary);
+    let safe_summary = if sanitized.was_modified {
+        &sanitized.content
+    } else {
+        raw_summary
+    };
+
+    // Build the review message content
+    let content = format!(
+        "Routine '{}' completed with status: {}\n\n\
+         Please review this result and decide what, if anything, \
+         to tell the user. If the result is routine and expected, \
+         you may choose not to send any message.\n\n\
+         Result summary:\n{}",
+        routine.name, status, safe_summary
+    );
+
+    let message = IncomingMessage::new("routine-review", &routine.user_id, content)
+        .with_conversation_scope(format!("routine-review:{}", routine.id))
+        .with_metadata(serde_json::json!({
+            "routine_name": routine.name,
+            "routine_id": routine.id.to_string(),
+            "status": status.to_string(),
+            "notify_channel": routine.notify.channel,
+            "notify_user": routine.notify.user,
+        }))
+        .into_routine_review();
+
+    if let Err(e) = inject_tx.send(message).await {
+        tracing::error!(
+            routine = %routine.name,
+            "Failed to inject agent review message: {}",
+            e
+        );
+    } else {
+        tracing::debug!(
+            routine = %routine.name,
+            status = %status,
+            "Injected agent review message"
+        );
     }
 }
 
@@ -2882,5 +3038,101 @@ mod tests {
             prompt.contains("C088K6C3SQZ"),
             "prompt should mention configured delivery target: {prompt}",
         );
+    }
+
+    #[test]
+    fn test_agent_review_respects_per_routine_config() {
+        // agent_review_on_success = false means Ok status should not trigger review
+        let notify = NotifyConfig {
+            agent_review_on_success: false,
+            agent_review_on_attention: true,
+            agent_review_on_failure: true,
+            ..NotifyConfig::default()
+        };
+
+        // Verify the should_review logic matches what inject_agent_review checks
+        let should_review_ok = match RunStatus::Ok {
+            RunStatus::Ok => notify.agent_review_on_success,
+            RunStatus::Attention => notify.agent_review_on_attention,
+            RunStatus::Failed => notify.agent_review_on_failure,
+            RunStatus::Running => false,
+        };
+        assert!(
+            !should_review_ok,
+            "Ok status should not trigger agent review when agent_review_on_success is false"
+        );
+
+        let should_review_attention = match RunStatus::Attention {
+            RunStatus::Ok => notify.agent_review_on_success,
+            RunStatus::Attention => notify.agent_review_on_attention,
+            RunStatus::Failed => notify.agent_review_on_failure,
+            RunStatus::Running => false,
+        };
+        assert!(
+            should_review_attention,
+            "Attention status should trigger agent review when agent_review_on_attention is true"
+        );
+    }
+
+    #[test]
+    fn test_agent_review_circuit_breaker_threshold() {
+        // Circuit breaker should open after AGENT_REVIEW_CIRCUIT_BREAKER_THRESHOLD failures
+        assert_eq!(
+            super::AGENT_REVIEW_CIRCUIT_BREAKER_THRESHOLD,
+            3,
+            "Circuit breaker should trigger after 3 consecutive failures"
+        );
+
+        // A routine with consecutive_failures >= threshold should be blocked
+        let threshold = super::AGENT_REVIEW_CIRCUIT_BREAKER_THRESHOLD;
+        assert!(threshold >= 3); // not too aggressive
+        assert!(threshold <= 10); // not too permissive
+    }
+
+    #[test]
+    fn test_notification_mode_label() {
+        use crate::tools::builtin::routine::notification_mode_label;
+
+        let silent = NotifyConfig {
+            on_success: false,
+            on_attention: false,
+            on_failure: false,
+            ..NotifyConfig::default()
+        };
+        assert_eq!(notification_mode_label(&silent), "silent");
+
+        let notify_only = NotifyConfig {
+            on_attention: true,
+            on_failure: true,
+            ..NotifyConfig::default()
+        };
+        assert_eq!(notification_mode_label(&notify_only), "notify");
+
+        let review_only = NotifyConfig {
+            on_success: false,
+            on_attention: false,
+            on_failure: false,
+            agent_review_on_attention: true,
+            ..NotifyConfig::default()
+        };
+        assert_eq!(notification_mode_label(&review_only), "review");
+
+        let both = NotifyConfig {
+            on_attention: true,
+            agent_review_on_attention: true,
+            ..NotifyConfig::default()
+        };
+        assert_eq!(notification_mode_label(&both), "notify+review");
+    }
+
+    #[test]
+    fn test_message_source_routine_review_construction() {
+        let msg = crate::channels::IncomingMessage::new("routine-review", "user1", "test content")
+            .with_conversation_scope("routine-review:some-uuid")
+            .into_routine_review();
+        assert_eq!(msg.source, crate::channels::MessageSource::RoutineReview);
+        assert!(!msg.is_internal());
+        assert_eq!(msg.channel, "routine-review");
+        assert_eq!(msg.conversation_scope(), Some("routine-review:some-uuid"));
     }
 }

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -2175,7 +2175,8 @@ async fn inject_agent_review(
             );
             return;
         }
-        rate.1 += 1;
+        // Counter incremented after successful injection (below) to avoid
+        // consuming budget on failed sends.
     }
 
     // 5. Check inject_tx is available
@@ -2229,6 +2230,11 @@ async fn inject_agent_review(
             e
         );
     } else {
+        // Increment rate counter only on successful injection
+        {
+            let mut rate = ctx.agent_review_rate.write().await;
+            rate.1 += 1;
+        }
         tracing::debug!(
             routine = %routine.name,
             status = %status,

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -2196,7 +2196,7 @@ mod tests {
             on_success: false,
             on_failure: true,
             on_attention: true,
-            ..Default::default()
+            ..NotifyConfig::default()
         };
 
         // on_success = false means Ok status should not notify
@@ -2288,6 +2288,7 @@ mod tests {
             on_attention: true,
             on_failure: true,
             on_success: false,
+            ..NotifyConfig::default()
         };
 
         let prompt = super::build_lightweight_prompt(
@@ -2428,7 +2429,7 @@ mod tests {
             metadata: serde_json::Value::Null,
             timezone: None,
             attachments: vec![],
-            is_internal: false,
+            source: crate::channels::MessageSource::User,
         }
     }
 
@@ -2582,7 +2583,7 @@ mod tests {
             on_success: true,
             on_failure: true,
             on_attention: true,
-            ..Default::default()
+            ..NotifyConfig::default()
         };
         let should_notify = match RunStatus::Running {
             RunStatus::Ok => config.on_success,
@@ -2867,6 +2868,7 @@ mod tests {
             on_attention: true,
             on_failure: true,
             on_success: false,
+            ..NotifyConfig::default()
         };
 
         let prompt =

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -2177,6 +2177,12 @@ async fn inject_agent_review(
         }
         // Counter incremented after successful injection (below) to avoid
         // consuming budget on failed sends.
+        // ACCEPTABLE RACE: the read-then-write across the lock drop is technically a
+        // TOCTOU window — two concurrent routines could both pass the check and both
+        // increment. In practice this is bounded (at most 2× the hourly limit in the
+        // worst case) and self-correcting within the next window reset. A stricter fix
+        // would require holding the write lock through the send, but that would block
+        // all other routines for the duration of an async channel send.
     }
 
     // 5. Check inject_tx is available

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -889,4 +889,32 @@ mod tests {
         let markdown = prompt.markdown_message();
         assert!(markdown.contains("\\`\\`\\`danger\\`\\`\\`"));
     }
+
+    #[test]
+    fn message_source_default_is_user() {
+        let source = MessageSource::default();
+        assert_eq!(source, MessageSource::User);
+    }
+
+    #[test]
+    fn into_internal_sets_source_to_internal() {
+        let msg = IncomingMessage::new("test", "user1", "hello").into_internal();
+        assert_eq!(msg.source, MessageSource::Internal);
+        assert!(msg.is_internal());
+    }
+
+    #[test]
+    fn into_routine_review_sets_source() {
+        let msg =
+            IncomingMessage::new("routine-review", "user1", "review this").into_routine_review();
+        assert_eq!(msg.source, MessageSource::RoutineReview);
+        assert!(!msg.is_internal());
+    }
+
+    #[test]
+    fn external_metadata_cannot_spoof_source() {
+        let msg = IncomingMessage::new("wasm", "user1", "test")
+            .with_metadata(serde_json::json!({ "source": "RoutineReview" }));
+        assert_eq!(msg.source, MessageSource::User);
+    }
 }

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -10,6 +10,24 @@ use uuid::Uuid;
 
 use crate::error::ChannelError;
 
+/// Origin of an incoming message.
+///
+/// Replaces the former `is_internal: bool` flag with a three-way
+/// classification so the agent loop can dispatch differently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MessageSource {
+    /// Normal user message from an external channel.
+    #[default]
+    User,
+    /// Generated inside the process (e.g. job-monitor notifications).
+    /// Bypasses the user-input pipeline; content is forwarded directly.
+    Internal,
+    /// Injected by the routine engine for agent review of routine results.
+    /// Enters the agentic loop but skips submission parsing, hooks, and
+    /// event triggers.
+    RoutineReview,
+}
+
 /// Kind of attachment carried on an incoming message.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AttachmentKind {
@@ -92,10 +110,10 @@ pub struct IncomingMessage {
     pub timezone: Option<String>,
     /// File or media attachments on this message.
     pub attachments: Vec<IncomingAttachment>,
-    /// Internal-only flag: message was generated inside the process (e.g. job
-    /// monitor) and must bypass the normal user-input pipeline. This field is
-    /// not settable via metadata, so external channels cannot spoof it.
-    pub(crate) is_internal: bool,
+    /// Message origin classification. Determines how the agent loop
+    /// dispatches this message. Not settable via metadata, so external
+    /// channels cannot spoof privileged sources.
+    pub(crate) source: MessageSource,
 }
 
 impl IncomingMessage {
@@ -119,7 +137,7 @@ impl IncomingMessage {
             metadata: serde_json::Value::Null,
             timezone: None,
             attachments: Vec::new(),
-            is_internal: false,
+            source: MessageSource::User,
         }
     }
 
@@ -169,8 +187,20 @@ impl IncomingMessage {
 
     /// Mark this message as internal (bypasses user-input pipeline).
     pub(crate) fn into_internal(mut self) -> Self {
-        self.is_internal = true;
+        self.source = MessageSource::Internal;
         self
+    }
+
+    /// Mark this message as a routine-review injection.
+    pub(crate) fn into_routine_review(mut self) -> Self {
+        self.source = MessageSource::RoutineReview;
+        self
+    }
+
+    /// Backward-compatible accessor: returns `true` for `Internal` source.
+    #[allow(dead_code)]
+    pub(crate) fn is_internal(&self) -> bool {
+        self.source == MessageSource::Internal
     }
 
     /// Effective conversation scope, falling back to thread_id for legacy callers.

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -39,7 +39,7 @@ mod webhook_server;
 
 pub use channel::{
     AttachmentKind, Channel, ChannelSecretUpdater, ChatApprovalPrompt, IncomingAttachment,
-    IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate, ToolDecision,
+    IncomingMessage, MessageSource, MessageStream, OutgoingResponse, StatusUpdate, ToolDecision,
     routing_target_from_metadata,
 };
 pub use http::{HttpChannel, HttpChannelState};

--- a/src/channels/web/tests/multi_tenant.rs
+++ b/src/channels/web/tests/multi_tenant.rs
@@ -145,6 +145,7 @@ fn make_routine(user_id: &str, name: &str) -> crate::agent::routine::Routine {
             on_success: false,
             on_failure: true,
             on_attention: true,
+            ..crate::agent::routine::NotifyConfig::default()
         },
         last_run_at: None,
         next_fire_at: None,

--- a/src/cli/routines.rs
+++ b/src/cli/routines.rs
@@ -310,6 +310,7 @@ fn cli_notify_config(notify_channel: Option<String>) -> NotifyConfig {
         on_attention: true,
         on_failure: true,
         on_success: false,
+        ..NotifyConfig::default()
     }
 }
 

--- a/src/config/routines.rs
+++ b/src/config/routines.rs
@@ -19,6 +19,10 @@ pub struct RoutineConfig {
     pub lightweight_tools_enabled: bool,
     /// Max tool iterations for lightweight routines (default: 3, max: 5).
     pub lightweight_max_iterations: u32,
+    /// Whether agent review of routine results is enabled (default: false).
+    pub agent_review_enabled: bool,
+    /// Max agent reviews per hour (tumbling window, default: 10).
+    pub max_agent_reviews_per_hour: u32,
 }
 
 impl Default for RoutineConfig {
@@ -31,6 +35,8 @@ impl Default for RoutineConfig {
             max_lightweight_tokens: 4096,
             lightweight_tools_enabled: true,
             lightweight_max_iterations: 3,
+            agent_review_enabled: false,
+            max_agent_reviews_per_hour: 10,
         }
     }
 }
@@ -73,6 +79,16 @@ impl RoutineConfig {
                 "ROUTINES_LIGHTWEIGHT_TOOLS",
             )?,
             lightweight_max_iterations: max_iterations.min(5), // cap at 5
+            agent_review_enabled: db_first_bool(
+                rs.agent_review_enabled,
+                defaults.agent_review_enabled,
+                "ROUTINES_AGENT_REVIEW_ENABLED",
+            )?,
+            max_agent_reviews_per_hour: db_first_or_default(
+                &rs.max_agent_reviews_per_hour,
+                &defaults.max_agent_reviews_per_hour,
+                "ROUTINES_MAX_AGENT_REVIEWS_PER_HOUR",
+            )?,
         })
     }
 }

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -42,7 +42,8 @@ pub(crate) const ROUTINE_COLUMNS: &str = "\
     cooldown_secs, max_concurrent, dedup_window_secs, \
     notify_channel, notify_user, notify_on_success, notify_on_failure, notify_on_attention, \
     state, last_run_at, next_fire_at, run_count, consecutive_failures, \
-    created_at, updated_at";
+    created_at, updated_at, \
+    agent_review_on_success, agent_review_on_failure, agent_review_on_attention";
 
 /// Explicit column list for routine_runs table (matches positional access in `row_to_routine_run_libsql`).
 pub(crate) const ROUTINE_RUN_COLUMNS: &str = "\
@@ -449,6 +450,9 @@ pub(crate) fn row_to_routine_libsql(row: &libsql::Row) -> Result<Routine, Databa
             on_success: get_i64(row, 14) != 0,
             on_failure: get_i64(row, 15) != 0,
             on_attention: get_i64(row, 16) != 0,
+            agent_review_on_success: get_i64(row, 24) != 0,
+            agent_review_on_failure: get_i64(row, 25) != 0,
+            agent_review_on_attention: get_i64(row, 26) != 0,
         },
         state: get_json(row, 17),
         last_run_at: get_opt_ts(row, 18),

--- a/src/db/libsql/routines.rs
+++ b/src/db/libsql/routines.rs
@@ -34,13 +34,15 @@ impl RoutineStore for LibSqlBackend {
                     trigger_type, trigger_config, action_type, action_config,
                     cooldown_secs, max_concurrent, dedup_window_secs,
                     notify_channel, notify_user, notify_on_success, notify_on_failure, notify_on_attention,
+                    agent_review_on_success, agent_review_on_failure, agent_review_on_attention,
                     state, next_fire_at, created_at, updated_at
                 ) VALUES (
                     ?1, ?2, ?3, ?4, ?5,
                     ?6, ?7, ?8, ?9,
                     ?10, ?11, ?12,
                     ?13, ?14, ?15, ?16, ?17,
-                    ?18, ?19, ?20, ?21
+                    ?18, ?19, ?20,
+                    ?21, ?22, ?23, ?24
                 )
                 "#,
                 params![
@@ -61,6 +63,9 @@ impl RoutineStore for LibSqlBackend {
                     routine.notify.on_success as i64,
                     routine.notify.on_failure as i64,
                     routine.notify.on_attention as i64,
+                    routine.notify.agent_review_on_success as i64,
+                    routine.notify.agent_review_on_failure as i64,
+                    routine.notify.agent_review_on_attention as i64,
                     routine.state.to_string(),
                     fmt_opt_ts(&routine.next_fire_at),
                     fmt_ts(&routine.created_at),
@@ -233,8 +238,9 @@ impl RoutineStore for LibSqlBackend {
                     cooldown_secs = ?9, max_concurrent = ?10, dedup_window_secs = ?11,
                     notify_channel = ?12, notify_user = ?13,
                     notify_on_success = ?14, notify_on_failure = ?15, notify_on_attention = ?16,
-                    state = ?17, next_fire_at = ?18,
-                    updated_at = ?19
+                    agent_review_on_success = ?17, agent_review_on_failure = ?18, agent_review_on_attention = ?19,
+                    state = ?20, next_fire_at = ?21,
+                    updated_at = ?22
                 WHERE id = ?1
                 "#,
             params![
@@ -254,6 +260,9 @@ impl RoutineStore for LibSqlBackend {
                 routine.notify.on_success as i64,
                 routine.notify.on_failure as i64,
                 routine.notify.on_attention as i64,
+                routine.notify.agent_review_on_success as i64,
+                routine.notify.agent_review_on_failure as i64,
+                routine.notify.agent_review_on_attention as i64,
                 routine.state.to_string(),
                 fmt_opt_ts(&routine.next_fire_at),
                 now,

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -469,6 +469,9 @@ CREATE TABLE IF NOT EXISTS routines (
     notify_on_success INTEGER NOT NULL DEFAULT 0,
     notify_on_failure INTEGER NOT NULL DEFAULT 1,
     notify_on_attention INTEGER NOT NULL DEFAULT 1,
+    agent_review_on_success INTEGER NOT NULL DEFAULT 0,
+    agent_review_on_failure INTEGER NOT NULL DEFAULT 0,
+    agent_review_on_attention INTEGER NOT NULL DEFAULT 0,
     state TEXT NOT NULL DEFAULT '{}',
     last_run_at TEXT,
     next_fire_at TEXT,
@@ -782,6 +785,9 @@ CREATE TABLE IF NOT EXISTS routines_new (
     notify_on_success INTEGER NOT NULL DEFAULT 0,
     notify_on_failure INTEGER NOT NULL DEFAULT 1,
     notify_on_attention INTEGER NOT NULL DEFAULT 1,
+    agent_review_on_success INTEGER NOT NULL DEFAULT 0,
+    agent_review_on_failure INTEGER NOT NULL DEFAULT 0,
+    agent_review_on_attention INTEGER NOT NULL DEFAULT 0,
     state TEXT NOT NULL DEFAULT '{}',
     last_run_at TEXT,
     next_fire_at TEXT,
@@ -957,6 +963,15 @@ CREATE TABLE IF NOT EXISTS pairing_requests (
 CREATE INDEX IF NOT EXISTS idx_pairing_requests_channel ON pairing_requests (channel, external_id);
 "#,
     ),
+    (
+        21,
+        "routine_agent_review",
+        r#"
+ALTER TABLE routines ADD COLUMN agent_review_on_success INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE routines ADD COLUMN agent_review_on_failure INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE routines ADD COLUMN agent_review_on_attention INTEGER NOT NULL DEFAULT 0;
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already
@@ -966,6 +981,9 @@ const IDEMPOTENT_ADD_COLUMN_MIGRATIONS: &[(i64, &str, &str)] = &[
     (15, "conversations", "source_channel"),
     (18, "wasm_tools", "scope"),
     (18, "dynamic_tools", "scope"),
+    (21, "routines", "agent_review_on_success"),
+    (21, "routines", "agent_review_on_failure"),
+    (21, "routines", "agent_review_on_attention"),
 ];
 
 /// Check whether `table` already contains `column` via `pragma_table_info`.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1066,13 +1066,15 @@ impl Store {
                 trigger_type, trigger_config, action_type, action_config,
                 cooldown_secs, max_concurrent, dedup_window_secs,
                 notify_channel, notify_user, notify_on_success, notify_on_failure, notify_on_attention,
+                agent_review_on_success, agent_review_on_failure, agent_review_on_attention,
                 state, next_fire_at, created_at, updated_at
             ) VALUES (
                 $1, $2, $3, $4, $5,
                 $6, $7, $8, $9,
                 $10, $11, $12,
                 $13, $14, $15, $16, $17,
-                $18, $19, $20, $21
+                $18, $19, $20,
+                $21, $22, $23, $24
             )
             "#,
             &[
@@ -1093,6 +1095,9 @@ impl Store {
                 &routine.notify.on_success,
                 &routine.notify.on_failure,
                 &routine.notify.on_attention,
+                &routine.notify.agent_review_on_success,
+                &routine.notify.agent_review_on_failure,
+                &routine.notify.agent_review_on_attention,
                 &routine.state,
                 &routine.next_fire_at,
                 &routine.created_at,
@@ -1227,7 +1232,8 @@ impl Store {
                 cooldown_secs = $9, max_concurrent = $10, dedup_window_secs = $11,
                 notify_channel = $12, notify_user = $13,
                 notify_on_success = $14, notify_on_failure = $15, notify_on_attention = $16,
-                state = $17, next_fire_at = $18,
+                agent_review_on_success = $17, agent_review_on_failure = $18, agent_review_on_attention = $19,
+                state = $20, next_fire_at = $21,
                 updated_at = now()
             WHERE id = $1
             "#,
@@ -1248,6 +1254,9 @@ impl Store {
                 &routine.notify.on_success,
                 &routine.notify.on_failure,
                 &routine.notify.on_attention,
+                &routine.notify.agent_review_on_success,
+                &routine.notify.agent_review_on_failure,
+                &routine.notify.agent_review_on_attention,
                 &routine.state,
                 &routine.next_fire_at,
             ],
@@ -1513,6 +1522,9 @@ fn row_to_routine(row: &tokio_postgres::Row) -> Result<Routine, DatabaseError> {
             on_attention: row.get("notify_on_attention"),
             on_failure: row.get("notify_on_failure"),
             on_success: row.get("notify_on_success"),
+            agent_review_on_success: row.get("agent_review_on_success"),
+            agent_review_on_attention: row.get("agent_review_on_attention"),
+            agent_review_on_failure: row.get("agent_review_on_failure"),
         },
         last_run_at: row.get("last_run_at"),
         next_fire_at: row.get("next_fire_at"),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -851,6 +851,14 @@ pub struct RoutineSettings {
     /// Max tool iterations for lightweight routines.
     #[serde(default = "default_routine_max_iterations")]
     pub lightweight_max_iterations: u32,
+
+    /// Enable agent review of routine results (default: false).
+    #[serde(default)]
+    pub agent_review_enabled: bool,
+
+    /// Max agent reviews per hour (default: 10).
+    #[serde(default = "default_routine_max_agent_reviews")]
+    pub max_agent_reviews_per_hour: u32,
 }
 
 fn default_routine_cron_interval() -> u64 {
@@ -873,6 +881,10 @@ fn default_routine_max_iterations() -> u32 {
     3
 }
 
+fn default_routine_max_agent_reviews() -> u32 {
+    10
+}
+
 impl Default for RoutineSettings {
     fn default() -> Self {
         Self {
@@ -883,6 +895,8 @@ impl Default for RoutineSettings {
             max_lightweight_tokens: default_routine_max_tokens(),
             lightweight_tools_enabled: true,
             lightweight_max_iterations: default_routine_max_iterations(),
+            agent_review_enabled: false,
+            max_agent_reviews_per_hour: default_routine_max_agent_reviews(),
         }
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1192,6 +1192,7 @@ mod tests {
                 on_attention: true,
                 on_failure: true,
                 on_success: false,
+                ..NotifyConfig::default()
             },
             last_run_at: None,
             next_fire_at: None,
@@ -1325,6 +1326,7 @@ mod tests {
                 on_attention: false,
                 on_failure: false,
                 on_success: false,
+                ..NotifyConfig::default()
             },
             last_run_at: None,
             next_fire_at: None,

--- a/src/tools/builtin/routine.rs
+++ b/src/tools/builtin/routine.rs
@@ -73,6 +73,9 @@ struct NormalizedExecutionRequest {
 struct NormalizedDeliveryRequest {
     channel: Option<String>,
     user: Option<String>,
+    agent_review_on_success: bool,
+    agent_review_on_attention: bool,
+    agent_review_on_failure: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -164,6 +167,21 @@ fn delivery_properties() -> Value {
         "user": {
             "type": "string",
             "description": "Default user or target for notifications and routine job message calls. If omitted, the owner's last-seen notification target is used."
+        },
+        "agent_review_on_success": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, inject routine result into the agent loop for review on success."
+        },
+        "agent_review_on_attention": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, inject routine result into the agent loop for review on attention."
+        },
+        "agent_review_on_failure": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, inject routine result into the agent loop for review on failure."
         }
     })
 }
@@ -428,6 +446,20 @@ fn routine_create_tool_summary() -> ToolDiscoverySummary {
             "Legacy flat aliases are still accepted for compatibility, but grouped fields are preferred.".into(),
         ],
         examples: routine_create_examples(),
+    }
+}
+
+/// Compact label describing how a routine delivers its results.
+pub(crate) fn notification_mode_label(notify: &NotifyConfig) -> &'static str {
+    let has_review = notify.agent_review_on_success
+        || notify.agent_review_on_attention
+        || notify.agent_review_on_failure;
+    let has_notify = notify.on_success || notify.on_attention || notify.on_failure;
+    match (has_notify, has_review) {
+        (true, true) => "notify+review",
+        (true, false) => "notify",
+        (false, true) => "review",
+        (false, false) => "silent",
     }
 }
 
@@ -936,6 +968,12 @@ fn parse_routine_delivery(params: &Value) -> NormalizedDeliveryRequest {
     NormalizedDeliveryRequest {
         channel: string_field(params, "delivery", "channel", &["notify_channel"]),
         user: string_field(params, "delivery", "user", &["notify_user"]),
+        agent_review_on_success: bool_field(params, "delivery", "agent_review_on_success", &[])
+            .unwrap_or(false),
+        agent_review_on_attention: bool_field(params, "delivery", "agent_review_on_attention", &[])
+            .unwrap_or(false),
+        agent_review_on_failure: bool_field(params, "delivery", "agent_review_on_failure", &[])
+            .unwrap_or(false),
     }
 }
 
@@ -1194,6 +1232,9 @@ impl Tool for RoutineCreateTool {
                         .filter(|v| *v != "default")
                         .map(ToOwned::to_owned)
                 }),
+                agent_review_on_success: normalized.delivery.agent_review_on_success,
+                agent_review_on_attention: normalized.delivery.agent_review_on_attention,
+                agent_review_on_failure: normalized.delivery.agent_review_on_failure,
                 ..NotifyConfig::default()
             },
             last_run_at: None,
@@ -1313,6 +1354,7 @@ impl Tool for RoutineListTool {
                     "consecutive_failures": r.consecutive_failures,
                     "status": status.as_str(),
                     "verification_status": verification_status.as_str(),
+                    "notification_mode": notification_mode_label(&r.notify),
                 })
             })
             .collect();
@@ -1459,6 +1501,25 @@ impl Tool for RoutineUpdateTool {
                     "Cannot update schedule or timezone on a non-cron routine.".to_string(),
                 ));
             }
+        }
+
+        // Apply delivery/agent_review updates
+        let delivery = parse_routine_delivery(&params);
+        if let Some(ch) = delivery.channel {
+            routine.notify.channel = Some(ch);
+        }
+        if let Some(u) = delivery.user {
+            routine.notify.user = Some(u);
+        }
+        // Agent review flags: only update if explicitly provided in params
+        if bool_field(&params, "delivery", "agent_review_on_success", &[]).is_some() {
+            routine.notify.agent_review_on_success = delivery.agent_review_on_success;
+        }
+        if bool_field(&params, "delivery", "agent_review_on_attention", &[]).is_some() {
+            routine.notify.agent_review_on_attention = delivery.agent_review_on_attention;
+        }
+        if bool_field(&params, "delivery", "agent_review_on_failure", &[]).is_some() {
+            routine.notify.agent_review_on_failure = delivery.agent_review_on_failure;
         }
 
         let updated_fingerprint = routine_verification_fingerprint(&routine);

--- a/src/tools/builtin/routine.rs
+++ b/src/tools/builtin/routine.rs
@@ -708,6 +708,11 @@ pub(crate) fn routine_update_parameters_schema() -> Value {
                 "description": "Maximum LLM iterations for full_job routines (1-200).",
                 "minimum": 1,
                 "maximum": 200
+            },
+            "delivery": {
+                "type": "object",
+                "description": "Update delivery settings (channel, user, agent review).",
+                "properties": delivery_properties()
             }
         },
         "required": ["name"]

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -290,6 +290,7 @@ impl GatewayWorkflowHarness {
                 max_lightweight_tokens: 4096,
                 lightweight_tools_enabled: true,
                 lightweight_max_iterations: 3,
+                ..RoutineConfig::default()
             }),
             Some(Arc::clone(&components.context_manager)),
             Some(Arc::clone(&agent_session_manager)),

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -923,6 +923,7 @@ impl TestRigBuilder {
                 max_lightweight_tokens: 4096,
                 lightweight_tools_enabled: true,
                 lightweight_max_iterations: 3,
+                ..ironclaw::config::RoutineConfig::default()
             })
         } else {
             None


### PR DESCRIPTION
## Summary
Supersedes #1738 (rebased fresh onto v2 engine + ownership model).

- Add per-routine agent_review_on_success/failure/attention flags that inject routine completion results into the agent agentic loop for LLM processing
- Replace is_internal: bool on IncomingMessage with typed MessageSource enum (User, Internal, RoutineReview)
- RoutineReview skips SubmissionParser/hooks/event triggers, enters full agentic loop with tool access (minus AUTONOMOUS_TOOL_DENYLIST)
- Route responses via broadcast to notify_channel with BeforeOutbound hooks
- Set message tool context before agentic loop (prevents stale channel leak)
- Handle NeedApproval explicitly -- auto-deny with warning (no interactive user)
- Rate limiter + circuit breaker (max_agent_reviews_per_hour, consecutive_failures)
- Rate counter incremented only after successful injection
- Per-routine thread isolation via conversation_scope
- Show notification_mode in routine_list/create/update output

## Change Type
- [x] New feature (non-breaking change which adds functionality)

## Linked Issue
Previous PR #1738 had 3 review rounds (zmanian approved, serrrfirat findings addressed).

## Validation
- cargo fmt, clippy x3: zero warnings
- 4233+ unit tests pass, 9 new tests
- Live integration tested

## Security Impact
- SubmissionParser bypass prevents command injection from routine output
- AUTONOMOUS_TOOL_DENYLIST prevents recursive loops
- NeedApproval auto-denied, message tool context set explicitly
- SafetyLayer sanitization before injection

## Database Impact
PostgreSQL V21 + libSQL: 3 BOOLEAN columns (DEFAULT false)

## Blast Radius
MessageSource enum (backward-compat accessor), RoutineEngine inject_tx param, NotifyConfig fields. All construction sites updated. Defaults to false/disabled.

## Rollback Plan
ROUTINE_AGENT_REVIEW_ENABLED=false (default). Per-routine flags default false. Purely additive.

## Review Track
Track C

## Feature Parity
No changes needed.