### PR TITLE
fix(db): repair V6 migration checksum and guard against re-modification (#1328)

### DIFF
--- a/migrations/V6__routines.sql
+++ b/migrations/V6__routines.sql
@@ -26,7 +26,7 @@ CREATE TABLE routines (
 
     -- Notification preferences
     notify_channel TEXT,                 -- NULL = use default
-    notify_user TEXT,
+    notify_user TEXT NOT NULL DEFAULT 'default',
     notify_on_success BOOLEAN NOT NULL DEFAULT false,
     notify_on_failure BOOLEAN NOT NULL DEFAULT true,
     notify_on_attention BOOLEAN NOT NULL DEFAULT true,

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -13,6 +13,15 @@
 # Regenerate locally with:
 #   cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile
 
+V1__initial = 13924994861355873385
+V2__wasm_secure_api = 7920426121433120191
+V3__tool_failures = 12003661105690258102
+V4__sandbox_columns = 4066773473211554372
+V5__claude_code = 879553427473911756
+V6__routines = 18049045188188232070
+V7__rename_events = 13503025792365661965
+V8__settings = 2960080429880963815
+V9__flexible_embedding_dimension = 8136426081104542386
 V10__wasm_versioning = 18212435829290780557
 V11__conversation_unique_indexes = 9262706107262242885
 V12__job_token_budget = 13685500183340941819
@@ -23,13 +32,4 @@ V16__document_versions = 6496010415720970575
 V17__user_identities = 14415325645069692436
 V18__tool_scope = 3125684809935466111
 V19__channel_identities = 409356689302266680
-V1__initial = 13924994861355873385
 V20__pairing_requests = 17756233693090004940
-V2__wasm_secure_api = 7920426121433120191
-V3__tool_failures = 12003661105690258102
-V4__sandbox_columns = 4066773473211554372
-V5__claude_code = 879553427473911756
-V6__routines = 18049045188188232070
-V7__rename_events = 13503025792365661965
-V8__settings = 2960080429880963815
-V9__flexible_embedding_dimension = 8136426081104542386

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -1,0 +1,35 @@
+# Released migration checksums (refinery SipHasher13 over name+version+sql).
+#
+# This file is the immutability guard for released migrations. The
+# `released_migrations_are_immutable` test in src/db/migration_fixup.rs
+# asserts every migration listed below still hashes to the pinned value
+# and that every migration on disk has a pinned value here.
+#
+# Modifying a released migration is forbidden — it desyncs every
+# production database from refinery's checksum validation. See issue
+# #1328 for the historical accident this guard prevents.
+#
+# When adding a new migration, append a new line in the same commit.
+# Regenerate locally with:
+#   cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile
+
+V10__wasm_versioning = 18212435829290780557
+V11__conversation_unique_indexes = 9262706107262242885
+V12__job_token_budget = 13685500183340941819
+V13__owner_scope_notify_targets = 2361305667196854503
+V14__users = 8534543610808829344
+V15__conversation_source_channel = 6931108907510923101
+V16__document_versions = 6496010415720970575
+V17__user_identities = 14415325645069692436
+V18__tool_scope = 3125684809935466111
+V19__channel_identities = 409356689302266680
+V1__initial = 13924994861355873385
+V20__pairing_requests = 17756233693090004940
+V2__wasm_secure_api = 7920426121433120191
+V3__tool_failures = 12003661105690258102
+V4__sandbox_columns = 4066773473211554372
+V5__claude_code = 879553427473911756
+V6__routines = 18049045188188232070
+V7__rename_events = 13503025792365661965
+V8__settings = 2960080429880963815
+V9__flexible_embedding_dimension = 8136426081104542386

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -188,6 +188,13 @@ pub(crate) async fn realign_diverged_checksums_with(
             })?;
 
         if updated > 0 {
+            // `warn!` is intentional here even though CLAUDE.md warns
+            // against `info!`/`warn!` in background tasks (they corrupt
+            // the REPL/TUI). This fix-up runs during database migration
+            // at startup, *before* any channel/REPL/TUI is initialized,
+            // so terminal-rendering interference is impossible. If this
+            // call is ever moved later in startup, downgrade to `debug!`
+            // or pre-buffer the message.
             tracing::warn!(
                 migration = %migration_label,
                 rows = updated,
@@ -229,7 +236,16 @@ mod tests {
                     lineno + 1
                 )
             });
-            map.insert(key.trim().to_string(), parsed);
+            // Reject duplicate keys: a stray duplicate would silently
+            // overwrite an earlier pinned checksum and weaken the
+            // immutability guard. Detect it loudly during the test.
+            let key = key.trim().to_string();
+            if map.insert(key.clone(), parsed).is_some() {
+                panic!(
+                    "checksums.lock line {} contains duplicate migration key: {key}",
+                    lineno + 1
+                );
+            }
         }
         map
     }
@@ -357,7 +373,18 @@ mod tests {
                 }
             })
             .collect();
