### PR TITLE
fix: color for tools use

### DIFF
--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -40,8 +40,6 @@
   --focus-ring: rgba(52, 211, 153, 0.1);
   --accent-subtle: rgba(52, 211, 153, 0.15);
   --accent-border-subtle: rgba(52, 211, 153, 0.3);
-  --info-subtle: rgba(96, 165, 250, 0.12);
-  --info-border-subtle: rgba(96, 165, 250, 0.3);
   --danger-subtle: rgba(230, 76, 76, 0.15);
   --danger-border-subtle: rgba(230, 76, 76, 0.3);
   --warning-subtle: rgba(245, 166, 35, 0.15);
@@ -1646,8 +1644,7 @@ body {
 
 /* Tool calls summary (persisted between user/assistant messages) */
 .tool-calls-summary {
-  background: linear-gradient(90deg, var(--info-subtle) 0, var(--bg-secondary) 28%);
-  border: 1px solid var(--info-border-subtle);
+  background: var(--bg-secondary);
   border-left: 3px solid var(--info);
   padding: 6px 12px;
   margin: 4px 0;
@@ -1666,7 +1663,6 @@ body {
   display: inline-block;
   margin-right: 6px;
   font-size: 0.7em;
-  color: var(--info);
   transition: transform 0.15s;
 }
 

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -11,6 +11,7 @@
   --accent-hover: #2fc48d;
   --accent-soft: rgba(52, 211, 153, 0.15);
   --success: #34d399;
+  --info: #60a5fa;
   --warning: #F5A623;
   --danger: #E64C4C;
   --code-bg: #111113;
@@ -39,6 +40,8 @@
   --focus-ring: rgba(52, 211, 153, 0.1);
   --accent-subtle: rgba(52, 211, 153, 0.15);
   --accent-border-subtle: rgba(52, 211, 153, 0.3);
+  --info-subtle: rgba(96, 165, 250, 0.12);
+  --info-border-subtle: rgba(96, 165, 250, 0.3);
   --danger-subtle: rgba(230, 76, 76, 0.15);
   --danger-border-subtle: rgba(230, 76, 76, 0.3);
   --warning-subtle: rgba(245, 166, 35, 0.15);
@@ -1643,8 +1646,9 @@ body {
 
 /* Tool calls summary (persisted between user/assistant messages) */
 .tool-calls-summary {
-  background: var(--bg-secondary);
-  border-left: 3px solid var(--warning);
+  background: linear-gradient(90deg, var(--info-subtle) 0, var(--bg-secondary) 28%);
+  border: 1px solid var(--info-border-subtle);
+  border-left: 3px solid var(--info);
   padding: 6px 12px;
   margin: 4px 0;
   font-size: 0.85em;
@@ -1662,6 +1666,7 @@ body {
   display: inline-block;
   margin-right: 6px;
   font-size: 0.7em;
+  color: var(--info);
   transition: transform 0.15s;
 }
 

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -5578,6 +5578,7 @@ input[type="checkbox"]:focus-visible {
   --accent: #059669;
   --accent-hover: #047857;
   --success: #059669;
+  --info: #2563eb;
   --warning: #d97706;
   --danger: #dc2626;
   --code-bg: #f0f0f2;


### PR DESCRIPTION
## Summary

- Change the web gateway tool-call summary accent from warning orange to an info blue so it no longer reads like an error state.
- Add a reusable `--info` color token in the web static theme for consistency.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: CSS-only change
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: restarted the gateway locally, refreshed the chat UI, and verified persisted tool-call summaries render with only the left accent bar changed to blue while background and chevron styling remain unchanged
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches only the web gateway static stylesheet for `.tool-calls-summary`. Risk is limited to the visual presentation of persisted tool-call summary cards in the chat UI.

## Rollback Plan

Revert this branch or revert the two branch commits (`f15f6538` and `98833213`) to restore the previous warning-colored left border styling.

## Review Follow-Through

This change intentionally keeps the update minimal after reviewer feedback: only the left accent bar changes color, while the existing background and chevron styles stay as-is.

---

**Review track**: B
