### PR TITLE
fix(acp): safety-net broadcast and idempotent terminal transitions (#1981 follow-up)

### DIFF
--- a/src/agent/job_monitor.rs
+++ b/src/agent/job_monitor.rs
@@ -531,4 +531,120 @@ mod tests {
         let ctx = cm.get_context(job_id).await.unwrap();
         assert_eq!(ctx.state, JobState::Completed);
     }
+
+    // === Regression: report_complete safety-net broadcast frees max_jobs slot ===
+    // When the worker's fire-and-forget post_event("result") is lost, the
+    // orchestrator's report_complete handler now broadcasts a safety-net
+    // JobResult. This test proves that a JobResult with session_id: None
+    // (as emitted by report_complete, which lacks session context) still
+    // transitions the job and frees the slot.
+
+    #[tokio::test]
+    async fn completion_watcher_frees_slot_from_report_complete_broadcast() {
+        use crate::context::{ContextManager, JobState};
+
+        let max_jobs = 2;
+        let cm = Arc::new(ContextManager::new(max_jobs));
+
+        // Fill both slots.
+        let job_a = Uuid::new_v4();
+        let job_b = Uuid::new_v4();
+        cm.register_sandbox_job(job_a, "user-1", "Job A", "desc")
+            .await
+            .unwrap();
+        cm.register_sandbox_job(job_b, "user-1", "Job B", "desc")
+            .await
+            .unwrap();
+
+        // A third job should be rejected (slots full).
+        let job_c = Uuid::new_v4();
+        assert!(
+            cm.register_sandbox_job(job_c, "user-1", "Job C", "desc")
+                .await
+                .is_err(),
+            "max_jobs should be exhausted"
+        );
+
+        // Wire a completion watcher for job_a.
+        let (event_tx, _) = broadcast::channel::<(Uuid, String, AppEvent)>(16);
+        let handle = spawn_completion_watcher(job_a, event_tx.subscribe(), Arc::clone(&cm));
+
+        // Simulate the safety-net broadcast from report_complete (no session_id).
+        event_tx
+            .send((
+                job_a,
+                "user-1".to_string(),
+                AppEvent::JobResult {
+                    job_id: job_a.to_string(),
+                    status: "completed".to_string(),
+                    session_id: None,
+                    fallback_deliverable: None,
+                },
+            ))
+            .unwrap();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("watcher should exit")
+            .expect("watcher should not panic");
+
+        // Job A should be Completed → slot freed.
+        let ctx = cm.get_context(job_a).await.unwrap();
+        assert_eq!(ctx.state, JobState::Completed);
+
+        // Now job C should succeed (slot available).
+        cm.register_sandbox_job(job_c, "user-1", "Job C", "desc")
+            .await
+            .expect("slot should be free after report_complete broadcast");
+    }
+
+    // === Idempotency: duplicate JobResult events are harmless ===
+    // Both post_event("result") and the report_complete safety-net may
+    // broadcast a JobResult. The completion watcher breaks on the first one,
+    // so the second is silently dropped with no extra state transition.
+
+    #[tokio::test]
+    async fn completion_watcher_ignores_duplicate_job_result() {
+        use crate::context::{ContextManager, JobState};
+
+        let cm = Arc::new(ContextManager::new(5));
+        let job_id = Uuid::new_v4();
+        cm.register_sandbox_job(job_id, "user-1", "Dup test", "desc")
+            .await
+            .unwrap();
+
+        let (event_tx, _) = broadcast::channel::<(Uuid, String, AppEvent)>(16);
+        let handle = spawn_completion_watcher(job_id, event_tx.subscribe(), Arc::clone(&cm));
+
+        let make_result = || {
+            (
+                job_id,
+                "user-1".to_string(),
+                AppEvent::JobResult {
+                    job_id: job_id.to_string(),
+                    status: "completed".to_string(),
+                    session_id: None,
+                    fallback_deliverable: None,
+                },
+            )
+        };
+
+        // Send two JobResult events back-to-back (simulates post_event +
+        // safety-net both arriving).
+        event_tx.send(make_result()).unwrap();
+        event_tx.send(make_result()).unwrap();
+
+        // The watcher should still exit cleanly after the first event.
+        tokio::time::timeout(std::time::Duration::from_secs(1), handle)
+            .await
+            .expect("watcher should exit")
+            .expect("watcher should not panic");
+
+        let ctx = cm.get_context(job_id).await.unwrap();
+        assert_eq!(ctx.state, JobState::Completed);
+        // register_sandbox_job starts at InProgress, so a real
+        // InProgress -> Completed transition is recorded; the duplicate
+        // Completed -> Completed from the second event is the idempotent
+        // no-op. The key assertion is that the watcher exited without error.
+    }
 }

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -49,11 +49,13 @@ impl JobState {
     pub fn can_transition_to(&self, target: JobState) -> bool {
         use JobState::*;
 
-        // Allow idempotent Completed -> Completed transition.
-        // Both the execution loop and the worker wrapper may race to mark a
-        // job complete; the second call should be a harmless no-op rather
-        // than an error that masks the successful completion.
-        if matches!((self, target), (Completed, Completed)) {
+        // Allow idempotent self-transitions for Completed and all terminal
+        // states. Multiple sources may race to mark a job finished (execution
+        // loop vs worker wrapper, post_event vs report_complete safety-net
+        // broadcast); the second call should be a harmless no-op rather than
+        // an error. Cross-terminal transitions (e.g. Failed -> Cancelled) are
+        // never allowed.
+        if *self == target && (self.is_terminal() || *self == Completed) {
             return true;
         }
 
@@ -284,8 +286,8 @@ impl JobContext {
         }
 
         // Idempotent: already in the target state, skip recording a duplicate
-        // transition. This handles the Completed -> Completed race between
-        // execution_loop and the worker wrapper.
+        // transition. Handles races between execution_loop/worker wrapper and
+        // between post_event/report_complete safety-net broadcasts.
         if self.state == new_state {
             tracing::debug!(
                 job_id = %self.job_id,
@@ -428,15 +430,56 @@ mod tests {
     }
 
     #[test]
-    fn test_other_self_transitions_still_rejected() {
-        // Ensure we only allow Completed -> Completed, not arbitrary X -> X.
+    fn test_non_terminal_self_transitions_rejected() {
+        // Only Completed and terminal states allow idempotent self-transitions.
         assert!(!JobState::Pending.can_transition_to(JobState::Pending));
         assert!(!JobState::InProgress.can_transition_to(JobState::InProgress));
-        assert!(!JobState::Failed.can_transition_to(JobState::Failed));
         assert!(!JobState::Stuck.can_transition_to(JobState::Stuck));
         assert!(!JobState::Submitted.can_transition_to(JobState::Submitted));
-        assert!(!JobState::Accepted.can_transition_to(JobState::Accepted));
-        assert!(!JobState::Cancelled.can_transition_to(JobState::Cancelled));
+    }
+
+    #[test]
+    fn test_terminal_self_transitions_are_idempotent() {
+        assert!(JobState::Accepted.can_transition_to(JobState::Accepted));
+        assert!(JobState::Failed.can_transition_to(JobState::Failed));
+        assert!(JobState::Cancelled.can_transition_to(JobState::Cancelled));
+    }
+
+    #[test]
+    fn test_cross_terminal_transitions_rejected() {
+        // No transition between distinct terminal states is allowed.
+        let terminals = [JobState::Failed, JobState::Accepted, JobState::Cancelled];
+        for &from in &terminals {
+            for &to in &terminals {
+                if from != to {
+                    assert!(
+                        !from.can_transition_to(to),
+                        "{} -> {} should be rejected",
+                        from,
+                        to,
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn test_failed_to_failed_is_idempotent() {
+        let mut ctx = JobContext::new("Test", "Idempotent failure test");
+        ctx.transition_to(JobState::InProgress, None).unwrap();
+        ctx.transition_to(JobState::Failed, Some("first".into()))
+            .unwrap();
+
+        let transitions_before = ctx.transitions.len();
+
+        let result = ctx.transition_to(JobState::Failed, Some("duplicate".into()));
+        assert!(result.is_ok(), "Failed -> Failed should be idempotent");
+        assert_eq!(ctx.state, JobState::Failed);
+        assert_eq!(
+            ctx.transitions.len(),
+            transitions_before,
+            "no new transition should be recorded"
+        );
     }
 
     #[test]

--- a/src/orchestrator/api.rs
+++ b/src/orchestrator/api.rs
@@ -249,6 +249,22 @@ async fn report_complete(
         tracing::error!(job_id = %job_id, "Failed to complete job cleanup: {}", e);
     }
 
+    // Safety-net broadcast: even if the worker's fire-and-forget post_event("result")
+    // was lost, this ensures job monitors receive the terminal signal and free the
+    // max_jobs slot. Consumers break on the first JobResult, so duplicates are harmless.
+    let status = if report.success { "completed" } else { "error" };
+    broadcast_app_event(
+        &state,
+        job_id,
+        AppEvent::JobResult {
+            job_id: job_id.to_string(),
+            status: status.to_string(),
+            session_id: None,
+            fallback_deliverable: None,
+        },
+    )
+    .await;
+
     Ok(Json(serde_json::json!({"status": "ok"})))
 }
 
@@ -370,8 +386,14 @@ async fn job_event_handler(
         },
     };
 
-    // Broadcast via the channel (if configured).
-    // Look up the job owner from the in-memory cache (populated at job creation).
+    broadcast_app_event(&state, job_id, app_event).await;
+
+    Ok(StatusCode::OK)
+}
+
+/// Broadcast an `AppEvent` through the job event channel, resolving the
+/// job owner from the in-memory cache (with DB fallback).
+async fn broadcast_app_event(state: &OrchestratorState, job_id: Uuid, event: AppEvent) {
     if let Some(ref tx) = state.job_event_tx {
         let cached_uid = state
             .job_owner_cache
@@ -385,12 +407,23 @@ async fn job_event_handler(
             None => {
                 // Cache miss: fall back to DB lookup and populate cache.
                 let uid = match state.store.as_ref() {
-                    Some(store) => store
-                        .get_sandbox_job(job_id)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|j| j.user_id),
+                    Some(store) => match store.get_sandbox_job(job_id).await {
+                        Ok(Some(j)) => Some(j.user_id),
+                        Ok(None) => {
+                            tracing::debug!(
+                                job_id = %job_id,
+                                "No job found in DB for owner lookup"
+                            );
+                            None
+                        }
+                        Err(e) => {
+                            tracing::debug!(
+                                job_id = %job_id,
+                                "DB fallback for job owner failed: {e}"
+                            );
+                            None
+                        }
+                    },
                     None => None,
                 };
                 if let Some(ref uid) = uid {
@@ -404,14 +437,8 @@ async fn job_event_handler(
             }
         };
 
-        if user_id.is_empty() {
-            let _ = tx.send((job_id, String::new(), app_event));
-        } else {
-            let _ = tx.send((job_id, user_id, app_event));
-        }
+        let _ = tx.send((job_id, user_id, event));
     }
-
-    Ok(StatusCode::OK)
 }
 
 /// Return the next queued follow-up prompt for a Claude Code bridge.
@@ -789,23 +816,9 @@ mod tests {
 
     #[tokio::test]
     async fn job_event_broadcasts_message() {
-        let (tx, mut rx) = broadcast::channel(16);
-        let token_store = TokenStore::new();
-        let jm = ContainerJobManager::new(ContainerJobConfig::default(), token_store.clone());
-        let state = OrchestratorState {
-            llm: Arc::new(StubLlm::default()),
-            job_manager: Arc::new(jm),
-            token_store: token_store.clone(),
-            job_event_tx: Some(tx),
-            prompt_queue: Arc::new(Mutex::new(HashMap::new())),
-            store: None,
-            secrets_store: None,
-            user_id: "<unset>".to_string(), // sentinel for tests only — real startup sets this from config.owner_id
-            job_owner_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
-        };
-
+        let (state, mut rx) = test_state_with_broadcast();
         let job_id = Uuid::new_v4();
-        let token = token_store.create_token(job_id).await;
+        let token = state.token_store.create_token(job_id).await;
         let router = OrchestratorApi::router(state);
 
         let payload = serde_json::json!({
@@ -847,23 +860,9 @@ mod tests {
 
     #[tokio::test]
     async fn job_event_handles_tool_use() {
-        let (tx, mut rx) = broadcast::channel(16);
-        let token_store = TokenStore::new();
-        let jm = ContainerJobManager::new(ContainerJobConfig::default(), token_store.clone());
-        let state = OrchestratorState {
-            llm: Arc::new(StubLlm::default()),
-            job_manager: Arc::new(jm),
-            token_store: token_store.clone(),
-            job_event_tx: Some(tx),
-            prompt_queue: Arc::new(Mutex::new(HashMap::new())),
-            store: None,
-            secrets_store: None,
-            user_id: "<unset>".to_string(), // sentinel for tests only — real startup sets this from config.owner_id
-            job_owner_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
-        };
-
+        let (state, mut rx) = test_state_with_broadcast();
         let job_id = Uuid::new_v4();
-        let token = token_store.create_token(job_id).await;
+        let token = state.token_store.create_token(job_id).await;
         let router = OrchestratorApi::router(state);
 
         let payload = serde_json::json!({
@@ -896,23 +895,9 @@ mod tests {
 
     #[tokio::test]
     async fn job_event_handles_unknown_type() {
-        let (tx, mut rx) = broadcast::channel(16);
-        let token_store = TokenStore::new();
-        let jm = ContainerJobManager::new(ContainerJobConfig::default(), token_store.clone());
-        let state = OrchestratorState {
-            llm: Arc::new(StubLlm::default()),
-            job_manager: Arc::new(jm),
-            token_store: token_store.clone(),
-            job_event_tx: Some(tx),
-            prompt_queue: Arc::new(Mutex::new(HashMap::new())),
-            store: None,
-            secrets_store: None,
-            user_id: "<unset>".to_string(), // sentinel for tests only — real startup sets this from config.owner_id
-            job_owner_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
-        };
-
+        let (state, mut rx) = test_state_with_broadcast();
         let job_id = Uuid::new_v4();
-        let token = token_store.create_token(job_id).await;
+        let token = state.token_store.create_token(job_id).await;
         let router = OrchestratorApi::router(state);
 
         let payload = serde_json::json!({
@@ -943,26 +928,7 @@ mod tests {
         let state = test_state();
         let job_id = Uuid::new_v4();
         let token = state.token_store.create_token(job_id).await;
-
-        // Insert a handle so update_worker_status has something to update
-        {
-            let mut containers = state.job_manager.containers.write().await;
-            containers.insert(
-                job_id,
-                crate::orchestrator::job_manager::ContainerHandle {
-                    job_id,
-                    container_id: "test-container".to_string(),
-                    state: crate::orchestrator::job_manager::ContainerState::Running,
-                    mode: crate::orchestrator::job_manager::JobMode::Worker,
-                    created_at: chrono::Utc::now(),
-                    project_dir: None,
-                    task_description: "test".to_string(),
-                    last_worker_status: None,
-                    worker_iteration: 0,
-                    completion_result: None,
-                },
-            );
-        }
+        insert_container_handle(&state, job_id).await;
 
         let jm = Arc::clone(&state.job_manager);
         let router = OrchestratorApi::router(state);
@@ -987,5 +953,177 @@ mod tests {
         let handle = jm.get_handle(job_id).await.unwrap();
         assert_eq!(handle.worker_iteration, 5);
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 5"));
+    }
+
+    // -- report_complete broadcast tests --
+
+    /// Helper: create state with a broadcast channel for event tests.
+    fn test_state_with_broadcast() -> (
+        OrchestratorState,
+        broadcast::Receiver<(Uuid, String, AppEvent)>,
+    ) {
+        let (tx, rx) = broadcast::channel(16);
+        let mut state = test_state();
+        state.job_event_tx = Some(tx);
+        (state, rx)
+    }
+
+    async fn insert_container_handle(state: &OrchestratorState, job_id: Uuid) {
+        let mut containers = state.job_manager.containers.write().await;
+        containers.insert(
+            job_id,
+            crate::orchestrator::job_manager::ContainerHandle {
+                job_id,
+                container_id: String::new(), // empty → skips Docker cleanup
+                state: crate::orchestrator::job_manager::ContainerState::Running,
+                mode: crate::orchestrator::job_manager::JobMode::Worker,
+                created_at: chrono::Utc::now(),
+                project_dir: None,
+                task_description: "test".to_string(),
+                last_worker_status: None,
+                worker_iteration: 0,
+                completion_result: None,
+            },
+        );
+    }
+
+    #[tokio::test]
+    async fn report_complete_broadcasts_job_result() {
+        let (state, mut rx) = test_state_with_broadcast();
+        let job_id = Uuid::new_v4();
+        let token = state.token_store.create_token(job_id).await;
+        insert_container_handle(&state, job_id).await;
+
+        let router = OrchestratorApi::router(state);
+        let payload = serde_json::json!({
+            "success": true,
+            "message": "ACP agent session completed",
+            "iterations": 3
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/complete", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let (recv_id, _recv_uid, event) = rx.recv().await.unwrap();
+        assert_eq!(recv_id, job_id);
+        match event {
+            AppEvent::JobResult {
+                job_id: jid,
+                status,
+                session_id,
+                fallback_deliverable,
+            } => {
+                assert_eq!(jid, job_id.to_string());
+                assert_eq!(status, "completed");
+                assert!(session_id.is_none());
+                assert!(fallback_deliverable.is_none());
+            }
+            other => panic!("Expected JobResult, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn report_complete_broadcasts_error_on_failure() {
+        let (state, mut rx) = test_state_with_broadcast();
+        let job_id = Uuid::new_v4();
+        let token = state.token_store.create_token(job_id).await;
+        insert_container_handle(&state, job_id).await;
+
+        let router = OrchestratorApi::router(state);
+        let payload = serde_json::json!({
+            "success": false,
+            "message": "Follow-up prompt failed: connection refused",
+            "iterations": 1
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/complete", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let (recv_id, _recv_uid, event) = rx.recv().await.unwrap();
+        assert_eq!(recv_id, job_id);
+        match event {
+            AppEvent::JobResult { status, .. } => {
+                assert_eq!(status, "error");
+            }
+            other => panic!("Expected JobResult, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn report_complete_works_without_broadcast_channel() {
+        let state = test_state(); // job_event_tx: None
+        let job_id = Uuid::new_v4();
+        let token = state.token_store.create_token(job_id).await;
+        insert_container_handle(&state, job_id).await;
+
+        let router = OrchestratorApi::router(state);
+        let payload = serde_json::json!({
+            "success": true,
+            "message": "done",
+            "iterations": 1
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/complete", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn report_complete_broadcast_uses_cached_user_id() {
+        let (state, mut rx) = test_state_with_broadcast();
+        let job_id = Uuid::new_v4();
+        let token = state.token_store.create_token(job_id).await;
+        insert_container_handle(&state, job_id).await;
+
+        // Pre-populate the owner cache.
+        state
+            .job_owner_cache
+            .write()
+            .unwrap()
+            .insert(job_id, "user-42".to_string());
+
+        let router = OrchestratorApi::router(state);
+        let payload = serde_json::json!({
+            "success": true,
+            "message": "done",
+            "iterations": 1
+        });
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/complete", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(serde_json::to_vec(&payload).unwrap()))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let (_recv_id, recv_uid, _event) = rx.recv().await.unwrap();
+        assert_eq!(recv_uid, "user-42");
     }
 }

--- a/src/worker/acp_bridge.rs
+++ b/src/worker/acp_bridge.rs
@@ -510,7 +510,7 @@ async fn run_follow_up_loop(
                     tracing::error!(job_id = %job_id, "{}", msg);
                     return Err(WorkerError::ExecutionFailed { reason: msg });
                 }
-                tracing::warn!(
+                tracing::debug!(
                     job_id = %job_id,
                     attempt = consecutive_poll_errors,
                     "Transient poll error: {}", e,

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -299,7 +299,21 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             }
             Ok(Err(e)) => {
                 tracing::error!("Worker for job {} failed: {}", self.job_id, e);
-                self.mark_failed(&e.to_string()).await?;
+                // Only mark failed if not already in a terminal state.
+                // A race (e.g. safety-net broadcast) may have already
+                // transitioned the job; re-running mark_failed would
+                // overwrite the fallback and emit a duplicate "result" event.
+                let current_state = self
+                    .context_manager()
+                    .get_context(self.job_id)
+                    .await
+                    .map(|ctx| ctx.state);
+                match current_state {
+                    Ok(state) if state.is_terminal() || state == JobState::Completed => {}
+                    _ => {
+                        self.mark_failed(&e.to_string()).await?;
+                    }
+                }
             }
             Err(_) => {
                 tracing::warn!("Worker for job {} timed out", self.job_id);


### PR DESCRIPTION
## Summary

Follow-up to #1981 (propagate follow-up prompt failures as job errors).

- **Safety-net broadcast in `report_complete`**: Even if the worker's fire-and-forget `post_event("result")` is lost, the orchestrator now broadcasts a `JobResult` so job monitors free the `max_jobs` slot. Duplicates are harmless — consumers break on the first `JobResult`.
- **Idempotent terminal self-transitions**: Extended from just `Completed→Completed` to all terminal states (`Failed`, `Accepted`, `Cancelled`) using `is_terminal()`. Cross-terminal transitions (e.g. `Failed→Cancelled`) are explicitly blocked.
- **DB fallback error logging**: `broadcast_app_event` now logs at `debug\!` when the DB owner lookup fails or returns no job, instead of silently swallowing the error.
- **Duplicate-event test**: Proves the completion watcher handles back-to-back `JobResult` events (simulating `post_event` + safety-net both arriving) without error.
- **Log level fix**: Demoted transient poll error log from `warn\!` to `debug\!` in `acp_bridge` to avoid REPL/TUI noise.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib` — 4295 passed
- [x] Verify safety-net broadcast fires when worker `post_event` is lost (manual or E2E)
- [x] Verify duplicate `JobResult` does not cause double state transition or slot leak