-        sql_files.sort();
+        // Natural-sort by parsed migration version (so V2 comes before
+        // V10), not lex-sort (which would order V10 before V2). The
+        // resulting lockfile reads in numeric order which makes review
+        // diffs easier to scan.
+        sql_files.sort_by_key(|path| {
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+            // V<n>__<name> → parse the digits between `V` and `__`.
+            stem.strip_prefix('V')
+                .and_then(|s| s.split_once("__"))
+                .and_then(|(v, _)| v.parse::<u32>().ok())
+                .unwrap_or(u32::MAX)
+        });
 
         let mut output = String::new();
         output.push_str(
@@ -637,5 +664,94 @@ mod tests {
             )
             .await
             .expect("cleanup post-run");
+    }
+
+    /// Regression test for the defensive check that rejects a
+    /// `KnownDivergence` whose canonical checksum is also listed in its
+    /// own `known_bad_checksums`. Such a misconfiguration would silently
+    /// rewrite already-correct rows to themselves; the production code
+    /// returns `Err(DatabaseError::Migration(...))` to refuse startup.
+    ///
+    /// Like the realignment integration test above, this requires a
+    /// `PgClient` and so is gated on `feature = "integration"`. The
+    /// error fires *before* any UPDATE query, so the test only needs a
+    /// reachable database — `refinery_schema_history` does not even
+    /// need to exist.
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn rejects_canonical_in_known_bad_checksums() {
+        use deadpool_postgres::{Manager, Pool};
+        use tokio_postgres::{Config, NoTls};
+
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/ironclaw_test".to_string());
+        let config: Config = match database_url.parse() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: invalid DATABASE_URL ({e})");
+                return;
+            }
+        };
+        let mgr = Manager::new(config, NoTls);
+        let pool = match Pool::builder(mgr).max_size(2).build() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping: failed to build pool ({e})");
+                return;
+            }
+        };
+        let mut client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: database unavailable ({e})");
+                return;
+            }
+        };
+
+        // Make sure refinery_schema_history exists so we exercise the
+        // post-history-check branch (the early-return on missing table
+        // would otherwise mask the validation we want to test).
+        client
+            .batch_execute(
+                "CREATE TABLE IF NOT EXISTS refinery_schema_history ( \
+                    version INT4 PRIMARY KEY, \
+                    name VARCHAR(255), \
+                    applied_on VARCHAR(255), \
+                    checksum VARCHAR(255))",
+            )
+            .await
+            .expect("create refinery_schema_history");
+
+        // Construct a deliberately-misconfigured divergence where the
+        // canonical checksum appears in its own known-bad list.
+        const TEST_SQL: &str = "-- bad-config test fixture\nSELECT 2;\n";
+        let canonical = Migration::unapplied("V99998__bad_config", TEST_SQL)
+            .unwrap()
+            .checksum();
+        let bad_divergences: &[KnownDivergence] = &[KnownDivergence {
+            version: 99998,
+            name: "bad_config",
+            sql: TEST_SQL,
+            known_bad_checksums: Box::leak(Box::new([canonical])),
+            explanation: "intentional misconfig for PR #2101 regression test",
+        }];
+
+        let result = super::realign_diverged_checksums_with(&mut client, bad_divergences).await;
+        match result {
+            Err(crate::error::DatabaseError::Migration(msg)) => {
+                assert!(
+                    msg.contains("known_bad_checksums"),
+                    "expected error to mention known_bad_checksums, got: {msg}",
+                );
+                assert!(
+                    msg.contains("V99998__bad_config"),
+                    "expected error to identify the offending migration label, got: {msg}",
+                );
+            }
+            Err(other) => panic!("expected Migration error, got: {other:?}"),
+            Ok(()) => {
+                panic!("expected Err — canonical checksum in known_bad list should refuse startup")
+            }
+        }
     }
 }

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -141,16 +141,23 @@ pub(crate) async fn realign_diverged_checksums_with(
         // Defensive: the canonical checksum must never appear in the bad
         // list, otherwise we'd be rewriting already-correct rows. This is
         // a programming error in `KNOWN_DIVERGENCES`, not a runtime
-        // condition. Use `assert!` rather than `debug_assert!` so the
-        // guard remains in release builds — `KNOWN_DIVERGENCES` has at
-        // most a handful of entries, so the cost is one constant-time
-        // slice lookup per startup.
-        assert!(
-            !divergence
-                .known_bad_checksums
-                .contains(&migration.checksum()),
-            "{migration_label}: canonical checksum is listed as known-bad",
-        );
+        // condition, but it must still be detected in release builds (a
+        // `debug_assert!` would be stripped). Return a hard error so the
+        // process refuses to start with a misconfigured fix-up table —
+        // see PR #2101 review by @serrrfirat. Cost is one constant-time
+        // slice lookup per startup; the `KNOWN_DIVERGENCES` list has at
+        // most a handful of entries.
+        if divergence
+            .known_bad_checksums
+            .contains(&migration.checksum())
+        {
+            return Err(DatabaseError::Migration(format!(
+                "{migration_label}: canonical checksum is listed in \
+                 known_bad_checksums — this is a programming error in \
+                 KNOWN_DIVERGENCES that would silently rewrite \
+                 already-correct rows",
+            )));
+        }
 
         // Only rewrite rows whose stored checksum is one of the known
         // historical bad values for this migration. Any other divergence

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -60,21 +60,21 @@ use crate::error::DatabaseError;
 /// release. Add a new entry here only if the same accident ever happens
 /// again — the immutability test in `migrations/checksums.lock` is the
 /// preferred guard.
-struct KnownDivergence {
-    version: i32,
-    name: &'static str,
+pub(crate) struct KnownDivergence {
+    pub(crate) version: i32,
+    pub(crate) name: &'static str,
     /// The current (canonical) SQL content, embedded at compile time.
-    sql: &'static str,
+    pub(crate) sql: &'static str,
     /// The exact set of historical bad checksums we are willing to rewrite
     /// for this migration. **The fix-up only fires when the stored checksum
     /// matches one of these literals** — any other divergence (manual
     /// tampering, hardware corruption, an unknown future regression) is
     /// left alone so refinery can still abort startup loudly.
-    known_bad_checksums: &'static [u64],
+    pub(crate) known_bad_checksums: &'static [u64],
     /// Human-readable explanation of why this divergence exists, surfaced
     /// in the realignment warning log so future entries are not coupled to
     /// the V6/#1328 wording.
-    explanation: &'static str,
+    pub(crate) explanation: &'static str,
 }
 
 const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
@@ -95,6 +95,16 @@ const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
 /// with the canonical checksum of the embedded migration. Must be called
 /// before `refinery::Runner::run_async`.
 pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), DatabaseError> {
+    realign_diverged_checksums_with(client, KNOWN_DIVERGENCES).await
+}
+
+/// Inner implementation that takes the divergence list as a parameter, so
+/// integration tests can drive it against synthetic rows without colliding
+/// with real V6 rows in a shared test database.
+pub(crate) async fn realign_diverged_checksums_with(
+    client: &mut PgClient,
+    divergences: &[KnownDivergence],
+) -> Result<(), DatabaseError> {
     // On a fresh install the history table does not yet exist. Refinery
     // will create it during the first `run_async()` call. There is nothing
     // to realign in that case.
@@ -115,7 +125,7 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
         return Ok(());
     }
 
-    for divergence in KNOWN_DIVERGENCES {
+    for divergence in divergences {
         // Compute the canonical checksum the same way refinery does
         // (SipHasher13 over name, version, sql in that order). Refinery
         // stores the resulting u64 as a decimal string in the `checksum`
@@ -131,8 +141,11 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
         // Defensive: the canonical checksum must never appear in the bad
         // list, otherwise we'd be rewriting already-correct rows. This is
         // a programming error in `KNOWN_DIVERGENCES`, not a runtime
-        // condition, so failing loudly here is appropriate.
-        debug_assert!(
+        // condition. Use `assert!` rather than `debug_assert!` so the
+        // guard remains in release builds — `KNOWN_DIVERGENCES` has at
+        // most a handful of entries, so the cost is one constant-time
+        // slice lookup per startup.
+        assert!(
             !divergence
                 .known_bad_checksums
                 .contains(&migration.checksum()),
@@ -463,5 +476,159 @@ mod tests {
             canonical, POST_1151_BAD_V6_CHECKSUM,
             "canonical V6 checksum collides with known-bad — fix-up would no-op"
         );
+    }
+
+    /// Integration test that drives `realign_diverged_checksums_with`
+    /// against a real PostgreSQL instance, codifying the manual smoke
+    /// test from PR #2101 and closing the last untested seam noted by
+    /// @serrrfirat. Skips gracefully if no database is reachable.
+    ///
+    /// To avoid racing real V6 rows in shared CI databases, the test
+    /// uses a synthetic version `99999` row with name `test_routines`
+    /// and a custom `KnownDivergence` slice — the production
+    /// `KNOWN_DIVERGENCES` constant is left untouched.
+    ///
+    /// Run with:
+    ///
+    /// ```text
+    /// DATABASE_URL=postgres://localhost/ironclaw_test \
+    ///     cargo test --features integration --lib \
+    ///     db::migration_fixup::tests::realign_repairs_known_bad_checksum_against_postgres
+    /// ```
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn realign_repairs_known_bad_checksum_against_postgres() {
+        use deadpool_postgres::{Manager, Pool};
+        use tokio_postgres::{Config, NoTls};
+
+        let database_url = std::env::var("DATABASE_URL")
+            .unwrap_or_else(|_| "postgres://localhost/ironclaw_test".to_string());
+        let config: Config = match database_url.parse() {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: invalid DATABASE_URL ({e})");
+                return;
+            }
+        };
+        let mgr = Manager::new(config, NoTls);
+        let pool = match Pool::builder(mgr).max_size(2).build() {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("skipping: failed to build pool ({e})");
+                return;
+            }
+        };
+        let mut client = match pool.get().await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("skipping: database unavailable ({e})");
+                return;
+            }
+        };
+
+        // Make sure refinery_schema_history exists. We can't rely on
+        // the test DB having had migrations run, so create it on
+        // demand using refinery's own DDL shape (4 columns matching
+        // the tokio_postgres driver in refinery 0.8.16).
+        client
+            .batch_execute(
+                "CREATE TABLE IF NOT EXISTS refinery_schema_history ( \
+                    version INT4 PRIMARY KEY, \
+                    name VARCHAR(255), \
+                    applied_on VARCHAR(255), \
+                    checksum VARCHAR(255))",
+            )
+            .await
+            .expect("create refinery_schema_history");
+
+        // Use a synthetic divergence so we don't touch any real V*
+        // row that another test or migration might depend on.
+        const TEST_VERSION: i32 = 99999;
+        const TEST_NAME: &str = "test_routines";
+        const TEST_SQL: &str = "-- synthetic test migration\nSELECT 1;\n";
+        // Compute the canonical checksum the same way the production
+        // code does, plus a deliberately-wrong "bad" value to seed.
+        let canonical = Migration::unapplied(&format!("V{TEST_VERSION}__{TEST_NAME}"), TEST_SQL)
+            .unwrap()
+            .checksum();
+        let bad: u64 = canonical.wrapping_add(1);
+        let test_divergences: &[KnownDivergence] = &[KnownDivergence {
+            version: TEST_VERSION,
+            name: TEST_NAME,
+            sql: TEST_SQL,
+            // Note: this is a `&'static [u64]` literal — `bad` is
+            // computed at runtime, so we use a slice we can build at
+            // runtime. The struct accepts a borrow with the same
+            // lifetime as the slice itself.
+            known_bad_checksums: Box::leak(Box::new([bad])),
+            explanation: "test fixture for PR #2101 integration test",
+        }];
+
+        // Clean any leftover row from a previous run, then seed the
+        // bad checksum.
+        client
+            .execute(
+                "DELETE FROM refinery_schema_history WHERE version = $1",
+                &[&TEST_VERSION],
+            )
+            .await
+            .expect("cleanup pre-run");
+        client
+            .execute(
+                "INSERT INTO refinery_schema_history (version, name, applied_on, checksum) \
+                 VALUES ($1, $2, $3, $4)",
+                &[
+                    &TEST_VERSION,
+                    &TEST_NAME,
+                    &"2026-01-01T00:00:00Z",
+                    &bad.to_string(),
+                ],
+            )
+            .await
+            .expect("seed bad checksum");
+
+        // Run the realignment with our synthetic divergence list.
+        super::realign_diverged_checksums_with(&mut client, test_divergences)
+            .await
+            .expect("realign");
+
+        // Assert the row now holds the canonical checksum.
+        let row = client
+            .query_one(
+                "SELECT checksum FROM refinery_schema_history WHERE version = $1",
+                &[&TEST_VERSION],
+            )
+            .await
+            .expect("read back row");
+        let stored: String = row.get(0);
+        assert_eq!(
+            stored,
+            canonical.to_string(),
+            "realign should have rewritten the bad checksum to canonical",
+        );
+
+        // Run the realignment a second time — it should be a no-op
+        // because the row no longer matches any known-bad value.
+        super::realign_diverged_checksums_with(&mut client, test_divergences)
+            .await
+            .expect("realign idempotent");
+        let row = client
+            .query_one(
+                "SELECT checksum FROM refinery_schema_history WHERE version = $1",
+                &[&TEST_VERSION],
+            )
+            .await
+            .expect("read back row 2");
+        let stored: String = row.get(0);
+        assert_eq!(stored, canonical.to_string(), "second run should no-op");
+
+        // Cleanup.
+        client
+            .execute(
+                "DELETE FROM refinery_schema_history WHERE version = $1",
+                &[&TEST_VERSION],
+            )
+            .await
+            .expect("cleanup post-run");
     }
 }

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -65,6 +65,12 @@ struct KnownDivergence {
     name: &'static str,
     /// The current (canonical) SQL content, embedded at compile time.
     sql: &'static str,
+    /// The exact set of historical bad checksums we are willing to rewrite
+    /// for this migration. **The fix-up only fires when the stored checksum
+    /// matches one of these literals** — any other divergence (manual
+    /// tampering, hardware corruption, an unknown future regression) is
+    /// left alone so refinery can still abort startup loudly.
+    known_bad_checksums: &'static [u64],
     /// Human-readable explanation of why this divergence exists, surfaced
     /// in the realignment warning log so future entries are not coupled to
     /// the V6/#1328 wording.
@@ -75,6 +81,11 @@ const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
     version: 6,
     name: "routines",
     sql: include_str!("../../migrations/V6__routines.sql"),
+    // The single historical bad checksum: V6 with `notify_user TEXT,`
+    // (the post-#1151 / v0.19.0 fresh-install variant). Computed from
+    // `git show 878a67cd:migrations/V6__routines.sql`. Pinned by the
+    // `v6_known_bad_checksum_matches_post_1151_content` test below.
+    known_bad_checksums: &[11230857244097235596],
     explanation: "Migration content matches the v0.18.0 release; the schema \
                   change introduced in PR #1151 is applied incrementally by \
                   V13__owner_scope_notify_targets.",
@@ -117,16 +128,39 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
         })?;
         let canonical_checksum = migration.checksum().to_string();
 
