### PR TITLE
fix(gateway): suppress duplicate auth response and unify extension config modal

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1878,6 +1878,11 @@ impl Agent {
                 Ok(HandleOutcome::Respond(format!("Error: {}", message)))
             }
             SubmissionResult::Interrupted => Ok(HandleOutcome::Respond("Interrupted.".into())),
+            SubmissionResult::AuthPending => {
+                // Auth-required status already sent by handle_auth_intercept.
+                // Thread is in auth mode — suppress text response and Done.
+                Ok(HandleOutcome::Pending)
+            }
             SubmissionResult::NeedApproval { .. } => {
                 // ApprovalNeeded status was already sent by thread_ops.rs before
                 // returning this result. The thread is now in AwaitingApproval —

--- a/src/agent/agentic_loop.rs
+++ b/src/agent/agentic_loop.rs
@@ -44,6 +44,8 @@ pub enum LoopOutcome {
     Failure(String),
     /// A tool requires user approval before continuing (chat delegate only).
     NeedApproval(Box<PendingApproval>),
+    /// Auth flow initiated — config card already sent, suppress text response.
+    AuthPending(String),
 }
 
 /// Configuration for the agentic loop.

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -46,6 +46,11 @@ pub(super) enum AgenticLoopResult {
         error: Error,
         turn_usage: TurnUsageSummary,
     },
+    /// Auth flow initiated — config card already sent, suppress text response.
+    AuthPending {
+        instructions: String,
+        turn_usage: TurnUsageSummary,
+    },
 }
 
 #[derive(Debug, Clone, Default)]
@@ -312,6 +317,10 @@ impl Agent {
             }),
             Ok(LoopOutcome::NeedApproval(pending)) => Ok(AgenticLoopResult::NeedApproval {
                 pending,
+                turn_usage,
+            }),
+            Ok(LoopOutcome::AuthPending(instructions)) => Ok(AgenticLoopResult::AuthPending {
+                instructions,
                 turn_usage,
             }),
             Err(error) => Ok(AgenticLoopResult::Failed { error, turn_usage }),
@@ -1247,7 +1256,7 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     auth_data.setup_url,
                 )
                 .await;
-                return Ok(Some(LoopOutcome::Response(instructions)));
+                return Ok(Some(LoopOutcome::AuthPending(instructions)));
             }
 
             emit_auth_required_status(
@@ -2314,6 +2323,9 @@ mod tests {
             }
             super::AgenticLoopResult::Failed { .. } => {
                 panic!("expected NeedApproval, got Failed")
+            }
+            super::AgenticLoopResult::AuthPending { .. } => {
+                panic!("expected NeedApproval, got AuthPending")
             }
         };
 
@@ -3568,6 +3580,9 @@ mod tests {
             super::AgenticLoopResult::Failed { error, .. } => {
                 panic!("Expected text response, got Failed: {error}");
             }
+            super::AgenticLoopResult::AuthPending { .. } => {
+                panic!("Expected text response, got AuthPending");
+            }
         }
     }
 
@@ -3612,6 +3627,9 @@ mod tests {
                 }
                 super::AgenticLoopResult::Failed { error, .. } => {
                     panic!("expected a text response, got Failed: {error}");
+                }
+                super::AgenticLoopResult::AuthPending { .. } => {
+                    panic!("expected a text response, got AuthPending");
                 }
             }
         }

--- a/src/agent/submission.rs
+++ b/src/agent/submission.rs
@@ -525,6 +525,9 @@ pub enum SubmissionResult {
 
     /// Turn was interrupted.
     Interrupted,
+
+    /// Auth flow initiated — config card sent, no text response needed.
+    AuthPending,
 }
 
 impl SubmissionResult {
@@ -546,6 +549,11 @@ impl SubmissionResult {
         Self::Ok {
             message: Some(message.into()),
         }
+    }
+
+    /// Create an auth-pending result (suppresses text response).
+    pub fn auth_pending() -> Self {
+        Self::AuthPending
     }
 
     /// Create an error result.

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -124,7 +124,8 @@ fn turn_usage_from_result(result: &Result<AgenticLoopResult, Error>) -> Option<&
     match result {
         Ok(AgenticLoopResult::Response { turn_usage, .. })
         | Ok(AgenticLoopResult::NeedApproval { turn_usage, .. })
-        | Ok(AgenticLoopResult::Failed { turn_usage, .. }) => Some(turn_usage),
+        | Ok(AgenticLoopResult::Failed { turn_usage, .. })
+        | Ok(AgenticLoopResult::AuthPending { turn_usage, .. }) => Some(turn_usage),
         Err(_) => None,
     }
 }
