### PR TITLE
feat(slack): fetch thread history when bot is mentioned in any thread

### DIFF
--- a/channels-src/slack/src/lib.rs
+++ b/channels-src/slack/src/lib.rs
@@ -565,8 +565,19 @@ fn handle_slack_event(event: SlackEvent, team_id: Option<String>, _event_id: Opt
                     // thread_ts != ts means this is a reply in an existing thread
                     match fetch_thread_replies(&channel, &thread_ts) {
                         Ok(replies) if !replies.is_empty() => {
-                            let context = format_thread_context(&replies);
-                            format!("{context}{text}")
+                            // Filter out the current message to avoid duplicating it,
+                            // as conversations.replies includes the triggering message.
+                            let prior_replies: Vec<_> = replies
+                                .into_iter()
+                                .filter(|reply| reply.ts.as_deref() != Some(&ts))
+                                .collect();
+
+                            if prior_replies.is_empty() {
+                                text
+                            } else {
+                                let context = format_thread_context(&prior_replies);
+                                format!("{context}{text}")
+                            }
                         }
                         Ok(_) => text,
                         Err(e) => {

--- a/channels-src/slack/src/lib.rs
+++ b/channels-src/slack/src/lib.rs
@@ -541,12 +541,52 @@ fn handle_slack_event(event: SlackEvent, team_id: Option<String>, _event_id: Opt
                 if !check_sender_permission(&user, &channel, false) {
                     return;
                 }
+
+                let thread_ts = event.thread_ts.unwrap_or_else(|| ts.clone());
+
+                // Check if this is a re-engagement in an expired thread.
+                let was_active =
+                    is_active_slack_thread(team_id.as_deref(), &channel, &thread_ts);
+
+                // Always (re-)activate the thread on @mention so follow-up
+                // messages without @mention are picked up.
+                if let Err(e) =
+                    remember_active_slack_thread(team_id.as_deref(), &channel, &thread_ts)
+                {
+                    channel_host::log(
+                        channel_host::LogLevel::Warn,
+                        &format!("Failed to track active thread: {e}"),
+                    );
+                }
+
+                // If re-engaging an expired thread, fetch history from Slack
+                // so the agent has context about the prior conversation.
+                let final_text = if !was_active && thread_ts != ts {
+                    // thread_ts != ts means this is a reply in an existing thread
+                    match fetch_thread_replies(&channel, &thread_ts) {
+                        Ok(replies) if !replies.is_empty() => {
+                            let context = format_thread_context(&replies);
+                            format!("{context}{text}")
+                        }
+                        Ok(_) => text,
+                        Err(e) => {
+                            channel_host::log(
+                                channel_host::LogLevel::Warn,
+                                &format!("Failed to fetch thread replies: {e}"),
+                            );
+                            text
+                        }
+                    }
+                } else {
+                    text
+                };
+
                 let attachments = prepare_inbound_attachments(&event.files);
                 emit_message(
                     user,
-                    text,
+                    final_text,
                     channel,
-                    event.thread_ts.or(Some(ts)),
+                    Some(thread_ts),
                     team_id,
                     attachments,
                 );
@@ -840,6 +880,81 @@ fn prune_active_threads(active_threads: &mut ActiveThreads, now_millis: u64) -> 
     }
 
     changed
+}
+
+// ============================================================================
+// Slack Thread History Fetch
+// ============================================================================
+
+/// A single message from `conversations.replies`.
+#[derive(Debug, Deserialize)]
+struct SlackThreadMessage {
+    user: Option<String>,
+    text: Option<String>,
+    #[allow(dead_code)]
+    ts: Option<String>,
+    bot_id: Option<String>,
+}
+
+/// Response from `conversations.replies`.
+#[derive(Debug, Deserialize)]
+struct ConversationsRepliesResponse {
+    ok: bool,
+    messages: Option<Vec<SlackThreadMessage>>,
+    error: Option<String>,
+}
+
+/// Fetch recent replies in a Slack thread via the `conversations.replies` API.
+/// Returns up to `limit` messages (default 20). The bot token is injected
+/// automatically by the host credential system.
+fn fetch_thread_replies(channel: &str, thread_ts: &str) -> Result<Vec<SlackThreadMessage>, String> {
+    let url = format!(
+        "https://slack.com/api/conversations.replies?channel={}&ts={}&limit=20&inclusive=true",
+        channel, thread_ts
+    );
+    let headers = serde_json::json!({});
+    let result =
+        channel_host::http_request("GET", &url, &headers.to_string(), None, Some(2000));
+
+    let response = result.map_err(|e| format!("conversations.replies failed: {e}"))?;
+    if response.status != 200 {
+        let body_str = String::from_utf8_lossy(&response.body);
+        return Err(format!(
+            "conversations.replies returned {}: {}",
+            response.status, body_str
+        ));
+    }
+
+    let parsed: ConversationsRepliesResponse = serde_json::from_slice(&response.body)
+        .map_err(|e| format!("Failed to parse conversations.replies: {e}"))?;
+
+    if !parsed.ok {
+        return Err(format!(
+            "conversations.replies error: {}",
+            parsed.error.unwrap_or_default()
+        ));
+    }
+
+    Ok(parsed.messages.unwrap_or_default())
+}
+
+/// Format thread history as a text preamble for the agent.
+fn format_thread_context(replies: &[SlackThreadMessage]) -> String {
+    let mut context = String::from(
+        "[Thread context — prior messages in this Slack thread before re-engagement]\n",
+    );
+    for msg in replies {
+        let user = msg.user.as_deref().unwrap_or("unknown");
+        let text = msg.text.as_deref().unwrap_or("");
+        let role = if msg.bot_id.is_some() {
+            "assistant"
+        } else {
+            "user"
+        };
+        context.push_str(&format!("[{role} ({user})]: {text}\n"));
+    }
+    context.push_str("[End thread context]\n\n");
+    context
 }
 
 // ============================================================================

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -262,10 +262,35 @@ impl Agent {
         message: &IncomingMessage,
         external_thread_id: &str,
     ) -> Option<String> {
-        // Only hydrate UUID-shaped thread IDs (web gateway uses UUIDs)
+        // Determine the conversation UUID to hydrate from.
+        // UUID-shaped IDs (web gateway) are used directly; non-UUID IDs
+        // (e.g. Slack channel/thread_ts) are resolved via a DB lookup on
+        // the conversations.thread_id column.
         let thread_uuid = match Uuid::parse_str(external_thread_id) {
             Ok(id) => id,
-            Err(_) => return None,
+            Err(_) => {
+                // Non-UUID external scope — look up by (user, channel, thread_id).
+                let store = self.store()?;
+                match store
+                    .find_conversation_by_scope(
+                        &message.user_id,
+                        &message.channel,
+                        external_thread_id,
+                    )
+                    .await
+                {
+                    Ok(Some(id)) => id,
+                    Ok(None) => return None, // No prior conversation — nothing to hydrate.
+                    Err(e) => {
+                        tracing::warn!(
+                            channel = %message.channel,
+                            thread_id = %external_thread_id,
+                            "Failed to look up conversation by scope: {e}"
+                        );
+                        return None;
+                    }
+                }
+            }
         };
 
         // Check if already in memory
@@ -673,6 +698,7 @@ impl Agent {
                 turn_number,
                 effective_content,
                 turn_started_at,
+                message.conversation_scope(),
             )
             .await;
 
@@ -716,8 +742,13 @@ impl Agent {
 
         if thread.state == ThreadState::Interrupted {
             drop(sess);
-            self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                .await;
+            self.clear_conversation_live_state(
+                thread_id,
+                &message.channel,
+                &message.user_id,
+                message.conversation_scope(),
+            )
+            .await;
             if let Some(turn_usage) = turn_usage_from_result(&result) {
                 self.send_turn_cost_status(&message.channel, &message.metadata, turn_usage)
                     .await;
@@ -777,6 +808,7 @@ impl Agent {
                     thread_id,
                     &message.channel,
                     &message.user_id,
+                    message.conversation_scope(),
                     turn_number,
                     &tool_calls,
                     narrative.as_deref(),
@@ -787,6 +819,7 @@ impl Agent {
                     &message.channel,
                     &message.user_id,
                     &response,
+                    message.conversation_scope(),
                 )
                 .await;
 
@@ -819,8 +852,13 @@ impl Agent {
                 let allow_always = pending.allow_always;
                 thread.await_approval(*pending);
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.conversation_scope(),
+                )
+                .await;
                 self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
                     .await;
                 let _ = self
@@ -866,6 +904,7 @@ impl Agent {
                     thread_id,
                     &message.channel,
                     &message.user_id,
+                    message.conversation_scope(),
                     turn_number,
                     &tool_calls,
                     narrative.as_deref(),
@@ -880,15 +919,25 @@ impl Agent {
                     .await;
                 thread.conclude_turn(TurnOutcome::Failed(error.to_string()));
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.conversation_scope(),
+                )
+                .await;
                 Ok(SubmissionResult::error(error.to_string()))
             }
             Err(e) => {
                 thread.conclude_turn(TurnOutcome::Failed(e.to_string()));
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.conversation_scope(),
+                )
+                .await;
                 // User message already persisted at turn start; nothing else to save
                 Ok(SubmissionResult::error(e.to_string()))
             }
@@ -904,9 +953,16 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
     ) -> bool {
         match store
-            .ensure_conversation(thread_id, channel, user_id, None, Some(channel))
+            .ensure_conversation(
+                thread_id,
+                channel,
+                user_id,
+                external_thread_id,
+                Some(channel),
+            )
             .await
         {
             Ok(true) => true,
@@ -953,6 +1009,7 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
         live_state: ProcessingLiveState<'_>,
     ) {
         let store = match self.store() {
@@ -961,7 +1018,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -983,6 +1040,7 @@ impl Agent {
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
     ) {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -990,7 +1048,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1016,6 +1074,7 @@ impl Agent {
     ///
     /// This ensures the user message is durable even if the process crashes
     /// mid-response. Call this right after `thread.start_turn()`.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn persist_user_message(
         &self,
         thread_id: Uuid,
@@ -1024,6 +1083,7 @@ impl Agent {
         turn_number: usize,
         user_input: &str,
         started_at: DateTime<Utc>,
+        external_thread_id: Option<&str>,
     ) -> Option<Uuid> {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -1031,7 +1091,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return None;
@@ -1046,6 +1106,7 @@ impl Agent {
                     thread_id,
                     channel,
                     user_id,
+                    external_thread_id,
                     ProcessingLiveState {
                         turn_number,
                         user_message_id: Some(user_message_id),
@@ -1062,6 +1123,7 @@ impl Agent {
                     thread_id,
                     channel,
                     user_id,
+                    external_thread_id,
                     ProcessingLiveState {
                         turn_number,
                         user_message_id: None,
@@ -1086,6 +1148,7 @@ impl Agent {
         channel: &str,
         user_id: &str,
         response: &str,
+        external_thread_id: Option<&str>,
     ) {
         let store = match self.store() {
             Some(s) => Arc::clone(s),
@@ -1093,7 +1156,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1130,11 +1193,13 @@ impl Agent {
     /// Content is a JSON object: `{ "calls": [...], "narrative": "..." }`.
     /// The `calls` array contains tool call summaries with optional `rationale`
     /// and `tool_call_id` fields. Legacy rows may be plain JSON arrays.
+    #[allow(clippy::too_many_arguments)]
     pub(super) async fn persist_tool_calls(
         &self,
         thread_id: Uuid,
         channel: &str,
         user_id: &str,
+        external_thread_id: Option<&str>,
         turn_number: usize,
         tool_calls: &[crate::agent::session::TurnToolCall],
         narrative: Option<&str>,
@@ -1200,7 +1265,7 @@ impl Agent {
         };
 
         if !self
-            .ensure_writable_conversation(&store, thread_id, channel, user_id)
+            .ensure_writable_conversation(&store, thread_id, channel, user_id, external_thread_id)
             .await
         {
             return;
@@ -1304,7 +1369,7 @@ impl Agent {
                     .unwrap_or_else(|| "gateway".to_string());
                 thread.interrupt();
                 drop(sess);
-                self.clear_conversation_live_state(thread_id, &channel, &user_id)
+                self.clear_conversation_live_state(thread_id, &channel, &user_id, None)
                     .await;
                 Ok(SubmissionResult::ok_with_message("Interrupted."))
             }
@@ -1372,7 +1437,7 @@ impl Agent {
         thread.pending_messages.clear();
         thread.state = ThreadState::Idle;
         drop(sess);
-        self.clear_conversation_live_state(thread_id, &channel, &user_id)
+        self.clear_conversation_live_state(thread_id, &channel, &user_id, None)
             .await;
 
         // Clear undo history too
@@ -1547,6 +1612,7 @@ impl Agent {
                     thread_id,
                     &message.channel,
                     &message.user_id,
+                    message.conversation_scope(),
                     ProcessingLiveState {
                         turn_number,
                         user_message_id,
@@ -1992,8 +2058,13 @@ impl Agent {
                     }
                 }
 
-                self.clear_conversation_live_state(thread_id, &message.channel, &message.user_id)
-                    .await;
+                self.clear_conversation_live_state(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    message.conversation_scope(),
+                )
+                .await;
 
                 let _ = self
                     .channels
@@ -2083,6 +2154,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.conversation_scope(),
                         turn_number,
                         &tool_calls,
                         narrative.as_deref(),
@@ -2093,6 +2165,7 @@ impl Agent {
                         &message.channel,
                         &message.user_id,
                         &response,
+                        message.conversation_scope(),
                     )
                     .await;
                     if !suggestions.is_empty() {
@@ -2124,6 +2197,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.conversation_scope(),
                     )
                     .await;
                     self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
@@ -2162,6 +2236,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.conversation_scope(),
                         turn_number,
                         &tool_calls,
                         narrative.as_deref(),
@@ -2180,6 +2255,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.conversation_scope(),
                     )
                     .await;
                     Ok(SubmissionResult::error(error.to_string()))
@@ -2191,6 +2267,7 @@ impl Agent {
                         thread_id,
                         &message.channel,
                         &message.user_id,
+                        message.conversation_scope(),
                     )
                     .await;
                     // User message already persisted at turn start
@@ -2216,6 +2293,7 @@ impl Agent {
                             &message.channel,
                             &message.user_id,
                             &rejection,
+                            message.conversation_scope(),
                         )
                         .await;
                     }
@@ -2266,6 +2344,7 @@ impl Agent {
                         &message.channel,
                         &message.user_id,
                         &instructions,
+                        message.conversation_scope(),
                     )
                     .await;
                 }

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -105,7 +105,8 @@ impl ConversationStore for LibSqlBackend {
                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
                 ON CONFLICT (id) DO UPDATE SET
                     last_activity = excluded.last_activity,
-                    source_channel = COALESCE(conversations.source_channel, excluded.source_channel)
+                    source_channel = COALESCE(conversations.source_channel, excluded.source_channel),
+                    thread_id = COALESCE(conversations.thread_id, excluded.thread_id)
                 WHERE conversations.user_id = excluded.user_id
                   AND conversations.channel = excluded.channel
                 "#,
@@ -684,6 +685,42 @@ impl ConversationStore for LibSqlBackend {
         {
             Some(row) => Ok(get_opt_text(&row, 0)),
             None => Ok(None),
+        }
+    }
+
+    async fn find_conversation_by_scope(
+        &self,
+        user_id: &str,
+        channel: &str,
+        thread_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                r#"
+                SELECT id FROM conversations
+                WHERE user_id = ?1 AND channel = ?2 AND thread_id = ?3
+                ORDER BY last_activity DESC
+                LIMIT 1
+                "#,
+                libsql::params![user_id, channel, thread_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+
+        if let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            let id_str: String = row.get(0).map_err(|e| {
+                DatabaseError::Query(format!("Failed to read conversation id: {e}"))
+            })?;
+            let id = Uuid::parse_str(&id_str)
+                .map_err(|e| DatabaseError::Query(format!("Invalid conversation UUID: {e}")))?;
+            Ok(Some(id))
+        } else {
+            Ok(None)
         }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -492,6 +492,15 @@ pub trait ConversationStore: Send + Sync {
         &self,
         conversation_id: Uuid,
     ) -> Result<Option<String>, DatabaseError>;
+    /// Look up an existing conversation by its external thread scope
+    /// (e.g. Slack `channel_id#thread_ts`). Returns the conversation UUID
+    /// if found, allowing thread hydration for non-UUID external IDs.
+    async fn find_conversation_by_scope(
+        &self,
+        user_id: &str,
+        channel: &str,
+        thread_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError>;
 }
 
 #[async_trait]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -299,6 +299,17 @@ impl ConversationStore for PgBackend {
             .get_conversation_source_channel(conversation_id)
             .await
     }
+
+    async fn find_conversation_by_scope(
+        &self,
+        user_id: &str,
+        channel: &str,
+        thread_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        self.store
+            .find_conversation_by_scope(user_id, channel, thread_id)
+            .await
+    }
 }
 
 // ==================== JobStore ====================

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1777,7 +1777,8 @@ impl Store {
             VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (id) DO UPDATE
             SET last_activity = NOW(),
-                source_channel = COALESCE(conversations.source_channel, EXCLUDED.source_channel)
+                source_channel = COALESCE(conversations.source_channel, EXCLUDED.source_channel),
+                thread_id = COALESCE(conversations.thread_id, EXCLUDED.thread_id)
             WHERE conversations.user_id = EXCLUDED.user_id
               AND conversations.channel = EXCLUDED.channel
             "#,
@@ -2151,6 +2152,27 @@ impl Store {
             )
             .await?;
         Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
+    }
+
+    pub async fn find_conversation_by_scope(
+        &self,
+        user_id: &str,
+        channel: &str,
+        thread_id: &str,
+    ) -> Result<Option<Uuid>, DatabaseError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                r#"
+                SELECT id FROM conversations
+                WHERE user_id = $1 AND channel = $2 AND thread_id = $3
+                ORDER BY last_activity DESC
+                LIMIT 1
+                "#,
+                &[&user_id, &channel, &thread_id],
+            )
+            .await?;
+        Ok(row.map(|r| r.get("id")))
     }
 
     /// Load messages for a conversation with cursor-based pagination.

--- a/src/hooks/session_summary.rs
+++ b/src/hooks/session_summary.rs
@@ -267,6 +267,15 @@ mod tests {
             unimplemented!()
         }
 
+        async fn find_conversation_by_scope(
+            &self,
+            _user_id: &str,
+            _channel: &str,
+            _thread_id: &str,
+        ) -> Result<Option<Uuid>, crate::error::DatabaseError> {
+            unimplemented!()
+        }
+
         async fn list_conversations_with_preview(
             &self,
             _user_id: &str,


### PR DESCRIPTION
## Summary

- When the bot is **@mentioned in any Slack thread** (even one it has never participated in), it now fetches the thread's conversation history via `conversations.replies` and receives it as context — enabling users to "call in" the bot to ongoing discussions
- On re-engagement of an expired thread (24h TTL), the same mechanism applies: fetch history, refresh the active thread timer, respond with full context
- Persist external thread scope (`conversation_scope_id`) to the `conversations.thread_id` DB column so future session restarts can hydrate from DB

## Use cases

1. **Cold join** — Team discusses a bug in a thread, then @mentions the bot mid-conversation. The bot reads back the thread and responds with full context.
2. **Re-engagement** — Bot participated in a thread yesterday, thread expired, user @mentions again. Bot catches up on anything said in between.
3. **Session recovery** — Bot restarts or session is evicted from memory. DB-persisted thread scope allows history to be restored without re-fetching from Slack.

## Changes

### Slack WASM channel (`channels-src/slack/src/lib.rs`)
- Add `fetch_thread_replies()` — calls `conversations.replies` with 2s timeout, limit 20
- Add `format_thread_context()` — formats replies as a text preamble for the agent
- Update `app_mention` handler: detect re-engagement (expired/unknown thread), fetch history, refresh active thread timer

### Host-side thread hydration (`src/agent/thread_ops.rs`)
- Extend `maybe_hydrate_thread()` to handle non-UUID external thread IDs by looking up existing conversations via `find_conversation_by_scope()`
- Pass `conversation_scope()` through `persist_user_message`, `persist_assistant_response`, `persist_tool_calls` to `ensure_conversation()` so thread scope reaches the DB

### Database (both backends)
- Add `find_conversation_by_scope(user_id, channel, thread_id)` to `ConversationStore` trait
- PostgreSQL + libSQL implementations
- Backfill NULL `thread_id` via `COALESCE` in `ensure_conversation` upsert

## Test plan

- [ ] @mention bot in a thread it has never been in → bot fetches history and responds with context
- [ ] @mention bot in an expired thread (>24h) → bot fetches history, refreshes timer, follow-up messages work without @mention
- [ ] Bot restart mid-thread → session restored from DB history via `find_conversation_by_scope`
- [ ] New thread (no prior history) → no Slack API call, normal flow
- [ ] DM behavior unchanged
- [ ] `cargo clippy --all --all-features` — zero warnings
- [ ] `cargo fmt -- --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)