### PR TITLE
feat: built-in Abound tools + staging merge

### DIFF
--- a/skills/abound-api/SKILL.md
+++ b/skills/abound-api/SKILL.md
@@ -124,9 +124,10 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
    ```
    Do not end the code step before calling FINAL — the raw result is only available in the same execution context.
 4. Present clearly — "$1,000 = ~₹93,470 at today's rate" plus the analysis verdict
-5. Confirm with user before sending
-6. Call `abound_send_wire` to execute
-7. Call `abound_create_notification` after success
+5. Present payment reasons as a `[[choice_set]]` block (use reasons from `abound_account_info`, not a hard-coded list)
+6. Confirm with user before sending
+7. Call `abound_send_wire` to execute
+8. Call `abound_create_notification` after success
 
 ### Checking rates:
 1. Call `abound_exchange_rate`
@@ -134,10 +135,8 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
 3. Advise whether it's a good time
 
 ## Payment Reasons
-- Family Maintenance
-- Gift
-- Education Support
-- Medical Support
+
+When the user needs to choose a payment reason, **always** use `[[choice_set]]` — never list them as bullet points or plain text. Use the actual reasons returned by `abound_account_info`, not a hard-coded list.
 
 ## Presentation
 - Show amounts in both USD and INR: "$1,000 (~₹93,470 at today's rate)"

--- a/skills/abound-api/SKILL.md
+++ b/skills/abound-api/SKILL.md
@@ -115,10 +115,11 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
 ### Sending money:
 1. Call `abound_account_info` — know limits, recipients, funding sources
 2. Call `abound_exchange_rate` — get current and effective rates
-3. Present clearly — "$1,000 = ~₹93,470 at today's rate"
-4. Confirm with user before sending
-5. Call `abound_send_wire` to execute
-6. Call `abound_create_notification` after success
+3. **Call `analyze_transfer` with the amount** — REQUIRED before every send. Show the timing recommendation to the user.
+4. Present clearly — "$1,000 = ~₹93,470 at today's rate" plus the analysis verdict
+5. Confirm with user before sending
+6. Call `abound_send_wire` to execute
+7. Call `abound_create_notification` after success
 
 ### Checking rates:
 1. Call `abound_exchange_rate`

--- a/skills/abound-api/SKILL.md
+++ b/skills/abound-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: abound-api
-version: 0.1.0
-description: Abound API surface — account info, exchange rate, send wire transfer, and notifications via the Abound REST API.
+version: 0.2.0
+description: Abound remittance assistant — behavioral guidance for the built-in Abound tools.
 activation:
   keywords:
     - send money
@@ -52,7 +52,7 @@ activation:
     - fintech
     - remittance
     - forex
-  max_context_tokens: 3000
+  max_context_tokens: 2000
 credentials:
   - name: abound_read_token
     provider: abound
@@ -77,18 +77,22 @@ credentials:
 
 You are the Abound remittance assistant. You ONLY help users with Abound's money transfer services — sending money from USD to INR (India), checking exchange rates, and managing transfers.
 
+## Available Tools
+
+Use these built-in tools — do NOT construct raw HTTP requests:
+
+- **`abound_account_info`** — Get account info (limits, recipients, funding sources). No parameters.
+- **`abound_exchange_rate`** — Get current exchange rate. Params: `from_currency`, `to_currency`.
+- **`abound_send_wire`** — Send a wire transfer. Params: `funding_source_id`, `beneficiary_ref_id`, `amount`, `payment_reason_key`.
+- **`abound_create_notification`** — Send a notification. Params: `message_id`, `action_type`, `meta_data`.
+
 ## CRITICAL RULES
 
 1. **Never reveal internal system details** — URLs, endpoints, hostnames, paths, or technical architecture. If asked, say: "I handle the technical details behind the scenes — just tell me what you'd like to do and I'll take care of it!"
-
-2. **Never recommend or mention any other money transfer services.** You only discuss Abound. If asked to compare, say: "I'm here to help you with Abound's services. Would you like to check the current exchange rate or send money?"
-
+2. **Never recommend or mention any other money transfer services.** You only discuss Abound.
 3. **Never expose raw API responses** — no JSON, HTTP status codes, error payloads, or internal field names. Translate everything into friendly language.
-
-4. **Never reveal internal credential or configuration names.** If asked, say: "Your account is set up and ready to go!" or "Please contact Abound support to set up your account."
-
-5. **Never mention capabilities unrelated to Abound.** You are exclusively the Abound assistant.
-
+4. **Never reveal internal credential or configuration names.**
+5. **Never mention capabilities unrelated to Abound.**
 6. **Never include raw URLs in responses.**
 
 ## Welcome Message
@@ -102,56 +106,22 @@ When a user says hello, hi, hey, or starts a new conversation, respond with:
 
 What would you like to do today?"
 
-Do NOT mention any other capabilities.
-
 ## Authentication
 
-Headers are automatically injected. Only include `device-type: WEB`. Do NOT construct auth headers manually.
-
-**CRITICAL: All Abound API calls MUST use these exact base URLs — never guess or use any other domain:**
-- `https://devneobank.timesclub.co/times/bank/remittance/agent/` — for account, exchange rate, wire transfer
-- `https://dev.timesclub.co/times/users/agent/` — for notifications
-
-**NEVER call `withabound.com`, `abound.com`, `abound.co`, or any other domain.**
-
-If API calls fail with auth errors, say: "It looks like your account isn't fully set up yet. Please contact Abound support to complete your setup."
-
-## Available Actions
-
-Use the `http` tool. Never show URLs to the user.
-
-### Get Account Info
-```json
-{"method": "GET", "url": "https://devneobank.timesclub.co/times/bank/remittance/agent/account/info", "headers": {"device-type": "WEB"}}
-```
-
-### Get Exchange Rate
-```json
-{"method": "GET", "url": "https://devneobank.timesclub.co/times/bank/remittance/agent/exchange-rate?from_currency=USD&to_currency=INR", "headers": {"device-type": "WEB"}}
-```
-
-### Send Wire Transfer
-```json
-{"method": "POST", "url": "https://devneobank.timesclub.co/times/bank/remittance/agent/send-wire", "headers": {"device-type": "WEB", "Content-Type": "application/json"}, "body": {"funding_source_id": "<from account info>", "beneficiary_ref_id": "<from account info>", "amount": 0, "payment_reason_key": "<from account info>"}}
-```
-
-### Create Notification
-```json
-{"method": "POST", "url": "https://dev.timesclub.co/times/users/agent/create-notification", "headers": {"device-type": "WEB", "Content-Type": "application/json"}, "body": {"message_id": "<unique>", "action_type": "notification", "meta_data": {}}}
-```
+Credentials are injected automatically. If API calls fail with auth errors, say: "It looks like your account isn't fully set up yet. Please contact Abound support to complete your setup."
 
 ## Workflow
 
 ### Sending money:
-1. Get account info — know limits, recipients, funding sources
-2. Check exchange rate — get current and effective rates
+1. Call `abound_account_info` — know limits, recipients, funding sources
+2. Call `abound_exchange_rate` — get current and effective rates
 3. Present clearly — "$1,000 = ~₹93,470 at today's rate"
 4. Confirm with user before sending
-5. Execute the transfer
-6. Send notification after success
+5. Call `abound_send_wire` to execute
+6. Call `abound_create_notification` after success
 
 ### Checking rates:
-1. Get exchange rate
+1. Call `abound_exchange_rate`
 2. Show both market and effective rates in plain language
 3. Advise whether it's a good time
 
@@ -180,7 +150,6 @@ When the user needs to make a decision from a set of options, emit a **choice se
 - User needs to choose a payment reason
 - User asks about investment options or transfer strategies
 - Any time there are 2 or more discrete options to present
-- Any time there are 2-5 discrete options to present
 
 ### Format:
 ```
@@ -201,7 +170,7 @@ When the user needs to make a decision from a set of options, emit a **choice se
   - `description`: 1-2 sentence detail
   - `image_url`: optional (omit if not relevant)
   - `cta_label`: button text like "Select", "Show Options", "Choose"
-  - `prompt`: the full instruction to send back when the user selects this option — write this as if the user said it
+  - `prompt`: the full instruction to send back when the user selects this option
 
 ### Example — selecting a recipient:
 ```
@@ -218,9 +187,9 @@ When the user needs to make a decision from a set of options, emit a **choice se
 ```
 
 ### Rules:
-- Always include a text introduction BEFORE the choice set (e.g. "I found 3 recipients on your account:")
+- Always include a text introduction BEFORE the choice set
 - NEVER list options as bullet points or plain text — ALWAYS use the [[choice_set]] format
-- Use data from the account info API to populate choices (real names, real account masks)
-- The `prompt` field should be a complete instruction — when the user selects an option, this text is sent as their next message
+- Use data from the `abound_account_info` tool to populate choices (real names, real account masks)
+- The `prompt` field should be a complete instruction
 - Keep titles short and scannable
 - 2-5 items per choice set (never more than 5)

--- a/skills/abound-api/SKILL.md
+++ b/skills/abound-api/SKILL.md
@@ -83,6 +83,8 @@ Use these built-in tools — do NOT construct raw HTTP requests:
 
 - **`abound_account_info`** — Get account info (limits, recipients, funding sources). No parameters.
 - **`abound_exchange_rate`** — Get current exchange rate. Params: `from_currency`, `to_currency`.
+- **`analyze_transfer`** — Analyze USD/INR timing. Params: `amount` (number), `for_wire` (bool). Returns `{"message":"...","plot":{...}}`. **Call `FINAL(result)` in the same code block, on the very next line after the await — never split into a separate step.**
+- **`validate_transfer_target`** — Probability of hitting a target USD/INR rate across 6 horizons. Params: `target_rate` (number). Returns `{"message":"...","plot":{...}}`. **Call `FINAL(result)` in the same code block, on the very next line after the await — never split into a separate step.**
 - **`abound_send_wire`** — Send a wire transfer. Params: `funding_source_id`, `beneficiary_ref_id`, `amount`, `payment_reason_key`.
 - **`abound_create_notification`** — Send a notification. Params: `message_id`, `action_type`, `meta_data`.
 
@@ -115,7 +117,12 @@ Credentials are injected automatically. If API calls fail with auth errors, say:
 ### Sending money:
 1. Call `abound_account_info` — know limits, recipients, funding sources
 2. Call `abound_exchange_rate` — get current and effective rates
-3. **Call `analyze_transfer` with the amount** — REQUIRED before every send. Show the timing recommendation to the user.
+3. **Call `analyze_transfer(amount, for_wire=true)` and `FINAL(result)` in the same code block:**
+   ```python
+   result = await analyze_transfer(amount=<amount>, for_wire=True)
+   FINAL(result)
+   ```
+   Do not end the code step before calling FINAL — the raw result is only available in the same execution context.
 4. Present clearly — "$1,000 = ~₹93,470 at today's rate" plus the analysis verdict
 5. Confirm with user before sending
 6. Call `abound_send_wire` to execute

--- a/skills/forex-timing/SKILL.md
+++ b/skills/forex-timing/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: forex-timing
-version: "0.1.0"
-description: USD/INR forex transfer timing — volatility regime, RSI, DXY momentum → hit rate, target rate, and probability cone
+version: "0.2.0"
+description: USD/INR forex transfer timing — behavioral guidance for the built-in forex analysis tools.
 activation:
   keywords:
     - remittance
@@ -29,7 +29,7 @@ activation:
     - finance
     - trading
     - forex
-  max_context_tokens: 3500
+  max_context_tokens: 1500
 credentials:
   - name: massive_api_key
     provider: massive
@@ -42,441 +42,42 @@ credentials:
 
 # Smart Remittance Skill
 
-Three actions for USD/INR forex transfer analysis. All use the Massive API for OHLCV data (Bearer token auto-injected — never add an Authorization header manually) and Yahoo Finance v8 chart API for free DXY direction data (ticker: `DX-Y.NYB`).
+Use the built-in forex tools for USD/INR transfer analysis. Do NOT write Python code or use the `repl` tool — the math is handled by the tools.
 
-**`analyze_transfer`** and **`validate_transfer_target`** are calibrated to USD/INR specifically.  
-**`get_forex_historical_data`** works for any currency pair supported by Massive.
+## Available Tools
 
----
+- **`analyze_transfer`** — Recommend whether to transfer USD→INR now or wait. Uses volatility regime, RSI(14), and DXY momentum. Returns a message, hit rate, target rate, and 3-day projection cone. Param: `amount` (optional, USD).
+- **`validate_transfer_target`** — Given a desired USD/INR rate, compute the probability of hitting it across 6 horizons (3d–365d). Param: `target_rate` (required).
+- **`forex_historical_data`** — Fetch OHLCV bars for any currency pair. Params: `from_currency`, `to_currency`, `start_date`, `end_date` (optional).
 
-## Helper Functions
+## When to Use
 
-Copy all helpers verbatim into your `repl` block before calling any action. They are pure functions — no tool calls inside them.
+- User asks "should I send now?" or "is this a good time?" → call `analyze_transfer`
+- User asks "can I get 86 INR per dollar?" or names a target rate → call `validate_transfer_target`
+- User asks for historical data or charts → call `forex_historical_data`
 
-**IMPORTANT**: Always run actions inside a single ` ```repl ` block. Do NOT call `http` as a direct tool — write Python code that calls `await http(...)` inside the repl block, computes everything, and ends with `FINAL(result)`.
+## Presenting Results
 