@@ -758,6 +759,38 @@ impl Agent {
                     parameters,
                     allow_always,
                 })
+            }
+            Ok(AgenticLoopResult::AuthPending {
+                instructions,
+                turn_usage,
+            }) => {
+                // Auth-required status already sent by the dispatcher.
+                // Persist the turn to DB (like Response) but suppress the text SSE event.
+                thread.complete_turn(&instructions);
+                let (turn_number, tool_calls, narrative) = thread
+                    .turns
+                    .last()
+                    .map(|t| (t.turn_number, t.tool_calls.clone(), t.narrative.clone()))
+                    .unwrap_or_default();
+                self.persist_tool_calls(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    turn_number,
+                    &tool_calls,
+                    narrative.as_deref(),
+                )
+                .await;
+                self.persist_assistant_response(
+                    thread_id,
+                    &message.channel,
+                    &message.user_id,
+                    &instructions,
+                )
+                .await;
+                self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
+                    .await;
+                Ok(SubmissionResult::auth_pending())
             }
             Ok(AgenticLoopResult::Failed { error, turn_usage }) => {
                 self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
@@ -1674,7 +1707,7 @@ impl Agent {
                         &auth_data,
                     )
                     .await;
-                    return Ok(SubmissionResult::response(instructions));
+                    return Ok(SubmissionResult::auth_pending());
                 }
 
                 emit_auth_required_status(
@@ -1783,6 +1816,36 @@ impl Agent {
                         parameters,
                         allow_always,
                     })