-        // `IS DISTINCT FROM` (rather than `<>`) is NULL-safe: refinery's
-        // `checksum` column is `NOT NULL` in practice, but using the
-        // NULL-aware operator means a corrupted row with a NULL checksum
-        // is also picked up for repair instead of being silently skipped.
+        // Defensive: the canonical checksum must never appear in the bad
+        // list, otherwise we'd be rewriting already-correct rows. This is
+        // a programming error in `KNOWN_DIVERGENCES`, not a runtime
+        // condition, so failing loudly here is appropriate.
+        debug_assert!(
+            !divergence
+                .known_bad_checksums
+                .contains(&migration.checksum()),
+            "{migration_label}: canonical checksum is listed as known-bad",
+        );
+
+        // Only rewrite rows whose stored checksum is one of the known
+        // historical bad values for this migration. Any other divergence
+        // (manual tampering, hardware corruption, an unrelated future
+        // regression) is intentionally left alone so refinery still aborts
+        // startup loudly. See PR #2101 review by @serrrfirat.
+        let known_bad: Vec<String> = divergence
+            .known_bad_checksums
+            .iter()
+            .map(|c| c.to_string())
+            .collect();
+
         let updated = client
             .execute(
                 "UPDATE refinery_schema_history \
                  SET checksum = $1 \
-                 WHERE version = $2 AND name = $3 AND checksum IS DISTINCT FROM $1",
-                &[&canonical_checksum, &divergence.version, &divergence.name],
+                 WHERE version = $2 AND name = $3 AND checksum = ANY($4)",
+                &[
+                    &canonical_checksum,
+                    &divergence.version,
+                    &divergence.name,
+                    &known_bad,
+                ],
             )
             .await
             .map_err(|e| {
@@ -334,6 +368,30 @@ mod tests {
         eprintln!("wrote {}", lockfile_path.display());
     }
 
+    /// One-shot helper: print the canonical checksum for an arbitrary
+    /// SQL file path supplied via the `MIGRATION_CHECKSUM_PATH` env var.
+    /// Used to compute the historical bad V6 checksum for the
+    /// `KNOWN_DIVERGENCES` whitelist:
+    ///
+    /// ```text
+    /// MIGRATION_CHECKSUM_PATH=/tmp/v6_modified.sql \
+    ///   cargo test -p ironclaw -- --ignored \
+    ///   compute_checksum_for_external_file --nocapture
+    /// ```
+    #[test]
+    #[ignore]
+    fn compute_checksum_for_external_file() {
+        let path = std::env::var("MIGRATION_CHECKSUM_PATH").expect("MIGRATION_CHECKSUM_PATH");
+        let stem = std::path::Path::new(&path)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap()
+            .to_string();
+        let sql = std::fs::read_to_string(&path).unwrap();
+        let migration = Migration::unapplied(&stem, &sql).unwrap();
+        eprintln!("{stem} = {}", migration.checksum());
+    }
+
     /// Sanity check that the embedded V6 SQL still hashes to the v0.18.0
     /// checksum. If this fails, V6 has been re-modified and issue #1328
     /// will recur on every existing PostgreSQL deployment.
@@ -365,6 +423,45 @@ mod tests {
              v0.18.0 checksum and issue #1328 will recur on every existing \
              PostgreSQL deployment. Revert your edit and put the schema \
              change in a new migration."
+        );
+    }
+
+    /// Pin the historical bad V6 checksum (the post-#1151 modified
+    /// content) so the realignment whitelist cannot drift. The fix-up
+    /// function rewrites *only* rows whose stored checksum matches a
+    /// value in `KNOWN_DIVERGENCES[..].known_bad_checksums`. If this
+    /// list is corrupted or accidentally widened, refinery's checksum
+    /// validation degrades from "narrowly exempt one historical row" to
+    /// "silently mask any V6 corruption". This sentinel ensures the V6
+    /// entry contains exactly one expected literal value.
+    ///
+    /// Source for the literal: `git show 878a67cd:migrations/V6__routines.sql`
+    /// (the commit from PR #1151 that introduced the divergence).
+    #[test]
+    fn v6_known_bad_checksum_matches_post_1151_content() {
+        const POST_1151_BAD_V6_CHECKSUM: u64 = 11230857244097235596;
+
+        let v6 = &KNOWN_DIVERGENCES[0];
+        assert_eq!(v6.version, 6);
+        assert_eq!(v6.name, "routines");
+        assert_eq!(
+            v6.known_bad_checksums,
+            &[POST_1151_BAD_V6_CHECKSUM],
+            "the V6 known-bad checksum list has been altered. The only \
+             value that should appear here is the SipHasher13 of \
+             `git show 878a67cd:migrations/V6__routines.sql`. Widening \
+             the list silently masks production database corruption — \
+             do not change this without a very good reason."
+        );
+
+        // Also assert canonical and bad are distinct, otherwise the
+        // fix-up would no-op.
+        let canonical = Migration::unapplied("V6__routines", v6.sql)
+            .unwrap()
+            .checksum();
+        assert_ne!(
+            canonical, POST_1151_BAD_V6_CHECKSUM,
+            "canonical V6 checksum collides with known-bad — fix-up would no-op"
         );
     }
 }

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -60,24 +60,31 @@ use crate::error::DatabaseError;
 /// release. Add a new entry here only if the same accident ever happens
 /// again — the immutability test in `migrations/checksums.lock` is the
 /// preferred guard.
