### PR TITLE
fix(engine): repair mission ACL regression and 4 stale engine tests

### DIFF
--- a/crates/ironclaw_engine/src/executor/loop_engine.rs
+++ b/crates/ironclaw_engine/src/executor/loop_engine.rs
@@ -617,8 +617,8 @@ mod tests {
         let outcome = exec.run().await.unwrap();
         assert!(matches!(outcome, ThreadOutcome::Completed { response: Some(r) } if r == "Done!"));
         assert_eq!(exec.thread.step_count, 2);
-        // Should have: system(nudge not counted), assistant+actions, action_result, assistant
-        assert!(exec.thread.messages.len() >= 3);
+        // Orchestrator stores working messages in internal_messages
+        assert!(exec.thread.internal_messages.len() >= 3);
     }
 
     #[tokio::test]
@@ -735,10 +735,10 @@ mod tests {
             matches!(outcome, ThreadOutcome::Completed { response: Some(r) } if r == "The answer is 42")
         );
         assert_eq!(exec.thread.step_count, 2);
-        // Should have nudge system message
+        // Nudge is stored in orchestrator's working messages (internal transcript)
         assert!(
             exec.thread
-                .messages
+                .internal_messages
                 .iter()
                 .any(|m| m.content.contains("did not include any tool calls"))
         );
@@ -833,7 +833,7 @@ mod tests {
             matches!(outcome, ThreadOutcome::Completed { response: Some(r) } if r == "got result")
         );
         // Should have at least 1 action result recorded
-        assert!(!exec.thread.messages.is_empty());
+        assert!(!exec.thread.internal_messages.is_empty());
     }
 
     #[tokio::test]
@@ -873,10 +873,10 @@ mod tests {
             matches!(outcome, ThreadOutcome::Completed { response: Some(r) } if r == "done, x was 30")
         );
         assert_eq!(exec.thread.step_count, 2);
-        // The output metadata from first step should be in messages
+        // The output metadata from first step should be in internal messages
         assert!(
             exec.thread
-                .messages
+                .internal_messages
                 .iter()
                 .any(|m| m.content.contains("x = 30"))
         );
@@ -904,7 +904,7 @@ mod tests {
         // First step should have error in output metadata
         assert!(
             exec.thread
-                .messages
+                .internal_messages
                 .iter()
                 .any(|m| { m.content.contains("NameError") || m.content.contains("Error") })
         );

--- a/crates/ironclaw_engine/src/executor/trace.rs
+++ b/crates/ironclaw_engine/src/executor/trace.rs
@@ -582,7 +582,12 @@ mod tests {
         ));
 
         let trace = build_trace(&thread);
