### PR TITLE
fix(staging): repair 4 categories of CI test failures

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2713,14 +2713,16 @@ impl ExtensionManager {
                 .unwrap_or("");
 
             if archive_names.is_wasm(filename) {
-                let mut data = Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
+                let mut data =
+                    Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 std::fs::write(target_wasm, &data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 found_wasm = true;
             } else if archive_names.is_caps(filename) {
-                let mut data = Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
+                let mut data =
+                    Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 std::fs::write(target_caps, &data)

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2681,8 +2681,12 @@ impl ExtensionManager {
         // 100 MB cap on decompressed entry size to prevent decompression bombs
         const MAX_ENTRY_SIZE: u64 = 100 * 1024 * 1024;
 
+        // Archives may use either underscored (canonical) or hyphenated (legacy)
+        // filenames, so accept both forms.
         let wasm_filename = format!("{}.wasm", name);
+        let alt_wasm_filename = format!("{}.wasm", name.replace('_', "-"));
         let caps_filename = format!("{}.capabilities.json", name);
+        let alt_caps_filename = format!("{}.capabilities.json", name.replace('_', "-"));
         let mut found_wasm = false;
 
         let entries = archive
@@ -2713,14 +2717,14 @@ impl ExtensionManager {
                 .and_then(|n| n.to_str())
                 .unwrap_or("");
 
-            if filename == wasm_filename {
+            if filename == wasm_filename || filename == alt_wasm_filename {
                 let mut data = Vec::with_capacity(entry.size() as usize);
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 std::fs::write(target_wasm, &data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 found_wasm = true;
-            } else if filename == caps_filename {
+            } else if filename == caps_filename || filename == alt_caps_filename {
                 let mut data = Vec::with_capacity(entry.size() as usize);
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
@@ -9428,6 +9432,10 @@ mod tests {
         // have their colon URL-encoded to %3A, as this breaks the validation endpoint.
         // Previously: form_urlencoded::byte_serialize encoded the token, causing 404s.
         // Fixed by removing URL-encoding and using the token directly.
+        //
+        // Hold the env mutex so concurrent tests that override
+        // IRONCLAW_TEST_TELEGRAM_API_BASE_URL don't change the base URL mid-read.
+        let _guard = crate::config::helpers::lock_env();
         let token = "123456789:AABBccDDeeFFgg_Test-Token";
 
         let url = telegram_bot_api_url(token, "getMe");

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2683,10 +2683,11 @@ impl ExtensionManager {
 
         // Archives may use either underscored (canonical) or hyphenated (legacy)
         // filenames, so accept both forms.
-        let wasm_filename = format!("{}.wasm", name);
-        let alt_wasm_filename = format!("{}.wasm", name.replace('_', "-"));
-        let caps_filename = format!("{}.capabilities.json", name);
-        let alt_caps_filename = format!("{}.capabilities.json", name.replace('_', "-"));
+        let alt_name = name.replace('_', "-");
+        let wasm_filename = format!("{name}.wasm");
+        let alt_wasm_filename = format!("{alt_name}.wasm");
+        let caps_filename = format!("{name}.capabilities.json");
+        let alt_caps_filename = format!("{alt_name}.capabilities.json");
         let mut found_wasm = false;
 
         let entries = archive
@@ -2734,9 +2735,13 @@ impl ExtensionManager {
         }
 
         if !found_wasm {
+            let expected = if wasm_filename == alt_wasm_filename {
+                wasm_filename.clone()
+            } else {
+                format!("'{wasm_filename}' or '{alt_wasm_filename}'")
+            };
             return Err(ExtensionError::InstallFailed(format!(
-                "tar.gz archive does not contain '{}'",
-                wasm_filename
+                "tar.gz archive does not contain {expected}"
             )));
         }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2713,14 +2713,14 @@ impl ExtensionManager {
                 .unwrap_or("");
 
             if archive_names.is_wasm(filename) {
-                let mut data = Vec::with_capacity(entry.size() as usize);
+                let mut data = Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 std::fs::write(target_wasm, &data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 found_wasm = true;
             } else if archive_names.is_caps(filename) {
-                let mut data = Vec::with_capacity(entry.size() as usize);
+                let mut data = Vec::with_capacity((entry.size() as usize).min(MAX_ENTRY_SIZE as usize));
                 std::io::Read::read_to_end(&mut entry.by_ref().take(MAX_ENTRY_SIZE), &mut data)
                     .map_err(|e| ExtensionError::InstallFailed(e.to_string()))?;
                 std::fs::write(target_caps, &data)

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2681,8 +2681,9 @@ impl ExtensionManager {
         // 100 MB cap on decompressed entry size to prevent decompression bombs
         const MAX_ENTRY_SIZE: u64 = 100 * 1024 * 1024;
 
-        // Archives may use either underscored (canonical) or hyphenated (legacy)
-        // filenames, so accept both forms.
+        // Canonical extension names always use underscores (enforced by
+        // canonicalize_extension_name). Archives from older releases may use
+        // hyphens, so we accept both forms.
         let alt_name = name.replace('_', "-");
         let wasm_filename = format!("{name}.wasm");
         let alt_wasm_filename = format!("{alt_name}.wasm");
@@ -2736,7 +2737,7 @@ impl ExtensionManager {
 
         if !found_wasm {
             let expected = if wasm_filename == alt_wasm_filename {
-                wasm_filename.clone()
+                format!("'{wasm_filename}'")
             } else {
                 format!("'{wasm_filename}' or '{alt_wasm_filename}'")
             };

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1112,6 +1112,11 @@ async def page(ironclaw_server, browser):
     await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
     # Wait for the app to initialize (auth screen hidden, SSE connected)
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    # Wait for SSE connection (dot loses 'disconnected' class)
+    await pg.wait_for_function(
+        "() => { const d = document.getElementById('sse-dot'); return d && !d.classList.contains('disconnected'); }",
+        timeout=10000,
+    )
     yield pg
     await context.close()
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1112,9 +1112,9 @@ async def page(ironclaw_server, browser):
     await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
     # Wait for the app to initialize (auth screen hidden, SSE connected)
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
-    # Wait for SSE connection (dot loses 'disconnected' class)
+    # Wait for SSE connection (onopen sets sseHasConnectedBefore = true)
     await pg.wait_for_function(
-        "() => { const d = document.getElementById('sse-dot'); return d && !d.classList.contains('disconnected'); }",
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
         timeout=10000,
     )
     yield pg

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1114,7 +1114,7 @@ async def page(ironclaw_server, browser):
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     # Wait for SSE connection (onopen sets sseHasConnectedBefore = true)
     await pg.wait_for_function(
-        "() => window.sseHasConnectedBefore === true",
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore === true",
         timeout=10000,
     )
     yield pg

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1114,7 +1114,7 @@ async def page(ironclaw_server, browser):
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     # Wait for SSE connection (onopen sets sseHasConnectedBefore = true)
     await pg.wait_for_function(
-        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
+        "() => window.sseHasConnectedBefore === true",
         timeout=10000,
     )
     yield pg

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -19,8 +19,6 @@ SEL = {
     # Auth
     "auth_screen": "#auth-screen",
     "token_input": "#token-input",
-    # Connection
-    "sse_status": "#sse-status",
     # Tabs
     "tab_button": '.tab-bar button[data-tab="{tab}"]',
     "tab_panel": "#tab-{tab}",

--- a/tests/e2e/scenarios/test_connection.py
+++ b/tests/e2e/scenarios/test_connection.py
@@ -6,12 +6,11 @@ from helpers import AUTH_TOKEN, SEL, TABS
 
 async def test_page_loads_and_connects(page):
     """After auth, the app shows Connected status and all tabs."""
-    # Connection status — the #sse-status text element was removed; check the
-    # coloured dot on the user avatar instead.
-    dot = page.locator(SEL["sse_dot"])
-    await dot.wait_for(state="visible", timeout=10000)
-    cls = await dot.get_attribute("class") or ""
-    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
+    # Connection status — verify SSE has connected via the JS flag set in onopen.
+    await page.wait_for_function(
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
+        timeout=10000,
+    )
 
     # All 6 main tabs visible
     for tab in TABS:

--- a/tests/e2e/scenarios/test_connection.py
+++ b/tests/e2e/scenarios/test_connection.py
@@ -8,7 +8,7 @@ async def test_page_loads_and_connects(page):
     """After auth, the app shows Connected status and all tabs."""
     # Connection status — verify SSE has connected via the JS flag set in onopen.
     await page.wait_for_function(
-        "() => window.sseHasConnectedBefore === true",
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore === true",
         timeout=10000,
     )
 

--- a/tests/e2e/scenarios/test_connection.py
+++ b/tests/e2e/scenarios/test_connection.py
@@ -6,12 +6,12 @@ from helpers import AUTH_TOKEN, SEL, TABS
 
 async def test_page_loads_and_connects(page):
     """After auth, the app shows Connected status and all tabs."""
-    # Connection status
-    status = page.locator(SEL["sse_status"])
-    await status.wait_for(state="visible", timeout=10000)
-    text = await status.text_content()
-    assert text is not None
-    assert "connect" in text.lower(), f"Expected 'Connected', got '{text}'"
+    # Connection status — the #sse-status text element was removed; check the
+    # coloured dot on the user avatar instead.
+    dot = page.locator(SEL["sse_dot"])
+    await dot.wait_for(state="visible", timeout=10000)
+    cls = await dot.get_attribute("class") or ""
+    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
 
     # All 6 main tabs visible
     for tab in TABS:

--- a/tests/e2e/scenarios/test_connection.py
+++ b/tests/e2e/scenarios/test_connection.py
@@ -8,7 +8,7 @@ async def test_page_loads_and_connects(page):
     """After auth, the app shows Connected status and all tabs."""
     # Connection status — verify SSE has connected via the JS flag set in onopen.
     await page.wait_for_function(
-        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
+        "() => window.sseHasConnectedBefore === true",
         timeout=10000,
     )
 

--- a/tests/e2e/scenarios/test_oauth_refresh.py
+++ b/tests/e2e/scenarios/test_oauth_refresh.py
@@ -106,7 +106,7 @@ async def _wait_for_gmail_tool_call(base_url: str, thread_id: str, timeout: floa
         response.raise_for_status()
         history = response.json()
 
-        pending = history.get("pending_approval")
+        pending = history.get("pending_gate")
         if pending and pending["request_id"] not in approved_request_ids:
             await _approve_pending_request(base_url, thread_id, pending["request_id"])
             approved_request_ids.add(pending["request_id"])
@@ -137,7 +137,7 @@ async def _wait_for_tool_call(
         response.raise_for_status()
         history = response.json()
 
-        pending = history.get("pending_approval")
+        pending = history.get("pending_gate")
         if pending and pending["request_id"] not in approved_request_ids:
             await _approve_pending_request(base_url, thread_id, pending["request_id"])
             approved_request_ids.add(pending["request_id"])

--- a/tests/e2e/scenarios/test_owner_scope.py
+++ b/tests/e2e/scenarios/test_owner_scope.py
@@ -141,7 +141,7 @@ async def _wait_for_pending_approval(
     thread_id: str,
     timeout: float = 20.0,
 ) -> dict:
-    """Poll chat history until the thread exposes a pending approval payload."""
+    """Poll chat history until the thread exposes a pending gate payload."""
     for _ in range(int(timeout * 2)):
         response = await api_get(
             base_url,
@@ -149,11 +149,11 @@ async def _wait_for_pending_approval(
             timeout=10,
         )
         response.raise_for_status()
-        pending = response.json().get("pending_approval")
+        pending = response.json().get("pending_gate")
         if pending:
             return pending
         await _poll_sleep()
-    raise AssertionError(f"Thread '{thread_id}' did not expose a pending approval")
+    raise AssertionError(f"Thread '{thread_id}' did not expose a pending gate")
 
 
 async def _approve_pending_request(base_url: str, thread_id: str, request_id: str) -> None:

--- a/tests/e2e/scenarios/test_owner_scope.py
+++ b/tests/e2e/scenarios/test_owner_scope.py
@@ -136,7 +136,7 @@ async def _wait_for_http_thread(base_url: str, title_fragment: str, timeout: flo
     )
 
 
-async def _wait_for_pending_approval(
+async def _wait_for_pending_gate(
     base_url: str,
     thread_id: str,
     timeout: float = 20.0,
@@ -256,7 +256,7 @@ async def test_http_created_full_job_routine_is_visible_in_web_after_approval(
     )
 
     thread_id = await _wait_for_http_thread(ironclaw_server, routine_name)
-    pending = await _wait_for_pending_approval(ironclaw_server, thread_id)
+    pending = await _wait_for_pending_gate(ironclaw_server, thread_id)
     assert pending["tool_name"] == "routine_create"
     await _approve_pending_request(
         ironclaw_server,

--- a/tests/e2e/scenarios/test_skill_oauth_flow.py
+++ b/tests/e2e/scenarios/test_skill_oauth_flow.py
@@ -131,7 +131,7 @@ async def _wait_for_response(
 
         # Auto-approve pending tool calls if requested
         if auto_approve:
-            pending = history.get("pending_approval")
+            pending = history.get("pending_gate")
             if pending and pending["request_id"] not in approved:
                 await api_post(
                     base_url,

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -25,15 +25,21 @@ async def _open_gateway_page(browser, base_url: str):
 
 
 async def _wait_for_connected(page, *, timeout: int = 10000) -> None:
-    """Wait until the frontend reports an active SSE connection."""
-    status = page.locator(SEL["sse_status"])
-    await status.wait_for(state="visible", timeout=timeout)
+    """Wait until the frontend reports an active SSE connection.
+
+    The ``#sse-status`` text element was removed in favour of a coloured dot
+    on the user avatar (``#sse-dot``).  A connected SSE link is indicated by
+    the dot **not** having the ``disconnected`` CSS class.
+    """
+    dot = page.locator(SEL["sse_dot"])
+    await dot.wait_for(state="visible", timeout=timeout)
     deadline = asyncio.get_running_loop().time() + (timeout / 1000)
     while asyncio.get_running_loop().time() < deadline:
-        if await status.text_content() == "Connected":
+        cls = await dot.get_attribute("class") or ""
+        if "disconnected" not in cls:
             return
         await asyncio.sleep(0.2)
-    raise AssertionError("SSE status did not return to Connected before timeout")
+    raise AssertionError("SSE dot still has 'disconnected' class after timeout")
 
 
 async def _wait_for_last_event_id(page, *, timeout: int = 15000) -> str:
@@ -59,11 +65,11 @@ async def _wait_for_turn_in_history(base_url: str, thread_id: str, expected_resp
 
 
 async def test_sse_status_shows_connected(page):
-    """SSE status should show Connected after page load."""
-    status = page.locator(SEL["sse_status"])
-    await status.wait_for(state="visible", timeout=5000)
-    text = await status.text_content()
-    assert text == "Connected", f"Expected 'Connected', got '{text}'"
+    """SSE dot should indicate connected after page load."""
+    dot = page.locator(SEL["sse_dot"])
+    await dot.wait_for(state="visible", timeout=5000)
+    cls = await dot.get_attribute("class") or ""
+    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
 
 
 async def test_sse_reconnect_after_disconnect(page):
@@ -72,8 +78,9 @@ async def test_sse_reconnect_after_disconnect(page):
     await page.evaluate("if (eventSource) eventSource.close()")
     await page.evaluate("connectSSE()")
     await _wait_for_connected(page, timeout=10000)
-    status = page.locator(SEL["sse_status"])
-    assert await status.text_content() == "Connected"
+    dot = page.locator(SEL["sse_dot"])
+    cls = await dot.get_attribute("class") or ""
+    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
 
 
 async def test_sse_reconnect_preserves_chat_history(page):

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -33,7 +33,7 @@ async def _wait_for_connected(page, *, timeout: int = 10000) -> None:
     ``disconnected`` class before SSE even connects.
     """
     await page.wait_for_function(
-        "() => window.sseHasConnectedBefore === true",
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore === true",
         timeout=timeout,
     )
 

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -61,14 +61,19 @@ async def _wait_for_turn_in_history(base_url: str, thread_id: str, expected_resp
 
 
 async def test_sse_status_shows_connected(page):
-    """SSE should be connected after page load."""
-    await _wait_for_connected(page, timeout=5000)
+    """SSE dot should show connected state after page load."""
+    dot = page.locator("#sse-dot")
+    cls = await dot.get_attribute("class") or ""
+    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
 
 
 async def test_sse_reconnect_after_disconnect(page):
     """After programmatic disconnect, SSE should reconnect."""
     await _wait_for_connected(page, timeout=5000)
     await page.evaluate("if (eventSource) eventSource.close()")
+    # Reset the flag so _wait_for_connected can detect the new onopen.
+    # The history-reload path (sseHasConnectedBefore=true on reconnect)
+    # is covered by test_sse_reconnect_preserves_chat_history.
     await page.evaluate("sseHasConnectedBefore = false; connectSSE()")
     await _wait_for_connected(page, timeout=10000)
 

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -27,19 +27,15 @@ async def _open_gateway_page(browser, base_url: str):
 async def _wait_for_connected(page, *, timeout: int = 10000) -> None:
     """Wait until the frontend reports an active SSE connection.
 
-    The ``#sse-status`` text element was removed in favour of a coloured dot
-    on the user avatar (``#sse-dot``).  A connected SSE link is indicated by
-    the dot **not** having the ``disconnected`` CSS class.
+    Uses the ``sseHasConnectedBefore`` JS flag which is set to ``true``
+    inside ``EventSource.onopen``.  This is more reliable than checking
+    CSS state on ``#sse-dot`` because the dot starts without the
+    ``disconnected`` class before SSE even connects.
     """
-    dot = page.locator(SEL["sse_dot"])
-    await dot.wait_for(state="visible", timeout=timeout)
-    deadline = asyncio.get_running_loop().time() + (timeout / 1000)
-    while asyncio.get_running_loop().time() < deadline:
-        cls = await dot.get_attribute("class") or ""
-        if "disconnected" not in cls:
-            return
-        await asyncio.sleep(0.2)
-    raise AssertionError("SSE dot still has 'disconnected' class after timeout")
+    await page.wait_for_function(
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
+        timeout=timeout,
+    )
 
 
 async def _wait_for_last_event_id(page, *, timeout: int = 15000) -> str:
@@ -65,22 +61,16 @@ async def _wait_for_turn_in_history(base_url: str, thread_id: str, expected_resp
 
 
 async def test_sse_status_shows_connected(page):
-    """SSE dot should indicate connected after page load."""
-    dot = page.locator(SEL["sse_dot"])
-    await dot.wait_for(state="visible", timeout=5000)
-    cls = await dot.get_attribute("class") or ""
-    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
+    """SSE should be connected after page load."""
+    await _wait_for_connected(page, timeout=5000)
 
 
 async def test_sse_reconnect_after_disconnect(page):
-    """After programmatic disconnect, SSE should reconnect and show Connected."""
+    """After programmatic disconnect, SSE should reconnect."""
     await _wait_for_connected(page, timeout=5000)
     await page.evaluate("if (eventSource) eventSource.close()")
-    await page.evaluate("connectSSE()")
+    await page.evaluate("sseHasConnectedBefore = false; connectSSE()")
     await _wait_for_connected(page, timeout=10000)
-    dot = page.locator(SEL["sse_dot"])
-    cls = await dot.get_attribute("class") or ""
-    assert "disconnected" not in cls, f"Expected connected dot, got class='{cls}'"
 
 
 async def test_sse_reconnect_preserves_chat_history(page):

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -33,7 +33,7 @@ async def _wait_for_connected(page, *, timeout: int = 10000) -> None:
     ``disconnected`` class before SSE even connects.
     """
     await page.wait_for_function(
-        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore",
+        "() => window.sseHasConnectedBefore === true",
         timeout=timeout,
     )
 

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -47,7 +47,7 @@ async def _wait_for_history(
         )
         assert response.status_code == 200, response.text
         history = response.json()
-        pending = history.get("pending_approval")
+        pending = history.get("pending_gate")
         turns = history.get("turns", [])
         latest_response = turns[-1].get("response") if turns else None
 
@@ -259,7 +259,7 @@ async def test_chat_reply_approve_resumes_pending_tool(ironclaw_server):
         turn_count_at_least=1,
     )
 
-    assert history.get("pending_approval") is None
+    assert history.get("pending_gate") is None
     assert history["turns"][-1]["response"] is not None
 
 
@@ -309,5 +309,5 @@ async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
         turn_count_at_least=2,
     )
 
-    assert history.get("pending_approval") is None
+    assert history.get("pending_gate") is None
     assert len(history["turns"]) >= 2

--- a/tests/e2e/scenarios/test_v2_engine_approval_flow.py
+++ b/tests/e2e/scenarios/test_v2_engine_approval_flow.py
@@ -156,9 +156,9 @@ async def _wait_for_approval(
     *,
     timeout: float = 45.0,
 ) -> dict:
-    """Poll /api/chat/history until pending_approval appears.
+    """Poll /api/chat/history until pending_gate appears.
 
-    Returns the pending_approval dict containing request_id, tool_name, etc.
+    Returns the pending_gate dict containing request_id, tool_name, etc.
     """
     for _ in range(int(timeout * 2)):
         r = await api_get(
@@ -191,7 +191,7 @@ async def _wait_for_approval(
     except Exception as e:
         debug_info = f"error: {e}"
     raise AssertionError(
-        f"Timed out waiting for pending_approval in thread {thread_id}. "
+        f"Timed out waiting for pending_gate in thread {thread_id}. "
         f"Debug: {debug_info}"
     )
 
@@ -230,7 +230,7 @@ async def _wait_for_response(
     )
 
 
-async def _wait_for_no_pending_approval(base_url: str, thread_id: str, *, timeout: float = 45.0):
+async def _wait_for_no_pending_gate(base_url: str, thread_id: str, *, timeout: float = 45.0):
     for _ in range(int(timeout * 2)):
         r = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}", timeout=15)
         r.raise_for_status()
@@ -238,7 +238,7 @@ async def _wait_for_no_pending_approval(base_url: str, thread_id: str, *, timeou
         if not history.get("pending_gate"):
             return history
         await asyncio.sleep(0.5)
-    raise AssertionError(f"Timed out waiting for pending_approval to clear in thread {thread_id}")
+    raise AssertionError(f"Timed out waiting for pending_gate to clear in thread {thread_id}")
 
 
 async def _approve(
@@ -294,7 +294,7 @@ class TestV2EngineApprovalFlow:
 
         approve_a = await _approve(base_url, thread_a, pending_a["request_id"], "approve")
         assert approve_a.status_code == 202, approve_a.text
-        await _wait_for_no_pending_approval(base_url, thread_a, timeout=60)
+        await _wait_for_no_pending_gate(base_url, thread_a, timeout=60)
 
         history_b = await api_get(base_url, f"/api/chat/history?thread_id={thread_b}", timeout=15)
         history_b.raise_for_status()
@@ -304,7 +304,7 @@ class TestV2EngineApprovalFlow:
 
         approve_b = await _approve(base_url, thread_b, pending_b["request_id"], "approve")
         assert approve_b.status_code == 202, approve_b.text
-        await _wait_for_no_pending_approval(base_url, thread_b, timeout=60)
+        await _wait_for_no_pending_gate(base_url, thread_b, timeout=60)
 
     """Test the v2 engine tool approval lifecycle.
 
@@ -352,13 +352,13 @@ class TestV2EngineApprovalFlow:
                 last = (turns[-1].get("response") or "").lower()
                 if last and "requires approval" not in last:
                     break
-            # Also check if pending_approval is cleared (approval processed)
+            # Also check if pending_gate is cleared (approval processed)
             if not history.get("pending_gate"):
                 break
 
-        # After approval, pending_approval should be cleared
+        # After approval, pending_gate should be cleared
         assert history.get("pending_gate") is None, (
-            f"After approval, pending_approval should be cleared. "
+            f"After approval, pending_gate should be cleared. "
             f"Got: {history.get('pending_gate')}"
         )
 
@@ -410,7 +410,7 @@ class TestV2EngineApprovalFlow:
 
         # After denial, approval prompt should no longer be pending
         assert history.get("pending_gate") is None, (
-            f"After denial, pending_approval should be cleared. "
+            f"After denial, pending_gate should be cleared. "
             f"Got: {history.get('pending_gate')}"
         )
 

--- a/tests/e2e/scenarios/test_v2_engine_approval_flow.py
+++ b/tests/e2e/scenarios/test_v2_engine_approval_flow.py
@@ -168,7 +168,7 @@ async def _wait_for_approval(
         )
         r.raise_for_status()
         history = r.json()
-        pending = history.get("pending_approval")
+        pending = history.get("pending_gate")
         if pending and pending.get("request_id"):
             return pending
         await asyncio.sleep(0.5)
@@ -179,7 +179,7 @@ async def _wait_for_approval(
         r = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}", timeout=15)
         data = r.json()
         turns = data.get("turns", [])
-        pending = data.get("pending_approval")
+        pending = data.get("pending_gate")
         debug_info = f"turns={len(turns)}, pending={pending}"
         if turns:
             last_turn = turns[-1]
@@ -235,7 +235,7 @@ async def _wait_for_no_pending_approval(base_url: str, thread_id: str, *, timeou
         r = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}", timeout=15)
         r.raise_for_status()
         history = r.json()
-        if not history.get("pending_approval"):
+        if not history.get("pending_gate"):
             return history
         await asyncio.sleep(0.5)
     raise AssertionError(f"Timed out waiting for pending_approval to clear in thread {thread_id}")
@@ -298,7 +298,7 @@ class TestV2EngineApprovalFlow:
 
         history_b = await api_get(base_url, f"/api/chat/history?thread_id={thread_b}", timeout=15)
         history_b.raise_for_status()
-        still_pending_b = history_b.json().get("pending_approval")
+        still_pending_b = history_b.json().get("pending_gate")
         assert still_pending_b is not None, history_b.json()
         assert still_pending_b["request_id"] == pending_b["request_id"]
 
@@ -353,13 +353,13 @@ class TestV2EngineApprovalFlow:
                 if last and "requires approval" not in last:
                     break
             # Also check if pending_approval is cleared (approval processed)
-            if not history.get("pending_approval"):
+            if not history.get("pending_gate"):
                 break
 
         # After approval, pending_approval should be cleared
-        assert history.get("pending_approval") is None, (
+        assert history.get("pending_gate") is None, (
             f"After approval, pending_approval should be cleared. "
-            f"Got: {history.get('pending_approval')}"
+            f"Got: {history.get('pending_gate')}"
         )
 
     async def test_approval_no(self, v2_approval_server):
@@ -409,9 +409,9 @@ class TestV2EngineApprovalFlow:
         ).lower()
 
         # After denial, approval prompt should no longer be pending
-        assert history.get("pending_approval") is None, (
+        assert history.get("pending_gate") is None, (
             f"After denial, pending_approval should be cleared. "
-            f"Got: {history.get('pending_approval')}"
+            f"Got: {history.get('pending_gate')}"
         )
 
     async def test_approval_always(self, v2_approval_server):

--- a/tests/e2e/scenarios/test_v2_engine_error_handling.py
+++ b/tests/e2e/scenarios/test_v2_engine_error_handling.py
@@ -179,7 +179,7 @@ async def _wait_for_response(
 
         # Auto-approve pending approvals so the loop doesn't stall
         if auto_approve:
-            pending = history.get("pending_approval")
+            pending = history.get("pending_gate")
             if pending:
                 request_id = pending.get("request_id", "")
                 if request_id:


### PR DESCRIPTION
## Summary

Fixes multiple CI test failures from [run #24048967956](https://github.com/nearai/ironclaw/actions/runs/24048967956):

- **Telegram token unit test** (flaky): add env mutex guard to prevent race with concurrent tests that override `IRONCLAW_TEST_TELEGRAM_API_BASE_URL`
- **SSE/connection E2E tests** (stale): `#sse-status` element was removed from HTML — update tests to use `#sse-dot` CSS class; add SSE-ready wait to `page` fixture
- **Tool approval E2E tests** (stale): API unified legacy `pending_approval` into `pending_gate` field — update all test helpers
- **WASM tar.gz extraction** (real bug): canonicalized names use underscores (`web_search`) but release archives use hyphens (`web-search.wasm`) — accept both forms

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib test_telegram_token_colon` — passes
- [ ] CI: unit tests (Tests default) should pass
- [ ] CI: E2E SSE/connection/chat tests should pass
- [ ] CI: E2E tool approval + owner scope tests should pass
- [ ] CI: E2E WASM lifecycle tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)