### PR TITLE
Gate multi-tenant workspace isolation behind AGENT_MULTI_TENANT flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -179,6 +179,12 @@ AGENT_STUCK_THRESHOLD_SECS=300
 # Enable planning phase before tool execution (default: true)
 AGENT_USE_PLANNING=true
 
+# Multi-tenant mode (default: false)
+# When true, each OIDC/authenticated user gets an isolated workspace scope.
+# When false, all users share the single owner-scoped workspace — suitable
+# for team deployments where the agent has one shared identity (e.g. a bot).
+# AGENT_MULTI_TENANT=false
+
 # Self-repair settings
 SELF_REPAIR_CHECK_INTERVAL_SECS=60
 SELF_REPAIR_MAX_ATTEMPTS=3

--- a/src/app.rs
+++ b/src/app.rs
@@ -353,12 +353,14 @@ impl AppBuilder {
             ws = ws.with_memory_layers(self.config.workspace.memory_layers.clone());
             let ws = Arc::new(ws);
 
-            // Detect multi-tenant mode: when the database has registered users,
-            // each authenticated user needs their own workspace scope. Use
-            // WorkspacePool (which implements WorkspaceResolver) to create
-            // per-user workspaces on demand instead of sharing the startup
-            // workspace across all users.
-            let is_multi_tenant = db.has_any_users().await.unwrap_or(false);
+            // Multi-tenant mode: when enabled, each authenticated user gets their
+            // own workspace scope via WorkspacePool. Activation requires both
+            // the explicit AGENT_MULTI_TENANT=true flag *and* at least one
+            // registered user in the database. When the flag is false (default),
+            // all users share the single owner-scoped workspace regardless of
+            // whether the users table has rows.
+            let is_multi_tenant =
+                self.config.agent.multi_tenant && db.has_any_users().await.unwrap_or(false);
 
             if is_multi_tenant {
                 let pool = Arc::new(crate::channels::web::server::WorkspacePool::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,7 +597,9 @@ async fn async_main() -> anyhow::Result<()> {
             gw = gw.with_workspace(Arc::clone(ws));
         }
         // Create per-user workspace pool for multi-user mode.
-        if let Some(ref db) = components.db {
+        if config.agent.multi_tenant
+            && let Some(ref db) = components.db
+        {
             let emb_cache_config = ironclaw::workspace::EmbeddingCacheConfig {
                 max_entries: config.embeddings.cache_size,
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -597,8 +597,11 @@ async fn async_main() -> anyhow::Result<()> {
             gw = gw.with_workspace(Arc::clone(ws));
         }
         // Create per-user workspace pool for multi-user mode.
+        // Requires both the explicit flag *and* at least one registered user,
+        // matching the same guard used in app.rs for tool initialization.
         if config.agent.multi_tenant
             && let Some(ref db) = components.db
+            && db.has_any_users().await.unwrap_or(false)
         {
             let emb_cache_config = ironclaw::workspace::EmbeddingCacheConfig {
                 max_entries: config.embeddings.cache_size,


### PR DESCRIPTION
## Summary

- Add explicit `AGENT_MULTI_TENANT` env var (default: `false`) to control per-user workspace isolation
- Previously multi-tenant mode auto-activated whenever `has_any_users()` was true, causing unintended workspace splits for team/bot deployments
- Both `app.rs` (tool init) and `main.rs` (gateway setup) now require the flag to be `true` before creating `WorkspacePool`

## Changes

- **`.env.example`** — document new `AGENT_MULTI_TENANT` variable
- **`src/app.rs`** — gate `is_multi_tenant` on `config.agent.multi_tenant && db.has_any_users()`
- **`src/main.rs`** — gate gateway workspace pool creation on `config.agent.multi_tenant`

## Test plan

- [ ] Start with `AGENT_MULTI_TENANT=false` (default) — verify all OIDC users share the single owner workspace
- [ ] Start with `AGENT_MULTI_TENANT=true` and users in DB — verify per-user workspace isolation activates
- [ ] Start with `AGENT_MULTI_TENANT=true` and empty users table — verify single workspace (flag alone is insufficient)
- [ ] `cargo fmt && cargo clippy --all --all-features` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)