-        match &trace.events[0].kind {
+        let approval = trace
+            .events
+            .iter()
+            .find(|e| matches!(&e.kind, EventKind::ApprovalRequested { .. }))
+            .expect("should have ApprovalRequested event");
+        match &approval.kind {
             EventKind::ApprovalRequested {
                 action_name,
                 call_id,
@@ -610,7 +615,8 @@ mod tests {
         assert!(json.contains("\"ApprovalRequested\""));
         assert!(json.contains("\"action_name\":\"tool_install\""));
         assert!(json.contains("\"call_id\":\"call_install_1\""));
-        assert!(json.contains("\"parameters\":{\"name\":\"notion\",\"kind\":\"mcp_server\"}"));
+        assert!(json.contains("\"name\":\"notion\""));
+        assert!(json.contains("\"kind\":\"mcp_server\""));
         assert!(json.contains("\"description\":\"Install an extension\""));
         assert!(json.contains("\"allow_always\":true"));
         assert!(json.contains("\"gate_name\":\"approval\""));

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -164,15 +164,18 @@ impl MissionManager {
     /// For shared missions, the caller (web handler) must
     /// verify admin role before calling this. The engine only checks ownership.
     pub async fn pause_mission(&self, id: MissionId, user_id: &str) -> Result<(), EngineError> {
-        // Validate ownership. Shared missions require admin role (checked by caller).
-        if let Some(mission) = self.store.load_mission(id).await?
-            && !mission.is_owned_by(user_id)
-            && !mission.owner_id().is_shared()
-        {
-            return Err(EngineError::AccessDenied {
-                user_id: user_id.to_string(),
-                entity: format!("mission {id}"),
-            });
+        if let Some(mission) = self.store.load_mission(id).await? {
+            let allowed = if mission.owner_id().is_shared() {
+                crate::types::is_shared_owner(user_id)
+            } else {
+                mission.is_owned_by(user_id)
+            };
+            if !allowed {
+                return Err(EngineError::AccessDenied {
+                    user_id: user_id.to_string(),
+                    entity: format!("mission {id}"),
+                });
+            }
         }
         self.store
             .update_mission_status(id, MissionStatus::Paused)
@@ -187,15 +190,18 @@ impl MissionManager {
     /// For shared missions, the caller (web handler) must
     /// verify admin role before calling this. The engine only checks ownership.
     pub async fn resume_mission(&self, id: MissionId, user_id: &str) -> Result<(), EngineError> {
-        // Validate ownership. Shared missions require admin role (checked by caller).
-        if let Some(mission) = self.store.load_mission(id).await?
-            && !mission.is_owned_by(user_id)
-            && !mission.owner_id().is_shared()
-        {
-            return Err(EngineError::AccessDenied {
-                user_id: user_id.to_string(),
-                entity: format!("mission {id}"),
-            });
+        if let Some(mission) = self.store.load_mission(id).await? {
+            let allowed = if mission.owner_id().is_shared() {
+                crate::types::is_shared_owner(user_id)
+            } else {
+                mission.is_owned_by(user_id)
+            };
+            if !allowed {
+                return Err(EngineError::AccessDenied {
+                    user_id: user_id.to_string(),
+                    entity: format!("mission {id}"),
+                });
+            }
         }
         self.store
             .update_mission_status(id, MissionStatus::Active)

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -127,7 +127,12 @@ impl MissionManager {
                 reason: format!("mission {id} not found"),
             })?;
 
-        if !mission.owner_id().is_shared() && !mission.is_owned_by(user_id) {
+        let allowed = if mission.owner_id().is_shared() {
+            crate::types::is_shared_owner(user_id)
+        } else {
+            mission.is_owned_by(user_id)
+        };
+        if !allowed {
             return Err(EngineError::AccessDenied {
                 user_id: user_id.to_string(),
                 entity: format!("mission {id}"),
@@ -161,21 +166,25 @@ impl MissionManager {
 
     /// Pause an active mission. No new threads will be spawned.
     ///
-    /// For shared missions, the caller (web handler) must
-    /// verify admin role before calling this. The engine only checks ownership.
+    /// Shared missions can only be managed by shared owners (system user).
     pub async fn pause_mission(&self, id: MissionId, user_id: &str) -> Result<(), EngineError> {
-        if let Some(mission) = self.store.load_mission(id).await? {
-            let allowed = if mission.owner_id().is_shared() {
-                crate::types::is_shared_owner(user_id)
-            } else {
-                mission.is_owned_by(user_id)
-            };
-            if !allowed {
-                return Err(EngineError::AccessDenied {
-                    user_id: user_id.to_string(),
-                    entity: format!("mission {id}"),
-                });
-            }
+        let mission = self
+            .store
+            .load_mission(id)
+            .await?
+            .ok_or_else(|| EngineError::Store {
+                reason: format!("mission {id} not found"),
+            })?;
+        let allowed = if mission.owner_id().is_shared() {
+            crate::types::is_shared_owner(user_id)
+        } else {
+            mission.is_owned_by(user_id)
+        };
+        if !allowed {
+            return Err(EngineError::AccessDenied {
+                user_id: user_id.to_string(),
+                entity: format!("mission {id}"),
+            });
         }
         self.store
             .update_mission_status(id, MissionStatus::Paused)
@@ -187,21 +196,25 @@ impl MissionManager {
 
     /// Resume a paused mission.
     ///
-    /// For shared missions, the caller (web handler) must
-    /// verify admin role before calling this. The engine only checks ownership.
+    /// Shared missions can only be managed by shared owners (system user).
     pub async fn resume_mission(&self, id: MissionId, user_id: &str) -> Result<(), EngineError> {
-        if let Some(mission) = self.store.load_mission(id).await? {
-            let allowed = if mission.owner_id().is_shared() {
-                crate::types::is_shared_owner(user_id)
-            } else {
-                mission.is_owned_by(user_id)
-            };
-            if !allowed {
-                return Err(EngineError::AccessDenied {
-                    user_id: user_id.to_string(),
-                    entity: format!("mission {id}"),
-                });
-            }
+        let mission = self
+            .store
+            .load_mission(id)
+            .await?
+            .ok_or_else(|| EngineError::Store {
+                reason: format!("mission {id} not found"),
+            })?;
+        let allowed = if mission.owner_id().is_shared() {
+            crate::types::is_shared_owner(user_id)
+        } else {
+            mission.is_owned_by(user_id)
+        };
+        if !allowed {
+            return Err(EngineError::AccessDenied {
+                user_id: user_id.to_string(),
+                entity: format!("mission {id}"),
+            });
         }
         self.store
             .update_mission_status(id, MissionStatus::Active)


### PR DESCRIPTION
## Summary

- **Security fix**: `pause_mission()` and `resume_mission()` had a broken access control check — the `&& !mission.owner_id().is_shared()` condition short-circuited the entire guard for shared missions, allowing any user to manage system missions. Replaced with proper two-branch logic using `is_shared_owner()`.
- **4 test fixes**: Updated loop_engine tests (`action_then_text`, `tool_intent_nudge_injected`, `codeact_multi_step`, `tool_call_basic`, `codeact_error_recovery`) to check `thread.internal_messages` instead of `thread.messages` — the orchestrator stores working messages in the internal transcript.
- **1 test fix**: Made `trace_serializes_approval_request_payload` resilient to event ordering by filtering events by `EventKind` instead of indexing `events[0]`, and fixed a JSON key-order assertion.

## Test plan

- [x] All 5 previously failing tests now pass
- [x] Full `cargo test -p ironclaw_engine` passes (267 tests)
- [x] `cargo clippy -p ironclaw_engine` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)