+                }
+                Ok(AgenticLoopResult::AuthPending {
+                    instructions,
+                    turn_usage,
+                }) => {
+                    thread.complete_turn(&instructions);
+                    let (turn_number, tool_calls, narrative) = thread
+                        .turns
+                        .last()
+                        .map(|t| (t.turn_number, t.tool_calls.clone(), t.narrative.clone()))
+                        .unwrap_or_default();
+                    self.persist_tool_calls(
+                        thread_id,
+                        &message.channel,
+                        &message.user_id,
+                        turn_number,
+                        &tool_calls,
+                        narrative.as_deref(),
+                    )
+                    .await;
+                    self.persist_assistant_response(
+                        thread_id,
+                        &message.channel,
+                        &message.user_id,
+                        &instructions,
+                    )
+                    .await;
+                    self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)
+                        .await;
+                    Ok(SubmissionResult::auth_pending())
                 }
                 Ok(AgenticLoopResult::Failed { error, turn_usage }) => {
                     self.send_turn_cost_status(&message.channel, &message.metadata, &turn_usage)

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -2098,159 +2098,9 @@ function buildSetupFields(form, extensionName, secrets, submitFn) {
 }
 
 function showSetupCardForExtension(data) {
-  apiFetch('/api/extensions/' + encodeURIComponent(data.extension_name) + '/setup')
-    .then((setup) => {
-      const secrets = Array.isArray(setup.secrets) ? setup.secrets : [];
-      const fields = Array.isArray(setup.fields) ? setup.fields : [];
-      if (secrets.length === 0 && fields.length === 0) {
-        showAuthCard(data);
-        return;
-      }
-      showSetupCard({
-        extension_name: data.extension_name,
-        onboarding: setup.onboarding || null,
-        secrets,
-      });
-    })
-    .catch(() => {
-      showAuthCard(data);
-    });
-}
-
-function showSetupCard(data) {
-  const existing = getAuthOverlay();
-  if (existing) existing.remove();
-
-  const overlay = document.createElement('div');
-  overlay.className = 'auth-overlay';
-  overlay.setAttribute('data-extension-name', data.extension_name);
-  overlay.addEventListener('click', (e) => {
-    if (e.target === overlay) cancelAuth(data.extension_name);
-  });
-
-  const card = document.createElement('div');
-  card.className = 'auth-card auth-modal setup-card';
-  card.setAttribute('data-extension-name', data.extension_name);
-
-  const onboarding = data.onboarding || {};
-
-  const header = document.createElement('div');
-  header.className = 'auth-header';
-  header.textContent = onboarding.credential_title || ('Configure credentials for ' + data.extension_name);
-  card.appendChild(header);
-
-  if (onboarding.credential_instructions) {
-    const instr = document.createElement('div');
-    instr.className = 'auth-instructions';
-    instr.textContent = onboarding.credential_instructions;
-    card.appendChild(instr);
-  }
-
-  if (onboarding.setup_url) {
-    // Strict HTTPS validation via shared helper — defends against
-    // `javascript:`/`data:` URLs in extension/registry metadata.
-    const parsedSetupUrl = parseHttpsExternalUrl(onboarding.setup_url, 'setup');
-    if (parsedSetupUrl) {
-      const links = document.createElement('div');
-      links.className = 'auth-links';
-      const setupLink = document.createElement('a');
-      setupLink.href = parsedSetupUrl.href;
-      setupLink.target = '_blank';
-      setupLink.rel = 'noopener noreferrer';
-      setupLink.textContent = I18n.t('authRequired.getToken');
-      links.appendChild(setupLink);
-      card.appendChild(links);
-    }
-  }
-
-  const form = document.createElement('div');
-  form.className = 'setup-form';
-  card.appendChild(form);
-
-  let fields = [];
-  const submit = () => submitSetupCard(data.extension_name, fields, card);
-  fields = buildSetupFields(form, data.extension_name, data.secrets || [], submit);
-
-  if (onboarding.credential_next_step) {
-    const nextStep = document.createElement('div');
-    nextStep.className = 'setup-next-step';
-    nextStep.textContent = onboarding.credential_next_step;
-    card.appendChild(nextStep);
-  }
-
-  const errorEl = document.createElement('div');
-  errorEl.className = 'auth-error';
-  errorEl.style.display = 'none';
-  card.appendChild(errorEl);
-
-  const actions = document.createElement('div');
-  actions.className = 'auth-actions';
-
-  const submitBtn = document.createElement('button');
-  submitBtn.className = 'auth-submit';
-  submitBtn.textContent = I18n.t('config.save');
-  submitBtn.addEventListener('click', submit);
-  actions.appendChild(submitBtn);
-
-  const cancelBtn = document.createElement('button');
-  cancelBtn.className = 'auth-cancel';
-  cancelBtn.textContent = I18n.t('btn.cancel');
-  cancelBtn.addEventListener('click', () => cancelAuth(data.extension_name));
-  actions.appendChild(cancelBtn);
-
-  card.appendChild(actions);
-  overlay.appendChild(card);
-  document.body.appendChild(overlay);
-  if (fields.length > 0) fields[0].input.focus();
-}
-
-function showSetupCardError(extensionName, message) {
-  const card = getAuthCard(extensionName);
-  if (!card) return;
-  card.querySelectorAll('button').forEach((btn) => {
-    btn.disabled = false;
-  });
-  const errorEl = card.querySelector('.auth-error');
-  if (errorEl) {
-    errorEl.textContent = message;
-    errorEl.style.display = 'block';
-  }
-}
-
-function submitSetupCard(extensionName, fields, cardEl) {
-  const secrets = {};
-  (fields || []).forEach((field) => {
-    const value = (field.input.value || '').trim();
-    if (value) secrets[field.name] = value;
-  });
-
-  const card = cardEl || getAuthCard(extensionName);
-  if (card) {
-    card.querySelectorAll('button').forEach((btn) => {
-      btn.disabled = true;
-    });
-  }
-
-  apiFetch('/api/extensions/' + encodeURIComponent(extensionName) + '/setup', {
-    method: 'POST',
-    body: { secrets, fields: {} },
-  }).then((result) => {
-    if (!result.success) {
-      showSetupCardError(extensionName, result.message || 'Configuration failed.');
-      return;
-    }
-    removeSetupCard(extensionName);
-    if (result.onboarding_state === 'pairing_required') {
-      showPairingCard({
-        channel: extensionName,
-        instructions: result.onboarding && result.onboarding.pairing_instructions,
-        onboarding: result.onboarding || null,
-      });
-    }
-    refreshCurrentSettingsTab();
-  }).catch((err) => {
-    showSetupCardError(extensionName, 'Configuration failed: ' + err.message);
-  });
+  // Dedup: don't open if a configure modal is already showing for this extension
+  if (getConfigureOverlay(data.extension_name)) return;
+  showConfigureModal(data.extension_name, { authData: data });
 }
 
 function showAuthCard(data) {
@@ -4108,28 +3958,56 @@ function removeExtension(name) {
   }, I18n.t('common.remove'), 'btn-danger');
 }
 