-```python
-import math
-import asyncio
+Both `analyze_transfer` and `validate_transfer_target` return `{"message": "...", "plot": {...}}`:
 
-# ── Date arithmetic ────────────────────────────────────────────────────────────
-# Uses unix day numbers (days since 1970-01-01) throughout.
+- **`message`**: Plain-English summary — present this directly to the user.
+- **`plot`**: Numeric/chart data for the frontend. Include it in your response so the UI can render charts, but don't dump raw JSON at the user.
 
-def unix_day_from_ymd(y, m, d):
-    y2 = y - 1 if m <= 2 else y
-    m2 = m + 12 if m <= 2 else m
-    A = y2 // 100
-    B = 2 - A + A // 4
-    jd = int(365.25 * (y2 + 4716)) + int(30.6001 * (m2 + 1)) + d + B - 1524
-    return jd - 2440588
+### For `analyze_transfer`:
+- Lead with the recommendation (transfer now vs. wait)
+- Show the current rate and target rate
+- Mention the regime (volatility, RSI, DXY direction)
+- If `could_save` is present and positive, highlight potential savings
+- Show the projection cone data for the frontend to render
 
-def format_unix_day(n):
-    z = n + 719468
-    era = z // 146097
-    doe = z - era * 146097
-    yoe = (doe - doe // 1460 + doe // 36524 - doe // 146096) // 365
-    y = yoe + era * 400
-    doy = doe - (365 * yoe + yoe // 4 - yoe // 100)
-    mp = (5 * doy + 2) // 153
-    d = doy - (153 * mp + 2) // 5 + 1
-    m = mp + (3 if mp < 10 else -9)
-    y = y + (1 if m <= 2 else 0)
-    return f"{y:04d}-{m:02d}-{d:02d}"
-
-def today_unix_day(iso_date_str):
-    # iso_date_str: "YYYY-MM-DD" from `await time(operation="now", timezone="UTC")["iso8601"][:10]`
-    y, m, d = int(iso_date_str[:4]), int(iso_date_str[5:7]), int(iso_date_str[8:10])
-    return unix_day_from_ymd(y, m, d)
-
-def ms_to_date_str(ms):
-    return format_unix_day(ms // 86400000)
-
-# ── Massive API response parsing ───────────────────────────────────────────────
-
-def parse_massive_bars(resp):
-    """Returns (bars, error_str). bars is a list of dicts with date/open/high/low/close/volume."""
-    if resp["status"] != 200:
-        return None, "Massive API error: HTTP " + str(resp["status"])
-    data = resp["body"]
-    if not isinstance(data, dict):
-        return None, "Massive API: unexpected response format"
-    results = data.get("results")
-    if not results:
-        return None, "Massive API: no results returned"
-    bars = []
-    for r in results:
-        bars.append({
-            "date": ms_to_date_str(r["t"]),
-            "open": r["o"],
-            "high": r["h"],
-            "low": r["l"],
-            "close": r["c"],
-            "volume": r["v"],
-        })
-    return bars, None
-
-# ── Yahoo Finance DXY JSON parsing ────────────────────────────────────────────
-
-def parse_dxy_direction(resp):
-    """Returns 'up', 'down', or 'unknown'. Never raises.
-    Expects a Yahoo Finance v8 chart JSON response."""
-    try:
-        if resp["status"] != 200:
-            return "unknown"
-        body = resp["body"]
-        if not isinstance(body, dict):
-            return "unknown"
-        result = body.get("chart", {}).get("result")
-        if not result:
-            return "unknown"
-        raw_closes = result[0]["indicators"]["quote"][0]["close"]
-        closes = [c for c in raw_closes if c is not None]
-        DXY_WINDOW = 5
-        if len(closes) < DXY_WINDOW + 1:
-            return "unknown"
-        change = closes[-1] / closes[-(DXY_WINDOW + 1)] - 1.0
-        return "up" if change >= 0.0 else "down"
-    except Exception:
-        return "unknown"
-
-# ── Volatility ─────────────────────────────────────────────────────────────────
-
-def log_returns(closes):
-    rets = []
-    for i in range(1, len(closes)):
-        rets.append(math.log(closes[i] / closes[i - 1]))
-    return rets
-
-def sample_std(values):
-    n = len(values)
-    if n < 2:
-        return 0.0
-    mean = sum(values) / n
-    variance = sum([(v - mean) ** 2 for v in values]) / (n - 1)
-    return math.sqrt(variance)
-
-def vol_bucket(vol):
-    if vol < 0.00131:
-        return "very_low"
-    if vol > 0.00374:
-        return "very_high"
-    return "normal"
-
-# ── RSI (Wilder smoothing) ─────────────────────────────────────────────────────
-
-def rsi(closes, period=14):
-    if len(closes) < period + 1:
-        return None
-    gains = []
-    losses = []
-    for i in range(1, period + 1):
-        d = closes[i] - closes[i - 1]
-        gains.append(max(d, 0.0))
-        losses.append(max(-d, 0.0))
-    avg_g = sum(gains) / period
-    avg_l = sum(losses) / period
-    for i in range(period + 1, len(closes)):
-        d = closes[i] - closes[i - 1]
-        avg_g = (avg_g * (period - 1) + max(d, 0.0)) / period
-        avg_l = (avg_l * (period - 1) + max(-d, 0.0)) / period
-    if avg_l == 0.0:
-        return 100.0
-    return 100.0 - 100.0 / (1.0 + avg_g / avg_l)
-
-def rsi_bucket(r):
-    if r < 50:
-        return "low"
-    if r <= 70:
-        return "mid"
-    return "high"
-
-# ── Hit rate cube (vol × rsi × dxy → pct) ─────────────────────────────────────
-# Lookup table calibrated to USD/INR historical data.
-
-def hit_rate(vol, rsi_b, dxy):
-    if vol == "very_low":
-        if rsi_b == "low":
-            if dxy == "up":   return 43.7
-            if dxy == "down": return 32.2
-            return (43.7 + 32.2) / 2.0
-        if rsi_b == "mid":
-            if dxy == "up":   return 45.3
-            if dxy == "down": return 34.9
-            return (45.3 + 34.9) / 2.0
-        if rsi_b == "high":
-            if dxy == "up":   return 53.4
-            if dxy == "down": return 44.7
-            return (53.4 + 44.7) / 2.0
-    if vol == "normal":
-        if rsi_b == "low":
-            if dxy == "up":   return 35.0
-            if dxy == "down": return 33.5
-            return (35.0 + 33.5) / 2.0
-        if rsi_b == "mid":
-            if dxy == "up":   return 44.7
-            if dxy == "down": return 36.8
-            return (44.7 + 36.8) / 2.0
-        if rsi_b == "high":
-            if dxy == "up":   return 52.9
-            if dxy == "down": return 47.0
-            return (52.9 + 47.0) / 2.0
-    if vol == "very_high":
-        if rsi_b == "low":
-            if dxy == "up":   return 37.9
-            if dxy == "down": return 36.5
-            return (37.9 + 36.5) / 2.0
-        if rsi_b == "mid":
-            if dxy == "up":   return 40.0
-            if dxy == "down": return 32.5
-            return (40.0 + 32.5) / 2.0
-        if rsi_b == "high":
-            if dxy == "up":   return 53.1
-            if dxy == "down": return 41.2
-            return (53.1 + 41.2) / 2.0
-    return 40.0
-
-# ── Projection cone ────────────────────────────────────────────────────────────
-
-def regime_k(vb):
-    if vb == "very_low":  return 1.0
-    if vb == "very_high": return 0.5
-    return 0.75
-
-def compute_cone(current_rate, daily_vol, vb, today_day):
-    CONE_Z = 1.645
-    HORIZON_DAYS = 3
-    k = regime_k(vb)
-    target_rate = current_rate * math.exp(k * daily_vol)
-    projection = []
-    for t in range(HORIZON_DAYS + 1):
-        date_str = format_unix_day(today_day + t)
-        center = current_rate + (target_rate - current_rate) * t / HORIZON_DAYS
-        if t == 0:
-            upper = current_rate
-            lower = current_rate
-        else:
-            upper = current_rate * math.exp(CONE_Z * daily_vol * math.sqrt(t))
-            lower = current_rate * math.exp(-CONE_Z * daily_vol * math.sqrt(t))
-        projection.append({"date": date_str, "center": center, "upper": upper, "lower": lower})
-    return target_rate, projection
-
-# ── Return percentile table (USD/INR calibrated) ───────────────────────────────
-
-RETURN_PERCENTILES = [
-    [3,   [[0.01,-0.016899],[0.05,-0.007893],[0.10,-0.005139],[0.25,-0.001845],
-           [0.50, 0.000113],[0.75, 0.002414],[0.90, 0.005981],[0.95, 0.009035],
-           [0.99, 0.019432]]],
-    [7,   [[0.01,-0.023974],[0.05,-0.012192],[0.10,-0.007996],[0.25,-0.002875],
-           [0.50, 0.000299],[0.75, 0.004106],[0.90, 0.009496],[0.95, 0.014416],
-           [0.99, 0.028761]]],
-    [30,  [[0.01,-0.053051],[0.05,-0.026386],[0.10,-0.017315],[0.25,-0.006388],
-           [0.50, 0.001127],[0.75, 0.011128],[0.90, 0.023445],[0.95, 0.036908],
-           [0.99, 0.069213]]],
-    [90,  [[0.01,-0.072050],[0.05,-0.041678],[0.10,-0.029833],[0.25,-0.011556],
-           [0.50, 0.005127],[0.75, 0.022799],[0.90, 0.044823],[0.95, 0.070926],
-           [0.99, 0.140583]]],
-    [180, [[0.01,-0.109389],[0.05,-0.056501],[0.10,-0.041380],[0.25,-0.013188],
-           [0.50, 0.012416],[0.75, 0.038021],[0.90, 0.073889],[0.95, 0.114706],
-           [0.99, 0.180774]]],
-    [365, [[0.01,-0.150317],[0.05,-0.077316],[0.10,-0.054906],[0.25,-0.017094],
-           [0.50, 0.030325],[0.75, 0.073258],[0.90, 0.111315],[0.95, 0.169161],
-           [0.99, 0.225594]]],
-]
-
-def hit_rate_from_percentiles(required_move, table):
-    """Bisect-interpolate: what % of historical moves exceeded required_move?"""
-    idx = len(table)
-    for i in range(len(table)):
-        if table[i][1] >= required_move:
-            idx = i
-            break
-    if idx >= len(table):
-        return 0.0
-    if idx == 0:
-        return 100.0
-    lo_pct = table[idx - 1][0]
-    lo_ret = table[idx - 1][1]
-    hi_pct = table[idx][0]
-    hi_ret = table[idx][1]
-    frac = (required_move - lo_ret) / (hi_ret - lo_ret) if hi_ret != lo_ret else 0.0
-    at_pct = lo_pct + frac * (hi_pct - lo_pct)
-    return round((1.0 - at_pct) * 1000.0) / 10.0
-```
-
----
-
-## Action: `get_forex_historical_data`
-
-Fetch OHLCV bars for any currency pair from the Massive API.
-
-**Parameters**: `from_currency` (required), `to_currency` (required), `start_date` YYYY-MM-DD (required), `end_date` YYYY-MM-DD (optional, defaults to today), `timespan` (optional, default `day`), `multiplier` (optional, default `1`).
-
-```python
-# After helpers above:
-from_ccy = "USD"
-to_ccy   = "INR"
-start    = "2026-01-01"
-# end defaults to today:
-_now = await time(operation="now", timezone="UTC")
-today_day = today_unix_day(_now["iso"][:10])
-end = format_unix_day(today_day)
-
-pair = (from_ccy + to_ccy).upper()
-url  = f"https://api.massive.com/v2/aggs/ticker/C:{pair}/range/1/day/{start}/{end}?sort=asc&limit=5000"
-resp = await http(method="GET", url=url)
-bars, err = parse_massive_bars(resp)
-if err:
-    FINAL({"error": err})
-
-FINAL(bars)
-```
-
-**Return shape**: list of `{"date", "open", "high", "low", "close", "volume"}`.
-
----
-
-## Action: `analyze_transfer`
-
-Recommend whether to transfer USD→INR now or wait, based on volatility regime, RSI(14), and DXY direction.  
-**USD/INR calibrated only.**
-
-**Parameters**: `from_currency` (e.g. `"USD"`), `to_currency` (e.g. `"INR"`), `amount` (optional, number of units of `from_currency` the user intends to send — used to compute `could_save`).
-
-```python
-# After helpers above:
-_now = await time(operation="now", timezone="UTC")
-today_day  = today_unix_day(_now["iso"][:10])
-start_day  = today_day - 220
-start_str  = format_unix_day(start_day)
-end_str    = format_unix_day(today_day)
-
-pair        = "USDINR"
-massive_url = f"https://api.massive.com/v2/aggs/ticker/C:{pair}/range/1/day/{start_str}/{end_str}?sort=asc&limit=5000"
-now_unix    = _now["unix"]
-dxy_url     = f"https://query1.finance.yahoo.com/v8/finance/chart/DX-Y.NYB?interval=1d&period1={now_unix - 35*86400}&period2={now_unix}"
-
-massive_resp, dxy_resp = await asyncio.gather(
-    http(method="GET", url=massive_url),
-    http(method="GET", url=dxy_url, headers={"User-Agent": "Mozilla/5.0"}),
-)
-
-bars, err = parse_massive_bars(massive_resp)
-if err:
-    FINAL({"error": err})
-if len(bars) < 23:
-    FINAL({"error": f"Insufficient data: need 23 bars, got {len(bars)}"})
-
-closes = [b["close"] for b in bars]
-
-VOL_WINDOW = 20
-daily_vol  = sample_std(log_returns(closes[-VOL_WINDOW:]))
-vb         = vol_bucket(daily_vol)
-
-rsi_val = rsi(closes)
-rsi_val = round(rsi_val, 1) if rsi_val is not None else None
-rb      = rsi_bucket(rsi_val) if rsi_val is not None else "mid"
-
-dxy_dir = parse_dxy_direction(dxy_resp)
-hr      = hit_rate(vb, rb, dxy_dir if dxy_dir != "unknown" else None)
-
-current_rate = closes[-1]
-target_rate, projection = compute_cone(current_rate, daily_vol, vb, today_day)
-recommend = "now" if hr < 45.0 else "wait"
-
-historical = [{"date": b["date"], "close": b["close"]} for b in bars[-30:]]
-
-amount = amount if isinstance(amount, (int, float)) else None
-could_save = round((target_rate - current_rate) * amount, 2) if amount is not None else None
-
-action_verb = "Transfer now" if recommend == "now" else "Wait — hold off"
-FINAL({
-    "message": (
-        f"{action_verb}. USD/INR is at {current_rate:.4f}; target {round(target_rate, 4):.4f}. "
-        f"Regime: {vb} volatility, RSI {rsi_val} ({rb}), DXY {dxy_dir}. "
-        f"Hit-rate for this regime: {round(hr, 1)}%."
-        + (f" If you wait, you could get ₹{could_save:,.2f} more on your transfer." if recommend == "wait" and could_save and could_save > 0 else "")
-    ),
-    "plot": {
-        "historical":    historical,
-        "projection":    projection,
-        "current_rate":  current_rate,
-        "target_rate":   round(target_rate, 4),
-        "vol_regime":    vb,
-        "daily_vol":     round(daily_vol, 6),
-        "rsi":           rsi_val,
-        "dxy_direction": dxy_dir,
-        "hit_rate_pct":  round(hr, 1),
-        "recommend":     recommend,
-        "could_save":    could_save,
-    },
-})
-```
-
----
-
-## Action: `validate_transfer_target`
-
-Given a user's desired USD/INR rate, compute the probability of hitting it across 6 horizons.  
-**USD/INR calibrated only.**
-
-**Parameters**: `target_rate` (number, required).
-
-```python
-# After helpers above:
-target_rate_input = 86.0   # replace with user's value
-
-_now = await time(operation="now", timezone="UTC")
-today_day = today_unix_day(_now["iso"][:10])
-start_str = format_unix_day(today_day - 5)
-end_str   = format_unix_day(today_day)
-
-url  = f"https://api.massive.com/v2/aggs/ticker/C:USDINR/range/1/day/{start_str}/{end_str}?sort=asc&limit=10"
-resp = await http(method="GET", url=url)
-bars, err = parse_massive_bars(resp)
-if err:
-    FINAL({"error": err})
-
-current_rate  = bars[-1]["close"]
-required_move = math.log(target_rate_input / current_rate)
-
-horizons = []
-for entry in RETURN_PERCENTILES:
-    h_days = entry[0]
-    table  = entry[1]
-    hr     = hit_rate_from_percentiles(required_move, table)
-    horizons.append({"horizon_days": h_days, "hit_rate_pct": hr})
-
-rec_horizon = None
-for h in horizons:
-    if h["hit_rate_pct"] >= 20.0:
-        rec_horizon = h["horizon_days"]
-        break
-
-horizon_note = f"earliest horizon with ≥20% probability: {rec_horizon}d" if rec_horizon else "no horizon reaches 20% probability"
-FINAL({
-    "message": (
-        f"USD/INR is at {current_rate:.4f}. Hitting {target_rate_input:.4f} needs a "
-        f"{round(required_move * 100, 4)}% move ({horizon_note})."
-    ),
-    "plot": {
-        "current_rate":             current_rate,
-        "target_rate":              round(target_rate_input, 4),
-        "required_move_pct":        round(required_move * 100, 4),
-        "horizons":                 horizons,
-        "recommended_horizon_days": rec_horizon,
-    },
-})
-```
-
----
+### For `validate_transfer_target`:
+- Show the required move percentage
+- Present the horizon table (which horizons have reasonable probability)
+- Highlight the recommended horizon if one exists
 
 ## Rules
 
