### PR TITLE
fix(web): add stop control for active chat turns

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -38,6 +38,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | HTTP endpoints for Control UI | ✅ | ✅ | Web dashboard with chat, memory, jobs, logs, extensions |
 | Channel connection lifecycle | ✅ | ✅ | ChannelManager + WebSocket tracker |
 | Session management/routing | ✅ | ✅ | SessionManager exists |
+| Visible Stop control during active chat turns | ✅ | 🚧 | Send button swaps to Stop; `/api/chat/interrupt` cancels the running turn |
 | Configuration hot-reload | ✅ | ❌ | |
 | Network modes (loopback/LAN/remote) | ✅ | 🚧 | HTTP only |
 | OpenAI-compatible HTTP API | ✅ | ✅ | /v1/chat/completions, per-request `model` override |

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -239,6 +239,7 @@ let _doneWithoutResponseTimer = null;
 // --- Send Cooldown State ---
 let _sendCooldown = false;
 let _recentLocalPairingApprovals = new Map();
+let _turnRunning = false;
 
 // --- Slash Commands ---
 
@@ -840,6 +841,7 @@ function connectSSE(lastEventIdOverride) {
     if (streamingMsg) streamingMsg.removeAttribute('data-streaming');
 
     _turnResponseReceived = true;
+    setTurnRunning(false);
     if (_doneWithoutResponseTimer) {
       clearTimeout(_doneWithoutResponseTimer);
       _doneWithoutResponseTimer = null;
@@ -862,6 +864,7 @@ function connectSSE(lastEventIdOverride) {
       if (data.thread_id) debouncedLoadThreads();
       return;
     }
+    setTurnRunning(true);
     clearSuggestionChips();
     showActivityThinking(data.message);
   });
