### PR TITLE
fix(docker): add python3-dev for pyo3 build dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,9 @@
 # Stage 1: Install cargo-chef
 FROM rust:1.92-bookworm AS chef
 
-RUN rustup target add wasm32-wasip2 \
+RUN apt-get update && apt-get install -y --no-install-recommends python3-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && rustup target add wasm32-wasip2 \
     && cargo install cargo-chef@0.1.77 wasm-tools@1.246.1
 
 WORKDIR /app
@@ -73,6 +75,8 @@ RUN apt-get update \
 
 COPY --from=builder /app/target/dist/ironclaw /usr/local/bin/ironclaw
 COPY --from=builder /app/migrations /app/migrations
+COPY skills/ /app/skills/
+COPY integrations/ /app/integrations/
 
 # Non-root user
 ENV HOME=/home/ironclaw

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@
 FROM rust:1.92-slim-bookworm AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    pkg-config libssl-dev cmake gcc g++ \
+    pkg-config libssl-dev cmake gcc g++ python3-dev \
     && rm -rf /var/lib/apt/lists/* \
     && rustup target add wasm32-wasip2 \
     && cargo install wasm-tools


### PR DESCRIPTION
## Summary

- **Add `python3-dev`** to both `Dockerfile` (chef stage) and `Dockerfile.test` (builder stage). The transitive dependency chain `ironclaw_engine` -> `monty` -> `jiter` -> `pyo3` requires a Python interpreter and development headers at build time.
- **Copy `skills/` and `integrations/`** into the runtime image so the deployed container has access to skill definitions and integration configs.

## Test plan

- [ ] `docker build --platform linux/amd64 -t ironclaw:latest .` completes successfully
- [ ] `docker build --platform linux/amd64 -f Dockerfile.test -t ironclaw-test .` completes successfully
- [ ] Runtime container has `/app/skills/` and `/app/integrations/` present

🤖 Generated with [Claude Code](https://claude.com/claude-code)