### PR TITLE
fix(ci): target wasm32-wasip2 in WASM build script

### DIFF
--- a/scripts/build-wasm-extensions.sh
+++ b/scripts/build-wasm-extensions.sh
@@ -43,7 +43,7 @@ build_extension() {
     fi
 
     echo "  BUILD $name ($crate_name) from $source_dir"
-    if ! cargo component build --release --manifest-path "$source_dir/Cargo.toml" 2>&1; then
+    if ! cargo component build --release --target wasm32-wasip2 --manifest-path "$source_dir/Cargo.toml" 2>&1; then
         echo "  FAIL $name"
         FAILED+=("$name")
         return 1

--- a/tests/slack_auth_integration.rs
+++ b/tests/slack_auth_integration.rs
@@ -215,7 +215,7 @@ async fn expect_no_message(stream: &mut ironclaw::channels::MessageStream, timeo
     );
 }
 
-// ── Tests without integration gate (on_http_request only) ───────────────
+// ── Tests without integration gate (on_http_request only) ───────────────────
 
 #[tokio::test]
 async fn test_dm_from_owner_accepted() {
@@ -866,4 +866,17 @@ async fn test_channel_message_without_mention_ignored() {
 
     assert_eq!(response.status, 200);
     expect_no_message(&mut stream, 500).await;
+}
+
+/// Regression: build script must target wasm32-wasip2 so binaries land at the
+/// path that `slack_wasm_path()` expects.  Without `--target wasm32-wasip2`
+/// cargo-component defaults to wasip1 and CI tests silently skip.
+#[test]
+fn build_script_targets_wasip2() {
+    let script = std::fs::read_to_string(find_project_file("scripts/build-wasm-extensions.sh"))
+        .expect("build script should exist");
+    assert!(
+        script.contains("--target wasm32-wasip2"),
+        "build-wasm-extensions.sh must pass --target wasm32-wasip2"
+    );
 }


### PR DESCRIPTION
## Summary
- CI's `cargo-component` defaults to `wasm32-wasip1`, placing WASM binaries at the wrong target path
- All 5 `slack_auth_integration` tests panic because they look for the module at `wasm32-wasip2`
- Adds explicit `--target wasm32-wasip2` to `cargo component build` in the build script

## Root cause
The `Creating component` step in CI outputs to `channels-src/slack/target/wasm32-wasip1/release/slack_channel.wasm`, but the test macro `require_slack_wasm!()` checks `wasm32-wasip2`. The binary was built successfully — just at the wrong path.

**CI run:** https://github.com/nearai/ironclaw/actions/runs/24160181770/job/70509336674

## Test plan
- [x] `./scripts/build-wasm-extensions.sh --channels` — confirms binary at `wasm32-wasip2` path
- [x] `cargo test --test slack_auth_integration` — all 5 tests pass locally
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)