### PR TITLE
feat(tools): config-driven credential loading via INTEGRATION_CREDENTIALS_DIR

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -342,6 +342,34 @@ impl AppBuilder {
         tools.register_builtin_tools();
         tools.register_tool_info();
 
+        // Load integration credential mappings from a directory.
+        // Scans for *.json files in the directory and one level of subdirectories
+        // (e.g. integrations/abound/credentials.json).
+        if let Ok(dir) = std::env::var("INTEGRATION_CREDENTIALS_DIR") {
+            let dir_path = std::path::Path::new(&dir);
+            if dir_path.is_dir() {
+                if let Ok(entries) = std::fs::read_dir(dir_path) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                            tools.load_credential_mappings(&path);
+                        } else if path.is_dir()
+                            && let Ok(sub) = std::fs::read_dir(&path)
+                        {
+                            for sub_entry in sub.flatten() {
+                                let sub_path = sub_entry.path();
+                                if sub_path.extension().and_then(|e| e.to_str()) == Some("json") {
+                                    tools.load_credential_mappings(&sub_path);
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if dir_path.is_file() {
+                tools.load_credential_mappings(dir_path);
+            }
+        }
+
         if let Some(ref ss) = self.secrets_store {
             tools.register_secrets_tools(Arc::clone(ss));
         }

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -4357,6 +4357,7 @@ mod tests {
                     prefix: Some("Bot ".to_string()),
                 },
                 host_patterns: vec!["discord.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         tool_capabilities.http = Some(http);

--- a/src/sandbox/proxy/policy.rs
+++ b/src/sandbox/proxy/policy.rs
@@ -271,6 +271,7 @@ mod tests {
             secret_name: "EXAMPLE_KEY".to_string(),
             location: CredentialLocation::AuthorizationBearer,
             host_patterns: vec!["*.example.com".to_string()],
+            path_patterns: Vec::new(),
         }];
         let decider = DefaultPolicyDecider::new(allowlist, credentials);
 

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -222,14 +222,37 @@ pub struct CredentialMapping {
     pub location: CredentialLocation,
     /// Host patterns this credential applies to (glob syntax).
     pub host_patterns: Vec<String>,
+    /// Optional path prefixes to scope this credential to specific endpoints.
+    /// When empty, matches all paths on the host. When set, the request path
+    /// must start with one of these prefixes for the credential to be injected.
+    #[serde(default)]
+    pub path_patterns: Vec<String>,
 }
 
 impl CredentialMapping {
+    /// Returns true if this mapping matches the given host and path.
+    pub fn matches(&self, host: &str, path: &str) -> bool {
+        let host_match = self
+            .host_patterns
+            .iter()
+            .any(|pattern| host_matches_pattern(host, pattern));
+        if !host_match {
+            return false;
+        }
+        if self.path_patterns.is_empty() {
+            return true;
+        }
+        self.path_patterns
+            .iter()
+            .any(|prefix| path.starts_with(prefix.as_str()))
+    }
+
     pub fn bearer(secret_name: impl Into<String>, host_pattern: impl Into<String>) -> Self {
         Self {
             secret_name: secret_name.into(),
             location: CredentialLocation::AuthorizationBearer,
             host_patterns: vec![host_pattern.into()],
+            path_patterns: Vec::new(),
         }
     }
 
@@ -245,8 +268,36 @@ impl CredentialMapping {
                 prefix: None,
             },
             host_patterns: vec![host_pattern.into()],
+            path_patterns: Vec::new(),
         }
     }
+}
+
+/// Check if a hostname matches a pattern (supports `*.` wildcard and port stripping).
+pub fn host_matches_pattern(host: &str, pattern: &str) -> bool {
+    if pattern == host {
+        return true;
+    }
+    // Support patterns with port: "127.0.0.1:8080" matches host "127.0.0.1"
+    if pattern.contains(':')
+        && pattern
+            .split(':')
+            .next()
+            .is_some_and(|pattern_host| pattern_host == host)
+    {
+        return true;
+    }
+    // Support wildcard: *.example.com matches sub.example.com
+    if let Some(suffix) = pattern.strip_prefix("*.")
+        && host.ends_with(suffix)
+        && host.len() > suffix.len()
+    {
+        let prefix = &host[..host.len() - suffix.len()];
+        if prefix.ends_with('.') || prefix.is_empty() {
+            return true;
+        }
+    }
+    false
 }
 
 #[cfg(test)]

--- a/src/skills/mod.rs
+++ b/src/skills/mod.rs
@@ -61,6 +61,7 @@ pub fn credential_spec_to_mapping(spec: &SkillCredentialSpec) -> CredentialMappi
         secret_name: spec.name.clone(),
         location: convert_credential_location(&spec.location),
         host_patterns: spec.hosts.clone(),
+        path_patterns: Vec::new(),
     }
 }
 

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -585,8 +585,9 @@ impl Tool for HttpTool {
             self.secrets_store.as_ref(),
         ) {
             let cred_host = parsed_url.host_str().unwrap_or("").to_string();
+            let cred_path = parsed_url.path();
             let matched: Vec<crate::secrets::CredentialMapping> =
-                registry.find_for_host(&cred_host);
+                registry.find_for_url(&cred_host, cred_path);
             tracing::debug!(
                 host = %cred_host,
                 matched_count = matched.len(),

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -374,6 +374,133 @@ impl ToolRegistry {
         tracing::debug!("Registered {} built-in tools", self.count());
     }
 
+    /// Load integration credential mappings from a JSON file.
+    ///
+    /// The file format is:
+    /// ```json
+    /// { "mappings": [{ "secret_name": "...", "location": {...}, "host_patterns": [...], "path_patterns": [...] }] }
+    /// ```
+    pub fn load_credential_mappings(&self, path: &std::path::Path) {
+        use crate::secrets::{CredentialLocation, CredentialMapping};
+
+        let cr = match &self.credential_registry {
+            Some(cr) => cr,
+            None => {
+                tracing::warn!("Cannot load credential mappings: no credential registry");
+                return;
+            }
+        };
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to read credential mappings from {}: {}",
+                    path.display(),
+                    e
+                );
+                return;
+            }
+        };
+
+        let json: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse credential mappings from {}: {}",
+                    path.display(),
+                    e
+                );
+                return;
+            }
+        };
+
+        let entries = match json.get("mappings").and_then(|v| v.as_array()) {
+            Some(arr) => arr,
+            None => {
+                tracing::warn!("No 'mappings' array in {}", path.display());
+                return;
+            }
+        };
+
+        let mut mappings = Vec::new();
+        for entry in entries {
+            let secret_name = match entry.get("secret_name").and_then(|v| v.as_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let host_patterns: Vec<String> = entry
+                .get("host_patterns")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let location = match entry
+                .get("location")
+                .and_then(|v| v.get("type"))
+                .and_then(|v| v.as_str())
+            {
+                Some("bearer") => CredentialLocation::AuthorizationBearer,
+                Some("header") => {
+                    let name = match entry["location"]["name"].as_str() {
+                        Some(n) => n.to_string(),
+                        None => {
+                            tracing::warn!(
+                                "Skipping credential mapping '{}': header location missing 'name'",
+                                secret_name
+                            );
+                            continue;
+                        }
+                    };
+                    CredentialLocation::Header { name, prefix: None }
+                }
+                Some("query") => {
+                    let name = match entry["location"]["name"].as_str() {
+                        Some(n) => n.to_string(),
+                        None => {
+                            tracing::warn!(
+                                "Skipping credential mapping '{}': query location missing 'name'",
+                                secret_name
+                            );
+                            continue;
+                        }
+                    };
+                    CredentialLocation::QueryParam { name }
+                }
+                _ => continue,
+            };
+
+            let path_patterns: Vec<String> = entry
+                .get("path_patterns")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            mappings.push(CredentialMapping {
+                secret_name,
+                location,
+                host_patterns,
+                path_patterns,
+            });
+        }
+
+        let count = mappings.len();
+        cr.add_mappings(mappings);
+        tracing::info!(
+            "Loaded {} credential mappings from {}",
+            count,
+            path.display()
+        );
+    }
+
     /// Register the `tool_info` discovery tool.
     ///
     /// Requires `Arc<Self>` so the tool can query the registry for other tools'

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -375,6 +375,7 @@ impl CredentialMappingSchema {
             secret_name: self.secret_name.clone(),
             location: self.location.to_credential_location(),
             host_patterns: self.host_patterns.clone(),
+            path_patterns: Vec::new(),
         }
     }
 }

