### PR TITLE
fix(test): use canonical extension name in setup submit test

### DIFF
--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4045,7 +4045,7 @@ mod tests {
         let secrets = test_secrets_store();
         let (ext_mgr, _wasm_tools_dir, wasm_channels_dir) = test_ext_mgr(secrets);
 
-        let channel_name = "test-failing-channel";
+        let channel_name = "test_failing_channel";
         std::fs::write(
             wasm_channels_dir
                 .path()


### PR DESCRIPTION
## Summary

- Fix failing `test_extensions_setup_submit_returns_failure_when_not_activated` by using an underscored channel name (`test_failing_channel`) instead of hyphenated (`test-failing-channel`)
- `canonicalize_extension_name()` converts hyphens to underscores, so `configure()` was looking for `test_failing_channel.capabilities.json` which didn't exist, causing an early `Err` before reaching the activation path the test exercises

## Test plan

- [x] `cargo test --lib channels::web::server::tests::test_extensions_setup_submit_returns_failure_when_not_activated` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)