-function showConfigureModal(name) {
+function showConfigureModal(name, options) {
   apiFetch('/api/extensions/' + encodeURIComponent(name) + '/setup')
     .then((setup) => {
       const secrets = Array.isArray(setup.secrets) ? setup.secrets : [];
       const setupFields = Array.isArray(setup.fields) ? setup.fields : [];
       if (secrets.length === 0 && setupFields.length === 0) {
-        showToast(I18n.t('extensions.noConfigNeeded', { name: name }), 'info');
+        if (options && options.authData) {
+          showAuthCard(options.authData);
+        } else {
+          showToast(I18n.t('extensions.noConfigNeeded', { name: name }), 'info');
+        }
         return;
       }
-      renderConfigureModal(name, secrets, setupFields, setup.onboarding || null);
+      renderConfigureModal(name, secrets, setupFields, setup.onboarding || null, options);
     })
-    .catch((err) => showToast(I18n.t('extensions.setupLoadFailed', { message: err.message }), 'error'));
+    .catch((err) => {
+      showToast(I18n.t('extensions.setupLoadFailed', { message: err.message }), 'error');
+      if (options && options.authData) {
+        showAuthCard(options.authData);
+      }
+    });
 }
 
-function renderConfigureModal(name, secrets, setupFields, onboarding) {
-  closeConfigureModal();
+function renderConfigureModal(name, secrets, setupFields, onboarding, options) {
+  // Cancel any existing auth-flow overlay before replacing it.
+  // Remove directly (don't clear authFlowPending) since a new overlay is about to be appended.
+  var existingOverlay = document.querySelector('.configure-overlay');
+  if (existingOverlay && existingOverlay.getAttribute('data-auth-flow')) {
+    var extName = existingOverlay.getAttribute('data-auth-extension') || existingOverlay.getAttribute('data-extension-name');
+    apiFetch('/api/chat/auth-cancel', { method: 'POST', body: { extension_name: extName } }).catch(function() {});
+    existingOverlay.remove();
+  } else {
+    closeConfigureModal();
+  }
   const overlay = document.createElement('div');
   overlay.className = 'configure-overlay';
   overlay.setAttribute('data-extension-name', name);
+  if (options && options.authData) {
+    overlay.setAttribute('data-auth-flow', 'true');
+    overlay.setAttribute('data-auth-extension', options.authData.extension_name || name);
+    if (options.authData.request_id) overlay.setAttribute('data-request-id', options.authData.request_id);
+    if (options.authData.thread_id) overlay.setAttribute('data-thread-id', options.authData.thread_id);
+  }
   overlay.addEventListener('click', (e) => {
     if (e.target !== overlay) return;
-    closeConfigureModal();
+    if (overlay.getAttribute('data-auth-flow')) {
+      cancelAuthFromConfigureModal(overlay);
+    } else {
+      closeConfigureModal();
+    }
   });
 
   const modal = document.createElement('div');
@@ -4254,7 +4132,13 @@ function renderConfigureModal(name, secrets, setupFields, onboarding) {
   const cancelBtn = document.createElement('button');
   cancelBtn.className = 'btn-ext remove';
   cancelBtn.textContent = I18n.t('config.cancel');
-  cancelBtn.addEventListener('click', closeConfigureModal);
+  cancelBtn.addEventListener('click', function() {
+    if (overlay.getAttribute('data-auth-flow')) {
+      cancelAuthFromConfigureModal(overlay);
+    } else {
+      closeConfigureModal();
+    }
+  });
   actions.appendChild(cancelBtn);
 
   modal.appendChild(actions);
@@ -4304,6 +4188,9 @@ function submitConfigureModal(name, fields, options) {
   })
     .then((res) => {
       if (res.success) {
+        // Strip auth-flow flag before closing so closeConfigureModal
+        // does not trigger a spurious auth-cancel API call.
+        if (overlay) overlay.removeAttribute('data-auth-flow');
         closeConfigureModal();
         if (res.auth_url) {
           showAuthCard({
@@ -4312,6 +4199,15 @@ function submitConfigureModal(name, fields, options) {
           });
           showToast(I18n.t('extensions.openingOAuth', { name: name }), 'info');
           openOAuthUrl(res.auth_url);
+          refreshCurrentSettingsTab();
+        }
+        // Transition to pairing if the channel requires it.
+        if (res.onboarding_state === 'pairing_required') {
+          showPairingCard({
+            channel: name,
+            instructions: res.onboarding && res.onboarding.pairing_instructions,
+            onboarding: res.onboarding || null,
+          });
           refreshCurrentSettingsTab();
         }
         // For non-OAuth success: the server always broadcasts auth_completed SSE,
@@ -4334,6 +4230,21 @@ function closeConfigureModal(extensionName) {
   if (typeof extensionName !== 'string') extensionName = null;
   const existing = getConfigureOverlay(extensionName);
   if (existing) existing.remove();
+  if (!document.querySelector('.configure-overlay') && !document.querySelector('.auth-card')) {
+    setAuthFlowPending(false);
+    enableChatInput();
+  }
+}
+
+function cancelAuthFromConfigureModal(overlay) {
+  var extName = overlay.getAttribute('data-auth-extension') || overlay.getAttribute('data-extension-name');
+  var requestId = overlay.getAttribute('data-request-id');
+  var threadId = overlay.getAttribute('data-thread-id');
+  var request = requestId
+    ? apiFetch('/api/chat/gate/resolve', { method: 'POST', body: { request_id: requestId, thread_id: threadId || currentThreadId || undefined, resolution: 'cancelled' } })
+    : apiFetch('/api/chat/auth-cancel', { method: 'POST', body: { extension_name: extName, thread_id: threadId || currentThreadId || undefined } });
+  request.catch(function() {});
+  overlay.remove();
   if (!document.querySelector('.configure-overlay') && !document.querySelector('.auth-card')) {
     setAuthFlowPending(false);
     enableChatInput();

--- a/src/worker/container.rs
+++ b/src/worker/container.rs
@@ -251,7 +251,9 @@ Work independently to complete this job. When finished, your final message MUST 
                     })
                     .await?;
             }
-            Ok(Ok(LoopOutcome::Stopped | LoopOutcome::NeedApproval(_))) => {
+            Ok(Ok(
+                LoopOutcome::Stopped | LoopOutcome::NeedApproval(_) | LoopOutcome::AuthPending(_),
+            )) => {
                 tracing::info!("Worker for job {} stopped", self.config.job_id);
                 self.client
                     .report_complete(&CompletionReport {

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -422,7 +422,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             LoopOutcome::Stopped => {
                 // Stop signal handled — nothing more to do
             }
-            LoopOutcome::NeedApproval(_) => {}
+            LoopOutcome::NeedApproval(_) | LoopOutcome::AuthPending(_) => {}
         }
 
         Ok(())

--- a/tests/e2e/scenarios/test_auth_no_duplicate_response.py
+++ b/tests/e2e/scenarios/test_auth_no_duplicate_response.py
@@ -1,0 +1,298 @@
+"""E2E regression test: auth_required SSE event fires without a duplicate response event.
+
+Bug fix regression: previously, when a tool triggered auth_required, the gateway sent
+BOTH an auth_required SSE event AND a response SSE event containing the same auth
+instructions. This caused the web UI to render the instructions twice — once as chat
+text and once inside the config card. After the fix (SubmissionResult::AuthPending),
+only auth_required is emitted; no response event accompanies it.
+
+This test:
+1. Starts an ironclaw instance with a GitHub skill + mock API (returns 401 without auth)
+2. Connects to the SSE stream
+3. Sends a chat message that triggers the GitHub skill → HTTP 401 → auth_required
+4. Collects SSE events and asserts:
+   - auth_required event IS present
+   - No response event contains auth instruction text (the regression)
+"""
+
+import asyncio
+import json
+import os
+import signal
+import socket
+import tempfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from helpers import api_get, api_post, AUTH_TOKEN, sse_stream, wait_for_ready
+
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_DB_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-auth-sse-e2e-")
+_HOME_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-auth-sse-e2e-home-")
+
+
+def _forward_coverage_env(env: dict):
+    for key in os.environ:
+        if key.startswith(("CARGO_LLVM_COV", "LLVM_", "CARGO_ENCODED_RUSTFLAGS",
+                           "CARGO_INCREMENTAL")):
+            env[key] = os.environ[key]
+
+
+async def _stop_process(proc, sig=signal.SIGINT, timeout=5):
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Mock API: returns 401 without Bearer auth
+# ---------------------------------------------------------------------------
+
+async def _start_mock_api():
+    from aiohttp import web
+
+    async def handle_issues(request):
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            return web.json_response({"message": "Bad credentials"}, status=401)
+        return web.json_response([{"number": 1, "title": "Test issue", "state": "open"}])
+
+    app = web.Application()
+    app.router.add_get("/repos/{owner}/{repo}/issues", handle_issues)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    return f"http://127.0.0.1:{port}", runner
+
+
+def _write_skill(skills_dir: str, mock_api_host: str):
+    skill_dir = os.path.join(skills_dir, "github")
+    os.makedirs(skill_dir, exist_ok=True)
+    with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+        f.write(f"""---
+name: github
+version: "1.0.0"
+keywords:
+  - github
+  - issues
+tags:
+  - github
+credentials:
+  - name: github_token
+    provider: github
+    location:
+      type: bearer
+    hosts:
+      - "{mock_api_host}"
+    setup_instructions: "Paste your GitHub personal access token below."
+---
+# GitHub API Skill
+
+Use the `http` tool to call the GitHub API.
+Credentials are automatically injected.
+""")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def mock_api():
+    base_url, runner = await _start_mock_api()
+    yield base_url
+    await runner.cleanup()
+
+
+@pytest.fixture(scope="module")
+async def auth_sse_server(ironclaw_binary, mock_llm_server, mock_api):
+    mock_api_host = mock_api.replace("http://", "")
+    home_dir = _HOME_TMPDIR.name
+    skills_dir = os.path.join(home_dir, ".ironclaw", "skills")
+    os.makedirs(skills_dir, exist_ok=True)
+    _write_skill(skills_dir, mock_api_host)
+
+    # Configure mock LLM to generate tool calls to mock API
+    async with httpx.AsyncClient() as client:
+        r = await client.post(
+            f"{mock_llm_server}/__mock/set_github_api_url",
+            json={"url": mock_api},
+        )
+        assert r.status_code == 200
+
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.bind(("127.0.0.1", 0))
+    gateway_port = s.getsockname()[1]
+    s.close()
+    s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s2.bind(("127.0.0.1", 0))
+    http_port = s2.getsockname()[1]
+    s2.close()
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+        "RUST_LOG": "ironclaw=debug",
+        "RUST_BACKTRACE": "1",
+        "ENGINE_V2": "true",
+        "HTTP_ALLOW_LOCALHOST": "true",
+        "SECRETS_MASTER_KEY": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "GATEWAY_ENABLED": "true",
+        "GATEWAY_HOST": "127.0.0.1",
+        "GATEWAY_PORT": str(gateway_port),
+        "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+        "GATEWAY_USER_ID": "e2e-auth-sse-tester",
+        "HTTP_HOST": "127.0.0.1",
+        "HTTP_PORT": str(http_port),
+        "CLI_ENABLED": "false",
+        "LLM_BACKEND": "openai_compatible",
+        "LLM_BASE_URL": mock_llm_server,
+        "LLM_MODEL": "mock-model",
+        "DATABASE_BACKEND": "libsql",
+        "LIBSQL_PATH": os.path.join(_DB_TMPDIR.name, "auth-sse-e2e.db"),
+        "SANDBOX_ENABLED": "false",
+        "SKILLS_ENABLED": "true",
+        "ROUTINES_ENABLED": "false",
+        "HEARTBEAT_ENABLED": "false",
+        "EMBEDDING_ENABLED": "false",
+        "WASM_ENABLED": "false",
+        "ONBOARD_COMPLETED": "true",
+    }
+    _forward_coverage_env(env)
+
+    proc = await asyncio.create_subprocess_exec(
+        ironclaw_binary, "--no-onboard",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+
+    base_url = f"http://127.0.0.1:{gateway_port}"
+    try:
+        await wait_for_ready(f"{base_url}/api/health", timeout=60)
+        yield base_url
+    except TimeoutError:
+        if proc.returncode is None:
+            await _stop_process(proc, timeout=2)
+        stderr_bytes = b""
+        if proc.stderr:
+            try:
+                stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+            except asyncio.TimeoutError:
+                pass
+        pytest.fail(
+            f"auth-sse server failed to start on port {gateway_port}.\n"
+            f"stderr: {stderr_bytes.decode('utf-8', errors='replace')}"
+        )
+    finally:
+        if proc.returncode is None:
+            await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+            if proc.returncode is None:
+                await _stop_process(proc, sig=signal.SIGTERM, timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+async def test_auth_required_sse_without_duplicate_response(auth_sse_server):
+    """When auth is triggered, SSE emits auth_required but NOT a response with instructions."""
+    base_url = auth_sse_server
+
+    # Create thread
+    thread_r = await api_post(base_url, "/api/chat/thread/new", timeout=15)
+    assert thread_r.status_code == 200
+    thread_id = thread_r.json()["id"]
+
+    # Collect SSE events in background
+    collected_events = []
+
+    async def collect_sse():
+        try:
+            async with sse_stream(base_url, timeout=60) as resp:
+                while len(collected_events) < 50:
+                    raw_line = await resp.content.readline()
+                    if not raw_line:
+                        break
+                    line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+                    if line.startswith("data:"):
+                        try:
+                            data = json.loads(line[5:].strip())
+                            collected_events.append(data)
+                        except json.JSONDecodeError:
+                            pass
+        except asyncio.CancelledError:
+            pass
+
+    sse_task = asyncio.create_task(collect_sse())
+    await asyncio.sleep(1)  # Let SSE connect
+
+    # Send message that triggers github skill → HTTP 401 → auth_required
+    send_r = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={
+            "content": "list issues in nearai/ironclaw github repo",
+            "thread_id": thread_id,
+        },
+        timeout=30,
+    )
+    assert send_r.status_code == 202
+
+    # Wait for auth_required, then collect for a grace period to catch any
+    # trailing duplicate response events that might arrive shortly after.
+    deadline = asyncio.get_running_loop().time() + 45
+    auth_seen_at = None
+    while asyncio.get_running_loop().time() < deadline:
+        event_types = [e.get("type") for e in collected_events]
+        if "auth_required" in event_types and auth_seen_at is None:
+            auth_seen_at = asyncio.get_running_loop().time()
+        if auth_seen_at and (asyncio.get_running_loop().time() - auth_seen_at) > 3:
+            break
+        await asyncio.sleep(0.5)
+
+    sse_task.cancel()
+    try:
+        await sse_task
+    except asyncio.CancelledError:
+        pass
+
+    # Assert auth_required event was emitted
+    event_types = [e.get("type") for e in collected_events]
+    assert "auth_required" in event_types, (
+        f"Expected auth_required in SSE events, got: {event_types}"
+    )
+
+    # Assert NO response event contains auth instruction text.
+    # The auth instructions typically contain phrases like "paste your token",
+    # "authentication required", or the credential setup instructions.
+    auth_indicators = ["paste your token", "token below", "authentication required"]
+    response_events = [
+        e for e in collected_events
+        if e.get("type") == "response"
+    ]
+    for resp_event in response_events:
+        content = (resp_event.get("content") or "").lower()
+        for indicator in auth_indicators:
+            assert indicator not in content, (
+                f"Bug regression: response SSE event contains auth instructions "
+                f"('{indicator}' found in: {content[:200]}). "
+                f"Auth instructions should only appear in the auth_required event, "
+                f"not as a duplicate text response."
+            )

--- a/tests/e2e/scenarios/test_telegram_hot_activation.py
+++ b/tests/e2e/scenarios/test_telegram_hot_activation.py
@@ -259,7 +259,7 @@ async def test_telegram_hot_activation_transitions_installed_to_pairing(page):
     ]
 
 
-async def test_telegram_auth_required_shows_setup_card_and_can_restart(page):
+async def test_telegram_auth_required_shows_configure_modal_and_can_cancel(page):
     setup_hits = {"count": 0}
     cancel_hits = {"count": 0}
 
@@ -305,15 +305,15 @@ async def test_telegram_auth_required_shows_setup_card_and_can_restart(page):
         """
     )
 
-    setup_card = page.locator(SEL["setup_card"])
-    await setup_card.wait_for(state="visible", timeout=5000)
-    assert "Telegram Bot API token" in await setup_card.text_content()
-    assert "pairing code" in await setup_card.text_content()
-    assert await setup_card.locator(SEL["setup_input"]).count() == 1
-    assert await setup_card.locator(SEL["setup_next_step"]).count() == 1
+    # Auth-required now opens the unified configure modal, not the old setup card
+    modal = page.locator(SEL["configure_overlay"])
+    await modal.wait_for(state="visible", timeout=5000)
+    assert "Telegram Bot API token" in await modal.text_content()
+    assert await modal.locator(SEL["configure_input"]).count() == 1
+    assert await page.locator(SEL["setup_card"]).count() == 0
 
-    await setup_card.locator(SEL["auth_cancel_btn"]).click()
-    await setup_card.wait_for(state="hidden", timeout=5000)
+    await modal.locator(".btn-ext.remove").click()
+    await modal.wait_for(state="hidden", timeout=5000)
     assert cancel_hits["count"] == 1
 
     await page.evaluate(
@@ -325,11 +325,11 @@ async def test_telegram_auth_required_shows_setup_card_and_can_restart(page):
         });
         """
     )
-    await page.locator(SEL["setup_card"]).wait_for(state="visible", timeout=5000)
+    await page.locator(SEL["configure_overlay"]).wait_for(state="visible", timeout=5000)
     assert setup_hits["count"] == 2
 
 
-async def test_telegram_setup_card_submit_then_cancel_pairing_and_restart(page):
+async def test_telegram_configure_modal_submit_then_cancel_pairing_and_restart(page):
     setup_payloads = []
 
     async def handle_setup(route):
@@ -385,11 +385,12 @@ async def test_telegram_setup_card_submit_then_cancel_pairing_and_restart(page):
         """
     )
 
-    setup_card = page.locator(SEL["setup_card"])
-    await setup_card.wait_for(state="visible", timeout=5000)
-    await setup_card.locator(SEL["setup_input"]).fill("123456789:ABCdefGhI")
-    await setup_card.locator(SEL["auth_submit_btn"]).click()
-    await setup_card.wait_for(state="hidden", timeout=5000)
+    # Auth-required now opens the unified configure modal
+    modal = page.locator(SEL["configure_overlay"])
+    await modal.wait_for(state="visible", timeout=5000)
+    await modal.locator(SEL["configure_input"]).fill("123456789:ABCdefGhI")
+    await modal.locator(".btn-ext.activate").click()
+    await modal.wait_for(state="hidden", timeout=5000)
 
     pairing_card = page.locator(SEL["pairing_card"])
     await pairing_card.wait_for(state="visible", timeout=5000)


### PR DESCRIPTION
## Summary

- **Bug 1 — Duplicate text response during auth**: When a tool triggered `auth_required`, the gateway sent both an `auth_required` SSE event (config card) AND a `response` SSE event (duplicate text). Users saw the same instructions twice. Fix: new `AuthPending` variant in `LoopOutcome` and `AgenticLoopResult` that carries the instructions for DB persistence but maps to `HandleOutcome::Pending` — suppressing the text SSE event. Covers both the dispatcher agentic loop path and the approval-resumption path.

- **Bug 2 — Overlapping extension config UI**: WASM extension configuration rendered in 3 overlapping places (install auto-open modal, extensions page Reconfigure button, SSE auth card in chat). Fix: redirect `showSetupCardForExtension` to use the unified `showConfigureModal` with auth-flow metadata for cancel/close handling. Removed ~130 lines of dead code (`showSetupCard`, `showSetupCardError`, `submitSetupCard`). Added `pairing_required` transition and error fallback to `showAuthCard` when setup API fails.

- **Review fixes**: Auth instructions persisted to DB via `complete_turn` + `persist_tool_calls` + `persist_assistant_response` (restores behavior from old `Response` path). `cancelAuthFromConfigureModal` checks for remaining overlays before clearing auth state. `renderConfigureModal` cancels existing auth-flow overlay before replacing. SSE test uses `readline()` with 3-second grace period.

- Updated 2 E2E tests from `.setup-card` → `.configure-overlay` selectors. Added new SSE regression test.

## Test plan

- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [ ] `cargo test` — all Rust tests pass
- [ ] Manual: trigger auth flow in web gateway → only config card appears, no duplicate text
- [ ] Manual: install WASM channel → single configure modal opens
- [ ] E2E: `pytest scenarios/test_telegram_hot_activation.py` — updated tests pass
- [ ] E2E: `pytest scenarios/test_auth_no_duplicate_response.py` — SSE regression test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)