### PR TITLE
fix(tools): preserve schema hints and normalize nullish params

### DIFF
--- a/src/tools/coercion.rs
+++ b/src/tools/coercion.rs
@@ -134,9 +134,23 @@ fn coerce_value(value: &serde_json::Value, schema: &serde_json::Value) -> serde_
             .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
             .unwrap_or_default();
         let mut coerced = obj.clone();
+        let mut keys_to_remove = Vec::new();
 
         for (key, current) in &mut coerced {
             if let Some(prop_schema) = properties.and_then(|props| props.get(key)) {
+                if let Some(s) = current.as_str() {
+                    let is_nullish =
+                        s.eq_ignore_ascii_case("null") || s.eq_ignore_ascii_case("none");
+                    if is_nullish && !required.contains(key.as_str()) {
+                        if prop_schema.get("default").is_some() {
+                            keys_to_remove.push(key.clone());
+                        } else {
+                            *current = serde_json::Value::Null;
+                        }
+                        continue;
+                    }
+                }
+
                 // LLMs send "" for optional fields instead of omitting them.
                 // Coerce to null only when the field is not required AND the schema
                 // allows null or doesn't allow string — a `type: "string"` field
@@ -156,6 +170,10 @@ fn coerce_value(value: &serde_json::Value, schema: &serde_json::Value) -> serde_
             if let Some(additional_schema) = additional_schema {
                 *current = coerce_value(current, additional_schema);
             }
+        }
+
+        for key in keys_to_remove {
+            coerced.remove(&key);
         }
 
         return serde_json::Value::Object(coerced);
@@ -328,6 +346,15 @@ fn coerce_string_value(s: &str, schema: &serde_json::Value) -> Option<serde_json
     }
 
     if schema_allows_type(schema, "string") {
+        // Some models emit a JSON string literal as the string contents,
+        // e.g. "\"private\"" instead of "private". Unwrap exactly one layer.
+        if s.len() >= 2
+            && s.starts_with('"')
+            && s.ends_with('"')
+            && let Ok(parsed) = serde_json::from_str::<String>(s)
+        {
+            return Some(serde_json::Value::String(parsed));
+        }
         return None;
     }
 
@@ -677,6 +704,97 @@ mod tests {
 
         // Required string-only field keeps empty string
         assert_eq!(result["name"], serde_json::json!(""));
+    }
+
+    #[test]
+    fn unwraps_double_quoted_string_value() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "calendar_id": { "type": "string" }
+            }
+        });
+        let params = serde_json::json!({
+            "calendar_id": "\"1rteko1f0ijt16ithkv7upn188@group.calendar.google.com\""
+        });
+
+        let result = prepare_params_for_schema(&params, &schema);
+
+        assert_eq!(
+            result["calendar_id"],
+            serde_json::json!("1rteko1f0ijt16ithkv7upn188@group.calendar.google.com")
+        );
+    }
+
+    #[test]
+    fn unwraps_double_quoted_rfc3339_string_value() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "time_min": { "type": "string" }
+            }
+        });
+        let params = serde_json::json!({
+            "time_min": "\"2026-04-08T00:00:00Z\""
+        });
+
+        let result = prepare_params_for_schema(&params, &schema);
+
+        assert_eq!(
+            result["time_min"],
+            serde_json::json!("2026-04-08T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn preserves_non_json_quoted_like_string() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "calendar_id": { "type": "string" }
+            }
+        });
+        let params = serde_json::json!({
+            "calendar_id": "\"unterminated"
+        });
+
+        let result = prepare_params_for_schema(&params, &schema);
+
+        assert_eq!(result["calendar_id"], serde_json::json!("\"unterminated"));
+    }
+
+    #[test]
+    fn nullish_optional_string_becomes_null() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" }
+            }
+        });
+        let params = serde_json::json!({
+            "query": "null"
+        });
+
+        let result = prepare_params_for_schema(&params, &schema);
+
+        assert_eq!(result["query"], serde_json::Value::Null);
+    }
+
+    #[test]
+    fn nullish_optional_string_with_default_is_omitted() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "calendar_id": { "type": "string", "default": "primary" }
+            }
+        });
+        let params = serde_json::json!({
+            "calendar_id": "null"
+        });
+
+        let result = prepare_params_for_schema(&params, &schema);
+
+        assert!(result.get("calendar_id").is_none());
     }
 
     #[test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -682,8 +682,11 @@ impl WasmToolSchemas {
     /// Derive a compact advertised schema from the full discovery schema.
     ///
     /// Collects properties from top-level `properties` and from
-    /// `oneOf`/`anyOf`/`allOf` variants. Keeps only properties that are in
-    /// the top-level `required` array or carry an `enum`/`const` constraint.
+    /// `oneOf`/`anyOf`/`allOf` variants. When a schema has typed top-level
+    /// properties, preserves them all in the advertised schema so the LLM sees
+    /// practical parameter hints for direct-object tools. For variant-only
+    /// schemas, keeps only properties that are in the top-level `required`
+    /// array or carry an `enum`/`const` constraint.
     /// For properties defined via `const` across multiple variants (e.g.
     /// `"action": {"const": "get_repo"}` in each `oneOf` branch), the `const`
     /// values are merged into a single `enum` array.