--- a/src/tools/wasm/credential_injector.rs
+++ b/src/tools/wasm/credential_injector.rs
@@ -121,33 +121,32 @@ impl SharedCredentialRegistry {
                 poisoned.into_inner()
             }
         };
-        guard.iter().any(|mapping| {
-            mapping
-                .host_patterns
-                .iter()
-                .any(|pattern| host_matches_pattern(host, pattern))
-        })
+        guard.iter().any(|mapping| mapping.matches(host, "/"))
     }
 
     /// Get all credential mappings matching a host (for injection).
     pub fn find_for_host(&self, host: &str) -> Vec<CredentialMapping> {
+        self.find_for_url(host, "/")
+    }
+
+    /// Get all credential mappings matching a host and path.
+    ///
+    /// Mappings without `path_patterns` match all paths on the host.
+    /// Mappings with `path_patterns` only match if the request path starts
+    /// with one of the patterns.
+    pub fn find_for_url(&self, host: &str, path: &str) -> Vec<CredentialMapping> {
         let guard = match self.mappings.read() {
             Ok(guard) => guard,
             Err(poisoned) => {
                 tracing::warn!(
-                    "SharedCredentialRegistry RwLock poisoned during find_for_host; recovering"
+                    "SharedCredentialRegistry RwLock poisoned during find_for_url; recovering"
                 );
                 poisoned.into_inner()
             }
         };
         guard
             .iter()
-            .filter(|mapping| {
-                mapping
-                    .host_patterns
-                    .iter()
-                    .any(|pattern| host_matches_pattern(host, pattern))
-            })
+            .filter(|mapping| mapping.matches(host, path))
             .cloned()
             .collect()
     }
