### PR TITLE
feat(cli): add gateway serve/start/stop/status subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3693,6 +3693,7 @@ dependencies = [
  "ironclaw_skills",
  "json5",
  "jsonwebtoken",
+ "libc",
  "libsql",
  "lru",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,6 +201,7 @@ security-framework = "3"
 
 # PTY allocation for Claude CLI stdout buffering fix (Unix only)
 [target.'cfg(unix)'.dependencies]
+libc = "0.2"
 pty-process = { version = "0.5", features = ["async"] }
 
 # Linux secret-service (GNOME Keyring, KWallet)

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -156,7 +156,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 |---------|----------|----------|----------|-------|
 | `run` (agent) | ✅ | ✅ | - | Default command |
 | `tool install/list/remove` | ✅ | ✅ | - | WASM tools |
-| `gateway start/stop` | ✅ | ❌ | P2 | |
+| `gateway serve/start/stop/status` | ✅ | ✅ | - | `serve` (foreground), `start` (background daemon), `stop` (SIGTERM, Unix-only), `status` (PID + health). Standalone: read-only APIs; agent-dependent APIs return 503. |
 | `onboard` (wizard) | ✅ | ✅ | - | Interactive setup |
 | `tui` | ✅ | ✅ | - | Ratatui TUI |
 | `config` | ✅ | ✅ | - | Read/write config plus validate/path helpers |

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -482,6 +482,24 @@ pub fn pid_lock_path() -> PathBuf {
     ironclaw_base_dir().join("ironclaw.pid")
 }
 
+/// Path to the gateway PID lock file: `~/.ironclaw/gateway.pid`.
+pub fn gateway_pid_lock_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.pid")
+}
+
+/// Path to the gateway log file: `~/.ironclaw/gateway.log`.
+pub fn gateway_log_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.log")
+}
+
+/// Path to the gateway auth token file: `~/.ironclaw/gateway.token`.
+///
+/// Written by `gateway serve` on startup, read by `gateway start` to
+/// display the auth token without parsing log output.
+pub fn gateway_token_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.token")
+}
+
 /// A PID-based lock that prevents multiple IronClaw instances from running
 /// simultaneously.
 ///
@@ -516,8 +534,8 @@ impl PidLock {
         Self::acquire_at(pid_lock_path())
     }
 