-pub(crate) struct KnownDivergence {
+/// One known historical migration whose on-disk content was modified after
+/// release.
+///
+/// Lifetime-generic so integration tests can construct stack-allocated
+/// instances with non-`'static` borrowed slices (avoiding `Box::leak` to
+/// satisfy `'static` bounds). Production `KNOWN_DIVERGENCES` is
+/// `&[KnownDivergence<'static>]` and is unaffected.
+pub(crate) struct KnownDivergence<'a> {
     pub(crate) version: i32,
-    pub(crate) name: &'static str,
+    pub(crate) name: &'a str,
     /// The current (canonical) SQL content, embedded at compile time.
-    pub(crate) sql: &'static str,
+    pub(crate) sql: &'a str,
     /// The exact set of historical bad checksums we are willing to rewrite
     /// for this migration. **The fix-up only fires when the stored checksum
     /// matches one of these literals** — any other divergence (manual
     /// tampering, hardware corruption, an unknown future regression) is
     /// left alone so refinery can still abort startup loudly.
-    pub(crate) known_bad_checksums: &'static [u64],
+    pub(crate) known_bad_checksums: &'a [u64],
     /// Human-readable explanation of why this divergence exists, surfaced
     /// in the realignment warning log so future entries are not coupled to
     /// the V6/#1328 wording.
-    pub(crate) explanation: &'static str,
+    pub(crate) explanation: &'a str,
 }
 
-const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
+const KNOWN_DIVERGENCES: &[KnownDivergence<'static>] = &[KnownDivergence {
     version: 6,
     name: "routines",
     sql: include_str!("../../migrations/V6__routines.sql"),
@@ -91,9 +98,90 @@ const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
                   V13__owner_scope_notify_targets.",
 }];
 
+/// Session-level PostgreSQL advisory lock key used to serialize concurrent
+/// migration runs across replicas. Set to issue number 1328 for grep-ability
+/// (`SELECT * FROM pg_locks WHERE locktype = 'advisory' AND objid = 1328`).
+const MIGRATION_LOCK_KEY: i64 = 1328;
+
+/// Run the full PostgreSQL migration sequence: acquire an advisory lock,
+/// realign any historically diverged checksums, then run refinery's embedded
+/// migrations. Releases the lock on every exit path including errors.
+///
+/// **This is the single entry point for running PostgreSQL migrations.** Both
+/// `Store::run_migrations` and `SetupWizard::run_migrations_postgres`
+/// delegate here. Adding a new migration entry point? Call this function;
+/// do not re-implement the fix-up + refinery sequence inline.
+///
+/// ## Why an advisory lock
+///
+/// Two replicas starting simultaneously against the same database can race:
+/// one finishes `realign_diverged_checksums` and commits, then the other's
+/// `refinery::Runner::run_async` reads its own SELECT-then-validate pair and
+/// the timing between them is unprotected, potentially causing spurious
+/// startup failures. The session-level advisory lock serializes the entire
+/// fix-up + refinery sequence per database. It also hardens the pre-existing
+/// refinery race that has always existed for concurrent multi-replica starts.
+///
+/// We use a *session-level* lock (not `pg_advisory_xact_lock`) because
+/// refinery's `run_async` opens its own internal transactions and an outer
+/// transaction-scoped lock would conflict with refinery's transaction
+/// boundaries.
+pub async fn run_postgres_migrations_with_fixup(
+    client: &mut PgClient,
+) -> Result<(), DatabaseError> {
+    use refinery::embed_migrations;
+    // The path is relative to `CARGO_MANIFEST_DIR`, not this file.
+    embed_migrations!("migrations");
+
+    // Acquire the lock. Blocks until released by any other holder.
+    client
+        .execute("SELECT pg_advisory_lock($1)", &[&MIGRATION_LOCK_KEY])
+        .await
+        .map_err(|e| DatabaseError::Migration(format!("acquire migration lock: {e}")))?;
+
+    // Run the realignment + refinery sequence, holding the lock for the
+    // duration. We capture the result and *always* release before
+    // returning, even on error.
+    //
+    // `client` is `&mut Object` (from `deadpool_postgres`); the triple
+    // deref reaches `tokio_postgres::Client` via
+    // `Object → ClientWrapper → Client`, which is what refinery's
+    // `AsyncMigrate` impl is bound to.
+    let result: Result<(), DatabaseError> = async {
+        realign_diverged_checksums_with(client, KNOWN_DIVERGENCES).await?;
+        migrations::runner()
+            .run_async(&mut ***client)
+            .await
+            .map_err(|e| DatabaseError::Migration(e.to_string()))?;
+        Ok(())
+    }
+    .await;
+
+    // Always release the lock. If the unlock itself fails, log it and
+    // surface the original migration error if there was one — losing the
+    // lock release is less important than reporting the underlying cause.
+    if let Err(e) = client
+        .execute("SELECT pg_advisory_unlock($1)", &[&MIGRATION_LOCK_KEY])
+        .await
+    {
+        tracing::error!(
+            error = %e,
+            "failed to release migration advisory lock — connection drop will \
+             release it eventually, but other replicas may block until then"
+        );
+    }
+
+    result
+}
+
 /// Realign `refinery_schema_history` rows whose stored checksum disagrees
 /// with the canonical checksum of the embedded migration. Must be called
 /// before `refinery::Runner::run_async`.
