### PR TITLE
feat(workspace): admin system prompt shared with all users

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# Scope labels for actions/labeler@v6
-# Maps file path globs to scope labels. Multiple labels can apply per PR.
+# Labels for actions/labeler@v6
+# Maps file path globs to labels. Multiple labels can apply per PR.
 
 "scope: agent":
   - changed-files:
@@ -164,3 +164,9 @@
       - any-glob-to-any-file:
           - Cargo.toml
           - Cargo.lock
+
+"DB MIGRATION":
+  - changed-files:
+      - any-glob-to-any-file:
+          - migrations/**
+          - src/db/libsql_migrations.rs

--- a/.github/scripts/create-labels.sh
+++ b/.github/scripts/create-labels.sh
@@ -62,6 +62,9 @@ create "scope: ci"            "546E7A" "CI/CD workflows"
 create "scope: docs"          "78909C" "Documentation"
 create "scope: dependencies"  "90A4AE" "Dependency updates"
 
+echo "==> Creating coordination labels..."
+create "DB MIGRATION"         "C62828" "PR adds or modifies PostgreSQL or libSQL migration definitions"
+
 echo "==> Creating workflow labels..."
 create "skip-regression-check" "9E9E9E" "Acknowledged: fix without regression test"
 

--- a/.github/workflows/pr-label-scope.yml
+++ b/.github/workflows/pr-label-scope.yml
@@ -6,13 +6,20 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
   scope:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - name: Ensure DB MIGRATION label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies PostgreSQL or libSQL migration definitions" --force
+
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false          # additive only — never remove scope labels

--- a/src/app.rs
+++ b/src/app.rs
@@ -351,7 +351,6 @@ impl AppBuilder {
                 );
             }
             ws = ws.with_memory_layers(self.config.workspace.memory_layers.clone());
-            let ws = Arc::new(ws);
 
             // Detect multi-tenant mode: when the database has registered users,
             // each authenticated user needs their own workspace scope. Use
@@ -359,6 +358,14 @@ impl AppBuilder {
             // per-user workspaces on demand instead of sharing the startup
             // workspace across all users.
             let is_multi_tenant = db.has_any_users().await.unwrap_or(false);
+
+            // In multi-tenant mode, enable admin system prompt on the owner
+            // workspace so the dispatcher reads SYSTEM.md from __admin__ scope.
+            if is_multi_tenant {
+                ws = ws.with_admin_prompt();
+            }
+
+            let ws = Arc::new(ws);
 
             if is_multi_tenant {
                 let pool = Arc::new(crate::channels::web::server::WorkspacePool::new(

--- a/src/channels/web/handlers/mod.rs
+++ b/src/channels/web/handlers/mod.rs
@@ -8,6 +8,7 @@ pub mod memory;
 pub mod routines;
 pub mod secrets;
 pub mod skills;
+pub mod system_prompt;
 pub mod tokens;
 pub mod users;
 

--- a/src/channels/web/handlers/system_prompt.rs
+++ b/src/channels/web/handlers/system_prompt.rs
@@ -1,0 +1,84 @@
+//! Admin system prompt management handlers.
+//!
+//! These endpoints allow admins to set a shared system prompt (`SYSTEM.md`)
+//! that is injected into every user's system prompt in multi-tenant mode.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::StatusCode};
+
+use crate::channels::web::auth::AdminUser;
+use crate::channels::web::server::GatewayState;
+use crate::channels::web::types::{SystemPromptRequest, SystemPromptResponse};
+use crate::workspace::{ADMIN_SCOPE, Workspace, paths};
+
+/// `GET /api/admin/system-prompt` — read the admin system prompt.
+pub async fn get_handler(
+    State(state): State<Arc<GatewayState>>,
+    AdminUser(_admin): AdminUser,
+) -> Result<Json<SystemPromptResponse>, (StatusCode, String)> {
+    // Gate behind multi-tenant mode.
+    if state.workspace_pool.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "System prompt management requires multi-tenant mode".to_string(),
+        ));
+    }
+
+    let db = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+
+    let ws = Workspace::new_with_db(ADMIN_SCOPE, Arc::clone(db));
+
+    match ws.read(paths::SYSTEM).await {
+        Ok(doc) => Ok(Json(SystemPromptResponse {
+            content: doc.content,
+            updated_at: Some(doc.updated_at.to_rfc3339()),
+        })),
+        Err(crate::error::WorkspaceError::DocumentNotFound { .. }) => {
+            Ok(Json(SystemPromptResponse {
+                content: String::new(),
+                updated_at: None,
+            }))
+        }
+        Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
+    }
+}
+
+/// `PUT /api/admin/system-prompt` — set the admin system prompt.
+pub async fn put_handler(
+    State(state): State<Arc<GatewayState>>,
+    AdminUser(_admin): AdminUser,
+    Json(req): Json<SystemPromptRequest>,
+) -> Result<Json<SystemPromptResponse>, (StatusCode, String)> {
+    // Gate behind multi-tenant mode.
+    if state.workspace_pool.is_none() {
+        return Err((
+            StatusCode::NOT_FOUND,
+            "System prompt management requires multi-tenant mode".to_string(),
+        ));
+    }
+
+    let db = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+
+    let ws = Workspace::new_with_db(ADMIN_SCOPE, Arc::clone(db));
+
+    let doc = ws.write(paths::SYSTEM, &req.content).await.map_err(|e| {
+        let status = if matches!(e, crate::error::WorkspaceError::InjectionRejected { .. }) {
+            StatusCode::BAD_REQUEST
+        } else {
+            StatusCode::INTERNAL_SERVER_ERROR
+        };
+        (status, e.to_string())
+    })?;
+
+    Ok(Json(SystemPromptResponse {
+        content: doc.content,
+        updated_at: Some(doc.updated_at.to_rfc3339()),
+    }))
+}

--- a/src/channels/web/handlers/system_prompt.rs
+++ b/src/channels/web/handlers/system_prompt.rs
@@ -12,6 +12,12 @@ use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::{SystemPromptRequest, SystemPromptResponse};
 use crate::workspace::{ADMIN_SCOPE, Workspace, paths};
 
+/// Maximum size for the admin system prompt (64 KB).
+///
+/// The admin prompt is injected into every user's system prompt on every
+/// message, so a large value directly impacts token budgets and latency.
+const MAX_SYSTEM_PROMPT_SIZE: usize = 64 * 1024;
+
 /// `GET /api/admin/system-prompt` — read the admin system prompt.
 pub async fn get_handler(
     State(state): State<Arc<GatewayState>>,
@@ -58,6 +64,17 @@ pub async fn put_handler(
         return Err((
             StatusCode::NOT_FOUND,
             "System prompt management requires multi-tenant mode".to_string(),
+        ));
+    }
+
+    if req.content.len() > MAX_SYSTEM_PROMPT_SIZE {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!(
+                "System prompt exceeds maximum size ({} bytes, limit {})",
+                req.content.len(),
+                MAX_SYSTEM_PROMPT_SIZE
+            ),
         ));
     }
 

--- a/src/channels/web/handlers/users.rs
+++ b/src/channels/web/handlers/users.rs
@@ -68,6 +68,16 @@ pub async fn users_create_handler(
 
     let user_id = Uuid::new_v4().to_string();
 
+    // Defense-in-depth: UUIDs cannot collide with reserved scopes, but
+    // validate anyway in case this code path is later changed to accept
+    // custom user IDs.
+    if crate::workspace::is_reserved_scope(&user_id) {
+        return Err((
+            StatusCode::CONFLICT,
+            "Generated user ID collides with a reserved scope".to_string(),
+        ));
+    }
+
     let now = chrono::Utc::now();
     let user_record = UserRecord {
         id: user_id.clone(),

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -252,10 +252,11 @@ impl WorkspacePool {
     }
 
     /// Build a workspace for a user, applying search config, embeddings,
-    /// global read scopes, and memory layers.
+    /// global read scopes, memory layers, and admin prompt.
     fn build_workspace(&self, user_id: &str) -> Workspace {
         let mut ws = Workspace::new_with_db(user_id, Arc::clone(&self.db))
-            .with_search_config(&self.search_config);
+            .with_search_config(&self.search_config)
+            .with_admin_prompt();
 
         if let Some(ref emb) = self.embeddings {
             ws = ws.with_embeddings_cached(Arc::clone(emb), self.embedding_cache_config.clone());
@@ -572,6 +573,12 @@ pub async fn start_server(
             "/api/admin/users/{user_id}/secrets/{name}",
             put(super::handlers::secrets::secrets_put_handler)
                 .delete(super::handlers::secrets::secrets_delete_handler),
+        )
+        // Admin system prompt
+        .route(
+            "/api/admin/system-prompt",
+            get(super::handlers::system_prompt::get_handler)
+                .put(super::handlers::system_prompt::put_handler),
         )
         // Usage reporting (admin)
         .route(

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -124,6 +124,20 @@ pub struct ApprovalRequest {
 
 pub use ironclaw_common::{AppEvent, ToolDecisionDto};
 
+// --- Admin System Prompt ---
+
+#[derive(Debug, Deserialize)]
+pub struct SystemPromptRequest {
+    pub content: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct SystemPromptResponse {
+    pub content: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub updated_at: Option<String>,
+}
+
 // --- Memory ---
 
 #[derive(Debug, Serialize)]

--- a/src/workspace/document.rs
+++ b/src/workspace/document.rs
@@ -31,11 +31,20 @@ pub mod paths {
     pub const TOOLS: &str = "TOOLS.md";
     /// First-run ritual file; self-deletes after onboarding completes.
     pub const BOOTSTRAP: &str = "BOOTSTRAP.md";
+    /// Admin-defined system instructions shared with all users.
+    pub const SYSTEM: &str = "SYSTEM.md";
     /// User psychographic profile (JSON).
     pub const PROFILE: &str = "context/profile.json";
     /// Assistant behavioral directives (derived from profile).
     pub const ASSISTANT_DIRECTIVES: &str = "context/assistant-directives.md";
 }
+
+/// Well-known scope identifier for admin-defined content (e.g., system prompt).
+///
+/// Documents stored under this scope are readable by all workspaces when
+/// `admin_prompt_enabled` is set (multi-tenant mode). The double-underscore
+/// prefix prevents collision with real user IDs.
+pub const ADMIN_SCOPE: &str = "__admin__";
 
 /// Paths treated as identity documents for multi-scope isolation.
 ///

--- a/src/workspace/document.rs
+++ b/src/workspace/document.rs
@@ -46,6 +46,14 @@ pub mod paths {
 /// prefix prevents collision with real user IDs.
 pub const ADMIN_SCOPE: &str = "__admin__";
 
+/// Check if a scope identifier is reserved for system use.
+///
+/// Reserved scopes must never be assigned as a user ID.
+/// Currently only `__admin__` is reserved (used for the admin system prompt).
+pub fn is_reserved_scope(scope: &str) -> bool {
+    scope == ADMIN_SCOPE
+}
+
 /// Paths treated as identity documents for multi-scope isolation.
 ///
 /// These files are always read from the primary scope only — never from
@@ -260,6 +268,16 @@ mod tests {
 
         doc.content = "Hello world, this is a test.".to_string();
         assert_eq!(doc.word_count(), 6);
+    }
+
+    #[test]
+    fn test_is_reserved_scope() {
+        assert!(is_reserved_scope("__admin__"));
+        assert!(!is_reserved_scope("alice"));
+        assert!(!is_reserved_scope(""));
+        assert!(!is_reserved_scope("admin"));
+        // UUIDs should never collide with reserved scopes
+        assert!(!is_reserved_scope("550e8400-e29b-41d4-a716-446655440000"));
     }
 
     #[test]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -53,7 +53,7 @@ mod search;
 
 pub use chunker::{ChunkConfig, chunk_document};
 pub use document::{
-    IDENTITY_PATHS, MemoryChunk, MemoryDocument, WorkspaceEntry, is_identity_path,
+    ADMIN_SCOPE, IDENTITY_PATHS, MemoryChunk, MemoryDocument, WorkspaceEntry, is_identity_path,
     merge_workspace_entries, paths,
 };
 pub use embedding_cache::{CachedEmbeddingProvider, EmbeddingCacheConfig};
@@ -94,6 +94,7 @@ const SYSTEM_PROMPT_FILES: &[&str] = &[
     paths::AGENTS,
     paths::USER,
     paths::IDENTITY,
+    paths::SYSTEM,
     paths::MEMORY,
     paths::TOOLS,
     paths::HEARTBEAT,
@@ -419,6 +420,9 @@ pub struct Workspace {
     /// Optional privacy classifier for shared layer writes.
     /// When None, writes go exactly where requested — no silent redirect.
     privacy_classifier: Option<Arc<dyn crate::workspace::privacy::PrivacyClassifier>>,
+    /// When true, the system prompt includes admin-defined instructions from
+    /// the `__admin__` scope. Set by `WorkspacePool` in multi-tenant mode.
+    admin_prompt_enabled: bool,
 }
 
 impl Workspace {
@@ -438,6 +442,7 @@ impl Workspace {
             search_defaults: SearchConfig::default(),
             memory_layers,
             privacy_classifier: None,
+            admin_prompt_enabled: false,
         }
     }
 
@@ -458,6 +463,7 @@ impl Workspace {
             search_defaults: SearchConfig::default(),
             memory_layers,
             privacy_classifier: None,
+            admin_prompt_enabled: false,
         }
     }
 
@@ -556,6 +562,16 @@ impl Workspace {
         self
     }
 
+    /// Enable admin system prompt reading from the `__admin__` scope.
+    ///
+    /// When enabled, `system_prompt_for_context_inner()` reads `SYSTEM.md`
+    /// from the `__admin__` scope and injects it before identity files.
+    /// Only set in multi-tenant mode (via `WorkspacePool`).
+    pub fn with_admin_prompt(mut self) -> Self {
+        self.admin_prompt_enabled = true;
+        self
+    }
+
     /// Get the configured memory layers.
     pub fn memory_layers(&self) -> &[crate::workspace::layer::MemoryLayer] {
         &self.memory_layers
@@ -628,6 +644,7 @@ impl Workspace {
             search_defaults: self.search_defaults.clone(),
             memory_layers,
             privacy_classifier: self.privacy_classifier.clone(),
+            admin_prompt_enabled: self.admin_prompt_enabled,
         }
     }
 
@@ -1203,6 +1220,20 @@ impl Workspace {
         } else {
             false
         };
+
+        // Admin system prompt: shared instructions set by an admin.
+        // Only read in multi-tenant mode (admin_prompt_enabled is set by WorkspacePool).
+        // Read directly from __admin__ scope with no agent_id — the admin prompt
+        // is global and applies to all users regardless of workspace config.
+        if self.admin_prompt_enabled
+            && let Ok(doc) = self
+                .storage
+                .get_document_by_path(ADMIN_SCOPE, None, paths::SYSTEM)
+                .await
+            && !doc.content.is_empty()
+        {
+            parts.push(format!("## System Instructions\n\n{}", doc.content));
+        }
 
         // Load identity files in order of importance.
         // These MUST use read_primary() — see comment above.
@@ -1961,12 +1992,25 @@ mod tests {
     // ── Injection scanning tests ─────────────────────────────────────
 
     #[test]
+    fn test_system_md_is_system_prompt_file_but_not_identity() {
+        assert!(
+            is_system_prompt_file(paths::SYSTEM),
+            "SYSTEM.md should be scanned for injection"
+        );
+        assert!(
+            !is_identity_path(paths::SYSTEM),
+            "SYSTEM.md must NOT be an identity path — it is shared, not per-user"
+        );
+    }
+
+    #[test]
     fn test_system_prompt_file_matching() {
         let cases = vec![
             ("SOUL.md", true),
             ("AGENTS.md", true),
             ("USER.md", true),
             ("IDENTITY.md", true),
+            ("SYSTEM.md", true),
             ("MEMORY.md", true),
             ("HEARTBEAT.md", true),
             ("TOOLS.md", true),

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -54,7 +54,7 @@ mod search;
 pub use chunker::{ChunkConfig, chunk_document};
 pub use document::{
     ADMIN_SCOPE, IDENTITY_PATHS, MemoryChunk, MemoryDocument, WorkspaceEntry, is_identity_path,
-    merge_workspace_entries, paths,
+    is_reserved_scope, merge_workspace_entries, paths,
 };
 pub use embedding_cache::{CachedEmbeddingProvider, EmbeddingCacheConfig};
 pub use embeddings::{

--- a/tests/admin_system_prompt.rs
+++ b/tests/admin_system_prompt.rs
@@ -1,0 +1,268 @@
+//! Tests for admin system prompt (SYSTEM.md in __admin__ scope).
+//!
+//! When an admin writes SYSTEM.md to the __admin__ scope, all users with
+//! `admin_prompt_enabled` set (multi-tenant mode) should see those
+//! instructions in their system prompt.
+//!
+//! These tests verify that:
+//! 1. Admin system prompt appears in all users' system prompts
+//! 2. No admin prompt when admin_prompt_enabled is false (single-user mode)
+//! 3. Admin prompt does not interfere with per-user identity files
+//! 4. Empty SYSTEM.md produces no section in the system prompt
+#![cfg(feature = "libsql")]
+
+use std::sync::Arc;
+
+use ironclaw::db::Database;
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::workspace::{ADMIN_SCOPE, Workspace, paths};
+
+async fn setup() -> (Arc<dyn Database>, tempfile::TempDir) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let db_path = dir.path().join("test.db");
+    let backend = LibSqlBackend::new_local(&db_path).await.expect("create db");
+    backend.run_migrations().await.expect("run migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+    (db, dir)
+}
+
+/// Seed a document into a specific user's workspace scope.
+async fn seed(db: &Arc<dyn Database>, user_id: &str, path: &str, content: &str) {
+    let ws = Workspace::new_with_db(user_id, db.clone());
+    ws.write(path, content)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to seed {path} for {user_id}: {e}"));
+}
+
+// ─── Test 1: Admin system prompt appears for all users ───────────────────
+
+#[tokio::test]
+async fn admin_system_prompt_appears_in_user_prompt() {
+    let (db, _dir) = setup().await;
+
+    // Admin writes SYSTEM.md to __admin__ scope
+    seed(
+        &db,
+        ADMIN_SCOPE,
+        paths::SYSTEM,
+        "This is a custom AI assistant for Acme Corp. Always be professional.",
+    )
+    .await;
+
+    // Create Alice's workspace with admin prompt enabled (multi-tenant mode)
+    let ws = Workspace::new_with_db("alice", db.clone()).with_admin_prompt();
+
+    let prompt = ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("system_prompt_for_context failed");
+
+    assert!(
+        prompt.contains("Acme Corp"),
+        "Admin system prompt should appear in user's system prompt.\nPrompt:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("## System Instructions"),
+        "Admin system prompt should be under '## System Instructions' header.\nPrompt:\n{prompt}"
+    );
+}
+
+// ─── Test 2: Admin system prompt is NOT shown in single-user mode ────────
+
+#[tokio::test]
+async fn admin_system_prompt_hidden_in_single_user_mode() {
+    let (db, _dir) = setup().await;
+
+    // Admin writes SYSTEM.md to __admin__ scope
+    seed(
+        &db,
+        ADMIN_SCOPE,
+        paths::SYSTEM,
+        "This is a custom AI assistant for Acme Corp.",
+    )
+    .await;
+
+    // Create workspace WITHOUT admin prompt enabled (single-user mode)
+    let ws = Workspace::new_with_db("alice", db.clone());
+
+    let prompt = ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("system_prompt_for_context failed");
+
+    assert!(
+        !prompt.contains("Acme Corp"),
+        "Admin system prompt must NOT appear when admin_prompt_enabled is false.\nPrompt:\n{prompt}"
+    );
+}
+
+// ─── Test 3: Admin prompt does not interfere with per-user identity ──────
+
+#[tokio::test]
+async fn admin_prompt_coexists_with_user_identity() {
+    let (db, _dir) = setup().await;
+
+    // Admin writes SYSTEM.md
+    seed(
+        &db,
+        ADMIN_SCOPE,
+        paths::SYSTEM,
+        "All agents must follow Acme Corp policies.",
+    )
+    .await;
+
+    // Alice has her own identity files
+    seed(&db, "alice", paths::SOUL, "Alice is kind and creative.").await;
+    seed(
+        &db,
+        "alice",
+        paths::USER,
+        "You are talking to Alice, a designer.",
+    )
+    .await;
+
+    let ws = Workspace::new_with_db("alice", db.clone()).with_admin_prompt();
+
+    let prompt = ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("system_prompt_for_context failed");
+
+    // Both admin prompt and user identity should be present
+    assert!(
+        prompt.contains("Acme Corp policies"),
+        "Admin system prompt should be present.\nPrompt:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("Alice is kind and creative"),
+        "User's SOUL.md should still be present.\nPrompt:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("Alice, a designer"),
+        "User's USER.md should still be present.\nPrompt:\n{prompt}"
+    );
+
+    // Admin prompt should come before identity files
+    let admin_pos = prompt
+        .find("Acme Corp policies")
+        .expect("admin prompt not found");
+    let identity_pos = prompt
+        .find("Alice is kind")
+        .expect("user identity not found");
+    assert!(
+        admin_pos < identity_pos,
+        "Admin system prompt should appear before user identity files.\n\
+         Admin position: {admin_pos}, Identity position: {identity_pos}"
+    );
+}
+
+// ─── Test 4: Empty SYSTEM.md produces no section ─────────────────────────
+
+#[tokio::test]
+async fn empty_system_prompt_produces_no_section() {
+    let (db, _dir) = setup().await;
+
+    // Admin writes empty SYSTEM.md
+    seed(&db, ADMIN_SCOPE, paths::SYSTEM, "").await;
+
+    let ws = Workspace::new_with_db("alice", db.clone()).with_admin_prompt();
+
+    let prompt = ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("system_prompt_for_context failed");
+
+    assert!(
+        !prompt.contains("System Instructions"),
+        "Empty SYSTEM.md should not produce a section.\nPrompt:\n{prompt}"
+    );
+}
+
+// ─── Test 5: Multiple users see the same admin prompt ────────────────────
+
+#[tokio::test]
+async fn multiple_users_see_same_admin_prompt() {
+    let (db, _dir) = setup().await;
+
+    seed(
+        &db,
+        ADMIN_SCOPE,
+        paths::SYSTEM,
+        "Company-wide instruction: always greet users by name.",
+    )
+    .await;
+
+    // Seed different identity for each user
+    seed(&db, "alice", paths::SOUL, "Alice values creativity.").await;
+    seed(&db, "bob", paths::SOUL, "Bob values precision.").await;
+
+    let alice_ws = Workspace::new_with_db("alice", db.clone()).with_admin_prompt();
+    let bob_ws = Workspace::new_with_db("bob", db.clone()).with_admin_prompt();
+
+    let alice_prompt = alice_ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("alice prompt");
+    let bob_prompt = bob_ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("bob prompt");
+
+    // Both see the admin prompt
+    assert!(
+        alice_prompt.contains("greet users by name"),
+        "Alice should see admin prompt.\nPrompt:\n{alice_prompt}"
+    );
+    assert!(
+        bob_prompt.contains("greet users by name"),
+        "Bob should see admin prompt.\nPrompt:\n{bob_prompt}"
+    );
+
+    // Each sees their own identity
+    assert!(
+        alice_prompt.contains("Alice values creativity"),
+        "Alice should see her own identity.\nPrompt:\n{alice_prompt}"
+    );
+    assert!(
+        !alice_prompt.contains("Bob values precision"),
+        "Alice should NOT see Bob's identity.\nPrompt:\n{alice_prompt}"
+    );
+    assert!(
+        bob_prompt.contains("Bob values precision"),
+        "Bob should see his own identity.\nPrompt:\n{bob_prompt}"
+    );
+}
+
+// ─── Test 6: scoped_to_user preserves admin_prompt_enabled ───────────────
+
+#[tokio::test]
+async fn scoped_to_user_preserves_admin_prompt() {
+    let (db, _dir) = setup().await;
+
+    seed(
+        &db,
+        ADMIN_SCOPE,
+        paths::SYSTEM,
+        "Admin prompt: use formal language.",
+    )
+    .await;
+    seed(&db, "bob", paths::SOUL, "Bob is analytical.").await;
+
+    // Create workspace for alice with admin prompt, then scope to bob
+    let alice_ws = Workspace::new_with_db("alice", db.clone()).with_admin_prompt();
+    let bob_ws = alice_ws.scoped_to_user("bob");
+
+    let prompt = bob_ws
+        .system_prompt_for_context(false)
+        .await
+        .expect("system_prompt_for_context failed");
+
+    assert!(
+        prompt.contains("use formal language"),
+        "scoped_to_user should preserve admin_prompt_enabled.\nPrompt:\n{prompt}"
+    );
+    assert!(
+        prompt.contains("Bob is analytical"),
+        "Scoped workspace should read Bob's identity.\nPrompt:\n{prompt}"
+    );
+}


### PR DESCRIPTION
## Summary
- Introduces `SYSTEM.md` in a well-known `__admin__` scope so admins can set a system prompt that all tenants receive
- Gated behind multi-tenant mode — `WorkspacePool` sets `admin_prompt_enabled` on each workspace; zero overhead in single-user deployments
- New admin-only API endpoints: `GET/PUT /api/admin/system-prompt`

Closes #2088

## Details

### How it works
1. Admin writes `SYSTEM.md` to `__admin__` scope via `PUT /api/admin/system-prompt`
2. In `system_prompt_for_context_inner()`, when `admin_prompt_enabled` is true, reads `SYSTEM.md` directly from `__admin__` scope (not via multi-scope reads)
3. Injected as "## System Instructions" section **before** per-user identity files (AGENTS.md, SOUL.md, etc.)
4. Injection scanning protects against prompt injection in admin content

### Multi-tenancy gating
- **API layer**: Handlers check `workspace_pool.is_some()` → 404 in single-user mode
- **Prompt layer**: `admin_prompt_enabled` flag on Workspace (set only by WorkspacePool) → no DB hit in single-user mode

### Files changed
| File | Change |
|------|--------|
| `src/workspace/document.rs` | `paths::SYSTEM` + `ADMIN_SCOPE` constants |
| `src/workspace/mod.rs` | Injection scan list, `admin_prompt_enabled` field/builder, gated read in prompt assembly |
| `src/channels/web/server.rs` | `.with_admin_prompt()` in WorkspacePool, route registration |
| `src/channels/web/types.rs` | Request/response DTOs |
| `src/channels/web/handlers/system_prompt.rs` | **New** — GET/PUT handlers |
| `src/channels/web/handlers/mod.rs` | Module registration |
| `tests/admin_system_prompt.rs` | **New** — 6 integration tests |

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib` — 3938 passed
- [x] `cargo test --test admin_system_prompt --features libsql` — 6 passed
- [ ] Verify admin can set/get/clear system prompt via API
- [ ] Verify non-admin gets 403 on system prompt endpoints
- [ ] Verify single-user mode returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)