### PR TITLE
feat(workspace): AGENTS_SEED_PATH env var for custom system prompt

### DIFF
--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2144,12 +2144,20 @@ impl Workspace {
     /// so user edits are never overwritten. Returns the number of files
     /// created (0 if all core files already existed).
     pub async fn seed_if_empty(&self) -> Result<usize, WorkspaceError> {
+        // Allow deployments to override the default AGENTS.md seed via env var.
+        let custom_agents = std::env::var("AGENTS_SEED_PATH")
+            .ok()
+            .and_then(|p| std::fs::read_to_string(&p).ok());
+        let agents_seed = custom_agents
+            .as_deref()
+            .unwrap_or(include_str!("seeds/AGENTS.md"));
+
         let seed_files: &[(&str, &str)] = &[
             (paths::README, include_str!("seeds/README.md")),
             (paths::MEMORY, include_str!("seeds/MEMORY.md")),
             (paths::IDENTITY, include_str!("seeds/IDENTITY.md")),
             (paths::SOUL, include_str!("seeds/SOUL.md")),
-            (paths::AGENTS, include_str!("seeds/AGENTS.md")),
+            (paths::AGENTS, agents_seed),
             (paths::USER, include_str!("seeds/USER.md")),
             (paths::HEARTBEAT, HEARTBEAT_SEED),
             (paths::TOOLS, TOOLS_SEED),


### PR DESCRIPTION
## Summary
Deployments can override the default AGENTS.md seed by setting `AGENTS_SEED_PATH` to a custom file path. New users automatically get the custom system prompt at workspace creation. Falls back to the built-in seed when not set.

## Test plan
- Set `AGENTS_SEED_PATH=/path/to/custom/AGENTS.md` and create a new user — verify they get the custom prompt
- Unset the env var — verify default seed is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)