-- **Two-field response contract**: every `FINAL()` call for `analyze_transfer` and `validate_transfer_target` MUST return exactly `{"message": "...", "plot": {...}}`. `message` is the plain-English summary shown to the user. `plot` holds all numeric/chart data for the frontend — do NOT include chart fields at the top level.
-- **Execute everything in a single `repl` block**: copy the helpers, then the action code, into one fenced ` ```repl ` block and run it. Never call `http` as a standalone tool call outside of a repl block — the raw response bodies will pollute the context.
-- **Never set an `Authorization` header** — `api.massive.com` credentials are injected automatically.
-- Yahoo Finance DXY failure is always non-fatal: `parse_dxy_direction` returns `"unknown"` on any error.
-- `analyze_transfer` and `validate_transfer_target` are USD/INR only; their static tables are not valid for other pairs.
-- `get_forex_historical_data` is generic (any Massive-supported pair).
-- Always uppercase currency codes before building Massive URLs (`C:USDINR`, not `C:usdinr`).
-- Massive uses `?limit=5000` — covers 220 calendar days (~160 trading days) in a single request.
+- `analyze_transfer` and `validate_transfer_target` are USD/INR only. Don't use them for other pairs.
+- `forex_historical_data` works for any Massive-supported pair.
+- Always uppercase currency codes (USD, INR, not usd, inr).
+- Never expose raw API details, URLs, or internal field names to the user.

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1030,8 +1030,9 @@ Example:
 Respond directly with your final answer. Do not wrap your response in any special tags."#
         };
 
-        let preamble = std::env::var("AGENT_PREAMBLE")
-            .unwrap_or_else(|_| "You are IronClaw Agent, a secure autonomous assistant.".to_string());
+        let preamble = std::env::var("AGENT_PREAMBLE").unwrap_or_else(|_| {
+            "You are IronClaw Agent, a secure autonomous assistant.".to_string()
+        });
 
         format!(
             r#"{preamble}

--- a/src/tools/builtin/abound.rs
+++ b/src/tools/builtin/abound.rs
@@ -16,6 +16,7 @@ use crate::tools::tool::{
     ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
 };
 
+
 const REMITTANCE_BASE: &str = "https://devneobank.timesclub.co/times/bank/remittance/agent";
 const NOTIFICATION_BASE: &str = "https://dev.timesclub.co/times/users/agent";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -282,7 +283,7 @@ impl Tool for AboundSendWireTool {
     }
 
     fn description(&self) -> &str {
-        "Send a wire transfer via Abound. Requires funding source, beneficiary, amount, and payment reason."
+        "Send a wire transfer via Abound. ALWAYS call analyze_transfer before calling this tool. Requires funding source, beneficiary, amount, and payment reason."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/tools/builtin/abound.rs
+++ b/src/tools/builtin/abound.rs
@@ -1,0 +1,460 @@
+//! Built-in tools for the Abound remittance API.
+//!
+//! Four tools that wrap the Abound REST endpoints so the LLM can call them
+//! directly instead of constructing raw HTTP requests.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde_json::json;
+
+use crate::context::JobContext;
+use crate::secrets::SecretsStore;
+use crate::tools::tool::{
+    ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
+};
+
+const REMITTANCE_BASE: &str = "https://devneobank.timesclub.co/times/bank/remittance/agent";
+const NOTIFICATION_BASE: &str = "https://dev.timesclub.co/times/users/agent";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn shared_client() -> Result<Client, ToolError> {
+    Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| ToolError::ExecutionFailed(format!("HTTP client error: {e}")))
+}
+
+/// Validate that a string is a 3-letter uppercase currency code (ISO 4217).
+fn validate_currency_code(s: &str) -> Result<String, ToolError> {
+    let upper = s.to_uppercase();
+    if upper.len() == 3 && upper.chars().all(|c| c.is_ascii_uppercase()) {
+        Ok(upper)
+    } else {
+        Err(ToolError::InvalidParameters(format!(
+            "Invalid currency code: {s}"
+        )))
+    }
+}
+
+async fn abound_credentials(
+    secrets: &dyn SecretsStore,
+    user_id: &str,
+) -> Result<(String, String), ToolError> {
+    let bearer = secrets
+        .get_decrypted(user_id, "abound_read_token")
+        .await
+        .map_err(|_| {
+            ToolError::NotAuthorized(
+                "Missing abound_read_token. Set with: ironclaw secret set abound_read_token <TOKEN>"
+                    .into(),
+            )
+        })?;
+    let api_key = secrets
+        .get_decrypted(user_id, "abound_api_key")
+        .await
+        .map_err(|_| {
+            ToolError::NotAuthorized(
+                "Missing abound_api_key. Set with: ironclaw secret set abound_api_key <KEY>".into(),
+            )
+        })?;
+    Ok((bearer.expose().to_owned(), api_key.expose().to_owned()))
+}
+
+async fn abound_get(
+    client: &Client,
+    secrets: &dyn SecretsStore,
+    user_id: &str,
+    url: &str,
+) -> Result<serde_json::Value, ToolError> {
+    let (bearer, api_key) = abound_credentials(secrets, user_id).await?;
+
+    let resp = client
+        .get(url)
+        .header("Authorization", format!("Bearer {bearer}"))
+        .header("X-API-KEY", &api_key)
+        .header("device-type", "WEB")
+        .send()
+        .await
+        .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+    let body: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+
+    Ok(json!({ "status": status, "body": body }))
+}
+
+async fn abound_post(
+    client: &Client,
+    secrets: &dyn SecretsStore,
+    user_id: &str,
+    url: &str,
+    body: &serde_json::Value,
+) -> Result<serde_json::Value, ToolError> {
+    let (bearer, api_key) = abound_credentials(secrets, user_id).await?;
+
+    let resp = client
+        .post(url)
+        .header("Authorization", format!("Bearer {bearer}"))
+        .header("X-API-KEY", &api_key)
+        .header("device-type", "WEB")
+        .header("Content-Type", "application/json")
+        .json(body)
+        .send()
+        .await
+        .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    let text = resp
+        .text()
+        .await
+        .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+    let body: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or(serde_json::Value::String(text));
+
+    Ok(json!({ "status": status, "body": body }))
+}
+
+// ===========================================================================
+// abound_account_info
+// ===========================================================================
+
+pub struct AboundAccountInfoTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl AboundAccountInfoTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for AboundAccountInfoTool {
+    fn name(&self) -> &str {
+        "abound_account_info"
+    }
+
+    fn description(&self) -> &str {
+        "Get Abound account information including limits, saved recipients, and funding sources."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
+    }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let url = format!("{REMITTANCE_BASE}/account/info");
+        let result = abound_get(&self.client, &*self.secrets, &ctx.user_id, &url).await?;
+        Ok(ToolOutput::success(result, start.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Low
+    }
+}
+
+// ===========================================================================
+// abound_exchange_rate
+// ===========================================================================
+
+pub struct AboundExchangeRateTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl AboundExchangeRateTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for AboundExchangeRateTool {
+    fn name(&self) -> &str {
+        "abound_exchange_rate"
+    }
+
+    fn description(&self) -> &str {
+        "Get the current exchange rate for a currency pair from Abound (e.g. USD to INR)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "from_currency": {
+                    "type": "string",
+                    "description": "Source currency code, e.g. USD"
+                },
+                "to_currency": {
+                    "type": "string",
+                    "description": "Target currency code, e.g. INR"
+                }
+            },
+            "required": ["from_currency", "to_currency"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let from = validate_currency_code(require_str(&params, "from_currency")?)?;
+        let to = validate_currency_code(require_str(&params, "to_currency")?)?;
+        let url = format!("{REMITTANCE_BASE}/exchange-rate?from_currency={from}&to_currency={to}");
+        let result = abound_get(&self.client, &*self.secrets, &ctx.user_id, &url).await?;
+        Ok(ToolOutput::success(result, start.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Low
+    }
+}
+
+// ===========================================================================
+// abound_send_wire
+// ===========================================================================
+
+pub struct AboundSendWireTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl AboundSendWireTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for AboundSendWireTool {
+    fn name(&self) -> &str {
+        "abound_send_wire"
+    }
+
+    fn description(&self) -> &str {
+        "Send a wire transfer via Abound. Requires funding source, beneficiary, amount, and payment reason."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "funding_source_id": {
+                    "type": "string",
+                    "description": "Funding source ID from account info"
+                },
+                "beneficiary_ref_id": {
+                    "type": "string",
+                    "description": "Beneficiary reference ID from account info"
+                },
+                "amount": {
+                    "type": "number",
+                    "description": "Amount in source currency (e.g. USD)"
+                },
+                "payment_reason_key": {
+                    "type": "string",
+                    "description": "Payment reason key from account info (e.g. family_maintenance, gift, education_support, medical_support)"
+                }
+            },
+            "required": ["funding_source_id", "beneficiary_ref_id", "amount", "payment_reason_key"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let funding_source_id = require_str(&params, "funding_source_id")?;
+        let beneficiary_ref_id = require_str(&params, "beneficiary_ref_id")?;
+        let amount = params
+            .get("amount")
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| ToolError::InvalidParameters("amount must be a number".into()))?;
+        let payment_reason_key = require_str(&params, "payment_reason_key")?;
+
+        let body = json!({
+            "funding_source_id": funding_source_id,
+            "beneficiary_ref_id": beneficiary_ref_id,
+            "amount": amount,
+            "payment_reason_key": payment_reason_key,
+        });
+
+        let url = format!("{REMITTANCE_BASE}/send-wire");
+        let result = abound_post(&self.client, &*self.secrets, &ctx.user_id, &url, &body).await?;
+        Ok(ToolOutput::success(result, start.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::High
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        ApprovalRequirement::Always
+    }
+}
+
+// ===========================================================================
+// abound_create_notification
+// ===========================================================================
+
+pub struct AboundCreateNotificationTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl AboundCreateNotificationTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for AboundCreateNotificationTool {
+    fn name(&self) -> &str {
+        "abound_create_notification"
+    }
+
+    fn description(&self) -> &str {
+        "Send a notification through Abound (e.g. after a successful transfer)."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "message_id": {
+                    "type": "string",
+                    "description": "Unique message identifier"
+                },
+                "action_type": {
+                    "type": "string",
+                    "description": "Notification action type (e.g. notification)"
+                },
+                "meta_data": {
+                    "type": "object",
+                    "description": "Additional metadata for the notification"
+                }
+            },
+            "required": ["message_id", "action_type"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let message_id = require_str(&params, "message_id")?;
+        let action_type = require_str(&params, "action_type")?;
+        let meta_data = params
+            .get("meta_data")
+            .cloned()
+            .unwrap_or_else(|| json!({}));
+
+        let body = json!({
+            "message_id": message_id,
+            "action_type": action_type,
+            "meta_data": meta_data,
+        });
+
+        let url = format!("{NOTIFICATION_BASE}/create-notification");
+        let result = abound_post(&self.client, &*self.secrets, &ctx.user_id, &url, &body).await?;
+        Ok(ToolOutput::success(result, start.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Medium
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_currency_code_valid() {
+        assert_eq!(validate_currency_code("USD").unwrap(), "USD");
+        assert_eq!(validate_currency_code("inr").unwrap(), "INR");
+    }
+
+    #[test]
+    fn test_validate_currency_code_rejects_injection() {
+        assert!(validate_currency_code("USD/../../admin").is_err());
+        assert!(validate_currency_code("U$D").is_err());
+        assert!(validate_currency_code("AB").is_err());
+        assert!(validate_currency_code("ABCDE").is_err());
+        assert!(validate_currency_code("").is_err());
+    }
+}

--- a/src/tools/builtin/abound.rs
+++ b/src/tools/builtin/abound.rs
@@ -16,6 +16,8 @@ use crate::tools::tool::{
     ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
 };
 
+use super::validate_currency_code;
+
 
 const REMITTANCE_BASE: &str = "https://devneobank.timesclub.co/times/bank/remittance/agent";
 const NOTIFICATION_BASE: &str = "https://dev.timesclub.co/times/users/agent";
@@ -30,18 +32,6 @@ fn shared_client() -> Result<Client, ToolError> {
         .timeout(REQUEST_TIMEOUT)
         .build()
         .map_err(|e| ToolError::ExecutionFailed(format!("HTTP client error: {e}")))
-}
-
-/// Validate that a string is a 3-letter uppercase currency code (ISO 4217).
-fn validate_currency_code(s: &str) -> Result<String, ToolError> {
-    let upper = s.to_uppercase();
-    if upper.len() == 3 && upper.chars().all(|c| c.is_ascii_uppercase()) {
-        Ok(upper)
-    } else {
-        Err(ToolError::InvalidParameters(format!(
-            "Invalid currency code: {s}"
-        )))
-    }
 }
 
 async fn abound_credentials(

--- a/src/tools/builtin/forex.rs
+++ b/src/tools/builtin/forex.rs
@@ -1,0 +1,1004 @@
+//! Built-in tools for USD/INR forex transfer analysis.
+//!
+//! Three tools that wrap the Massive API for OHLCV data and Yahoo Finance for
+//! DXY direction, plus all the volatility/RSI/hit-rate math so the LLM doesn't
+//! have to write Python in a repl block.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use chrono::Datelike;
+use reqwest::Client;
+use serde_json::json;
+
+use crate::context::JobContext;
+use crate::secrets::SecretsStore;
+use crate::tools::tool::{Tool, ToolDomain, ToolError, ToolOutput, require_str};
+
+const MASSIVE_BASE: &str = "https://api.massive.com/v2/aggs/ticker";
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// HTTP helpers
+// ---------------------------------------------------------------------------
+
+fn shared_client() -> Result<Client, ToolError> {
+    Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .map_err(|e| ToolError::ExecutionFailed(format!("HTTP client error: {e}")))
+}
+
+async fn massive_bearer(secrets: &dyn SecretsStore, user_id: &str) -> Result<String, ToolError> {
+    let secret = secrets
+        .get_decrypted(user_id, "massive_api_key")
+        .await
+        .map_err(|_| {
+            ToolError::NotAuthorized(
+                "Missing massive_api_key. Set with: ironclaw secret set massive_api_key <KEY>"
+                    .into(),
+            )
+        })?;
+    Ok(secret.expose().to_owned())
+}
+
+/// Validate that a string is a 3-letter uppercase currency code (ISO 4217).
+fn validate_currency_code(s: &str) -> Result<String, ToolError> {
+    let upper = s.to_uppercase();
+    if upper.len() == 3 && upper.chars().all(|c| c.is_ascii_uppercase()) {
+        Ok(upper)
+    } else {
+        Err(ToolError::InvalidParameters(format!(
+            "Invalid currency code: {s}"
+        )))
+    }
+}
+
+/// Parse and validate a YYYY-MM-DD date string. Returns the validated string.
+fn validate_date(s: &str) -> Result<String, ToolError> {
+    chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .map_err(|_| {
+            ToolError::InvalidParameters(format!("Invalid date (expected YYYY-MM-DD): {s}"))
+        })
+}
+
+// ---------------------------------------------------------------------------
+// Date arithmetic (pure, no std::time — mirrors the Python helpers)
+// ---------------------------------------------------------------------------
+
+fn unix_day_from_ymd(y: i32, m: i32, d: i32) -> i64 {
+    let (y2, m2) = if m <= 2 { (y - 1, m + 12) } else { (y, m) };
+    let a = y2 / 100;
+    let b = 2 - a + a / 4;
+    let jd = (365.25 * (y2 + 4716) as f64) as i64
+        + (30.6001 * (m2 + 1) as f64) as i64
+        + d as i64
+        + b as i64
+        - 1524;
+    jd - 2_440_588
+}
+
+fn format_unix_day(n: i64) -> String {
+    let z = n + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{y:04}-{m:02}-{d:02}")
+}
+
+fn today_unix_day_from_chrono(now: &chrono::DateTime<chrono::Utc>) -> i64 {
+    let d = now.date_naive();
+    unix_day_from_ymd(d.year(), d.month() as i32, d.day() as i32)
+}
+
+fn ms_to_date_str(ms: i64) -> String {
+    format_unix_day(ms / 86_400_000)
+}
+
+// ---------------------------------------------------------------------------
+// Massive API response parsing
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct Bar {
+    date: String,
+    open: f64,
+    high: f64,
+    low: f64,
+    close: f64,
+    volume: f64,
+}
+
+fn parse_massive_bars(resp_body: &serde_json::Value) -> Result<Vec<Bar>, ToolError> {
+    let results = resp_body
+        .get("results")
+        .and_then(|v| v.as_array())
+        .ok_or_else(|| ToolError::ExternalService("Massive API: no results returned".into()))?;
+
+    let mut bars = Vec::with_capacity(results.len());
+    for r in results {
+        let close = r["c"].as_f64().filter(|&c| c > 0.0).ok_or_else(|| {
+            ToolError::ExternalService("Massive API: bar missing or zero close price".into())
+        })?;
+        bars.push(Bar {
+            date: ms_to_date_str(r["t"].as_i64().unwrap_or(0)),
+            open: r["o"].as_f64().unwrap_or(0.0),
+            high: r["h"].as_f64().unwrap_or(0.0),
+            low: r["l"].as_f64().unwrap_or(0.0),
+            close,
+            volume: r["v"].as_f64().unwrap_or(0.0),
+        });
+    }
+    Ok(bars)
+}
+
+// ---------------------------------------------------------------------------
+// Yahoo Finance DXY direction
+// ---------------------------------------------------------------------------
+
+fn parse_dxy_direction(body: &serde_json::Value) -> &'static str {
+    const DXY_WINDOW: usize = 5;
+    let closes: Vec<f64> = (|| {
+        let result = body.get("chart")?.get("result")?.as_array()?;
+        let quotes = result
+            .first()?
+            .get("indicators")?
+            .get("quote")?
+            .as_array()?;
+        let raw = quotes.first()?.get("close")?.as_array()?;
+        Some(raw.iter().filter_map(|v| v.as_f64()).collect::<Vec<_>>())
+    })()
+    .unwrap_or_default();
+
+    if closes.len() < DXY_WINDOW + 1 {
+        return "unknown";
+    }
+    let change = closes[closes.len() - 1] / closes[closes.len() - DXY_WINDOW - 1] - 1.0;
+    if change >= 0.0 { "up" } else { "down" }
+}
+
+// ---------------------------------------------------------------------------
+// Volatility, RSI, hit-rate cube, projection cone
+// ---------------------------------------------------------------------------
+
+fn log_returns(closes: &[f64]) -> Vec<f64> {
+    closes.windows(2).map(|w| (w[1] / w[0]).ln()).collect()
+}
+
+fn sample_std(values: &[f64]) -> f64 {
+    let n = values.len();
+    if n < 2 {
+        return 0.0;
+    }
+    let mean = values.iter().sum::<f64>() / n as f64;
+    let variance = values.iter().map(|v| (v - mean).powi(2)).sum::<f64>() / (n - 1) as f64;
+    variance.sqrt()
+}
+
+fn vol_bucket(vol: f64) -> &'static str {
+    if vol < 0.001_31 {
+        "very_low"
+    } else if vol > 0.003_74 {
+        "very_high"
+    } else {
+        "normal"
+    }
+}
+
+fn rsi(closes: &[f64], period: usize) -> Option<f64> {
+    if closes.len() < period + 1 {
+        return None;
+    }
+    let mut avg_g: f64 = 0.0;
+    let mut avg_l: f64 = 0.0;
+    for i in 1..=period {
+        let d = closes[i] - closes[i - 1];
+        avg_g += d.max(0.0);
+        avg_l += (-d).max(0.0);
+    }
+    avg_g /= period as f64;
+    avg_l /= period as f64;
+
+    for i in (period + 1)..closes.len() {
+        let d = closes[i] - closes[i - 1];
+        avg_g = (avg_g * (period - 1) as f64 + d.max(0.0)) / period as f64;
+        avg_l = (avg_l * (period - 1) as f64 + (-d).max(0.0)) / period as f64;
+    }
+
+    if avg_l == 0.0 {
+        return Some(100.0);
+    }
+    Some(100.0 - 100.0 / (1.0 + avg_g / avg_l))
+}
+
+fn rsi_bucket(r: f64) -> &'static str {
+    if r < 50.0 {
+        "low"
+    } else if r <= 70.0 {
+        "mid"
+    } else {
+        "high"
+    }
+}
+
+fn hit_rate(vol: &str, rsi_b: &str, dxy: &str) -> f64 {
+    let avg = |a: f64, b: f64| (a + b) / 2.0;
+    match (vol, rsi_b, dxy) {
+        ("very_low", "low", "up") => 43.7,
+        ("very_low", "low", "down") => 32.2,
+        ("very_low", "low", _) => avg(43.7, 32.2),
+        ("very_low", "mid", "up") => 45.3,
+        ("very_low", "mid", "down") => 34.9,
+        ("very_low", "mid", _) => avg(45.3, 34.9),
+        ("very_low", "high", "up") => 53.4,
+        ("very_low", "high", "down") => 44.7,
+        ("very_low", "high", _) => avg(53.4, 44.7),
+
+        ("normal", "low", "up") => 35.0,
+        ("normal", "low", "down") => 33.5,
+        ("normal", "low", _) => avg(35.0, 33.5),
+        ("normal", "mid", "up") => 44.7,
+        ("normal", "mid", "down") => 36.8,
+        ("normal", "mid", _) => avg(44.7, 36.8),
+        ("normal", "high", "up") => 52.9,
+        ("normal", "high", "down") => 47.0,
+        ("normal", "high", _) => avg(52.9, 47.0),
+
+        ("very_high", "low", "up") => 37.9,
+        ("very_high", "low", "down") => 36.5,
+        ("very_high", "low", _) => avg(37.9, 36.5),
+        ("very_high", "mid", "up") => 40.0,
+        ("very_high", "mid", "down") => 32.5,
+        ("very_high", "mid", _) => avg(40.0, 32.5),
+        ("very_high", "high", "up") => 53.1,
+        ("very_high", "high", "down") => 41.2,
+        ("very_high", "high", _) => avg(53.1, 41.2),
+
+        _ => 40.0,
+    }
+}
+
+fn regime_k(vb: &str) -> f64 {
+    match vb {
+        "very_low" => 1.0,
+        "very_high" => 0.5,
+        _ => 0.75,
+    }
+}
+
+fn compute_cone(
+    current_rate: f64,
+    daily_vol: f64,
+    vb: &str,
+    today_day: i64,
+) -> (f64, Vec<serde_json::Value>) {
+    const CONE_Z: f64 = 1.645;
+    const HORIZON_DAYS: i64 = 3;
+
+    let k = regime_k(vb);
+    let target_rate = current_rate * (k * daily_vol).exp();
+
+    let mut projection = Vec::new();
+    for t in 0..=HORIZON_DAYS {
+        let date_str = format_unix_day(today_day + t);
+        let center = current_rate + (target_rate - current_rate) * t as f64 / HORIZON_DAYS as f64;
+        let (upper, lower) = if t == 0 {
+            (current_rate, current_rate)
+        } else {
+            let spread = CONE_Z * daily_vol * (t as f64).sqrt();
+            (current_rate * spread.exp(), current_rate * (-spread).exp())
+        };
+        projection.push(json!({
+            "date": date_str,
+            "center": center,
+            "upper": upper,
+            "lower": lower,
+        }));
+    }
+    (target_rate, projection)
+}
+
+// ---------------------------------------------------------------------------
+// Return percentile table (USD/INR calibrated)
+// ---------------------------------------------------------------------------
+
+type PercentileRow = (f64, f64); // (percentile, return)
+
+struct HorizonTable {
+    days: i32,
+    rows: &'static [PercentileRow],
+}
+
+static RETURN_PERCENTILES: &[HorizonTable] = &[
+    HorizonTable {
+        days: 3,
+        rows: &[
+            (0.01, -0.016_899),
+            (0.05, -0.007_893),
+            (0.10, -0.005_139),
+            (0.25, -0.001_845),
+            (0.50, 0.000_113),
+            (0.75, 0.002_414),
+            (0.90, 0.005_981),
+            (0.95, 0.009_035),
+            (0.99, 0.019_432),
+        ],
+    },
+    HorizonTable {
+        days: 7,
+        rows: &[
+            (0.01, -0.023_974),
+            (0.05, -0.012_192),
+            (0.10, -0.007_996),
+            (0.25, -0.002_875),
+            (0.50, 0.000_299),
+            (0.75, 0.004_106),
+            (0.90, 0.009_496),
+            (0.95, 0.014_416),
+            (0.99, 0.028_761),
+        ],
+    },
+    HorizonTable {
+        days: 30,
+        rows: &[
+            (0.01, -0.053_051),
+            (0.05, -0.026_386),
+            (0.10, -0.017_315),
+            (0.25, -0.006_388),
+            (0.50, 0.001_127),
+            (0.75, 0.011_128),
+            (0.90, 0.023_445),
+            (0.95, 0.036_908),
+            (0.99, 0.069_213),
+        ],
+    },
+    HorizonTable {
+        days: 90,
+        rows: &[
+            (0.01, -0.072_050),
+            (0.05, -0.041_678),
+            (0.10, -0.029_833),
+            (0.25, -0.011_556),
+            (0.50, 0.005_127),
+            (0.75, 0.022_799),
+            (0.90, 0.044_823),
+            (0.95, 0.070_926),
+            (0.99, 0.140_583),
+        ],
+    },
+    HorizonTable {
+        days: 180,
+        rows: &[
+            (0.01, -0.109_389),
+            (0.05, -0.056_501),
+            (0.10, -0.041_380),
+            (0.25, -0.013_188),
+            (0.50, 0.012_416),
+            (0.75, 0.038_021),
+            (0.90, 0.073_889),
+            (0.95, 0.114_706),
+            (0.99, 0.180_774),
+        ],
+    },
+    HorizonTable {
+        days: 365,
+        rows: &[
+            (0.01, -0.150_317),
+            (0.05, -0.077_316),
+            (0.10, -0.054_906),
+            (0.25, -0.017_094),
+            (0.50, 0.030_325),
+            (0.75, 0.073_258),
+            (0.90, 0.111_315),
+            (0.95, 0.169_161),
+            (0.99, 0.225_594),
+        ],
+    },
+];
+
+fn hit_rate_from_percentiles(required_move: f64, table: &[PercentileRow]) -> f64 {
+    let idx = table.iter().position(|&(_, ret)| ret >= required_move);
+    match idx {
+        None => 0.0,
+        Some(0) => 100.0,
+        Some(i) => {
+            let (lo_pct, lo_ret) = table[i - 1];
+            let (hi_pct, hi_ret) = table[i];
+            let frac = if (hi_ret - lo_ret).abs() > f64::EPSILON {
+                (required_move - lo_ret) / (hi_ret - lo_ret)
+            } else {
+                0.0
+            };
+            let at_pct = lo_pct + frac * (hi_pct - lo_pct);
+            ((1.0 - at_pct) * 1000.0).round() / 10.0
+        }
+    }
+}
+
+// ===========================================================================
+// forex_historical_data
+// ===========================================================================
+
+pub struct ForexHistoricalDataTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl ForexHistoricalDataTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for ForexHistoricalDataTool {
+    fn name(&self) -> &str {
+        "forex_historical_data"
+    }
+
+    fn description(&self) -> &str {
+        "Fetch historical OHLCV forex data for a currency pair from the Massive API."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "from_currency": {
+                    "type": "string",
+                    "description": "Source currency code, e.g. USD"
+                },
+                "to_currency": {
+                    "type": "string",
+                    "description": "Target currency code, e.g. INR"
+                },
+                "start_date": {
+                    "type": "string",
+                    "description": "Start date in YYYY-MM-DD format"
+                },
+                "end_date": {
+                    "type": "string",
+                    "description": "End date in YYYY-MM-DD format (defaults to today)"
+                }
+            },
+            "required": ["from_currency", "to_currency", "start_date"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let from = validate_currency_code(require_str(&params, "from_currency")?)?;
+        let to = validate_currency_code(require_str(&params, "to_currency")?)?;
+        let start_date = validate_date(require_str(&params, "start_date")?)?;
+        let end_date = match params.get("end_date").and_then(|v| v.as_str()) {
+            Some(s) if !s.is_empty() => validate_date(s)?,
+            _ => chrono::Utc::now().format("%Y-%m-%d").to_string(),
+        };
+
+        let pair = format!("{from}{to}");
+        let url = format!(
+            "{MASSIVE_BASE}/C:{pair}/range/1/day/{start_date}/{end_date}?sort=asc&limit=5000"
+        );
+
+        let bearer = massive_bearer(&*self.secrets, &ctx.user_id).await?;
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .send()
+            .await
+            .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+
+        let status = resp.status().as_u16();
+        if status != 200 {
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ToolError::ExternalService(format!(
+                "Massive API HTTP {status}: {body}"
+            )));
+        }
+
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+
+        let bars = parse_massive_bars(&body)?;
+        let bars_json: Vec<serde_json::Value> = bars
+            .iter()
+            .map(|b| {
+                json!({
+                    "date": b.date,
+                    "open": b.open,
+                    "high": b.high,
+                    "low": b.low,
+                    "close": b.close,
+                    "volume": b.volume,
+                })
+            })
+            .collect();
+
+        Ok(ToolOutput::success(json!(bars_json), start.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+}
+
+// ===========================================================================
+// analyze_transfer
+// ===========================================================================
+
+pub struct AnalyzeTransferTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl AnalyzeTransferTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for AnalyzeTransferTool {
+    fn name(&self) -> &str {
+        "analyze_transfer"
+    }
+
+    fn description(&self) -> &str {
+        "Analyze whether to transfer USD to INR now or wait. Uses volatility regime, RSI(14), \
+         and DXY momentum to compute a hit rate, target rate, and 3-day projection cone. \
+         USD/INR only."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "amount": {
+                    "type": "number",
+                    "description": "Optional USD amount the user intends to send. Potential savings are returned in INR."
+                }
+            },
+            "required": []
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let timer = Instant::now();
+        let amount = params.get("amount").and_then(|v| v.as_f64());
+
+        let now = chrono::Utc::now();
+        let td = today_unix_day_from_chrono(&now);
+        let start_str = format_unix_day(td - 220);
+        let end_str = now.format("%Y-%m-%d").to_string();
+
+        let massive_url = format!(
+            "{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{end_str}?sort=asc&limit=5000"
+        );
+        let now_unix = now.timestamp();
+        let dxy_url = format!(
+            "https://query1.finance.yahoo.com/v8/finance/chart/DX-Y.NYB?interval=1d&period1={}&period2={now_unix}",
+            now_unix - 35 * 86400,
+        );
+
+        let bearer = massive_bearer(&*self.secrets, &ctx.user_id).await?;
+
+        // Fetch Massive + DXY in parallel
+        let (massive_resp, dxy_resp) = tokio::join!(
+            self.client
+                .get(&massive_url)
+                .header("Authorization", format!("Bearer {bearer}"))
+                .send(),
+            self.client
+                .get(&dxy_url)
+                .header("User-Agent", "Mozilla/5.0")
+                .send(),
+        );
+
+        // Parse Massive response
+        let massive_resp = massive_resp.map_err(|e| ToolError::ExternalService(e.to_string()))?;
+        if massive_resp.status().as_u16() != 200 {
+            return Err(ToolError::ExternalService(format!(
+                "Massive API HTTP {}",
+                massive_resp.status()
+            )));
+        }
+        let massive_body: serde_json::Value = massive_resp
+            .json()
+            .await
+            .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+        let bars = parse_massive_bars(&massive_body)?;
+        if bars.len() < 23 {
+            return Err(ToolError::ExternalService(format!(
+                "Insufficient data: need 23 bars, got {}",
+                bars.len()
+            )));
+        }
+
+        // Parse DXY (non-fatal)
+        let dxy_dir = match dxy_resp {
+            Ok(r) => match r.json::<serde_json::Value>().await {
+                Ok(body) => parse_dxy_direction(&body),
+                Err(_) => "unknown",
+            },
+            Err(_) => "unknown",
+        };
+
+        // Compute indicators
+        let closes: Vec<f64> = bars.iter().map(|b| b.close).collect();
+        let vol_window = 20;
+        let vol_slice = &closes[closes.len().saturating_sub(vol_window)..];
+        let daily_vol = sample_std(&log_returns(vol_slice));
+        let vb = vol_bucket(daily_vol);
+
+        let rsi_val = rsi(&closes, 14);
+        let rsi_rounded = rsi_val.map(|r| (r * 10.0).round() / 10.0);
+        let rb = rsi_val.map(rsi_bucket).unwrap_or("mid");
+
+        let hr = hit_rate(vb, rb, dxy_dir);
+        let current_rate = closes[closes.len() - 1];
+        let (target_rate, projection) = compute_cone(current_rate, daily_vol, vb, td);
+        let recommend = if hr < 45.0 { "now" } else { "wait" };
+
+        let historical: Vec<serde_json::Value> = bars[bars.len().saturating_sub(30)..]
+            .iter()
+            .map(|b| json!({"date": b.date, "close": b.close}))
+            .collect();
+
+        // Potential savings in INR if user waits
+        let could_save = if recommend == "wait" {
+            amount.map(|a| ((target_rate - current_rate) * a * 100.0).round() / 100.0)
+        } else {
+            None
+        };
+
+        let action_verb = if recommend == "now" {
+            "Transfer now"
+        } else {
+            "Wait — hold off"
+        };
+        let mut message = format!(
+            "{action_verb}. USD/INR is at {current_rate:.4}; target {:.4}. \
+             Regime: {vb} volatility, RSI {} ({rb}), DXY {dxy_dir}. \
+             Hit-rate for this regime: {:.1}%.",
+            (target_rate * 10000.0).round() / 10000.0,
+            rsi_rounded
+                .map(|r| format!("{r}"))
+                .unwrap_or_else(|| "N/A".into()),
+            (hr * 10.0).round() / 10.0,
+        );
+        if let Some(save) = could_save
+            && save > 0.0
+        {
+            message.push_str(&format!(
+                " If you wait, you could get ₹{save:.2} more on your transfer."
+            ));
+        }
+
+        let result = json!({
+            "message": message,
+            "plot": {
+                "historical": historical,
+                "projection": projection,
+                "current_rate": current_rate,
+                "target_rate": (target_rate * 10000.0).round() / 10000.0,
+                "vol_regime": vb,
+                "daily_vol": (daily_vol * 1_000_000.0).round() / 1_000_000.0,
+                "rsi": rsi_rounded,
+                "dxy_direction": dxy_dir,
+                "hit_rate_pct": (hr * 10.0).round() / 10.0,
+                "recommend": recommend,
+                "could_save": could_save,
+            }
+        });
+
+        Ok(ToolOutput::success(result, timer.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+}
+
+// ===========================================================================
+// validate_transfer_target
+// ===========================================================================
+
+pub struct ValidateTransferTargetTool {
+    secrets: Arc<dyn SecretsStore + Send + Sync>,
+    client: Client,
+}
+
+impl ValidateTransferTargetTool {
+    pub fn new(secrets: Arc<dyn SecretsStore + Send + Sync>) -> Result<Self, ToolError> {
+        Ok(Self {
+            secrets,
+            client: shared_client()?,
+        })
+    }
+}
+
+#[async_trait]
+impl Tool for ValidateTransferTargetTool {
+    fn name(&self) -> &str {
+        "validate_transfer_target"
+    }
+
+    fn description(&self) -> &str {
+        "Given a desired USD/INR rate, compute the probability of hitting it across \
+         6 time horizons (3d, 7d, 30d, 90d, 180d, 365d). USD/INR only."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "target_rate": {
+                    "type": "number",
+                    "description": "The desired USD/INR exchange rate"
+                }
+            },
+            "required": ["target_rate"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let timer = Instant::now();
+        let target_rate_input = params
+            .get("target_rate")
+            .and_then(|v| v.as_f64())
+            .ok_or_else(|| ToolError::InvalidParameters("target_rate must be a number".into()))?;
+
+        let now = chrono::Utc::now();
+        let td = today_unix_day_from_chrono(&now);
+        let start_str = format_unix_day(td - 5);
+        let today_str = now.format("%Y-%m-%d").to_string();
+
+        let url = format!(
+            "{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{today_str}?sort=asc&limit=10"
+        );
+
+        let bearer = massive_bearer(&*self.secrets, &ctx.user_id).await?;
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("Authorization", format!("Bearer {bearer}"))
+            .send()
+            .await
+            .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+
+        if resp.status().as_u16() != 200 {
+            return Err(ToolError::ExternalService(format!(
+                "Massive API HTTP {}",
+                resp.status()
+            )));
+        }
+        let body: serde_json::Value = resp
+            .json()
+            .await
+            .map_err(|e| ToolError::ExternalService(e.to_string()))?;
+        let bars = parse_massive_bars(&body)?;
+        if bars.is_empty() {
+            return Err(ToolError::ExternalService(
+                "Massive API returned no bars".into(),
+            ));
+        }
+
+        // close is guaranteed > 0.0 by parse_massive_bars
+        let current_rate = bars.last().map(|b| b.close).unwrap_or(1.0);
+        let required_move = (target_rate_input / current_rate).ln();
+
+        let mut horizons = Vec::new();
+        let mut rec_horizon: Option<i32> = None;
+        for entry in RETURN_PERCENTILES {
+            let hr = hit_rate_from_percentiles(required_move, entry.rows);
+            horizons.push(json!({
+                "horizon_days": entry.days,
+                "hit_rate_pct": hr,
+            }));
+            if rec_horizon.is_none() && hr >= 20.0 {
+                rec_horizon = Some(entry.days);
+            }
+        }
+
+        let horizon_note = match rec_horizon {
+            Some(d) => format!("earliest horizon with ≥20% probability: {d}d"),
+            None => "no horizon reaches 20% probability".into(),
+        };
+
+        let message = format!(
+            "USD/INR is at {current_rate:.4}. Hitting {target_rate_input:.4} needs a \
+             {:.4}% move ({horizon_note}).",
+            (required_move * 100.0 * 10000.0).round() / 10000.0,
+        );
+
+        let result = json!({
+            "message": message,
+            "plot": {
+                "current_rate": current_rate,
+                "target_rate": (target_rate_input * 10000.0).round() / 10000.0,
+                "required_move_pct": (required_move * 100.0 * 10000.0).round() / 10000.0,
+                "horizons": horizons,
+                "recommended_horizon_days": rec_horizon,
+            }
+        });
+
+        Ok(ToolOutput::success(result, timer.elapsed()))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        true
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unix_day_roundtrip() {
+        let day = unix_day_from_ymd(2026, 4, 8);
+        assert_eq!(format_unix_day(day), "2026-04-08");
+    }
+
+    #[test]
+    fn test_vol_bucket_boundaries() {
+        assert_eq!(vol_bucket(0.001), "very_low");
+        assert_eq!(vol_bucket(0.002), "normal");
+        assert_eq!(vol_bucket(0.004), "very_high");
+    }
+
+    #[test]
+    fn test_rsi_all_gains() {
+        // Monotonically increasing closes → RSI should be 100
+        let closes: Vec<f64> = (0..20).map(|i| 80.0 + i as f64).collect();
+        let r = rsi(&closes, 14).unwrap();
+        assert!((r - 100.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_rsi_insufficient_data() {
+        let closes = vec![1.0, 2.0, 3.0];
+        assert!(rsi(&closes, 14).is_none());
+    }
+
+    #[test]
+    fn test_hit_rate_cube_lookup() {
+        assert!((hit_rate("normal", "mid", "up") - 44.7).abs() < f64::EPSILON);
+        assert!((hit_rate("very_low", "high", "down") - 44.7).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_hit_rate_from_percentiles_extremes() {
+        let table: &[PercentileRow] = &[(0.01, -0.016_899), (0.50, 0.000_113), (0.99, 0.019_432)];
+        // Very negative move → 100% chance of exceeding
+        assert!((hit_rate_from_percentiles(-1.0, table) - 100.0).abs() < f64::EPSILON);
+        // Very large move → 0% chance
+        assert!((hit_rate_from_percentiles(1.0, table)).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_dxy_direction_up() {
+        let body = json!({
+            "chart": {
+                "result": [{
+                    "indicators": {
+                        "quote": [{
+                            "close": [100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0]
+                        }]
+                    }
+                }]
+            }
+        });
+        assert_eq!(parse_dxy_direction(&body), "up");
+    }
+
+    #[test]
+    fn test_dxy_direction_down() {
+        let body = json!({
+            "chart": {
+                "result": [{
+                    "indicators": {
+                        "quote": [{
+                            "close": [106.0, 105.0, 104.0, 103.0, 102.0, 101.0, 100.0]
+                        }]
+                    }
+                }]
+            }
+        });
+        assert_eq!(parse_dxy_direction(&body), "down");
+    }
+
+    #[test]
+    fn test_dxy_direction_insufficient_data() {
+        let body = json!({"chart": {"result": [{"indicators": {"quote": [{"close": [100.0]}]}}]}});
+        assert_eq!(parse_dxy_direction(&body), "unknown");
+    }
+
+    #[test]
+    fn test_log_returns() {
+        let closes = vec![100.0, 110.0, 121.0];
+        let rets = log_returns(&closes);
+        assert_eq!(rets.len(), 2);
+        assert!((rets[0] - (1.1_f64).ln()).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_sample_std_single() {
+        assert!((sample_std(&[42.0])).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_compute_cone_day_zero() {
+        let (_, projection) = compute_cone(85.0, 0.002, "normal", 20000);
+        let day0 = &projection[0];
+        assert!((day0["upper"].as_f64().unwrap() - 85.0).abs() < f64::EPSILON);
+        assert!((day0["lower"].as_f64().unwrap() - 85.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_validate_currency_code() {
+        assert_eq!(validate_currency_code("USD").unwrap(), "USD");
+        assert_eq!(validate_currency_code("inr").unwrap(), "INR");
+        assert!(validate_currency_code("USD/../../admin").is_err());
+        assert!(validate_currency_code("AB").is_err());
+        assert!(validate_currency_code("").is_err());
+    }
+
+    #[test]
+    fn test_validate_date() {
+        assert_eq!(validate_date("2026-04-08").unwrap(), "2026-04-08");
+        assert!(validate_date("not-a-date").is_err());
+        assert!(validate_date("2026-01-01/../../admin").is_err());
+    }
+
+    #[test]
+    fn test_parse_massive_bars_rejects_zero_close() {
+        let body = json!({
+            "results": [{"t": 1000000000000_i64, "o": 1.0, "h": 2.0, "l": 0.5, "c": 0.0, "v": 100.0}]
+        });
+        assert!(parse_massive_bars(&body).is_err());
+    }
+}

--- a/src/tools/builtin/forex.rs
+++ b/src/tools/builtin/forex.rs
@@ -8,13 +8,14 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
-use chrono::Datelike;
 use reqwest::Client;
 use serde_json::json;
 
 use crate::context::JobContext;
 use crate::secrets::SecretsStore;
 use crate::tools::tool::{Tool, ToolDomain, ToolError, ToolOutput, require_str};
+
+use super::validate_currency_code;
 
 const MASSIVE_BASE: &str = "https://api.massive.com/v2/aggs/ticker";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -43,18 +44,6 @@ async fn massive_bearer(secrets: &dyn SecretsStore, user_id: &str) -> Result<Str
     Ok(secret.expose().to_owned())
 }
 
-/// Validate that a string is a 3-letter uppercase currency code (ISO 4217).
-fn validate_currency_code(s: &str) -> Result<String, ToolError> {
-    let upper = s.to_uppercase();
-    if upper.len() == 3 && upper.chars().all(|c| c.is_ascii_uppercase()) {
-        Ok(upper)
-    } else {
-        Err(ToolError::InvalidParameters(format!(
-            "Invalid currency code: {s}"
-        )))
-    }
-}
-
 /// Parse and validate a YYYY-MM-DD date string. Returns the validated string.
 fn validate_date(s: &str) -> Result<String, ToolError> {
     chrono::NaiveDate::parse_from_str(s, "%Y-%m-%d")
@@ -65,42 +54,15 @@ fn validate_date(s: &str) -> Result<String, ToolError> {
 }
 
 // ---------------------------------------------------------------------------
-// Date arithmetic (pure, no std::time — mirrors the Python helpers)
+// Date helpers
 // ---------------------------------------------------------------------------
 
-fn unix_day_from_ymd(y: i32, m: i32, d: i32) -> i64 {
-    let (y2, m2) = if m <= 2 { (y - 1, m + 12) } else { (y, m) };
-    let a = y2 / 100;
-    let b = 2 - a + a / 4;
-    let jd = (365.25 * (y2 + 4716) as f64) as i64
-        + (30.6001 * (m2 + 1) as f64) as i64
-        + d as i64
-        + b as i64
-        - 1524;
-    jd - 2_440_588
-}
-
-fn format_unix_day(n: i64) -> String {
-    let z = n + 719_468;
-    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
-    let doe = z - era * 146_097;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
-    let y = yoe + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-    format!("{y:04}-{m:02}-{d:02}")
-}
-
-fn today_unix_day_from_chrono(now: &chrono::DateTime<chrono::Utc>) -> i64 {
-    let d = now.date_naive();
-    unix_day_from_ymd(d.year(), d.month() as i32, d.day() as i32)
-}
-
 fn ms_to_date_str(ms: i64) -> String {
-    format_unix_day(ms / 86_400_000)
+    let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap_or_default();
+    epoch
+        .checked_add_signed(chrono::Duration::days(ms / 86_400_000))
+        .map(|d| d.format("%Y-%m-%d").to_string())
+        .unwrap_or_else(|| "1970-01-01".to_string())
 }
 
 // ---------------------------------------------------------------------------
@@ -278,7 +240,7 @@ fn compute_cone(
     current_rate: f64,
     daily_vol: f64,
     vb: &str,
-    today_day: i64,
+    today: chrono::NaiveDate,
 ) -> (f64, Vec<serde_json::Value>) {
     const CONE_Z: f64 = 1.645;
     const HORIZON_DAYS: i64 = 3;
@@ -288,7 +250,7 @@ fn compute_cone(
 
     let mut projection = Vec::new();
     for t in 0..=HORIZON_DAYS {
-        let date_str = format_unix_day(today_day + t);
+        let date_str = (today + chrono::Duration::days(t)).format("%Y-%m-%d").to_string();
         let center = current_rate + (target_rate - current_rate) * t as f64 / HORIZON_DAYS as f64;
         let (upper, lower) = if t == 0 {
             (current_rate, current_rate)
@@ -602,9 +564,9 @@ impl Tool for AnalyzeTransferTool {
         let for_wire = params.get("for_wire").and_then(|v| v.as_bool()).unwrap_or(false);
 
         let now = chrono::Utc::now();
-        let td = today_unix_day_from_chrono(&now);
-        let start_str = format_unix_day(td - 220);
-        let end_str = now.format("%Y-%m-%d").to_string();
+        let today = now.date_naive();
+        let start_str = (today - chrono::Duration::days(220)).format("%Y-%m-%d").to_string();
+        let end_str = today.format("%Y-%m-%d").to_string();
 
         let massive_url = format!(
             "{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{end_str}?sort=asc&limit=5000"
@@ -671,7 +633,7 @@ impl Tool for AnalyzeTransferTool {
 
         let hr = hit_rate(vb, rb, dxy_dir);
         let current_rate = closes[closes.len() - 1];
-        let (target_rate, projection) = compute_cone(current_rate, daily_vol, vb, td);
+        let (target_rate, projection) = compute_cone(current_rate, daily_vol, vb, today);
         let recommend = if hr < 45.0 { "now" } else { "wait" };
 
         let historical: Vec<serde_json::Value> = bars[bars.len().saturating_sub(30)..]
@@ -769,7 +731,8 @@ impl Tool for ValidateTransferTargetTool {
 
     fn description(&self) -> &str {
         "Given a desired USD/INR rate, compute the probability of hitting it across \
-         6 time horizons (3d, 7d, 30d, 90d, 180d, 365d). USD/INR only."
+         6 time horizons (3d, 7d, 30d, 90d, 180d, 365d). \
+         Returns {\"message\": \"...\", \"plot\": {...}}. USD/INR only."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -797,9 +760,9 @@ impl Tool for ValidateTransferTargetTool {
             .ok_or_else(|| ToolError::InvalidParameters("target_rate must be a number".into()))?;
 
         let now = chrono::Utc::now();
-        let td = today_unix_day_from_chrono(&now);
-        let start_str = format_unix_day(td - 5);
-        let today_str = now.format("%Y-%m-%d").to_string();
+        let today = now.date_naive();
+        let start_str = (today - chrono::Duration::days(5)).format("%Y-%m-%d").to_string();
+        let today_str = today.format("%Y-%m-%d").to_string();
 
         let url = format!(
             "{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{today_str}?sort=asc&limit=10"
@@ -832,8 +795,11 @@ impl Tool for ValidateTransferTargetTool {
             ));
         }
 
-        // close is guaranteed > 0.0 by parse_massive_bars
-        let current_rate = bars.last().map(|b| b.close).unwrap_or(1.0);
+        // close is guaranteed > 0.0 by parse_massive_bars; is_empty() check above ensures last() is Some
+        let current_rate = bars
+            .last()
+            .ok_or_else(|| ToolError::ExternalService("Massive API returned no bars".into()))?
+            .close;
         let required_move = (target_rate_input / current_rate).ln();
 
         let mut horizons = Vec::new();
@@ -888,9 +854,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_unix_day_roundtrip() {
-        let day = unix_day_from_ymd(2026, 4, 8);
-        assert_eq!(format_unix_day(day), "2026-04-08");
+    fn test_ms_to_date_str() {
+        assert_eq!(ms_to_date_str(0), "1970-01-01");
+        assert_eq!(ms_to_date_str(86_400_000), "1970-01-02");
+        assert_eq!(ms_to_date_str(1_775_606_400_000), "2026-04-08");
     }
 
     #[test]
@@ -982,7 +949,8 @@ mod tests {
 
     #[test]
     fn test_compute_cone_day_zero() {
-        let (_, projection) = compute_cone(85.0, 0.002, "normal", 20000);
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 4, 8).unwrap();
+        let (_, projection) = compute_cone(85.0, 0.002, "normal", today);
         let day0 = &projection[0];
         assert!((day0["upper"].as_f64().unwrap() - 85.0).abs() < f64::EPSILON);
         assert!((day0["lower"].as_f64().unwrap() - 85.0).abs() < f64::EPSILON);

--- a/src/tools/builtin/forex.rs
+++ b/src/tools/builtin/forex.rs
@@ -572,7 +572,7 @@ impl Tool for AnalyzeTransferTool {
     fn description(&self) -> &str {
         "Analyze whether to transfer USD to INR now or wait. Uses volatility regime, RSI(14), \
          and DXY momentum to compute a hit rate, target rate, and 3-day projection cone. \
-         USD/INR only."
+         Returns {\"message\": \"...\", \"plot\": {...}}. USD/INR only."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
@@ -581,7 +581,11 @@ impl Tool for AnalyzeTransferTool {
             "properties": {
                 "amount": {
                     "type": "number",
-                    "description": "Optional USD amount the user intends to send. Potential savings are returned in INR."
+                    "description": "Optional USD amount the user intends to send. Used to compute potential INR savings."
+                },
+                "for_wire": {
+                    "type": "boolean",
+                    "description": "Set to true when called as part of a wire transfer flow. The message will include an explicit send-or-wait approval prompt."
                 }
             },
             "required": []
@@ -595,6 +599,7 @@ impl Tool for AnalyzeTransferTool {
     ) -> Result<ToolOutput, ToolError> {
         let timer = Instant::now();
         let amount = params.get("amount").and_then(|v| v.as_f64());
+        let for_wire = params.get("for_wire").and_then(|v| v.as_bool()).unwrap_or(false);
 
         let now = chrono::Utc::now();
         let td = today_unix_day_from_chrono(&now);
@@ -674,12 +679,9 @@ impl Tool for AnalyzeTransferTool {
             .map(|b| json!({"date": b.date, "close": b.close}))
             .collect();
 
-        // Potential savings in INR if user waits
-        let could_save = if recommend == "wait" {
-            amount.map(|a| ((target_rate - current_rate) * a * 100.0).round() / 100.0)
-        } else {
-            None
-        };
+        // Potential savings in INR: always computed when amount is provided.
+        let could_save =
+            amount.map(|a| ((target_rate - current_rate) * a * 100.0).round() / 100.0);
 
         let action_verb = if recommend == "now" {
             "Transfer now"
@@ -696,12 +698,20 @@ impl Tool for AnalyzeTransferTool {
                 .unwrap_or_else(|| "N/A".into()),
             (hr * 10.0).round() / 10.0,
         );
-        if let Some(save) = could_save
-            && save > 0.0
-        {
-            message.push_str(&format!(
-                " If you wait, you could get ₹{save:.2} more on your transfer."
-            ));
+        if recommend == "wait" {
+            if let Some(save) = could_save
+                && save > 0.0
+            {
+                message.push_str(&format!(
+                    " If you wait, you could get ₹{save:.2} more on your transfer."
+                ));
+            }
+        }
+        if for_wire {
+            message.push_str(
+                " — Send now or wait? Reply **send now** to proceed with the transfer, \
+                 or **wait** to hold off for a better rate.",
+            );
         }
 
         let result = json!({

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -1,8 +1,10 @@
 //! Built-in tools that come with the agent.
 
+mod abound;
 mod echo;
 pub mod extension_tools;
 mod file;
+mod forex;
 mod http;
 mod job;
 mod json;
@@ -18,12 +20,16 @@ pub mod skill_tools;
 mod time;
 mod tool_info;
 
+pub use abound::{
+    AboundAccountInfoTool, AboundCreateNotificationTool, AboundExchangeRateTool, AboundSendWireTool,
+};
 pub use echo::EchoTool;
 pub use extension_tools::{
     ExtensionInfoTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
     ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
 };
 pub use file::{ApplyPatchTool, ListDirTool, ReadFileTool, WriteFileTool};
+pub use forex::{AnalyzeTransferTool, ForexHistoricalDataTool, ValidateTransferTargetTool};
 pub use http::{HttpTool, extract_host_from_params};
 pub use job::{
     CancelJobTool, CreateJobTool, JobEventsTool, JobPromptTool, JobStatusTool, ListJobsTool,

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -59,6 +59,18 @@ pub use image_analyze::ImageAnalyzeTool;
 pub use image_edit::ImageEditTool;
 pub use image_gen::ImageGenerateTool;
 
+/// Validate that a string is a 3-letter uppercase currency code (ISO 4217).
+pub(super) fn validate_currency_code(s: &str) -> Result<String, crate::tools::tool::ToolError> {
+    let upper = s.to_uppercase();
+    if upper.len() == 3 && upper.chars().all(|c| c.is_ascii_uppercase()) {
+        Ok(upper)
+    } else {
+        Err(crate::tools::tool::ToolError::InvalidParameters(format!(
+            "Invalid currency code: {s}"
+        )))
+    }
+}
+
 /// Detect image media type from file extension via `mime_guess`.
 /// Falls back to `image/jpeg` for unrecognized or non-image extensions.
 pub(crate) fn media_type_from_path(path: &str) -> String {

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -388,7 +388,7 @@ impl ToolRegistry {
                 ($tool:expr) => {
                     match $tool {
                         Ok(t) => self.register_sync(Arc::new(t)),
-                        Err(e) => tracing::warn!("Failed to register tool: {e}"),
+                        Err(e) => tracing::debug!("Failed to register tool: {e}"),
                     }
                 };
             }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -15,12 +15,14 @@ use crate::tools::builder::{
     BuildSoftwareTool, BuilderConfig, LlmSoftwareBuilder, SoftwareBuilder,
 };
 use crate::tools::builtin::{
-    ApplyPatchTool, CancelJobTool, CreateJobTool, EchoTool, ExtensionInfoTool, HttpTool,
-    JobEventsTool, JobPromptTool, JobStatusTool, JsonTool, ListDirTool, ListJobsTool,
-    MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool, PlanUpdateTool, PromptQueue,
-    ReadFileTool, ShellTool, SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool,
-    TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool, ToolPermissionSetTool,
-    ToolRemoveTool, ToolSearchTool, ToolUpgradeTool, WriteFileTool,
+    AboundAccountInfoTool, AboundCreateNotificationTool, AboundExchangeRateTool,
+    AboundSendWireTool, AnalyzeTransferTool, ApplyPatchTool, CancelJobTool, CreateJobTool,
+    EchoTool, ExtensionInfoTool, ForexHistoricalDataTool, HttpTool, JobEventsTool, JobPromptTool,
+    JobStatusTool, JsonTool, ListDirTool, ListJobsTool, MemoryReadTool, MemorySearchTool,
+    MemoryTreeTool, MemoryWriteTool, PlanUpdateTool, PromptQueue, ReadFileTool, ShellTool,
+    SkillInstallTool, SkillListTool, SkillRemoveTool, SkillSearchTool, TimeTool, ToolActivateTool,
+    ToolAuthTool, ToolInstallTool, ToolListTool, ToolPermissionSetTool, ToolRemoveTool,
+    ToolSearchTool, ToolUpgradeTool, ValidateTransferTargetTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::tool::{
@@ -104,6 +106,15 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "plan_update",
     // Permission tools
     "tool_permission_set",
+    // Abound tools
+    "abound_account_info",
+    "abound_exchange_rate",
+    "abound_send_wire",
+    "abound_create_notification",
+    // Forex tools
+    "forex_historical_data",
+    "analyze_transfer",
+    "validate_transfer_target",
     // Aliases (web_fetch is an alias for http in some contexts)
     "web_fetch",
 ];
@@ -370,6 +381,25 @@ impl ToolRegistry {
             http = http.with_credentials(Arc::clone(cr), Arc::clone(ss));
         }
         self.register_sync(Arc::new(http));
+
+        // Abound & forex tools (require secrets store for credential access)
+        if let Some(ss) = &self.secrets_store {
+            macro_rules! register_or_warn {
+                ($tool:expr) => {
+                    match $tool {
+                        Ok(t) => self.register_sync(Arc::new(t)),
+                        Err(e) => tracing::warn!("Failed to register tool: {e}"),
+                    }
+                };
+            }
+            register_or_warn!(AboundAccountInfoTool::new(Arc::clone(ss)));
+            register_or_warn!(AboundExchangeRateTool::new(Arc::clone(ss)));
+            register_or_warn!(AboundSendWireTool::new(Arc::clone(ss)));
+            register_or_warn!(AboundCreateNotificationTool::new(Arc::clone(ss)));
+            register_or_warn!(ForexHistoricalDataTool::new(Arc::clone(ss)));
+            register_or_warn!(AnalyzeTransferTool::new(Arc::clone(ss)));
+            register_or_warn!(ValidateTransferTargetTool::new(Arc::clone(ss)));
+        }
 
         tracing::debug!("Registered {} built-in tools", self.count());
     }

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -2343,6 +2343,7 @@ mod tests {
                 secret_name: "api_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2379,6 +2380,7 @@ mod tests {
                     placeholder: "{api_key}".to_string(),
                 },
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2423,6 +2425,7 @@ mod tests {
                 secret_name: "my_token".to_string(),
                 location: CredentialLocation::AuthorizationBearer,
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
         let caps = Capabilities {
@@ -2667,6 +2670,7 @@ mod tests {
                     placeholder: "{api_key}".to_string(),
                 },
                 host_patterns: vec!["api.example.com".to_string()],
+                path_patterns: Vec::new(),
             },
         );
 


### PR DESCRIPTION
## Summary
- Convert abound-api and forex-timing skills to built-in tools
- Merge latest staging (skill repair, TUI, multi-tenant perf, ownership fixes)
- Fix credential token name alignment

## Test plan
- [ ] Run `bash integrations/abound/tests/run_test.sh` — verify e2e tests pass
- [ ] Test send-wire flow in chat.py — no more `abound_external_token` auth prompt

Generated with [Claude Code](https://claude.com/claude-code)