### PR TITLE
fix(v2): skill project fallback, faster polling, customizable preamble

### DIFF
--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -146,6 +146,9 @@ pub struct ThreadConfig {
     pub depth: u32,
     /// Maximum recursion depth for rlm_query() sub-calls.
     pub max_depth: u32,
+    /// Fallback project to search for skills when the thread's project
+    /// differs from the owner's default project (e.g. gateway per-user projects).
+    pub skill_project_id: Option<ProjectId>,
 }
 
 impl Default for ThreadConfig {
@@ -163,6 +166,7 @@ impl Default for ThreadConfig {
             compaction_threshold: 0.85,
             depth: 0,
             max_depth: 1,
+            skill_project_id: None,
         }
     }
 }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1956,6 +1956,14 @@ async fn handle_with_engine_inner(
     let project_id =
         resolve_user_project(&state.store, &message.user_id, state.default_project_id).await?;
 
+    // Gateway users get their own per-user project, but skills are in the
+    // owner's default project. Pass the default project as a fallback so
+    // __list_skills__ can find them.
+    let mut thread_config = ThreadConfig::default();
+    if project_id != state.default_project_id {
+        thread_config.skill_project_id = Some(state.default_project_id);
+    }
+
     // Handle the message — spawns a new thread or injects into active one
     let thread_id = state
         .conversation_manager
@@ -1964,7 +1972,7 @@ async fn handle_with_engine_inner(
             content,
             project_id,
             &message.user_id,
-            ThreadConfig::default(),
+            thread_config,
         )
         .await
         .map_err(|e| engine_err("thread error", e))?;
@@ -2036,7 +2044,7 @@ async fn await_thread_outcome(
                     _ => {}
                 }
             }
-            _ = tokio::time::sleep(std::time::Duration::from_millis(500)) => {
+            _ = tokio::time::sleep(std::time::Duration::from_millis(50)) => {
                 if !state.thread_manager.is_running(thread_id).await {
                     break;
                 }

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1030,8 +1030,12 @@ Example:
 Respond directly with your final answer. Do not wrap your response in any special tags."#
         };
 
+        let preamble = std::env::var("AGENT_PREAMBLE").unwrap_or_else(|_| {
+            "You are IronClaw Agent, a secure autonomous assistant.".to_string()
+        });
+
         format!(
-            r#"You are IronClaw Agent, a secure autonomous assistant.
+            r#"{preamble}
 
 {response_format}
 


### PR DESCRIPTION
## Summary
- **Skill project fallback**: Gateway users get per-user projects but skills live in the owner's default project. Pass default project as fallback so `__list_skills__` finds them.
- **Faster polling**: Reduce thread outcome polling from 500ms to 50ms for snappier response delivery.
- **Customizable preamble**: `AGENT_PREAMBLE` env var overrides the hardcoded "You are IronClaw Agent" prefix.

## Test plan
- Deploy with skills, verify non-owner users can use skills
- Check response latency improvement with 50ms polling
- Set `AGENT_PREAMBLE="You are X"` and verify system prompt changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)