### PR TITLE
fix(web): emit Done after response — SSE ordering fix (#2079)

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -33,6 +33,41 @@ use crate::workspace::Workspace;
 use ironclaw_safety::SafetyLayer;
 use ironclaw_skills::SkillRegistry;
 
+/// Outcome of [`Agent::handle_message`] — drives the run-loop's response/Done dispatch.
+///
+/// Distinguishes "no response, turn is over" from "no response, turn is paused"
+/// so the run loop can decide whether to emit the terminal `Done` status. Sending
+/// `Done` after a pause (e.g. while awaiting tool approval) is incorrect because
+/// the thread is not in a terminal state, and would also trip the web UI's
+/// missing-response safety net (see #2079).
+#[derive(Debug)]
+enum HandleOutcome {
+    /// Shutdown signal (e.g. `/quit`). Run loop should break.
+    Shutdown,
+    /// Send this content via the channel, then emit terminal `Done`.
+    Respond(String),
+    /// No response to send, but the turn is complete — emit `Done` only.
+    NoResponse,
+    /// Turn is paused (awaiting approval/auth/etc). Do not emit `Done`.
+    Pending,
+}
+
+impl HandleOutcome {
+    /// Convert a legacy `Option<String>` return into a [`HandleOutcome`].
+    ///
+    /// `None` → `Shutdown`, empty string → `NoResponse`, otherwise `Respond`.
+    /// Used to wrap bridge handlers that still return `Option<String>`. Bridge
+    /// approval flows return non-empty descriptive text, so they never need the
+    /// `Pending` variant — only the v1 `process_user_input` path does.
+    fn from_legacy(opt: Option<String>) -> Self {
+        match opt {
+            None => HandleOutcome::Shutdown,
+            Some(s) if s.is_empty() => HandleOutcome::NoResponse,
+            Some(s) => HandleOutcome::Respond(s),
+        }
+    }
+}
+
 /// Static greeting persisted to DB and broadcast on first launch.
 ///
 /// Collapse a tool output string into a single-line preview for display.
@@ -992,7 +1027,7 @@ impl Agent {
             self.store_extracted_documents(&message).await;
 
             match self.handle_message(&message).await {
-                Ok(Some(response)) if !response.is_empty() => {
+                Ok(HandleOutcome::Respond(response)) => {
                     // Hook: BeforeOutbound — allow hooks to modify or suppress outbound
                     let event = crate::hooks::HookEvent::Outbound {
                         user_id: message.user_id.clone(),
@@ -1035,18 +1070,28 @@ impl Agent {
                         }
                     }
                 }
-                Ok(Some(empty)) => {
-                    // Empty response, nothing to send (e.g. approval handled via send_status).
-                    // Still send Done so the client knows the turn is complete.
+                Ok(HandleOutcome::NoResponse) => {
+                    // Empty response (e.g. routine consumed the message, silent reply).
+                    // Send Done so the client knows the turn is complete.
                     tracing::debug!(
                         channel = %message.channel,
                         user = %message.user_id,
-                        empty_len = empty.len(),
                         "Suppressed empty response (not sent to channel)"
                     );
                     self.send_done(&message).await;
                 }
-                Ok(None) => {
+                Ok(HandleOutcome::Pending) => {
+                    // Turn paused awaiting user action (approval, auth, etc).
+                    // Do NOT emit Done — the thread is not in a terminal state.
+                    // The relevant ApprovalNeeded/AuthRequired status was already
+                    // sent by the inner handler before returning.
+                    tracing::debug!(
+                        channel = %message.channel,
+                        user = %message.user_id,
+                        "Turn paused (Pending); suppressing Done"
+                    );
+                }
+                Ok(HandleOutcome::Shutdown) => {
                     // Shutdown signal received (/quit, /exit, /shutdown)
                     tracing::debug!("Shutdown command received, exiting...");
                     break;
@@ -1153,7 +1198,7 @@ impl Agent {
         }
     }
 
-    async fn handle_message(&self, message: &IncomingMessage) -> Result<Option<String>, Error> {
+    async fn handle_message(&self, message: &IncomingMessage) -> Result<HandleOutcome, Error> {
         // Log sensitive details at debug level for troubleshooting
         tracing::debug!(
             message_id = %message.id,
@@ -1174,7 +1219,7 @@ impl Agent {
                 channel = %message.channel,
                 "Forwarding internal message"
             );
-            return Ok(Some(message.content.clone()));
+            return Ok(HandleOutcome::Respond(message.content.clone()));
         }
 
         // Set message tool context for this turn (current channel and target)
@@ -1204,10 +1249,16 @@ impl Agent {
             };
             match self.hooks().run(&event).await {
                 Err(crate::hooks::HookError::Rejected { reason }) => {
-                    return Ok(Some(format!("[Message rejected: {}]", reason)));
+                    return Ok(HandleOutcome::Respond(format!(
+                        "[Message rejected: {}]",
+                        reason
+                    )));
                 }
                 Err(err) => {
-                    return Ok(Some(format!("[Message blocked by hook policy: {}]", err)));
+                    return Ok(HandleOutcome::Respond(format!(
+                        "[Message blocked by hook policy: {}]",
+                        err
+                    )));
                 }
                 Ok(crate::hooks::HookOutcome::Continue {
                     modified: Some(new_content),
@@ -1220,11 +1271,16 @@ impl Agent {
             }
         }
 
-        // Engine V2 routing (Strategy C: parallel deployment)
+        // Engine V2 routing (Strategy C: parallel deployment).
+        // Bridge handlers return `Option<String>` legacy results; wrap with
+        // `HandleOutcome::from_legacy`. Bridge approval flows emit non-empty
+        // descriptive text, so they map to `Respond` (not `Pending`).
         if self.config.engine_v2 {
             match &submission {
                 Submission::UserInput { content } => {
-                    return crate::bridge::handle_with_engine(self, message, content).await;
+                    return crate::bridge::handle_with_engine(self, message, content)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 Submission::ApprovalResponse { approved, always } => {
                     // If there's a pending auth, "cancel"/"no" should clear the
@@ -1232,9 +1288,13 @@ impl Agent {
                     // Route through handle_with_engine so PendingAuth is checked.
                     if crate::bridge::has_pending_auth(&message.user_id).await {
                         let content = &message.content;
-                        return crate::bridge::handle_with_engine(self, message, content).await;
+                        return crate::bridge::handle_with_engine(self, message, content)
+                            .await
+                            .map(HandleOutcome::from_legacy);
                     }
-                    return crate::bridge::handle_approval(self, message, *approved, *always).await;
+                    return crate::bridge::handle_approval(self, message, *approved, *always)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 Submission::ExecApproval {
                     request_id,
@@ -1248,19 +1308,28 @@ impl Agent {
                         *approved,
                         *always,
                     )
-                    .await;
+                    .await
+                    .map(HandleOutcome::from_legacy);
                 }
                 Submission::Interrupt => {
-                    return crate::bridge::handle_interrupt(self, message).await;
+                    return crate::bridge::handle_interrupt(self, message)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 Submission::NewThread => {
-                    return crate::bridge::handle_new_thread(self, message).await;
+                    return crate::bridge::handle_new_thread(self, message)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 Submission::Clear => {
-                    return crate::bridge::handle_clear(self, message).await;
+                    return crate::bridge::handle_clear(self, message)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 Submission::Expected { description } => {
-                    return crate::bridge::handle_expected(self, message, description).await;
+                    return crate::bridge::handle_expected(self, message, description)
+                        .await
+                        .map(HandleOutcome::from_legacy);
                 }
                 // Undo/Redo/Resume/SwitchThread: v1-only (engine has no undo;
                 // thread switching is implicit via ConversationManager).
@@ -1278,7 +1347,7 @@ impl Agent {
                 "Hydrating thread from DB"
             );
             if let Some(rejection) = self.maybe_hydrate_thread(message, external_thread_id).await {
-                return Ok(Some(format!("Error: {}", rejection)));
+                return Ok(HandleOutcome::Respond(format!("Error: {}", rejection)));
             }
         }
 
@@ -1315,7 +1384,9 @@ impl Agent {
                         "Blocked approval for thread with no pending approval"
                     );
                     drop(sess);
-                    return Ok(Some("Error: no pending approval on this thread".into()));
+                    return Ok(HandleOutcome::Respond(
+                        "Error: no pending approval on this thread".into(),
+                    ));
                 }
 
                 let authorized = crate::agent::session::is_approval_authorized(
@@ -1330,7 +1401,7 @@ impl Agent {
                         "Blocked cross-channel approval attempt"
                     );
                     drop(sess);
-                    return Ok(Some(
+                    return Ok(HandleOutcome::Respond(
                         "Error: approval not authorized for this channel".into(),
                     ));
                 }
@@ -1398,7 +1469,7 @@ impl Agent {
                 // If this was a user message (possibly a pasted token), return an
                 // explicit error instead of forwarding it to the LLM/history.
                 if matches!(submission, Submission::UserInput { .. }) {
-                    return Ok(Some(format!(
+                    return Ok(HandleOutcome::Respond(format!(
                         "Authentication for **{}** expired. Please try again.",
                         pending.extension_name
                     )));
@@ -1409,7 +1480,8 @@ impl Agent {
                     Submission::UserInput { content } => {
                         return self
                             .process_auth_token(message, &pending, content, session, thread_id)
-                            .await;
+                            .await
+                            .map(HandleOutcome::from_legacy);
                     }
                     _ => {
                         // Any control submission (interrupt, undo, etc.) cancels auth mode
@@ -1450,9 +1522,9 @@ impl Agent {
                     "Consumed inbound user message with matching event-triggered routine(s)"
                 );
                 return if single_message_repl {
-                    Ok(None)
+                    Ok(HandleOutcome::Shutdown)
                 } else {
-                    Ok(Some(String::new()))
+                    Ok(HandleOutcome::NoResponse)
                 };
             }
         }
@@ -1577,16 +1649,18 @@ impl Agent {
                         .handle_reasoning_command(&args, &session, thread_id)
                         .await;
                     return match result {
-                        SubmissionResult::Response { content } => Ok(Some(content)),
-                        SubmissionResult::Ok { message } => Ok(message),
+                        SubmissionResult::Response { content } => {
+                            Ok(HandleOutcome::Respond(content))
+                        }
+                        SubmissionResult::Ok { message } => Ok(HandleOutcome::from_legacy(message)),
                         SubmissionResult::Error { message } => {
-                            Ok(Some(format!("Error: {}", message)))
+                            Ok(HandleOutcome::Respond(format!("Error: {}", message)))
                         }
                         _ => {
                             if is_single_message_repl(message) {
-                                Ok(None)
+                                Ok(HandleOutcome::Shutdown)
                             } else {
-                                Ok(Some(String::new()))
+                                Ok(HandleOutcome::NoResponse)
                             }
                         }
                     };
@@ -1612,7 +1686,7 @@ impl Agent {
                 self.process_job_status(&tenant, job_id.as_deref()).await
             }
             Submission::JobCancel { job_id } => self.process_job_cancel(&tenant, &job_id).await,
-            Submission::Quit => return Ok(None),
+            Submission::Quit => return Ok(HandleOutcome::Shutdown),
             Submission::SwitchThread { thread_id: target } => {
                 self.process_switch_thread(message, target).await
             }
@@ -1675,15 +1749,18 @@ impl Agent {
             }
         };
 
-        // Convert SubmissionResult to response string
+        // Convert SubmissionResult to a HandleOutcome.
         match result? {
             SubmissionResult::Response { content } => {
-                // Suppress silent replies (e.g. from group chat "nothing to say" responses)
+                // Suppress silent replies (e.g. from group chat "nothing to say" responses).
+                // Silent replies exit single-message REPL invocations.
                 if crate::llm::is_silent_reply(&content) {
                     tracing::debug!("Suppressing silent reply token");
-                    Ok(None)
+                    Ok(HandleOutcome::Shutdown)
+                } else if content.is_empty() {
+                    Ok(HandleOutcome::NoResponse)
                 } else {
-                    Ok(Some(content))
+                    Ok(HandleOutcome::Respond(content))
                 }
             }
             SubmissionResult::Ok {
@@ -1701,18 +1778,22 @@ impl Agent {
                     };
 
                 if should_exit {
-                    Ok(None)
+                    Ok(HandleOutcome::Shutdown)
                 } else {
-                    Ok(output_message)
+                    Ok(HandleOutcome::from_legacy(output_message))
                 }
             }
-            SubmissionResult::Error { message } => Ok(Some(format!("Error: {}", message))),
-            SubmissionResult::Interrupted => Ok(Some("Interrupted.".into())),
+            SubmissionResult::Error { message } => {
+                Ok(HandleOutcome::Respond(format!("Error: {}", message)))
+            }
+            SubmissionResult::Interrupted => Ok(HandleOutcome::Respond("Interrupted.".into())),
             SubmissionResult::NeedApproval { .. } => {
                 // ApprovalNeeded status was already sent by thread_ops.rs before
-                // returning this result. Empty string signals the caller to skip
-                // respond() (no duplicate text).
-                Ok(Some(String::new()))
+                // returning this result. The thread is now in AwaitingApproval —
+                // do NOT emit a terminal Done because the turn is paused, not
+                // complete. Sending Done here would also trip the web UI's
+                // missing-response safety net (see #2079).
+                Ok(HandleOutcome::Pending)
             }
         }
     }

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -979,6 +979,23 @@ impl Agent {
                     match self.hooks().run(&event).await {
                         Err(err) => {
                             tracing::warn!("BeforeOutbound hook blocked response: {}", err);
+                            // Still send Done so the client knows the turn is complete
+                            // even though the response was suppressed by the hook.
+                            if let Err(e) = self
+                                .channels
+                                .send_status(
+                                    &message.channel,
+                                    StatusUpdate::Status("Done".into()),
+                                    &message.metadata,
+                                )
+                                .await
+                            {
+                                tracing::warn!(
+                                    channel = %message.channel,
+                                    error = %e,
+                                    "Failed to send Done status after hook-blocked response"
+                                );
+                            }
                         }
                         Ok(crate::hooks::HookOutcome::Continue {
                             modified: Some(new_content),
@@ -1009,13 +1026,29 @@ impl Agent {
                     }
                 }
                 Ok(Some(empty)) => {
-                    // Empty response, nothing to send (e.g. approval handled via send_status)
+                    // Empty response, nothing to send (e.g. approval handled via send_status).
+                    // Still send Done so the client knows the turn is complete.
                     tracing::debug!(
                         channel = %message.channel,
                         user = %message.user_id,
                         empty_len = empty.len(),
                         "Suppressed empty response (not sent to channel)"
                     );
+                    if let Err(e) = self
+                        .channels
+                        .send_status(
+                            &message.channel,
+                            StatusUpdate::Status("Done".into()),
+                            &message.metadata,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            channel = %message.channel,
+                            error = %e,
+                            "Failed to send Done status after empty response"
+                        );
+                    }
                 }
                 Ok(None) => {
                     // Shutdown signal received (/quit, /exit, /shutdown)

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -321,7 +321,9 @@ impl Agent {
         message: &IncomingMessage,
         response: OutgoingResponse,
     ) -> Result<(), ChannelError> {
-        self.channels.respond(message, response).await?;
+        let respond_result = self.channels.respond(message, response).await;
+        // Always emit Done regardless of whether respond succeeded, so the
+        // client knows the turn is over even when the response delivery fails.
         if let Err(e) = self
             .channels
             .send_status(
@@ -337,7 +339,29 @@ impl Agent {
                 "Failed to send Done status after response"
             );
         }
-        Ok(())
+        respond_result
+    }
+
+    /// Emit the terminal "Done" status without sending a response first.
+    ///
+    /// Used by code paths that suppress the response (hook-blocked, empty
+    /// response) but still need to close the turn for the client.
+    async fn send_done(&self, message: &IncomingMessage) {
+        if let Err(e) = self
+            .channels
+            .send_status(
+                &message.channel,
+                StatusUpdate::Status("Done".into()),
+                &message.metadata,
+            )
+            .await
+        {
+            tracing::warn!(
+                channel = %message.channel,
+                error = %e,
+                "Failed to send Done status"
+            );
+        }
     }
 
     pub(crate) fn llm(&self) -> &Arc<dyn LlmProvider> {
@@ -981,21 +1005,7 @@ impl Agent {
                             tracing::warn!("BeforeOutbound hook blocked response: {}", err);
                             // Still send Done so the client knows the turn is complete
                             // even though the response was suppressed by the hook.
-                            if let Err(e) = self
-                                .channels
-                                .send_status(
-                                    &message.channel,
-                                    StatusUpdate::Status("Done".into()),
-                                    &message.metadata,
-                                )
-                                .await
-                            {
-                                tracing::warn!(
-                                    channel = %message.channel,
-                                    error = %e,
-                                    "Failed to send Done status after hook-blocked response"
-                                );
-                            }
+                            self.send_done(&message).await;
                         }
                         Ok(crate::hooks::HookOutcome::Continue {
                             modified: Some(new_content),
@@ -1034,21 +1044,7 @@ impl Agent {
                         empty_len = empty.len(),
                         "Suppressed empty response (not sent to channel)"
                     );
-                    if let Err(e) = self
-                        .channels
-                        .send_status(
-                            &message.channel,
-                            StatusUpdate::Status("Done".into()),
-                            &message.metadata,
-                        )
-                        .await
-                    {
-                        tracing::warn!(
-                            channel = %message.channel,
-                            error = %e,
-                            "Failed to send Done status after empty response"
-                        );
-                    }
+                    self.send_done(&message).await;
                 }
                 Ok(None) => {
                     // Shutdown signal received (/quit, /exit, /shutdown)

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -20,7 +20,7 @@ use crate::agent::session::ThreadState;
 use crate::agent::session_manager::SessionManager;
 use crate::agent::submission::{Submission, SubmissionParser, SubmissionResult};
 use crate::agent::{HeartbeatConfig as AgentHeartbeatConfig, Router, Scheduler, SchedulerDeps};
-use crate::channels::{ChannelManager, IncomingMessage, OutgoingResponse};
+use crate::channels::{ChannelManager, IncomingMessage, OutgoingResponse, StatusUpdate};
 use crate::config::{AgentConfig, HeartbeatConfig, RoutineConfig, SkillsConfig};
 use crate::context::ContextManager;
 use crate::db::Database;
@@ -309,6 +309,35 @@ impl Agent {
 
     pub(super) fn store(&self) -> Option<&Arc<dyn Database>> {
         self.deps.store.as_ref()
+    }
+
+    /// Send a response to the channel, then emit the terminal "Done" status.
+    ///
+    /// This ordering guarantees that the SSE client receives the assistant
+    /// message before the turn-closing event, preventing the web UI from
+    /// closing the turn before the message renders (see #2079).
+    async fn respond_then_done(
+        &self,
+        message: &IncomingMessage,
+        response: OutgoingResponse,
+    ) -> Result<(), ChannelError> {
+        self.channels.respond(message, response).await?;
+        if let Err(e) = self
+            .channels
+            .send_status(
+                &message.channel,
+                StatusUpdate::Status("Done".into()),
+                &message.metadata,
+            )
+            .await
+        {
+            tracing::warn!(
+                channel = %message.channel,
+                error = %e,
+                "Failed to send Done status after response"
+            );
+        }
+        Ok(())
     }
 
     pub(crate) fn llm(&self) -> &Arc<dyn LlmProvider> {
@@ -955,8 +984,7 @@ impl Agent {
                             modified: Some(new_content),
                         }) => {
                             if let Err(e) = self
-                                .channels
-                                .respond(&message, OutgoingResponse::text(new_content))
+                                .respond_then_done(&message, OutgoingResponse::text(new_content))
                                 .await
                             {
                                 tracing::error!(
@@ -968,8 +996,7 @@ impl Agent {
                         }
                         _ => {
                             if let Err(e) = self
-                                .channels
-                                .respond(&message, OutgoingResponse::text(response))
+                                .respond_then_done(&message, OutgoingResponse::text(response))
                                 .await
                             {
                                 tracing::error!(
@@ -998,8 +1025,10 @@ impl Agent {
                 Err(e) => {
                     tracing::error!("Error handling message: {}", e);
                     if let Err(send_err) = self
-                        .channels
-                        .respond(&message, OutgoingResponse::text(format!("Error: {}", e)))
+                        .respond_then_done(
+                            &message,
+                            OutgoingResponse::text(format!("Error: {}", e)),
+                        )
                         .await
                     {
                         tracing::error!(
@@ -1464,8 +1493,7 @@ impl Agent {
                     //   message. This is acceptable for the current
                     //   single-user-per-thread model.
                     if let Err(e) = self
-                        .channels
-                        .respond(message, OutgoingResponse::text(outgoing.clone()))
+                        .respond_then_done(message, OutgoingResponse::text(outgoing.clone()))
                         .await
                     {
                         tracing::warn!(

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -575,14 +575,6 @@ impl Agent {
                     .last()
                     .map(|t| (t.turn_number, t.tool_calls.clone(), t.narrative.clone()))
                     .unwrap_or_default();
-                let _ = self
-                    .channels
-                    .send_status(
-                        &message.channel,
-                        StatusUpdate::Status("Done".into()),
-                        &message.metadata,
-                    )
-                    .await;
 
                 // Persist tool calls then assistant response (user message already persisted at turn start)
                 self.persist_tool_calls(
@@ -1609,14 +1601,6 @@ impl Agent {
                         &response,
                     )
                     .await;
-                    let _ = self
-                        .channels
-                        .send_status(
-                            &message.channel,
-                            StatusUpdate::Status("Done".into()),
-                            &message.metadata,
-                        )
-                        .await;
                     if !suggestions.is_empty() {
                         let _ = self
                             .channels

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -107,6 +107,13 @@ let _connectionLostAt = null;
 let _reconnectAttempts = 0;
 let _lastSseEventId = null;
 
+// --- Turn Response Tracking State ---
+// Safety net for lost SSE response events (see #2079): tracks whether we
+// received a `response` event for the current turn so that a "Done" status
+// arriving without one can trigger a history reload.
+let _turnResponseReceived = false;
+let _doneWithoutResponseTimer = null;
+
 // --- Send Cooldown State ---
 let _sendCooldown = false;
 
@@ -670,6 +677,11 @@ function connectSSE(lastEventIdOverride) {
     const streamingMsg = document.querySelector('.message.assistant[data-streaming="true"]');
     if (streamingMsg) streamingMsg.removeAttribute('data-streaming');
 
+    _turnResponseReceived = true;
+    if (_doneWithoutResponseTimer) {
+      clearTimeout(_doneWithoutResponseTimer);
+      _doneWithoutResponseTimer = null;
+    }
     finalizeActivityGroup();
     addMessage('assistant', data.content);
     enableChatInput();
@@ -767,6 +779,19 @@ function connectSSE(lastEventIdOverride) {
     if (data.message === 'Done' || data.message === 'Awaiting approval') {
       finalizeActivityGroup();
       enableChatInput();
+      // Safety net (#2079): if "Done" arrives but we never received a
+      // `response` event for this turn, the message may have been lost
+      // (broadcast lag, proxy buffering, brief SSE disconnect). Reload
+      // history after a short delay so the user sees the answer.
+      if (!_turnResponseReceived && data.message === 'Done') {
+        if (!_doneWithoutResponseTimer) {
+          _doneWithoutResponseTimer = setTimeout(() => {
+            _doneWithoutResponseTimer = null;
+            if (currentThreadId) loadHistory();
+          }, 1500);
+        }
+      }
+      _turnResponseReceived = false;
     }
   });
 
@@ -930,6 +955,7 @@ function clearSuggestionChips() {
 function sendMessage() {
   clearSuggestionChips();
   removeWelcomeCard();
+  _turnResponseReceived = false;
   const input = document.getElementById('chat-input');
   if (authFlowPending) {
     showToast(I18n.t('chat.authRequiredBeforeSend'), 'info');

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -592,6 +592,12 @@ function connectSSE(lastEventIdOverride) {
     var statusEl = document.getElementById('sse-status');
     if (statusEl) statusEl.textContent = I18n.t('status.connected');
     _reconnectAttempts = 0;
+    // Clear stale turn-tracking state from before the disconnect
+    _turnResponseReceived = false;
+    if (_doneWithoutResponseTimer) {
+      clearTimeout(_doneWithoutResponseTimer);
+      _doneWithoutResponseTimer = null;
+    }
 
     // Dismiss connection-lost banner and show reconnected flash
     if (_connectionLostTimer) {
@@ -748,6 +754,10 @@ function connectSSE(lastEventIdOverride) {
       lastAssistant = container.querySelector('.message.assistant:last-of-type');
     }
     if (lastAssistant) lastAssistant.setAttribute('data-streaming', 'true');
+
+    // Mark turn as having received content so the Done safety net
+    // does not trigger a spurious loadHistory() for streaming responses.
+    _turnResponseReceived = true;
 
     // Accumulate chunks and debounce rendering at 50ms intervals
     _streamBuffer += data.content;
@@ -956,6 +966,10 @@ function sendMessage() {
   clearSuggestionChips();
   removeWelcomeCard();
   _turnResponseReceived = false;
+  if (_doneWithoutResponseTimer) {
+    clearTimeout(_doneWithoutResponseTimer);
+    _doneWithoutResponseTimer = null;
+  }
   const input = document.getElementById('chat-input');
   if (authFlowPending) {
     showToast(I18n.t('chat.authRequiredBeforeSend'), 'info');
@@ -2515,6 +2529,11 @@ function switchToAssistant() {
 function switchThread(threadId) {
   clearSuggestionChips();
   finalizeActivityGroup();
+  _turnResponseReceived = false;
+  if (_doneWithoutResponseTimer) {
+    clearTimeout(_doneWithoutResponseTimer);
+    _doneWithoutResponseTimer = null;
+  }
   currentThreadId = threadId;
   unreadThreads.delete(threadId);
   hasMore = false;

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -111,6 +111,10 @@ let _lastSseEventId = null;
 // Safety net for lost SSE response events (see #2079): tracks whether we
 // received a `response` event for the current turn so that a "Done" status
 // arriving without one can trigger a history reload.
+const DONE_WITHOUT_RESPONSE_TIMEOUT_MS = 1500;
+// Single-thread tracking is intentional: background thread events are already
+// filtered out by `isCurrentThread`, so only the active thread's turn state
+// matters here. Per-thread state is unnecessary.
 let _turnResponseReceived = false;
 let _doneWithoutResponseTimer = null;
 
@@ -798,7 +802,7 @@ function connectSSE(lastEventIdOverride) {
           _doneWithoutResponseTimer = setTimeout(() => {
             _doneWithoutResponseTimer = null;
             if (currentThreadId) loadHistory();
-          }, 1500);
+          }, DONE_WITHOUT_RESPONSE_TIMEOUT_MS);
         }
       }
       _turnResponseReceived = false;

--- a/tests/e2e_response_order.rs
+++ b/tests/e2e_response_order.rs
@@ -8,14 +8,61 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod response_order_tests {
+    use std::sync::Arc;
     use std::time::Duration;
+
+    use async_trait::async_trait;
 
     use crate::support::test_channel::CapturedEvent;
     use crate::support::test_rig::TestRigBuilder;
-    use crate::support::trace_llm::{LlmTrace, TraceResponse, TraceStep, TraceTurn};
+    use crate::support::trace_llm::{LlmTrace, TraceResponse, TraceStep, TraceToolCall, TraceTurn};
     use ironclaw::channels::StatusUpdate;
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
 
     const TIMEOUT: Duration = Duration::from_secs(15);
+
+    /// Tool that always requires explicit approval. Used to drive the v1
+    /// `SubmissionResult::NeedApproval` path so we can verify the agent does
+    /// **not** emit a terminal `Done` while the turn is paused awaiting input.
+    struct AlwaysApproveTool;
+
+    #[async_trait]
+    impl Tool for AlwaysApproveTool {
+        fn name(&self) -> &str {
+            "always_approve_probe"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that always requires explicit approval"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "string" }
+                },
+                "required": ["value"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            // Should never run during this test — the turn pauses on approval.
+            Ok(ToolOutput::success(
+                serde_json::json!({"ok": true}),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::Always
+        }
+    }
 
     fn single_response_trace() -> LlmTrace {
         LlmTrace::new(
@@ -67,10 +114,13 @@ mod response_order_tests {
         rig.shutdown();
     }
 
-    /// When the LLM returns an empty string, the agent suppresses the response
-    /// but must still emit a `Done` status so the client knows the turn ended.
+    /// When the LLM returns an empty Text response, the dispatcher's fallback
+    /// substitutes "I'm not sure how to respond to that." (see
+    /// `src/llm/reasoning.rs`). The agent must still send the substituted
+    /// response **before** the terminal `Done` status — same ordering invariant
+    /// as the happy path, just with the fallback text.
     #[tokio::test]
-    async fn done_emitted_for_empty_response() {
+    async fn done_emitted_after_empty_response_fallback() {
         let empty_response_trace = LlmTrace::new(
             "trace-empty-response",
             vec![TraceTurn {
@@ -96,27 +146,143 @@ mod response_order_tests {
 
         rig.send_message("Do nothing").await;
 
-        // No response will arrive, but Done must still be emitted.
-        assert!(
-            rig.wait_for_done(TIMEOUT).await,
-            "Done status must be emitted even when the response is empty"
+        // The dispatcher substitutes an empty LLM response with a fallback
+        // message, so the Response event is still captured.
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(responses.len(), 1);
+        assert_eq!(
+            responses[0].content, "I'm not sure how to respond to that.",
+            "empty LLM response should be replaced with the dispatcher fallback"
         );
 
-        // Verify no response event was emitted (the empty string is suppressed).
+        assert!(
+            rig.wait_for_done(TIMEOUT).await,
+            "Done status must be emitted after the fallback response"
+        );
+
+        // Verify the fallback Response is emitted before Done.
         let events = rig.captured_events();
+        let response_index = events
+            .iter()
+            .position(|event| matches!(event, CapturedEvent::Response(_)))
+            .expect("fallback response event not captured");
+        let done_index = events
+            .iter()
+            .position(|event| matches!(event, CapturedEvent::Status(StatusUpdate::Status(message)) if message == "Done"))
+            .expect("Done status not captured");
+        assert!(
+            response_index < done_index,
+            "fallback response must be emitted before Done"
+        );
+
+        rig.shutdown();
+    }
+
+    /// When a tool requires user approval, the agent must emit `ApprovalNeeded`
+    /// but **not** a terminal `Done` — the thread is paused, not complete.
+    /// Sending `Done` while awaiting approval would trip the web UI's
+    /// missing-response safety net (see #2079) and trigger a spurious history
+    /// reload underneath the live approval prompt.
+    #[tokio::test]
+    async fn no_done_emitted_while_awaiting_approval() {
+        let approval_trace = LlmTrace::new(
+            "trace-approval-pending",
+            vec![TraceTurn {
+                user_input: "Run the probe".to_string(),
+                steps: vec![TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::ToolCalls {
+                        tool_calls: vec![TraceToolCall {
+                            id: "call_1".to_string(),
+                            name: "always_approve_probe".to_string(),
+                            arguments: serde_json::json!({"value": "go"}),
+                        }],
+                        input_tokens: 1,
+                        output_tokens: 1,
+                    },
+                    expected_tool_results: Vec::new(),
+                }],
+                expects: Default::default(),
+            }],
+        );
+
+        let rig = TestRigBuilder::new()
+            .with_trace(approval_trace)
+            .with_extra_tools(vec![Arc::new(AlwaysApproveTool)])
+            // Disable session-level auto-approve so the approval is actually requested.
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the probe").await;
+
+        // Wait for the ApprovalNeeded status — that proves the turn reached
+        // the pause point. We poll the captured status events directly because
+        // ApprovalNeeded is not exposed via a dedicated waiter.
+        let deadline = tokio::time::Instant::now() + TIMEOUT;
+        let approval_seen = loop {
+            let seen = rig
+                .captured_status_events()
+                .iter()
+                .any(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }));
+            if seen {
+                break true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                break false;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        };
+        assert!(
+            approval_seen,
+            "ApprovalNeeded status must be emitted for the always-approve tool"
+        );
+
+        // Give the agent a small window after the approval to (incorrectly)
+        // emit a trailing Done. The bug we are guarding against happens
+        // immediately after handle_message returns, so 200ms is generous.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let events = rig.captured_events();
+
+        // No assistant Response should have been delivered — the tool never
+        // executed, so the LLM never produced a final text response.
         assert!(
             !events
                 .iter()
                 .any(|e| matches!(e, CapturedEvent::Response(_))),
-            "empty response should not produce a Response event"
+            "no Response event should be emitted while awaiting approval, got: {events:?}"
         );
 
-        // Verify Done IS present in events.
-        assert!(
-            events.iter().any(
-                |e| matches!(e, CapturedEvent::Status(StatusUpdate::Status(msg)) if msg == "Done")
-            ),
-            "Done status must appear in captured events"
+        // The critical assertion: no terminal Done while the turn is paused.
+        let done_count = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    CapturedEvent::Status(StatusUpdate::Status(msg)) if msg == "Done"
+                )
+            })
+            .count();
+        assert_eq!(
+            done_count, 0,
+            "no Done status should be emitted while awaiting approval, got events: {events:?}"
+        );
+
+        // Sanity: ApprovalNeeded should be the last status-shaped signal.
+        let approval_needed_count = events
+            .iter()
+            .filter(|e| {
+                matches!(
+                    e,
+                    CapturedEvent::Status(StatusUpdate::ApprovalNeeded { .. })
+                )
+            })
+            .count();
+        assert_eq!(
+            approval_needed_count, 1,
+            "exactly one ApprovalNeeded status should be emitted, got events: {events:?}"
         );
 
         rig.shutdown();

--- a/tests/e2e_response_order.rs
+++ b/tests/e2e_response_order.rs
@@ -1,0 +1,69 @@
+//! Regression test for web SSE ordering.
+//!
+//! The assistant response must be emitted before the terminal `Done` status
+//! so the browser can render the message before the turn closes.
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod response_order_tests {
+    use std::time::Duration;
+
+    use crate::support::test_channel::CapturedEvent;
+    use crate::support::test_rig::TestRigBuilder;
+    use crate::support::trace_llm::{LlmTrace, TraceResponse, TraceStep, TraceTurn};
+    use ironclaw::channels::StatusUpdate;
+
+    const TIMEOUT: Duration = Duration::from_secs(15);
+
+    fn single_response_trace() -> LlmTrace {
+        LlmTrace::new(
+            "trace-order-test",
+            vec![TraceTurn {
+                user_input: "Say hello".to_string(),
+                steps: vec![TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::Text {
+                        content: "Hello there".to_string(),
+                        input_tokens: 1,
+                        output_tokens: 1,
+                    },
+                    expected_tool_results: Vec::new(),
+                }],
+                expects: Default::default(),
+            }],
+        )
+    }
+
+    #[tokio::test]
+    async fn response_arrives_before_done_status() {
+        let rig = TestRigBuilder::new()
+            .with_trace(single_response_trace())
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Say hello").await;
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(responses.len(), 1);
+        assert_eq!(responses[0].content, "Hello there");
+
+        let events = rig.captured_events();
+        let response_index = events
+            .iter()
+            .position(|event| matches!(event, CapturedEvent::Response(_)))
+            .expect("response event not captured");
+        let done_index = events
+            .iter()
+            .position(|event| matches!(event, CapturedEvent::Status(StatusUpdate::Status(message)) if message == "Done"))
+            .expect("Done status not captured");
+
+        assert!(
+            response_index < done_index,
+            "response must be emitted before Done"
+        );
+
+        rig.shutdown();
+    }
+}

--- a/tests/e2e_response_order.rs
+++ b/tests/e2e_response_order.rs
@@ -66,4 +66,59 @@ mod response_order_tests {
 
         rig.shutdown();
     }
+
+    /// When the LLM returns an empty string, the agent suppresses the response
+    /// but must still emit a `Done` status so the client knows the turn ended.
+    #[tokio::test]
+    async fn done_emitted_for_empty_response() {
+        let empty_response_trace = LlmTrace::new(
+            "trace-empty-response",
+            vec![TraceTurn {
+                user_input: "Do nothing".to_string(),
+                steps: vec![TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::Text {
+                        content: String::new(),
+                        input_tokens: 1,
+                        output_tokens: 0,
+                    },
+                    expected_tool_results: Vec::new(),
+                }],
+                expects: Default::default(),
+            }],
+        );
+
+        let rig = TestRigBuilder::new()
+            .with_trace(empty_response_trace)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Do nothing").await;
+
+        // No response will arrive, but Done must still be emitted.
+        assert!(
+            rig.wait_for_done(TIMEOUT).await,
+            "Done status must be emitted even when the response is empty"
+        );
+
+        // Verify no response event was emitted (the empty string is suppressed).
+        let events = rig.captured_events();
+        assert!(
+            !events
+                .iter()
+                .any(|e| matches!(e, CapturedEvent::Response(_))),
+            "empty response should not produce a Response event"
+        );
+
+        // Verify Done IS present in events.
+        assert!(
+            events.iter().any(
+                |e| matches!(e, CapturedEvent::Status(StatusUpdate::Status(msg)) if msg == "Done")
+            ),
+            "Done status must appear in captured events"
+        );
+
+        rig.shutdown();
+    }
 }

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -18,6 +18,13 @@ use tokio_stream::wrappers::ReceiverStream;
 use ironclaw::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
 use ironclaw::error::ChannelError;
 
+/// Captured outbound event in the order it was emitted.
+#[derive(Clone, Debug)]
+pub enum CapturedEvent {
+    Response(OutgoingResponse),
+    Status(StatusUpdate),
+}
+
 // ---------------------------------------------------------------------------
 // TestChannel
 // ---------------------------------------------------------------------------
@@ -35,6 +42,8 @@ pub struct TestChannel {
     pub responses: Arc<Mutex<Vec<OutgoingResponse>>>,
     /// Captured status events.
     status_events: Arc<Mutex<Vec<StatusUpdate>>>,
+    /// Ordered log of responses and status events.
+    captured_events: Arc<Mutex<Vec<CapturedEvent>>>,
     /// Tracks when each tool started (by name). Supports nested/overlapping tools
     /// by using a Vec of start times per tool name.
     tool_start_times: Arc<Mutex<HashMap<String, Vec<Instant>>>>,
@@ -66,6 +75,7 @@ impl TestChannel {
             rx: Mutex::new(Some(rx)),
             responses: Arc::new(Mutex::new(Vec::new())),
             status_events: Arc::new(Mutex::new(Vec::new())),
+            captured_events: Arc::new(Mutex::new(Vec::new())),
             tool_start_times: Arc::new(Mutex::new(HashMap::new())),
             tool_timings: Arc::new(Mutex::new(Vec::new())),
             user_id: user_id.into(),
@@ -162,6 +172,14 @@ impl TestChannel {
             .clone()
     }
 
+    /// Return the ordered log of emitted outbound events.
+    pub fn captured_events(&self) -> Vec<CapturedEvent> {
+        self.captured_events
+            .try_lock()
+            .expect("captured_events lock contention")
+            .clone()
+    }
+
     /// Return the names of all `ToolStarted` events captured so far.
     pub fn tool_calls_started(&self) -> Vec<String> {
         self.captured_status_events()
@@ -209,6 +227,7 @@ impl TestChannel {
     pub async fn clear(&self) {
         self.responses.lock().await.clear();
         self.status_events.lock().await.clear();
+        self.captured_events.lock().await.clear();
         self.tool_start_times.lock().await.clear();
         self.tool_timings.lock().await.clear();
     }
@@ -326,7 +345,11 @@ impl Channel for TestChannel {
         _msg: &IncomingMessage,
         response: OutgoingResponse,
     ) -> Result<(), ChannelError> {
-        self.responses.lock().await.push(response);
+        self.responses.lock().await.push(response.clone());
+        self.captured_events
+            .lock()
+            .await
+            .push(CapturedEvent::Response(response));
         Ok(())
     }
 
@@ -357,7 +380,11 @@ impl Channel for TestChannel {
             }
             _ => {}
         }
-        self.status_events.lock().await.push(status);
+        self.status_events.lock().await.push(status.clone());
+        self.captured_events
+            .lock()
+            .await
+            .push(CapturedEvent::Status(status));
         Ok(())
     }
 

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -162,6 +162,31 @@ impl TestChannel {
         }
     }
 
+    /// Wait until a `Status("Done")` event has been captured, or `timeout` elapses.
+    ///
+    /// Returns `true` if the Done status was observed within the deadline.
+    pub async fn wait_for_done(&self, timeout: Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        let mut interval = Duration::from_millis(50);
+        let max_interval = Duration::from_millis(500);
+        loop {
+            {
+                let guard = self.status_events.lock().await;
+                if guard
+                    .iter()
+                    .any(|s| matches!(s, StatusUpdate::Status(msg) if msg == "Done"))
+                {
+                    return true;
+                }
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(interval).await;
+            interval = (interval * 2).min(max_interval);
+        }
+    }
+
     /// Return a snapshot of all captured status events.
     ///
     /// Uses `try_lock` so it can be called from sync contexts in tests.

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -20,7 +20,7 @@ use ironclaw::tools::Tool;
 
 use crate::support::instrumented_llm::InstrumentedLlm;
 use crate::support::metrics::{ToolInvocation, TraceMetrics};
-use crate::support::test_channel::{TestChannel, TestChannelHandle};
+use crate::support::test_channel::{CapturedEvent, TestChannel, TestChannelHandle};
 use crate::support::trace_llm::{LlmTrace, TraceLlm};
 
 use ironclaw::llm::recording::{HttpExchange, HttpInterceptor, ReplayingHttpInterceptor};
@@ -169,6 +169,11 @@ impl TestRig {
     /// Return a snapshot of all captured status events.
     pub fn captured_status_events(&self) -> Vec<StatusUpdate> {
         self.channel.captured_status_events()
+    }
+
+    /// Return the ordered log of captured outbound events.
+    pub fn captured_events(&self) -> Vec<CapturedEvent> {
+        self.channel.captured_events()
     }
 
     /// Clear all captured responses and status events.

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -166,6 +166,11 @@ impl TestRig {
         self.channel.tool_timings()
     }
 
+    /// Wait until a `Status("Done")` event has been captured, or `timeout` elapses.
+    pub async fn wait_for_done(&self, timeout: Duration) -> bool {
+        self.channel.wait_for_done(timeout).await
+    }
+
     /// Return a snapshot of all captured status events.
     pub fn captured_status_events(&self) -> Vec<StatusUpdate> {
         self.channel.captured_status_events()


### PR DESCRIPTION
## Summary

- **Backend**: Move the terminal "Done" status out of `thread_ops.rs` and emit it only after `agent_loop.rs` successfully sends the response, via a new `respond_then_done()` helper. This guarantees the browser receives the assistant message before the turn-closing SSE event.
- **Frontend safety net**: Track whether a `response` SSE event was received for the current turn. When "Done" arrives without one, trigger `loadHistory()` after 1500ms to recover the message from the server — handles residual edge cases like proxy buffering or brief SSE disconnects.
- **Regression test**: Asserts the response event is captured before the Done status in an ordered event log.

Closes #2079

## Test plan

- [x] `cargo test -p ironclaw --test e2e_response_order response_order_tests::response_arrives_before_done_status`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] Manual: send message in web UI, verify in browser devtools EventStream that `response` arrives before `Done`
- [ ] Manual: simulate lost response (e.g. throttle network) — verify history reloads after 1500ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)