### PR TITLE
fix(ownership): unify ownership checks via Owned trait, fix mission visibility

### DIFF
--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -15,6 +15,7 @@ use crate::channels::{IncomingMessage, StatusUpdate};
 use crate::context::JobState;
 use crate::error::Error;
 use crate::llm::{ChatMessage, Reasoning};
+use crate::ownership::Owned;
 
 /// Format a count with a suffix, using K/M abbreviations for large numbers.
 fn format_count(n: u64, suffix: &str) -> String {
@@ -134,7 +135,7 @@ impl Agent {
                 }
 
                 let ctx = self.context_manager.get_context(uuid).await?;
-                if ctx.user_id != tenant.user_id() {
+                if !ctx.is_owned_by(tenant.user_id()) {
                     return Err(crate::error::JobError::NotFound { id: uuid }.into());
                 }
 
@@ -202,7 +203,7 @@ impl Agent {
             .map_err(|_| crate::error::JobError::NotFound { id: Uuid::nil() })?;
 
         let ctx = self.context_manager.get_context(uuid).await?;
-        if ctx.user_id != tenant.user_id() {
+        if !ctx.is_owned_by(tenant.user_id()) {
             return Err(crate::error::JobError::NotFound { id: uuid }.into());
         }
 
@@ -282,7 +283,7 @@ impl Agent {
             .map_err(|_| crate::error::JobError::NotFound { id: Uuid::nil() })?;
 
         let ctx = self.context_manager.get_context(uuid).await?;
-        if ctx.user_id != tenant.user_id() {
+        if !ctx.is_owned_by(tenant.user_id()) {
             return Err(crate::error::JobError::NotFound { id: uuid }.into());
         }
 

--- a/src/agent/routine.rs
+++ b/src/agent/routine.rs
@@ -54,6 +54,12 @@ pub struct Routine {
     pub updated_at: DateTime<Utc>,
 }
 
+impl crate::ownership::Owned for Routine {
+    fn owner_user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
 const ROUTINE_VERIFICATION_STATE_KEY: &str = "_verification";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -34,6 +34,7 @@ use crate::extensions::ExtensionManager;
 use crate::llm::{
     ChatMessage, CompletionRequest, FinishReason, LlmProvider, ToolCall, ToolCompletionRequest,
 };
+use crate::ownership::Owned;
 use crate::tenant::SystemScope;
 use crate::tools::{
     ToolError, ToolRegistry, autonomous_allowed_tool_names, autonomous_unavailable_message,
@@ -81,7 +82,7 @@ pub(crate) fn routine_matches_message(routine: &Routine, message: &IncomingMessa
     }
 
     // User ownership filter — only fire routines scoped to this user.
-    if routine.user_id != message.user_id {
+    if !routine.is_owned_by(&message.user_id) {
         return false;
     }
 
@@ -291,7 +292,7 @@ impl RoutineEngine {
             if !routine_matches_message(routine, message) {
                 // User mismatch is expected for multi-user setups — keep at
                 // trace to avoid one log per routine per inbound message.
-                if routine.user_id != message.user_id {
+                if !routine.is_owned_by(&message.user_id) {
                     tracing::trace!(
                         routine = %routine.name,
                         routine_user = %routine.user_id,
@@ -405,7 +406,7 @@ impl RoutineEngine {
             }
 
             if let Some(uid) = user_id
-                && routine.user_id != uid
+                && !routine.is_owned_by(uid)
             {
                 continue;
             }
@@ -770,7 +771,7 @@ impl RoutineEngine {
 
         // Enforce ownership when a user_id is provided (gateway calls).
         if let Some(uid) = user_id
-            && routine.user_id != uid
+            && !routine.is_owned_by(uid)
         {
             return Err(RoutineError::NotAuthorized { id: routine_id });
         }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2771,7 +2771,7 @@ pub async fn list_engine_threads(
             let uuid = uuid::Uuid::parse_str(id).map_err(|e| engine_err("parse project_id", e))?;
             ironclaw_engine::ProjectId(uuid)
         }
-        None => state.default_project_id,
+        None => resolve_user_project(&state.store, user_id, state.default_project_id).await?,
     };
 
     let threads = state
@@ -3001,7 +3001,7 @@ pub async fn list_engine_missions(
             let uuid = uuid::Uuid::parse_str(id).map_err(|e| engine_err("parse project_id", e))?;
             ironclaw_engine::ProjectId(uuid)
         }
-        None => state.default_project_id,
+        None => resolve_user_project(&state.store, user_id, state.default_project_id).await?,
     };
 
     let missions = state

--- a/src/channels/web/auth.rs
+++ b/src/channels/web/auth.rs
@@ -56,7 +56,6 @@ use tokio::sync::RwLock;
 
 use crate::config::GatewayOidcConfig;
 use crate::db::Database;
-use crate::ownership::{Identity, OwnerId, UserRole};
 
 /// Cookie name for OAuth browser sessions. Shared between the auth middleware
 /// (cookie extraction) and the auth handlers (cookie set/clear).
@@ -72,16 +71,6 @@ pub struct UserIdentity {
     pub role: String,
     /// Additional user scopes this identity can read from.
     pub workspace_read_scopes: Vec<String>,
-}
-
-/// Convert an authenticated web user into the ownership-layer identity type.
-pub(crate) fn ownership_identity(user: &UserIdentity) -> Identity {
-    let role = if user.role.eq_ignore_ascii_case("admin") {
-        UserRole::Admin
-    } else {
-        UserRole::Member
-    };
-    Identity::new(OwnerId::from(user.user_id.clone()), role)
 }
 
 /// Hash a token with SHA-256 for constant-size, timing-safe storage.

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -11,11 +11,11 @@ use axum::{
 use serde::Deserialize;
 use uuid::Uuid;
 
-use crate::channels::web::auth::{AuthenticatedUser, ownership_identity};
+use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
-use crate::ownership::{OwnerId, can_act_on};
+use crate::ownership::Owned;
 
 fn db_error(context: &str, e: impl std::fmt::Display) -> (StatusCode, String) {
     tracing::error!(%e, context, "Database error in jobs handler");
@@ -204,8 +204,7 @@ pub async fn jobs_detail_handler(
     // Try sandbox job from DB first.
     match store.get_sandbox_job(job_id).await {
         Ok(Some(job)) => {
-            let actor = ownership_identity(&user);
-            if !can_act_on(&actor, &OwnerId::from(job.user_id.clone())) {
+            if !job.is_owned_by(&user.user_id) {
                 return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
             }
             let browse_id = std::path::Path::new(&job.project_dir)
@@ -276,8 +275,7 @@ pub async fn jobs_detail_handler(
     // Fall back to agent job from DB.
     match store.get_job(job_id).await {
         Ok(Some(ctx)) => {
-            let actor = ownership_identity(&user);
-            if !can_act_on(&actor, &OwnerId::from(ctx.user_id.clone())) {
+            if !ctx.is_owned_by(&user.user_id) {
                 return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
             }
             let elapsed_secs = ctx.started_at.map(|start| {
@@ -339,8 +337,7 @@ pub async fn jobs_cancel_handler(
     if let Some(ref store) = state.store {
         match store.get_sandbox_job(job_id).await {
             Ok(Some(job)) => {
-                let actor = ownership_identity(&user);
-                if !can_act_on(&actor, &OwnerId::from(job.user_id.clone())) {
+                if !job.is_owned_by(&user.user_id) {
                     return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
                 }
                 if job.status == "running" || job.status == "creating" {
@@ -379,8 +376,7 @@ pub async fn jobs_cancel_handler(
     if let Some(ref store) = state.store {
         match store.get_job(job_id).await {
             Ok(Some(job)) => {
-                let actor = ownership_identity(&user);
-                if !can_act_on(&actor, &OwnerId::from(job.user_id.clone())) {
+                if !job.is_owned_by(&user.user_id) {
                     return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
                 }
                 if job.state.is_active() {
@@ -436,8 +432,7 @@ pub async fn jobs_restart_handler(
     // Try sandbox job restart first.
     match store.get_sandbox_job(old_job_id).await {
         Ok(Some(old_job)) => {
-            let actor = ownership_identity(&user);
-            if !can_act_on(&actor, &OwnerId::from(old_job.user_id.clone())) {
+            if !old_job.is_owned_by(&user.user_id) {
                 return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
             }
             if old_job.status != "interrupted" && old_job.status != "failed" {
@@ -580,8 +575,7 @@ pub async fn jobs_restart_handler(
     // Try agent job restart: dispatch a new job via the scheduler.
     match store.get_job(old_job_id).await {
         Ok(Some(old_job)) => {
-            let actor = ownership_identity(&user);
-            if !can_act_on(&actor, &OwnerId::from(old_job.user_id.clone())) {
+            if !old_job.is_owned_by(&user.user_id) {
                 return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
             }
             if old_job.state.is_active() {
@@ -666,8 +660,7 @@ pub async fn jobs_prompt_handler(
         && let Ok(Some(sandbox_job)) = s.get_sandbox_job(job_id).await
     {
         // Verify ownership.
-        let actor = ownership_identity(&user);
-        if !can_act_on(&actor, &OwnerId::from(sandbox_job.user_id.clone())) {
+        if !sandbox_job.is_owned_by(&user.user_id) {
             return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
         }
 
@@ -702,8 +695,7 @@ pub async fn jobs_prompt_handler(
     if let Some(ref store) = state.store {
         match store.get_job(job_id).await {
             Ok(Some(agent_job)) => {
-                let actor = ownership_identity(&user);
-                if !can_act_on(&actor, &OwnerId::from(agent_job.user_id.clone())) {
+                if !agent_job.is_owned_by(&user.user_id) {
                     return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
                 }
             }
@@ -756,13 +748,12 @@ pub async fn jobs_events_handler(
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid job ID".to_string()))?;
 
     // Verify ownership before returning events (check both sandbox and agent jobs).
-    let actor = ownership_identity(&user);
     let is_owner = match store.get_sandbox_job(job_id).await {
-        Ok(Some(job)) => can_act_on(&actor, &OwnerId::from(job.user_id.clone())),
+        Ok(Some(job)) => job.is_owned_by(&user.user_id),
         Ok(None) => {
             // Fall back to agent job ownership check.
             match store.get_job(job_id).await {
-                Ok(Some(ctx)) => can_act_on(&actor, &OwnerId::from(ctx.user_id.clone())),
+                Ok(Some(ctx)) => ctx.is_owned_by(&user.user_id),
                 _ => false,
             }
         }
@@ -824,8 +815,7 @@ pub async fn job_files_list_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Job not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(job.user_id.clone())) {
+    if !job.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
     }
 
@@ -893,8 +883,7 @@ pub async fn job_files_read_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Job not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(job.user_id.clone())) {
+    if !job.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Job not found".to_string()));
     }
 

--- a/src/channels/web/handlers/routines.rs
+++ b/src/channels/web/handlers/routines.rs
@@ -14,11 +14,11 @@ use crate::agent::routine::{
     RoutineDisplayStatus, RoutineVerificationStatus, Trigger, next_cron_fire,
     routine_display_status_for_verification, routine_verification_status,
 };
-use crate::channels::web::auth::{AuthenticatedUser, ownership_identity};
+use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 use crate::error::RoutineError;
-use crate::ownership::{OwnerId, can_act_on};
+use crate::ownership::Owned;
 
 pub async fn routines_list_handler(
     State(state): State<Arc<GatewayState>>,
@@ -140,8 +140,7 @@ pub async fn routines_detail_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(routine.user_id.clone())) {
+    if !routine.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 
@@ -216,6 +215,20 @@ pub async fn routines_trigger_handler(
     let routine_id = Uuid::parse_str(&id)
         .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid routine ID".to_string()))?;
 
+    // Verify ownership before triggering.
+    let store = state.store.as_ref().ok_or((
+        StatusCode::SERVICE_UNAVAILABLE,
+        "Database not available".to_string(),
+    ))?;
+    let routine = store
+        .get_routine(routine_id)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
+    if !routine.is_owned_by(&user.user_id) {
+        return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
+    }
+
     let run_id = engine
         .fire_manual(routine_id, Some(&user.user_id))
         .await
@@ -253,8 +266,7 @@ pub async fn routines_toggle_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(routine.user_id.clone())) {
+    if !routine.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 
@@ -321,8 +333,7 @@ pub async fn routines_delete_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(routine.user_id.clone())) {
+    if !routine.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 
@@ -370,8 +381,7 @@ pub async fn routines_runs_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    let actor = ownership_identity(&user);
-    if !can_act_on(&actor, &OwnerId::from(routine.user_id.clone())) {
+    if !routine.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -26,6 +26,7 @@ use tower_http::cors::{AllowHeaders, CorsLayer};
 use tower_http::set_header::SetResponseHeaderLayer;
 use uuid::Uuid;
 
+use crate::ownership::Owned;
 use axum::http::HeaderMap;
 
 use crate::agent::SessionManager;
@@ -2838,7 +2839,7 @@ async fn verify_project_ownership(state: &GatewayState, project_id: &str, user_i
         return false;
     };
     match store.get_sandbox_job(job_id).await {
-        Ok(Some(job)) => job.user_id == user_id,
+        Ok(Some(job)) => job.is_owned_by(user_id),
         _ => false,
     }
 }
@@ -3135,7 +3136,7 @@ async fn routines_runs_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Routine not found".to_string()))?;
 
-    if routine.user_id != user.user_id {
+    if !routine.is_owned_by(&user.user_id) {
         return Err((StatusCode::NOT_FOUND, "Routine not found".to_string()));
     }
 

--- a/src/context/manager.rs
+++ b/src/context/manager.rs
@@ -8,6 +8,7 @@ use uuid::Uuid;
 
 use crate::context::{JobContext, JobState, Memory};
 use crate::error::JobError;
+use crate::ownership::Owned;
 
 /// Manages contexts for multiple concurrent jobs.
 pub struct ContextManager {
@@ -194,7 +195,7 @@ impl ContextManager {
             .read()
             .await
             .iter()
-            .filter(|(_, c)| c.user_id == user_id && c.state.is_active())
+            .filter(|(_, c)| c.is_owned_by(user_id) && c.state.is_active())
             .map(|(id, _)| *id)
             .collect()
     }
@@ -209,7 +210,7 @@ impl ContextManager {
             .read()
             .await
             .iter()
-            .filter(|(_, c)| c.user_id == user_id && c.state.is_parallel_blocking())
+            .filter(|(_, c)| c.is_owned_by(user_id) && c.state.is_parallel_blocking())
             .count()
     }
 
@@ -219,7 +220,7 @@ impl ContextManager {
             .read()
             .await
             .iter()
-            .filter(|(_, c)| c.user_id == user_id)
+            .filter(|(_, c)| c.is_owned_by(user_id))
             .map(|(id, _)| *id)
             .collect()
     }
@@ -325,7 +326,7 @@ impl ContextManager {
         let contexts = self.contexts.read().await;
 
         let mut summary = ContextSummary::default();
-        for ctx in contexts.values().filter(|c| c.user_id == user_id) {
+        for ctx in contexts.values().filter(|c| c.is_owned_by(user_id)) {
             match ctx.state {
                 crate::context::JobState::Pending => summary.pending += 1,
                 crate::context::JobState::InProgress => summary.in_progress += 1,

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -209,6 +209,12 @@ pub struct JobContext {
     pub approval_context: Option<ApprovalContext>,
 }
 
+impl crate::ownership::Owned for JobContext {
+    fn owner_user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
 impl JobContext {
     /// Create a new job context.
     pub fn new(title: impl Into<String>, description: impl Into<String>) -> Self {

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -498,6 +498,12 @@ pub struct SandboxJobRecord {
     pub credential_grants_json: String,
 }
 
+impl crate::ownership::Owned for SandboxJobRecord {
+    fn owner_user_id(&self) -> &str {
+        &self.user_id
+    }
+}
+
 /// Summary of sandbox job counts grouped by status.
 #[derive(Debug, Clone, Default)]
 pub struct SandboxJobSummary {
@@ -520,6 +526,12 @@ pub struct AgentJobRecord {
     pub started_at: Option<DateTime<Utc>>,
     pub completed_at: Option<DateTime<Utc>>,
     pub failure_reason: Option<String>,
+}
+
+impl crate::ownership::Owned for AgentJobRecord {
+    fn owner_user_id(&self) -> &str {
+        &self.user_id
+    }
 }
 
 /// Summary counts for agent (non-sandbox) jobs.

--- a/src/ownership/mod.rs
+++ b/src/ownership/mod.rs
@@ -1,8 +1,8 @@
 //! Centralized ownership types for IronClaw.
 //!
 //! `Identity` is the single struct that flows from the channel boundary through
-//! every scope constructor and authorization check. `can_act_on` is the sole
-//! place that decides whether an actor may mutate a resource.
+//! every scope constructor and authorization check. The [`Owned`] trait provides
+//! a uniform `is_owned_by(user_id)` check across all resource types.
 //!
 //! Known single-tenant assumptions still remain elsewhere in the app. In
 //! particular, extension lifecycle/configuration, orchestrator secret injection,
@@ -76,13 +76,24 @@ impl Identity {
     }
 }
 
-/// Central authorization check: returns true if the actor owns the resource.
+/// Trait for types that have a user owner.
 ///
-/// Ownership is strict equality — role has no effect here.
-/// Admin-only operations are gated by a separate scope type; do not add
-/// role-based bypasses to this function.
-pub fn can_act_on(actor: &Identity, resource_owner: &OwnerId) -> bool {
-    actor.owner_id == *resource_owner
+/// Provides a uniform `is_owned_by(user_id)` check across all resource types
+/// (jobs, routines, etc.). Engine types (Mission, Thread, Project) have their
+/// own inherent `is_owned_by` that additionally handles shared ownership
+/// (`__shared__`); those are left as-is.
+///
+/// **Do NOT implement on engine types** (`Mission`, `Thread`, `Project`,
+/// `MemoryDoc`). They have inherent `is_owned_by()` methods with
+/// shared-ownership semantics that differ from this trait's default.
+pub trait Owned {
+    /// Returns the raw `user_id` string identifying the owner.
+    fn owner_user_id(&self) -> &str;
+
+    /// Returns true if `user_id` owns this resource.
+    fn is_owned_by(&self, user_id: &str) -> bool {
+        self.owner_user_id() == user_id
+    }
 }
 
 pub mod cache;
@@ -91,34 +102,6 @@ pub use cache::OwnershipCache;
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_can_act_on_own_resource() {
-        let actor = Identity {
-            owner_id: OwnerId::from("alice"),
-            role: UserRole::Member,
-        };
-        assert!(can_act_on(&actor, &OwnerId::from("alice")));
-    }
-
-    #[test]
-    fn test_cannot_act_on_others_resource() {
-        let actor = Identity {
-            owner_id: OwnerId::from("alice"),
-            role: UserRole::Member,
-        };
-        assert!(!can_act_on(&actor, &OwnerId::from("bob")));
-    }
-
-    #[test]
-    fn test_admin_cannot_act_on_others_resource() {
-        // Admin role does NOT bypass ownership in can_act_on
-        let actor = Identity {
-            owner_id: OwnerId::from("alice"),
-            role: UserRole::Admin,
-        };
-        assert!(!can_act_on(&actor, &OwnerId::from("bob")));
-    }
 
     #[test]
     fn test_owner_id_display() {
@@ -145,5 +128,41 @@ mod tests {
         let id = Identity::new("alice", UserRole::Admin);
         assert_eq!(id.owner_id.as_str(), "alice");
         assert_eq!(id.role, UserRole::Admin);
+    }
+
+    // --- Owned trait tests ---
+
+    struct FakeResource {
+        user_id: String,
+    }
+
+    impl Owned for FakeResource {
+        fn owner_user_id(&self) -> &str {
+            &self.user_id
+        }
+    }
+
+    #[test]
+    fn test_owned_is_owned_by_own_user() {
+        let r = FakeResource {
+            user_id: "alice".to_string(),
+        };
+        assert!(r.is_owned_by("alice"));
+    }
+
+    #[test]
+    fn test_owned_is_not_owned_by_other_user() {
+        let r = FakeResource {
+            user_id: "alice".to_string(),
+        };
+        assert!(!r.is_owned_by("bob"));
+    }
+
+    #[test]
+    fn test_owned_owner_user_id() {
+        let r = FakeResource {
+            user_id: "henry".to_string(),
+        };
+        assert_eq!(r.owner_user_id(), "henry");
     }
 }

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -36,6 +36,7 @@ use crate::history::{
     AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationSummary, LlmCallRecord,
     SandboxJobRecord, SandboxJobSummary, SettingRow,
 };
+use crate::ownership::Owned;
 use crate::workspace::Workspace;
 
 // ---------------------------------------------------------------------------
@@ -98,7 +99,7 @@ impl TenantScope {
     /// Fetch a job by ID, returning `None` if it doesn't belong to this user.
     pub async fn get_job(&self, id: Uuid) -> Result<Option<JobContext>, DatabaseError> {
         match self.inner.get_job(id).await? {
-            Some(ctx) if ctx.user_id == self.identity.owner_id.as_str() => Ok(Some(ctx)),
+            Some(ctx) if ctx.is_owned_by(self.identity.owner_id.as_str()) => Ok(Some(ctx)),
             _ => Ok(None),
         }
     }
@@ -152,7 +153,7 @@ impl TenantScope {
         id: Uuid,
     ) -> Result<Option<SandboxJobRecord>, DatabaseError> {
         match self.inner.get_sandbox_job(id).await? {
-            Some(job) if job.user_id == self.identity.owner_id.as_str() => Ok(Some(job)),
+            Some(job) if job.is_owned_by(self.identity.owner_id.as_str()) => Ok(Some(job)),
             _ => Ok(None),
         }
     }
@@ -180,7 +181,7 @@ impl TenantScope {
     /// Fetch a routine by ID, returning `None` if it doesn't belong to this user.
     pub async fn get_routine(&self, id: Uuid) -> Result<Option<Routine>, DatabaseError> {
         match self.inner.get_routine(id).await? {
-            Some(r) if r.user_id == self.identity.owner_id.as_str() => Ok(Some(r)),
+            Some(r) if r.is_owned_by(self.identity.owner_id.as_str()) => Ok(Some(r)),
             _ => Ok(None),
         }
     }

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -22,6 +22,7 @@ use crate::db::Database;
 use crate::history::SandboxJobRecord;
 use crate::orchestrator::auth::CredentialGrant;
 use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
+use crate::ownership::Owned;
 use crate::secrets::SecretsStore;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 use ironclaw_common::AppEvent;
@@ -1206,7 +1207,7 @@ impl Tool for JobStatusTool {
 
         match self.context_manager.get_context(job_id).await {
             Ok(job_ctx) => {
-                if job_ctx.user_id != requester_id {
+                if !job_ctx.is_owned_by(&requester_id) {
                     let result = serde_json::json!({
                         "error": "Job not found".to_string()
                     });
@@ -1309,7 +1310,7 @@ impl Tool for CancelJobTool {
         match self
             .context_manager
             .update_context(job_id, |ctx| {
-                if ctx.user_id != requester_id {
+                if !ctx.is_owned_by(&requester_id) {
                     return Err("Job not found".to_string());
                 }
                 ctx.transition_to(JobState::Cancelled, Some("Cancelled by user".to_string()))
@@ -1462,7 +1463,7 @@ impl Tool for JobEventsTool {
                 ))
             })?;
 
-        if job_ctx.user_id != ctx.user_id {
+        if !job_ctx.is_owned_by(&ctx.user_id) {
             return Err(ToolError::ExecutionFailed(format!(
                 "job {} does not belong to current user",
                 job_id
@@ -1600,7 +1601,7 @@ impl Tool for JobPromptTool {
                 ))
             })?;
 
-        if job_ctx.user_id != ctx.user_id {
+        if !job_ctx.is_owned_by(&ctx.user_id) {
             return Err(ToolError::ExecutionFailed(format!(
                 "job {} does not belong to current user",
                 job_id

--- a/tests/ownership_integration.rs
+++ b/tests/ownership_integration.rs
@@ -333,19 +333,101 @@ mod tests {
     }
 
     #[test]
-    fn test_can_act_on_own_resource() {
-        use ironclaw::ownership::can_act_on;
-        let actor = Identity::new(OwnerId::from("alice"), UserRole::Member);
-        assert!(can_act_on(&actor, &OwnerId::from("alice")));
-        assert!(!can_act_on(&actor, &OwnerId::from("bob")));
+    fn test_owned_trait_is_owned_by() {
+        use ironclaw::ownership::Owned;
+
+        struct TestResource {
+            user_id: String,
+        }
+        impl Owned for TestResource {
+            fn owner_user_id(&self) -> &str {
+                &self.user_id
+            }
+        }
+
+        let r = TestResource {
+            user_id: "alice".to_string(),
+        };
+        assert!(r.is_owned_by("alice"));
+        assert!(!r.is_owned_by("bob"));
     }
 
     #[test]
-    fn test_admin_role_does_not_bypass_ownership() {
-        use ironclaw::ownership::can_act_on;
-        // Admin role has no special bypass in can_act_on
-        let admin = Identity::new(OwnerId::from("admin-user"), UserRole::Admin);
-        assert!(!can_act_on(&admin, &OwnerId::from("bob")));
-        assert!(can_act_on(&admin, &OwnerId::from("admin-user")));
+    fn test_owned_sandbox_job_record() {
+        use ironclaw::history::SandboxJobRecord;
+        use ironclaw::ownership::Owned;
+
+        let job = SandboxJobRecord {
+            id: uuid::Uuid::new_v4(),
+            task: "test".to_string(),
+            status: "running".to_string(),
+            user_id: "alice".to_string(),
+            project_dir: "/tmp/test".to_string(),
+            success: None,
+            failure_reason: None,
+            created_at: chrono::Utc::now(),
+            started_at: None,
+            completed_at: None,
+            credential_grants_json: "[]".to_string(),
+        };
+        assert_eq!(job.owner_user_id(), "alice");
+        assert!(job.is_owned_by("alice"));
+        assert!(!job.is_owned_by("bob"));
+    }
+
+    #[test]
+    fn test_owned_agent_job_record() {
+        use ironclaw::history::AgentJobRecord;
+        use ironclaw::ownership::Owned;
+
+        let job = AgentJobRecord {
+            id: uuid::Uuid::new_v4(),
+            title: "test job".to_string(),
+            status: "pending".to_string(),
+            user_id: "henry".to_string(),
+            created_at: chrono::Utc::now(),
+            started_at: None,
+            completed_at: None,
+            failure_reason: None,
+        };
+        assert_eq!(job.owner_user_id(), "henry");
+        assert!(job.is_owned_by("henry"));
+        assert!(!job.is_owned_by("alice"));
+    }
+
+    #[test]
+    fn test_owned_routine() {
+        use ironclaw::agent::routine::{
+            NotifyConfig, Routine, RoutineAction, RoutineGuardrails, Trigger,
+        };
+        use ironclaw::ownership::Owned;
+
+        let routine = Routine {
+            id: uuid::Uuid::new_v4(),
+            name: "test-routine".to_string(),
+            description: String::new(),
+            user_id: "bob".to_string(),
+            enabled: true,
+            trigger: Trigger::Manual,
+            action: RoutineAction::Lightweight {
+                prompt: "test prompt".to_string(),
+                context_paths: Vec::new(),
+                max_tokens: 4096,
+                use_tools: false,
+                max_tool_rounds: 3,
+            },
+            guardrails: RoutineGuardrails::default(),
+            notify: NotifyConfig::default(),
+            last_run_at: None,
+            next_fire_at: None,
+            run_count: 0,
+            consecutive_failures: 0,
+            state: serde_json::json!({}),
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        };
+        assert_eq!(routine.owner_user_id(), "bob");
+        assert!(routine.is_owned_by("bob"));
+        assert!(!routine.is_owned_by("alice"));
     }
 }


### PR DESCRIPTION
## Summary

- **Fix mission visibility bug**: `list_engine_missions()` and `list_engine_threads()` used the engine owner's `default_project_id` instead of resolving the authenticated user's per-user project — missions created by non-owner users were invisible in the gateway UI
- **Unify ownership model**: Replace three inconsistent patterns (`can_act_on`, engine `is_owned_by`, raw `user_id ==`) with a single `Owned` trait providing `is_owned_by(user_id)` across all resource types
- **Fix missing authorization**: `routines_trigger_handler` had no ownership check — any authenticated user could trigger any routine by ID

## Changes

| File | Change |
|------|--------|
| `src/ownership/mod.rs` | Add `Owned` trait, remove `can_act_on` |
| `src/bridge/router.rs` | Fix project_id resolution via `resolve_user_project()` |
| `src/history/store.rs` | `impl Owned` for `SandboxJobRecord`, `AgentJobRecord` |
| `src/agent/routine.rs` | `impl Owned` for `Routine` |
| `src/context/state.rs` | `impl Owned` for `JobContext` |
| `src/channels/web/handlers/jobs.rs` | Migrate 10 `can_act_on` → `is_owned_by` |
| `src/channels/web/handlers/routines.rs` | Migrate 4 sites + add missing trigger check |
| `src/channels/web/server.rs` | Migrate `routines_runs_handler` + `verify_project_ownership` |
| `src/tenant.rs` | Migrate 3 raw comparisons |
| `src/agent/commands.rs` | Migrate 3 raw comparisons |
| `src/tools/builtin/job.rs` | Migrate 4 raw comparisons |
| `src/agent/routine_engine.rs` | Migrate 4 authorization checks |
| `src/context/manager.rs` | Migrate 4 filtering comparisons |
| `src/channels/web/auth.rs` | Remove dead `ownership_identity()` |
| `tests/ownership_integration.rs` | Add concrete `Owned` impl tests on real types |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test` — 4600+ tests, 0 failures
- [x] New tests: `test_owned_sandbox_job_record`, `test_owned_agent_job_record`, `test_owned_routine`
- [ ] Manual: multi-user deployment — create mission as non-owner user, verify it appears in missions tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)