### PR TITLE
perf: fix multi-tenant inference latency (per-conversation locking + workspace indexing)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 # Database Configuration
 DATABASE_URL=postgres://localhost/ironclaw
-DATABASE_POOL_SIZE=10
+DATABASE_POOL_SIZE=30  # multi-tenant default; reduce to 5-10 for single-user or low-resource deployments
 
 # LLM Provider
 # LLM_BACKEND=nearai           # default

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -20,6 +20,7 @@ use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
 use crate::types::thread::{ThreadConfig, ThreadId, ThreadState, ThreadType};
 
+#[derive(Clone, Copy)]
 enum ActiveForeground {
     Running(ThreadId),
     Resumable(ThreadId),
@@ -126,26 +127,41 @@ impl ConversationManager {
         user_id: &str,
         thread_config: ThreadConfig,
     ) -> Result<ThreadId, EngineError> {
-        let mut convs = self.conversations.write().await;
-        let conv = convs.get_mut(&conversation_id).ok_or(EngineError::Store {
-            reason: format!("conversation {conversation_id} not found"),
-        })?;
+        // Phase 1: synchronous in-memory reads under the write lock — no I/O.
+        // Extract everything find_active_foreground needs before releasing the
+        // lock so that the async I/O calls happen lock-free.
+        let (active_thread_ids, entries_snapshot, channel_name) = {
+            let mut convs = self.conversations.write().await;
+            let conv = convs.get_mut(&conversation_id).ok_or(EngineError::Store {
+                reason: format!("conversation {conversation_id} not found"),
+            })?;
 
-        // Tenant isolation: verify the requesting user owns this conversation.
-        if conv.user_id != user_id {
-            return Err(EngineError::AccessDenied {
-                user_id: user_id.to_string(),
-                entity: format!("conversation {conversation_id}"),
-            });
-        }
+            // Tenant isolation: verify the requesting user owns this conversation.
+            if conv.user_id != user_id {
+                return Err(EngineError::AccessDenied {
+                    user_id: user_id.to_string(),
+                    entity: format!("conversation {conversation_id}"),
+                });
+            }
 
-        // Record the user entry
-        conv.add_entry(ConversationEntry::user(content));
+            // Record the user entry while we still hold the lock.
+            conv.add_entry(ConversationEntry::user(content));
 
-        // Check for an active foreground thread
-        let active_foreground = self.find_active_foreground(conv).await;
+            // Snapshot everything find_active_foreground needs so we can drop
+            // the lock before making any async calls.
+            (
+                conv.active_threads.clone(),
+                conv.entries.clone(),
+                conv.channel.clone(),
+            )
+        }; // write lock released here — no async awaits were held above
 
-        match active_foreground {
+        // Phase 2: async I/O outside the lock to find the active foreground
+        // thread (calls thread_manager.is_running and store.load_thread).
+        let active_foreground = self.find_active_foreground(&active_thread_ids).await;
+
+        // Phase 3: async I/O outside the lock — thread operations.
+        let thread_id = match active_foreground {
             Some(ActiveForeground::Running(thread_id)) => {
                 debug!(
                     conversation_id = %conversation_id,
@@ -155,8 +171,7 @@ impl ConversationManager {
                 self.thread_manager
                     .inject_message(thread_id, user_id, ThreadMessage::user(content))
                     .await?;
-                self.store.save_conversation(conv).await?;
-                Ok(thread_id)
+                thread_id
             }
             Some(ActiveForeground::Resumable(thread_id)) => {
                 debug!(
@@ -173,18 +188,14 @@ impl ConversationManager {
                         None,
                     )
                     .await?;
-                conv.add_entry(ConversationEntry::system_for_thread(
-                    thread_id,
-                    "Thread resumed",
-                ));
-                self.store.save_conversation(conv).await?;
-                Ok(thread_id)
+                thread_id
             }
             None => {
-                // Build conversation history from prior entries for context continuity
-                let history = build_history_from_entries(&conv.entries);
+                // Build conversation history from prior entries for context continuity.
+                // Use the snapshot taken under the lock (already includes the user entry).
+                let history = build_history_from_entries(&entries_snapshot);
 
-                // Spawn new foreground thread with conversation history
+                // Spawn new foreground thread with conversation history.
                 let thread_id = self
                     .thread_manager
                     .spawn_thread_with_history(
@@ -201,31 +212,60 @@ impl ConversationManager {
                 // Store the base channel name in thread metadata so the
                 // orchestrator can populate `source_channel` in the execution
                 // context (used by mission_create to default notify_channels).
-                let base_channel = conv
-                    .channel
+                let base_channel = channel_name
                     .split(':')
                     .next()
-                    .unwrap_or(&conv.channel)
+                    .unwrap_or(&channel_name)
                     .to_string();
                 self.thread_manager
                     .set_thread_metadata(thread_id, "source_channel", &base_channel)
                     .await;
 
-                conv.track_thread(thread_id);
-                conv.add_entry(ConversationEntry::system_for_thread(
-                    thread_id,
-                    "Thread started",
-                ));
-                self.store.save_conversation(conv).await?;
-
-                debug!(
-                    conversation_id = %conversation_id,
-                    thread_id = %thread_id,
-                    "spawned new foreground thread"
-                );
-                Ok(thread_id)
+                thread_id
             }
-        }
+        };
+
+        // Phase 4: re-acquire the write lock for the final in-memory mutations
+        // (track_thread / add_entry) and take the snapshot for DB persistence.
+        let conv_to_save = {
+            let mut convs = self.conversations.write().await;
+            let conv = convs.get_mut(&conversation_id).ok_or(EngineError::Store {
+                reason: format!("conversation {conversation_id} not found"),
+            })?;
+
+            match active_foreground {
+                Some(ActiveForeground::Running(_)) => {
+                    // No additional in-memory mutation needed; entry was already
+                    // added in Phase 1.
+                }
+                Some(ActiveForeground::Resumable(_)) => {
+                    conv.add_entry(ConversationEntry::system_for_thread(
+                        thread_id,
+                        "Thread resumed",
+                    ));
+                }
+                None => {
+                    conv.track_thread(thread_id);
+                    conv.add_entry(ConversationEntry::system_for_thread(
+                        thread_id,
+                        "Thread started",
+                    ));
+                    debug!(
+                        conversation_id = %conversation_id,
+                        thread_id = %thread_id,
+                        "spawned new foreground thread"
+                    );
+                }
+            }
+
+            conv.clone()
+        }; // write lock released here
+
+        // Phase 5: persist outside the lock so concurrent tenants are not
+        // serialized through this slow workspace/DB write.
+        self.store.save_conversation(&conv_to_save).await?;
+
+        Ok(thread_id)
     }
 
     /// Record a thread's outcome in its conversation.
@@ -328,9 +368,17 @@ impl ConversationManager {
             .collect()
     }
 
-    /// Find an active foreground thread in a conversation.
-    async fn find_active_foreground(&self, conv: &ConversationSurface) -> Option<ActiveForeground> {
-        for &tid in &conv.active_threads {
+    /// Find an active foreground thread given a snapshot of active thread IDs.
+    ///
+    /// Accepts a plain slice rather than a `&ConversationSurface` so callers
+    /// can drop the conversations write lock before invoking this method —
+    /// it performs async I/O (is_running, load_thread) that must not be held
+    /// under any lock.
+    async fn find_active_foreground(
+        &self,
+        active_thread_ids: &[ThreadId],
+    ) -> Option<ActiveForeground> {
+        for &tid in active_thread_ids {
             if self.thread_manager.is_running(tid).await {
                 return Some(ActiveForeground::Running(tid));
             }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -452,11 +452,7 @@ impl ConversationManager {
     /// Test helper: track a thread in a conversation without accessing the
     /// internal HashMap directly.
     #[cfg(test)]
-    pub async fn track_thread_in_conversation(
-        &self,
-        conv_id: ConversationId,
-        thread_id: ThreadId,
-    ) {
+    pub async fn track_thread_in_conversation(&self, conv_id: ConversationId, thread_id: ThreadId) {
         let arc = self
             .get_conversation_lock(conv_id)
             .await

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -46,6 +46,8 @@ enum ActiveForeground {
 pub struct ConversationManager {
     thread_manager: Arc<ThreadManager>,
     store: Arc<dyn Store>,
+    // LOCK ORDER: when acquiring both write locks, always take `conversations` before
+    // `channel_user_index`. Reversing this order will deadlock under concurrent access.
     conversations: RwLock<HashMap<ConversationId, Arc<Mutex<ConversationSurface>>>>,
     /// Maps (channel, user_id) → conversation ID for lookup.
     channel_user_index: RwLock<HashMap<(String, String), ConversationId>>,
@@ -84,6 +86,9 @@ impl ConversationManager {
         let mut index = self.channel_user_index.write().await;
 
         for conversation in conversations {
+            if convs.contains_key(&conversation.id) {
+                continue;
+            }
             index.insert(
                 (conversation.channel.clone(), conversation.user_id.clone()),
                 conversation.id,
@@ -196,10 +201,9 @@ impl ConversationManager {
             });
         }
 
-        // Record the user entry.
-        conv.add_entry(ConversationEntry::user(content));
-
         // Snapshot what find_active_foreground needs before the async calls.
+        // NOTE: do NOT add the user entry yet — it will be added after the thread
+        // operation succeeds to avoid orphaned entries if the async op fails.
         let active_thread_ids = conv.active_threads.clone();
         let entries_snapshot = conv.entries.clone();
         let channel_name = conv.channel.clone();
@@ -239,7 +243,8 @@ impl ConversationManager {
             }
             None => {
                 // Build conversation history from prior entries for context continuity.
-                // Use the snapshot taken above (already includes the user entry).
+                // The snapshot was taken before the current user entry was appended, so
+                // all entries in the snapshot are prior-turn history.
                 let history = build_history_from_entries(&entries_snapshot);
 
                 // Spawn new foreground thread with conversation history.
@@ -273,9 +278,13 @@ impl ConversationManager {
         };
 
         // Final in-memory mutations under the already-held per-conv Mutex.
+        // The user entry is added here — after the thread operation succeeded — to
+        // prevent orphaned entries if inject_message/resume_thread/spawn_thread_with_history
+        // returned an error above.
+        conv.add_entry(ConversationEntry::user(content));
         match active_foreground {
             Some(ActiveForeground::Running(_)) => {
-                // No additional in-memory mutation needed; entry was already added above.
+                // No additional in-memory mutation needed beyond the user entry above.
             }
             Some(ActiveForeground::Resumable(_)) => {
                 conv.add_entry(ConversationEntry::system_for_thread(
@@ -310,50 +319,53 @@ impl ConversationManager {
         thread_id: ThreadId,
         outcome: &ThreadOutcome,
     ) -> Result<(), EngineError> {
-        if let Ok(conv_arc) = self.get_conversation_lock(conversation_id).await {
-            let mut conv = conv_arc.lock().await;
-            match outcome {
-                ThreadOutcome::Completed { response } => {
-                    if let Some(text) = response {
-                        conv.add_entry(ConversationEntry::agent(thread_id, text));
-                    }
-                    conv.untrack_thread(thread_id);
+        let conv_arc = self.get_conversation_lock(conversation_id).await?;
+        let mut conv = conv_arc.lock().await;
+        match outcome {
+            ThreadOutcome::Completed { response } => {
+                if let Some(text) = response {
+                    conv.add_entry(ConversationEntry::agent(thread_id, text));
                 }
-                ThreadOutcome::Stopped => {
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        "Thread stopped",
-                    ));
-                    conv.untrack_thread(thread_id);
-                }
-                ThreadOutcome::MaxIterations => {
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        "Thread reached max iterations",
-                    ));
-                    conv.untrack_thread(thread_id);
-                }
-                ThreadOutcome::Failed { error } => {
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        format!("Thread failed: {error}"),
-                    ));
-                    conv.untrack_thread(thread_id);
-                }
-                ThreadOutcome::GatePaused {
-                    gate_name,
-                    action_name,
-                    ..
-                } => {
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        format!("Gate '{gate_name}' paused execution of action: {action_name}"),
-                    ));
-                    // Thread stays active — waiting for gate resolution
-                }
+                conv.untrack_thread(thread_id);
             }
-            self.store.save_conversation(&conv).await?;
+            ThreadOutcome::Stopped => {
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    "Thread stopped",
+                ));
+                conv.untrack_thread(thread_id);
+            }
+            ThreadOutcome::MaxIterations => {
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    "Thread reached max iterations",
+                ));
+                conv.untrack_thread(thread_id);
+            }
+            ThreadOutcome::Failed { error } => {
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    format!("Thread failed: {error}"),
+                ));
+                conv.untrack_thread(thread_id);
+            }
+            ThreadOutcome::GatePaused {
+                gate_name,
+                action_name,
+                ..
+            } => {
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    format!("Gate '{gate_name}' paused execution of action: {action_name}"),
+                ));
+                // Thread stays active — waiting for gate resolution
+            }
         }
+        // Known limitation: if save_conversation fails, the in-memory mutations (add_entry,
+        // untrack_thread) are already applied but not persisted. Memory and DB diverge until
+        // the next successful save. Rolling back would require snapshotting the prior state,
+        // which is not implemented here — accepted as a low-probability failure mode.
+        self.store.save_conversation(&conv).await?;
         Ok(())
     }
 
@@ -366,21 +378,20 @@ impl ConversationManager {
         conversation_id: ConversationId,
         user_id: &str,
     ) -> Result<(), EngineError> {
-        if let Ok(conv_arc) = self.get_conversation_lock(conversation_id).await {
-            let mut conv = conv_arc.lock().await;
-            // Tenant isolation: verify ownership.
-            if conv.user_id != user_id {
-                return Err(EngineError::AccessDenied {
-                    user_id: user_id.to_string(),
-                    entity: format!("conversation {conversation_id}"),
-                });
-            }
-            conv.active_threads.clear();
-            conv.entries.clear();
-            conv.updated_at = chrono::Utc::now();
-            self.store.save_conversation(&conv).await?;
-            debug!(conversation_id = %conversation_id, "cleared conversation");
+        let conv_arc = self.get_conversation_lock(conversation_id).await?;
+        let mut conv = conv_arc.lock().await;
+        // Tenant isolation: verify ownership.
+        if conv.user_id != user_id {
+            return Err(EngineError::AccessDenied {
+                user_id: user_id.to_string(),
+                entity: format!("conversation {conversation_id}"),
+            });
         }
+        conv.active_threads.clear();
+        conv.entries.clear();
+        conv.updated_at = chrono::Utc::now();
+        self.store.save_conversation(&conv).await?;
+        debug!(conversation_id = %conversation_id, "cleared conversation");
         Ok(())
     }
 
@@ -396,7 +407,9 @@ impl ConversationManager {
         Some(arc.lock().await.clone())
     }
 
-    /// List all conversations for a user.
+    /// Returns conversations for the given user. This is a best-effort snapshot:
+    /// each conversation is locked and read individually, so concurrent mutations
+    /// between locks may be partially visible. Not a point-in-time consistent view.
     pub async fn list_conversations(&self, user_id: &str) -> Vec<ConversationSurface> {
         let arcs: Vec<Arc<Mutex<ConversationSurface>>> = {
             let convs = self.conversations.read().await;
@@ -456,21 +469,17 @@ impl ConversationManager {
 ///
 /// Converts user and agent entries into ThreadMessages so a new thread
 /// inherits context from prior turns in the same conversation.
+///
+/// The caller passes a snapshot taken *before* the current user message was
+/// appended, so all entries here are prior-turn history — include them all.
+/// System entries (thread lifecycle notifications) are skipped as they are not
+/// useful LLM context.
 fn build_history_from_entries(
     entries: &[ConversationEntry],
 ) -> Vec<crate::types::message::ThreadMessage> {
     use crate::types::conversation::EntrySender;
 
-    // Skip the last entry (it's the current user message, added by the caller
-    // before this function runs). Also skip system entries (thread lifecycle
-    // notifications aren't useful as LLM context).
-    let history_entries = if entries.len() > 1 {
-        &entries[..entries.len() - 1] // safety: slice index on Vec<Entry>, not a string — no UTF-8 concern
-    } else {
-        return Vec::new();
-    };
-
-    history_entries
+    entries
         .iter()
         .filter_map(|entry| match &entry.sender {
             EntrySender::User => Some(crate::types::message::ThreadMessage::user(&entry.content)),
@@ -941,5 +950,82 @@ mod tests {
         let conv = cm.get_conversation(conv_id).await.unwrap();
         assert!(conv.entries.is_empty());
         assert!(conv.active_threads.is_empty());
+    }
+
+    #[tokio::test]
+    async fn concurrent_handle_user_message_spawns_one_thread() {
+        // T1: Two concurrent handle_user_message calls on the same conversation
+        // must serialize — only ONE new thread should be spawned.
+        let (_, cm) = make_conv_manager();
+        let conv_id = cm.get_or_create_conversation("web", "user1").await.unwrap();
+        let project = ProjectId::new();
+        let cm = Arc::new(cm);
+
+        let cm1 = Arc::clone(&cm);
+        let cm2 = Arc::clone(&cm);
+
+        let t1 = tokio::spawn(async move {
+            cm1.handle_user_message(
+                conv_id,
+                "message one",
+                project,
+                "user1",
+                ThreadConfig::default(),
+            )
+            .await
+        });
+        let t2 = tokio::spawn(async move {
+            cm2.handle_user_message(
+                conv_id,
+                "message two",
+                project,
+                "user1",
+                ThreadConfig::default(),
+            )
+            .await
+        });
+
+        let r1 = t1.await.unwrap();
+        let r2 = t2.await.unwrap();
+
+        // Both calls must succeed.
+        assert!(r1.is_ok(), "first handle_user_message failed: {r1:?}");
+        assert!(r2.is_ok(), "second handle_user_message failed: {r2:?}");
+
+        // The per-conv Mutex serializes the two calls. The second call sees the
+        // first thread as Running (or the same thread ID if inject_message is used),
+        // so at most one NEW thread should exist in active_threads.
+        let conv = cm.get_conversation(conv_id).await.unwrap();
+        assert_eq!(
+            conv.active_threads.len(),
+            1,
+            "expected exactly 1 active thread, got {}: {:?}",
+            conv.active_threads.len(),
+            conv.active_threads
+        );
+    }
+
+    #[tokio::test]
+    async fn record_thread_outcome_unknown_conv_returns_err() {
+        // T4: After C1 fix, record_thread_outcome with an unknown ConversationId
+        // must return Err, not silently succeed.
+        let (_, cm) = make_conv_manager();
+        let unknown_conv_id = ConversationId::new();
+        let tid = ThreadId::new();
+
+        let result = cm
+            .record_thread_outcome(
+                unknown_conv_id,
+                tid,
+                &ThreadOutcome::Completed {
+                    response: Some("irrelevant".into()),
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "expected Err for unknown conversation, got Ok"
+        );
     }
 }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -87,6 +87,12 @@ impl ConversationManager {
 
         for conversation in conversations {
             if convs.contains_key(&conversation.id) {
+                // Still upsert the index — it may be missing if a prior
+                // get_or_create_conversation inserted the conv but then rolled
+                // back the index entry on a failed save_conversation.
+                index
+                    .entry((conversation.channel.clone(), conversation.user_id.clone()))
+                    .or_insert(conversation.id);
                 continue;
             }
             index.insert(

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -81,9 +81,9 @@ impl ConversationManager {
     /// Restore persisted conversations for a user into the in-memory index.
     pub async fn bootstrap_user(&self, user_id: &str) -> Result<usize, EngineError> {
         let conversations = self.store.list_conversations(user_id).await?;
-        let count = conversations.len();
         let mut convs = self.conversations.write().await;
         let mut index = self.channel_user_index.write().await;
+        let mut inserted = 0usize;
 
         for conversation in conversations {
             if convs.contains_key(&conversation.id) {
@@ -94,9 +94,10 @@ impl ConversationManager {
                 conversation.id,
             );
             convs.insert(conversation.id, Arc::new(Mutex::new(conversation)));
+            inserted += 1;
         }
 
-        Ok(count)
+        Ok(inserted)
     }
 
     /// Get or create a conversation for a channel+user pair.
@@ -205,7 +206,6 @@ impl ConversationManager {
         // NOTE: do NOT add the user entry yet — it will be added after the thread
         // operation succeeds to avoid orphaned entries if the async op fails.
         let active_thread_ids = conv.active_threads.clone();
-        let entries_snapshot = conv.entries.clone();
         let channel_name = conv.channel.clone();
 
         // Async I/O to find the active foreground thread — allowed here because
@@ -243,9 +243,9 @@ impl ConversationManager {
             }
             None => {
                 // Build conversation history from prior entries for context continuity.
-                // The snapshot was taken before the current user entry was appended, so
-                // all entries in the snapshot are prior-turn history.
-                let history = build_history_from_entries(&entries_snapshot);
+                // Clone here (None branch only) — inject/resume paths don't need history,
+                // so deferring avoids an O(entries) allocation on those fast paths.
+                let history = build_history_from_entries(&conv.entries);
 
                 // Spawn new foreground thread with conversation history.
                 let thread_id = self
@@ -407,20 +407,25 @@ impl ConversationManager {
         Some(arc.lock().await.clone())
     }
 
-    /// Returns conversations for the given user. This is a best-effort snapshot:
-    /// each conversation is locked and read individually, so concurrent mutations
-    /// between locks may be partially visible. Not a point-in-time consistent view.
+    /// Returns conversations for the given user.
+    ///
+    /// Uses `channel_user_index` to pre-filter by user before acquiring any
+    /// per-conversation locks, keeping lock scope minimal. This is a best-effort
+    /// snapshot: each conversation is locked and read individually, so concurrent
+    /// mutations between locks may be partially visible.
     pub async fn list_conversations(&self, user_id: &str) -> Vec<ConversationSurface> {
         let arcs: Vec<Arc<Mutex<ConversationSurface>>> = {
             let convs = self.conversations.read().await;
-            convs.values().cloned().collect()
+            let index = self.channel_user_index.read().await;
+            index
+                .iter()
+                .filter(|((_, uid), _)| uid == user_id)
+                .filter_map(|(_, id)| convs.get(id).cloned())
+                .collect()
         };
-        let mut result = Vec::new();
+        let mut result = Vec::with_capacity(arcs.len());
         for arc in arcs {
-            let conv = arc.lock().await;
-            if conv.user_id == user_id {
-                result.push(conv.clone());
-            }
+            result.push(arc.lock().await.clone());
         }
         result
     }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -8,7 +8,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::debug;
 
 use crate::runtime::manager::ThreadManager;
@@ -32,10 +32,21 @@ enum ActiveForeground {
 /// 1. Spawn a new foreground thread for the message
 /// 2. Inject the message into an existing active thread
 /// 3. Create a new conversation if none exists for this channel+user
+///
+/// ## Locking strategy
+///
+/// `conversations` is a *directory*: the global `RwLock` is held only for
+/// HashMap lookups/inserts and is never held across an `.await`. Each
+/// `ConversationSurface` is wrapped in a `tokio::sync::Mutex` so concurrent
+/// messages to *different* conversations run fully in parallel.
+///
+/// **Lock ordering invariant:** NEVER hold the global `RwLock` and a
+/// per-conversation `Mutex` simultaneously. `get_conversation_lock()` enforces
+/// this — it drops the read guard before returning the `Arc<Mutex<…>>`.
 pub struct ConversationManager {
     thread_manager: Arc<ThreadManager>,
     store: Arc<dyn Store>,
-    conversations: RwLock<HashMap<ConversationId, ConversationSurface>>,
+    conversations: RwLock<HashMap<ConversationId, Arc<Mutex<ConversationSurface>>>>,
     /// Maps (channel, user_id) → conversation ID for lookup.
     channel_user_index: RwLock<HashMap<(String, String), ConversationId>>,
 }
@@ -50,6 +61,21 @@ impl ConversationManager {
         }
     }
 
+    /// Get the per-conversation lock. Holds the global RwLock only briefly
+    /// (HashMap lookup), then releases it. Returns Err if the conversation
+    /// does not exist.
+    async fn get_conversation_lock(
+        &self,
+        conversation_id: ConversationId,
+    ) -> Result<Arc<Mutex<ConversationSurface>>, EngineError> {
+        let map = self.conversations.read().await;
+        map.get(&conversation_id)
+            .map(Arc::clone)
+            .ok_or_else(|| EngineError::Store {
+                reason: format!("conversation {conversation_id} not found"),
+            })
+    } // RwLockReadGuard dropped here
+
     /// Restore persisted conversations for a user into the in-memory index.
     pub async fn bootstrap_user(&self, user_id: &str) -> Result<usize, EngineError> {
         let conversations = self.store.list_conversations(user_id).await?;
@@ -62,7 +88,7 @@ impl ConversationManager {
                 (conversation.channel.clone(), conversation.user_id.clone()),
                 conversation.id,
             );
-            convs.insert(conversation.id, conversation);
+            convs.insert(conversation.id, Arc::new(Mutex::new(conversation)));
         }
 
         Ok(count)
@@ -94,20 +120,48 @@ impl ConversationManager {
             let conv_id = conv.id;
             let mut convs = self.conversations.write().await;
             let mut index = self.channel_user_index.write().await;
-            convs.insert(conv_id, conv);
+            // Double-check: another task may have inserted while we did I/O.
+            if let Some(existing_id) = index.get(&key) {
+                return Ok(*existing_id);
+            }
+            convs.insert(conv_id, Arc::new(Mutex::new(conv)));
             index.insert(key, conv_id);
             return Ok(conv_id);
         }
 
-        // Create new conversation
+        // Create new conversation.
         let conv = ConversationSurface::new(channel, user_id);
         let conv_id = conv.id;
 
-        let mut convs = self.conversations.write().await;
-        let mut index = self.channel_user_index.write().await;
-        convs.insert(conv_id, conv.clone());
-        index.insert(key, conv_id);
-        self.store.save_conversation(&conv).await?;
+        {
+            let mut convs = self.conversations.write().await;
+            let mut index = self.channel_user_index.write().await;
+            // Double-check: another task may have inserted while we did I/O.
+            if let Some(existing_id) = index.get(&key) {
+                return Ok(*existing_id);
+            }
+            convs.insert(conv_id, Arc::new(Mutex::new(conv.clone())));
+            index.insert(key.clone(), conv_id);
+        } // write locks released before the async save
+
+        if let Err(e) = self.store.save_conversation(&conv).await {
+            // Known limitation: a concurrent caller that observed the new conv_id via the
+            // double-check fast path (between our insert and this rollback) will hold a
+            // now-deleted, never-persisted ConversationId. This race requires simultaneous
+            // first-time logins from the same user+channel AND a store write failure — it
+            // is unlikely in practice and accepted as a structural trade-off of optimistic
+            // in-memory caching with async persistence. The alternative (holding write
+            // locks across the async save) would re-introduce cross-tenant serialization.
+            // Roll back the in-memory insertion so the next caller does not
+            // receive an unpersisted ConversationId.
+            let mut convs = self.conversations.write().await;
+            let mut index = self.channel_user_index.write().await;
+            convs.remove(&conv_id);
+            index.remove(&key);
+            return Err(EngineError::Store {
+                reason: e.to_string(),
+            });
+        }
 
         debug!(conversation_id = %conv_id, channel, user_id, "created conversation");
         Ok(conv_id)
@@ -119,6 +173,10 @@ impl ConversationManager {
     /// injected into it. Otherwise, a new foreground thread is spawned.
     ///
     /// Returns the thread ID that is handling the message.
+    ///
+    /// The per-conversation `Mutex` is held for the entire operation — from
+    /// the active-thread check through `save_conversation`. This eliminates
+    /// the TOCTOU double-spawn window present in the old 5-phase split.
     pub async fn handle_user_message(
         &self,
         conversation_id: ConversationId,
@@ -127,40 +185,29 @@ impl ConversationManager {
         user_id: &str,
         thread_config: ThreadConfig,
     ) -> Result<ThreadId, EngineError> {
-        // Phase 1: synchronous in-memory reads under the write lock — no I/O.
-        // Extract everything find_active_foreground needs before releasing the
-        // lock so that the async I/O calls happen lock-free.
-        let (active_thread_ids, entries_snapshot, channel_name) = {
-            let mut convs = self.conversations.write().await;
-            let conv = convs.get_mut(&conversation_id).ok_or(EngineError::Store {
-                reason: format!("conversation {conversation_id} not found"),
-            })?;
+        let conv_arc = self.get_conversation_lock(conversation_id).await?;
+        let mut conv = conv_arc.lock().await;
 
-            // Tenant isolation: verify the requesting user owns this conversation.
-            if conv.user_id != user_id {
-                return Err(EngineError::AccessDenied {
-                    user_id: user_id.to_string(),
-                    entity: format!("conversation {conversation_id}"),
-                });
-            }
+        // Tenant isolation: verify the requesting user owns this conversation.
+        if conv.user_id != user_id {
+            return Err(EngineError::AccessDenied {
+                user_id: user_id.to_string(),
+                entity: format!("conversation {conversation_id}"),
+            });
+        }
 
-            // Record the user entry while we still hold the lock.
-            conv.add_entry(ConversationEntry::user(content));
+        // Record the user entry.
+        conv.add_entry(ConversationEntry::user(content));
 
-            // Snapshot everything find_active_foreground needs so we can drop
-            // the lock before making any async calls.
-            (
-                conv.active_threads.clone(),
-                conv.entries.clone(),
-                conv.channel.clone(),
-            )
-        }; // write lock released here — no async awaits were held above
+        // Snapshot what find_active_foreground needs before the async calls.
+        let active_thread_ids = conv.active_threads.clone();
+        let entries_snapshot = conv.entries.clone();
+        let channel_name = conv.channel.clone();
 
-        // Phase 2: async I/O outside the lock to find the active foreground
-        // thread (calls thread_manager.is_running and store.load_thread).
+        // Async I/O to find the active foreground thread — allowed here because
+        // we hold a tokio::sync::Mutex (not std::sync::Mutex).
         let active_foreground = self.find_active_foreground(&active_thread_ids).await;
 
-        // Phase 3: async I/O outside the lock — thread operations.
         let thread_id = match active_foreground {
             Some(ActiveForeground::Running(thread_id)) => {
                 debug!(
@@ -192,7 +239,7 @@ impl ConversationManager {
             }
             None => {
                 // Build conversation history from prior entries for context continuity.
-                // Use the snapshot taken under the lock (already includes the user entry).
+                // Use the snapshot taken above (already includes the user entry).
                 let history = build_history_from_entries(&entries_snapshot);
 
                 // Spawn new foreground thread with conversation history.
@@ -225,45 +272,33 @@ impl ConversationManager {
             }
         };
 
-        // Phase 4: re-acquire the write lock for the final in-memory mutations
-        // (track_thread / add_entry) and take the snapshot for DB persistence.
-        let conv_to_save = {
-            let mut convs = self.conversations.write().await;
-            let conv = convs.get_mut(&conversation_id).ok_or(EngineError::Store {
-                reason: format!("conversation {conversation_id} not found"),
-            })?;
-
-            match active_foreground {
-                Some(ActiveForeground::Running(_)) => {
-                    // No additional in-memory mutation needed; entry was already
-                    // added in Phase 1.
-                }
-                Some(ActiveForeground::Resumable(_)) => {
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        "Thread resumed",
-                    ));
-                }
-                None => {
-                    conv.track_thread(thread_id);
-                    conv.add_entry(ConversationEntry::system_for_thread(
-                        thread_id,
-                        "Thread started",
-                    ));
-                    debug!(
-                        conversation_id = %conversation_id,
-                        thread_id = %thread_id,
-                        "spawned new foreground thread"
-                    );
-                }
+        // Final in-memory mutations under the already-held per-conv Mutex.
+        match active_foreground {
+            Some(ActiveForeground::Running(_)) => {
+                // No additional in-memory mutation needed; entry was already added above.
             }
+            Some(ActiveForeground::Resumable(_)) => {
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    "Thread resumed",
+                ));
+            }
+            None => {
+                conv.track_thread(thread_id);
+                conv.add_entry(ConversationEntry::system_for_thread(
+                    thread_id,
+                    "Thread started",
+                ));
+                debug!(
+                    conversation_id = %conversation_id,
+                    thread_id = %thread_id,
+                    "spawned new foreground thread"
+                );
+            }
+        }
 
-            conv.clone()
-        }; // write lock released here
-
-        // Phase 5: persist outside the lock so concurrent tenants are not
-        // serialized through this slow workspace/DB write.
-        self.store.save_conversation(&conv_to_save).await?;
+        // Persist outside the global RwLock (per-conv Mutex is still held).
+        self.store.save_conversation(&conv).await?;
 
         Ok(thread_id)
     }
@@ -275,8 +310,8 @@ impl ConversationManager {
         thread_id: ThreadId,
         outcome: &ThreadOutcome,
     ) -> Result<(), EngineError> {
-        let mut convs = self.conversations.write().await;
-        if let Some(conv) = convs.get_mut(&conversation_id) {
+        if let Ok(conv_arc) = self.get_conversation_lock(conversation_id).await {
+            let mut conv = conv_arc.lock().await;
             match outcome {
                 ThreadOutcome::Completed { response } => {
                     if let Some(text) = response {
@@ -317,7 +352,7 @@ impl ConversationManager {
                     // Thread stays active — waiting for gate resolution
                 }
             }
-            self.store.save_conversation(conv).await?;
+            self.store.save_conversation(&conv).await?;
         }
         Ok(())
     }
@@ -331,8 +366,8 @@ impl ConversationManager {
         conversation_id: ConversationId,
         user_id: &str,
     ) -> Result<(), EngineError> {
-        let mut convs = self.conversations.write().await;
-        if let Some(conv) = convs.get_mut(&conversation_id) {
+        if let Ok(conv_arc) = self.get_conversation_lock(conversation_id).await {
+            let mut conv = conv_arc.lock().await;
             // Tenant isolation: verify ownership.
             if conv.user_id != user_id {
                 return Err(EngineError::AccessDenied {
@@ -343,7 +378,7 @@ impl ConversationManager {
             conv.active_threads.clear();
             conv.entries.clear();
             conv.updated_at = chrono::Utc::now();
-            self.store.save_conversation(conv).await?;
+            self.store.save_conversation(&conv).await?;
             debug!(conversation_id = %conversation_id, "cleared conversation");
         }
         Ok(())
@@ -354,18 +389,27 @@ impl ConversationManager {
         &self,
         conversation_id: ConversationId,
     ) -> Option<ConversationSurface> {
-        let convs = self.conversations.read().await;
-        convs.get(&conversation_id).cloned()
+        let arc = {
+            let convs = self.conversations.read().await;
+            convs.get(&conversation_id).map(Arc::clone)
+        }?;
+        Some(arc.lock().await.clone())
     }
 
     /// List all conversations for a user.
     pub async fn list_conversations(&self, user_id: &str) -> Vec<ConversationSurface> {
-        let convs = self.conversations.read().await;
-        convs
-            .values()
-            .filter(|c| c.user_id == user_id)
-            .cloned()
-            .collect()
+        let arcs: Vec<Arc<Mutex<ConversationSurface>>> = {
+            let convs = self.conversations.read().await;
+            convs.values().cloned().collect()
+        };
+        let mut result = Vec::new();
+        for arc in arcs {
+            let conv = arc.lock().await;
+            if conv.user_id == user_id {
+                result.push(conv.clone());
+            }
+        }
+        result
     }
 
     /// Find an active foreground thread given a snapshot of active thread IDs.
@@ -390,6 +434,21 @@ impl ConversationManager {
             }
         }
         None
+    }
+
+    /// Test helper: track a thread in a conversation without accessing the
+    /// internal HashMap directly.
+    #[cfg(test)]
+    pub async fn track_thread_in_conversation(
+        &self,
+        conv_id: ConversationId,
+        thread_id: ThreadId,
+    ) {
+        let arc = self
+            .get_conversation_lock(conv_id)
+            .await
+            .expect("conversation exists in test");
+        arc.lock().await.track_thread(thread_id);
     }
 }
 
@@ -754,11 +813,7 @@ mod tests {
             .unwrap();
         store.save_thread(&thread).await.unwrap();
 
-        {
-            let mut convs = cm.conversations.write().await;
-            let conv = convs.get_mut(&conv_id).unwrap();
-            conv.track_thread(thread.id);
-        }
+        cm.track_thread_in_conversation(conv_id, thread.id).await;
 
         let resumed = cm
             .handle_user_message(
@@ -783,11 +838,7 @@ mod tests {
         let tid = ThreadId::new();
 
         // Manually track a thread
-        {
-            let mut convs = cm.conversations.write().await;
-            let conv = convs.get_mut(&conv_id).unwrap();
-            conv.track_thread(tid);
-        }
+        cm.track_thread_in_conversation(conv_id, tid).await;
 
         // Record completion
         cm.record_thread_outcome(

--- a/src/config/database.rs
+++ b/src/config/database.rs
@@ -130,7 +130,7 @@ impl DatabaseConfig {
                 hint: "Run 'ironclaw onboard' or set DATABASE_URL environment variable".to_string(),
             })?;
 
-        let pool_size = parse_optional_env("DATABASE_POOL_SIZE", 10)?;
+        let pool_size = parse_optional_env("DATABASE_POOL_SIZE", 30)?;
 
         let ssl_mode: SslMode = if let Some(s) = optional_env("DATABASE_SSLMODE")? {
             s.parse().map_err(|e| ConfigError::InvalidValue {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -112,6 +112,16 @@ fn is_system_prompt_file(path: &str) -> bool {
         .any(|p| path.eq_ignore_ascii_case(p))
 }
 
+/// Returns `true` for engine runtime state paths that should never be chunked
+/// or indexed for FTS/vector search.
+///
+/// These are JSON execution-state blobs written by the engine bridge on every
+/// turn (`engine/.runtime/threads/`, `engine/.runtime/steps/`, etc.).  Indexing
+/// them floods the DB connection pool under multi-tenant load.
+fn is_engine_runtime_path(path: &str) -> bool {
+    path.starts_with("engine/.runtime/")
+}
+
 /// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.
 static SANITIZER: std::sync::LazyLock<Sanitizer> = std::sync::LazyLock::new(Sanitizer::new);
 
@@ -1015,6 +1025,24 @@ impl Workspace {
             .storage
             .get_or_create_document_by_path(&self.user_id, self.agent_id, &path)
             .await?;
+
+        // Engine runtime state files are execution-state blobs, not semantic
+        // documents.  Skip the resolve_metadata DB query and all
+        // chunking/embedding work for them entirely.
+        if is_engine_runtime_path(&path) {
+            if doc.content == content {
+                return Ok(doc);
+            }
+            let skip_meta = DocumentMetadata {
+                skip_indexing: Some(true),
+                ..Default::default()
+            };
+            let _ = self
+                .maybe_save_version(doc.id, &doc.content, &skip_meta, Some(&self.user_id))
+                .await;
+            self.storage.update_document(doc.id, content).await?;
+            return self.storage.get_document_by_id(doc.id).await;
+        }
 
         // Short-circuit when content is unchanged: skip versioning and update,
         // but still reindex so metadata-driven flags (e.g. skip_indexing toggled

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -132,12 +132,16 @@ fn is_system_prompt_file(path: &str) -> bool {
 /// Indexing the excluded paths floods the DB connection pool under
 /// multi-tenant load.
 fn is_engine_runtime_path(path: &str) -> bool {
-    // Guard against path traversal: `engine/.runtime/../knowledge/foo.md` would
-    // pass a naive starts_with check but refers to a semantic document.
+    // normalize_path() does not resolve '..' segments — this guard is
+    // load-bearing. Without it, `engine/.runtime/../knowledge/foo.md`
+    // would pass the starts_with check but refer to a semantic document.
     !path.contains("..")
         && (path.starts_with("engine/.runtime/")
             || path.starts_with("engine/projects/")
-            || path == "engine/orchestrator/failures.json")
+            || path == "engine/orchestrator/failures.json"
+            // Auto-generated per-workspace README — regenerated at engine-turn
+            // frequency; should not accumulate version rows.
+            || path == "engine/README.md")
 }
 
 /// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1052,6 +1052,13 @@ impl Workspace {
         // documents.  Skip the resolve_metadata DB query and all
         // chunking/embedding work for them entirely.
         if is_engine_runtime_path(&path) {
+            // One-time cleanup: delete any chunks that were created before this
+            // guard existed. This is a no-op once the document has no chunks,
+            // and prevents stale chunks from polluting search results or
+            // consuming storage indefinitely.
+            // Fail-open: chunk deletion failure must not block state writes.
+            let _ = self.storage.delete_chunks(doc.id).await;
+
             if doc.content == content {
                 return Ok(doc);
             }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -115,11 +115,26 @@ fn is_system_prompt_file(path: &str) -> bool {
 /// Returns `true` for engine runtime state paths that should never be chunked
 /// or indexed for FTS/vector search.
 ///
-/// These are JSON execution-state blobs written by the engine bridge on every
-/// turn (`engine/.runtime/threads/`, `engine/.runtime/steps/`, etc.).  Indexing
-/// them floods the DB connection pool under multi-tenant load.
+/// Covered prefixes / paths (all machine-generated blobs, not semantic docs):
+/// - `engine/.runtime/` — execution-state blobs (threads, steps, events, leases,
+///   conversations, compacted summaries) written by the bridge on every turn.
+/// - `engine/projects/` — project and mission JSON files serialised on every
+///   state mutation (e.g. `engine/projects/{slug}/project.json`,
+///   `engine/projects/{slug}/missions/{slug}/mission.json`).
+/// - `engine/orchestrator/failures.json` — orchestrator failure-tracker blob,
+///   updated at engine-turn frequency.
+///
+/// Semantic content that is intentionally KEPT indexed:
+/// - `engine/knowledge/` — summaries, lessons, plans, specs, notes.
+/// - `engine/orchestrator/v{N}.py` — versioned orchestrator code.
+/// - `engine/orchestrator/*.md` — prompt overlays.
+///
+/// Indexing the excluded paths floods the DB connection pool under
+/// multi-tenant load.
 fn is_engine_runtime_path(path: &str) -> bool {
     path.starts_with("engine/.runtime/")
+        || path.starts_with("engine/projects/")
+        || path == "engine/orchestrator/failures.json"
 }
 
 /// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.
@@ -1035,8 +1050,10 @@ impl Workspace {
             }
             let skip_meta = DocumentMetadata {
                 skip_indexing: Some(true),
+                skip_versioning: Some(true),
                 ..Default::default()
             };
+            // Fail-open: versioning failures must not block state writes.
             let _ = self
                 .maybe_save_version(doc.id, &doc.content, &skip_meta, Some(&self.user_id))
                 .await;
@@ -2887,5 +2904,66 @@ mod versioning_tests {
         let result = ws.patch("test.md", " cruel", "", false).await.unwrap();
 
         assert_eq!(result.document.content, "hello world");
+    }
+
+    // T2: engine/projects/ paths skip FTS/vector indexing; engine/knowledge/ paths do not.
+    #[tokio::test]
+    async fn engine_projects_path_skips_indexing_but_knowledge_does_not() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        // Write to an engine/projects/ path — should skip chunking entirely.
+        ws.write(
+            "engine/projects/test-proj--abc12345/project.json",
+            r#"{"id":"abc12345","name":"test-proj"}"#,
+        )
+        .await
+        .unwrap();
+
+        // No chunks should exist for this document.
+        let chunks = ws
+            .storage
+            .get_chunks_without_embeddings("test_version", None, 100)
+            .await
+            .unwrap();
+        assert!(
+            chunks.is_empty(),
+            "engine/projects/ write must not produce any chunks, got: {chunks:?}"
+        );
+
+        // Write to an engine/knowledge/ path — should be indexed normally.
+        ws.write(
+            "engine/knowledge/lessons/lesson-one--abc12345.md",
+            "This is a lesson learned from the last run.",
+        )
+        .await
+        .unwrap();
+
+        // At least one chunk should now exist for the knowledge document.
+        let chunks = ws
+            .storage
+            .get_chunks_without_embeddings("test_version", None, 100)
+            .await
+            .unwrap();
+        assert!(
+            !chunks.is_empty(),
+            "engine/knowledge/ write must produce chunks for FTS/vector indexing"
+        );
+    }
+
+    // T3: writes to engine/.runtime/ paths produce zero version rows.
+    #[tokio::test]
+    async fn runtime_path_writes_produce_no_versions() {
+        let (ws, _dir) = create_test_workspace().await;
+
+        let path = "engine/.runtime/threads/test-thread.json";
+        let doc = ws.write(path, "v1").await.unwrap();
+        ws.write(path, "v2").await.unwrap();
+
+        let versions = ws.list_versions(doc.id, 50).await.unwrap();
+        assert_eq!(
+            versions.len(),
+            0,
+            "runtime path writes must not accumulate version rows, got: {versions:?}"
+        );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -132,9 +132,12 @@ fn is_system_prompt_file(path: &str) -> bool {
 /// Indexing the excluded paths floods the DB connection pool under
 /// multi-tenant load.
 fn is_engine_runtime_path(path: &str) -> bool {
-    path.starts_with("engine/.runtime/")
-        || path.starts_with("engine/projects/")
-        || path == "engine/orchestrator/failures.json"
+    // Guard against path traversal: `engine/.runtime/../knowledge/foo.md` would
+    // pass a naive starts_with check but refers to a semantic document.
+    !path.contains("..")
+        && (path.starts_with("engine/.runtime/")
+            || path.starts_with("engine/projects/")
+            || path == "engine/orchestrator/failures.json")
 }
 
 /// Shared sanitizer instance — avoids rebuilding Aho-Corasick + regexes on every write.


### PR DESCRIPTION
## Problem

Multi-tenant conversational turns were taking ~20s E2E for messages that required only ~1.7s of actual LLM inference. Trace analysis revealed two bottlenecks in the bridge layer:

- **6s pre-LLM gap**: `bridge::router` blocked before launching the Python orchestrator
- **7s post-execution gap**: bridge blocked after `thread execution finished` before logging `completed`

Root cause: every engine state write triggered full FTS/vector document chunking via `workspace.write()`, flooding the shared DB connection pool (default: 10 connections) with chunk INSERTs. This cascaded into lock contention in `ConversationManager` where a global `RwLock` was held across slow DB writes — serializing all concurrent tenants.

## Changes

### Fix 1 — Skip workspace indexing for engine runtime state
Engine execution state files (`engine/.runtime/`, `engine/projects/`, `engine/orchestrator/failures.json`, `engine/README.md`) are machine-generated blobs, not semantic documents. They no longer trigger `reindex_document_with_metadata()`, version row creation, or FTS/vector indexing on write. The `normalize_path()` does not resolve `..` segments — an explicit `!path.contains("..")` guard prevents path traversal bypass.

### Fix 2 — Per-conversation mutex in `ConversationManager`
Replaces `RwLock<HashMap<ConversationId, ConversationSurface>>` with `RwLock<HashMap<ConversationId, Arc<Mutex<ConversationSurface>>>>`. The global `RwLock` is now a directory only (held for brief HashMap lookups). A single `get_conversation_lock()` helper encapsulates the two-step access pattern and enforces the lock ordering invariant in one place.

- Different conversations now run fully in parallel
- Closes the TOCTOU double-spawn race in `handle_user_message`
- Fixes `record_thread_outcome` 7s post-execution gap
- `record_thread_outcome` and `clear_conversation` now propagate `Err` when conversation not in memory (previously silently returned `Ok`)
- `bootstrap_user` upserts `channel_user_index` even for already-present conversations (repairs stale index entries after rollback)
- `list_conversations` pre-filters via `channel_user_index` before acquiring per-conv locks — O(matched) not O(all)
- `entries_snapshot` clone deferred to `None` branch only (inject/resume paths skip the allocation)

### Fix 3 — `DATABASE_POOL_SIZE` default 10→30
Immediate pool headroom while structural fixes take effect. Configurable via env var. `.env.example` updated.

## Tests

- `concurrent_handle_user_message_spawns_one_thread` — two concurrent messages to same conversation; asserts exactly one thread spawned (validates TOCTOU fix)
- `record_thread_outcome_unknown_conv_returns_err` — validates error propagation fix
- `engine_projects_path_skips_indexing_but_knowledge_does_not` — validates workspace fix coverage
- `runtime_path_writes_produce_no_versions` — validates versioning suppression

**267 tests passing, 0 failures, 0 clippy warnings**

## Known limitations (documented in code)
- `list_conversations` is a best-effort snapshot, not point-in-time consistent (accepted trade-off of two-phase collect)
- `get_or_create_conversation` has a narrow concurrent-creation race where a caller that races between insert and rollback may hold a transiently unpersisted `ConversationId` (documented with comment)
- `record_thread_outcome` in-memory mutations are not rolled back if `save_conversation` fails (accepted, documented)
- `clear_engine_conversation` in `router.rs` has a pre-existing TOCTOU where threads spawned concurrently may be cleared without being stopped (pre-existing, out of scope)