### PR TITLE
fix(e2e): canonicalize extension names + fix remaining test failures

### DIFF
--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3016,11 +3016,13 @@ async fn extensions_setup_handler(
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
+    let canonical_name = crate::extensions::naming::canonicalize_extension_name(&name)
+        .unwrap_or_else(|_| name.clone());
     let kind = ext_mgr
         .list(None, false, &user.user_id)
         .await
         .ok()
-        .and_then(|list| list.into_iter().find(|e| e.name == name))
+        .and_then(|list| list.into_iter().find(|e| e.name == canonical_name))
         .map(|e| e.kind.to_string())
         .unwrap_or_default();
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5145,7 +5145,8 @@ impl ExtensionManager {
         name: &str,
         user_id: &str,
     ) -> Result<ExtensionSetupSchema, ExtensionError> {
-        Self::validate_extension_name(name)?;
+        let canonical = canonicalize_extension_name(name)?;
+        let name = canonical.as_str();
         let kind = self.determine_installed_kind(name, user_id).await?;
         match kind {
             ExtensionKind::WasmChannel => {
@@ -5415,7 +5416,8 @@ impl ExtensionManager {
         fields: &std::collections::HashMap<String, String>,
         user_id: &str,
     ) -> Result<ConfigureResult, ExtensionError> {
-        Self::validate_extension_name(name)?;
+        let canonical = canonicalize_extension_name(name)?;
+        let name = canonical.as_str();
         let kind = self.determine_installed_kind(name, user_id).await?;
 
         // Load allowed secret names and tool setup field definitions from capabilities.

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -9,13 +9,19 @@ async def test_send_message_and_receive_response(page):
     chat_input = page.locator(SEL["chat_input"])
     await chat_input.wait_for(state="visible", timeout=5000)
 
+    # Count existing messages (onboarding greeting may already be present)
+    before_count = await page.locator(SEL["message_assistant"]).count()
+
     # Send message
     await chat_input.fill("What is 2+2?")
     await chat_input.press("Enter")
 
-    # Wait for assistant response
-    assistant_msg = page.locator(SEL["message_assistant"]).last
-    await assistant_msg.wait_for(state="visible", timeout=15000)
+    # Wait for a NEW assistant message to appear
+    await page.wait_for_function(
+        "(before) => document.querySelectorAll('#chat-messages .message.assistant').length > before",
+        arg=before_count,
+        timeout=15000,
+    )
 
     # Verify user message
     user_msgs = page.locator(SEL["message_user"])
@@ -25,6 +31,7 @@ async def test_send_message_and_receive_response(page):
     assert "2+2" in user_text or "2 + 2" in user_text
 
     # Verify assistant response contains "4" (from mock LLM canned response)
+    assistant_msg = page.locator(SEL["message_assistant"]).last
     assistant_text = await assistant_msg.text_content()
     assert "4" in assistant_text, f"Expected '4' in response, got: '{assistant_text}'"
 

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -10,7 +10,8 @@ async def test_send_message_and_receive_response(page):
     await chat_input.wait_for(state="visible", timeout=5000)
 
     # Count existing messages (onboarding greeting may already be present)
-    before_count = await page.locator(SEL["message_assistant"]).count()
+    assistant_selector = SEL["message_assistant"]
+    before_count = await page.locator(assistant_selector).count()
 
     # Send message
     await chat_input.fill("What is 2+2?")
@@ -18,8 +19,8 @@ async def test_send_message_and_receive_response(page):
 
     # Wait for a NEW assistant message to appear
     await page.wait_for_function(
-        "(before) => document.querySelectorAll('#chat-messages .message.assistant').length > before",
-        arg=before_count,
+        "([selector, before]) => document.querySelectorAll(selector).length > before",
+        arg=[assistant_selector, before_count],
         timeout=15000,
     )
 

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -1,40 +1,15 @@
 """Scenario 2: Chat message round-trip via SSE streaming."""
 
 import pytest
-from helpers import SEL
+from helpers import SEL, send_chat_and_wait_for_terminal_message
 
 
 async def test_send_message_and_receive_response(page):
     """Type a message, receive a streamed response from mock LLM."""
-    chat_input = page.locator(SEL["chat_input"])
-    await chat_input.wait_for(state="visible", timeout=5000)
+    result = await send_chat_and_wait_for_terminal_message(page, "What is 2+2?")
 
-    # Count existing messages (onboarding greeting may already be present)
-    assistant_selector = SEL["message_assistant"]
-    before_count = await page.locator(assistant_selector).count()
-
-    # Send message
-    await chat_input.fill("What is 2+2?")
-    await chat_input.press("Enter")
-
-    # Wait for a NEW assistant message to appear
-    await page.wait_for_function(
-        "([selector, before]) => document.querySelectorAll(selector).length > before",
-        arg=[assistant_selector, before_count],
-        timeout=15000,
-    )
-
-    # Verify user message
-    user_msgs = page.locator(SEL["message_user"])
-    assert await user_msgs.count() >= 1
-    last_user = user_msgs.last
-    user_text = await last_user.text_content()
-    assert "2+2" in user_text or "2 + 2" in user_text
-
-    # Verify assistant response contains "4" (from mock LLM canned response)
-    assistant_msg = page.locator(SEL["message_assistant"]).last
-    assistant_text = await assistant_msg.text_content()
-    assert "4" in assistant_text, f"Expected '4' in response, got: '{assistant_text}'"
+    assert result["role"] == "assistant"
+    assert "4" in result["text"], f"Expected '4' in response, got: '{result['text']}'"
 
 
 async def test_multiple_messages(page):

--- a/tests/e2e/scenarios/test_mcp_auth_flow.py
+++ b/tests/e2e/scenarios/test_mcp_auth_flow.py
@@ -52,21 +52,21 @@ async def _ensure_removed(base_url, name):
 
 async def test_mcp_install(ironclaw_server, mock_llm_server):
     """Install a mock MCP server pointing at mock_llm.py's /mcp endpoint."""
-    await _ensure_removed(ironclaw_server, "mock-mcp")
+    await _ensure_removed(ironclaw_server, "mock_mcp")
 
     mcp_url = f"{mock_llm_server}/mcp"
     r = await api_post(
         ironclaw_server,
         "/api/extensions/install",
-        json={"name": "mock-mcp", "url": mcp_url, "kind": "mcp_server"},
+        json={"name": "mock_mcp", "url": mcp_url, "kind": "mcp_server"},
         timeout=30,
     )
     assert r.status_code == 200
     data = r.json()
     assert data.get("success") is True, f"Install failed: {data}"
 
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
-    assert ext is not None, "mock-mcp should appear in extensions list"
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
+    assert ext is not None, "mock_mcp should appear in extensions list"
     assert ext["kind"] == "mcp_server"
 
 
@@ -80,13 +80,13 @@ async def test_mcp_activate_triggers_auth(ironclaw_server):
     is present. The activate handler should detect this as auth-required
     and return an auth_url.
     """
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
     if ext is None:
-        pytest.skip("mock-mcp not installed")
+        pytest.skip("mock_mcp not installed")
 
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/mock-mcp/activate",
+        "/api/extensions/mock_mcp/activate",
         timeout=30,
     )
     assert r.status_code == 200
@@ -110,14 +110,14 @@ async def test_mcp_activate_triggers_auth(ironclaw_server):
 
 async def test_mcp_oauth_callback(ironclaw_server):
     """Complete the OAuth flow via setup + callback for the MCP server."""
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
     if ext is None:
-        pytest.skip("mock-mcp not installed")
+        pytest.skip("mock_mcp not installed")
 
     # Configure with empty secrets to trigger OAuth
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/mock-mcp/setup",
+        "/api/extensions/mock_mcp/setup",
         json={"secrets": {}},
         timeout=30,
     )
@@ -129,7 +129,7 @@ async def test_mcp_oauth_callback(ironclaw_server):
     if auth_url is None:
         r = await api_post(
             ironclaw_server,
-            "/api/extensions/mock-mcp/activate",
+            "/api/extensions/mock_mcp/activate",
             timeout=30,
         )
         data = r.json()
@@ -137,10 +137,10 @@ async def test_mcp_oauth_callback(ironclaw_server):
 
     if auth_url is None:
         # Server might have been auto-authenticated via DCR; check if active
-        ext = await _get_extension(ironclaw_server, "mock-mcp")
+        ext = await _get_extension(ironclaw_server, "mock_mcp")
         if ext and ext.get("authenticated"):
             return  # Already authenticated, skip callback test
-        pytest.skip("Could not obtain auth_url for mock-mcp")
+        pytest.skip("Could not obtain auth_url for mock_mcp")
 
     csrf_state = _extract_state(auth_url)
 
@@ -161,21 +161,21 @@ async def test_mcp_oauth_callback(ironclaw_server):
 
 async def test_mcp_authenticated_after_oauth(ironclaw_server):
     """After OAuth callback, MCP server shows authenticated=True."""
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
     if ext is None:
-        pytest.skip("mock-mcp not installed")
+        pytest.skip("mock_mcp not installed")
     assert ext["authenticated"] is True, (
-        f"mock-mcp should be authenticated after OAuth: {ext}"
+        f"mock_mcp should be authenticated after OAuth: {ext}"
     )
 
 
 async def test_mcp_tools_registered(ironclaw_server):
     """After authentication, MCP tools appear in the extension."""
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
     if ext is None:
-        pytest.skip("mock-mcp not installed")
+        pytest.skip("mock_mcp not installed")
     tools = ext.get("tools", [])
-    assert len(tools) > 0, f"mock-mcp should have tools after auth: {ext}"
+    assert len(tools) > 0, f"mock_mcp should have tools after auth: {ext}"
     # The mock MCP serves a tool named "mock_search", prefixed with server name
     tool_names = [t for t in tools if "mock_search" in t]
     assert len(tool_names) > 0, f"Expected mock_search tool, got: {tools}"
@@ -226,13 +226,13 @@ async def test_mcp_400_activate_triggers_auth(ironclaw_server, mock_llm_server):
     Previously, only 401 triggered the auth flow. GitHub's MCP returns 400
     with "Authorization header is badly formatted" instead.
     """
-    await _ensure_removed(ironclaw_server, "mock-mcp-400")
+    await _ensure_removed(ironclaw_server, "mock_mcp_400")
 
     mcp_url = f"{mock_llm_server}/mcp-400"
     r = await api_post(
         ironclaw_server,
         "/api/extensions/install",
-        json={"name": "mock-mcp-400", "url": mcp_url, "kind": "mcp_server"},
+        json={"name": "mock_mcp_400", "url": mcp_url, "kind": "mcp_server"},
         timeout=30,
     )
     assert r.status_code == 200
@@ -241,7 +241,7 @@ async def test_mcp_400_activate_triggers_auth(ironclaw_server, mock_llm_server):
     # Activate should detect 400 + "authorization" as auth-required
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/mock-mcp-400/activate",
+        "/api/extensions/mock_mcp_400/activate",
         timeout=30,
     )
     assert r.status_code == 200, f"Activate returned {r.status_code}: {r.text[:300]}"
@@ -268,14 +268,14 @@ async def test_mcp_400_oauth_discovery_returns_auth_url(ironclaw_server):
     This test would have failed before the wildcard .well-known routes were
     added to mock_llm.py.
     """
-    ext = await _get_extension(ironclaw_server, "mock-mcp-400")
+    ext = await _get_extension(ironclaw_server, "mock_mcp_400")
     if ext is None:
-        pytest.skip("mock-mcp-400 not installed")
+        pytest.skip("mock_mcp_400 not installed")
 
     # Re-activate to get a fresh auth response
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/mock-mcp-400/activate",
+        "/api/extensions/mock_mcp_400/activate",
         timeout=30,
     )
     assert r.status_code == 200, f"Activate returned {r.status_code}: {r.text[:300]}"
@@ -301,14 +301,14 @@ async def test_mcp_400_full_oauth_roundtrip(ironclaw_server):
     no auth_url is produced, so this test would fail at the csrf_state
     extraction step.
     """
-    ext = await _get_extension(ironclaw_server, "mock-mcp-400")
+    ext = await _get_extension(ironclaw_server, "mock_mcp_400")
     if ext is None:
-        pytest.skip("mock-mcp-400 not installed")
+        pytest.skip("mock_mcp_400 not installed")
 
     # Get a fresh auth_url via activate
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/mock-mcp-400/activate",
+        "/api/extensions/mock_mcp_400/activate",
         timeout=30,
     )
     data = r.json()
@@ -333,27 +333,27 @@ async def test_mcp_400_full_oauth_roundtrip(ironclaw_server):
     )
 
     # Verify authenticated + tools loaded
-    ext = await _get_extension(ironclaw_server, "mock-mcp-400")
-    assert ext is not None, "mock-mcp-400 should still be installed"
+    ext = await _get_extension(ironclaw_server, "mock_mcp_400")
+    assert ext is not None, "mock_mcp_400 should still be installed"
     assert ext["authenticated"] is True, (
-        f"mock-mcp-400 should be authenticated after OAuth: {ext}"
+        f"mock_mcp_400 should be authenticated after OAuth: {ext}"
     )
     tools = ext.get("tools", [])
-    assert len(tools) > 0, f"mock-mcp-400 should have tools after auth: {ext}"
+    assert len(tools) > 0, f"mock_mcp_400 should have tools after auth: {ext}"
 
 
 async def test_mcp_400_cleanup(ironclaw_server):
     """Clean up the 400-variant MCP server."""
-    await _ensure_removed(ironclaw_server, "mock-mcp-400")
-    ext = await _get_extension(ironclaw_server, "mock-mcp-400")
-    assert ext is None, "mock-mcp-400 should be removed"
+    await _ensure_removed(ironclaw_server, "mock_mcp_400")
+    ext = await _get_extension(ironclaw_server, "mock_mcp_400")
+    assert ext is None, "mock_mcp_400 should be removed"
 
 
 # ── Section F: Cleanup ───────────────────────────────────────────────────
 
 
 async def test_mcp_cleanup(ironclaw_server):
-    """Remove mock-mcp (cleanup for other test files)."""
-    await _ensure_removed(ironclaw_server, "mock-mcp")
-    ext = await _get_extension(ironclaw_server, "mock-mcp")
-    assert ext is None, "mock-mcp should be removed"
+    """Remove mock_mcp (cleanup for other test files)."""
+    await _ensure_removed(ironclaw_server, "mock_mcp")
+    ext = await _get_extension(ironclaw_server, "mock_mcp")
+    assert ext is None, "mock_mcp should be removed"

--- a/tests/e2e/scenarios/test_wasm_lifecycle.py
+++ b/tests/e2e/scenarios/test_wasm_lifecycle.py
@@ -48,26 +48,26 @@ async def _install_extension(base_url, name):
 @pytest.fixture(scope="module", autouse=True)
 async def extension_lifecycle_cleanup(ironclaw_server):
     """Start and end the module with a clean extension set."""
-    await _ensure_removed(ironclaw_server, "web-search")
+    await _ensure_removed(ironclaw_server, "web_search")
     await _ensure_removed(ironclaw_server, "gmail")
     yield
-    await _ensure_removed(ironclaw_server, "web-search")
+    await _ensure_removed(ironclaw_server, "web_search")
     await _ensure_removed(ironclaw_server, "gmail")
 
 
 @pytest.fixture(scope="module")
 async def web_search_installed(ironclaw_server, extension_lifecycle_cleanup):
-    """Install web-search once for tests that require the pre-configure state."""
-    data = await _install_extension(ironclaw_server, "web-search")
-    return {"name": "web-search", "install": data}
+    """Install web_search once for tests that require the pre-configure state."""
+    data = await _install_extension(ironclaw_server, "web_search")
+    return {"name": "web_search", "install": data}
 
 
 @pytest.fixture(scope="module")
 async def web_search_configured(ironclaw_server, web_search_installed):
-    """Configure web-search once for tests that require the active state."""
+    """Configure web_search once for tests that require the active state."""
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/web-search/setup",
+        "/api/extensions/web_search/setup",
         json={"secrets": {"brave_api_key": "test-key-123"}},
         timeout=30,
     )
@@ -75,7 +75,7 @@ async def web_search_configured(ironclaw_server, web_search_installed):
     data = r.json()
     assert data.get("success") is True, f"Configure failed: {data.get('message', '')}"
     assert data.get("activated") is True, "Should auto-activate after configure"
-    return {"name": "web-search", "configure": data}
+    return {"name": "web_search", "configure": data}
 
 
 @pytest.fixture(scope="module")
@@ -87,22 +87,22 @@ async def gmail_installed(ironclaw_server, extension_lifecycle_cleanup):
 
 @pytest.fixture(scope="module")
 async def web_search_removed(ironclaw_server, web_search_configured):
-    """Remove web-search once for post-uninstall assertions."""
+    """Remove web_search once for post-uninstall assertions."""
     r = await api_post(
-        ironclaw_server, "/api/extensions/web-search/remove", timeout=30
+        ironclaw_server, "/api/extensions/web_search/remove", timeout=30
     )
     assert r.status_code == 200
     data = r.json()
     assert data.get("success") is True, f"Remove failed: {data.get('message', '')}"
-    return {"name": "web-search", "remove": data}
+    return {"name": "web_search", "remove": data}
 
 
 @pytest.fixture(scope="module")
 async def web_search_reinstalled(ironclaw_server, web_search_removed):
-    """Reinstall web-search after removal to verify it returns unconfigured."""
-    await _ensure_removed(ironclaw_server, "web-search")
-    data = await _install_extension(ironclaw_server, "web-search")
-    return {"name": "web-search", "install": data}
+    """Reinstall web_search after removal to verify it returns unconfigured."""
+    await _ensure_removed(ironclaw_server, "web_search")
+    data = await _install_extension(ironclaw_server, "web_search")
+    return {"name": "web_search", "install": data}
 
 
 # ── Section A: Registry Validation ──────────────────────────────────────
@@ -115,7 +115,7 @@ async def test_registry_lists_extensions(ironclaw_server):
     data = r.json()
     assert "entries" in data
     names = [e["name"] for e in data["entries"]]
-    assert "web-search" in names
+    assert "web_search" in names
     assert "gmail" in names
 
 
@@ -136,13 +136,13 @@ async def test_registry_entry_fields(ironclaw_server):
 async def test_registry_installed_flag_false_initially(ironclaw_server):
     """Before any install, all registry entries have installed=False."""
     # Clean up in case previous test run left extensions installed
-    await _ensure_removed(ironclaw_server, "web-search")
+    await _ensure_removed(ironclaw_server, "web_search")
     await _ensure_removed(ironclaw_server, "gmail")
 
     r = await api_get(ironclaw_server, "/api/extensions/registry")
     entries = r.json()["entries"]
     for entry in entries:
-        if entry["name"] in ("web-search", "gmail"):
+        if entry["name"] in ("web_search", "gmail"):
             assert entry["installed"] is False, (
                 f"{entry['name']} should not be installed yet"
             )
@@ -156,7 +156,7 @@ async def test_registry_search_filters(ironclaw_server):
     assert r.status_code == 200
     entries = r.json()["entries"]
     names = [e["name"] for e in entries]
-    assert "web-search" in names
+    assert "web_search" in names
 
 
 async def test_registry_search_no_match(ironclaw_server):
@@ -170,19 +170,19 @@ async def test_registry_search_no_match(ironclaw_server):
     assert len(r.json()["entries"]) == 0
 
 
-# ── Section B: Install Lifecycle (web-search) ───────────────────────────
+# ── Section B: Install Lifecycle (web_search) ───────────────────────────
 
 
 async def test_install_web_search(web_search_installed):
-    """Install web-search from registry. Asserts success — failure here means
+    """Install web_search from registry. Asserts success — failure here means
     the registry/download/build pipeline is broken."""
     assert "message" in web_search_installed["install"]
 
 
 async def test_installed_extension_fields(ironclaw_server, web_search_installed):
     """After install, extension list shows correct fields."""
-    ext = await _get_extension(ironclaw_server, "web-search")
-    assert ext is not None, "web-search not in extensions list after install"
+    ext = await _get_extension(ironclaw_server, "web_search")
+    assert ext is not None, "web_search not in extensions list after install"
     assert ext["kind"] == "wasm_tool"
     assert ext["needs_setup"] is True, "Should need setup (has brave_api_key secret)"
     assert ext["authenticated"] is False, "Should not be authenticated before configure"
@@ -192,14 +192,14 @@ async def test_installed_in_registry(ironclaw_server, web_search_installed):
     """Registry marks installed extension with installed=True."""
     r = await api_get(ironclaw_server, "/api/extensions/registry")
     entries = r.json()["entries"]
-    ws_entry = next((e for e in entries if e["name"] == "web-search"), None)
+    ws_entry = next((e for e in entries if e["name"] == "web_search"), None)
     assert ws_entry is not None
     assert ws_entry["installed"] is True, "Registry should show installed=True"
 
 
 async def test_setup_schema_has_secrets(ironclaw_server, web_search_installed):
     """Setup schema returns brave_api_key with correct field info."""
-    r = await api_get(ironclaw_server, "/api/extensions/web-search/setup")
+    r = await api_get(ironclaw_server, "/api/extensions/web_search/setup")
     assert r.status_code == 200
     data = r.json()
     assert "secrets" in data
@@ -215,7 +215,7 @@ async def test_extension_not_authenticated_before_configure(
     ironclaw_server, web_search_installed
 ):
     """Installed but not configured extension is not authenticated."""
-    ext = await _get_extension(ironclaw_server, "web-search")
+    ext = await _get_extension(ironclaw_server, "web_search")
     assert ext is not None
     # Before configuring secrets, extension shouldn't be fully authenticated
     assert ext["needs_setup"] is True, "Should still need setup before configure"
@@ -224,7 +224,7 @@ async def test_extension_not_authenticated_before_configure(
 async def test_activate_before_configure_rejected(ironclaw_server, web_search_installed):
     """Activating a tool that needs setup secrets is rejected."""
     r = await api_post(
-        ironclaw_server, "/api/extensions/web-search/activate", timeout=30
+        ironclaw_server, "/api/extensions/web_search/activate", timeout=30
     )
     assert r.status_code == 200
     data = r.json()
@@ -237,14 +237,14 @@ async def test_activate_before_configure_rejected(ironclaw_server, web_search_in
     )
 
 
-# ── Section C: Configure + Activate (web-search) ────────────────────────
+# ── Section C: Configure + Activate (web_search) ────────────────────────
 
 
 async def test_configure_rejects_unknown_secret(ironclaw_server, web_search_installed):
     """Submitting an unknown secret name is rejected."""
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/web-search/setup",
+        "/api/extensions/web_search/setup",
         json={"secrets": {"fake_unknown_key": "value"}},
     )
     assert r.status_code == 200
@@ -262,7 +262,7 @@ async def test_configure_with_valid_secret(web_search_configured):
 
 async def test_extension_active_after_configure(ironclaw_server, web_search_configured):
     """After configure, extension shows authenticated=True and active=True."""
-    ext = await _get_extension(ironclaw_server, "web-search")
+    ext = await _get_extension(ironclaw_server, "web_search")
     assert ext is not None
     assert ext["authenticated"] is True, "Should be authenticated after configure"
     assert ext["active"] is True, "Should be active after auto-activation"
@@ -271,7 +271,7 @@ async def test_extension_active_after_configure(ironclaw_server, web_search_conf
 
 async def test_setup_shows_provided(ironclaw_server, web_search_configured):
     """After configure, setup schema shows secret as provided."""
-    r = await api_get(ironclaw_server, "/api/extensions/web-search/setup")
+    r = await api_get(ironclaw_server, "/api/extensions/web_search/setup")
     assert r.status_code == 200
     secrets = {s["name"]: s for s in r.json()["secrets"]}
     assert "brave_api_key" in secrets
@@ -285,8 +285,8 @@ async def test_tools_registered_after_activate(
     r = await api_get(ironclaw_server, "/api/extensions/tools")
     assert r.status_code == 200
     tool_names = [t["name"] for t in r.json()["tools"]]
-    assert "web-search" in tool_names, (
-        f"web-search tool not found in tools list: {tool_names}"
+    assert "web_search" in tool_names, (
+        f"web_search tool not found in tools list: {tool_names}"
     )
 
 
@@ -295,7 +295,7 @@ async def test_activate_already_active_idempotent(
 ):
     """Activating an already-active extension succeeds (idempotent)."""
     r = await api_post(
-        ironclaw_server, "/api/extensions/web-search/activate", timeout=30
+        ironclaw_server, "/api/extensions/web_search/activate", timeout=30
     )
     assert r.status_code == 200
     data = r.json()
@@ -308,7 +308,7 @@ async def test_configure_empty_secret_skipped(ironclaw_server, web_search_config
     """Submitting an empty string for a secret skips it (doesn't overwrite)."""
     r = await api_post(
         ironclaw_server,
-        "/api/extensions/web-search/setup",
+        "/api/extensions/web_search/setup",
         json={"secrets": {"brave_api_key": ""}},
         timeout=30,
     )
@@ -317,7 +317,7 @@ async def test_configure_empty_secret_skipped(ironclaw_server, web_search_config
     assert data.get("success") is True
 
     # Verify the secret is still provided (not cleared)
-    r2 = await api_get(ironclaw_server, "/api/extensions/web-search/setup")
+    r2 = await api_get(ironclaw_server, "/api/extensions/web_search/setup")
     secrets = {s["name"]: s for s in r2.json()["secrets"]}
     assert secrets["brave_api_key"]["provided"] is True, (
         "Empty value should not clear existing secret"
@@ -343,10 +343,10 @@ async def test_gmail_fields(ironclaw_server, gmail_installed):
 async def test_both_extensions_listed(
     ironclaw_server, web_search_configured, gmail_installed
 ):
-    """Both web-search and gmail appear in extensions list (no clobbering)."""
+    """Both web_search and gmail appear in extensions list (no clobbering)."""
     r = await api_get(ironclaw_server, "/api/extensions")
     names = [e["name"] for e in r.json()["extensions"]]
-    assert "web-search" in names, f"web-search missing from: {names}"
+    assert "web_search" in names, f"web_search missing from: {names}"
     assert "gmail" in names, f"gmail missing from: {names}"
 
 
@@ -370,14 +370,14 @@ async def test_gmail_setup_schema_auto_resolves(ironclaw_server, gmail_installed
 
 
 async def test_remove_web_search(web_search_removed):
-    """Remove web-search succeeds."""
+    """Remove web_search succeeds."""
     assert web_search_removed["remove"].get("success") is True
 
 
 async def test_removed_not_in_extensions(ironclaw_server, web_search_removed):
     """Removed extension no longer appears in extensions list."""
-    ext = await _get_extension(ironclaw_server, "web-search")
-    assert ext is None, "web-search should not be in extensions list after removal"
+    ext = await _get_extension(ironclaw_server, "web_search")
+    assert ext is None, "web_search should not be in extensions list after removal"
 
 
 async def test_removed_extension_not_listed(ironclaw_server, web_search_removed):
@@ -385,8 +385,8 @@ async def test_removed_extension_not_listed(ironclaw_server, web_search_removed)
     r = await api_get(ironclaw_server, "/api/extensions/tools")
     assert r.status_code == 200
     tool_names = [t["name"] for t in r.json()["tools"]]
-    assert "web-search" not in tool_names, (
-        f"Removed web-search tool should not remain registered: {tool_names}"
+    assert "web_search" not in tool_names, (
+        f"Removed web_search tool should not remain registered: {tool_names}"
     )
 
 
@@ -394,7 +394,7 @@ async def test_removed_not_in_registry_installed(ironclaw_server, web_search_rem
     """Registry shows removed extension as installed=False."""
     r = await api_get(ironclaw_server, "/api/extensions/registry")
     ws_entry = next(
-        (e for e in r.json()["entries"] if e["name"] == "web-search"), None
+        (e for e in r.json()["entries"] if e["name"] == "web_search"), None
     )
     assert ws_entry is not None
     assert ws_entry["installed"] is False, "Registry should show installed=False"
@@ -404,11 +404,11 @@ async def test_activate_after_remove_uses_replacement_bytes_not_cached_module(
     ironclaw_server, wasm_tools_dir, web_search_removed
 ):
     """After removal, activation must use the replacement bytes rather than a stale cache."""
-    wasm_path = Path(wasm_tools_dir) / "web-search.wasm"
+    wasm_path = Path(wasm_tools_dir) / "web_search.wasm"
     wasm_path.write_bytes(b"not-a-valid-wasm-component")
 
     r = await api_post(
-        ironclaw_server, "/api/extensions/web-search/activate", timeout=30
+        ironclaw_server, "/api/extensions/web_search/activate", timeout=30
     )
     assert r.status_code == 200
     data = r.json()
@@ -419,8 +419,8 @@ async def test_activate_after_remove_uses_replacement_bytes_not_cached_module(
 
 async def test_reinstall_after_remove(ironclaw_server, web_search_reinstalled):
     """Extension can be reinstalled after removal without stale activation errors."""
-    ext = await _get_extension(ironclaw_server, "web-search")
-    assert ext is not None, "web-search not found after reinstall"
+    ext = await _get_extension(ironclaw_server, "web_search")
+    assert ext is not None, "web_search not found after reinstall"
     assert ext["active"] is False, "Reinstalled tool should require setup before activation"
     assert ext["authenticated"] is False, "Reinstalled tool should not reuse deleted secrets"
     assert ext["needs_setup"] is True, "Reinstalled tool should require setup again"


### PR DESCRIPTION
## Summary

- **Bug fix**: `configure()` and `get_setup_schema()` in `ExtensionManager` used `validate_extension_name()` which discards the canonical form — hyphenated names from URL paths (e.g., `web-search`) caused "Capabilities file not found" errors. Now both canonicalize properly (`web-search` → `web_search`).
- **Bug fix**: `extensions_setup_handler` kind lookup compared raw URL path param against canonical stored names.
- **Test fix**: Update `test_wasm_lifecycle.py` extension names from `web-search` to `web_search` (canonical form).
- **Test fix**: Update `test_mcp_auth_flow.py` names from `mock-mcp` to `mock_mcp`.
- **Test fix**: `test_chat.py` now counts assistant messages before sending to avoid picking up the onboarding greeting.

## Test plan

- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] E2E core suite — 16/16 passed locally
- [x] E2E extensions suite — 103/103 passed locally (test_wasm_lifecycle + test_mcp_auth_flow + test_extensions)
- [x] E2E features suite — already passing in CI
- [x] E2E routines suite — already passing in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)