@@ -877,12 +880,14 @@ function connectSSE(lastEventIdOverride) {
   addTrackedEventListener('tool_started', (e) => {
     const data = JSON.parse(e.data);
     if (!isCurrentThread(data.thread_id)) return;
+    setTurnRunning(true);
     addToolCard(data.name);
   });
 
   addTrackedEventListener('tool_completed', (e) => {
     const data = JSON.parse(e.data);
     if (!isCurrentThread(data.thread_id)) return;
+    setTurnRunning(true);
     completeToolCard(data.name, data.success, data.error, data.parameters);
 
     // Show restart modal only when the restart tool succeeds
@@ -900,6 +905,7 @@ function connectSSE(lastEventIdOverride) {
   addTrackedEventListener('stream_chunk', (e) => {
     const data = JSON.parse(e.data);
     if (!isCurrentThread(data.thread_id)) return;
+    setTurnRunning(true);
     finalizeActivityGroup();
 
     // Mark the active assistant message as streaming
@@ -942,8 +948,9 @@ function connectSSE(lastEventIdOverride) {
     // the agentic loop finished, so re-enable input as a safety net in case
     // the response SSE event is empty or lost.
     // Status text is not displayed — inline activity cards handle visual feedback.
-    if (data.message === 'Done' || data.message === 'Awaiting approval') {
+    if (data.message === 'Done' || data.message === 'Awaiting approval' || data.message === 'Interrupted') {
       finalizeActivityGroup();
+      setTurnRunning(false);
       enableChatInput();
       // Safety net (#2079): if "Done" arrives but we never received a
       // `response` event for this turn, the message may have been lost
@@ -972,6 +979,7 @@ function connectSSE(lastEventIdOverride) {
     const forCurrentThread = !hasThread || isCurrentThread(data.thread_id);
 
     if (forCurrentThread) {
+      setTurnRunning(false);
       showApproval(data);
     } else {
       // Keep thread list fresh when approval is requested in a background thread.
@@ -1004,11 +1012,13 @@ function connectSSE(lastEventIdOverride) {
 
   addTrackedEventListener('gate_required', (e) => {
     const data = JSON.parse(e.data);
+    setTurnRunning(false);
     handleGateRequired(data);
   });
 
   addTrackedEventListener('gate_resolved', (e) => {
     const data = JSON.parse(e.data);
+    setTurnRunning(false);
     handleGateResolved(data);
   });
 
@@ -1027,6 +1037,7 @@ function connectSSE(lastEventIdOverride) {
       const data = JSON.parse(e.data);
       if (!isCurrentThread(data.thread_id)) return;
       finalizeActivityGroup();
+      setTurnRunning(false);
       addMessage('system', 'Error: ' + data.message);
       enableChatInput();
     }
@@ -1195,10 +1206,12 @@ function sendMessage() {
     renderImagePreviews();
   }
 
+  setTurnRunning(true);
   apiFetch('/api/chat/send', {
     method: 'POST',
     body: body,
   }).catch((err) => {
+    setTurnRunning(false);
     // Handle rate limiting (429)
     if (err.status === 429) {
       showToast(I18n.t('chat.rateLimited'), 'error');
@@ -1229,6 +1242,36 @@ function sendMessage() {
   });
 }
 
+function interruptCurrentTurn() {
+  if (!currentThreadId) return;
+  apiFetch('/api/chat/interrupt', {
+    method: 'POST',
+    body: { thread_id: currentThreadId },
+  }).then(() => {
+    setTurnRunning(false);
+  }).catch((err) => {
+    addMessage('system', 'Failed to interrupt current turn: ' + err.message);
+  });
+}
+
+function setTurnRunning(running) {
+  _turnRunning = !!running;
+  const btn = document.getElementById('send-btn');
+  if (btn) {
+    btn.textContent = _turnRunning ? (I18n.t('chat.stop') || 'Stop') : I18n.t('chat.send');
+    btn.title = _turnRunning ? (I18n.t('chat.stop') || 'Stop the current turn') : I18n.t('chat.send');
+    btn.classList.toggle('btn-cancel', _turnRunning);
+  }
+}
+
+function handleChatActionButton() {
+  if (_turnRunning) {
+    interruptCurrentTurn();
+  } else {
+    sendMessage();
+  }
+}
+
 function enableChatInput() {
   if (currentThreadIsReadOnly || authFlowPending) return;
   const input = document.getElementById('chat-input');
@@ -1237,6 +1280,7 @@ function enableChatInput() {
     input.disabled = false;
   }
   if (btn) btn.disabled = false;
+  setTurnRunning(_turnRunning);
 }
 
 // --- Image Upload ---
@@ -2946,7 +2990,12 @@ function loadHistory(before) {
       // Show processing indicator if the last turn is still in-progress
       var lastTurn = data.turns.length > 0 ? data.turns[data.turns.length - 1] : null;
       if (lastTurn && !lastTurn.response && lastTurn.state === 'Processing') {
+        setTurnRunning(true);
         showActivityThinking('Processing...');
+      } else if (lastTurn && lastTurn.state === 'Interrupted') {
+        setTurnRunning(false);
+      } else {
+        setTurnRunning(false);
       }
       if (data.pending_gate) {
         handleGateRequired({
@@ -3263,6 +3312,7 @@ function disableChatInputReadOnly() {
     input.placeholder = I18n.t('chat.readOnlyThread');
   }
   if (btn) btn.disabled = true;
+  setTurnRunning(false);
 }
 
 function switchToAssistant() {
@@ -3382,7 +3432,10 @@ chatInput.addEventListener('keydown', (e) => {
   if (e.key === 'Enter' && !e.shiftKey && !e.isComposing && e.keyCode !== 229) {
     e.preventDefault();
     hideSlashAutocomplete();
-    sendMessage();
+    if (_turnRunning) {
+      return;
+    }
+    handleChatActionButton();
   }
 });
 chatInput.addEventListener('input', () => {
@@ -8052,7 +8105,7 @@ document.getElementById('restart-btn').addEventListener('click', () => triggerRe
 document.getElementById('thread-new-btn').addEventListener('click', () => createNewThread());
 document.getElementById('thread-toggle-btn').addEventListener('click', () => toggleThreadSidebar());
 document.getElementById('assistant-thread').addEventListener('click', () => switchToAssistant());
-document.getElementById('send-btn').addEventListener('click', () => sendMessage());
+document.getElementById('send-btn').addEventListener('click', () => handleChatActionButton());
 document.getElementById('memory-edit-btn').addEventListener('click', () => startMemoryEdit());
 document.getElementById('memory-save-btn').addEventListener('click', () => saveMemoryEdit());
 document.getElementById('memory-cancel-btn').addEventListener('click', () => cancelMemoryEdit());

--- a/crates/ironclaw_gateway/static/i18n/en.js
+++ b/crates/ironclaw_gateway/static/i18n/en.js
@@ -118,6 +118,7 @@ I18n.register('en', {
   'chat.assistant': 'Assistant',
   'chat.conversations': 'Conversations',
   'chat.send': 'Send',
+  'chat.stop': 'Stop',
   'chat.attachImages': 'Attach Images',
   'chat.scrollToBottom': 'Scroll to bottom',
   'chat.empty': 'Select a file to view content',

--- a/crates/ironclaw_gateway/static/i18n/ko.js
+++ b/crates/ironclaw_gateway/static/i18n/ko.js
@@ -18,6 +18,7 @@ I18n.register('ko', {
   'auth.errorInvalid': '잘못된 토큰',
   // 채팅
   'chat.inputPlaceholder': '메시지 또는 명령어 입력 (/)...',
+  'chat.stop': '중지',
 
   // 재시작 모달
   'restart.title': 'IronClaw 인스턴스 재시작',

--- a/crates/ironclaw_gateway/static/i18n/zh-CN.js
+++ b/crates/ironclaw_gateway/static/i18n/zh-CN.js
@@ -118,6 +118,7 @@ I18n.register('zh-CN', {
   'chat.assistant': '助手',
   'chat.conversations': '对话列表',
   'chat.send': '发送',
+  'chat.stop': '停止',
   'chat.attachImages': '附加图片',
   'chat.scrollToBottom': '滚动到底部',
   'chat.empty': '选择文件查看内容',

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use tokio::sync::Mutex;
 use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::agent::Agent;
@@ -253,6 +254,13 @@ impl Agent {
             thread_id,
             message,
             job_ctx,
+            turn_cancel: {
+                let sess = session.lock().await;
+                sess.threads
+                    .get(&thread_id)
+                    .and_then(|thread| thread.current_turn_cancel())
+                    .unwrap_or_else(CancellationToken::new)
+            },
             active_skills,
             cached_prompt,
             cached_prompt_no_tools,
@@ -369,6 +377,7 @@ struct ChatDelegate<'a> {
     thread_id: Uuid,
     message: &'a IncomingMessage,
     job_ctx: JobContext,
+    turn_cancel: CancellationToken,
     active_skills: Vec<ironclaw_skills::LoadedSkill>,
     cached_prompt: String,
     cached_prompt_no_tools: String,
@@ -405,10 +414,7 @@ impl ChatDelegate<'_> {
 #[async_trait]
 impl<'a> LoopDelegate for ChatDelegate<'a> {
     async fn check_signals(&self) -> LoopSignal {
-        let sess = self.session.lock().await;
-        if let Some(thread) = sess.threads.get(&self.thread_id)
-            && thread.state == ThreadState::Interrupted
-        {
+        if self.turn_cancel.is_cancelled() {
             return LoopSignal::Stop;
         }
         LoopSignal::Continue
@@ -628,7 +634,17 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
             }
         }
 
-        let output = match reasoning.respond_with_tools(reason_ctx).await {
+        let output = match tokio::select! {
+            biased;
+            _ = self.turn_cancel.cancelled() => {
+                return Err(crate::error::JobError::ContextError {
+                    id: self.thread_id,
+                    reason: "Interrupted".to_string(),
+                }
+                .into());
+            }
+            output = reasoning.respond_with_tools(reason_ctx) => output,
+        } {
             Ok(output) => output,
             Err(crate::error::LlmError::ContextLengthExceeded { used, limit }) => {
                 tracing::warn!(
@@ -646,18 +662,28 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     reason_ctx.available_tools.clear();
                 }
 
-                reasoning
-                    .respond_with_tools(reason_ctx)
-                    .await
-                    .map_err(|retry_err| {
+                match tokio::select! {
+                    biased;
+                    _ = self.turn_cancel.cancelled() => {
+                        return Err(crate::error::JobError::ContextError {
+                            id: self.thread_id,
+                            reason: "Interrupted".to_string(),
+                        }
+                        .into());
+                    }
+                    output = reasoning.respond_with_tools(reason_ctx) => output,
+                } {
+                    Ok(output) => output,
+                    Err(retry_err) => {
                         tracing::error!(
                             original_used = used,
                             original_limit = limit,
                             retry_error = %retry_err,
                             "Retry after auto-compaction also failed"
                         );
-                        crate::error::Error::from(retry_err)
-                    })?
+                        return Err(crate::error::Error::from(retry_err));
+                    }
+                }
             }
             Err(e) => return Err(e.into()),
         };
@@ -994,10 +1020,19 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     )
                     .await;
 
-                let result = self
-                    .agent
-                    .execute_chat_tool(&tc.name, &tc.arguments, &self.job_ctx)
-                    .await;
+                let result = tokio::select! {
+                    biased;
+                    _ = self.turn_cancel.cancelled() => {
+                        Err(crate::error::JobError::ContextError {
+                            id: self.thread_id,
+                            reason: "Interrupted".to_string(),
+                        }
+                        .into())
+                    }
+                    result = self
+                        .agent
+                        .execute_chat_tool(&tc.name, &tc.arguments, &self.job_ctx) => result,
+                };
 
                 let disp_tool = self.agent.tools().get(&tc.name).await;
                 let _ = self
@@ -1030,6 +1065,8 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 let tc = tc.clone();
                 let channel = self.message.channel.clone();
                 let metadata = self.message.metadata.clone();
+                let turn_cancel = self.turn_cancel.clone();
+                let thread_id = self.thread_id;
 
                 join_set.spawn(async move {
                     let _ = channels
@@ -1044,14 +1081,23 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                         )
                         .await;
 
-                    let result = execute_chat_tool_standalone(
-                        &tools,
-                        &safety,
-                        &tc.name,
-                        &tc.arguments,
-                        &job_ctx,
-                    )
-                    .await;
+                    let result = tokio::select! {
+                        biased;
+                        _ = turn_cancel.cancelled() => {
+                            Err(crate::error::JobError::ContextError {
+                                id: thread_id,
+                                reason: "Interrupted".to_string(),
+                            }
+                            .into())
+                        }
+                        result = execute_chat_tool_standalone(
+                            &tools,
+                            &safety,
+                            &tc.name,
+                            &tc.arguments,
+                            &job_ctx,
+                        ) => result,
+                    };
 
                     let par_tool = tools.get(&tc.name).await;
                     let _ = channels
@@ -1073,6 +1119,14 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
             }
 
             while let Some(join_result) = join_set.join_next().await {
+                if self.turn_cancel.is_cancelled() {
+                    join_set.abort_all();
+                    return Err(crate::error::JobError::ContextError {
+                        id: self.thread_id,
+                        reason: "Interrupted".to_string(),
+                    }
+                    .into());
+                }
                 match join_result {
                     Ok((pf_idx, result)) => {
                         exec_results[pf_idx] = Some(result);
@@ -1085,6 +1139,14 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                         }
                     }
                 }
+            }
+
+            if self.turn_cancel.is_cancelled() {
+                return Err(crate::error::JobError::ContextError {
+                    id: self.thread_id,
+                    reason: "Interrupted".to_string(),
+                }
+                .into());
             }
 
             // Fill panicked slots with error results

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -11,7 +11,7 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::agent::Agent;
-use crate::agent::session::{PendingApproval, PendingAuthPrompt, Session, ThreadState};
+use crate::agent::session::{PendingApproval, PendingAuthPrompt, Session};
 use crate::channels::{ChannelManager, IncomingMessage, StatusUpdate};
 use crate::context::JobContext;
 use crate::error::Error;

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -259,7 +259,13 @@ impl Agent {
                 sess.threads
                     .get(&thread_id)
                     .and_then(|thread| thread.current_turn_cancel())
-                    .unwrap_or_else(CancellationToken::new)
+                    .unwrap_or_else(|| {
+                        tracing::debug!(
+                            thread_id = %thread_id,
+                            "Thread turn cancellation token missing; using detached fallback token"
+                        );
+                        CancellationToken::new()
+                    })
             },
             active_skills,
             cached_prompt,

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -14,6 +14,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use chrono::{DateTime, TimeDelta, Utc};
 use serde::{Deserialize, Serialize};
+use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::llm::{ChatMessage, ToolCall, generate_tool_call_id};
@@ -280,6 +281,9 @@ pub struct Thread {
     /// Channel that created this thread (for approval authorization).
     #[serde(default)]
     pub source_channel: Option<String>,
+    /// Cancellation token for the active turn. Not persisted.
+    #[serde(skip, default)]
+    pub turn_cancel: Option<CancellationToken>,
 }
 
 /// Maximum number of messages that can be queued while a thread is processing.
@@ -329,6 +333,7 @@ impl Thread {
             pending_auth: None,
             pending_messages: VecDeque::new(),
             source_channel: source_channel.map(String::from),
+            turn_cancel: None,
         }
     }
 
@@ -347,6 +352,7 @@ impl Thread {
             pending_auth: None,
             pending_messages: VecDeque::new(),
             source_channel: source_channel.map(String::from),
+            turn_cancel: None,
         }
     }
 
@@ -411,6 +417,7 @@ impl Thread {
         let turn_number = self.turns.len();
         let turn = Turn::new(turn_number, user_input);
         self.turns.push(turn);
+        self.turn_cancel = Some(CancellationToken::new());
         self.state = ThreadState::Processing;
         self.updated_at = Utc::now();
         // turn_number was len() before push, so it's a valid index after push
@@ -422,6 +429,7 @@ impl Thread {
         if let Some(turn) = self.turns.last_mut() {
             turn.complete(response);
         }
+        self.turn_cancel = None;
         self.state = ThreadState::Idle;
         self.updated_at = Utc::now();
     }
@@ -431,6 +439,7 @@ impl Thread {
         if let Some(turn) = self.turns.last_mut() {
             turn.fail(error);
         }
+        self.turn_cancel = None;
         self.state = ThreadState::Idle;
         self.updated_at = Utc::now();
     }
@@ -471,12 +480,20 @@ impl Thread {
 
     /// Interrupt the current turn and discard any queued messages.
     pub fn interrupt(&mut self) {
+        if let Some(token) = self.turn_cancel.as_ref() {
+            token.cancel();
+        }
         if let Some(turn) = self.turns.last_mut() {
             turn.interrupt();
         }
         self.pending_messages.clear();
         self.state = ThreadState::Interrupted;
         self.updated_at = Utc::now();
+    }
+
+    /// Get a clone of the active turn cancellation token.
+    pub fn current_turn_cancel(&self) -> Option<CancellationToken> {
+        self.turn_cancel.clone()
     }
 
     /// Resume after interruption.

--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -30,6 +30,7 @@ Browser-facing HTTP API and SSE/WebSocket real-time streaming. Axum-based, singl
 | Method | Path | Description |
 |--------|------|-------------|
 | POST | `/api/chat/send` | Send message → queues to agent loop |
+| POST | `/api/chat/interrupt` | Stop the active turn and cancel the running agent loop |
 | GET | `/api/chat/events` | SSE stream of agent events |
 | GET | `/api/chat/ws` | WebSocket alternative to SSE |
 | GET | `/api/chat/history` | Paginated turn history for a thread |

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -28,7 +28,7 @@ use uuid::Uuid;
 
 use axum::http::HeaderMap;
 
-use crate::agent::SessionManager;
+use crate::agent::{SessionManager, ThreadState};
 use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::IncomingMessage;
 use crate::channels::relay::DEFAULT_RELAY_NAME;
@@ -593,6 +593,7 @@ pub async fn start_server(
     let protected = Router::new()
         // Chat
         .route("/api/chat/send", post(chat_send_handler))
+        .route("/api/chat/interrupt", post(chat_interrupt_handler))
         .route("/api/chat/gate/resolve", post(chat_gate_resolve_handler))
         .route("/api/chat/approval", post(chat_approval_handler))
         .route("/api/chat/auth-token", post(chat_auth_token_handler))
@@ -2349,6 +2350,54 @@ async fn chat_approval_handler(
             status: "accepted",
         }),
     ))
+}
+
+async fn chat_interrupt_handler(
+    State(state): State<Arc<GatewayState>>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Json(req): Json<InterruptRequest>,
+) -> Result<Json<ActionResponse>, (StatusCode, String)> {
+    let session_manager = state.session_manager.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Session manager not available".to_string(),
+    ))?;
+
+    let session = session_manager.get_or_create_session(&user.user_id).await;
+
+    let thread_id = if let Some(thread_id) = req.thread_id.as_ref() {
+        Uuid::parse_str(thread_id)
+            .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid thread_id".to_string()))?
+    } else {
+        let sess = session.lock().await;
+        sess.active_thread
+            .ok_or((StatusCode::NOT_FOUND, "No active thread".to_string()))?
+    };
+
+    let interrupted = {
+        let mut sess = session.lock().await;
+        let thread = sess
+            .threads
+            .get_mut(&thread_id)
+            .ok_or((StatusCode::NOT_FOUND, "Thread not found".to_string()))?;
+
+        match thread.state {
+            ThreadState::Processing | ThreadState::AwaitingApproval => {
+                thread.interrupt();
+                true
+            }
+            _ => false,
+        }
+    };
+
+    if interrupted {
+        state.sse.broadcast(AppEvent::Status {
+            message: "Interrupted".into(),
+            thread_id: Some(thread_id.to_string()),
+        });
+        return Ok(Json(ActionResponse::ok("Interrupted.")));
+    }
+
+    Ok(Json(ActionResponse::ok("Nothing to interrupt.")))
 }
 
 async fn chat_gate_resolve_handler(

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -30,6 +30,11 @@ pub struct SendMessageResponse {
     pub status: &'static str,
 }
 
+#[derive(Debug, Deserialize)]
+pub struct InterruptRequest {
+    pub thread_id: Option<String>,
+}
+
 #[derive(Debug, Serialize)]
 pub struct ThreadInfo {
     pub id: Uuid,

--- a/tests/stop_control_regression.rs
+++ b/tests/stop_control_regression.rs
@@ -1,0 +1,24 @@
+use ironclaw::agent::session::{Thread, ThreadState};
+use uuid::Uuid;
+
+#[test]
+fn interrupt_cancels_active_turn_and_marks_thread_interrupted() {
+    let session_id = Uuid::new_v4();
+    let mut thread = Thread::with_id(Uuid::new_v4(), session_id, Some("web"));
+
+    let cancel = {
+        let turn = thread.start_turn("please stop me");
+        assert_eq!(turn.user_input, "please stop me");
+        thread
+            .current_turn_cancel()
+            .expect("turn should expose a cancellation token")
+    };
+
+    assert!(!cancel.is_cancelled(), "token should start active");
+
+    thread.interrupt();
+
+    assert_eq!(thread.state, ThreadState::Interrupted);
+    assert!(cancel.is_cancelled(), "interrupt should cancel the token");
+    assert!(thread.current_turn_cancel().is_some());
+}


### PR DESCRIPTION
Implements #2121 by adding a visible Stop control for active chat turns and a direct interrupt endpoint that cancels the running turn instead of relying on the normal chat pipeline.

What changed:
- the chat send button now swaps to Stop while a turn is running
- added  for out-of-band cancellation
- thread state now tracks a cancellation token for the active turn
- the agent loop and tool execution paths observe cancellation mid-flight
- added a regression test for interrupt-token cancellation
- updated the web gateway docs and feature parity matrix

Validation:
- cargo fmt --all
- cargo check -q
- cargo test -p ironclaw agent::session::tests::test_thread_interrupt_and_resume -- --nocapture
- cargo clippy -p ironclaw --lib --all-features -- -D warnings