### PR TITLE
fix(cli): use -m will not quit

### DIFF
--- a/src/channels/repl.rs
+++ b/src/channels/repl.rs
@@ -492,12 +492,9 @@ impl Channel for ReplChannel {
 
     async fn start(&self) -> Result<MessageStream, ChannelError> {
         let (tx, rx) = mpsc::channel(32);
-        // Store tx so send_status can inject approval responses directly.
-        // Skip for single-message mode — no interactive approval is needed
-        // and the extra sender would keep the stream open after /quit.
-        if self.single_message.is_none()
-            && let Ok(mut guard) = self.msg_tx.lock()
-        {
+        // Store tx so send_status can inject approval responses directly and
+        // single-message mode can send `/quit` after the first response.
+        if let Ok(mut guard) = self.msg_tx.lock() {
             *guard = Some(tx.clone());
         }
         let single_message = self.single_message.clone();
@@ -942,8 +939,10 @@ mod tests {
 
     use super::*;
 
-    /// Regression: single-message mode must close the stream after the one
-    /// message so callers (and tests) don't hang forever.
+    /// Regression: single-message mode sends the user line, then after the agent
+    /// completes the turn `finish_single_message_turn()` injects `/quit` so the
+    /// main loop can exit; only then should the stream close (msg_tx clone kept
+    /// the channel open after the input thread exited).
     #[tokio::test]
     async fn single_message_mode_sends_message_and_closes_stream() {
         let repl = ReplChannel::with_message("hi".to_string());
@@ -956,15 +955,21 @@ mod tests {
         assert_eq!(first.channel, "repl");
         assert_eq!(first.content, "hi");
 
-        // The spawned thread sent the message and returned, dropping its
-        // sender. Because we skip storing a clone in msg_tx for single-
-        // message mode, the stream should close immediately.
+        repl.finish_single_message_turn().await;
+
+        let quit = timeout(Duration::from_secs(1), stream.next())
+            .await
+            .expect("timed out waiting for /quit injection")
+            .expect("/quit message missing");
+        assert_eq!(quit.channel, "repl");
+        assert_eq!(quit.content, "/quit");
+
         assert!(
             timeout(Duration::from_secs(1), stream.next())
                 .await
                 .expect("timed out waiting for stream to close")
                 .is_none(),
-            "stream should end after the single message"
+            "stream should end after /quit sender is dropped"
         );
     }
 }


### PR DESCRIPTION
Now the guard will be take and custom, So we should not skip msg_tx clone.

## Summary

use -m will not quit .  Like “cargo run -- -m "hello"”
-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