-    /// Acquire at a specific path (for testing).
-    fn acquire_at(path: PathBuf) -> Result<Self, PidLockError> {
+    /// Acquire at a specific path (for gateway PID or testing).
+    pub(crate) fn acquire_at(path: PathBuf) -> Result<Self, PidLockError> {
         use fs4::FileExt;
         use std::fs::OpenOptions;
         use std::io::Write;

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -5592,7 +5592,7 @@ mod tests {
             capabilities,
             std::collections::HashMap::new(),
             Vec::new(),
-            Arc::new(PairingStore::new()),
+            Arc::new(PairingStore::new_noop()),
         );
 
         let result = super::near::agent::channel_host::Host::http_request(

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -62,6 +62,32 @@ use self::server::GatewayState;
 use self::sse::SseManager;
 use self::types::AppEvent;
 
+/// Components shared between full agent mode (`main.rs`) and standalone
+/// gateway mode (`cli/gateway.rs`). Used by [`GatewayChannel::from_components`]
+/// to eliminate wiring duplication.
+pub struct GatewayComponents {
+    pub llm: Arc<dyn crate::llm::LlmProvider>,
+    pub workspace: Option<Arc<Workspace>>,
+    pub session_manager: Arc<SessionManager>,
+    pub log_broadcaster: Arc<LogBroadcaster>,
+    pub log_level_handle: Arc<LogLevelHandle>,
+    pub tools: Arc<ToolRegistry>,
+    pub extension_manager: Option<Arc<ExtensionManager>>,
+    pub catalog_entries: Vec<crate::extensions::RegistryEntry>,
+    pub db: Option<Arc<dyn Database>>,
+    pub skill_registry: Option<Arc<std::sync::RwLock<SkillRegistry>>>,
+    pub skill_catalog: Option<Arc<SkillCatalog>>,
+    pub cost_guard: Arc<crate::agent::cost_guard::CostGuard>,
+    pub secrets_store: Option<Arc<dyn crate::secrets::SecretsStore + Send + Sync>>,
+    /// If set, enables gateway mode on the extension manager with this base URL.
+    pub gateway_base_url: Option<String>,
+    /// If set, creates a per-user workspace pool for multi-user isolation.
+    pub workspace_pool: Option<Arc<server::WorkspacePool>>,
+    /// If true and a DB is present, enable database-backed authentication
+    /// and bootstrap the admin user if none exist.
+    pub enable_db_auth: bool,
+}
+
 /// Web gateway channel implementing the Channel trait.
 pub struct GatewayChannel {
     config: GatewayConfig,
@@ -154,6 +180,98 @@ impl GatewayChannel {
             state,
             auth,
         }
+    }
+
+    /// Build a gateway channel from shared components.
+    ///
+    /// Wires all subsystems that are common to both full agent mode and
+    /// standalone gateway mode. Agent-loop-only features (scheduler,
+    /// job_manager, routine_engine, prompt_queue, active_config) must
+    /// be added separately via `with_*`.
+    pub async fn from_components(
+        config: GatewayConfig,
+        owner_id: String,
+        c: GatewayComponents,
+    ) -> Self {
+        let mut gw = Self::new(config, owner_id.clone());
+        gw = gw.with_llm_provider(c.llm);
+        if let Some(ws) = c.workspace {
+            gw = gw.with_workspace(ws);
+        }
+        if let Some(pool) = c.workspace_pool {
+            gw = gw.with_workspace_pool(pool);
+        }
+        gw = gw.with_session_manager(c.session_manager);
+        gw = gw.with_log_broadcaster(c.log_broadcaster);
+        gw = gw.with_log_level_handle(c.log_level_handle);
+        gw = gw.with_tool_registry(c.tools);
+        if let Some(ext_mgr) = c.extension_manager {
+            if let Some(ref gw_base) = c.gateway_base_url {
+                ext_mgr.enable_gateway_mode(gw_base.clone()).await;
+            }
+            gw = gw.with_extension_manager(ext_mgr);
+        }
+        if !c.catalog_entries.is_empty() {
+            gw = gw.with_registry_entries(c.catalog_entries);
+        }
+        if let Some(ref d) = c.db {
+            gw = gw.with_store(Arc::clone(d));
+            if c.enable_db_auth {
+                gw = gw.with_db_auth(Arc::clone(d));
+                // Bootstrap: create the first admin user so the owner appears
+                // in the Users admin panel immediately.
+                if let Ok(false) = d.has_any_users().await {
+                    let now = chrono::Utc::now();
+                    let user = crate::db::UserRecord {
+                        id: owner_id.clone(),
+                        email: None,
+                        display_name: owner_id.clone(),
+                        status: "active".to_string(),
+                        role: "admin".to_string(),
+                        created_at: now,
+                        updated_at: now,
+                        last_login_at: None,
+                        created_by: None,
+                        metadata: serde_json::json!({"source": "bootstrap"}),
+                    };
+                    let auth_token = gw.auth_token();
+                    if auth_token.is_empty() {
+                        if let Err(e) = d.create_user(&user).await {
+                            tracing::warn!("Failed to bootstrap admin user: {}", e);
+                        }
+                    } else {
+                        let hash = auth::hash_token(auth_token);
+                        let prefix = if auth_token.len() >= 8 {
+                            &auth_token[..8]
+                        } else {
+                            auth_token
+                        };
+                        if let Err(e) = d
+                            .create_user_with_token(&user, "bootstrap", &hash, prefix, None)
+                            .await
+                        {
+                            tracing::warn!("Failed to bootstrap admin user: {}", e);
+                        } else {
+                            tracing::info!(
+                                user_id = owner_id,
+                                "Bootstrapped admin user from gateway config"
+                            );
+                        }
+                    }
+                }
+            }
+        }
+        if let Some(ss) = c.secrets_store {
+            gw = gw.with_secrets_store(ss);
+        }
+        if let Some(sr) = c.skill_registry {
+            gw = gw.with_skill_registry(sr);
+        }
+        if let Some(sc) = c.skill_catalog {
+            gw = gw.with_skill_catalog(sc);
+        }
+        gw = gw.with_cost_guard(c.cost_guard);
+        gw
     }
 
     /// Helper to rebuild state, copying existing fields and applying a mutation.
@@ -483,6 +601,11 @@ impl GatewayChannel {
         self.auth.env_auth.first_token().unwrap_or("")
     }
 
+    /// Get a reference to the combined auth state.
+    pub fn auth(&self) -> &CombinedAuthState {
+        &self.auth
+    }
+
     /// Get a reference to the shared gateway state (for the agent to push SSE events).
     pub fn state(&self) -> &Arc<GatewayState> {
         &self.state
@@ -509,7 +632,8 @@ impl Channel for GatewayChannel {
                 ),
             })?;
 
-        server::start_server(addr, self.state.clone(), self.auth.clone()).await?;
+        let (_bound_addr, _server_handle) =
+            server::start_server(addr, self.state.clone(), self.auth.clone()).await?;
 
         Ok(Box::pin(ReceiverStream::new(rx)))
     }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -463,12 +463,14 @@ pub struct GatewayState {
 
 /// Start the gateway HTTP server.
 ///
-/// Returns the actual bound `SocketAddr` (useful when binding to port 0).
+/// Returns the actual bound `SocketAddr` and the server task handle.
+/// Callers that need graceful shutdown can await the handle after sending
+/// the shutdown signal via `state.shutdown_tx`.
 pub async fn start_server(
     addr: SocketAddr,
     state: Arc<GatewayState>,
     auth: CombinedAuthState,
-) -> Result<SocketAddr, crate::error::ChannelError> {
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), crate::error::ChannelError> {
     let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
         crate::error::ChannelError::StartupFailed {
             name: "gateway".to_string(),
@@ -858,7 +860,7 @@ pub async fn start_server(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     *state.shutdown_tx.write().await = Some(shutdown_tx);
 
-    tokio::spawn(async move {
+    let server_handle = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app)
             .with_graceful_shutdown(async {
                 let _ = shutdown_rx.await;
@@ -870,7 +872,7 @@ pub async fn start_server(
         }
     });
 
-    Ok(bound_addr)
+    Ok((bound_addr, server_handle))
 }
 
 // --- Static file handlers ---
@@ -4144,7 +4146,7 @@ mod tests {
             "test-token".to_string(),
             "test".to_string(),
         ));
-        let bound = start_server(addr, state.clone(), auth)
+        let (bound, _server_handle) = start_server(addr, state.clone(), auth)
             .await
             .expect("server should start");
 

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -116,7 +116,7 @@ impl TestGatewayBuilder {
         let addr: SocketAddr = "127.0.0.1:0"
             .parse()
             .expect("hard-coded address must parse"); // safety: constant literal
-        let bound = start_server(addr, state.clone(), auth.into()).await?;
+        let (bound, _handle) = start_server(addr, state.clone(), auth.into()).await?;
         Ok((bound, state))
     }
 
@@ -130,7 +130,7 @@ impl TestGatewayBuilder {
         let addr: SocketAddr = "127.0.0.1:0"
             .parse()
             .expect("hard-coded address must parse"); // safety: constant literal
-        let bound = start_server(addr, state.clone(), auth.into()).await?;
+        let (bound, _handle) = start_server(addr, state.clone(), auth.into()).await?;
         Ok((bound, state))
     }
 }

--- a/src/cli/gateway.rs
+++ b/src/cli/gateway.rs
@@ -1,0 +1,689 @@
+//! Gateway management CLI commands.
+//!
+//! Provides standalone gateway lifecycle management:
+//!
+//! - `gateway serve`  — foreground mode (Ctrl-C to stop), for dev/debug
+//! - `gateway start`  — background daemon, spawns `serve` as detached child
+//! - `gateway stop`   — sends SIGTERM to background daemon via PID file
+//! - `gateway status` — checks PID liveness + health probe
+//!
+//! Read-only APIs work in standalone mode (health, threads, history, memory,
+//! settings, skills, extensions, logs). Write/control APIs that require the
+//! agent loop (chat send/ws, routine trigger, job restart/cancel/prompt)
+//! return 503. For full agent mode, use `ironclaw run`.
+
+use std::net::SocketAddr;
+use std::path::Path;
+use std::sync::Arc;
+
+use clap::Subcommand;
+
+use crate::app::{AppBuilder, AppBuilderFlags};
+use crate::bootstrap::{PidLock, gateway_log_path, gateway_pid_lock_path, gateway_token_path};
+use crate::channels::GatewayChannel;
+use crate::channels::web::log_layer::{LogBroadcaster, init_tracing};
+use crate::channels::web::server;
+use crate::config::Config;
+use crate::llm::create_session_manager;
+
+/// Maximum time to wait for the background gateway to become healthy.
+const START_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Polling interval when waiting for health check.
+const START_HEALTH_POLL: std::time::Duration = std::time::Duration::from_millis(300);
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum GatewayCommand {
+    /// Run the web gateway in the foreground (Ctrl-C to stop).
+    ///
+    /// Starts the gateway API server without the agent loop. Useful for
+    /// development and debugging. Use `gateway start` for background mode.
+    Serve,
+
+    /// Start the web gateway as a background daemon.
+    ///
+    /// Spawns the gateway in the background, writes a PID file, and returns
+    /// immediately. Use `gateway stop` to shut it down.
+    Start,
+
+    /// Stop a running background gateway.
+    ///
+    /// Reads the PID from ~/.ironclaw/gateway.pid and sends SIGTERM
+    /// for graceful shutdown.
+    Stop,
+
+    /// Show gateway status.
+    ///
+    /// Checks the PID file and probes the health endpoint.
+    Status,
+}
+
+/// Run the gateway CLI subcommand.
+pub async fn run_gateway_command(
+    cmd: GatewayCommand,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    // Start and stop rely on Unix process signals (kill, setsid).
+    // Status uses the health probe (cross-platform) but skips PID checks on non-Unix.
+    #[cfg(not(unix))]
+    match cmd {
+        GatewayCommand::Serve | GatewayCommand::Status => {}
+        GatewayCommand::Start => anyhow::bail!("`gateway start` is currently Unix-only"),
+        GatewayCommand::Stop => anyhow::bail!("`gateway stop` is currently Unix-only"),
+    }
+
+    match cmd {
+        GatewayCommand::Serve => cmd_serve(config_path).await,
+        GatewayCommand::Start => cmd_start(config_path).await,
+        GatewayCommand::Stop => cmd_stop(),
+        GatewayCommand::Status => cmd_status(config_path).await,
+    }
+}
+
+// ─── serve (foreground) ─────────────────────────────────────────
+
+async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
+    // Load config first.
+    let config = Config::from_env_with_toml(config_path).await?;
+
+    let gw_config = config
+        .channels
+        .gateway
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Gateway is not enabled. Set GATEWAY_ENABLED=true"))?;
+
+    // Acquire PID lock before any heavy init — ensures single instance.
+    let _pid_lock = PidLock::acquire_at(gateway_pid_lock_path())
+        .map_err(|e| anyhow::anyhow!("Cannot start gateway: {e}"))?;
+
+    // Initialize full tracing (with LogBroadcaster for /api/logs/events).
+    let log_broadcaster = Arc::new(LogBroadcaster::new());
+    let log_level_handle = init_tracing(Arc::clone(&log_broadcaster));
+
+    tracing::info!("Starting standalone gateway...");
+
+    // Capture values before config is moved into AppBuilder.
+    let owner_id = config.owner_id.clone();
+    let tunnel_public_url = config.tunnel.public_url.clone();
+
+    // Build core components via the standard AppBuilder pipeline.
+    let session = create_session_manager(config.llm.session.clone()).await;
+    let flags = AppBuilderFlags { no_db: false };
+    let components = AppBuilder::new(
+        config,
+        flags,
+        config_path.map(std::path::PathBuf::from),
+        session,
+        Arc::clone(&log_broadcaster),
+    )
+    .build_all()
+    .await?;
+
+    // Wire the GatewayChannel via shared factory — no more manual duplication
+    // with main.rs. Agent-loop-only features (scheduler, job_manager, etc.)
+    // are intentionally omitted; those APIs return 503 in standalone mode.
+    let session_manager =
+        Arc::new(crate::agent::SessionManager::new().with_hooks(components.hooks.clone()));
+    let gateway_base_url = tunnel_public_url
+        .unwrap_or_else(|| format!("http://{}:{}", gw_config.host, gw_config.port));
+    // Build workspace pool for multi-user isolation if DB is available.
+    let workspace_pool = components.db.as_ref().map(|db| {
+        let emb_cache_config = crate::workspace::EmbeddingCacheConfig {
+            max_entries: components.config.embeddings.cache_size,
+        };
+        Arc::new(crate::channels::web::server::WorkspacePool::new(
+            Arc::clone(db),
+            components.embeddings.clone(),
+            emb_cache_config,
+            components.config.search.clone(),
+            components.config.workspace.clone(),
+        ))
+    });
+
+    let gw = GatewayChannel::from_components(
+        gw_config.clone(),
+        owner_id,
+        crate::channels::web::GatewayComponents {
+            llm: Arc::clone(&components.llm),
+            workspace: components.workspace.clone(),
+            session_manager,
+            log_broadcaster: Arc::clone(&log_broadcaster),
+            log_level_handle: Arc::clone(&log_level_handle),
+            tools: Arc::clone(&components.tools),
+            extension_manager: components.extension_manager.clone(),
+            catalog_entries: components.catalog_entries.clone(),
+            db: components.db.clone(),
+            skill_registry: components.skill_registry.clone(),
+            skill_catalog: components.skill_catalog.clone(),
+            cost_guard: Arc::clone(&components.cost_guard),
+            secrets_store: components.secrets_store.clone(),
+            gateway_base_url: Some(gateway_base_url),
+            workspace_pool,
+            enable_db_auth: true,
+        },
+    )
+    .await;
+
+    // Start the HTTP server directly — do NOT call Channel::start() so
+    // msg_tx stays None and chat send/ws naturally return 503.
+    let addr: SocketAddr = format!("{}:{}", gw_config.host, gw_config.port)
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid gateway address: {e}"))?;
+
+    let state = Arc::clone(gw.state());
+    let auth_token = gw.auth_token().to_string();
+
+    let (bound_addr, server_handle) =
+        server::start_server(addr, Arc::clone(&state), gw.auth().clone()).await?;
+
+    // Write auth token to a dedicated file so `gateway start` can read it
+    // without parsing log output (which is brittle if tracing interleaves).
+    let token_path = gateway_token_path();
+    if let Err(e) = write_gateway_token_file(&token_path, &auth_token) {
+        tracing::warn!("Failed to write token file {}: {e}", token_path.display());
+    }
+
+    println!("Gateway running at http://{bound_addr}/");
+    println!("Auth token: {auth_token}");
+    println!("Web UI: http://{bound_addr}/?token={auth_token}");
+    println!();
+    println!("Standalone mode: chat endpoints return 503 (no agent loop).");
+    println!("Press Ctrl-C to stop.");
+
+    // Wait for shutdown signal, then bridge to axum's graceful shutdown.
+    wait_for_shutdown_signal().await;
+
+    tracing::info!("Shutting down gateway...");
+    if let Some(tx) = state.shutdown_tx.write().await.take() {
+        let _ = tx.send(());
+    }
+
+    // Await the server task so in-flight requests can drain gracefully.
+    let _ = server_handle.await;
+
+    // Clean up token file and PID lock.
+    cleanup_gateway_token_file(&token_path);
+    // _pid_lock is dropped here, cleaning up gateway.pid.
+    Ok(())
+}
+
+/// Wait for SIGTERM or Ctrl-C.
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut sigterm) = signal(SignalKind::terminate()) {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {},
+                _ = sigterm.recv() => {},
+            }
+        } else {
+            // SIGTERM registration failed — fall back to Ctrl-C only.
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+fn write_gateway_token_file(path: &Path, auth_token: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(auth_token.as_bytes())?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, auth_token)?;
+    }
+
+    Ok(())
+}
+
+fn cleanup_gateway_token_file(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!("Failed to remove token file {}: {e}", path.display());
+    }
+}
+
+// ─── start (background daemon) ──────────────────────────────────
+
+async fn cmd_start(config_path: Option<&Path>) -> anyhow::Result<()> {
+    // Pre-flight: check that gateway is enabled before spawning.
+    let config = Config::from_env_with_toml(config_path).await?;
+    let gw_config = config
+        .channels
+        .gateway
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Gateway is not enabled. Set GATEWAY_ENABLED=true"))?;
+
+    // Best-effort pre-flight check: try to acquire the PID lock to detect
+    // an already-running instance. This is NOT authoritative — there is a
+    // TOCTOU window between this check and the child's PidLock::acquire_at
+    // in `cmd_serve`. The child's lock is the real mutual exclusion point.
+    // If two `gateway start` commands race, the loser's child will fail to
+    // acquire the lock and exit, which the parent detects via health-check
+    // timeout or process exit.
+    let pid_path = gateway_pid_lock_path();
+    match PidLock::acquire_at(pid_path.clone()) {
+        Ok(lock) => {
+            // Lock acquired — no other instance holds it. Release immediately
+            // so the child can acquire it.
+            drop(lock);
+        }
+        Err(crate::bootstrap::PidLockError::AlreadyRunning { pid }) => {
+            anyhow::bail!("Gateway is already running (PID {pid})");
+        }
+        Err(crate::bootstrap::PidLockError::Io(e)) => {
+            anyhow::bail!("Cannot check gateway PID lock: {e}");
+        }
+    }
+
+    // Spawn `ironclaw gateway serve` as a detached child process.
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("Cannot determine own executable path: {e}"))?;
+
+    let log_path = gateway_log_path();
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("Cannot create directory {}: {e}", parent.display()))?;
+    }
+    let log_file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| anyhow::anyhow!("Cannot open log file {}: {e}", log_path.display()))?;
+    let stderr_file = log_file
+        .try_clone()
+        .map_err(|e| anyhow::anyhow!("Cannot clone log file handle: {e}"))?;
+
+    let mut cmd = std::process::Command::new(exe);
+    cmd.arg("gateway").arg("serve");
+    if let Some(cp) = config_path {
+        cmd.arg("--config").arg(cp);
+    }
+    cmd.stdout(log_file)
+        .stderr(stderr_file)
+        .stdin(std::process::Stdio::null());
+
+    // On Unix, start a new session so the child survives parent exit.
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        // SAFETY: setsid() is async-signal-safe and is the standard way to
+        // detach a child process from the parent's terminal session.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    let child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn gateway process: {e}"))?;
+
+    let child_pid = child.id();
+    println!("Gateway starting in background (PID {child_pid})...");
+    println!("Log file: {}", log_path.display());
+
+    // Poll health endpoint until it responds or timeout.
+    // Normalize unspecified bind addresses to localhost for probing.
+    let health_host = normalize_probe_host(&gw_config.host);
+    let health_url = format!("http://{health_host}:{}/api/health", gw_config.port);
+    let deadline = std::time::Instant::now() + START_HEALTH_TIMEOUT;
+    let mut healthy = false;
+
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(START_HEALTH_POLL).await;
+
+        // Also verify the child hasn't crashed.
+        if !is_process_alive(child_pid) {
+            anyhow::bail!(
+                "Gateway process exited unexpectedly. Check logs: {}",
+                log_path.display()
+            );
+        }
+
+        if probe_health(&health_url).await.unwrap_or(false) {
+            healthy = true;
+            break;
+        }
+    }
+
+    if healthy {
+        let base_url = format!("http://{}:{}", gw_config.host, gw_config.port);
+        println!("Gateway is running at {base_url}/");
+
+        // Read auth token from the dedicated token file written by `serve`.
+        let token_path = gateway_token_path();
+        if let Ok(token) = std::fs::read_to_string(&token_path) {
+            let token = token.trim();
+            if !token.is_empty() {
+                println!("Auth token: {token}");
+                println!("Web UI: {base_url}/?token={token}");
+            }
+        } else {
+            println!("Auth token: see {}", log_path.display());
+        }
+    } else {
+        println!(
+            "Warning: gateway process started but health check did not pass within {}s.",
+            START_HEALTH_TIMEOUT.as_secs()
+        );
+        println!("Check logs: {}", log_path.display());
+    }
+
+    Ok(())
+}
+
+// ─── stop ────────────────────────────────────────────────────────
+
+fn cmd_stop() -> anyhow::Result<()> {
+    let pid_path = gateway_pid_lock_path();
+    let pid_str = std::fs::read_to_string(&pid_path).map_err(|_| {
+        anyhow::anyhow!(
+            "Gateway is not running (no PID file at {})",
+            pid_path.display()
+        )
+    })?;
+
+    let pid: u32 = pid_str.trim().parse().map_err(|_| {
+        anyhow::anyhow!(
+            "Invalid PID in {}: '{}'",
+            pid_path.display(),
+            pid_str.trim()
+        )
+    })?;
+
+    #[cfg(unix)]
+    {
+        // Note: is_process_alive uses kill(pid, 0) which can return false
+        // positives if the PID has been reused by an unrelated process.
+        // This is inherent to PID-file-based lifecycle management; the
+        // flock held by PidLock is the authoritative ownership signal.
+        if !is_process_alive(pid) {
+            // Process already gone — clean up stale PID file.
+            let _ = std::fs::remove_file(&pid_path);
+            cleanup_gateway_token_file(&gateway_token_path());
+            anyhow::bail!("Gateway process (PID {pid}) is not running (stale PID file removed)");
+        }
+
+        let pid_t = to_pid_t(pid).ok_or_else(|| anyhow::anyhow!("PID {pid} overflows i32"))?;
+        // SAFETY: We are sending a signal to a process identified by our PID file.
+        let ret = unsafe { libc::kill(pid_t, libc::SIGTERM) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ESRCH) {
+                let _ = std::fs::remove_file(&pid_path);
+                cleanup_gateway_token_file(&gateway_token_path());
+                anyhow::bail!(
+                    "Gateway process (PID {pid}) exited before SIGTERM could be delivered (stale PID file removed)"
+                );
+            }
+            anyhow::bail!("Failed to send SIGTERM to PID {pid}: {err}");
+        }
+        println!("Sent SIGTERM to gateway (PID {pid}).");
+
+        // Poll for process exit, then clean up the PID file if the serve
+        // process didn't remove it (e.g. killed by SIGKILL or OOM).
+        let stop_deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        while std::time::Instant::now() < stop_deadline {
+            if !is_process_alive(pid) {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(200));
+        }
+
+        // If the PID file still exists and the process has exited, remove it.
+        if pid_path.exists() && !is_process_alive(pid) {
+            let _ = std::fs::remove_file(&pid_path);
+        }
+
+        if is_process_alive(pid) {
+            println!(
+                "Warning: process (PID {pid}) still running after 5s. You may need to `kill -9 {pid}`."
+            );
+        } else {
+            cleanup_gateway_token_file(&gateway_token_path());
+            println!("Gateway stopped.");
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        anyhow::bail!("gateway stop is currently Unix-only");
+    }
+
+    Ok(())
+}
+
+// ─── status ──────────────────────────────────────────────────────
+
+async fn cmd_status(config_path: Option<&Path>) -> anyhow::Result<()> {
+    // PID-based liveness check is Unix-only; on other platforms we skip
+    // straight to the health probe.
+    #[cfg(unix)]
+    {
+        let pid_path = gateway_pid_lock_path();
+        match std::fs::read_to_string(&pid_path) {
+            Ok(pid_str) => match pid_str.trim().parse::<u32>() {
+                Ok(pid) => {
+                    if is_process_alive(pid) {
+                        println!("Gateway is running (PID {pid}).");
+                    } else {
+                        println!("Gateway is not running (stale PID {pid}).");
+                        return Ok(());
+                    }
+                }
+                Err(_) => {
+                    println!("Gateway PID file exists but is invalid.");
+                    return Ok(());
+                }
+            },
+            Err(_) => {
+                println!("No PID file found.");
+            }
+        }
+    }
+
+    // Health probe — works on all platforms.
+    let config = Config::from_env_with_toml(config_path).await.ok();
+    let probe_addr = config
+        .as_ref()
+        .and_then(|c| c.channels.gateway.as_ref())
+        .map(|gw| {
+            let host = normalize_probe_host(&gw.host);
+            format!("{host}:{}", gw.port)
+        });
+
+    if let Some(ref addr) = probe_addr {
+        println!("Address: {addr}");
+
+        // Probe /api/health (unauthenticated endpoint)
+        let url = format!("http://{addr}/api/health");
+        match probe_health(&url).await {
+            Ok(true) => println!("Health:  ok"),
+            Ok(false) => println!("Health:  unhealthy"),
+            Err(reason) => println!("Health:  unreachable ({reason})"),
+        }
+    }
+
+    Ok(())
+}
+
+/// Check if a process is alive by sending signal 0.
+///
+/// **PID reuse caveat:** `kill(pid, 0)` only checks that *some* process with
+/// that PID exists. After the original gateway exits, the OS may reassign
+/// the PID to an unrelated process. Callers (especially `cmd_stop`) should
+/// be aware that a `true` return does not guarantee the process is *our*
+/// gateway. The `PidLock` flock is the authoritative ownership signal.
+fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let Some(pid_t) = to_pid_t(pid) else {
+            return false;
+        };
+        // SAFETY: Signal 0 is a null signal used only for existence checking.
+        unsafe { libc::kill(pid_t, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+/// Safely convert a u32 PID to libc::pid_t (i32), returning None on overflow.
+#[cfg(unix)]
+fn to_pid_t(pid: u32) -> Option<libc::pid_t> {
+    libc::pid_t::try_from(pid).ok()
+}
+
+/// Normalize a bind host for health probing. Unspecified addresses like
+/// `0.0.0.0` or `::` cannot be connected to; use `127.0.0.1` instead.
+fn normalize_probe_host(host: &str) -> &str {
+    match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    }
+}
+
+async fn probe_health(url: &str) -> Result<bool, String> {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .map_err(|e| format!("client build error: {e}"))?;
+
+    let resp = client.get(url).send().await.map_err(|e| format!("{e}"))?;
+    Ok(resp.status().is_success())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_pid_lock_path_is_in_base_dir() {
+        let path = gateway_pid_lock_path();
+        assert!(
+            path.ends_with("gateway.pid"),
+            "expected gateway.pid, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn gateway_log_path_is_in_base_dir() {
+        let path = gateway_log_path();
+        assert!(
+            path.ends_with("gateway.log"),
+            "expected gateway.log, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn normalize_probe_host_rewrites_unspecified() {
+        assert_eq!(normalize_probe_host("0.0.0.0"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("::"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("[::]"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("10.0.0.1"), "10.0.0.1");
+        assert_eq!(normalize_probe_host("127.0.0.1"), "127.0.0.1");
+    }
+
+    #[test]
+    fn is_process_alive_for_current_process() {
+        let pid = std::process::id();
+        assert!(is_process_alive(pid), "current process should be alive");
+    }
+
+    #[test]
+    fn is_process_alive_for_nonexistent_pid() {
+        // PID 4_000_000 is extremely unlikely to exist
+        assert!(
+            !is_process_alive(4_000_000),
+            "nonexistent PID should not be alive"
+        );
+    }
+
+    #[test]
+    fn pid_lock_prevents_double_start() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pid_path = dir.path().join("gateway.pid");
+
+        let lock1 = PidLock::acquire_at(pid_path.clone());
+        assert!(lock1.is_ok(), "first lock should succeed");
+
+        let lock2 = PidLock::acquire_at(pid_path);
+        assert!(lock2.is_err(), "second lock should fail");
+
+        let err = lock2.unwrap_err().to_string();
+        assert!(
+            err.contains("already running"),
+            "expected 'already running' in error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn gateway_token_path_is_in_base_dir() {
+        let path = gateway_token_path();
+        assert!(
+            path.ends_with("gateway.token"),
+            "expected gateway.token, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn token_file_round_trip() {
+        let dir = tempfile::tempdir().expect("create temp dir"); // safety: test
+        let token_path = dir.path().join("gateway.token");
+        let token = "abc123def456";
+        write_gateway_token_file(&token_path, token).expect("write token"); // safety: test
+        let read_back = std::fs::read_to_string(&token_path).expect("read token"); // safety: test
+        assert_eq!(read_back.trim(), token);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn token_file_permissions_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let token_path = dir.path().join("gateway.token");
+
+        write_gateway_token_file(&token_path, "secret").expect("write token");
+
+        let mode = std::fs::metadata(&token_path)
+            .expect("token metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -20,6 +20,7 @@ mod completion;
 mod config;
 mod doctor;
 pub mod fmt;
+mod gateway;
 mod hooks;
 #[cfg(feature = "import")]
 pub mod import;
@@ -41,6 +42,7 @@ pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
+pub use gateway::{GatewayCommand, run_gateway_command};
 pub use hooks::{HooksCommand, run_hooks_command};
 #[cfg(feature = "import")]
 pub use import::{ImportCommand, run_import_command};
@@ -204,6 +206,14 @@ pub enum Command {
         long_about = "Approve or manage pairing requests.\nExamples:\n  ironclaw pairing list telegram\n  ironclaw pairing approve telegram ABC12345"
     )]
     Pairing(PairingCommand),
+
+    /// Manage the web gateway (standalone mode)
+    #[command(
+        subcommand,
+        about = "Manage web gateway",
+        long_about = "Manage the web gateway in standalone mode (no agent loop).\nExamples:\n  ironclaw gateway serve   # Foreground (Ctrl-C to stop)\n  ironclaw gateway start   # Background daemon\n  ironclaw gateway stop    # Stop background daemon\n  ironclaw gateway status  # Check if running"
+    )]
+    Gateway(GatewayCommand),
 
     /// Manage OS service (launchd / systemd)
     #[command(

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 447
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -17,6 +18,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  gateway     Manage web gateway
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -1,6 +1,6 @@
 ---
 source: src/cli/mod.rs
-assertion_line: 422
+assertion_line: 455
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -18,6 +18,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  gateway     Manage web gateway
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 463
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -20,6 +21,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  gateway     Manage web gateway
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -1,6 +1,6 @@
 ---
 source: src/cli/mod.rs
-assertion_line: 438
+assertion_line: 471
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -21,6 +21,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  gateway     Manage web gateway
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks
@@ -51,7 +52,7 @@ Options:
 
       --auto-approve
           Auto-approve tool execution (shell, file writes, HTTP, etc.)
-
+          
           Skips interactive approval prompts for standard tools. Destructive operations still require explicit approval. Other safeguards remain active: rate limits, hooks, authentication gates.
 
   -h, --help

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,13 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return run_pairing_command(pairing_cmd.clone()).await;
         }
+        Some(Command::Gateway(gw_cmd)) => {
+            // Serve initializes its own full tracing; other subcommands use lightweight CLI tracing.
+            if !matches!(gw_cmd, ironclaw::cli::GatewayCommand::Serve) {
+                init_cli_tracing();
+            }
+            return ironclaw::cli::run_gateway_command(gw_cmd.clone(), cli.config.as_deref()).await;
+        }
         Some(Command::Service(service_cmd)) => {
             init_cli_tracing();
             return run_service_command(service_cmd);
@@ -613,114 +620,64 @@ async fn async_main() -> anyhow::Result<()> {
     let mut gateway_url: Option<String> = None;
     let mut sse_manager: Option<std::sync::Arc<ironclaw::channels::web::sse::SseManager>> = None;
     if let Some(ref gw_config) = config.channels.gateway {
-        let mut gw = GatewayChannel::new(gw_config.clone(), config.owner_id.clone());
-        gw = gw.with_llm_provider(Arc::clone(&components.llm));
-        if let Some(ref ws) = components.workspace {
-            gw = gw.with_workspace(Arc::clone(ws));
-        }
-        // Create per-user workspace pool for multi-user mode.
-        if let Some(ref db) = components.db {
-            let emb_cache_config = ironclaw::workspace::EmbeddingCacheConfig {
-                max_entries: config.embeddings.cache_size,
-            };
-            let pool = Arc::new(ironclaw::channels::web::server::WorkspacePool::new(
-                Arc::clone(db),
-                components.embeddings.clone(),
-                emb_cache_config,
-                config.search.clone(),
-                config.workspace.clone(),
-            ));
-            gw = gw.with_workspace_pool(pool);
-        }
-        gw = gw.with_session_manager(Arc::clone(&session_manager));
-        gw = gw.with_log_broadcaster(Arc::clone(&log_broadcaster));
-        gw = gw.with_log_level_handle(Arc::clone(&log_level_handle));
-        gw = gw.with_tool_registry(Arc::clone(&components.tools));
-        if let Some(ref ext_mgr) = components.extension_manager {
-            // Enable gateway mode so MCP OAuth returns auth URLs to the frontend
-            // instead of calling open::that() on the server.
-            let gw_base = config
-                .tunnel
-                .public_url
-                .clone()
-                .unwrap_or_else(|| format!("http://{}:{}", gw_config.host, gw_config.port));
-            ext_mgr.enable_gateway_mode(gw_base).await;
-            gw = gw.with_extension_manager(Arc::clone(ext_mgr));
-        }
-        if !components.catalog_entries.is_empty() {
-            gw = gw.with_registry_entries(components.catalog_entries.clone());
-        }
+        let gw_base = config
+            .tunnel
+            .public_url
+            .clone()
+            .unwrap_or_else(|| format!("http://{}:{}", gw_config.host, gw_config.port));
+
+        // Build gateway from shared components (same factory as cli/gateway.rs).
+        let mut gw = GatewayChannel::from_components(gw_config.clone(), config.owner_id.clone(), {
+            // Build workspace pool for multi-user isolation if DB is available.
+            let workspace_pool = components.db.as_ref().map(|db| {
+                let emb_cache_config = ironclaw::workspace::EmbeddingCacheConfig {
+                    max_entries: config.embeddings.cache_size,
+                };
+                Arc::new(ironclaw::channels::web::server::WorkspacePool::new(
+                    Arc::clone(db),
+                    components.embeddings.clone(),
+                    emb_cache_config,
+                    config.search.clone(),
+                    config.workspace.clone(),
+                ))
+            });
+
+            ironclaw::channels::web::GatewayComponents {
+                llm: Arc::clone(&components.llm),
+                workspace: components.workspace.clone(),
+                session_manager: Arc::clone(&session_manager),
+                log_broadcaster: Arc::clone(&log_broadcaster),
+                log_level_handle: Arc::clone(&log_level_handle),
+                tools: Arc::clone(&components.tools),
+                extension_manager: components.extension_manager.clone(),
+                catalog_entries: components.catalog_entries.clone(),
+                db: components.db.clone(),
+                skill_registry: components.skill_registry.clone(),
+                skill_catalog: components.skill_catalog.clone(),
+                cost_guard: Arc::clone(&components.cost_guard),
+                secrets_store: components.secrets_store.clone(),
+                gateway_base_url: Some(gw_base),
+                workspace_pool,
+                enable_db_auth: true,
+            }
+        })
+        .await;
+
+        // Wire pairing store (requires ownership_cache from main).
         if let Some(ref d) = components.db {
-            gw = gw.with_store(Arc::clone(d));
-            gw = gw.with_db_auth(Arc::clone(d));
             let pairing_store = Arc::new(ironclaw::pairing::PairingStore::new(
                 Arc::clone(d),
                 Arc::clone(&components.ownership_cache),
             ));
             gw = gw.with_pairing_store(pairing_store);
-            if let Some(ref ss) = components.secrets_store {
-                gw = gw.with_secrets_store(Arc::clone(ss));
-            }
+        }
 
-            // Bootstrap: create the first admin user from single-user config
-            // so the owner appears in the Users admin panel immediately.
-            if let Ok(false) = d.has_any_users().await {
-                let now = chrono::Utc::now();
-                let user = ironclaw::db::UserRecord {
-                    id: config.owner_id.clone(),
-                    email: None,
-                    display_name: config.owner_id.clone(),
-                    status: "active".to_string(),
-                    role: "admin".to_string(),
-                    created_at: now,
-                    updated_at: now,
-                    last_login_at: None,
-                    created_by: None,
-                    metadata: serde_json::json!({"source": "bootstrap"}),
-                };
-                // Create admin user + bootstrap token atomically.
-                let auth_token = gw.auth_token();
-                if auth_token.is_empty() {
-                    if let Err(e) = d.create_user(&user).await {
-                        tracing::warn!("Failed to bootstrap admin user: {}", e);
-                    }
-                } else {
-                    use ironclaw::channels::web::auth::hash_token;
-                    let hash = hash_token(auth_token);
-                    let prefix = if auth_token.len() >= 8 {
-                        &auth_token[..8]
-                    } else {
-                        auth_token
-                    };
-                    if let Err(e) = d
-                        .create_user_with_token(&user, "bootstrap", &hash, prefix, None)
-                        .await
-                    {
-                        tracing::warn!("Failed to bootstrap admin user: {}", e);
-                    } else {
-                        tracing::debug!(
-                            user_id = config.owner_id,
-                            "Bootstrapped admin user from gateway config"
-                        );
-                    }
-                }
-            }
-        }
-        if let Some(ref ss) = components.secrets_store {
-            gw = gw.with_secrets_store(Arc::clone(ss));
-        }
+        // Agent-loop-only features beyond the shared factory:
         if let Some(ref jm) = container_job_manager {
             gw = gw.with_job_manager(Arc::clone(jm));
         }
         gw = gw.with_scheduler(scheduler_slot.clone());
         gw = gw.with_routine_engine_slot(Arc::clone(&shared_routine_engine_slot));
-        if let Some(ref sr) = components.skill_registry {
-            gw = gw.with_skill_registry(Arc::clone(sr));
-        }
-        if let Some(ref sc) = components.skill_catalog {
-            gw = gw.with_skill_catalog(Arc::clone(sc));
-        }
-        gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
         gw = gw.with_oauth(config.oauth.clone(), gw_config.port);
         {
             let active_model = components.llm.model_name().to_string();

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -660,7 +660,7 @@ async fn start_owner_scoped_sender_server() -> (
 
     let auth = MultiAuthState::multi(tokens).into();
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound = start_server(addr, state.clone(), auth)
+    let (bound, _server_handle) = start_server(addr, state.clone(), auth)
         .await
         .expect("Failed to start owner-scoped sender test server");
 
@@ -1054,9 +1054,10 @@ async fn start_multi_user_server_with_db() -> (
     });
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound = ironclaw::channels::web::server::start_server(addr, state.clone(), auth.into())
-        .await
-        .expect("Failed to start server with DB");
+    let (bound, _server_handle) =
+        ironclaw::channels::web::server::start_server(addr, state.clone(), auth.into())
+            .await
+            .expect("Failed to start server with DB");
 
     (bound, state, db, temp_dir)
 }

--- a/tests/oauth_greeting_integration.rs
+++ b/tests/oauth_greeting_integration.rs
@@ -100,9 +100,10 @@ mod tests {
         });
 
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
-        start_server(addr, state, auth.into())
+        let (bound_addr, _server_handle) = start_server(addr, state, auth.into())
             .await
-            .expect("start server")
+            .expect("start server");
+        bound_addr
     }
 
     fn client() -> reqwest::Client {

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -236,7 +236,7 @@ async fn start_test_server_with_provider(
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state.clone(), auth.into())
+    let (bound_addr, _server_handle) = start_server(addr, state.clone(), auth.into())
         .await
         .expect("Failed to start test server");
 
@@ -745,7 +745,7 @@ async fn test_no_llm_provider_returns_503() {
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state, auth.into()).await.unwrap();
+    let (bound_addr, _server_handle) = start_server(addr, state, auth.into()).await.unwrap();
 
     let url = format!("http://{}/v1/chat/completions", bound_addr);
     let resp = client()

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -307,7 +307,7 @@ impl GatewayWorkflowHarness {
 
         let auth_token = "gateway-test-token".to_string();
         let auth = MultiAuthState::single(auth_token.clone(), user_id.clone());
-        let addr = start_server(
+        let (addr, _server_handle) = start_server(
             "127.0.0.1:0".parse().expect("valid localhost addr"),
             Arc::clone(&gateway_state),
             auth.into(),

--- a/tests/ws_gateway_integration.rs
+++ b/tests/ws_gateway_integration.rs
@@ -83,7 +83,7 @@ async fn start_test_server() -> (
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state.clone(), auth.into())
+    let (bound_addr, _server_handle) = start_server(addr, state.clone(), auth.into())
         .await
         .expect("Failed to start test server");
 


### PR DESCRIPTION
## Summary

Takes over #1050 by @reidliu41, rebased on staging with all review feedback addressed.

Adds standalone gateway lifecycle management:
- `gateway serve` — foreground mode for dev/debug (Ctrl-C to stop)
- `gateway start` — background daemon via detached child process (setsid), health-check poll, auth token from dedicated file
- `gateway stop` — SIGTERM via PID file (Unix-only), polls for exit, cleans up PID + token files
- `gateway status` — PID liveness + /api/health probe

Standalone serves read-only APIs. Agent-dependent APIs return 503.

### Review feedback addressed (from #1050)
- **Shared factory** (`GatewayComponents` + `from_components()`) eliminates ~60 lines of duplicated gateway wiring between `main.rs` and `cli/gateway.rs`
- **No `.expect()` in production** — SIGTERM fallback uses `if let Ok(...)`
- **Token file** with 0600 permissions instead of log parsing
- **Token + PID cleanup** in `cmd_stop` on both normal and abnormal exit
- **`probe_health`** returns `Result<bool, String>` for diagnostic output in `status`
- **TOCTOU** pre-check in `start` documented as best-effort
- **`setsid()` error handling** + `pid_t` safe cast via `try_from()`
- **Host normalization** for `0.0.0.0`/`::` probe addresses
- **Log file** opened in append mode
- **Server handle** returned from `start_server()` for graceful shutdown

## Change Type
- [x] New feature

## Linked Issue
Part of #83, supersedes #1050

## Validation
- [x] `cargo fmt`
- [x] `cargo clippy --lib --all-features` (zero warnings)
- [x] All 9 gateway unit tests pass
- [x] All CLI snapshot tests pass (with and without `import` feature)
- [x] 4246/4247 lib tests pass (1 pre-existing SQLite failure)

## Blast Radius
- `src/channels/web/mod.rs` — new `GatewayComponents` struct + `from_components()` factory
- `src/channels/web/server.rs` — `start_server()` return type changed to include `JoinHandle`
- `src/main.rs` — gateway setup refactored to use shared factory (net -66 lines)
- All `start_server()` callers updated (tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)