### PR TITLE
fix(mcp): skip OAuth/DCR for servers with custom Authorization headers #1948

### DIFF
--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -5592,7 +5592,7 @@ mod tests {
             capabilities,
             std::collections::HashMap::new(),
             Vec::new(),
-            Arc::new(PairingStore::new()),
+            Arc::new(PairingStore::new_noop()),
         );
 
         let result = super::near::agent::channel_host::Host::http_request(

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1490,7 +1490,8 @@ impl ExtensionManager {
             match self.load_mcp_servers(user_id).await {
                 Ok(servers) => {
                     for server in &servers.servers {
-                        let authenticated = is_authenticated(server, &self.secrets, user_id).await;
+                        let authenticated = server.has_custom_auth_header()
+                            || is_authenticated(server, &self.secrets, user_id).await;
                         let clients = self.mcp_clients.read().await;
                         let active = clients.contains_key(&server.name);
 
@@ -2822,6 +2823,10 @@ impl ExtensionManager {
             .get_mcp_server(name, user_id)
             .await
             .map_err(|e| ExtensionError::NotInstalled(e.to_string()))?;
+
+        if server.has_custom_auth_header() {
+            return Ok(AuthResult::authenticated(name, ExtensionKind::McpServer));
+        }
 
         // Check if already authenticated
         if is_authenticated(&server, &self.secrets, user_id).await {
@@ -8536,6 +8541,64 @@ mod tests {
                 "MCP secret {secret_name} should be deleted"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn test_auth_mcp_custom_authorization_header_is_treated_as_authenticated() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        let mgr = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+        let server = McpServerConfig::new("custom_auth", "https://example.com/mcp").with_headers(
+            std::collections::HashMap::from([(
+                "Authorization".to_string(),
+                "Bearer sk-test".to_string(),
+            )]),
+        );
+        mgr.add_mcp_server(server, "test")
+            .await
+            .expect("add mcp server");
+
+        let auth = mgr.auth("custom_auth", "test").await.expect("mcp auth");
+
+        assert!(auth.is_authenticated());
+    }
+
+    #[tokio::test]
+    async fn test_list_mcp_server_custom_authorization_header_is_authenticated() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        let mgr = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+        let server = McpServerConfig::new("custom_auth", "https://example.com/mcp").with_headers(
+            std::collections::HashMap::from([(
+                "authorization".to_string(),
+                "Bearer sk-test".to_string(),
+            )]),
+        );
+        mgr.add_mcp_server(server, "test")
+            .await
+            .expect("add mcp server");
+
+        let extensions = mgr
+            .list(Some(ExtensionKind::McpServer), false, "test")
+            .await
+            .expect("list extensions");
+
+        let extension = extensions
+            .iter()
+            .find(|ext| ext.name == "custom_auth")
+            .expect("custom_auth extension should be listed");
+        assert!(extension.authenticated);
+        assert!(!extension.active);
     }
 
     #[test]

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -234,6 +234,10 @@ impl McpServerConfig {
             return false;
         }
 
+        if self.has_custom_auth_header() {
+            return false;
+        }
+
         if self.oauth.is_some() {
             return true;
         }
@@ -800,6 +804,17 @@ mod tests {
 
         let config = McpServerConfig::new("notion", "https://mcp.notion.com");
         assert!(config.requires_auth());
+    }
+
+    #[test]
+    fn test_requires_auth_custom_authorization_header_skips_remote_https_heuristic() {
+        let headers = HashMap::from([("authorization".to_string(), "Bearer token".to_string())]);
+        let config =
+            McpServerConfig::new("server", "https://mcp.example.com").with_headers(headers);
+        assert!(
+            !config.requires_auth(),
+            "custom Authorization headers should skip OAuth/DCR heuristics"
+        );
     }
 
     #[test]


### PR DESCRIPTION

## Summary

<!-- 2-5 bullet points: what changed and why -->

  - Fix MCP auth gating for servers that already use a manually configured `Authorization` header.
  - Skip the remote-HTTPS OAuth/DCR heuristic when custom `Authorization` credentials are present.
  - Treat those MCP servers as authenticated in extension auth/list flows so the UI and activation path stay consistent.
  - Add narrow regression tests for config auth detection and MCP extension auth behavior.
  - Fix a stale test-only `PairingStore` constructor call on current `staging` so validation can run.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

Fixes #1948

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

  This narrows auth flow initiation for MCP servers that already provide explicit credentials via `Authorization`
  headers. It does not expand permissions, secrets access, or network scope.

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

None.

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

  Touches MCP auth classification and extension auth/status handling:
  - MCP config auth heuristic
  - MCP extension auth flow
  - MCP extension list/authenticated state

  Potential regressions would be limited to MCP servers using manual headers or OAuth/DCR auth detection.

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

Revert this commit to restore the previous MCP auth gating behavior.

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

  Please review whether treating a manually configured `Authorization` header as authenticated is the intended long-term
  contract across both CLI and web extension flows. The included tests cover the current bug path and the UI/auth-state
  consistency path.

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->

B