@@ -709,8 +712,12 @@ impl WasmToolSchemas {
             .unwrap_or_default();
 
         // Collect properties from top-level and oneOf/anyOf/allOf variants.
-        // For properties with `const` across variants, merge into an `enum`.
+        // For direct-object schemas, preserve all typed top-level properties.
+        // For variant-only schemas, merge `const` discriminators into enums so
+        // the LLM can still discover valid actions without loading the full
+        // discovery schema up front.
         let mut all_properties = serde_json::Map::new();
+        let mut top_level_typed = serde_json::Map::new();
         // Track const values per property to merge into enum.
         let mut const_values: std::collections::HashMap<String, Vec<serde_json::Value>> =
             std::collections::HashMap::new();
@@ -719,6 +726,9 @@ impl WasmToolSchemas {
             for (k, v) in props {
                 if all_properties.len() >= MAX_COMPACT_PROPERTIES {
                     break;
+                }
+                if schema_is_typed_property(v) {
+                    top_level_typed.insert(k.clone(), v.clone());
                 }
                 all_properties.insert(k.clone(), v.clone());
             }
@@ -760,6 +770,35 @@ impl WasmToolSchemas {
 
         if all_properties.is_empty() {
             return Self::permissive_schema();
+        }
+
+        if !top_level_typed.is_empty() {
+            let mut kept = top_level_typed;
+            for (name, prop) in &all_properties {
+                if (required.contains(name.as_str())
+                    || prop.get("enum").is_some()
+                    || prop.get("const").is_some())
+                    && !kept.contains_key(name)
+                {
+                    kept.insert(name.clone(), prop.clone());
+                }
+            }
+
+            let kept_required: Vec<serde_json::Value> = required
+                .iter()
+                .filter(|name| kept.contains_key(name.as_str()))
+                .map(|name| serde_json::Value::String(name.clone()))
+                .collect();
+
+            let mut result = serde_json::json!({
+                "type": "object",
+                "properties": kept,
+                "additionalProperties": true,
+            });
+            if !kept_required.is_empty() {
+                result["required"] = serde_json::Value::Array(kept_required);
+            }
+            return result;
         }
 
         let kept: serde_json::Map<String, serde_json::Value> = all_properties
@@ -1952,13 +1991,15 @@ mod tests {
         wrapper.schemas = super::WasmToolSchemas::new(discovery_schema.clone());
         wrapper.description = "Search documents".to_string();
 
-        // Advertised schema is auto-compacted: keeps required props, drops optional
+        // Advertised schema keeps all typed top-level properties so optional
+        // arguments remain visible to the LLM.
         assert_eq!(
             wrapper.parameters_schema(),
             serde_json::json!({
                 "type": "object",
                 "properties": {
-                    "query": { "type": "string" }
+                    "query": { "type": "string" },
+                    "limit": { "type": "integer" }
                 },
                 "required": ["query"],
                 "additionalProperties": true
@@ -2029,7 +2070,7 @@ mod tests {
     }
 
     #[test]
-    fn test_compact_schema_keeps_required_and_enum_properties() {
+    fn test_compact_schema_keeps_typed_top_level_properties() {
         let schema = serde_json::json!({
             "type": "object",
             "properties": {
@@ -2051,15 +2092,11 @@ mod tests {
         let compacted = super::WasmToolSchemas::compact_schema(&schema);
         let props = compacted["properties"].as_object().unwrap();
 
-        // action: required + enum → kept
+        // Top-level typed properties remain visible to the LLM.
         assert!(props.contains_key("action"));
-        // format: has enum → kept
         assert!(props.contains_key("format"));
-        // query: not required, no enum → dropped
-        assert!(!props.contains_key("query"));
-        // limit: not required, no enum → dropped
-        assert!(!props.contains_key("limit"));
-        // additionalProperties lets the LLM still pass dropped props
+        assert!(props.contains_key("query"));
+        assert!(props.contains_key("limit"));
         assert_eq!(compacted["additionalProperties"], true);
         assert_eq!(compacted["required"], serde_json::json!(["action"]));
     }


### PR DESCRIPTION
## Summary

- preserve typed top-level properties in compact WASM tool schemas so optional arguments like `calendar_id`, `time_min`, and `time_max` stay visible to the model
- normalize nullish string params for non-required tool arguments so `"null"` and `"none"` do not get forwarded as literal strings into tool API calls
- unwrap one accidental JSON-string layer for string fields so calls like `"\"private\""` normalize to `"private"`

## Root Cause

Two host-side issues were interacting:

- compact schema generation in the WASM wrapper hid useful optional top-level params from the advertised schema for direct-object tools, which made follow-up calls less reliable
- coercion tolerated quoted strings but still let nullish string values like `"null"` pass through for optional params, so tools could receive bad inputs such as `query="null"` or `time_max="null"`

The Google Calendar failures were a concrete example of this: the host was sending successful tool calls with `calendar_id` present but optional fields like `time_max` and `query` still set to the literal string `"null"`, which produced `400 Bad Request` from Google.

## Impact

- direct-object WASM tools now advertise more useful parameter hints to the model
- optional params with defaults can fall back to their serde defaults again
- optional params without defaults now become `null` instead of the string `"null"`
- this should improve robustness across multiple tools that build outbound query params or request bodies from optional strings, not just `google_calendar`

## Validation

- `cargo build --release`
- live cluster deployment of the patched host image
- reproduced and fixed `google_calendar` failures in a real IronClaw deployment

