### PR TITLE
fix(config): support allowlisted private LLM base URLs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3437,6 +3437,7 @@ dependencies = [
  "hyper-util",
  "iana-time-zone",
  "insta",
+ "ipnet",
  "ironclaw_common",
  "ironclaw_safety",
  "json5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ secrecy = { version = "0.10", features = ["serde"] }
 # URL parsing and encoding
 url = "2"
 urlencoding = "2"
+ipnet = "2"
 
 # Open URLs in browser
 open = "5"

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -246,7 +246,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | NVIDIA API | ✅ | ✅ | P3 | Via `nvidia` adapter and `providers.json` |
 | OpenRouter | ✅ | ✅ | - | Via OpenAI-compatible provider (RigAdapter) |
 | Tinfoil | ❌ | ✅ | - | Private inference provider (IronClaw-only) |
-| OpenAI-compatible | ❌ | ✅ | - | Generic OpenAI-compatible endpoint (RigAdapter) |
+| OpenAI-compatible | ❌ | ✅ | - | Generic OpenAI-compatible endpoint (RigAdapter); private-network endpoints supported via explicit `LLM_BASE_URL_ALLOW_PRIVATE_*` allowlists |
 | GitHub Copilot | ✅ | ✅ | - | Dedicated provider with OAuth token exchange (`GithubCopilotProvider`) |
 | Ollama (local) | ✅ | ✅ | - | via `rig::providers::ollama` (full support) |
 | Perplexity | ✅ | ❌ | P3 | Freshness parameter for web_search |

--- a/docs/LLM_PROVIDERS.md
+++ b/docs/LLM_PROVIDERS.md
@@ -295,6 +295,22 @@ LLM_API_KEY=sk-...
 LLM_MODEL=gpt-4o                 # as configured in litellm config.yaml
 ```
 
+For private-network deployments, IronClaw still blocks private/internal
+`LLM_BASE_URL` values by default. If your LiteLLM or vLLM endpoint is intentionally
+inside a trusted VPN/VPC, you can allow it explicitly:
+
+```env
+LLM_BACKEND=openai_compatible
+LLM_BASE_URL=https://corp-llm.internal.example/v1
+LLM_BASE_URL_ALLOW_PRIVATE_HOSTS=corp-llm.internal.example
+LLM_BASE_URL_ALLOW_PRIVATE_CIDRS=10.0.0.0/8
+LLM_API_KEY=sk-...
+LLM_MODEL=gpt-4o
+```
+
+Use the smallest allowlist you can. Metadata endpoints and other blocked address
+classes remain rejected.
+
 ### LM Studio (local GUI)
 
 Start LM Studio's local server, then:

--- a/src/config/helpers.rs
+++ b/src/config/helpers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::sync::{Mutex, OnceLock};
 
 use crate::error::ConfigError;
@@ -186,6 +187,102 @@ pub(crate) fn parse_string_env(
     Ok(optional_env(key)?.unwrap_or_else(|| default.into()))
 }
 
+fn parse_csv_list(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+pub(crate) fn parse_csv_env(key: &str) -> Result<Vec<String>, ConfigError> {
+    Ok(optional_env(key)?
+        .map(|v| parse_csv_list(&v))
+        .unwrap_or_default())
+}
+
+fn is_metadata_ip(ip: &IpAddr) -> bool {
+    matches!(ip, IpAddr::V4(v4) if *v4 == Ipv4Addr::new(169, 254, 169, 254))
+}
+
+fn is_allowlist_eligible_private_ip(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => v4.is_private(),
+        IpAddr::V6(v6) => {
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                v4.is_private()
+            } else {
+                (v6.octets()[0] & 0xfe) == 0xfc
+            }
+        }
+    }
+}
+
+fn ipv4_in_cidr(ip: Ipv4Addr, base: Ipv4Addr, prefix: u8) -> bool {
+    let ip_u = u32::from(ip);
+    let base_u = u32::from(base);
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u32::MAX << (32 - prefix)
+    };
+    (ip_u & mask) == (base_u & mask)
+}
+
+fn ipv6_in_cidr(ip: Ipv6Addr, base: Ipv6Addr, prefix: u8) -> bool {
+    let ip_u = u128::from_be_bytes(ip.octets());
+    let base_u = u128::from_be_bytes(base.octets());
+    let mask = if prefix == 0 {
+        0
+    } else {
+        u128::MAX << (128 - prefix)
+    };
+    (ip_u & mask) == (base_u & mask)
+}
+
+fn ip_in_cidr(ip: &IpAddr, cidr: &str) -> Result<bool, String> {
+    let (base_str, prefix_str) = cidr
+        .split_once('/')
+        .ok_or_else(|| format!("CIDR '{cidr}' is missing '/'"))?;
+    let base_ip: IpAddr = base_str
+        .parse()
+        .map_err(|e| format!("invalid CIDR base '{base_str}': {e}"))?;
+    match (ip, base_ip) {
+        (IpAddr::V4(ipv4), IpAddr::V4(base_v4)) => {
+            let prefix: u8 = prefix_str
+                .parse()
+                .map_err(|e| format!("invalid IPv4 CIDR prefix '{prefix_str}': {e}"))?;
+            if prefix > 32 {
+                return Err(format!("IPv4 CIDR prefix out of range in '{cidr}'"));
+            }
+            Ok(ipv4_in_cidr(*ipv4, base_v4, prefix))
+        }
+        (IpAddr::V6(ipv6), IpAddr::V6(base_v6)) => {
+            let prefix: u8 = prefix_str
+                .parse()
+                .map_err(|e| format!("invalid IPv6 CIDR prefix '{prefix_str}': {e}"))?;
+            if prefix > 128 {
+                return Err(format!("IPv6 CIDR prefix out of range in '{cidr}'"));
+            }
+            Ok(ipv6_in_cidr(*ipv6, base_v6, prefix))
+        }
+        _ => Ok(false),
+    }
+}
+
+fn is_private_ip_allowed(ip: &IpAddr, allow_private_cidrs: &[String]) -> Result<bool, String> {
+    if !is_allowlist_eligible_private_ip(ip) {
+        return Ok(false);
+    }
+    for cidr in allow_private_cidrs {
+        if ip_in_cidr(ip, cidr)? {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
 /// Validate a user-configurable base URL to prevent SSRF attacks (#1103).
 ///
 /// Rejects:
@@ -196,7 +293,16 @@ pub(crate) fn parse_string_env(
 /// This is intended for config-time validation of base URLs like
 /// `OLLAMA_BASE_URL`, `EMBEDDING_BASE_URL`, `NEARAI_BASE_URL`, etc.
 pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), ConfigError> {
-    use std::net::{IpAddr, Ipv4Addr};
+    validate_base_url_with_allowlists(url, field_name, &[], &[])
+}
+
+pub(crate) fn validate_base_url_with_allowlists(
+    url: &str,
+    field_name: &str,
+    allow_private_hosts: &[String],
+    allow_private_cidrs: &[String],
+) -> Result<(), ConfigError> {
+    use std::net::ToSocketAddrs;
 
     let parsed = reqwest::Url::parse(url).map_err(|e| ConfigError::InvalidValue {
         key: field_name.to_string(),
@@ -276,6 +382,16 @@ pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), Confi
     // Check both IP literals and resolved hostnames to prevent DNS-based SSRF.
     if let Ok(ip) = host.parse::<IpAddr>() {
         if is_dangerous_ip(&ip) {
+            if !is_metadata_ip(&ip)
+                && is_private_ip_allowed(&ip, allow_private_cidrs).map_err(|e| {
+                    ConfigError::InvalidValue {
+                        key: field_name.to_string(),
+                        message: e,
+                    }
+                })?
+            {
+                return Ok(());
+            }
             return Err(ConfigError::InvalidValue {
                 key: field_name.to_string(),
                 message: format!(
@@ -297,12 +413,25 @@ pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), Confi
         // before the async runtime is fully driving I/O. If this ever moves to
         // a hot path, wrap in `tokio::task::spawn_blocking` or use
         // `tokio::net::lookup_host`.
-        use std::net::ToSocketAddrs;
         let port = parsed.port().unwrap_or(443);
         match (host, port).to_socket_addrs() {
             Ok(addrs) => {
+                let host_allowed = allow_private_hosts
+                    .iter()
+                    .any(|allowed| allowed.eq_ignore_ascii_case(host));
                 for addr in addrs {
                     if is_dangerous_ip(&addr.ip()) {
+                        if !is_metadata_ip(&addr.ip())
+                            && (host_allowed
+                                || is_private_ip_allowed(&addr.ip(), allow_private_cidrs).map_err(
+                                    |e| ConfigError::InvalidValue {
+                                        key: field_name.to_string(),
+                                        message: e,
+                                    },
+                                )?)
+                        {
+                            continue;
+                        }
                         return Err(ConfigError::InvalidValue {
                             key: field_name.to_string(),
                             message: format!(
@@ -518,5 +647,55 @@ mod tests {
             err.contains("failed to resolve"),
             "Expected DNS resolution failure, got: {err}"
         );
+    }
+
+    #[test]
+    fn validate_base_url_with_allowlists_allows_private_ip_cidr() {
+        let allow_cidrs = vec!["10.0.0.0/8".to_string()];
+        assert!(
+            validate_base_url_with_allowlists("https://10.1.2.3/v1", "TEST", &[], &allow_cidrs)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_base_url_with_allowlists_allows_private_hostname() {
+        let allow_hosts = vec!["localhost".to_string()];
+        assert!(
+            validate_base_url_with_allowlists(
+                "https://localhost:8443/v1",
+                "TEST",
+                &allow_hosts,
+                &[]
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn validate_base_url_with_allowlists_still_rejects_metadata_ip() {
+        let allow_cidrs = vec!["169.254.169.254/32".to_string()];
+        let result =
+            validate_base_url_with_allowlists("https://169.254.169.254", "TEST", &[], &allow_cidrs);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_csv_env_splits_and_trims() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_CSV_ENV";
+        set_runtime_env(key, " a.example.com , b.example.com ,, 10.0.0.0/8 ");
+        assert_eq!(
+            parse_csv_env(key).unwrap(),
+            vec![
+                "a.example.com".to_string(),
+                "b.example.com".to_string(),
+                "10.0.0.0/8".to_string()
+            ]
+        );
+        runtime_overrides()
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .remove(key);
     }
 }

--- a/src/config/helpers.rs
+++ b/src/config/helpers.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr};
 use std::sync::{Mutex, OnceLock};
+
+use ipnet::IpNet;
 
 use crate::error::ConfigError;
 
@@ -219,56 +221,11 @@ fn is_allowlist_eligible_private_ip(ip: &IpAddr) -> bool {
     }
 }
 
-fn ipv4_in_cidr(ip: Ipv4Addr, base: Ipv4Addr, prefix: u8) -> bool {
-    let ip_u = u32::from(ip);
-    let base_u = u32::from(base);
-    let mask = if prefix == 0 {
-        0
-    } else {
-        u32::MAX << (32 - prefix)
-    };
-    (ip_u & mask) == (base_u & mask)
-}
-
-fn ipv6_in_cidr(ip: Ipv6Addr, base: Ipv6Addr, prefix: u8) -> bool {
-    let ip_u = u128::from_be_bytes(ip.octets());
-    let base_u = u128::from_be_bytes(base.octets());
-    let mask = if prefix == 0 {
-        0
-    } else {
-        u128::MAX << (128 - prefix)
-    };
-    (ip_u & mask) == (base_u & mask)
-}
-
 fn ip_in_cidr(ip: &IpAddr, cidr: &str) -> Result<bool, String> {
-    let (base_str, prefix_str) = cidr
-        .split_once('/')
-        .ok_or_else(|| format!("CIDR '{cidr}' is missing '/'"))?;
-    let base_ip: IpAddr = base_str
+    let net: IpNet = cidr
         .parse()
-        .map_err(|e| format!("invalid CIDR base '{base_str}': {e}"))?;
-    match (ip, base_ip) {
-        (IpAddr::V4(ipv4), IpAddr::V4(base_v4)) => {
-            let prefix: u8 = prefix_str
-                .parse()
-                .map_err(|e| format!("invalid IPv4 CIDR prefix '{prefix_str}': {e}"))?;
-            if prefix > 32 {
-                return Err(format!("IPv4 CIDR prefix out of range in '{cidr}'"));
-            }
-            Ok(ipv4_in_cidr(*ipv4, base_v4, prefix))
-        }
-        (IpAddr::V6(ipv6), IpAddr::V6(base_v6)) => {
-            let prefix: u8 = prefix_str
-                .parse()
-                .map_err(|e| format!("invalid IPv6 CIDR prefix '{prefix_str}': {e}"))?;
-            if prefix > 128 {
-                return Err(format!("IPv6 CIDR prefix out of range in '{cidr}'"));
-            }
-            Ok(ipv6_in_cidr(*ipv6, base_v6, prefix))
-        }
-        _ => Ok(false),
-    }
+        .map_err(|e| format!("invalid CIDR '{cidr}': {e}"))?;
+    Ok(net.contains(ip))
 }
 
 fn is_private_ip_allowed(ip: &IpAddr, allow_private_cidrs: &[String]) -> Result<bool, String> {

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use secrecy::SecretString;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_optional_env, validate_base_url};
+use crate::config::helpers::{
+    optional_env, parse_csv_env, parse_optional_env, validate_base_url,
+    validate_base_url_with_allowlists,
+};
 use crate::error::ConfigError;
 use crate::llm::config::*;
 use crate::llm::registry::{ProviderProtocol, ProviderRegistry};
@@ -530,7 +533,18 @@ impl LlmConfig {
         // Validate base URL to prevent SSRF (#1103).
         if !base_url.is_empty() {
             let field = base_url_env.unwrap_or("LLM_BASE_URL");
-            validate_base_url(&base_url, field)?;
+            if field == "LLM_BASE_URL" {
+                let allow_private_hosts = parse_csv_env("LLM_BASE_URL_ALLOW_PRIVATE_HOSTS")?;
+                let allow_private_cidrs = parse_csv_env("LLM_BASE_URL_ALLOW_PRIVATE_CIDRS")?;
+                validate_base_url_with_allowlists(
+                    &base_url,
+                    field,
+                    &allow_private_hosts,
+                    &allow_private_cidrs,
+                )?;
+            } else {
+                validate_base_url(&base_url, field)?;
+            }
         }
 
         // Resolve model: selected_model (DB) > per-provider override (DB) > env var > registry default
@@ -693,7 +707,11 @@ mod tests {
         unsafe {
             std::env::remove_var("LLM_BACKEND");
             std::env::remove_var("LLM_BASE_URL");
+            std::env::remove_var("LLM_BASE_URL_ALLOW_PRIVATE_HOSTS");
+            std::env::remove_var("LLM_BASE_URL_ALLOW_PRIVATE_CIDRS");
             std::env::remove_var("LLM_MODEL");
+            std::env::remove_var("NEARAI_AUTH_URL");
+            std::env::remove_var("NEARAI_BASE_URL");
         }
     }
 
@@ -1169,6 +1187,73 @@ mod tests {
             std::env::remove_var("LLM_BACKEND");
             std::env::remove_var("LLM_BASE_URL");
         }
+    }
+
+    #[test]
+    fn openai_compatible_private_https_base_url_rejected_by_default() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        unsafe {
+            std::env::set_var("LLM_BACKEND", "openai_compatible");
+            std::env::set_var("LLM_BASE_URL", "https://10.1.1.20/v1");
+            std::env::set_var("NEARAI_AUTH_URL", "http://localhost:11434");
+            std::env::set_var("NEARAI_BASE_URL", "http://localhost:11434");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            ..Default::default()
+        };
+        let err = LlmConfig::resolve(&settings).unwrap_err().to_string();
+        assert!(err.contains("private/internal IP"));
+
+        clear_openai_compatible_env();
+    }
+
+    #[test]
+    fn openai_compatible_private_https_base_url_allowed_with_cidr_override() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        unsafe {
+            std::env::set_var("LLM_BACKEND", "openai_compatible");
+            std::env::set_var("LLM_BASE_URL", "https://10.1.1.20/v1");
+            std::env::set_var("LLM_BASE_URL_ALLOW_PRIVATE_CIDRS", "10.0.0.0/8");
+            std::env::set_var("NEARAI_AUTH_URL", "http://localhost:11434");
+            std::env::set_var("NEARAI_BASE_URL", "http://localhost:11434");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            ..Default::default()
+        };
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        let provider = cfg.provider.expect("should have provider config");
+        assert_eq!(provider.base_url, "https://10.1.1.20/v1");
+
+        clear_openai_compatible_env();
+    }
+
+    #[test]
+    fn openai_compatible_private_hostname_allowed_with_host_override() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        unsafe {
+            std::env::set_var("LLM_BACKEND", "openai_compatible");
+            std::env::set_var("LLM_BASE_URL", "https://localhost:8443/v1");
+            std::env::set_var("LLM_BASE_URL_ALLOW_PRIVATE_HOSTS", "localhost");
+            std::env::set_var("NEARAI_AUTH_URL", "http://localhost:11434");
+            std::env::set_var("NEARAI_BASE_URL", "http://localhost:11434");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            ..Default::default()
+        };
+        let cfg = LlmConfig::resolve(&settings).expect("resolve should succeed");
+        let provider = cfg.provider.expect("should have provider config");
+        assert_eq!(provider.base_url, "https://localhost:8443/v1");
+
+        clear_openai_compatible_env();
     }
 
     // ── OAuth resolution tests ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- add explicit allowlists for private `LLM_BASE_URL` hosts and CIDRs
- keep SSRF protection enabled by default
- document the override for private-network `openai_compatible` deployments

## Why
This is related to [#1754](https://github.com/nearai/ironclaw/issues/1754).

I ran into this in a private enterprise deployment where `LLM_BASE_URL` points to a centralized internal LiteLLM gateway. The hostname intentionally resolves to an internal IP because that is how we keep authentication, routing, observability, quotas, and egress controls centralized inside the private network.

I understand and agree with the security motivation behind the SSRF protections. The issue is that the current behavior is too strict for legitimate private-network operator-managed deployments. In my case, I had to downgrade to `v0.21.0` because `v0.22.0+` rejects the internal `LLM_BASE_URL` configuration that worked before.

My goal with this PR is to preserve the secure default while adding a narrow, explicit operator override for trusted internal endpoints.

## Scope
- default SSRF protections remain unchanged
- private/internal destinations are still blocked by default
- the override applies only to `LLM_BASE_URL`
- metadata endpoints remain blocked

## Validation
- `cargo fmt --all --manifest-path ./Cargo.toml`
- `cargo test --manifest-path ./Cargo.toml validate_base_url_with_allowlists_allows_private_ip_cidr -- --nocapture`
- `cargo test --manifest-path ./Cargo.toml openai_compatible_private_https_base_url_allowed_with_cidr_override -- --nocapture`
- `cargo test --manifest-path ./Cargo.toml openai_compatible_private_hostname_allowed_with_host_override -- --nocapture`
- `cargo build --manifest-path ./Cargo.toml`