@@ -438,6 +437,7 @@ mod tests {
                 secret_name: "openai_key".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.openai.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -471,6 +471,7 @@ mod tests {
                     prefix: None,
                 },
                 host_patterns: vec!["*.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -503,6 +504,7 @@ mod tests {
                     username: "myuser".to_string(),
                 },
                 host_patterns: vec!["api.service.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -545,6 +547,7 @@ mod tests {
                 secret_name: "secret_key".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.test.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -2343,6 +2343,7 @@ mod tests {
                 secret_name: "api_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2379,6 +2380,7 @@ mod tests {
                     placeholder: "{api_key}".to_string(),
                 },
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2423,6 +2425,7 @@ mod tests {
                 secret_name: "my_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2486,6 +2489,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2534,6 +2538,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2583,6 +2588,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2620,6 +2626,7 @@ mod tests {
                 secret_name: "missing_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2663,6 +2670,7 @@ mod tests {
                     placeholder: "{api_key}".to_string(),
                 },
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2709,6 +2717,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2768,6 +2777,7 @@ mod tests {
                 secret_name: "my_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2812,6 +2822,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2879,6 +2890,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -2989,6 +3001,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -3057,6 +3070,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["www.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 
@@ -3310,6 +3324,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["sheets.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -3350,6 +3365,7 @@ mod tests {
                 secret_name: "google_oauth_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["sheets.googleapis.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         Capabilities {


### PR DESCRIPTION
## Summary
New `INTEGRATION_CREDENTIALS_DIR` env var that scans a directory for `*.json` credential mapping files at startup. Each JSON file declares secret names, injection locations (bearer/header/query), and host/path patterns.

Depends on #2168 (path-based credential matching).

## Example
```json
{"mappings": [{"secret_name": "my_token", "location": {"type": "bearer"}, "host_patterns": ["api.example.com"], "path_patterns": ["/v1/read"]}]}
```

## Test plan
- Set `INTEGRATION_CREDENTIALS_DIR=/path/to/dir` with a JSON file, verify credentials auto-inject on matching requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)