+///
+/// **Most callers should use [`run_postgres_migrations_with_fixup`]**, which
+/// bundles this with refinery and the advisory lock. This function is
+/// retained as a public entry point only for callers that already manage
+/// their own refinery invocation (none today).
 pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), DatabaseError> {
     realign_diverged_checksums_with(client, KNOWN_DIVERGENCES).await
 }
@@ -103,7 +191,7 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
 /// with real V6 rows in a shared test database.
 pub(crate) async fn realign_diverged_checksums_with(
     client: &mut PgClient,
-    divergences: &[KnownDivergence],
+    divergences: &[KnownDivergence<'_>],
 ) -> Result<(), DatabaseError> {
     // On a fresh install the history table does not yet exist. Refinery
     // will create it during the first `run_async()` call. There is nothing
@@ -586,15 +674,15 @@ mod tests {
             .unwrap()
             .checksum();
         let bad: u64 = canonical.wrapping_add(1);
-        let test_divergences: &[KnownDivergence] = &[KnownDivergence {
+        // `KnownDivergence` is lifetime-generic, so we can borrow a
+        // stack-allocated slice here — no `Box::leak` needed (would
+        // otherwise flag under leak sanitizers).
+        let bad_checksums = [bad];
+        let test_divergences = [KnownDivergence {
             version: TEST_VERSION,
             name: TEST_NAME,
             sql: TEST_SQL,
-            // Note: this is a `&'static [u64]` literal — `bad` is
-            // computed at runtime, so we use a slice we can build at
-            // runtime. The struct accepts a borrow with the same
-            // lifetime as the slice itself.
-            known_bad_checksums: Box::leak(Box::new([bad])),
+            known_bad_checksums: &bad_checksums,
             explanation: "test fixture for PR #2101 integration test",
         }];
 
@@ -622,7 +710,7 @@ mod tests {
             .expect("seed bad checksum");
 
         // Run the realignment with our synthetic divergence list.
-        super::realign_diverged_checksums_with(&mut client, test_divergences)
+        super::realign_diverged_checksums_with(&mut client, &test_divergences)
             .await
             .expect("realign");
 
@@ -643,7 +731,7 @@ mod tests {
 
         // Run the realignment a second time — it should be a no-op
         // because the row no longer matches any known-bad value.
-        super::realign_diverged_checksums_with(&mut client, test_divergences)
+        super::realign_diverged_checksums_with(&mut client, &test_divergences)
             .await
             .expect("realign idempotent");
         let row = client
@@ -728,15 +816,18 @@ mod tests {
         let canonical = Migration::unapplied("V99998__bad_config", TEST_SQL)
             .unwrap()
             .checksum();
-        let bad_divergences: &[KnownDivergence] = &[KnownDivergence {
+        // Stack-allocated, no Box::leak — `KnownDivergence` is
+        // lifetime-generic.
+        let bad_checksums = [canonical];
+        let bad_divergences = [KnownDivergence {
             version: 99998,
             name: "bad_config",
             sql: TEST_SQL,
-            known_bad_checksums: Box::leak(Box::new([canonical])),
+            known_bad_checksums: &bad_checksums,
             explanation: "intentional misconfig for PR #2101 regression test",
         }];
 
-        let result = super::realign_diverged_checksums_with(&mut client, bad_divergences).await;
+        let result = super::realign_diverged_checksums_with(&mut client, &bad_divergences).await;
         match result {
             Err(crate::error::DatabaseError::Migration(msg)) => {
                 assert!(

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -65,12 +65,19 @@ struct KnownDivergence {
     name: &'static str,
     /// The current (canonical) SQL content, embedded at compile time.
     sql: &'static str,
+    /// Human-readable explanation of why this divergence exists, surfaced
+    /// in the realignment warning log so future entries are not coupled to
+    /// the V6/#1328 wording.
+    explanation: &'static str,
 }
 
 const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
     version: 6,
     name: "routines",
     sql: include_str!("../../migrations/V6__routines.sql"),
+    explanation: "Migration content matches the v0.18.0 release; the schema \
+                  change introduced in PR #1151 is applied incrementally by \
+                  V13__owner_scope_notify_targets.",
 }];
 
 /// Realign `refinery_schema_history` rows whose stored checksum disagrees
@@ -80,9 +87,13 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
     // On a fresh install the history table does not yet exist. Refinery
     // will create it during the first `run_async()` call. There is nothing
     // to realign in that case.
+    // Use an unqualified identifier so PostgreSQL resolves the table via
+    // the active `search_path` — matching how refinery itself locates the
+    // history table. Hard-coding `public.` would silently skip the fix-up
+    // on deployments using a non-default schema.
     let history_exists: bool = client
         .query_one(
-            "SELECT to_regclass('public.refinery_schema_history') IS NOT NULL",
+            "SELECT to_regclass('refinery_schema_history') IS NOT NULL",
             &[],
         )
         .await
@@ -106,11 +117,15 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
         })?;
         let canonical_checksum = migration.checksum().to_string();
 
+        // `IS DISTINCT FROM` (rather than `<>`) is NULL-safe: refinery's
+        // `checksum` column is `NOT NULL` in practice, but using the
+        // NULL-aware operator means a corrupted row with a NULL checksum
+        // is also picked up for repair instead of being silently skipped.
         let updated = client
             .execute(
                 "UPDATE refinery_schema_history \
                  SET checksum = $1 \
-                 WHERE version = $2 AND name = $3 AND checksum <> $1",
+                 WHERE version = $2 AND name = $3 AND checksum IS DISTINCT FROM $1",
                 &[&canonical_checksum, &divergence.version, &divergence.name],
             )
             .await
@@ -122,10 +137,8 @@ pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), Dat
             tracing::warn!(
                 migration = %migration_label,
                 rows = updated,
-                "Realigned refinery_schema_history checksum (issue #1328 fix-up). \
-                 Migration content matches the v0.18.0 release; the schema \
-                 change introduced in PR #1151 is applied incrementally by \
-                 V13__owner_scope_notify_targets."
+                "Realigned refinery_schema_history checksum: {}",
+                divergence.explanation
             );
         }
     }

--- a/src/db/migration_fixup.rs
+++ b/src/db/migration_fixup.rs
@@ -1,0 +1,357 @@
+//! PostgreSQL migration checksum fix-up.
+//!
+//! This module exists because of a single historical accident: PR #1151
+//! ("Refactor owner scope across channels and fix default routing fallback")
+//! modified `migrations/V6__routines.sql` *in place* after that migration
+//! had already shipped in v0.18.0 and been applied to production databases.
+//! Refinery records a SipHasher13 checksum of every applied migration in
+//! `refinery_schema_history`, and on every startup it re-validates each
+//! filesystem migration against the stored checksum. The in-place edit
+//! caused refinery to abort startup with:
+//!
+//!   Error: Migration failed: applied migration V6__routines is different
+//!   than filesystem one V6__routines
+//!
+//! See [issue #1328](https://github.com/nearai/ironclaw/issues/1328).
+//!
+//! ## Why a runtime fix-up is required
+//!
+//! Two populations of databases exist in the wild:
+//!
+//! 1. **Pre-#1151 installs** (v0.18.0 and earlier) — `refinery_schema_history`
+//!    holds the checksum of the *original* V6 (`notify_user TEXT NOT NULL
+//!    DEFAULT 'default'`).
+//! 2. **Post-#1151 installs** (fresh installs of v0.19.0 or any
+//!    staging build after the merge) — `refinery_schema_history` holds the
+//!    checksum of the *modified* V6 (`notify_user TEXT,`).
+//!
+//! Reverting V6 on its own (which we have also done) only fixes population
+//! #1; population #2 would then break in the opposite direction. To handle
+//! both, we recompute the canonical checksum from the embedded V6 SQL on
+//! startup and rewrite any divergent row in `refinery_schema_history`
+//! before refinery validates it.
+//!
+//! V13 (`V13__owner_scope_notify_targets.sql`) handles the schema change
+//! incrementally for population #1 and is a no-op for population #2
+//! (`ALTER COLUMN ... DROP NOT NULL` is idempotent), so both populations
+//! converge to the same final schema.
+//!
+//! ## Why this is safe and narrowly scoped
+//!
+//! - We only touch one row: `version = 6 AND name = 'routines'`.
+//! - We only update when the stored checksum disagrees with the embedded
+//!   one — so on a clean install or already-realigned database the call
+//!   is a no-op.
+//! - We never disable refinery's checksum validation
+//!   (`set_abort_divergent(false)`) — that would mask future genuine drift.
+//! - The set of known divergences is hard-coded as a list, so adding a
+//!   future fix-up is an explicit code change visible in review.
+//!
+//! See also `migrations/checksums.lock` and the
+//! `released_migrations_are_immutable` test, which together prevent any
+//! future PR from modifying an already-released migration.
+
+use deadpool_postgres::Object as PgClient;
+use refinery::Migration;
+
+use crate::error::DatabaseError;
+
+/// One known historical migration whose on-disk content was modified after
+/// release. Add a new entry here only if the same accident ever happens
+/// again — the immutability test in `migrations/checksums.lock` is the
+/// preferred guard.
+struct KnownDivergence {
+    version: i32,
+    name: &'static str,
+    /// The current (canonical) SQL content, embedded at compile time.
+    sql: &'static str,
+}
+
+const KNOWN_DIVERGENCES: &[KnownDivergence] = &[KnownDivergence {
+    version: 6,
+    name: "routines",
+    sql: include_str!("../../migrations/V6__routines.sql"),
+}];
+
+/// Realign `refinery_schema_history` rows whose stored checksum disagrees
+/// with the canonical checksum of the embedded migration. Must be called
+/// before `refinery::Runner::run_async`.
+pub async fn realign_diverged_checksums(client: &mut PgClient) -> Result<(), DatabaseError> {
+    // On a fresh install the history table does not yet exist. Refinery
+    // will create it during the first `run_async()` call. There is nothing
+    // to realign in that case.
+    let history_exists: bool = client
+        .query_one(
+            "SELECT to_regclass('public.refinery_schema_history') IS NOT NULL",
+            &[],
+        )
+        .await
+        .map_err(|e| DatabaseError::Migration(format!("probe refinery_schema_history: {e}")))?
+        .get(0);
+
+    if !history_exists {
+        return Ok(());
+    }
+
+    for divergence in KNOWN_DIVERGENCES {
+        // Compute the canonical checksum the same way refinery does
+        // (SipHasher13 over name, version, sql in that order). Refinery
+        // stores the resulting u64 as a decimal string in the `checksum`
+        // column.
+        let migration_label = format!("V{}__{}", divergence.version, divergence.name);
+        let migration = Migration::unapplied(&migration_label, divergence.sql).map_err(|e| {
+            DatabaseError::Migration(format!(
+                "compute canonical checksum for {migration_label}: {e}"
+            ))
+        })?;
+        let canonical_checksum = migration.checksum().to_string();
+
+        let updated = client
+            .execute(
+                "UPDATE refinery_schema_history \
+                 SET checksum = $1 \
+                 WHERE version = $2 AND name = $3 AND checksum <> $1",
+                &[&canonical_checksum, &divergence.version, &divergence.name],
+            )
+            .await
+            .map_err(|e| {
+                DatabaseError::Migration(format!("realign checksum for {migration_label}: {e}"))
+            })?;
+
+        if updated > 0 {
+            tracing::warn!(
+                migration = %migration_label,
+                rows = updated,
+                "Realigned refinery_schema_history checksum (issue #1328 fix-up). \
+                 Migration content matches the v0.18.0 release; the schema \
+                 change introduced in PR #1151 is applied incrementally by \
+                 V13__owner_scope_notify_targets."
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn migrations_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("migrations")
+    }
+
+    fn parse_lockfile(contents: &str) -> HashMap<String, u64> {
+        let mut map = HashMap::new();
+        for (lineno, raw) in contents.lines().enumerate() {
+            let line = raw.trim();
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let (key, value) = line.split_once('=').unwrap_or_else(|| {
+                panic!(
+                    "checksums.lock line {} is not `name = checksum`: {raw}",
+                    lineno + 1
+                )
+            });
+            let parsed: u64 = value.trim().parse().unwrap_or_else(|e| {
+                panic!(
+                    "checksums.lock line {} has invalid u64 checksum {value}: {e}",
+                    lineno + 1
+                )
+            });
+            map.insert(key.trim().to_string(), parsed);
+        }
+        map
+    }
+
+    /// Immutability guard for released migrations.
+    ///
+    /// Modifying an already-released migration is silently catastrophic:
+    /// production databases store a checksum of the original content and
+    /// refinery aborts on startup if the file changes (see issue #1328).
+    /// This test pins every migration's checksum to a value in
+    /// `migrations/checksums.lock`. Modifying any released migration —
+    /// even by a single character — fails this test. Adding a new
+    /// migration also fails this test until you add a matching lockfile
+    /// entry in the same commit.
+    ///
+    /// **If this test fails, do not "fix" it by editing the lockfile to
+    /// match.** The correct response is almost always:
+    ///
+    /// 1. Revert your edit to the released migration.
+    /// 2. Put the schema change in a *new* `V<next>__*.sql` migration.
+    /// 3. Add the new migration's checksum to `checksums.lock`.
+    ///
+    /// The only legitimate reason to overwrite an existing lockfile entry
+    /// is if the migration has *never* shipped on `staging` or `main`
+    /// (still in your local feature branch). When in doubt, ask.
+    #[test]
+    fn released_migrations_are_immutable() {
+        let dir = migrations_dir();
+        let lockfile_path = dir.join("checksums.lock");
+        let lockfile_contents = std::fs::read_to_string(&lockfile_path).unwrap_or_else(|e| {
+            panic!(
+                "missing {}: {e}\nRun `cargo test -p ironclaw -- --ignored \
+                 regenerate_migration_checksums_lockfile` to bootstrap it.",
+                lockfile_path.display()
+            )
+        });
+        let expected = parse_lockfile(&lockfile_contents);
+
+        let mut sql_files: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                if path.extension().and_then(|s| s.to_str()) == Some("sql") {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        sql_files.sort();
+
+        let mut errors = Vec::new();
+        let mut seen = std::collections::HashSet::new();
+
+        for path in &sql_files {
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap();
+            let sql = std::fs::read_to_string(path).unwrap();
+            let migration = match Migration::unapplied(stem, &sql) {
+                Ok(m) => m,
+                Err(e) => {
+                    errors.push(format!("{stem}: invalid migration name or SQL: {e}"));
+                    continue;
+                }
+            };
+            let actual = migration.checksum();
+            seen.insert(stem.to_string());
+
+            match expected.get(stem) {
+                Some(&pinned) if pinned == actual => {}
+                Some(&pinned) => errors.push(format!(
+                    "{stem}: checksum mismatch — file produces {actual}, \
+                     lockfile pins {pinned}. \
+                     If you intentionally modified this migration AND it has \
+                     never shipped on staging/main, update checksums.lock. \
+                     Otherwise REVERT your edit and put the change in a new \
+                     migration."
+                )),
+                None => errors.push(format!(
+                    "{stem}: missing from migrations/checksums.lock. \
+                     Add `{stem} = {actual}` to checksums.lock in this commit."
+                )),
+            }
+        }
+
+        for pinned in expected.keys() {
+            if !seen.contains(pinned) {
+                errors.push(format!(
+                    "{pinned}: present in checksums.lock but no matching \
+                     migrations/{pinned}.sql file exists. Did you delete a \
+                     released migration?"
+                ));
+            }
+        }
+
+        if !errors.is_empty() {
+            panic!(
+                "released migrations are immutable — {} problem(s):\n  - {}",
+                errors.len(),
+                errors.join("\n  - ")
+            );
+        }
+    }
+
+    /// Bootstrap helper. Run with:
+    ///
+    /// ```text
+    /// cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile
+    /// ```
+    ///
+    /// Writes a fresh `migrations/checksums.lock` from the current
+    /// filesystem state. Only use this when intentionally adding a new
+    /// migration or bootstrapping the lockfile for the first time.
+    #[test]
+    #[ignore]
+    fn regenerate_migration_checksums_lockfile() {
+        let dir = migrations_dir();
+        let mut sql_files: Vec<_> = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|entry| {
+                let path = entry.ok()?.path();
+                if path.extension().and_then(|s| s.to_str()) == Some("sql") {
+                    Some(path)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        sql_files.sort();
+
+        let mut output = String::new();
+        output.push_str(
+            "# Released migration checksums (refinery SipHasher13 over name+version+sql).\n\
+             #\n\
+             # This file is the immutability guard for released migrations. The\n\
+             # `released_migrations_are_immutable` test in src/db/migration_fixup.rs\n\
+             # asserts every migration listed below still hashes to the pinned value\n\
+             # and that every migration on disk has a pinned value here.\n\
+             #\n\
+             # Modifying a released migration is forbidden — it desyncs every\n\
+             # production database from refinery's checksum validation. See issue\n\
+             # #1328 for the historical accident this guard prevents.\n\
+             #\n\
+             # When adding a new migration, append a new line in the same commit.\n\
+             # Regenerate locally with:\n\
+             #   cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile\n\n",
+        );
+        for path in &sql_files {
+            let stem = path.file_stem().and_then(|s| s.to_str()).unwrap();
+            let sql = std::fs::read_to_string(path).unwrap();
+            let migration = Migration::unapplied(stem, &sql).unwrap();
+            output.push_str(&format!("{stem} = {}\n", migration.checksum()));
+        }
+
+        let lockfile_path = dir.join("checksums.lock");
+        std::fs::write(&lockfile_path, output).unwrap();
+        eprintln!("wrote {}", lockfile_path.display());
+    }
+
+    /// Sanity check that the embedded V6 SQL still hashes to the v0.18.0
+    /// checksum. If this fails, V6 has been re-modified and issue #1328
+    /// will recur on every existing PostgreSQL deployment.
+    ///
+    /// This test pins the literal checksum value as a second line of
+    /// defence: a malicious or careless edit that updates *both* V6 and
+    /// `checksums.lock` would still defeat `released_migrations_are_immutable`,
+    /// but it cannot defeat this hard-coded sentinel.
+    #[test]
+    fn v6_routines_matches_v018_checksum() {
+        // The v0.18.0 V6__routines.sql checksum (refinery's SipHasher13
+        // over name "routines" + version 6 + the original SQL content).
+        // This is the value stored in `refinery_schema_history` on every
+        // pre-#1151 PostgreSQL deployment. Do not change.
+        const V018_V6_CHECKSUM: u64 = 18049045188188232070;
+
+        let on_disk = std::fs::read_to_string(migrations_dir().join("V6__routines.sql")).unwrap();
+        let embedded = KNOWN_DIVERGENCES[0].sql;
+        assert_eq!(
+            embedded, on_disk,
+            "embedded V6 SQL has drifted from migrations/V6__routines.sql"
+        );
+
+        let migration = Migration::unapplied("V6__routines", &on_disk).unwrap();
+        assert_eq!(
+            migration.checksum(),
+            V018_V6_CHECKSUM,
+            "V6__routines.sql has been modified — it no longer matches the \
+             v0.18.0 checksum and issue #1328 will recur on every existing \
+             PostgreSQL deployment. Revert your edit and put the schema \
+             change in a new migration."
+        );
+    }
+}

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -10,6 +10,9 @@
 //! types become thin wrappers that delegate to `Arc<dyn Database>`.
 
 #[cfg(feature = "postgres")]
+pub mod migration_fixup;
+
+#[cfg(feature = "postgres")]
 pub mod postgres;
 
 #[cfg(feature = "postgres")]

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -60,28 +60,14 @@ impl Store {
         Ok(Self { pool })
     }
 
-    /// Run database migrations (embedded via refinery).
+    /// Run database migrations: acquires the migration advisory lock,
+    /// realigns any historically diverged checksums (issue #1328), then
+    /// runs refinery's embedded migrations. All bundled into a single
+    /// helper so this call site cannot drift from
+    /// `SetupWizard::run_migrations_postgres` (see PR #2101 review).
     pub async fn run_migrations(&self) -> Result<(), DatabaseError> {
-        use refinery::embed_migrations;
-        embed_migrations!("migrations");
-
         let mut client = self.pool.get().await?;
-
-        // Realign any historically modified migration checksums before
-        // refinery validates them. See `crate::db::migration_fixup` and
-        // issue #1328 for context.
-        //
-        // NOTE: this same fix-up call is duplicated in
-        // `src/setup/wizard.rs::Wizard::run_migrations_postgres`. If you
-        // change one, change the other — both call sites embed refinery
-        // migrations independently and must stay in sync.
-        crate::db::migration_fixup::realign_diverged_checksums(&mut client).await?;
-
-        migrations::runner()
-            .run_async(&mut **client)
-            .await
-            .map_err(|e| DatabaseError::Migration(e.to_string()))?;
-        Ok(())
+        crate::db::migration_fixup::run_postgres_migrations_with_fixup(&mut client).await
     }
 
     /// Get a connection from the pool.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -70,6 +70,11 @@ impl Store {
         // Realign any historically modified migration checksums before
         // refinery validates them. See `crate::db::migration_fixup` and
         // issue #1328 for context.
+        //
+        // NOTE: this same fix-up call is duplicated in
+        // `src/setup/wizard.rs::Wizard::run_migrations_postgres`. If you
+        // change one, change the other — both call sites embed refinery
+        // migrations independently and must stay in sync.
         crate::db::migration_fixup::realign_diverged_checksums(&mut client).await?;
 
         migrations::runner()

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -66,6 +66,12 @@ impl Store {
         embed_migrations!("migrations");
 
         let mut client = self.pool.get().await?;
+
+        // Realign any historically modified migration checksums before
+        // refinery validates them. See `crate::db::migration_fixup` and
+        // issue #1328 for context.
+        crate::db::migration_fixup::realign_diverged_checksums(&mut client).await?;
+
         migrations::runner()
             .run_async(&mut **client)
             .await

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -909,6 +909,11 @@ impl SetupWizard {
             // Realign any historically modified migration checksums before
             // refinery validates them. See `crate::db::migration_fixup` and
             // issue #1328 for context.
+            //
+            // NOTE: this same fix-up call is duplicated in
+            // `src/history/store.rs::Store::run_migrations`. If you change
+            // one, change the other — both call sites embed refinery
+            // migrations independently and must stay in sync.
             crate::db::migration_fixup::realign_diverged_checksums(&mut client)
                 .await
                 .map_err(|e| SetupError::Database(format!("Migration fix-up failed: {}", e)))?;

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -890,12 +890,15 @@ impl SetupWizard {
     }
 
     /// Run PostgreSQL migrations.
+    ///
+    /// Delegates to `crate::db::migration_fixup::run_postgres_migrations_with_fixup`,
+    /// which acquires the migration advisory lock, realigns any historically
+    /// diverged checksums (issue #1328), then runs refinery's embedded
+    /// migrations. Bundled into a single helper so this call site cannot
+    /// drift from `Store::run_migrations` (see PR #2101 review).
     #[cfg(feature = "postgres")]
     async fn run_migrations_postgres(&self) -> Result<(), SetupError> {
         if let Some(ref pool) = self.db_pool {
-            use refinery::embed_migrations;
-            embed_migrations!("migrations");
-
             if !self.config.quick {
                 print_info("Running migrations...");
             }
@@ -906,20 +909,7 @@ impl SetupWizard {
                 .await
                 .map_err(|e| SetupError::Database(format!("Pool error: {}", e)))?;
 
-            // Realign any historically modified migration checksums before
-            // refinery validates them. See `crate::db::migration_fixup` and
-            // issue #1328 for context.
-            //
-            // NOTE: this same fix-up call is duplicated in
-            // `src/history/store.rs::Store::run_migrations`. If you change
-            // one, change the other — both call sites embed refinery
-            // migrations independently and must stay in sync.
-            crate::db::migration_fixup::realign_diverged_checksums(&mut client)
-                .await
-                .map_err(|e| SetupError::Database(format!("Migration fix-up failed: {}", e)))?;
-
-            migrations::runner()
-                .run_async(&mut **client)
+            crate::db::migration_fixup::run_postgres_migrations_with_fixup(&mut client)
                 .await
                 .map_err(|e| SetupError::Database(format!("Migration failed: {}", e)))?;
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -906,6 +906,13 @@ impl SetupWizard {
                 .await
                 .map_err(|e| SetupError::Database(format!("Pool error: {}", e)))?;
 
+            // Realign any historically modified migration checksums before
+            // refinery validates them. See `crate::db::migration_fixup` and
+            // issue #1328 for context.
+            crate::db::migration_fixup::realign_diverged_checksums(&mut client)
+                .await
+                .map_err(|e| SetupError::Database(format!("Migration fix-up failed: {}", e)))?;
+
             migrations::runner()
                 .run_async(&mut **client)
                 .await


### PR DESCRIPTION
## Summary

Fixes #1328. Upgrading from v0.18.0 (or any earlier release) to v0.19.0 currently fails on startup with `applied migration V6__routines is different than filesystem one V6__routines` because PR #1151 modified `migrations/V6__routines.sql` in place after it had already shipped and been applied to production databases.

This PR repairs the regression for both populations of databases in the wild **and** adds a CI guard so the same accident cannot happen again.

### The runtime fix

- Reverts `migrations/V6__routines.sql` to its v0.18.0 content. `V13__owner_scope_notify_targets.sql` already applies the schema change incrementally and is idempotent (`ALTER COLUMN ... DROP NOT NULL` is a no-op when the column is already nullable).
- Adds `src/db/migration_fixup.rs::realign_diverged_checksums()`, called from both `Store::run_migrations` (`src/history/store.rs`) and `Wizard::run_migrations_postgres` (`src/setup/wizard.rs`) immediately before refinery validates. It recomputes V6's canonical SipHasher13 checksum from the embedded SQL via `refinery::Migration::unapplied()` and rewrites any divergent row in `refinery_schema_history`. Idempotent: no-op on fresh installs and already-aligned databases.

This handles **both** populations:
| Population | `refinery_schema_history` before | After fix-up |
|---|---|---|
| Pre-#1151 (v0.18.0 or earlier) | original V6 checksum | unchanged (already canonical) |
| Post-#1151 (v0.19.0 fresh installs) | modified V6 checksum | rewritten to canonical |

We deliberately do **not** disable refinery's checksum validation (`set_abort_divergent(false)`) — that would mask future genuine drift. The set of known divergences is a hard-coded list so any future fix-up is an explicit code change visible in review.

### The "never again" guard

- `migrations/checksums.lock` pins every migration's SipHasher13 checksum (the same value refinery stores in production databases).
- `released_migrations_are_immutable` (`src/db/migration_fixup.rs`) is a `cargo test` test that loads the lockfile, recomputes every `V*.sql` checksum, and fails if any value drifts or any migration is missing from the lockfile. **Modifying a released migration → CI fails. Adding a new migration → must add a lockfile line in the same PR.**
- `v6_routines_matches_v018_checksum` is a second line of defence pinning V6's literal checksum `18049045188188232070` as a hard-coded sentinel — a malicious or careless edit of both V6 and the lockfile would defeat the previous test but not this one.
- `regenerate_migration_checksums_lockfile` (ignored) is the bootstrap helper for new migrations: `cargo test -p ironclaw -- --ignored regenerate_migration_checksums_lockfile`.

libSQL is unaffected: `INCREMENTAL_MIGRATIONS` in `libsql_migrations.rs` is keyed by name (not checksumed) and the corresponding `routine_notify_user_nullable` entry is already idempotent.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo check --no-default-features --features libsql` — libSQL-only build clean
- [x] `cargo test --lib db::migration_fixup` — 2 passed, 1 ignored (bootstrap helper)
- [x] `cargo test --lib` — 4245 passed; the only failure (`extensions::manager::tests::test_telegram_token_colon_preserved_in_validation_url`) is a pre-existing flake on staging unrelated to this PR (filed separately)
- [ ] **Manual upgrade smoke test on a v0.18.0 PostgreSQL database** — recommended before merge:
  1. Start a PG instance, run v0.18.0 IronClaw against it (V1–V12 applied)
  2. Switch to this branch and start IronClaw — should succeed, V13 should apply, no checksum error
  3. Restart IronClaw — should be a no-op (no warn log for realignment)
- [ ] **Manual smoke test on a v0.19.0 fresh-install database** — also recommended:
  1. Start a clean PG instance, run staging (or v0.19.0) — V1–V20 applied with the modified V6 checksum
  2. Switch to this branch and start IronClaw — should succeed; should log one realignment warning for V6
  3. Restart IronClaw — should be a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)