### PR TITLE
feat: add extensible deployment profiles (IRONCLAW_PROFILE)

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,5 @@
-# Scope labels for actions/labeler@v6
-# Maps file path globs to scope labels. Multiple labels can apply per PR.
+# Labels for actions/labeler@v6
+# Maps file path globs to labels. Multiple labels can apply per PR.
 
 "scope: agent":
   - changed-files:
@@ -164,3 +164,9 @@
       - any-glob-to-any-file:
           - Cargo.toml
           - Cargo.lock
+
+"DB MIGRATION":
+  - changed-files:
+      - any-glob-to-any-file:
+          - migrations/**
+          - src/db/libsql_migrations.rs

--- a/.github/scripts/create-labels.sh
+++ b/.github/scripts/create-labels.sh
@@ -62,6 +62,9 @@ create "scope: ci"            "546E7A" "CI/CD workflows"
 create "scope: docs"          "78909C" "Documentation"
 create "scope: dependencies"  "90A4AE" "Dependency updates"
 
+echo "==> Creating coordination labels..."
+create "DB MIGRATION"         "C62828" "PR adds or modifies PostgreSQL or libSQL migration definitions"
+
 echo "==> Creating workflow labels..."
 create "skip-regression-check" "9E9E9E" "Acknowledged: fix without regression test"
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -61,7 +61,7 @@ jobs:
           - group: features
             files: "tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"
           - group: extensions
-            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
+            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
           - group: routines
             files: "tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"
     steps:

--- a/.github/workflows/pr-label-scope.yml
+++ b/.github/workflows/pr-label-scope.yml
@@ -6,13 +6,20 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 jobs:
   scope:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v5
+      - name: Ensure DB MIGRATION label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: gh label create "DB MIGRATION" --repo "$REPO" --color C62828 --description "PR adds or modifies PostgreSQL or libSQL migration definitions" --force
+
+      - uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false          # additive only — never remove scope labels

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,69 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.23.0...ironclaw-v0.24.0) - 2026-03-31
+
+### Added
+
+- *(gateway)* OIDC JWT authentication for reverse-proxy deployments ([#1463](https://github.com/nearai/ironclaw/pull/1463))
+- support custom LLM provider configuration via web UI ([#1340](https://github.com/nearai/ironclaw/pull/1340))
+- *(skills)* recursive bundle directory scanning for skill discovery ([#1667](https://github.com/nearai/ironclaw/pull/1667))
+- *(discord)* add gateway channel flow in wasm ([#944](https://github.com/nearai/ironclaw/pull/944))
+- DB-backed user management, admin secrets provisioning, and multi-tenant isolation ([#1626](https://github.com/nearai/ironclaw/pull/1626))
+- *(gateway)* add OpenAI Responses API endpoints ([#1656](https://github.com/nearai/ironclaw/pull/1656))
+
+### Fixed
+
+- *(routines)* clone Arc before await in web handler event cache refresh ([#1756](https://github.com/nearai/ironclaw/pull/1756))
+- *(slack)* respond to thread replies without requiring @mention ([#1405](https://github.com/nearai/ironclaw/pull/1405))
+- resolve 11 test failures from multi-tenant bootstrap and sandbox gate regressions ([#1746](https://github.com/nearai/ironclaw/pull/1746))
+- *(auth)* make shared Google tool status scope-aware ([#1532](https://github.com/nearai/ironclaw/pull/1532))
+- *(wasm)* inject Content-Length: 0 for bodyless mutating HTTP requests ([#1529](https://github.com/nearai/ironclaw/pull/1529))
+- *(bedrock)* strip tool blocks from messages when toolConfig is absent ([#1630](https://github.com/nearai/ironclaw/pull/1630))
+- prevent UTF-8 panics in byte-index string truncation ([#1688](https://github.com/nearai/ironclaw/pull/1688))
+- *(gemini)* preserve thought signatures on all tool calls ([#1565](https://github.com/nearai/ironclaw/pull/1565))
+- pin staging ci jobs to a single tested sha ([#1628](https://github.com/nearai/ironclaw/pull/1628))
+- *(routines)* complete full_job execution reliability overhaul ([#1650](https://github.com/nearai/ironclaw/pull/1650))
+- *(worker)* treat empty LLM response after text output as completion ([#1677](https://github.com/nearai/ironclaw/pull/1677))
+- *(worker)* replace script -qfc with pty-process for injection-safe PTY ([#1678](https://github.com/nearai/ironclaw/pull/1678))
+- *(web)* redact database error details from API responses ([#1711](https://github.com/nearai/ironclaw/pull/1711))
+- *(oauth)* tighten legacy state validation and fallback handling ([#1701](https://github.com/nearai/ironclaw/pull/1701))
+- *(db)* add tracing warn for naive timestamp fallback and improve parse_timestamp tests ([#1700](https://github.com/nearai/ironclaw/pull/1700))
+- *(wasm)* use typed WASM schema as advertised schema when available ([#1699](https://github.com/nearai/ironclaw/pull/1699))
+- sanitize tool error results before llm injection ([#1639](https://github.com/nearai/ironclaw/pull/1639))
+- require Feishu webhook authentication ([#1638](https://github.com/nearai/ironclaw/pull/1638))
+- *(llm)* prevent UTF-8 panic in line_bounds() (fixes #1669) ([#1679](https://github.com/nearai/ironclaw/pull/1679))
+- downgrade excessive debug logging in hot path (closes #1686) ([#1694](https://github.com/nearai/ironclaw/pull/1694))
+
+### Other
+
+- Stabilize MCP refresh regression tests ([#1772](https://github.com/nearai/ironclaw/pull/1772))
+- Fix hosted MCP OAuth refresh flow ([#1767](https://github.com/nearai/ironclaw/pull/1767))
+- Track routine verification state across updates ([#1716](https://github.com/nearai/ironclaw/pull/1716))
+- *(e2e)* align WASM reinstall expectation with uninstall cleanup ([#1762](https://github.com/nearai/ironclaw/pull/1762))
+- Handle empty tool completions in autonomous jobs ([#1720](https://github.com/nearai/ironclaw/pull/1720))
+- Clarify message tool vs channel setup guidance ([#1715](https://github.com/nearai/ironclaw/pull/1715))
+- tighten contribution and PR guidance ([#1704](https://github.com/nearai/ironclaw/pull/1704))
+- Clean up extension credentials on uninstall ([#1718](https://github.com/nearai/ironclaw/pull/1718))
+
+## [0.23.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.22.0...ironclaw-v0.23.0) - 2026-03-27
+
+### Added
+
+- complete multi-tenant isolation — phases 2–4 ([#1614](https://github.com/nearai/ironclaw/pull/1614))
+
+### Fixed
+
+- *(routines)* recover delete name after failed update fallback ([#1108](https://github.com/nearai/ironclaw/pull/1108))
+- *(mcp)* handle 202 Accepted and wire session manager for Streamable HTTP ([#1437](https://github.com/nearai/ironclaw/pull/1437))
+- *(extensions)* channel-relay auth dead-end, observability, and URL override ([#1681](https://github.com/nearai/ironclaw/pull/1681))
+- *(agent)* discard truncated tool calls when finish_reason == Length ([#1631](https://github.com/nearai/ironclaw/pull/1631)) ([#1632](https://github.com/nearai/ironclaw/pull/1632))
+- *(llm)* filter XML tool-call recovery by context ([#1641](https://github.com/nearai/ironclaw/pull/1641))
+
+### Other
+
+- Support direct hosted OAuth callbacks with proxy auth token ([#1684](https://github.com/nearai/ironclaw/pull/1684))
+
 ## [0.22.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.21.0...ironclaw-v0.22.0) - 2026-03-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3399,7 +3399,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw"
-version = "0.22.0"
+version = "0.24.0"
 dependencies = [
  "aes-gcm",
  "aho-corasick",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 
 [package]
 name = "ironclaw"
-version = "0.22.0"
+version = "0.24.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -97,6 +97,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | Cron/heartbeat topic targeting | ✅ | ❌ | Messages land in correct topic |
 | DM topics support | ✅ | ❌ | Agent/topic bindings in DMs and agent-scoped SessionKeys |
 | Persistent ACP topic binding | ✅ | ❌ | ACP harness sessions can pin to Telegram forum or DM topics |
+| sendVoice (voice note replies) | ✅ | ✅ | audio/ogg attachments sent as voice notes; prerequisite for TTS (#90) |
 
 ### Discord-Specific Features (since Feb 2025)
 

--- a/channels-src/telegram/Cargo.lock
+++ b/channels-src/telegram/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "telegram-channel"
-version = "0.2.1"
+version = "0.2.6"
 dependencies = [
  "serde",
  "serde_json",

--- a/channels-src/telegram/Cargo.toml
+++ b/channels-src/telegram/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telegram-channel"
-version = "0.2.1"
+version = "0.2.6"
 edition = "2021"
 description = "Telegram Bot API channel for IronClaw"
 license = "MIT OR Apache-2.0"

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -363,6 +363,26 @@ const TELEGRAM_STATUS_MAX_CHARS: usize = 600;
 /// Telegram's hard limit for message text length.
 const TELEGRAM_MAX_MESSAGE_LEN: usize = 4096;
 
+fn utf16_code_unit_len(text: &str) -> usize {
+    text.encode_utf16().count()
+}
+
+fn prefix_within_utf16_limit(text: &str, max_units: usize) -> usize {
+    let mut units = 0;
+    let mut end = 0;
+
+    for (byte_idx, ch) in text.char_indices() {
+        let ch_units = ch.len_utf16();
+        if units + ch_units > max_units {
+            break;
+        }
+        units += ch_units;
+        end = byte_idx + ch.len_utf8();
+    }
+
+    end
+}
+
 fn truncate_status_message(input: &str, max_chars: usize) -> String {
     let mut iter = input.chars();
     let truncated: String = iter.by_ref().take(max_chars).collect();
@@ -373,7 +393,7 @@ fn truncate_status_message(input: &str, max_chars: usize) -> String {
     }
 }
 
-/// Split a long message into chunks that fit within Telegram's 4096-char limit.
+/// Split a long message into chunks that fit within Telegram's 4096 UTF-16-unit limit.
 ///
 /// Tries to split at the most natural boundary available (in priority order):
 /// 1. Double newline (paragraph break)
@@ -382,7 +402,7 @@ fn truncate_status_message(input: &str, max_chars: usize) -> String {
 /// 4. Word boundary (space)
 /// 5. Hard cut at the limit (last resort for pathological input)
 fn split_message(text: &str) -> Vec<String> {
-    if text.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN {
+    if utf16_code_unit_len(text) <= TELEGRAM_MAX_MESSAGE_LEN {
         return vec![text.to_string()];
     }
 
@@ -390,13 +410,8 @@ fn split_message(text: &str) -> Vec<String> {
     let mut remaining = text;
 
     while !remaining.is_empty() {
-        // Count chars to find the byte offset for our window.
-        let window_bytes = remaining
-            .char_indices()
-            .take(TELEGRAM_MAX_MESSAGE_LEN)
-            .last()
-            .map(|(byte_idx, ch)| byte_idx + ch.len_utf8())
-            .unwrap_or(remaining.len());
+        // Find the longest UTF-8 prefix that fits within Telegram's UTF-16 limit.
+        let window_bytes = prefix_within_utf16_limit(remaining, TELEGRAM_MAX_MESSAGE_LEN);
 
         if window_bytes >= remaining.len() {
             // Remainder fits entirely.
@@ -404,10 +419,24 @@ fn split_message(text: &str) -> Vec<String> {
             break;
         }
 
+        if window_bytes == 0 {
+            // Defensive fallback: make progress even if a future caller uses a
+            // smaller limit than a single scalar value can fit within.
+            let first_char_len = remaining
+                .chars()
+                .next()
+                .map(|ch| ch.len_utf8())
+                .unwrap_or(remaining.len());
+            chunks.push(remaining[..first_char_len].to_string());
+            remaining = &remaining[first_char_len..];
+            continue;
+        }
+
         let window = &remaining[..window_bytes];
 
         // 1. Double newline — best paragraph boundary
-        let split_at = window.rfind("\n\n")
+        let split_at = window
+            .rfind("\n\n")
             // 2. Single newline
             .or_else(|| window.rfind('\n'))
             // 3. Sentence-ending punctuation followed by space.
@@ -417,9 +446,9 @@ fn split_message(text: &str) -> Vec<String> {
             .or_else(|| {
                 let bytes = window.as_bytes();
                 // Search backwards for '. ', '! ', '? '
-                (1..bytes.len()).rev().find(|&i| {
-                    matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' '
-                })
+                (1..bytes.len())
+                    .rev()
+                    .find(|&i| matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' ')
             })
             // 4. Word boundary (last space)
             .or_else(|| window.rfind(' '))
@@ -427,7 +456,11 @@ fn split_message(text: &str) -> Vec<String> {
             .unwrap_or(window_bytes);
 
         // Avoid empty chunks (e.g. text starting with \n\n).
-        let split_at = if split_at == 0 { window_bytes } else { split_at };
+        let split_at = if split_at == 0 {
+            window_bytes
+        } else {
+            split_at
+        };
 
         // Trim whitespace at chunk boundaries for clean Telegram display.
         // Note: this drops leading/trailing spaces at split points, which is
@@ -1321,7 +1354,13 @@ fn send_response(
 
     for (i, chunk) in chunks.into_iter().enumerate() {
         // Try Markdown, fall back to plain text on parse errors
-        let result = send_message(chat_id, &chunk, reply_to, Some("Markdown"), message_thread_id);
+        let result = send_message(
+            chat_id,
+            &chunk,
+            reply_to,
+            Some("Markdown"),
+            message_thread_id,
+        );
 
         let msg_id = match result {
             Ok(id) => {
@@ -2150,6 +2189,10 @@ export!(TelegramChannel);
 mod tests {
     use super::*;
 
+    fn utf16_len(text: &str) -> usize {
+        text.encode_utf16().count()
+    }
+
     #[test]
     fn test_split_message_short() {
         let text = "Hello, world!";
@@ -2177,7 +2220,7 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() > 1, "expected multiple chunks");
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
         // Rejoined chunks must equal the original text exactly.
         let rejoined = chunks.join(" ");
@@ -2193,7 +2236,7 @@ mod tests {
         assert!(text.len() > TELEGRAM_MAX_MESSAGE_LEN);
         let chunks = split_message(&text);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
     }
 
@@ -2223,7 +2266,7 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
         // Rejoined must preserve all characters
         let rejoined: String = chunks.concat();
@@ -2240,10 +2283,23 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
             // Every char should be a complete emoji
             assert!(chunk.chars().all(|c| c == '\u{1F600}'));
         }
+    }
+
+    #[test]
+    fn test_split_message_exact_utf16_limit_for_surrogate_pairs() {
+        let emoji = "\u{1F600}"; // 😀
+        let text = emoji.repeat(TELEGRAM_MAX_MESSAGE_LEN);
+
+        let chunks = split_message(&text);
+
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks
+            .iter()
+            .all(|chunk| utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN));
     }
 
     #[test]

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -407,7 +407,8 @@ fn split_message(text: &str) -> Vec<String> {
         let window = &remaining[..window_bytes];
 
         // 1. Double newline — best paragraph boundary
-        let split_at = window.rfind("\n\n")
+        let split_at = window
+            .rfind("\n\n")
             // 2. Single newline
             .or_else(|| window.rfind('\n'))
             // 3. Sentence-ending punctuation followed by space.
@@ -417,9 +418,9 @@ fn split_message(text: &str) -> Vec<String> {
             .or_else(|| {
                 let bytes = window.as_bytes();
                 // Search backwards for '. ', '! ', '? '
-                (1..bytes.len()).rev().find(|&i| {
-                    matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' '
-                })
+                (1..bytes.len())
+                    .rev()
+                    .find(|&i| matches!(bytes[i - 1], b'.' | b'!' | b'?') && bytes[i] == b' ')
             })
             // 4. Word boundary (last space)
             .or_else(|| window.rfind(' '))
@@ -427,7 +428,11 @@ fn split_message(text: &str) -> Vec<String> {
             .unwrap_or(window_bytes);
 
         // Avoid empty chunks (e.g. text starting with \n\n).
-        let split_at = if split_at == 0 { window_bytes } else { split_at };
+        let split_at = if split_at == 0 {
+            window_bytes
+        } else {
+            split_at
+        };
 
         // Trim whitespace at chunk boundaries for clean Telegram display.
         // Note: this drops leading/trailing spaces at split points, which is
@@ -1090,11 +1095,8 @@ fn download_telegram_file(file_id: &str) -> Result<Vec<u8>, String> {
 }
 
 // ============================================================================
-// Attachment Sending (Photo / Document)
+// Attachment Sending (Photo / Voice / Document)
 // ============================================================================
-
-/// Maximum photo size for Telegram sendPhoto (10 MB).
-const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
 
 /// Write a multipart/form-data text field.
 fn write_multipart_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
@@ -1138,6 +1140,95 @@ fn write_multipart_file(
     body.extend_from_slice(b"\r\n");
 }
 
+/// Image MIME types that Telegram's sendPhoto API supports.
+const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Audio MIME types that Telegram's sendVoice API supports (ogg/opus container).
+const VOICE_MIME_TYPES: &[&str] = &["audio/ogg", "audio/opus"];
+
+/// Maximum photo size for Telegram sendPhoto (10 MB).
+const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum voice note size for Telegram sendVoice (50 MB).
+const MAX_VOICE_SIZE: usize = 50 * 1024 * 1024;
+
+/// Send a multipart file upload to a Telegram Bot API endpoint.
+///
+/// Shared implementation for sendPhoto, sendVoice, and sendDocument.
+/// `api_method` is the Telegram method name (e.g. "sendPhoto"),
+/// `field_name` is the multipart field (e.g. "photo", "voice", "document").
+#[allow(clippy::too_many_arguments)]
+fn send_multipart_upload(
+    api_method: &str,
+    field_name: &str,
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    let message_thread_id = normalize_thread_id(message_thread_id);
+
+    let boundary = format!("ironclaw-{}", channel_host::now_millis());
+    let mut body = Vec::new();
+
+    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
+    if let Some(msg_id) = reply_to_message_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "reply_to_message_id",
+            &msg_id.to_string(),
+        );
+    }
+    if let Some(thread_id) = message_thread_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "message_thread_id",
+            &thread_id.to_string(),
+        );
+    }
+    write_multipart_file(&mut body, &boundary, field_name, filename, mime_type, data);
+    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+    let headers = serde_json::json!({
+        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
+    });
+
+    let url = format!(
+        "https://api.telegram.org/bot{{TELEGRAM_BOT_TOKEN}}/{}",
+        api_method
+    );
+
+    let result = channel_host::http_request(
+        "POST",
+        &url,
+        &headers.to_string(),
+        Some(&body),
+        Some(60_000), // 60s timeout for file uploads
+    );
+
+    match result {
+        Ok(resp) if resp.status == 200 => {
+            channel_host::log(
+                channel_host::LogLevel::Debug,
+                &format!("Sent {} '{}' to chat {}", field_name, filename, chat_id),
+            );
+            Ok(())
+        }
+        Ok(resp) => {
+            let body_str = String::from_utf8_lossy(&resp.body);
+            Err(format!(
+                "{} failed (HTTP {}): {}",
+                api_method, resp.status, body_str
+            ))
+        }
+        Err(e) => Err(format!("{} HTTP request failed: {}", api_method, e)),
+    }
+}
+
 /// Send a photo via the Telegram Bot API (multipart upload).
 ///
 /// Falls back to `send_document()` if the photo exceeds 10 MB.
@@ -1149,8 +1240,6 @@ fn send_photo(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
     if data.len() > MAX_PHOTO_SIZE {
         channel_host::log(
             channel_host::LogLevel::Info,
@@ -1169,59 +1258,16 @@ fn send_photo(
             message_thread_id,
         );
     }
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "photo", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendPhoto",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent photo '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendPhoto failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendPhoto HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendPhoto",
+        "photo",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
 /// Send a document via the Telegram Bot API (multipart upload).
@@ -1233,64 +1279,60 @@ fn send_document(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "document", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendDocument",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent document '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendDocument failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendDocument HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendDocument",
+        "document",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
-/// Image MIME types that Telegram's sendPhoto API supports.
-const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+/// Send a voice note via the Telegram Bot API (multipart upload).
+///
+/// Telegram's `sendVoice` requires ogg/opus audio and displays it as an
+/// in-chat voice note with waveform and playback controls.
+/// Falls back to `send_document()` if the voice note exceeds 50 MB.
+fn send_voice(
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    if data.len() > MAX_VOICE_SIZE {
+        channel_host::log(
+            channel_host::LogLevel::Info,
+            &format!(
+                "Voice note {} exceeds 50MB ({}), sending as document",
+                filename,
+                data.len()
+            ),
+        );
+        return send_document(
+            chat_id,
+            filename,
+            mime_type,
+            data,
+            reply_to_message_id,
+            message_thread_id,
+        );
+    }
+    send_multipart_upload(
+        "sendVoice",
+        "voice",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
+}
 
 /// Send a full agent response (attachments + text) to a chat.
 ///
@@ -1321,7 +1363,13 @@ fn send_response(
 
     for (i, chunk) in chunks.into_iter().enumerate() {
         // Try Markdown, fall back to plain text on parse errors
-        let result = send_message(chat_id, &chunk, reply_to, Some("Markdown"), message_thread_id);
+        let result = send_message(
+            chat_id,
+            &chunk,
+            reply_to,
+            Some("Markdown"),
+            message_thread_id,
+        );
 
         let msg_id = match result {
             Ok(id) => {
@@ -1371,31 +1419,65 @@ fn send_response(
     Ok(())
 }
 
-/// Send a single attachment, choosing sendPhoto or sendDocument based on MIME type.
+/// Extract the base MIME type, stripping any parameters after `;`.
+///
+/// e.g. `"audio/ogg; codecs=opus"` → `"audio/ogg"`
+fn base_mime_type(mime: &str) -> &str {
+    mime.split(';').next().unwrap_or(mime).trim()
+}
+
+/// Attachment routing category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachmentKind {
+    Photo,
+    Voice,
+    Document,
+}
+
+/// Classify an attachment's send method based on its MIME type.
+fn classify_attachment(mime_type: &str) -> AttachmentKind {
+    let base = base_mime_type(mime_type);
+    if PHOTO_MIME_TYPES.contains(&base) {
+        AttachmentKind::Photo
+    } else if VOICE_MIME_TYPES.contains(&base) {
+        AttachmentKind::Voice
+    } else {
+        AttachmentKind::Document
+    }
+}
+
+/// Send a single attachment, choosing sendPhoto, sendVoice, or sendDocument based on MIME type.
 fn send_attachment(
     chat_id: i64,
     attachment: &Attachment,
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    if PHOTO_MIME_TYPES.contains(&attachment.mime_type.as_str()) {
-        send_photo(
+    match classify_attachment(&attachment.mime_type) {
+        AttachmentKind::Photo => send_photo(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
-    } else {
-        send_document(
+        ),
+        AttachmentKind::Voice => send_voice(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
+        ),
+        AttachmentKind::Document => send_document(
+            chat_id,
+            &attachment.filename,
+            &attachment.mime_type,
+            &attachment.data,
+            reply_to_message_id,
+            message_thread_id,
+        ),
     }
 }
 
@@ -2968,5 +3050,39 @@ mod tests {
     fn test_max_download_size_constant() {
         // Verify the constant is 20 MB, matching the Slack channel limit
         assert_eq!(MAX_DOWNLOAD_SIZE_BYTES, 20 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_base_mime_type() {
+        assert_eq!(base_mime_type("audio/ogg"), "audio/ogg");
+        assert_eq!(base_mime_type("audio/ogg; codecs=opus"), "audio/ogg");
+        assert_eq!(base_mime_type("image/jpeg"), "image/jpeg");
+        assert_eq!(base_mime_type("text/plain; charset=utf-8"), "text/plain");
+        assert_eq!(base_mime_type(""), "");
+    }
+
+    #[test]
+    fn test_classify_attachment_routing() {
+        // Photos
+        assert_eq!(classify_attachment("image/jpeg"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/png"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/gif"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/webp"), AttachmentKind::Photo);
+
+        // Voice notes — exact and parameterized
+        assert_eq!(classify_attachment("audio/ogg"), AttachmentKind::Voice);
+        assert_eq!(classify_attachment("audio/opus"), AttachmentKind::Voice);
+        assert_eq!(
+            classify_attachment("audio/ogg; codecs=opus"),
+            AttachmentKind::Voice
+        );
+
+        // Everything else falls through to document
+        assert_eq!(
+            classify_attachment("application/pdf"),
+            AttachmentKind::Document
+        );
+        assert_eq!(classify_attachment("audio/mpeg"), AttachmentKind::Document);
+        assert_eq!(classify_attachment("video/mp4"), AttachmentKind::Document);
     }
 }

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -363,6 +363,26 @@ const TELEGRAM_STATUS_MAX_CHARS: usize = 600;
 /// Telegram's hard limit for message text length.
 const TELEGRAM_MAX_MESSAGE_LEN: usize = 4096;
 
+fn utf16_code_unit_len(text: &str) -> usize {
+    text.encode_utf16().count()
+}
+
+fn prefix_within_utf16_limit(text: &str, max_units: usize) -> usize {
+    let mut units = 0;
+    let mut end = 0;
+
+    for (byte_idx, ch) in text.char_indices() {
+        let ch_units = ch.len_utf16();
+        if units + ch_units > max_units {
+            break;
+        }
+        units += ch_units;
+        end = byte_idx + ch.len_utf8();
+    }
+
+    end
+}
+
 fn truncate_status_message(input: &str, max_chars: usize) -> String {
     let mut iter = input.chars();
     let truncated: String = iter.by_ref().take(max_chars).collect();
@@ -373,7 +393,7 @@ fn truncate_status_message(input: &str, max_chars: usize) -> String {
     }
 }
 
-/// Split a long message into chunks that fit within Telegram's 4096-char limit.
+/// Split a long message into chunks that fit within Telegram's 4096 UTF-16-unit limit.
 ///
 /// Tries to split at the most natural boundary available (in priority order):
 /// 1. Double newline (paragraph break)
@@ -382,7 +402,7 @@ fn truncate_status_message(input: &str, max_chars: usize) -> String {
 /// 4. Word boundary (space)
 /// 5. Hard cut at the limit (last resort for pathological input)
 fn split_message(text: &str) -> Vec<String> {
-    if text.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN {
+    if utf16_code_unit_len(text) <= TELEGRAM_MAX_MESSAGE_LEN {
         return vec![text.to_string()];
     }
 
@@ -390,18 +410,26 @@ fn split_message(text: &str) -> Vec<String> {
     let mut remaining = text;
 
     while !remaining.is_empty() {
-        // Count chars to find the byte offset for our window.
-        let window_bytes = remaining
-            .char_indices()
-            .take(TELEGRAM_MAX_MESSAGE_LEN)
-            .last()
-            .map(|(byte_idx, ch)| byte_idx + ch.len_utf8())
-            .unwrap_or(remaining.len());
+        // Find the longest UTF-8 prefix that fits within Telegram's UTF-16 limit.
+        let window_bytes = prefix_within_utf16_limit(remaining, TELEGRAM_MAX_MESSAGE_LEN);
 
         if window_bytes >= remaining.len() {
             // Remainder fits entirely.
             chunks.push(remaining.to_string());
             break;
+        }
+
+        if window_bytes == 0 {
+            // Defensive fallback: make progress even if a future caller uses a
+            // smaller limit than a single scalar value can fit within.
+            let first_char_len = remaining
+                .chars()
+                .next()
+                .map(|ch| ch.len_utf8())
+                .unwrap_or(remaining.len());
+            chunks.push(remaining[..first_char_len].to_string());
+            remaining = &remaining[first_char_len..];
+            continue;
         }
 
         let window = &remaining[..window_bytes];
@@ -2232,6 +2260,10 @@ export!(TelegramChannel);
 mod tests {
     use super::*;
 
+    fn utf16_len(text: &str) -> usize {
+        text.encode_utf16().count()
+    }
+
     #[test]
     fn test_split_message_short() {
         let text = "Hello, world!";
@@ -2259,7 +2291,7 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() > 1, "expected multiple chunks");
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
         // Rejoined chunks must equal the original text exactly.
         let rejoined = chunks.join(" ");
@@ -2275,7 +2307,7 @@ mod tests {
         assert!(text.len() > TELEGRAM_MAX_MESSAGE_LEN);
         let chunks = split_message(&text);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
     }
 
@@ -2305,7 +2337,7 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
         }
         // Rejoined must preserve all characters
         let rejoined: String = chunks.concat();
@@ -2322,10 +2354,23 @@ mod tests {
         let chunks = split_message(&text);
         assert!(chunks.len() >= 2);
         for chunk in &chunks {
-            assert!(chunk.chars().count() <= TELEGRAM_MAX_MESSAGE_LEN);
+            assert!(utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN);
             // Every char should be a complete emoji
             assert!(chunk.chars().all(|c| c == '\u{1F600}'));
         }
+    }
+
+    #[test]
+    fn test_split_message_exact_utf16_limit_for_surrogate_pairs() {
+        let emoji = "\u{1F600}"; // 😀
+        let text = emoji.repeat(TELEGRAM_MAX_MESSAGE_LEN);
+
+        let chunks = split_message(&text);
+
+        assert_eq!(chunks.len(), 2);
+        assert!(chunks
+            .iter()
+            .all(|chunk| utf16_len(chunk) <= TELEGRAM_MAX_MESSAGE_LEN));
     }
 
     #[test]

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -1123,11 +1123,8 @@ fn download_telegram_file(file_id: &str) -> Result<Vec<u8>, String> {
 }
 
 // ============================================================================
-// Attachment Sending (Photo / Document)
+// Attachment Sending (Photo / Voice / Document)
 // ============================================================================
-
-/// Maximum photo size for Telegram sendPhoto (10 MB).
-const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
 
 /// Write a multipart/form-data text field.
 fn write_multipart_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
@@ -1171,6 +1168,95 @@ fn write_multipart_file(
     body.extend_from_slice(b"\r\n");
 }
 
+/// Image MIME types that Telegram's sendPhoto API supports.
+const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+
+/// Audio MIME types that Telegram's sendVoice API supports (ogg/opus container).
+const VOICE_MIME_TYPES: &[&str] = &["audio/ogg", "audio/opus"];
+
+/// Maximum photo size for Telegram sendPhoto (10 MB).
+const MAX_PHOTO_SIZE: usize = 10 * 1024 * 1024;
+
+/// Maximum voice note size for Telegram sendVoice (50 MB).
+const MAX_VOICE_SIZE: usize = 50 * 1024 * 1024;
+
+/// Send a multipart file upload to a Telegram Bot API endpoint.
+///
+/// Shared implementation for sendPhoto, sendVoice, and sendDocument.
+/// `api_method` is the Telegram method name (e.g. "sendPhoto"),
+/// `field_name` is the multipart field (e.g. "photo", "voice", "document").
+#[allow(clippy::too_many_arguments)]
+fn send_multipart_upload(
+    api_method: &str,
+    field_name: &str,
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    let message_thread_id = normalize_thread_id(message_thread_id);
+
+    let boundary = format!("ironclaw-{}", channel_host::now_millis());
+    let mut body = Vec::new();
+
+    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
+    if let Some(msg_id) = reply_to_message_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "reply_to_message_id",
+            &msg_id.to_string(),
+        );
+    }
+    if let Some(thread_id) = message_thread_id {
+        write_multipart_field(
+            &mut body,
+            &boundary,
+            "message_thread_id",
+            &thread_id.to_string(),
+        );
+    }
+    write_multipart_file(&mut body, &boundary, field_name, filename, mime_type, data);
+    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
+
+    let headers = serde_json::json!({
+        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
+    });
+
+    let url = format!(
+        "https://api.telegram.org/bot{{TELEGRAM_BOT_TOKEN}}/{}",
+        api_method
+    );
+
+    let result = channel_host::http_request(
+        "POST",
+        &url,
+        &headers.to_string(),
+        Some(&body),
+        Some(60_000), // 60s timeout for file uploads
+    );
+
+    match result {
+        Ok(resp) if resp.status == 200 => {
+            channel_host::log(
+                channel_host::LogLevel::Debug,
+                &format!("Sent {} '{}' to chat {}", field_name, filename, chat_id),
+            );
+            Ok(())
+        }
+        Ok(resp) => {
+            let body_str = String::from_utf8_lossy(&resp.body);
+            Err(format!(
+                "{} failed (HTTP {}): {}",
+                api_method, resp.status, body_str
+            ))
+        }
+        Err(e) => Err(format!("{} HTTP request failed: {}", api_method, e)),
+    }
+}
+
 /// Send a photo via the Telegram Bot API (multipart upload).
 ///
 /// Falls back to `send_document()` if the photo exceeds 10 MB.
@@ -1182,8 +1268,6 @@ fn send_photo(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
     if data.len() > MAX_PHOTO_SIZE {
         channel_host::log(
             channel_host::LogLevel::Info,
@@ -1202,59 +1286,16 @@ fn send_photo(
             message_thread_id,
         );
     }
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "photo", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendPhoto",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent photo '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendPhoto failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendPhoto HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendPhoto",
+        "photo",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
 /// Send a document via the Telegram Bot API (multipart upload).
@@ -1266,64 +1307,60 @@ fn send_document(
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    let message_thread_id = normalize_thread_id(message_thread_id);
-
-    let boundary = format!("ironclaw-{}", channel_host::now_millis());
-    let mut body = Vec::new();
-
-    write_multipart_field(&mut body, &boundary, "chat_id", &chat_id.to_string());
-    if let Some(msg_id) = reply_to_message_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "reply_to_message_id",
-            &msg_id.to_string(),
-        );
-    }
-    if let Some(thread_id) = message_thread_id {
-        write_multipart_field(
-            &mut body,
-            &boundary,
-            "message_thread_id",
-            &thread_id.to_string(),
-        );
-    }
-    write_multipart_file(&mut body, &boundary, "document", filename, mime_type, data);
-    body.extend_from_slice(format!("--{}--\r\n", boundary).as_bytes());
-
-    let headers = serde_json::json!({
-        "Content-Type": format!("multipart/form-data; boundary={}", boundary)
-    });
-
-    let result = channel_host::http_request(
-        "POST",
-        "https://api.telegram.org/bot{TELEGRAM_BOT_TOKEN}/sendDocument",
-        &headers.to_string(),
-        Some(&body),
-        Some(60_000), // 60s timeout for file uploads
-    );
-
-    match result {
-        Ok(resp) if resp.status == 200 => {
-            channel_host::log(
-                channel_host::LogLevel::Debug,
-                &format!("Sent document '{}' to chat {}", filename, chat_id),
-            );
-            Ok(())
-        }
-        Ok(resp) => {
-            let body_str = String::from_utf8_lossy(&resp.body);
-            Err(format!(
-                "sendDocument failed (HTTP {}): {}",
-                resp.status, body_str
-            ))
-        }
-        Err(e) => Err(format!("sendDocument HTTP request failed: {}", e)),
-    }
+    send_multipart_upload(
+        "sendDocument",
+        "document",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
 }
 
-/// Image MIME types that Telegram's sendPhoto API supports.
-const PHOTO_MIME_TYPES: &[&str] = &["image/jpeg", "image/png", "image/gif", "image/webp"];
+/// Send a voice note via the Telegram Bot API (multipart upload).
+///
+/// Telegram's `sendVoice` requires ogg/opus audio and displays it as an
+/// in-chat voice note with waveform and playback controls.
+/// Falls back to `send_document()` if the voice note exceeds 50 MB.
+fn send_voice(
+    chat_id: i64,
+    filename: &str,
+    mime_type: &str,
+    data: &[u8],
+    reply_to_message_id: Option<i64>,
+    message_thread_id: Option<i64>,
+) -> Result<(), String> {
+    if data.len() > MAX_VOICE_SIZE {
+        channel_host::log(
+            channel_host::LogLevel::Info,
+            &format!(
+                "Voice note {} exceeds 50MB ({}), sending as document",
+                filename,
+                data.len()
+            ),
+        );
+        return send_document(
+            chat_id,
+            filename,
+            mime_type,
+            data,
+            reply_to_message_id,
+            message_thread_id,
+        );
+    }
+    send_multipart_upload(
+        "sendVoice",
+        "voice",
+        chat_id,
+        filename,
+        mime_type,
+        data,
+        reply_to_message_id,
+        message_thread_id,
+    )
+}
 
 /// Send a full agent response (attachments + text) to a chat.
 ///
@@ -1410,31 +1447,65 @@ fn send_response(
     Ok(())
 }
 
-/// Send a single attachment, choosing sendPhoto or sendDocument based on MIME type.
+/// Extract the base MIME type, stripping any parameters after `;`.
+///
+/// e.g. `"audio/ogg; codecs=opus"` → `"audio/ogg"`
+fn base_mime_type(mime: &str) -> &str {
+    mime.split(';').next().unwrap_or(mime).trim()
+}
+
+/// Attachment routing category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AttachmentKind {
+    Photo,
+    Voice,
+    Document,
+}
+
+/// Classify an attachment's send method based on its MIME type.
+fn classify_attachment(mime_type: &str) -> AttachmentKind {
+    let base = base_mime_type(mime_type);
+    if PHOTO_MIME_TYPES.contains(&base) {
+        AttachmentKind::Photo
+    } else if VOICE_MIME_TYPES.contains(&base) {
+        AttachmentKind::Voice
+    } else {
+        AttachmentKind::Document
+    }
+}
+
+/// Send a single attachment, choosing sendPhoto, sendVoice, or sendDocument based on MIME type.
 fn send_attachment(
     chat_id: i64,
     attachment: &Attachment,
     reply_to_message_id: Option<i64>,
     message_thread_id: Option<i64>,
 ) -> Result<(), String> {
-    if PHOTO_MIME_TYPES.contains(&attachment.mime_type.as_str()) {
-        send_photo(
+    match classify_attachment(&attachment.mime_type) {
+        AttachmentKind::Photo => send_photo(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
-    } else {
-        send_document(
+        ),
+        AttachmentKind::Voice => send_voice(
             chat_id,
             &attachment.filename,
             &attachment.mime_type,
             &attachment.data,
             reply_to_message_id,
             message_thread_id,
-        )
+        ),
+        AttachmentKind::Document => send_document(
+            chat_id,
+            &attachment.filename,
+            &attachment.mime_type,
+            &attachment.data,
+            reply_to_message_id,
+            message_thread_id,
+        ),
     }
 }
 
@@ -3024,5 +3095,39 @@ mod tests {
     fn test_max_download_size_constant() {
         // Verify the constant is 20 MB, matching the Slack channel limit
         assert_eq!(MAX_DOWNLOAD_SIZE_BYTES, 20 * 1024 * 1024);
+    }
+
+    #[test]
+    fn test_base_mime_type() {
+        assert_eq!(base_mime_type("audio/ogg"), "audio/ogg");
+        assert_eq!(base_mime_type("audio/ogg; codecs=opus"), "audio/ogg");
+        assert_eq!(base_mime_type("image/jpeg"), "image/jpeg");
+        assert_eq!(base_mime_type("text/plain; charset=utf-8"), "text/plain");
+        assert_eq!(base_mime_type(""), "");
+    }
+
+    #[test]
+    fn test_classify_attachment_routing() {
+        // Photos
+        assert_eq!(classify_attachment("image/jpeg"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/png"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/gif"), AttachmentKind::Photo);
+        assert_eq!(classify_attachment("image/webp"), AttachmentKind::Photo);
+
+        // Voice notes — exact and parameterized
+        assert_eq!(classify_attachment("audio/ogg"), AttachmentKind::Voice);
+        assert_eq!(classify_attachment("audio/opus"), AttachmentKind::Voice);
+        assert_eq!(
+            classify_attachment("audio/ogg; codecs=opus"),
+            AttachmentKind::Voice
+        );
+
+        // Everything else falls through to document
+        assert_eq!(
+            classify_attachment("application/pdf"),
+            AttachmentKind::Document
+        );
+        assert_eq!(classify_attachment("audio/mpeg"), AttachmentKind::Document);
+        assert_eq!(classify_attachment("video/mp4"), AttachmentKind::Document);
     }
 }

--- a/channels-src/telegram/telegram.capabilities.json
+++ b/channels-src/telegram/telegram.capabilities.json
@@ -18,6 +18,14 @@
         "name": "telegram_bot_token",
         "prompt": "Enter your Telegram Bot API token (from @BotFather)",
         "optional": false
+      },
+      {
+        "name": "telegram_webhook_secret",
+        "prompt": "Webhook secret (leave empty to auto-generate)",
+        "optional": true,
+        "auto_generate": {
+          "length": 64
+        }
       }
     ],
     "setup_url": "https://t.me/BotFather",

--- a/channels-src/whatsapp/Cargo.lock
+++ b/channels-src/whatsapp/Cargo.lock
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "whatsapp-channel"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -5,3 +5,8 @@ mod util;
 
 pub use event::{AppEvent, ToolDecisionDto};
 pub use util::truncate_preview;
+
+/// Maximum worker agent loop iterations. Used by the orchestrator (server-side
+/// clamp in `create_job_inner`) and the worker runtime (`worker/job.rs`).
+/// A single source of truth prevents the two from drifting.
+pub const MAX_WORKER_ITERATIONS: u32 = 500;

--- a/docs/TELEGRAM_SETUP.md
+++ b/docs/TELEGRAM_SETUP.md
@@ -33,7 +33,7 @@ ironclaw onboard
 When prompted, enable the Telegram channel and paste your bot token. The wizard will:
 
 - Validate the token
-- Optionally configure a webhook secret
+- Auto-generate a webhook secret for webhook mode
 - Set up tunnel (if you want webhook mode)
 
 ### 3. (Optional) Configure Tunnel for Webhooks

--- a/migrations/V15__conversation_source_channel.sql
+++ b/migrations/V15__conversation_source_channel.sql
@@ -1,0 +1,4 @@
+-- Add source_channel to conversations for cross-channel approval authorization.
+-- Tracks which channel originally created a conversation so that approval
+-- messages from other channels can be validated.
+ALTER TABLE conversations ADD COLUMN source_channel TEXT;

--- a/profiles/local-sandbox.toml
+++ b/profiles/local-sandbox.toml
@@ -1,0 +1,28 @@
+# IronClaw Profile: local-sandbox
+#
+# Solo developer setup with Docker sandbox enabled for secure tool execution.
+# Same as 'local' but tools run inside isolated containers.
+#
+# Prerequisites:
+#   - Docker daemon running
+#
+# Usage: set IRONCLAW_PROFILE=local-sandbox in your environment or .env file.
+
+database_backend = "libsql"
+
+[channels]
+gateway_enabled = false
+cli_mode = "tui"
+
+[sandbox]
+enabled = true
+policy = "readonly"
+
+[heartbeat]
+enabled = false
+
+[routines]
+enabled = false
+
+[hygiene]
+enabled = false

--- a/profiles/local.toml
+++ b/profiles/local.toml
@@ -1,0 +1,28 @@
+# IronClaw Profile: local
+#
+# Stripped-down configuration for solo developers working locally.
+# Disables server-oriented features (gateway, heartbeat, routines, sandbox)
+# and enables the rich TUI for an interactive terminal experience.
+#
+# Usage: set IRONCLAW_PROFILE=local in your environment or .env file.
+#
+# You can override any setting here via ~/.ironclaw/config.toml or
+# environment variables.
+
+database_backend = "libsql"
+
+[channels]
+gateway_enabled = false
+cli_mode = "tui"
+
+[sandbox]
+enabled = false
+
+[heartbeat]
+enabled = false
+
+[routines]
+enabled = false
+
+[hygiene]
+enabled = false

--- a/profiles/server-multitenant.toml
+++ b/profiles/server-multitenant.toml
@@ -1,0 +1,29 @@
+# IronClaw Profile: server-multitenant
+#
+# Multi-user SaaS deployment. Builds on the 'server' profile with higher
+# concurrency limits.
+#
+# Required environment variables:
+#   DATABASE_URL=postgres://user:pass@host/db
+#   AGENT_MULTI_TENANT=true          (env-only, cannot be set via profile)
+#
+# Recommended environment variables:
+#   MAX_COST_PER_USER_PER_DAY_CENTS=1000   (env-only cost controls)
+#   GATEWAY_AUTH_TOKEN=<secret>             (env-only auth)
+#
+# Usage: set IRONCLAW_PROFILE=server-multitenant in your environment or .env file.
+
+database_backend = "postgres"
+
+[agent]
+max_parallel_jobs = 10
+
+[sandbox]
+enabled = true
+policy = "readonly"
+
+[heartbeat]
+enabled = true
+
+[hygiene]
+enabled = true

--- a/profiles/server.toml
+++ b/profiles/server.toml
@@ -1,0 +1,21 @@
+# IronClaw Profile: server
+#
+# Single-user server deployment with PostgreSQL, web gateway, Docker sandbox,
+# and proactive background features enabled.
+#
+# Required environment variables:
+#   DATABASE_URL=postgres://user:pass@host/db
+#
+# Usage: set IRONCLAW_PROFILE=server in your environment or .env file.
+
+database_backend = "postgres"
+
+[sandbox]
+enabled = true
+policy = "readonly"
+
+[heartbeat]
+enabled = true
+
+[hygiene]
+enabled = true

--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -2,7 +2,7 @@
   "name": "discord",
   "display_name": "Discord Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Discord",
   "keywords": [
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/download/v0.19.0/channel-discord-0.2.1-wasm32-wasip2.tar.gz",
-      "sha256": "6159cb54aa44a9d8219e29bf0aea9404213b20ff567506fe75f23d4698d6ec18"
+      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.24.0/channel-discord-0.2.2-wasm32-wasip2.tar.gz",
+      "sha256": "b126e4af7a8079a7178b5ae03f1b44c8eab02fa209fb102346e3be661428aece"
     }
   },
   "auth_summary": {

--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [
@@ -19,8 +19,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "sha256": "a66ff0dafb67d2216d8161bb7e96e724a94acb0ab993b85d2782d30412f8fe94",
-      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.22.0/channel-feishu-0.1.3-wasm32-wasip2.tar.gz"
+      "sha256": "393d2d5d8766ace574e3a4978d47d5976548a3e862a80ba42a456f2f457e45cf",
+      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.24.0/channel-feishu-0.1.4-wasm32-wasip2.tar.gz"
     }
   },
   "auth_summary": {

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -2,7 +2,7 @@
   "name": "slack",
   "display_name": "Slack Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Slack",
   "keywords": [
@@ -18,8 +18,8 @@
   },
   "artifacts": {
     "wasm32-wasip2": {
-      "url": "https://github.com/nearai/ironclaw/releases/download/v0.18.0/slack-0.2.1-wasm32-wasip2.tar.gz",
-      "sha256": "d4667e35126986509d862bc3a0088777305d8f41c75de83c1e223b42312ede48"
+      "url": "https://github.com/nearai/ironclaw/releases/download/ironclaw-v0.24.0/channel-slack-0.2.2-wasm32-wasip2.tar.gz",
+      "sha256": "38a06480456fe15e5003792c2309d56f38b544f8ea7c90ab7baf451438a082de"
     }
   },
   "auth_summary": {

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [

--- a/registry/channels/whatsapp.json
+++ b/registry/channels/whatsapp.json
@@ -2,7 +2,7 @@
   "name": "whatsapp",
   "display_name": "WhatsApp Channel",
   "kind": "channel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through WhatsApp",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wit_version": "0.3.0",
   "description": "GitHub integration for repositories, issues, pull requests, search, branches, file writes, releases, and workflows",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -4,13 +4,15 @@
   "kind": "tool",
   "version": "0.2.2",
   "wit_version": "0.3.0",
-  "description": "GitHub integration for issues, PRs, repos, and code search",
+  "description": "GitHub integration for repositories, issues, pull requests, search, branches, file writes, releases, and workflows",
   "keywords": [
     "git",
     "code",
     "issues",
     "pull-requests",
-    "repositories"
+    "repositories",
+    "search",
+    "releases"
   ],
   "source": {
     "dir": "tools-src/github",

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,15 +2,17 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wit_version": "0.3.0",
-  "description": "GitHub integration for issues, PRs, repos, and code search",
+  "description": "GitHub integration for repositories, issues, pull requests, search, branches, file writes, releases, and workflows",
   "keywords": [
     "git",
     "code",
     "issues",
     "pull-requests",
-    "repositories"
+    "repositories",
+    "search",
+    "releases"
   ],
   "source": {
     "dir": "tools-src/github",

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -843,7 +843,10 @@ impl Agent {
             {
                 use crate::agent::session::Thread;
                 let mut sess = session.lock().await;
-                let thread = Thread::with_id(id, sess.id);
+                // Bootstrap thread has no incoming message -- use the
+                // "__bootstrap__" sentinel so approvals from any channel are
+                // permitted. None means "deny by default" (fail-closed).
+                let thread = Thread::with_id(id, sess.id, Some("__bootstrap__"));
                 sess.active_thread = Some(id);
                 sess.threads.entry(id).or_insert(thread);
             }
@@ -1148,7 +1151,37 @@ impl Agent {
                 .get_or_create_session(&message.user_id)
                 .await;
             let mut sess = session.lock().await;
-            if sess.threads.contains_key(&target_thread_id) {
+            if let Some(thread) = sess.threads.get(&target_thread_id) {
+                // Verify the thread actually has a pending approval before
+                // allowing approval-shaped messages to target it. Without this
+                // check, an attacker could use approval messages to hijack any
+                // thread by UUID.
+                if thread.pending_approval.is_none() {
+                    tracing::warn!(
+                        %target_thread_id,
+                        approval_channel = %message.channel,
+                        "Blocked approval for thread with no pending approval"
+                    );
+                    drop(sess);
+                    return Ok(Some("Error: no pending approval on this thread".into()));
+                }
+
+                let authorized = crate::agent::session::is_approval_authorized(
+                    thread.source_channel.as_deref(),
+                    &message.channel,
+                );
+                if !authorized {
+                    tracing::warn!(
+                        %target_thread_id,
+                        source_channel = ?thread.source_channel,
+                        approval_channel = %message.channel,
+                        "Blocked cross-channel approval attempt"
+                    );
+                    drop(sess);
+                    return Ok(Some(
+                        "Error: approval not authorized for this channel".into(),
+                    ));
+                }
                 sess.active_thread = Some(target_thread_id);
                 sess.last_active_at = chrono::Utc::now();
                 drop(sess);

--- a/src/agent/compaction.rs
+++ b/src/agent/compaction.rs
@@ -319,7 +319,7 @@ mod tests {
 
     #[test]
     fn test_format_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("Hello");
         thread.complete_turn("Hi there");
         thread.start_turn("How are you?");
@@ -351,7 +351,7 @@ mod tests {
     /// Helper: build a thread with `n` completed turns.
     /// Turn `i` has user_input "msg-{i}" and response "resp-{i}".
     fn make_thread(n: usize) -> Thread {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         for i in 0..n {
             thread.start_turn(format!("msg-{}", i));
             thread.complete_turn(format!("resp-{}", i));
@@ -457,7 +457,7 @@ mod tests {
     async fn test_compact_truncate_empty_turns() {
         let llm = Arc::new(StubLlm::new("unused"));
         let compactor = make_compactor(llm);
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         assert!(thread.turns.is_empty());
 
         let result = compactor
@@ -698,7 +698,7 @@ mod tests {
 
     #[test]
     fn test_format_turns_for_storage_with_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("Search for X");
         // Record a tool call on the current turn
         if let Some(turn) = thread.turns.last_mut() {
@@ -719,7 +719,7 @@ mod tests {
 
     #[test]
     fn test_format_turns_for_storage_incomplete_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("In progress message");
         // Don't complete the turn
 

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -2313,7 +2313,7 @@ mod tests {
         // Initialize a thread in the session so the loop can record tool calls.
         let thread_id = {
             let mut sess = session.lock().await;
-            sess.create_thread().id
+            sess.create_thread(Some("test")).id
         };
 
         let message = IncomingMessage::new("test", "test-user", "do something");
@@ -2426,7 +2426,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("test-user")));
         let thread_id = {
             let mut sess = session.lock().await;
-            sess.create_thread().id
+            sess.create_thread(Some("test")).id
         };
 
         let message = IncomingMessage::new("test", "test-user", "keep calling tools");

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -97,6 +97,10 @@ pub(crate) fn routine_matches_message(routine: &Routine, message: &IncomingMessa
     true
 }
 
+fn trigger_uses_event_cache(trigger: &Trigger) -> bool {
+    matches!(trigger, Trigger::Event { .. } | Trigger::SystemEvent { .. })
+}
+
 /// The routine execution engine.
 pub struct RoutineEngine {
     config: RoutineConfig,
@@ -666,7 +670,7 @@ impl RoutineEngine {
             None
         };
 
-        if let Err(e) = self
+        let runtime_updated = match self
             .store
             .update_routine_runtime(
                 routine.id,
@@ -678,10 +682,25 @@ impl RoutineEngine {
             )
             .await
         {
-            tracing::error!(
-                routine = %routine.name,
-                "Failed to update routine runtime after dispatched run: {}", e
-            );
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    routine = %routine.name,
+                    "Failed to update routine runtime after dispatched run: {}", e
+                );
+                false
+            }
+        };
+
+        if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+            update_cached_event_runtime(
+                self.event_cache.as_ref(),
+                routine.id,
+                now,
+                routine.run_count + 1,
+                new_failures,
+            )
+            .await;
         }
 
         // Persist result to the routine's conversation thread
@@ -812,6 +831,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -897,6 +917,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -951,6 +972,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         // Record the run in DB, then spawn execution
@@ -1089,6 +1111,7 @@ struct EngineContext {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     sandbox_readiness: SandboxReadiness,
+    event_cache: Arc<RwLock<Vec<EventMatcher>>>,
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
@@ -1175,7 +1198,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         0
     };
 
-    if let Err(e) = ctx
+    let runtime_updated = match ctx
         .store
         .update_routine_runtime(
             routine.id,
@@ -1187,7 +1210,22 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         )
         .await
     {
-        tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+            false
+        }
+    };
+
+    if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+        update_cached_event_runtime(
+            ctx.event_cache.as_ref(),
+            routine.id,
+            now,
+            routine.run_count + 1,
+            new_failures,
+        )
+        .await;
     }
 
     // Persist routine result to its dedicated conversation thread
@@ -1234,6 +1272,27 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         thread_id.as_deref(),
     )
     .await;
+}
+
+async fn update_cached_event_runtime(
+    event_cache: &RwLock<Vec<EventMatcher>>,
+    routine_id: Uuid,
+    last_run_at: chrono::DateTime<Utc>,
+    run_count: u64,
+    consecutive_failures: u32,
+) {
+    let mut cache = event_cache.write().await;
+    for matcher in cache.iter_mut() {
+        let routine = match matcher {
+            EventMatcher::Message { routine, .. } | EventMatcher::System { routine } => routine,
+        };
+        if routine.id == routine_id {
+            routine.last_run_at = Some(last_run_at);
+            routine.run_count = run_count;
+            routine.consecutive_failures = consecutive_failures;
+            break;
+        }
+    }
 }
 
 /// Sanitize a routine name for use in workspace paths.

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -97,6 +97,10 @@ pub(crate) fn routine_matches_message(routine: &Routine, message: &IncomingMessa
     true
 }
 
+fn trigger_uses_event_cache(trigger: &Trigger) -> bool {
+    matches!(trigger, Trigger::Event { .. } | Trigger::SystemEvent { .. })
+}
+
 /// The routine execution engine.
 pub struct RoutineEngine {
     config: RoutineConfig,
@@ -666,7 +670,7 @@ impl RoutineEngine {
             None
         };
 
-        if let Err(e) = self
+        let runtime_updated = match self
             .store
             .update_routine_runtime(
                 routine.id,
@@ -678,10 +682,25 @@ impl RoutineEngine {
             )
             .await
         {
-            tracing::error!(
-                routine = %routine.name,
-                "Failed to update routine runtime after dispatched run: {}", e
-            );
+            Ok(()) => true,
+            Err(e) => {
+                tracing::error!(
+                    routine = %routine.name,
+                    "Failed to update routine runtime after dispatched run: {}", e
+                );
+                false
+            }
+        };
+
+        if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+            update_cached_event_runtime(
+                self.event_cache.as_ref(),
+                routine.id,
+                now,
+                routine.run_count + 1,
+                new_failures,
+            )
+            .await;
         }
 
         // Persist result to the routine's conversation thread
@@ -812,6 +831,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -897,6 +917,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         tokio::spawn(async move {
@@ -951,6 +972,7 @@ impl RoutineEngine {
             tools: self.tools.clone(),
             safety: self.safety.clone(),
             sandbox_readiness: self.sandbox_readiness,
+            event_cache: Arc::clone(&self.event_cache),
         };
 
         // Record the run in DB, then spawn execution
@@ -1089,6 +1111,7 @@ struct EngineContext {
     tools: Arc<ToolRegistry>,
     safety: Arc<SafetyLayer>,
     sandbox_readiness: SandboxReadiness,
+    event_cache: Arc<RwLock<Vec<EventMatcher>>>,
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
@@ -1175,7 +1198,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         0
     };
 
-    if let Err(e) = ctx
+    let runtime_updated = match ctx
         .store
         .update_routine_runtime(
             routine.id,
@@ -1187,7 +1210,22 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         )
         .await
     {
-        tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+        Ok(()) => true,
+        Err(e) => {
+            tracing::error!(routine = %routine.name, "Failed to update runtime state: {}", e);
+            false
+        }
+    };
+
+    if runtime_updated && trigger_uses_event_cache(&routine.trigger) {
+        update_cached_event_runtime(
+            ctx.event_cache.as_ref(),
+            routine.id,
+            now,
+            routine.run_count + 1,
+            new_failures,
+        )
+        .await;
     }
 
     // Persist routine result to its dedicated conversation thread
@@ -1234,6 +1272,27 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
         thread_id.as_deref(),
     )
     .await;
+}
+
+async fn update_cached_event_runtime(
+    event_cache: &RwLock<Vec<EventMatcher>>,
+    routine_id: Uuid,
+    last_run_at: chrono::DateTime<Utc>,
+    run_count: u64,
+    consecutive_failures: u32,
+) {
+    let mut cache = event_cache.write().await;
+    for matcher in cache.iter_mut() {
+        let routine = match matcher {
+            EventMatcher::Message { routine, .. } | EventMatcher::System { routine } => routine,
+        };
+        if routine.id == routine_id {
+            routine.last_run_at = Some(last_run_at);
+            routine.run_count = run_count;
+            routine.consecutive_failures = consecutive_failures;
+            break;
+        }
+    }
 }
 
 /// Sanitize a routine name for use in workspace paths.
@@ -1613,13 +1672,23 @@ async fn execute_lightweight_with_tools(
     let mut total_input_tokens = 0;
     let mut total_output_tokens = 0;
 
-    // Create a minimal job context for tool execution with unique run ID
+    // Create a minimal job context for tool execution with unique run ID.
+    // Carry the routine's notify config in metadata so the message tool can
+    // resolve channel/target — mirrors the full-job path in execute_full_job().
     let run_id = Uuid::new_v4();
+    let mut lw_metadata = serde_json::json!({
+        "owner_id": routine.user_id
+    });
+    if let Some(channel) = &routine.notify.channel {
+        lw_metadata["notify_channel"] = serde_json::json!(channel);
+    }
+    lw_metadata["notify_user"] = serde_json::json!(&routine.notify.user);
     let job_ctx = JobContext {
         job_id: run_id,
         user_id: routine.user_id.clone(),
         title: "Lightweight Routine".to_string(),
         description: routine.name.clone(),
+        metadata: lw_metadata,
         ..Default::default()
     };
     let allowed_tools =
@@ -2574,5 +2643,32 @@ mod tests {
         let result = sanitize_summary(&s);
         assert!(result.len() <= 503);
         assert!(result.ends_with("..."));
+    }
+
+    /// Regression: lightweight routines must carry notify metadata in JobContext
+    /// so the message tool can route to the correct channel. Previously,
+    /// `..Default::default()` left metadata as null, causing messages to land
+    /// in the user's DM instead of the originating Slack channel.
+    #[test]
+    fn test_build_lightweight_prompt_preserves_notify_config() {
+        let notify = NotifyConfig {
+            channel: Some("slack-relay".to_string()),
+            user: Some("C088K6C3SQZ".to_string()),
+            on_attention: true,
+            on_failure: true,
+            on_success: false,
+        };
+
+        let prompt =
+            super::build_lightweight_prompt("Send Ping in this channel.", &[], None, &notify, true);
+
+        assert!(
+            prompt.contains("slack-relay"),
+            "prompt should mention configured delivery channel: {prompt}",
+        );
+        assert!(
+            prompt.contains("C088K6C3SQZ"),
+            "prompt should mention configured delivery target: {prompt}",
+        );
     }
 }

--- a/src/agent/scheduler.rs
+++ b/src/agent/scheduler.rs
@@ -197,26 +197,28 @@ impl Scheduler {
             })
             .unwrap_or(self.config.max_tokens_per_job);
 
-        // Apply both metadata and token budget in one closure (Issue #813: atomic update).
-        // Use update_context_and_get to ensure atomicity: no gap where concurrent workers
-        // can modify the context between update and DB persist (Issue #807).
-        let ctx = if let Some(meta) = metadata {
+        // Apply metadata, token budget, and approval context in one closure
+        // (Issue #813: atomic update). Use update_context_and_get to ensure atomicity:
+        // no gap where concurrent workers can modify the context between update and
+        // DB persist (Issue #807).
+        let needs_update = metadata.is_some() || max_tokens > 0 || approval_context.is_some();
+        let ctx = if needs_update {
             self.context_manager
                 .update_context_and_get(job_id, |ctx| {
-                    ctx.metadata = meta;
+                    if let Some(meta) = metadata {
+                        ctx.metadata = meta;
+                    }
                     if max_tokens > 0 {
                         ctx.max_tokens = max_tokens;
                     }
-                })
-                .await?
-        } else if max_tokens > 0 {
-            self.context_manager
-                .update_context_and_get(job_id, |ctx| {
-                    ctx.max_tokens = max_tokens;
+                    if let Some(ref approval) = approval_context {
+                        ctx.approval_context = Some(approval.clone());
+                    }
                 })
                 .await?
         } else {
-            // No metadata or token budget to set; get the initial context
+            // Currently unreachable via dispatch_job() which always provides
+            // Some(approval_context), but kept as a safe fallback.
             self.context_manager.get_context(job_id).await?
         };
 

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -68,8 +68,8 @@ impl Session {
     }
 
     /// Create a new thread in this session.
-    pub fn create_thread(&mut self) -> &mut Thread {
-        let thread = Thread::new(self.id);
+    pub fn create_thread(&mut self, channel: Option<&str>) -> &mut Thread {
+        let thread = Thread::new(self.id, channel);
         let thread_id = thread.id;
         self.active_thread = Some(thread_id);
         self.last_active_at = Utc::now();
@@ -87,9 +87,9 @@ impl Session {
     }
 
     /// Get or create the active thread.
-    pub fn get_or_create_thread(&mut self) -> &mut Thread {
+    pub fn get_or_create_thread(&mut self, channel: Option<&str>) -> &mut Thread {
         match self.active_thread {
-            None => self.create_thread(),
+            None => self.create_thread(channel),
             Some(id) => {
                 if self.threads.contains_key(&id) {
                     // Entry existence confirmed by contains_key above.
@@ -100,7 +100,7 @@ impl Session {
                 } else {
                     // Stale active_thread ID: create a new thread, which
                     // updates self.active_thread to the new thread's ID.
-                    self.create_thread()
+                    self.create_thread(channel)
                 }
             }
         }
@@ -225,6 +225,9 @@ pub struct Thread {
     /// Messages queued while the thread was processing a turn.
     #[serde(default, skip_serializing_if = "VecDeque::is_empty")]
     pub pending_messages: VecDeque<String>,
+    /// Channel that created this thread (for approval authorization).
+    #[serde(default)]
+    pub source_channel: Option<String>,
 }
 
 /// Maximum number of messages that can be queued while a thread is processing.
@@ -233,9 +236,34 @@ pub struct Thread {
 /// rapid follow-ups. The drain loop processes them as one newline-delimited turn.
 pub const MAX_PENDING_MESSAGES: usize = 10;
 
+/// Sentinel value for bootstrap threads that accept approvals from any channel.
+pub const BOOTSTRAP_SOURCE_CHANNEL: &str = "__bootstrap__";
+
+/// Channels that are always authorized to approve tool calls on any thread,
+/// regardless of which channel originally created the thread. These are
+/// trusted UI surfaces (the web dashboard and its gateway).
+pub const TRUSTED_APPROVAL_CHANNELS: &[&str] = &["web", "gateway"];
+
+/// Check whether an approval from `requesting_channel` is authorized for a
+/// thread whose `source_channel` is `source`.
+///
+/// Rules:
+/// - `None` (unknown origin) -> denied (fail-closed)
+/// - `Some("__bootstrap__")` -> authorized from any channel
+/// - `Some(src) == requesting` -> same channel, authorized
+/// - requesting is in `TRUSTED_APPROVAL_CHANNELS` -> always authorized
+/// - Otherwise -> denied
+pub fn is_approval_authorized(source: Option<&str>, requesting: &str) -> bool {
+    match source {
+        None => false,
+        Some(src) if src == BOOTSTRAP_SOURCE_CHANNEL => true,
+        Some(src) => src == requesting || TRUSTED_APPROVAL_CHANNELS.contains(&requesting),
+    }
+}
+
 impl Thread {
     /// Create a new thread.
-    pub fn new(session_id: Uuid) -> Self {
+    pub fn new(session_id: Uuid, source_channel: Option<&str>) -> Self {
         let now = Utc::now();
         Self {
             id: Uuid::new_v4(),
@@ -248,11 +276,12 @@ impl Thread {
             pending_approval: None,
             pending_auth: None,
             pending_messages: VecDeque::new(),
+            source_channel: source_channel.map(String::from),
         }
     }
 
     /// Create a thread with a specific ID (for DB hydration).
-    pub fn with_id(id: Uuid, session_id: Uuid) -> Self {
+    pub fn with_id(id: Uuid, session_id: Uuid, source_channel: Option<&str>) -> Self {
         let now = Utc::now();
         Self {
             id,
@@ -265,6 +294,7 @@ impl Thread {
             pending_approval: None,
             pending_auth: None,
             pending_messages: VecDeque::new(),
+            source_channel: source_channel.map(String::from),
         }
     }
 
@@ -787,13 +817,13 @@ mod tests {
         let mut session = Session::new("user-123");
         assert!(session.active_thread.is_none());
 
-        session.create_thread();
+        session.create_thread(None);
         assert!(session.active_thread.is_some());
     }
 
     #[test]
     fn test_thread_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Hello");
         assert_eq!(thread.state, ThreadState::Processing);
@@ -806,7 +836,7 @@ mod tests {
 
     #[test]
     fn test_thread_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("First message");
         thread.complete_turn("First response");
@@ -829,7 +859,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // First add some turns
         thread.start_turn("Original message");
@@ -855,7 +885,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_incomplete_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Messages with incomplete last turn (no assistant response)
         let messages = vec![
@@ -874,7 +904,7 @@ mod tests {
     #[test]
     fn test_enter_auth_mode() {
         let before = Utc::now();
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         assert!(thread.pending_auth.is_none());
 
         thread.enter_auth_mode("telegram".to_string());
@@ -887,7 +917,7 @@ mod tests {
 
     #[test]
     fn test_take_pending_auth() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.enter_auth_mode("notion".to_string());
 
         let pending = thread.take_pending_auth();
@@ -902,7 +932,7 @@ mod tests {
 
     #[test]
     fn test_pending_auth_serialization() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.enter_auth_mode("openai".to_string());
 
         let json = serde_json::to_string(&thread).expect("should serialize");
@@ -932,7 +962,7 @@ mod tests {
     #[test]
     fn test_pending_auth_default_none() {
         // Deserialization of old data without pending_auth should default to None
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.pending_auth = None;
         let json = serde_json::to_string(&thread).expect("serialize");
 
@@ -946,7 +976,7 @@ mod tests {
     fn test_thread_with_id() {
         let specific_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let thread = Thread::with_id(specific_id, session_id);
+        let thread = Thread::with_id(specific_id, session_id, None);
 
         assert_eq!(thread.id, specific_id);
         assert_eq!(thread.session_id, session_id);
@@ -958,7 +988,7 @@ mod tests {
     fn test_thread_with_id_restore_messages() {
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
 
         let messages = vec![
             ChatMessage::user("Hello from DB"),
@@ -977,7 +1007,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_empty() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Add a turn first, then restore with empty vec
         thread.start_turn("hello");
@@ -993,7 +1023,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_only_assistant_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Only assistant messages (no user messages to anchor turns)
         let messages = vec![
@@ -1010,7 +1040,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_multiple_user_messages_in_a_row() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Two user messages with no assistant response between them
         let messages = vec![
@@ -1037,8 +1067,8 @@ mod tests {
     fn test_thread_switch() {
         let mut session = Session::new("user-1");
 
-        let t1_id = session.create_thread().id;
-        let t2_id = session.create_thread().id;
+        let t1_id = session.create_thread(None).id;
+        let t2_id = session.create_thread(None).id;
 
         // After creating two threads, active should be the last one
         assert_eq!(session.active_thread, Some(t2_id));
@@ -1058,8 +1088,8 @@ mod tests {
     fn test_get_or_create_thread_idempotent() {
         let mut session = Session::new("user-1");
 
-        let tid1 = session.get_or_create_thread().id;
-        let tid2 = session.get_or_create_thread().id;
+        let tid1 = session.get_or_create_thread(None).id;
+        let tid2 = session.get_or_create_thread(None).id;
 
         // Should return the same thread (not create a new one each time)
         assert_eq!(tid1, tid2);
@@ -1068,7 +1098,7 @@ mod tests {
 
     #[test]
     fn test_truncate_turns() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         for i in 0..5 {
             thread.start_turn(format!("msg-{}", i));
@@ -1092,7 +1122,7 @@ mod tests {
 
     #[test]
     fn test_truncate_turns_noop_when_fewer() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("only one");
         thread.complete_turn("response");
@@ -1104,7 +1134,7 @@ mod tests {
 
     #[test]
     fn test_thread_interrupt_and_resume() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("do something");
         assert_eq!(thread.state, ThreadState::Processing);
@@ -1122,7 +1152,7 @@ mod tests {
 
     #[test]
     fn test_resume_only_from_interrupted() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Idle thread: resume should be a no-op
         assert_eq!(thread.state, ThreadState::Idle);
@@ -1138,7 +1168,7 @@ mod tests {
 
     #[test]
     fn test_turn_fail() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("risky operation");
         thread.fail_turn("connection timed out");
@@ -1154,7 +1184,7 @@ mod tests {
 
     #[test]
     fn test_messages_with_incomplete_last_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("first");
         thread.complete_turn("first reply");
@@ -1170,7 +1200,7 @@ mod tests {
 
     #[test]
     fn test_thread_serialization_round_trip() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("hello");
         thread.complete_turn("world");
@@ -1188,7 +1218,7 @@ mod tests {
     #[test]
     fn test_session_serialization_round_trip() {
         let mut session = Session::new("user-ser");
-        session.create_thread();
+        session.create_thread(None);
         session.auto_approve_tool("echo");
 
         let json = serde_json::to_string(&session).unwrap();
@@ -1226,7 +1256,7 @@ mod tests {
 
     #[test]
     fn test_turn_number_increments() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Before any turns, turn_number() is 1 (1-indexed for display)
         assert_eq!(thread.turn_number(), 1);
@@ -1241,7 +1271,7 @@ mod tests {
 
     #[test]
     fn test_complete_turn_on_empty_thread() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Completing a turn when there are no turns should be a safe no-op
         thread.complete_turn("phantom response");
@@ -1251,7 +1281,7 @@ mod tests {
 
     #[test]
     fn test_fail_turn_on_empty_thread() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Failing a turn when there are no turns should be a safe no-op
         thread.fail_turn("phantom error");
@@ -1261,7 +1291,7 @@ mod tests {
 
     #[test]
     fn test_pending_approval_flow() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let approval = PendingApproval {
             request_id: Uuid::new_v4(),
@@ -1288,7 +1318,7 @@ mod tests {
 
     #[test]
     fn test_clear_pending_approval() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let approval = PendingApproval {
             request_id: Uuid::new_v4(),
@@ -1317,7 +1347,7 @@ mod tests {
         assert!(session.active_thread().is_none());
         assert!(session.active_thread_mut().is_none());
 
-        let tid = session.create_thread().id;
+        let tid = session.create_thread(None).id;
 
         assert!(session.active_thread().is_some());
         assert_eq!(session.active_thread().unwrap().id, tid);
@@ -1334,7 +1364,7 @@ mod tests {
 
     #[test]
     fn test_messages_includes_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Search for X");
         {
@@ -1366,7 +1396,7 @@ mod tests {
 
     #[test]
     fn test_messages_multiple_tool_calls_per_turn() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Do two things");
         {
@@ -1393,7 +1423,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_with_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Build a message sequence with tool calls
         let tc = ToolCall {
@@ -1425,7 +1455,7 @@ mod tests {
 
     #[test]
     fn test_restore_from_messages_with_tool_error() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let tc = ToolCall {
             id: "call_0".to_string(),
@@ -1456,7 +1486,7 @@ mod tests {
     fn test_messages_round_trip_with_tools() {
         // Build a thread with tool calls, get messages(), restore, get messages() again
         // The two message sequences should be equivalent.
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Do search");
         {
@@ -1469,7 +1499,7 @@ mod tests {
         let messages_original = thread.messages();
 
         // Restore into a new thread
-        let mut thread2 = Thread::new(Uuid::new_v4());
+        let mut thread2 = Thread::new(Uuid::new_v4(), None);
         thread2.restore_from_messages(messages_original.clone());
 
         let messages_restored = thread2.messages();
@@ -1491,7 +1521,7 @@ mod tests {
 
     #[test]
     fn test_restore_multi_stage_tool_calls() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         let tc1 = ToolCall {
             id: "call_a".to_string(),
@@ -1534,7 +1564,7 @@ mod tests {
 
     #[test]
     fn test_messages_truncates_large_tool_results() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         thread.start_turn("Read big file");
         {
@@ -1557,7 +1587,7 @@ mod tests {
 
     #[test]
     fn test_thread_message_queue() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Queue is initially empty
         assert!(thread.pending_messages.is_empty());
@@ -1593,7 +1623,7 @@ mod tests {
 
     #[test]
     fn test_thread_message_queue_serialization() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Empty queue should not appear in serialization (skip_serializing_if)
         let json = serde_json::to_string(&thread).unwrap();
@@ -1613,7 +1643,7 @@ mod tests {
     #[test]
     fn test_thread_message_queue_default_on_old_data() {
         // Deserialization of old data without pending_messages should default to empty
-        let thread = Thread::new(Uuid::new_v4());
+        let thread = Thread::new(Uuid::new_v4(), None);
         let json = serde_json::to_string(&thread).unwrap();
 
         // The field is absent (skip_serializing_if), simulating old data
@@ -1624,7 +1654,7 @@ mod tests {
 
     #[test]
     fn test_interrupt_clears_pending_messages() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Start a turn so there's something to interrupt
         thread.start_turn("initial input");
@@ -1643,7 +1673,7 @@ mod tests {
 
     #[test]
     fn test_thread_state_idle_after_full_drain() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Simulate a full drain cycle: start turn, queue messages, complete turn,
         // then drain all queued messages as a single merged turn (#259).
@@ -1671,7 +1701,7 @@ mod tests {
 
     #[test]
     fn test_drain_pending_messages_merges_with_newlines() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Empty queue returns None
         assert!(thread.drain_pending_messages().is_none());
@@ -1700,7 +1730,7 @@ mod tests {
 
     #[test]
     fn test_requeue_drained_preserves_content_at_front() {
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
 
         // Re-queue into empty queue
         thread.requeue_drained("failed batch".to_string());
@@ -1809,6 +1839,202 @@ mod tests {
         assert_eq!(
             turn.tool_calls[0].result.as_ref().unwrap(),
             &serde_json::json!("done")
+        );
+    }
+
+    #[test]
+    fn test_thread_new_stores_source_channel() {
+        let thread = Thread::new(Uuid::new_v4(), Some("telegram"));
+        assert_eq!(thread.source_channel.as_deref(), Some("telegram"));
+    }
+
+    #[test]
+    fn test_thread_new_none_channel() {
+        let thread = Thread::new(Uuid::new_v4(), None);
+        assert!(thread.source_channel.is_none());
+    }
+
+    #[test]
+    fn test_source_channel_serde_backcompat() {
+        // Simulate deserializing a Thread from older DB records that lack source_channel.
+        let thread = Thread::new(Uuid::new_v4(), Some("cli"));
+        let json = serde_json::to_string(&thread).unwrap();
+
+        // Remove the source_channel field to simulate an old record.
+        let mut value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        value.as_object_mut().unwrap().remove("source_channel");
+        let old_json = serde_json::to_string(&value).unwrap();
+
+        let deserialized: Thread = serde_json::from_str(&old_json).unwrap();
+        assert!(
+            deserialized.source_channel.is_none(),
+            "missing source_channel should deserialize as None"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_same_channel() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "telegram"),
+            "same channel should be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_different_channel_blocked() {
+        assert!(
+            !is_approval_authorized(Some("telegram"), "http"),
+            "different channel should be blocked"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_web_always_allowed() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "web"),
+            "web channel should always be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_gateway_always_allowed() {
+        assert!(
+            is_approval_authorized(Some("telegram"), "gateway"),
+            "gateway channel should always be authorized"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_none_denied() {
+        assert!(
+            !is_approval_authorized(None, "telegram"),
+            "None source_channel should be denied (fail-closed)"
+        );
+        assert!(
+            !is_approval_authorized(None, "web"),
+            "None source_channel should be denied even for web"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_bootstrap_any_channel() {
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "telegram"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "http"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+        assert!(
+            is_approval_authorized(Some(BOOTSTRAP_SOURCE_CHANNEL), "cli"),
+            "__bootstrap__ should be authorized from any channel"
+        );
+    }
+
+    #[test]
+    fn test_approval_authorized_uses_trusted_channels_constant() {
+        // Every channel in TRUSTED_APPROVAL_CHANNELS should be authorized
+        // against any source, ensuring the constant drives the logic.
+        for &trusted in TRUSTED_APPROVAL_CHANNELS {
+            assert!(
+                is_approval_authorized(Some("any-source"), trusted),
+                "TRUSTED_APPROVAL_CHANNELS entry '{}' should always be authorized",
+                trusted
+            );
+        }
+    }
+
+    #[test]
+    fn test_approval_blocks_thread_without_pending_approval() {
+        // A thread with no pending_approval should not be eligible for
+        // approval routing. This test verifies the data-level invariant
+        // that `agent_loop.rs` checks before calling is_approval_authorized.
+        let thread = Thread::new(Uuid::new_v4(), Some("telegram"));
+        assert!(
+            thread.pending_approval.is_none(),
+            "new thread should have no pending approval"
+        );
+
+        // Set up a thread WITH a pending approval to contrast
+        let mut thread_with_approval = Thread::new(Uuid::new_v4(), Some("telegram"));
+        thread_with_approval.pending_approval = Some(PendingApproval {
+            request_id: Uuid::new_v4(),
+            tool_name: "shell".to_string(),
+            parameters: serde_json::json!({"cmd": "rm -rf /"}),
+            display_parameters: serde_json::json!({"cmd": "rm -rf /"}),
+            description: "run shell command".to_string(),
+            tool_call_id: "call_1".to_string(),
+            context_messages: vec![],
+            deferred_tool_calls: vec![],
+            user_timezone: None,
+            allow_always: true,
+        });
+        assert!(
+            thread_with_approval.pending_approval.is_some(),
+            "thread with pending approval should be eligible"
+        );
+
+        // Authorization check should pass for the thread with pending approval
+        // (same channel), confirming the two checks compose correctly.
+        assert!(is_approval_authorized(
+            thread_with_approval.source_channel.as_deref(),
+            "telegram"
+        ));
+    }
+
+    #[test]
+    fn test_approval_wasm_channel_cannot_impersonate_trusted() {
+        // A WASM channel named "web" or "gateway" would bypass authorization.
+        // This test documents the invariant that WASM setup must reject these
+        // names (tested separately in wasm/setup.rs).
+        // Here we verify the authorization logic itself treats them as trusted.
+        assert!(is_approval_authorized(Some("telegram"), "web"));
+        assert!(is_approval_authorized(Some("telegram"), "gateway"));
+        // But a random WASM channel name should NOT be trusted
+        assert!(!is_approval_authorized(Some("telegram"), "my-wasm-channel"));
+    }
+
+    #[test]
+    fn test_approval_bootstrap_sentinel_not_a_normal_channel() {
+        // If a channel happens to be named __bootstrap__, it should be treated
+        // as the source (always authorized), NOT as a requesting channel with
+        // special trust. Only TRUSTED_APPROVAL_CHANNELS get that privilege.
+        assert!(
+            !is_approval_authorized(Some("telegram"), BOOTSTRAP_SOURCE_CHANNEL),
+            "__bootstrap__ as requesting channel should not have special trust"
+        );
+    }
+
+    #[test]
+    fn test_create_thread_propagates_channel() {
+        let mut session = Session::new("user-chan");
+        let tid = session.create_thread(Some("signal")).id;
+        let thread = session.threads.get(&tid).unwrap();
+        assert_eq!(thread.source_channel.as_deref(), Some("signal"));
+    }
+
+    #[test]
+    fn test_get_or_create_thread_propagates_channel() {
+        let mut session = Session::new("user-chan2");
+        // First call creates
+        let tid = session.get_or_create_thread(Some("http")).id;
+        assert_eq!(
+            session.threads.get(&tid).unwrap().source_channel.as_deref(),
+            Some("http")
+        );
+        // Second call returns existing (channel param ignored)
+        let tid2 = session.get_or_create_thread(Some("different")).id;
+        assert_eq!(tid, tid2);
+        assert_eq!(
+            session
+                .threads
+                .get(&tid2)
+                .unwrap()
+                .source_channel
+                .as_deref(),
+            Some("http"),
+            "existing thread should keep its original source_channel"
         );
     }
 }

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -200,7 +200,7 @@ impl SessionManager {
         // Create new thread (always create a new one for a new key)
         let thread_id = {
             let mut sess = session.lock().await;
-            let thread = sess.create_thread();
+            let thread = sess.create_thread(Some(channel));
             thread.id
         };
 
@@ -476,7 +476,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-hydrate")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(thread_id, sess.id);
+            let thread = Thread::with_id(thread_id, sess.id, None);
             sess.threads.insert(thread_id, thread);
             sess.active_thread = Some(thread_id);
         }
@@ -600,7 +600,7 @@ mod tests {
         // Simulate hydration: create thread with a known UUID
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_uuid, session_id);
+            let thread = Thread::with_id(known_uuid, session_id, None);
             sess.threads.insert(known_uuid, thread);
         }
 
@@ -627,7 +627,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-idem")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -656,7 +656,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-undo")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -680,7 +680,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-new")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -788,7 +788,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-cross")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -815,7 +815,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-cross")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
 
@@ -966,7 +966,7 @@ mod tests {
         let adopted_id = Uuid::new_v4();
         {
             let mut sess = session1.lock().await;
-            let thread = Thread::with_id(adopted_id, sess.id);
+            let thread = Thread::with_id(adopted_id, sess.id, None);
             sess.threads.insert(adopted_id, thread);
         }
         // Resolve with the UUID as external_thread_id -- should adopt it
@@ -992,7 +992,7 @@ mod tests {
         let session = Arc::new(Mutex::new(Session::new("user-direct")));
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(tid, sess.id);
+            let thread = Thread::with_id(tid, sess.id, None);
             sess.threads.insert(tid, thread);
         }
         {
@@ -1030,7 +1030,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1057,7 +1057,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1081,7 +1081,7 @@ mod tests {
         let known_id = Uuid::new_v4();
         {
             let mut sess = session.lock().await;
-            let thread = Thread::with_id(known_id, sess.id);
+            let thread = Thread::with_id(known_id, sess.id, None);
             sess.threads.insert(known_id, thread);
         }
 
@@ -1100,6 +1100,21 @@ mod tests {
         assert_ne!(
             resolved, known_id,
             "should NOT adopt UUID when external_thread_id is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_thread_stores_source_channel() {
+        let manager = SessionManager::new();
+
+        let (session, thread_id) = manager.resolve_thread("user-1", "telegram", None).await;
+
+        let sess = session.lock().await;
+        let thread = sess.threads.get(&thread_id).unwrap();
+        assert_eq!(
+            thread.source_channel.as_deref(),
+            Some("telegram"),
+            "resolve_thread should store source_channel from the channel parameter"
         );
     }
 }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -135,13 +135,52 @@ impl Agent {
             msg_count = 0;
         }
 
-        // Create thread with the historical ID and restore messages
+        // Create thread with the historical ID and restore messages.
+        // Read source_channel from DB so the authorization check uses the
+        // original creator's channel, not the requesting message's channel.
+        //
+        // Fail-closed policy: if the DB lookup fails or the conversation has
+        // no stored source_channel (legacy row), the thread is hydrated with
+        // source_channel = None.  `is_approval_authorized(None, _)` returns
+        // false, so approvals are denied until the conversation is backfilled
+        // with a source_channel via an explicit migration or re-creation.
+        let db_source_channel = if let Some(store) = self.store() {
+            match store.get_conversation_source_channel(thread_uuid).await {
+                Ok(sc) => {
+                    if sc.is_none() {
+                        tracing::warn!(
+                            thread_id = %thread_uuid,
+                            "Legacy thread has no stored source_channel; \
+                             cross-channel approvals will be denied (fail-closed)"
+                        );
+                    }
+                    sc
+                }
+                Err(e) => {
+                    tracing::error!(
+                        thread_id = %thread_uuid,
+                        error = %e,
+                        "Failed to read source_channel from DB; \
+                         cross-channel approvals will be denied (fail-closed)"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+        let effective_source_channel = db_source_channel.as_deref();
+
         let session_id = {
             let sess = session.lock().await;
             sess.id
         };
 
-        let mut thread = crate::agent::session::Thread::with_id(thread_uuid, session_id);
+        let mut thread = crate::agent::session::Thread::with_id(
+            thread_uuid,
+            session_id,
+            effective_source_channel,
+        );
         if !chat_messages.is_empty() {
             thread.restore_from_messages(chat_messages);
         }
@@ -636,7 +675,7 @@ impl Agent {
         user_id: &str,
     ) -> bool {
         match store
-            .ensure_conversation(thread_id, channel, user_id, None)
+            .ensure_conversation(thread_id, channel, user_id, None, Some(channel))
             .await
         {
             Ok(true) => true,
@@ -1781,7 +1820,7 @@ impl Agent {
             .get_or_create_session(&message.user_id)
             .await;
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some(&message.channel));
         let thread_id = thread.id;
         Ok(SubmissionResult::ok_with_message(format!(
             "New thread: {}",
@@ -2117,7 +2156,7 @@ mod tests {
 
         let session_id = Uuid::new_v4();
         let thread_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
 
         // Set thread to AwaitingApproval with a pending tool approval
         let pending = PendingApproval {
@@ -2185,7 +2224,7 @@ mod tests {
         use crate::agent::session::{MAX_PENDING_MESSAGES, Thread, ThreadState};
         use uuid::Uuid;
 
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("processing something");
         assert_eq!(thread.state, ThreadState::Processing);
 
@@ -2211,7 +2250,7 @@ mod tests {
         use crate::agent::session::{Thread, ThreadState};
         use uuid::Uuid;
 
-        let mut thread = Thread::new(Uuid::new_v4());
+        let mut thread = Thread::new(Uuid::new_v4(), None);
         thread.start_turn("processing");
 
         thread.queue_message("pending-1".to_string());
@@ -2241,7 +2280,7 @@ mod tests {
 
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
         thread.start_turn("working");
         assert_eq!(thread.state, ThreadState::Processing);
 
@@ -2268,7 +2307,7 @@ mod tests {
 
         let thread_id = Uuid::new_v4();
         let session_id = Uuid::new_v4();
-        let mut thread = Thread::with_id(thread_id, session_id);
+        let mut thread = Thread::with_id(thread_id, session_id, None);
         thread.start_turn("working");
         assert_eq!(thread.state, ThreadState::Processing);
 

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -201,28 +201,26 @@ impl IncomingMessage {
 }
 
 /// Extract a channel-specific proactive routing target from message metadata.
+///
+/// Checked keys (first match wins):
+/// - `signal_target` — Signal phone number or group ID
+/// - `chat_id` — Telegram chat ID
+/// - `channel_id` — Slack channel/DM ID (used by channel-relay)
+/// - `target` — generic fallback
 pub fn routing_target_from_metadata(metadata: &serde_json::Value) -> Option<String> {
-    metadata
-        .get("signal_target")
-        .and_then(|value| match value {
+    // Helper to extract a string or numeric value from a JSON key.
+    let extract = |key: &str| -> Option<String> {
+        metadata.get(key).and_then(|value| match value {
             serde_json::Value::String(s) => Some(s.clone()),
             serde_json::Value::Number(n) => Some(n.to_string()),
             _ => None,
         })
-        .or_else(|| {
-            metadata.get("chat_id").and_then(|value| match value {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-        })
-        .or_else(|| {
-            metadata.get("target").and_then(|value| match value {
-                serde_json::Value::String(s) => Some(s.clone()),
-                serde_json::Value::Number(n) => Some(n.to_string()),
-                _ => None,
-            })
-        })
+    };
+
+    extract("signal_target")
+        .or_else(|| extract("chat_id"))
+        .or_else(|| extract("channel_id"))
+        .or_else(|| extract("target"))
 }
 
 /// Stream of incoming messages.
@@ -357,6 +355,20 @@ pub enum StatusUpdate {
     },
 }
 
+/// Shared chat-style approval prompt formatting used by non-web channels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatApprovalPrompt {
+    pub request_id: String,
+    pub tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub allow_always: bool,
+}
+
+const APPROVAL_PARAMETER_PREVIEW_BYTES: usize = 1200;
+const APPROVAL_PARAMETER_TRUNCATION_SUFFIX: &str = "\n... [parameters truncated]";
+const APPROVAL_SUMMARY_DESCRIPTION_BYTES: usize = 120;
+
 impl StatusUpdate {
     /// Build a `ToolCompleted` status with redacted parameters.
     ///
@@ -386,6 +398,131 @@ impl StatusUpdate {
                 None
             },
         }
+    }
+}
+
+impl ChatApprovalPrompt {
+    /// Build a shared chat approval prompt from a status update.
+    pub fn from_status(status: &StatusUpdate) -> Option<Self> {
+        let StatusUpdate::ApprovalNeeded {
+            request_id,
+            tool_name,
+            description,
+            parameters,
+            allow_always,
+        } = status
+        else {
+            return None;
+        };
+
+        Some(Self {
+            request_id: request_id.clone(),
+            tool_name: tool_name.clone(),
+            description: description.clone(),
+            parameters: parameters.clone(),
+            allow_always: *allow_always,
+        })
+    }
+
+    fn truncated_text(input: &str, max_bytes: usize, suffix: &str) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let budget = max_bytes.saturating_sub(suffix.len());
+        let end = crate::util::floor_char_boundary(input, budget);
+        format!("{}{}", &input[..end], suffix)
+    }
+
+    /// Pretty-printed tool parameters for display, bounded for chat channels.
+    pub fn parameters_preview(&self) -> String {
+        let rendered = serde_json::to_string_pretty(&self.parameters)
+            .unwrap_or_else(|_| self.parameters.to_string());
+        Self::truncated_text(
+            &rendered,
+            APPROVAL_PARAMETER_PREVIEW_BYTES,
+            APPROVAL_PARAMETER_TRUNCATION_SUFFIX,
+        )
+    }
+
+    /// Shared reply vocabulary summary for compact status surfaces.
+    pub fn reply_summary(&self) -> &'static str {
+        if self.allow_always {
+            "yes (or /approve), no (or /deny), or always (or /always)"
+        } else {
+            "yes (or /approve) or no (or /deny)"
+        }
+    }
+
+    /// Compact approval summary for fallback/accessibility surfaces.
+    pub fn summary_text(&self) -> String {
+        let description = Self::truncated_text(
+            &self.description.replace('\n', " "),
+            APPROVAL_SUMMARY_DESCRIPTION_BYTES,
+            "...",
+        );
+        format!(
+            "Approval needed for {}: {} (Request ID: {}). Reply with {}.",
+            self.tool_name,
+            description,
+            self.request_id,
+            self.reply_summary()
+        )
+    }
+
+    fn markdown_parameters_preview(&self) -> String {
+        self.parameters_preview().replace('`', "\\`")
+    }
+
+    /// Approval prompt formatted for plain-text chat channels.
+    pub fn plain_text_message(&self) -> String {
+        let mut lines = vec![
+            format!("Approval needed: {}", self.tool_name),
+            self.description.clone(),
+            String::new(),
+            format!("Request ID: {}", self.request_id),
+            "Parameters:".to_string(),
+            self.parameters_preview(),
+            String::new(),
+            "Reply with:".to_string(),
+            "- yes, y, approve, or /approve to approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "- always, a, or /always to approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("- no, n, deny, or /deny to deny this request".to_string());
+        lines.join("\n")
+    }
+
+    /// Approval prompt formatted for Markdown-capable chat channels.
+    pub fn markdown_message(&self) -> String {
+        let mut lines = vec![
+            "⚠️ *Approval Required*".to_string(),
+            String::new(),
+            format!("*Request ID:* `{}`", self.request_id),
+            format!("*Tool:* {}", self.tool_name),
+            format!("*Description:* {}", self.description),
+            "*Parameters:*".to_string(),
+            format!("```json\n{}\n```", self.markdown_parameters_preview()),
+            String::new(),
+            "Reply with:".to_string(),
+            "• `yes`, `y`, `approve`, or `/approve` - Approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "• `always`, `a`, or `/always` - Approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("• `no`, `n`, `deny`, or `/deny` - Deny this request".to_string());
+        lines.join("\n")
     }
 }
 
@@ -611,5 +748,121 @@ mod tests {
     fn test_incoming_message_with_timezone() {
         let msg = IncomingMessage::new("test", "user1", "hello").with_timezone("America/New_York");
         assert_eq!(msg.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn routing_target_extracts_slack_channel_id() {
+        // Slack relay messages carry channel_id in metadata — this must be
+        // picked up for proactive broadcasts to land in the correct channel
+        // instead of falling back to sender_id (which routes to DMs).
+        let metadata = serde_json::json!({
+            "team_id": "T05CUBCSQPL",
+            "channel_id": "C088K6C3SQZ",
+            "sender_id": "UCBGL1WNS",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("C088K6C3SQZ"),
+        );
+    }
+
+    #[test]
+    fn routing_target_prefers_signal_over_channel_id() {
+        let metadata = serde_json::json!({
+            "signal_target": "+15551234567",
+            "channel_id": "C088K6C3SQZ",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("+15551234567"),
+        );
+    }
+
+    #[test]
+    fn routing_target_prefers_chat_id_over_channel_id() {
+        let metadata = serde_json::json!({
+            "chat_id": "123456789",
+            "channel_id": "C088K6C3SQZ",
+        });
+        assert_eq!(
+            routing_target_from_metadata(&metadata).as_deref(),
+            Some("123456789"),
+        );
+    }
+
+    #[test]
+    fn routing_target_returns_none_for_empty_metadata() {
+        let metadata = serde_json::json!({});
+        assert!(routing_target_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn chat_approval_prompt_plain_text_includes_all_reply_forms() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-123".into(),
+            tool_name: "http".into(),
+            description: "Fetch weather data".into(),
+            parameters: serde_json::json!({"url": "https://api.weather.test"}),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let text = prompt.plain_text_message();
+        assert!(text.contains("Request ID: req-123"));
+        assert!(text.contains("approve, or /approve"));
+        assert!(text.contains("always, a, or /always"));
+        assert!(text.contains("deny, or /deny"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_hides_always_when_not_allowed() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-456".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({"command": "rm -rf /tmp/demo"}),
+            allow_always: false,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("`/approve`"));
+        assert!(markdown.contains("`/deny`"));
+        assert!(!markdown.contains("`/always`"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_truncates_large_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-789".into(),
+            tool_name: "http".into(),
+            description: "Fetch large payload".into(),
+            parameters: serde_json::json!({
+                "body": "x".repeat(APPROVAL_PARAMETER_PREVIEW_BYTES + 200),
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let preview = prompt.parameters_preview();
+        assert!(preview.contains("[parameters truncated]"));
+        assert!(preview.len() <= APPROVAL_PARAMETER_PREVIEW_BYTES);
+    }
+
+    #[test]
+    fn chat_approval_prompt_escapes_backticks_in_markdown_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-999".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({
+                "command": "printf '```danger```'"
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("\\`\\`\\`danger\\`\\`\\`"));
     }
 }

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -355,6 +355,20 @@ pub enum StatusUpdate {
     },
 }
 
+/// Shared chat-style approval prompt formatting used by non-web channels.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatApprovalPrompt {
+    pub request_id: String,
+    pub tool_name: String,
+    pub description: String,
+    pub parameters: serde_json::Value,
+    pub allow_always: bool,
+}
+
+const APPROVAL_PARAMETER_PREVIEW_BYTES: usize = 1200;
+const APPROVAL_PARAMETER_TRUNCATION_SUFFIX: &str = "\n... [parameters truncated]";
+const APPROVAL_SUMMARY_DESCRIPTION_BYTES: usize = 120;
+
 impl StatusUpdate {
     /// Build a `ToolCompleted` status with redacted parameters.
     ///
@@ -384,6 +398,131 @@ impl StatusUpdate {
                 None
             },
         }
+    }
+}
+
+impl ChatApprovalPrompt {
+    /// Build a shared chat approval prompt from a status update.
+    pub fn from_status(status: &StatusUpdate) -> Option<Self> {
+        let StatusUpdate::ApprovalNeeded {
+            request_id,
+            tool_name,
+            description,
+            parameters,
+            allow_always,
+        } = status
+        else {
+            return None;
+        };
+
+        Some(Self {
+            request_id: request_id.clone(),
+            tool_name: tool_name.clone(),
+            description: description.clone(),
+            parameters: parameters.clone(),
+            allow_always: *allow_always,
+        })
+    }
+
+    fn truncated_text(input: &str, max_bytes: usize, suffix: &str) -> String {
+        if input.len() <= max_bytes {
+            return input.to_string();
+        }
+
+        let budget = max_bytes.saturating_sub(suffix.len());
+        let end = crate::util::floor_char_boundary(input, budget);
+        format!("{}{}", &input[..end], suffix)
+    }
+
+    /// Pretty-printed tool parameters for display, bounded for chat channels.
+    pub fn parameters_preview(&self) -> String {
+        let rendered = serde_json::to_string_pretty(&self.parameters)
+            .unwrap_or_else(|_| self.parameters.to_string());
+        Self::truncated_text(
+            &rendered,
+            APPROVAL_PARAMETER_PREVIEW_BYTES,
+            APPROVAL_PARAMETER_TRUNCATION_SUFFIX,
+        )
+    }
+
+    /// Shared reply vocabulary summary for compact status surfaces.
+    pub fn reply_summary(&self) -> &'static str {
+        if self.allow_always {
+            "yes (or /approve), no (or /deny), or always (or /always)"
+        } else {
+            "yes (or /approve) or no (or /deny)"
+        }
+    }
+
+    /// Compact approval summary for fallback/accessibility surfaces.
+    pub fn summary_text(&self) -> String {
+        let description = Self::truncated_text(
+            &self.description.replace('\n', " "),
+            APPROVAL_SUMMARY_DESCRIPTION_BYTES,
+            "...",
+        );
+        format!(
+            "Approval needed for {}: {} (Request ID: {}). Reply with {}.",
+            self.tool_name,
+            description,
+            self.request_id,
+            self.reply_summary()
+        )
+    }
+
+    fn markdown_parameters_preview(&self) -> String {
+        self.parameters_preview().replace('`', "\\`")
+    }
+
+    /// Approval prompt formatted for plain-text chat channels.
+    pub fn plain_text_message(&self) -> String {
+        let mut lines = vec![
+            format!("Approval needed: {}", self.tool_name),
+            self.description.clone(),
+            String::new(),
+            format!("Request ID: {}", self.request_id),
+            "Parameters:".to_string(),
+            self.parameters_preview(),
+            String::new(),
+            "Reply with:".to_string(),
+            "- yes, y, approve, or /approve to approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "- always, a, or /always to approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("- no, n, deny, or /deny to deny this request".to_string());
+        lines.join("\n")
+    }
+
+    /// Approval prompt formatted for Markdown-capable chat channels.
+    pub fn markdown_message(&self) -> String {
+        let mut lines = vec![
+            "⚠️ *Approval Required*".to_string(),
+            String::new(),
+            format!("*Request ID:* `{}`", self.request_id),
+            format!("*Tool:* {}", self.tool_name),
+            format!("*Description:* {}", self.description),
+            "*Parameters:*".to_string(),
+            format!("```json\n{}\n```", self.markdown_parameters_preview()),
+            String::new(),
+            "Reply with:".to_string(),
+            "• `yes`, `y`, `approve`, or `/approve` - Approve this request".to_string(),
+        ];
+
+        if self.allow_always {
+            lines.push(format!(
+                "• `always`, `a`, or `/always` - Approve this request and auto-approve future {} requests",
+                self.tool_name
+            ));
+        }
+
+        lines.push("• `no`, `n`, `deny`, or `/deny` - Deny this request".to_string());
+        lines.join("\n")
     }
 }
 
@@ -655,5 +794,75 @@ mod tests {
     fn routing_target_returns_none_for_empty_metadata() {
         let metadata = serde_json::json!({});
         assert!(routing_target_from_metadata(&metadata).is_none());
+    }
+
+    #[test]
+    fn chat_approval_prompt_plain_text_includes_all_reply_forms() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-123".into(),
+            tool_name: "http".into(),
+            description: "Fetch weather data".into(),
+            parameters: serde_json::json!({"url": "https://api.weather.test"}),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let text = prompt.plain_text_message();
+        assert!(text.contains("Request ID: req-123"));
+        assert!(text.contains("approve, or /approve"));
+        assert!(text.contains("always, a, or /always"));
+        assert!(text.contains("deny, or /deny"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_hides_always_when_not_allowed() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-456".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({"command": "rm -rf /tmp/demo"}),
+            allow_always: false,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("`/approve`"));
+        assert!(markdown.contains("`/deny`"));
+        assert!(!markdown.contains("`/always`"));
+    }
+
+    #[test]
+    fn chat_approval_prompt_truncates_large_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-789".into(),
+            tool_name: "http".into(),
+            description: "Fetch large payload".into(),
+            parameters: serde_json::json!({
+                "body": "x".repeat(APPROVAL_PARAMETER_PREVIEW_BYTES + 200),
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let preview = prompt.parameters_preview();
+        assert!(preview.contains("[parameters truncated]"));
+        assert!(preview.len() <= APPROVAL_PARAMETER_PREVIEW_BYTES);
+    }
+
+    #[test]
+    fn chat_approval_prompt_escapes_backticks_in_markdown_parameters() {
+        let prompt = ChatApprovalPrompt::from_status(&StatusUpdate::ApprovalNeeded {
+            request_id: "req-999".into(),
+            tool_name: "shell".into(),
+            description: "Run command".into(),
+            parameters: serde_json::json!({
+                "command": "printf '```danger```'"
+            }),
+            allow_always: true,
+        })
+        .expect("approval prompt");
+
+        let markdown = prompt.markdown_message();
+        assert!(markdown.contains("\\`\\`\\`danger\\`\\`\\`"));
     }
 }

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -38,8 +38,9 @@ pub mod web;
 mod webhook_server;
 
 pub use channel::{
-    AttachmentKind, Channel, ChannelSecretUpdater, IncomingAttachment, IncomingMessage,
-    MessageStream, OutgoingResponse, StatusUpdate, ToolDecision, routing_target_from_metadata,
+    AttachmentKind, Channel, ChannelSecretUpdater, ChatApprovalPrompt, IncomingAttachment,
+    IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate, ToolDecision,
+    routing_target_from_metadata,
 };
 pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::channels::relay::client::{ChannelEvent, RelayClient};
-use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
+use crate::channels::{
+    Channel, ChatApprovalPrompt, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate,
+};
 use crate::error::ChannelError;
 
 /// Default channel name for the Slack relay integration.
@@ -126,6 +128,58 @@ impl RelayChannel {
             .proxy_provider(self.provider.as_str(), team_id, method, body)
             .await
     }
+
+    fn build_approval_body(
+        &self,
+        channel_id: &str,
+        thread_id: Option<&str>,
+        prompt: &ChatApprovalPrompt,
+        approval_token: &str,
+    ) -> serde_json::Value {
+        let value_payload = serde_json::json!({
+            "approval_token": approval_token,
+        });
+        let value_str = value_payload.to_string();
+
+        let blocks = serde_json::json!([
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": prompt.markdown_message(),
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Approve" },
+                        "style": "primary",
+                        "action_id": "approve_tool",
+                        "value": value_str,
+                    },
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Deny" },
+                        "style": "danger",
+                        "action_id": "deny_tool",
+                        "value": value_str,
+                    }
+                ]
+            }
+        ]);
+
+        let mut body = serde_json::json!({
+            "channel": channel_id,
+            "text": prompt.summary_text(),
+            "blocks": blocks,
+        });
+        if let Some(tid) = thread_id {
+            body["thread_ts"] = serde_json::Value::String(tid.to_string());
+        }
+        body
+    }
 }
 
 #[async_trait]
@@ -194,12 +248,18 @@ impl Channel for RelayChannel {
                         "sender_id": event.sender_id,
                         "sender_name": event.display_name(),
                         "event_type": event.event_type,
-                        "thread_id": event.thread_id,
+                        "thread_id": event.thread_id.as_deref().unwrap_or(&event.id),
                         "provider": event.provider,
                     }));
 
+                // Use the original thread_id if present (already in a thread),
+                // otherwise use the message timestamp (event.id) so that
+                // responses are threaded under the user's message in channels.
+                // Fall back to channel_id only if event.id is missing.
                 let msg = if let Some(ref thread_id) = event.thread_id {
                     msg.with_thread(thread_id)
+                } else if !event.id.is_empty() {
+                    msg.with_thread(&event.id)
                 } else {
                     msg.with_thread(&event.channel_id)
                 };
@@ -260,14 +320,7 @@ impl Channel for RelayChannel {
         metadata: &serde_json::Value,
     ) -> Result<(), ChannelError> {
         // Only handle ApprovalNeeded — all other variants are no-ops
-        let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            parameters,
-            allow_always: _,
-        } = status
-        else {
+        let Some(prompt) = ChatApprovalPrompt::from_status(&status) else {
             return Ok(());
         };
 
@@ -278,7 +331,7 @@ impl Channel for RelayChannel {
             .unwrap_or("");
         if event_type != "direct_message" {
             tracing::warn!(
-                tool = %tool_name,
+                tool = %prompt.tool_name,
                 event_type,
                 "Approval requested in non-DM, skipping buttons"
             );
@@ -303,60 +356,13 @@ impl Channel for RelayChannel {
         // The button value contains ONLY the token — no routing fields.
         let approval_token = self
             .client
-            .create_approval(team_id, channel_id, thread_id, &request_id)
+            .create_approval(team_id, channel_id, thread_id, &prompt.request_id)
             .await
             .map_err(|e| ChannelError::SendFailed {
                 name: self.name().to_string(),
                 reason: format!("Failed to register approval: {e}"),
             })?;
-        let value_payload = serde_json::json!({
-            "approval_token": approval_token,
-        });
-        let value_str = value_payload.to_string();
-
-        // Parameters are already redacted via redact_params() in dispatcher.rs
-        let params_display =
-            serde_json::to_string_pretty(&parameters).unwrap_or_else(|_| parameters.to_string());
-
-        let blocks = serde_json::json!([
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": format!(
-                        "*Tool approval required*\n`{tool_name}`: {description}\n```{params_display}```"
-                    )
-                }
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Approve" },
-                        "style": "primary",
-                        "action_id": "approve_tool",
-                        "value": value_str,
-                    },
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Deny" },
-                        "style": "danger",
-                        "action_id": "deny_tool",
-                        "value": value_str,
-                    }
-                ]
-            }
-        ]);
-
-        let mut body = serde_json::json!({
-            "channel": channel_id,
-            "text": format!("Tool approval required: {tool_name} - {description}"),
-            "blocks": blocks,
-        });
-        if let Some(tid) = thread_id {
-            body["thread_ts"] = serde_json::Value::String(tid.to_string());
-        }
+        let body = self.build_approval_body(channel_id, thread_id, &prompt, &approval_token);
 
         self.proxy_send(team_id, "chat.postMessage", body)
             .await
@@ -497,6 +503,29 @@ mod tests {
         assert_eq!(body["thread_ts"], "1234567.890");
     }
 
+    #[test]
+    fn build_approval_body_includes_chat_reply_instructions() {
+        let channel = make_channel();
+        let prompt = ChatApprovalPrompt {
+            request_id: "req-1".into(),
+            tool_name: "http".into(),
+            description: "HTTP requests to external APIs".into(),
+            parameters: serde_json::json!({"method": "POST", "url": "https://example.com"}),
+            allow_always: true,
+        };
+
+        let body = channel.build_approval_body("C456", Some("1234567.890"), &prompt, "token-123");
+        let text = body["text"].as_str().expect("plain text");
+        let block_text = body["blocks"][0]["text"]["text"].as_str().expect("mrkdwn");
+
+        assert!(text.contains("Request ID: req-1"));
+        assert!(text.contains("Reply with yes (or /approve)"));
+        assert!(!text.contains("Parameters:"));
+        assert!(block_text.contains("`/approve`"));
+        assert!(block_text.contains("`/always`"));
+        assert_eq!(body["thread_ts"], "1234567.890");
+    }
+
     #[tokio::test]
     async fn start_processes_events() {
         let (tx, rx) = mpsc::channel(64);
@@ -530,6 +559,41 @@ mod tests {
 
         assert_eq!(msg.content, "hello");
         assert_eq!(msg.user_id, "U789");
+    }
+
+    #[tokio::test]
+    async fn start_threaded_message_preserves_thread_scope() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        tx.send(ChannelEvent {
+            id: "threaded-1".into(),
+            event_type: "direct_message".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "D456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("approve".into()),
+            thread_id: Some("1712345678.123".into()),
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(msg.content, "approve");
+        assert_eq!(msg.thread_id.as_deref(), Some("1712345678.123"));
+        assert_eq!(msg.conversation_scope(), Some("1712345678.123"));
     }
 
     #[tokio::test]
@@ -646,6 +710,53 @@ mod tests {
         assert!(
             err.contains("channel_id"),
             "expected channel_id error, got: {err}"
+        );
+    }
+
+    /// Regression: channel mentions must use the message timestamp (event.id)
+    /// as thread_id, not the channel_id. Slack requires thread_ts to be a
+    /// message timestamp for threading to work.
+    #[tokio::test]
+    async fn start_uses_message_ts_as_thread_id_for_mentions() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        // Simulate a channel mention (no thread_id, id = message ts)
+        tx.send(ChannelEvent {
+            id: "1609459200.000100".into(),
+            event_type: "mention".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "C456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("hello bot".into()),
+            thread_id: None,
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        // thread_id should be the message timestamp, NOT the channel_id
+        assert_eq!(
+            msg.thread_id.as_deref(),
+            Some("1609459200.000100"),
+            "thread_id should be the message ts for threading, not the channel_id"
+        );
+        // metadata should also have the correct thread_id
+        assert_eq!(
+            msg.metadata.get("thread_id").and_then(|v| v.as_str()),
+            Some("1609459200.000100"),
         );
     }
 

--- a/src/channels/relay/channel.rs
+++ b/src/channels/relay/channel.rs
@@ -11,7 +11,9 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::channels::relay::client::{ChannelEvent, RelayClient};
-use crate::channels::{Channel, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate};
+use crate::channels::{
+    Channel, ChatApprovalPrompt, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate,
+};
 use crate::error::ChannelError;
 
 /// Default channel name for the Slack relay integration.
@@ -125,6 +127,58 @@ impl RelayChannel {
         self.client
             .proxy_provider(self.provider.as_str(), team_id, method, body)
             .await
+    }
+
+    fn build_approval_body(
+        &self,
+        channel_id: &str,
+        thread_id: Option<&str>,
+        prompt: &ChatApprovalPrompt,
+        approval_token: &str,
+    ) -> serde_json::Value {
+        let value_payload = serde_json::json!({
+            "approval_token": approval_token,
+        });
+        let value_str = value_payload.to_string();
+
+        let blocks = serde_json::json!([
+            {
+                "type": "section",
+                "text": {
+                    "type": "mrkdwn",
+                    "text": prompt.markdown_message(),
+                }
+            },
+            {
+                "type": "actions",
+                "elements": [
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Approve" },
+                        "style": "primary",
+                        "action_id": "approve_tool",
+                        "value": value_str,
+                    },
+                    {
+                        "type": "button",
+                        "text": { "type": "plain_text", "text": "Deny" },
+                        "style": "danger",
+                        "action_id": "deny_tool",
+                        "value": value_str,
+                    }
+                ]
+            }
+        ]);
+
+        let mut body = serde_json::json!({
+            "channel": channel_id,
+            "text": prompt.summary_text(),
+            "blocks": blocks,
+        });
+        if let Some(tid) = thread_id {
+            body["thread_ts"] = serde_json::Value::String(tid.to_string());
+        }
+        body
     }
 }
 
@@ -266,14 +320,7 @@ impl Channel for RelayChannel {
         metadata: &serde_json::Value,
     ) -> Result<(), ChannelError> {
         // Only handle ApprovalNeeded — all other variants are no-ops
-        let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            parameters,
-            allow_always: _,
-        } = status
-        else {
+        let Some(prompt) = ChatApprovalPrompt::from_status(&status) else {
             return Ok(());
         };
 
@@ -284,7 +331,7 @@ impl Channel for RelayChannel {
             .unwrap_or("");
         if event_type != "direct_message" {
             tracing::warn!(
-                tool = %tool_name,
+                tool = %prompt.tool_name,
                 event_type,
                 "Approval requested in non-DM, skipping buttons"
             );
@@ -309,60 +356,13 @@ impl Channel for RelayChannel {
         // The button value contains ONLY the token — no routing fields.
         let approval_token = self
             .client
-            .create_approval(team_id, channel_id, thread_id, &request_id)
+            .create_approval(team_id, channel_id, thread_id, &prompt.request_id)
             .await
             .map_err(|e| ChannelError::SendFailed {
                 name: self.name().to_string(),
                 reason: format!("Failed to register approval: {e}"),
             })?;
-        let value_payload = serde_json::json!({
-            "approval_token": approval_token,
-        });
-        let value_str = value_payload.to_string();
-
-        // Parameters are already redacted via redact_params() in dispatcher.rs
-        let params_display =
-            serde_json::to_string_pretty(&parameters).unwrap_or_else(|_| parameters.to_string());
-
-        let blocks = serde_json::json!([
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": format!(
-                        "*Tool approval required*\n`{tool_name}`: {description}\n```{params_display}```"
-                    )
-                }
-            },
-            {
-                "type": "actions",
-                "elements": [
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Approve" },
-                        "style": "primary",
-                        "action_id": "approve_tool",
-                        "value": value_str,
-                    },
-                    {
-                        "type": "button",
-                        "text": { "type": "plain_text", "text": "Deny" },
-                        "style": "danger",
-                        "action_id": "deny_tool",
-                        "value": value_str,
-                    }
-                ]
-            }
-        ]);
-
-        let mut body = serde_json::json!({
-            "channel": channel_id,
-            "text": format!("Tool approval required: {tool_name} - {description}"),
-            "blocks": blocks,
-        });
-        if let Some(tid) = thread_id {
-            body["thread_ts"] = serde_json::Value::String(tid.to_string());
-        }
+        let body = self.build_approval_body(channel_id, thread_id, &prompt, &approval_token);
 
         self.proxy_send(team_id, "chat.postMessage", body)
             .await
@@ -503,6 +503,29 @@ mod tests {
         assert_eq!(body["thread_ts"], "1234567.890");
     }
 
+    #[test]
+    fn build_approval_body_includes_chat_reply_instructions() {
+        let channel = make_channel();
+        let prompt = ChatApprovalPrompt {
+            request_id: "req-1".into(),
+            tool_name: "http".into(),
+            description: "HTTP requests to external APIs".into(),
+            parameters: serde_json::json!({"method": "POST", "url": "https://example.com"}),
+            allow_always: true,
+        };
+
+        let body = channel.build_approval_body("C456", Some("1234567.890"), &prompt, "token-123");
+        let text = body["text"].as_str().expect("plain text");
+        let block_text = body["blocks"][0]["text"]["text"].as_str().expect("mrkdwn");
+
+        assert!(text.contains("Request ID: req-1"));
+        assert!(text.contains("Reply with yes (or /approve)"));
+        assert!(!text.contains("Parameters:"));
+        assert!(block_text.contains("`/approve`"));
+        assert!(block_text.contains("`/always`"));
+        assert_eq!(body["thread_ts"], "1234567.890");
+    }
+
     #[tokio::test]
     async fn start_processes_events() {
         let (tx, rx) = mpsc::channel(64);
@@ -536,6 +559,41 @@ mod tests {
 
         assert_eq!(msg.content, "hello");
         assert_eq!(msg.user_id, "U789");
+    }
+
+    #[tokio::test]
+    async fn start_threaded_message_preserves_thread_scope() {
+        let (tx, rx) = mpsc::channel(64);
+        let channel =
+            RelayChannel::new(test_client(), "T123".into(), "inst1".into(), tx.clone(), rx);
+
+        let mut stream = channel.start().await.unwrap();
+
+        tx.send(ChannelEvent {
+            id: "threaded-1".into(),
+            event_type: "direct_message".into(),
+            provider: "slack".into(),
+            provider_scope: "T123".into(),
+            channel_id: "D456".into(),
+            sender_id: "U789".into(),
+            sender_name: Some("alice".into()),
+            content: Some("approve".into()),
+            thread_id: Some("1712345678.123".into()),
+            raw: serde_json::Value::Null,
+            timestamp: None,
+        })
+        .await
+        .unwrap();
+
+        use futures::StreamExt;
+        let msg = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(msg.content, "approve");
+        assert_eq!(msg.thread_id.as_deref(), Some("1712345678.123"));
+        assert_eq!(msg.conversation_scope(), Some("1712345678.123"));
     }
 
     #[tokio::test]

--- a/src/channels/relay/client.rs
+++ b/src/channels/relay/client.rs
@@ -277,9 +277,30 @@ impl RelayClient {
             });
         }
 
-        resp.json()
+        let json: serde_json::Value = resp
+            .json()
             .await
-            .map_err(|e| RelayError::Protocol(e.to_string()))
+            .map_err(|e| RelayError::Protocol(e.to_string()))?;
+
+        // Slack API always returns HTTP 200 but signals errors via {"ok": false}.
+        // Surface these as relay errors so callers get actionable feedback.
+        if json.get("ok") == Some(&serde_json::Value::Bool(false)) {
+            let slack_error = json
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            tracing::warn!(
+                relay_url = %url,
+                slack_error = %slack_error,
+                "RelayClient::proxy_provider: Slack API returned ok=false"
+            );
+            return Err(RelayError::Api {
+                status: 200,
+                message: format!("Slack API error: {slack_error}"),
+            });
+        }
+
+        Ok(json)
     }
 
     /// Fetch the per-instance callback signing secret from channel-relay.

--- a/src/channels/signal.rs
+++ b/src/channels/signal.rs
@@ -910,34 +910,10 @@ impl Channel for SignalChannel {
         }
 
         // Send approval prompt to user
-        if let StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description: _,
-            parameters,
-            allow_always,
-        } = &status
+        if let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status)
             && let Some(target_str) = metadata.get("signal_target").and_then(|v| v.as_str())
         {
-            let params_json = serde_json::to_string_pretty(parameters).unwrap_or_default();
-            let always_line = if *allow_always {
-                format!(
-                    "\n• `always` or `a` - Approve and auto-approve future {} requests",
-                    tool_name
-                )
-            } else {
-                String::new()
-            };
-            let message = format!(
-                "⚠️ *Approval Required*\n\n\
-                 *Request ID:* `{}`\n\
-                 *Tool:* {}\n\
-                 *Parameters:*\n```\n{}\n```\n\n\
-                 Reply with:\n\
-                 • `yes` or `y` - Approve this request{}\n\
-                 • `no` or `n` - Deny",
-                request_id, tool_name, params_json, always_line
-            );
+            let message = prompt.markdown_message();
             self.send_status_message(target_str, &message).await;
         }
 

--- a/src/channels/wasm/schema.rs
+++ b/src/channels/wasm/schema.rs
@@ -702,6 +702,29 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_telegram_bundled_setup_includes_webhook_secret() {
+        let json = include_str!("../../../channels-src/telegram/telegram.capabilities.json");
+        let file = ChannelCapabilitiesFile::from_json(json).unwrap();
+
+        let webhook_secret = file
+            .setup
+            .required_secrets
+            .iter()
+            .find(|secret| secret.name == "telegram_webhook_secret")
+            .expect("telegram webhook secret should be declared in the bundled manifest");
+
+        assert!(webhook_secret.optional);
+        assert_eq!(
+            webhook_secret
+                .auto_generate
+                .as_ref()
+                .expect("telegram webhook secret should auto-generate")
+                .length,
+            64
+        );
+    }
+
     // ── Category 5: Discord Capabilities Setup & Configuration ──────────
 
     #[test]

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -34,6 +34,7 @@ pub async fn setup_wasm_channels(
     secrets_store: &Option<Arc<dyn SecretsStore + Send + Sync>>,
     extension_manager: Option<&Arc<ExtensionManager>>,
     database: Option<&Arc<dyn Database>>,
+    registered_channel_names: &[String],
 ) -> Option<WasmChannelSetup> {
     let runtime = match WasmChannelRuntime::new(WasmChannelRuntimeConfig::default()) {
         Ok(r) => Arc::new(r),
@@ -71,7 +72,51 @@ pub async fn setup_wasm_channels(
     let mut channels: Vec<(String, Box<dyn crate::channels::Channel>)> = Vec::new();
     let mut channel_names: Vec<String> = Vec::new();
 
+    // Reserved channel names that WASM modules must not claim.
+    // A malicious module could otherwise register as a trusted built-in
+    // channel and bypass cross-channel authorization checks.
+    //
+    // This list includes:
+    // - All built-in channel names (prevent impersonation)
+    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
+    // - The bootstrap sentinel (universal approval wildcard)
+    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
+
+    let mut reserved: Vec<&str> = vec![
+        "cli",
+        "repl",
+        "http",
+        "signal",
+        "telegram",
+        "slack-relay",
+        "secret_save",
+    ];
+    reserved.extend(TRUSTED_APPROVAL_CHANNELS);
+    reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
+
     for loaded in results.loaded {
+        let name_lower = loaded.name().to_ascii_lowercase();
+        if reserved.contains(&name_lower.as_str()) {
+            tracing::warn!(
+                channel = %loaded.name(),
+                "Rejected WASM channel with reserved name"
+            );
+            continue;
+        }
+        // Also reject any name that collides with an already-registered
+        // channel to prevent a WASM module from shadowing a channel that
+        // was registered earlier in the startup sequence.
+        if registered_channel_names
+            .iter()
+            .any(|n| n.to_ascii_lowercase() == name_lower)
+        {
+            tracing::warn!(
+                channel = %loaded.name(),
+                "Rejected WASM channel that collides with already-registered channel"
+            );
+            continue;
+        }
+
         let (name, channel) = register_channel(
             loaded,
             config,
@@ -446,6 +491,78 @@ async fn inject_channel_secrets_into_config(
                     );
                 }
             }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::agent::session::{BOOTSTRAP_SOURCE_CHANNEL, TRUSTED_APPROVAL_CHANNELS};
+
+    /// Build the same reserved-name list that `setup_wasm_channels` uses.
+    fn reserved_names() -> Vec<&'static str> {
+        let mut reserved: Vec<&str> = vec![
+            "cli",
+            "repl",
+            "http",
+            "signal",
+            "telegram",
+            "slack-relay",
+            "secret_save",
+        ];
+        reserved.extend(TRUSTED_APPROVAL_CHANNELS);
+        reserved.push(BOOTSTRAP_SOURCE_CHANNEL);
+        reserved
+    }
+
+    #[test]
+    fn reserved_names_include_trusted_approval_channels() {
+        let reserved = reserved_names();
+        for &trusted in TRUSTED_APPROVAL_CHANNELS {
+            assert!(
+                reserved.contains(&trusted),
+                "trusted approval channel '{}' must be in WASM reserved names",
+                trusted
+            );
+        }
+    }
+
+    #[test]
+    fn reserved_names_include_bootstrap_sentinel() {
+        let reserved = reserved_names();
+        assert!(
+            reserved.contains(&BOOTSTRAP_SOURCE_CHANNEL),
+            "__bootstrap__ sentinel must be in WASM reserved names"
+        );
+    }
+
+    #[test]
+    fn reserved_names_reject_case_insensitive() {
+        // The setup logic lowercases the WASM channel name before checking.
+        // Verify that "Web" or "GATEWAY" would be caught.
+        let reserved = reserved_names();
+        let test_cases = ["Web", "GATEWAY", "CLI", "Repl", "__BOOTSTRAP__"];
+        for name in test_cases {
+            let lowered = name.to_ascii_lowercase();
+            assert!(
+                reserved.contains(&lowered.as_str()),
+                "'{}' (lowercased to '{}') should match a reserved name",
+                name,
+                lowered
+            );
+        }
+    }
+
+    #[test]
+    fn non_reserved_names_allowed() {
+        let reserved = reserved_names();
+        let allowed = ["discord", "my-custom-channel", "slack-bot"];
+        for name in allowed {
+            assert!(
+                !reserved.contains(&name),
+                "'{}' should NOT be reserved",
+                name
+            );
         }
     }
 }

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -2298,63 +2298,16 @@ impl WasmChannel {
             StatusUpdate::StreamChunk(_) => {
                 // No-op, too noisy
             }
-            StatusUpdate::ApprovalNeeded {
-                tool_name,
-                description,
-                parameters,
-                allow_always,
-                ..
-            } => {
+            StatusUpdate::ApprovalNeeded { .. } => {
                 // WASM channels (Telegram, Slack, etc.) cannot render
                 // interactive approval overlays.  Send the approval prompt
                 // as an actual message so the user can reply yes/no.
                 self.cancel_typing_task().await;
 
-                let params_preview = parameters
-                    .as_object()
-                    .map(|obj| {
-                        obj.iter()
-                            .map(|(k, v)| {
-                                let val = match v {
-                                    serde_json::Value::String(s) => {
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("\"{}...\"", truncated)
-                                        } else {
-                                            format!("\"{}\"", s)
-                                        }
-                                    }
-                                    other => {
-                                        let s = other.to_string();
-                                        if s.chars().count() > 80 {
-                                            let truncated: String = s.chars().take(77).collect();
-                                            format!("{}...", truncated)
-                                        } else {
-                                            s
-                                        }
-                                    }
-                                };
-                                format!("  {}: {}", k, val)
-                            })
-                            .collect::<Vec<_>>()
-                            .join("\n")
-                    })
-                    .unwrap_or_default();
-
-                let reply_hint = if *allow_always {
-                    "Reply \"yes\" to approve, \"no\" to deny, or \"always\" to auto-approve."
-                } else {
-                    "Reply \"yes\" to approve or \"no\" to deny."
+                let Some(prompt) = crate::channels::ChatApprovalPrompt::from_status(&status) else {
+                    return Ok(());
                 };
-                let prompt = format!(
-                    "Approval needed: {tool_name}\n\
-                     {description}\n\
-                     \n\
-                     Parameters:\n\
-                     {params_preview}\n\
-                     \n\
-                     {reply_hint}"
-                );
+                let prompt = prompt.plain_text_message();
 
                 let metadata_json = serde_json::to_string(metadata).unwrap_or_default();
                 if let Err(e) = self
@@ -3813,24 +3766,11 @@ fn status_to_wit(
                 metadata_json,
             }
         }
-        StatusUpdate::ApprovalNeeded {
-            request_id,
-            tool_name,
-            description,
-            allow_always,
-            ..
-        } => {
-            let reply_hint = if *allow_always {
-                "yes (or /approve), no (or /deny), or always (or /always)"
-            } else {
-                "yes (or /approve) or no (or /deny)"
-            };
+        StatusUpdate::ApprovalNeeded { .. } => {
+            let prompt = crate::channels::ChatApprovalPrompt::from_status(status)?;
             wit_channel::StatusUpdate {
                 status: wit_channel::StatusType::ApprovalNeeded,
-                message: format!(
-                    "Approval needed for tool '{}'. {}\nRequest ID: {}\nReply with: {}.",
-                    tool_name, description, request_id, reply_hint
-                ),
+                message: prompt.plain_text_message(),
                 metadata_json,
             }
         }

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -574,7 +574,7 @@ pub async fn chat_new_thread_handler(
         .await;
     let (thread_id, info) = {
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some("web"));
         let id = thread.id;
         let info = ThreadInfo {
             id: thread.id,
@@ -593,7 +593,13 @@ pub async fn chat_new_thread_handler(
     // so that the subsequent loadThreads() call from the frontend sees it.
     if let Some(ref store) = state.store {
         match store
-            .ensure_conversation(thread_id, "gateway", &identity.user_id, None)
+            .ensure_conversation(
+                thread_id,
+                "gateway",
+                &identity.user_id,
+                None,
+                Some("gateway"),
+            )
             .await
         {
             Ok(true) => {}

--- a/src/channels/web/handlers/jobs.rs
+++ b/src/channels/web/handlers/jobs.rs
@@ -456,7 +456,10 @@ pub async fn jobs_restart_handler(
                     &task,
                     Some(project_dir),
                     mode,
-                    credential_grants,
+                    crate::orchestrator::job_manager::JobCreationParams {
+                        credential_grants,
+                        ..Default::default()
+                    },
                 )
                 .await
                 .map_err(|e| {

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2063,7 +2063,7 @@ async fn chat_new_thread_handler(
     let session = session_manager.get_or_create_session(&user.user_id).await;
     let (thread_id, info) = {
         let mut sess = session.lock().await;
-        let thread = sess.create_thread();
+        let thread = sess.create_thread(Some("gateway"));
         let id = thread.id;
         let info = ThreadInfo {
             id: thread.id,
@@ -2082,7 +2082,7 @@ async fn chat_new_thread_handler(
     // so that the subsequent loadThreads() call from the frontend sees it.
     if let Some(ref store) = state.store {
         match store
-            .ensure_conversation(thread_id, "gateway", &user.user_id, None)
+            .ensure_conversation(thread_id, "gateway", &user.user_id, None, Some("gateway"))
             .await
         {
             Ok(true) => {}

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -80,7 +80,7 @@ pub async fn run_doctor_command() -> anyhow::Result<()> {
 
     check(
         "Routines config",
-        check_routines_config(),
+        check_routines_config(&settings),
         &mut passed,
         &mut failed,
         &mut skipped,
@@ -434,8 +434,8 @@ fn check_embeddings(settings: &Settings) -> CheckResult {
 
 // ── Routines config ─────────────────────────────────────────
 
-fn check_routines_config() -> CheckResult {
-    match crate::config::RoutineConfig::resolve() {
+fn check_routines_config(settings: &Settings) -> CheckResult {
+    match crate::config::RoutineConfig::resolve(settings) {
         Ok(config) => {
             if config.enabled {
                 CheckResult::Pass(format!(
@@ -737,7 +737,8 @@ mod tests {
 
     #[test]
     fn check_routines_config_does_not_panic() {
-        let result = check_routines_config();
+        let settings = Settings::default();
+        let result = check_routines_config(&settings);
         match result {
             CheckResult::Pass(_) | CheckResult::Fail(_) | CheckResult::Skip(_) => {}
         }
@@ -866,7 +867,8 @@ mod tests {
         unsafe {
             std::env::remove_var("ROUTINES_ENABLED");
         }
-        match check_routines_config() {
+        let settings = Settings::default();
+        match check_routines_config(&settings) {
             CheckResult::Pass(msg) => {
                 assert!(
                     msg.contains("enabled"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -288,7 +288,7 @@ pub enum Command {
         orchestrator_url: String,
 
         /// Maximum iterations before stopping.
-        #[arg(long, default_value = "50")]
+        #[arg(long, env = "IRONCLAW_MAX_ITERATIONS", default_value = "50")]
         max_iterations: u32,
     },
 

--- a/src/config/agent.rs
+++ b/src/config/agent.rs
@@ -1,6 +1,8 @@
 use std::time::Duration;
 
-use crate::config::helpers::{parse_bool_env, parse_option_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, parse_bool_env, parse_option_env,
+};
 use crate::error::ConfigError;
 use crate::settings::Settings;
 
@@ -73,49 +75,65 @@ impl AgentConfig {
     }
 
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::AgentSettings::default();
+
         Ok(Self {
-            name: parse_optional_env("AGENT_NAME", settings.agent.name.clone())?,
-            max_parallel_jobs: parse_optional_env(
+            name: db_first_or_default(&settings.agent.name, &defaults.name, "AGENT_NAME")?,
+            // Settings stores u32, config uses usize — cast for comparison.
+            max_parallel_jobs: db_first_or_default(
+                &(settings.agent.max_parallel_jobs as usize),
+                &(defaults.max_parallel_jobs as usize),
                 "AGENT_MAX_PARALLEL_JOBS",
-                settings.agent.max_parallel_jobs as usize,
             )?,
-            job_timeout: Duration::from_secs(parse_optional_env(
+            job_timeout: Duration::from_secs(db_first_or_default(
+                &settings.agent.job_timeout_secs,
+                &defaults.job_timeout_secs,
                 "AGENT_JOB_TIMEOUT_SECS",
-                settings.agent.job_timeout_secs,
             )?),
-            stuck_threshold: Duration::from_secs(parse_optional_env(
+            stuck_threshold: Duration::from_secs(db_first_or_default(
+                &settings.agent.stuck_threshold_secs,
+                &defaults.stuck_threshold_secs,
                 "AGENT_STUCK_THRESHOLD_SECS",
-                settings.agent.stuck_threshold_secs,
             )?),
-            repair_check_interval: Duration::from_secs(parse_optional_env(
+            repair_check_interval: Duration::from_secs(db_first_or_default(
+                &settings.agent.repair_check_interval_secs,
+                &defaults.repair_check_interval_secs,
                 "SELF_REPAIR_CHECK_INTERVAL_SECS",
-                settings.agent.repair_check_interval_secs,
             )?),
-            max_repair_attempts: parse_optional_env(
+            max_repair_attempts: db_first_or_default(
+                &settings.agent.max_repair_attempts,
+                &defaults.max_repair_attempts,
                 "SELF_REPAIR_MAX_ATTEMPTS",
-                settings.agent.max_repair_attempts,
             )?,
-            use_planning: parse_bool_env("AGENT_USE_PLANNING", settings.agent.use_planning)?,
-            session_idle_timeout: Duration::from_secs(parse_optional_env(
+            use_planning: db_first_bool(
+                settings.agent.use_planning,
+                defaults.use_planning,
+                "AGENT_USE_PLANNING",
+            )?,
+            session_idle_timeout: Duration::from_secs(db_first_or_default(
+                &settings.agent.session_idle_timeout_secs,
+                &defaults.session_idle_timeout_secs,
                 "SESSION_IDLE_TIMEOUT_SECS",
-                settings.agent.session_idle_timeout_secs,
             )?),
             allow_local_tools: parse_bool_env("ALLOW_LOCAL_TOOLS", false)?,
             max_cost_per_day_cents: parse_option_env("MAX_COST_PER_DAY_CENTS")?,
             max_actions_per_hour: parse_option_env("MAX_ACTIONS_PER_HOUR")?,
             max_cost_per_user_per_day_cents: parse_option_env("MAX_COST_PER_USER_PER_DAY_CENTS")?,
-            max_tool_iterations: parse_optional_env(
+            max_tool_iterations: db_first_or_default(
+                &settings.agent.max_tool_iterations,
+                &defaults.max_tool_iterations,
                 "AGENT_MAX_TOOL_ITERATIONS",
-                settings.agent.max_tool_iterations,
             )?,
-            auto_approve_tools: parse_bool_env(
-                "AGENT_AUTO_APPROVE_TOOLS",
+            auto_approve_tools: db_first_bool(
                 settings.agent.auto_approve_tools,
+                defaults.auto_approve_tools,
+                "AGENT_AUTO_APPROVE_TOOLS",
             )?,
             default_timezone: {
-                let tz: String = parse_optional_env(
+                let tz: String = db_first_or_default(
+                    &settings.agent.default_timezone,
+                    &defaults.default_timezone,
                     "DEFAULT_TIMEZONE",
-                    settings.agent.default_timezone.clone(),
                 )?;
                 if crate::timezone::parse_timezone(&tz).is_none() {
                     return Err(ConfigError::InvalidValue {
@@ -126,9 +144,10 @@ impl AgentConfig {
                 tz
             },
             max_jobs_per_user: parse_option_env("MAX_JOBS_PER_USER")?,
-            max_tokens_per_job: parse_optional_env(
+            max_tokens_per_job: db_first_or_default(
+                &settings.agent.max_tokens_per_job,
+                &defaults.max_tokens_per_job,
                 "AGENT_MAX_TOKENS_PER_JOB",
-                settings.agent.max_tokens_per_job,
             )?,
             multi_tenant: parse_bool_env("AGENT_MULTI_TENANT", false)?,
             max_llm_concurrent_per_user: parse_option_env("TENANT_MAX_LLM_CONCURRENT")?,

--- a/src/config/builder.rs
+++ b/src/config/builder.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 use std::time::Duration;
 
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default, optional_env};
 use crate::error::ConfigError;
 
 /// Builder mode configuration.
@@ -34,14 +34,29 @@ impl Default for BuilderModeConfig {
 impl BuilderModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let bs = &settings.builder;
+        let defaults = crate::settings::BuilderSettings::default();
         Ok(Self {
-            enabled: parse_bool_env("BUILDER_ENABLED", bs.enabled)?,
-            build_dir: optional_env("BUILDER_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| bs.build_dir.clone()),
-            max_iterations: parse_optional_env("BUILDER_MAX_ITERATIONS", bs.max_iterations)?,
-            timeout_secs: parse_optional_env("BUILDER_TIMEOUT_SECS", bs.timeout_secs)?,
-            auto_register: parse_bool_env("BUILDER_AUTO_REGISTER", bs.auto_register)?,
+            enabled: db_first_bool(bs.enabled, defaults.enabled, "BUILDER_ENABLED")?,
+            build_dir: if let Some(ref dir) = bs.build_dir {
+                Some(dir.clone())
+            } else {
+                optional_env("BUILDER_DIR")?.map(PathBuf::from)
+            },
+            max_iterations: db_first_or_default(
+                &bs.max_iterations,
+                &defaults.max_iterations,
+                "BUILDER_MAX_ITERATIONS",
+            )?,
+            timeout_secs: db_first_or_default(
+                &bs.timeout_secs,
+                &defaults.timeout_secs,
+                "BUILDER_TIMEOUT_SECS",
+            )?,
+            auto_register: db_first_bool(
+                bs.auto_register,
+                defaults.auto_register,
+                "BUILDER_AUTO_REGISTER",
+            )?,
         })
     }
 
@@ -79,7 +94,7 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
         settings.builder.timeout_secs = 123;
@@ -89,6 +104,22 @@ mod tests {
         let cfg = BuilderModeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("BUILDER_TIMEOUT_SECS") };
 
-        assert_eq!(cfg.timeout_secs, 3);
+        assert_eq!(cfg.timeout_secs, 123, "DB setting should win over env");
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("BUILDER_TIMEOUT_SECS", "42") };
+        let cfg = BuilderModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("BUILDER_TIMEOUT_SECS") };
+
+        assert_eq!(
+            cfg.timeout_secs, 42,
+            "env should be used when DB has the default value"
+        );
     }
 }

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -14,6 +14,8 @@ use secrecy::SecretString;
 #[derive(Debug, Clone)]
 pub struct ChannelsConfig {
     pub cli: CliConfig,
+    /// CLI mode: "tui" for rich terminal UI, empty for simple REPL.
+    pub cli_mode: Option<String>,
     pub http: Option<HttpConfig>,
     pub gateway: Option<GatewayConfig>,
     pub signal: Option<SignalConfig>,
@@ -349,10 +351,13 @@ impl ChannelsConfig {
 
         let cli_enabled = db_first_bool(cs.cli_enabled, defaults.cli_enabled, "CLI_ENABLED")?;
 
+        let cli_mode = db_first_optional_string(&cs.cli_mode, "CLI_MODE")?;
+
         Ok(Self {
             cli: CliConfig {
                 enabled: cli_enabled,
             },
+            cli_mode,
             http,
             gateway,
             signal,
@@ -517,6 +522,7 @@ mod tests {
     fn channels_config_fields() {
         let cfg = ChannelsConfig {
             cli: CliConfig { enabled: true },
+            cli_mode: None,
             http: None,
             gateway: None,
             signal: None,
@@ -541,6 +547,7 @@ mod tests {
 
         let cfg = ChannelsConfig {
             cli: CliConfig { enabled: false },
+            cli_mode: None,
             http: None,
             gateway: None,
             signal: None,

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_optional_string, db_first_or_default, optional_env, parse_bool_env,
+    parse_optional_env,
+};
 use crate::error::ConfigError;
-use crate::settings::Settings;
+use crate::settings::{ChannelSettings, Settings};
 use secrecy::SecretString;
 
 /// Channel configurations.
@@ -120,15 +123,24 @@ pub struct SignalConfig {
 impl ChannelsConfig {
     pub(crate) fn resolve(settings: &Settings, owner_id: &str) -> Result<Self, ConfigError> {
         let cs = &settings.channels;
+        let defaults = ChannelSettings::default();
 
         let http_enabled_by_env =
             optional_env("HTTP_PORT")?.is_some() || optional_env("HTTP_HOST")?.is_some();
-        let http = if http_enabled_by_env || cs.http_enabled {
+        let http_enabled_by_db =
+            db_first_bool(cs.http_enabled, defaults.http_enabled, "HTTP_ENABLED")?;
+        let http = if http_enabled_by_env || http_enabled_by_db {
             Some(HttpConfig {
-                host: optional_env("HTTP_HOST")?
-                    .or_else(|| cs.http_host.clone())
+                host: db_first_optional_string(&cs.http_host, "HTTP_HOST")?
                     .unwrap_or_else(|| "0.0.0.0".to_string()),
-                port: parse_optional_env("HTTP_PORT", cs.http_port.unwrap_or(8080))?,
+                port: {
+                    // defaults.http_port is None, so any Some(..) is an explicit DB override.
+                    if let Some(ref db_port) = cs.http_port {
+                        db_first_or_default(db_port, &8080, "HTTP_PORT")?
+                    } else {
+                        parse_optional_env("HTTP_PORT", 8080)?
+                    }
+                },
                 webhook_secret: optional_env("HTTP_WEBHOOK_SECRET")?.map(SecretString::from),
                 user_id: owner_id.to_string(),
             })
@@ -136,7 +148,11 @@ impl ChannelsConfig {
             None
         };
 
-        let gateway_enabled = parse_bool_env("GATEWAY_ENABLED", cs.gateway_enabled)?;
+        let gateway_enabled = db_first_bool(
+            cs.gateway_enabled,
+            defaults.gateway_enabled,
+            "GATEWAY_ENABLED",
+        )?;
         let gateway = if gateway_enabled {
             let memory_layers: Vec<crate::workspace::layer::MemoryLayer> =
                 match optional_env("MEMORY_LAYERS")? {
@@ -234,15 +250,26 @@ impl ChannelsConfig {
             };
 
             Some(GatewayConfig {
-                host: optional_env("GATEWAY_HOST")?
-                    .or_else(|| cs.gateway_host.clone())
+                host: db_first_optional_string(&cs.gateway_host, "GATEWAY_HOST")?
                     .unwrap_or_else(|| "127.0.0.1".to_string()),
-                port: parse_optional_env(
-                    "GATEWAY_PORT",
-                    cs.gateway_port.unwrap_or(DEFAULT_GATEWAY_PORT),
-                )?,
-                auth_token: optional_env("GATEWAY_AUTH_TOKEN")?
-                    .or_else(|| cs.gateway_auth_token.clone()),
+                port: {
+                    // defaults.gateway_port is None, so any Some(..) is an explicit DB override.
+                    if let Some(ref db_port) = cs.gateway_port {
+                        db_first_or_default(db_port, &DEFAULT_GATEWAY_PORT, "GATEWAY_PORT")?
+                    } else {
+                        parse_optional_env("GATEWAY_PORT", DEFAULT_GATEWAY_PORT)?
+                    }
+                },
+                // Security: auth token is env-only — never read from DB settings.
+                auth_token: {
+                    if cs.gateway_auth_token.is_some() {
+                        tracing::warn!(
+                            "gateway_auth_token is set in DB/TOML but is now env-only \
+                             (GATEWAY_AUTH_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("GATEWAY_AUTH_TOKEN")?
+                },
                 workspace_read_scopes,
                 memory_layers,
                 oidc,
@@ -251,16 +278,24 @@ impl ChannelsConfig {
             None
         };
 
-        let signal_url = optional_env("SIGNAL_HTTP_URL")?.or_else(|| cs.signal_http_url.clone());
-        let signal = if let Some(http_url) = signal_url {
-            let account = optional_env("SIGNAL_ACCOUNT")?
-                .or_else(|| cs.signal_account.clone())
-                .ok_or(ConfigError::InvalidValue {
+        let signal_enabled =
+            db_first_bool(cs.signal_enabled, defaults.signal_enabled, "SIGNAL_ENABLED")?;
+        let signal_url = db_first_optional_string(&cs.signal_http_url, "SIGNAL_HTTP_URL")?;
+        let signal = if signal_enabled || signal_url.is_some() {
+            let http_url = signal_url.ok_or(ConfigError::InvalidValue {
+                key: "SIGNAL_HTTP_URL".to_string(),
+                message: "SIGNAL_HTTP_URL is required when signal_enabled is set in DB/TOML \
+                         or SIGNAL_ENABLED env var is true"
+                    .to_string(),
+            })?;
+            let account = db_first_optional_string(&cs.signal_account, "SIGNAL_ACCOUNT")?.ok_or(
+                ConfigError::InvalidValue {
                     key: "SIGNAL_ACCOUNT".to_string(),
                     message: "SIGNAL_ACCOUNT is required when SIGNAL_HTTP_URL is set".to_string(),
-                })?;
+                },
+            )?;
             let allow_from =
-                match optional_env("SIGNAL_ALLOW_FROM")?.or_else(|| cs.signal_allow_from.clone()) {
+                match db_first_optional_string(&cs.signal_allow_from, "SIGNAL_ALLOW_FROM")? {
                     None => vec![account.clone()],
                     Some(s) => s
                         .split(',')
@@ -268,36 +303,39 @@ impl ChannelsConfig {
                         .filter(|s| !s.is_empty())
                         .collect(),
                 };
-            let dm_policy = optional_env("SIGNAL_DM_POLICY")?
-                .or_else(|| cs.signal_dm_policy.clone())
+            let dm_policy = db_first_optional_string(&cs.signal_dm_policy, "SIGNAL_DM_POLICY")?
                 .unwrap_or_else(|| "pairing".to_string());
-            let group_policy = optional_env("SIGNAL_GROUP_POLICY")?
-                .or_else(|| cs.signal_group_policy.clone())
-                .unwrap_or_else(|| "allowlist".to_string());
+            let group_policy =
+                db_first_optional_string(&cs.signal_group_policy, "SIGNAL_GROUP_POLICY")?
+                    .unwrap_or_else(|| "allowlist".to_string());
             Some(SignalConfig {
                 http_url,
                 account,
                 allow_from,
-                allow_from_groups: optional_env("SIGNAL_ALLOW_FROM_GROUPS")?
-                    .or_else(|| cs.signal_allow_from_groups.clone())
-                    .map(|s| {
-                        s.split(',')
-                            .map(|e| e.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                allow_from_groups: db_first_optional_string(
+                    &cs.signal_allow_from_groups,
+                    "SIGNAL_ALLOW_FROM_GROUPS",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
                 dm_policy,
                 group_policy,
-                group_allow_from: optional_env("SIGNAL_GROUP_ALLOW_FROM")?
-                    .or_else(|| cs.signal_group_allow_from.clone())
-                    .map(|s| {
-                        s.split(',')
-                            .map(|e| e.trim().to_string())
-                            .filter(|s| !s.is_empty())
-                            .collect()
-                    })
-                    .unwrap_or_default(),
+                group_allow_from: db_first_optional_string(
+                    &cs.signal_group_allow_from,
+                    "SIGNAL_GROUP_ALLOW_FROM",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
                 ignore_attachments: optional_env("SIGNAL_IGNORE_ATTACHMENTS")?
                     .map(|s| s.to_lowercase() == "true" || s == "1")
                     .unwrap_or(false),
@@ -309,7 +347,7 @@ impl ChannelsConfig {
             None
         };
 
-        let cli_enabled = parse_bool_env("CLI_ENABLED", cs.cli_enabled)?;
+        let cli_enabled = db_first_bool(cs.cli_enabled, defaults.cli_enabled, "CLI_ENABLED")?;
 
         Ok(Self {
             cli: CliConfig {
@@ -318,13 +356,21 @@ impl ChannelsConfig {
             http,
             gateway,
             signal,
-            wasm_channels_dir: optional_env("WASM_CHANNELS_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| cs.wasm_channels_dir.clone())
-                .unwrap_or_else(default_channels_dir),
-            wasm_channels_enabled: parse_bool_env(
-                "WASM_CHANNELS_ENABLED",
+            wasm_channels_dir: {
+                // DB-first: use settings if explicitly set, else env, else default.
+                // defaults.wasm_channels_dir is None, so any Some(..) is an explicit DB override.
+                if let Some(ref db_dir) = cs.wasm_channels_dir {
+                    db_dir.clone()
+                } else {
+                    optional_env("WASM_CHANNELS_DIR")?
+                        .map(PathBuf::from)
+                        .unwrap_or_else(default_channels_dir)
+                }
+            },
+            wasm_channels_enabled: db_first_bool(
                 cs.wasm_channels_enabled,
+                defaults.wasm_channels_enabled,
+                "WASM_CHANNELS_ENABLED",
             )?,
             wasm_channel_owner_ids: {
                 let mut ids = cs.wasm_channel_owner_ids.clone();
@@ -526,7 +572,9 @@ mod tests {
         settings.channels.gateway_enabled = true;
         settings.channels.gateway_host = Some("127.0.0.3".to_string());
         settings.channels.gateway_port = Some(9191);
-        settings.channels.gateway_auth_token = Some("tok".to_string());
+        // auth_token is env-only (security), set via env var
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var("GATEWAY_AUTH_TOKEN", "tok") };
         settings.channels.signal_http_url = Some("http://127.0.0.1:8080".to_string());
         settings.channels.signal_account = Some("+15551234567".to_string());
         settings.channels.signal_allow_from = Some("+15551234567,+15557654321".to_string());
@@ -554,5 +602,8 @@ mod tests {
             PathBuf::from("/tmp/settings-channels")
         );
         assert!(!cfg.wasm_channels_enabled);
+
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::remove_var("GATEWAY_AUTH_TOKEN") };
     }
 }

--- a/src/config/embeddings.rs
+++ b/src/config/embeddings.rs
@@ -2,7 +2,9 @@ use std::sync::Arc;
 
 use secrecy::{ExposeSecret, SecretString};
 
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env, validate_base_url};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_optional_env, validate_base_url,
+};
 use crate::error::ConfigError;
 use crate::llm::SessionManager;
 use crate::settings::Settings;
@@ -71,22 +73,44 @@ pub(crate) fn default_dimension_for_model(model: &str) -> usize {
 
 impl EmbeddingsConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::EmbeddingsSettings::default();
+
         let openai_api_key = optional_env("OPENAI_API_KEY")?.map(SecretString::from);
 
-        let provider = optional_env("EMBEDDING_PROVIDER")?
-            .unwrap_or_else(|| settings.embeddings.provider.clone());
+        let provider = db_first_or_default(
+            &settings.embeddings.provider,
+            &defaults.provider,
+            "EMBEDDING_PROVIDER",
+        )?;
 
-        let model =
-            optional_env("EMBEDDING_MODEL")?.unwrap_or_else(|| settings.embeddings.model.clone());
+        let model = db_first_or_default(
+            &settings.embeddings.model,
+            &defaults.model,
+            "EMBEDDING_MODEL",
+        )?;
 
-        let ollama_base_url = optional_env("OLLAMA_BASE_URL")?
-            .or_else(|| settings.ollama_base_url.clone())
-            .unwrap_or_else(|| "http://localhost:11434".to_string());
+        // ollama_base_url lives on the top-level Settings, not the embeddings
+        // sub-struct. Use a manual DB > env > default chain.
+        let default_ollama_url = "http://localhost:11434".to_string();
+        let ollama_base_url = match settings
+            .ollama_base_url
+            .as_ref()
+            .filter(|s| !s.is_empty())
+            .cloned()
+        {
+            Some(url) => url,
+            None => optional_env("OLLAMA_BASE_URL")?.unwrap_or(default_ollama_url),
+        };
 
+        // Dimension depends on the resolved model, not on a DB setting — env-only.
         let dimension =
             parse_optional_env("EMBEDDING_DIMENSION", default_dimension_for_model(&model))?;
 
-        let enabled = parse_bool_env("EMBEDDING_ENABLED", settings.embeddings.enabled)?;
+        let enabled = db_first_bool(
+            settings.embeddings.enabled,
+            defaults.enabled,
+            "EMBEDDING_ENABLED",
+        )?;
 
         let openai_base_url = optional_env("EMBEDDING_BASE_URL")?;
 
@@ -207,9 +231,11 @@ mod tests {
             std::env::remove_var("EMBEDDING_ENABLED");
             std::env::remove_var("EMBEDDING_PROVIDER");
             std::env::remove_var("EMBEDDING_MODEL");
+            std::env::remove_var("EMBEDDING_DIMENSION");
             std::env::remove_var("OPENAI_API_KEY");
             std::env::remove_var("EMBEDDING_BASE_URL");
             std::env::remove_var("EMBEDDING_CACHE_SIZE");
+            std::env::remove_var("OLLAMA_BASE_URL");
         }
     }
 
@@ -264,18 +290,21 @@ mod tests {
     }
 
     #[test]
-    fn embeddings_env_override_takes_precedence() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         clear_embedding_env();
         // SAFETY: Under ENV_MUTEX.
         unsafe {
-            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_ENABLED", "false");
+            std::env::set_var("EMBEDDING_PROVIDER", "ollama");
+            std::env::set_var("EMBEDDING_MODEL", "all-minilm");
         }
 
         let settings = Settings {
             embeddings: EmbeddingsSettings {
-                enabled: false,
-                ..Default::default()
+                enabled: true,
+                provider: "openai".to_string(),
+                model: "text-embedding-3-large".to_string(),
             },
             ..Default::default()
         };
@@ -283,12 +312,55 @@ mod tests {
         let config = EmbeddingsConfig::resolve(&settings).expect("resolve should succeed");
         assert!(
             config.enabled,
-            "EMBEDDING_ENABLED=true env var should override settings"
+            "DB enabled=true should win over env EMBEDDING_ENABLED=false"
+        );
+        assert_eq!(config.provider, "openai", "DB provider should win over env");
+        assert_eq!(
+            config.model, "text-embedding-3-large",
+            "DB model should win over env"
         );
 
         // SAFETY: Under ENV_MUTEX.
         unsafe {
             std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_MODEL");
+        }
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        clear_embedding_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("EMBEDDING_ENABLED", "true");
+            std::env::set_var("EMBEDDING_PROVIDER", "ollama");
+            std::env::set_var("EMBEDDING_MODEL", "nomic-embed-text");
+        }
+
+        // Settings left at defaults — no explicit DB/TOML override
+        let settings = Settings::default();
+
+        let config = EmbeddingsConfig::resolve(&settings).expect("resolve should succeed");
+        assert!(
+            config.enabled,
+            "env EMBEDDING_ENABLED should be used when settings at default"
+        );
+        assert_eq!(
+            config.provider, "ollama",
+            "env EMBEDDING_PROVIDER should be used when settings at default"
+        );
+        assert_eq!(
+            config.model, "nomic-embed-text",
+            "env EMBEDDING_MODEL should be used when settings at default"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("EMBEDDING_ENABLED");
+            std::env::remove_var("EMBEDDING_PROVIDER");
+            std::env::remove_var("EMBEDDING_MODEL");
         }
     }
 

--- a/src/config/heartbeat.rs
+++ b/src/config/heartbeat.rs
@@ -1,4 +1,7 @@
-use crate::config::helpers::{optional_env, parse_bool_env, parse_option_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_option, db_first_optional_string, db_first_or_default, optional_env,
+    parse_bool_env,
+};
 use crate::error::ConfigError;
 use crate::settings::Settings;
 
@@ -44,8 +47,11 @@ impl Default for HeartbeatConfig {
 
 impl HeartbeatConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::HeartbeatSettings::default();
+
+        // fire_at: DB > env, then parse into NaiveTime
         let fire_at_str =
-            optional_env("HEARTBEAT_FIRE_AT")?.or_else(|| settings.heartbeat.fire_at.clone());
+            db_first_optional_string(&settings.heartbeat.fire_at, "HEARTBEAT_FIRE_AT")?;
         let fire_at = fire_at_str
             .map(|s| {
                 chrono::NaiveTime::parse_from_str(&s, "%H:%M").map_err(|e| {
@@ -57,31 +63,24 @@ impl HeartbeatConfig {
             })
             .transpose()?;
 
-        Ok(Self {
-            enabled: parse_bool_env("HEARTBEAT_ENABLED", settings.heartbeat.enabled)?,
-            interval_secs: parse_optional_env(
-                "HEARTBEAT_INTERVAL_SECS",
-                settings.heartbeat.interval_secs,
-            )?,
-            notify_channel: optional_env("HEARTBEAT_NOTIFY_CHANNEL")?
-                .or_else(|| settings.heartbeat.notify_channel.clone()),
-            notify_user: optional_env("HEARTBEAT_NOTIFY_USER")?
-                .or_else(|| settings.heartbeat.notify_user.clone()),
-            fire_at,
-            quiet_hours_start: parse_option_env::<u32>("HEARTBEAT_QUIET_START")?
-                .or(settings.heartbeat.quiet_hours_start)
-                .map(|h| {
-                    if h > 23 {
-                        return Err(ConfigError::InvalidValue {
-                            key: "HEARTBEAT_QUIET_START".into(),
-                            message: "must be 0-23".into(),
-                        });
-                    }
-                    Ok(h)
-                })
-                .transpose()?,
-            quiet_hours_end: parse_option_env::<u32>("HEARTBEAT_QUIET_END")?
-                .or(settings.heartbeat.quiet_hours_end)
+        // quiet_hours: DB > env (using db_first_option for shadow warnings)
+        let quiet_hours_start = db_first_option(
+            &settings.heartbeat.quiet_hours_start,
+            "HEARTBEAT_QUIET_START",
+        )?
+        .map(|h| {
+            if h > 23 {
+                return Err(ConfigError::InvalidValue {
+                    key: "HEARTBEAT_QUIET_START".into(),
+                    message: "must be 0-23".into(),
+                });
+            }
+            Ok(h)
+        })
+        .transpose()?;
+
+        let quiet_hours_end =
+            db_first_option(&settings.heartbeat.quiet_hours_end, "HEARTBEAT_QUIET_END")?
                 .map(|h| {
                     if h > 23 {
                         return Err(ConfigError::InvalidValue {
@@ -91,10 +90,33 @@ impl HeartbeatConfig {
                     }
                     Ok(h)
                 })
-                .transpose()?,
+                .transpose()?;
+
+        Ok(Self {
+            enabled: db_first_bool(
+                settings.heartbeat.enabled,
+                defaults.enabled,
+                "HEARTBEAT_ENABLED",
+            )?,
+            interval_secs: db_first_or_default(
+                &settings.heartbeat.interval_secs,
+                &defaults.interval_secs,
+                "HEARTBEAT_INTERVAL_SECS",
+            )?,
+            notify_channel: db_first_optional_string(
+                &settings.heartbeat.notify_channel,
+                "HEARTBEAT_NOTIFY_CHANNEL",
+            )?,
+            notify_user: db_first_optional_string(
+                &settings.heartbeat.notify_user,
+                "HEARTBEAT_NOTIFY_USER",
+            )?,
+            fire_at,
+            quiet_hours_start,
+            quiet_hours_end,
             timezone: {
-                let tz = optional_env("HEARTBEAT_TIMEZONE")?
-                    .or_else(|| settings.heartbeat.timezone.clone());
+                let tz =
+                    db_first_optional_string(&settings.heartbeat.timezone, "HEARTBEAT_TIMEZONE")?;
                 if let Some(ref tz_str) = tz
                     && crate::timezone::parse_timezone(tz_str).is_none()
                 {
@@ -105,7 +127,12 @@ impl HeartbeatConfig {
                 }
                 tz
             },
-            multi_tenant: parse_bool_env("HEARTBEAT_MULTI_TENANT", false)?,
+            // Auto-detect multi-tenant mode from GATEWAY_USER_TOKENS presence,
+            // or allow explicit override via HEARTBEAT_MULTI_TENANT. Stays env-only.
+            multi_tenant: parse_bool_env(
+                "HEARTBEAT_MULTI_TENANT",
+                optional_env("GATEWAY_USER_TOKENS")?.is_some(),
+            )?,
         })
     }
 }
@@ -113,10 +140,11 @@ impl HeartbeatConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::helpers::lock_env;
 
     #[test]
-    fn test_quiet_hours_settings_fallback() {
-        // When env vars are not set, settings values should be used
+    fn test_quiet_hours_settings_have_priority() {
+        // DB/settings values should take priority over env
         let mut settings = Settings::default();
         settings.heartbeat.quiet_hours_start = Some(22);
         settings.heartbeat.quiet_hours_end = Some(6);
@@ -162,5 +190,117 @@ mod tests {
 
         let config = HeartbeatConfig::resolve(&settings).expect("resolve");
         assert_eq!(config.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn test_db_first_enabled_beats_env() {
+        let _guard = lock_env();
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var("HEARTBEAT_ENABLED", "false") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.enabled = true; // DB says enabled
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert!(config.enabled, "DB value (true) should beat env (false)");
+
+        unsafe { std::env::remove_var("HEARTBEAT_ENABLED") };
+    }
+
+    #[test]
+    fn test_db_first_interval_beats_env() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_INTERVAL_SECS", "999") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.interval_secs = 600; // DB says 600
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(config.interval_secs, 600, "DB value should beat env");
+
+        unsafe { std::env::remove_var("HEARTBEAT_INTERVAL_SECS") };
+    }
+
+    #[test]
+    fn test_db_first_notify_channel_beats_env() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_NOTIFY_CHANNEL", "env-channel") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.notify_channel = Some("db-channel".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.notify_channel.as_deref(),
+            Some("db-channel"),
+            "DB value should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_NOTIFY_CHANNEL") };
+    }
+
+    #[test]
+    fn test_env_fallback_when_db_at_default() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_INTERVAL_SECS", "999") };
+
+        // Settings at default => env should win
+        let settings = Settings::default();
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.interval_secs, 999,
+            "env should win when DB at default"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_INTERVAL_SECS") };
+    }
+
+    #[test]
+    fn test_fire_at_db_first() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_FIRE_AT", "08:00") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.fire_at = Some("14:30".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.fire_at,
+            Some(chrono::NaiveTime::from_hms_opt(14, 30, 0).unwrap()),
+            "DB fire_at should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_FIRE_AT") };
+    }
+
+    #[test]
+    fn test_timezone_db_first() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_TIMEZONE", "UTC") };
+
+        let mut settings = Settings::default();
+        settings.heartbeat.timezone = Some("America/New_York".to_string());
+
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert_eq!(
+            config.timezone.as_deref(),
+            Some("America/New_York"),
+            "DB timezone should beat env"
+        );
+
+        unsafe { std::env::remove_var("HEARTBEAT_TIMEZONE") };
+    }
+
+    #[test]
+    fn test_multi_tenant_stays_env_only() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("HEARTBEAT_MULTI_TENANT", "true") };
+
+        let settings = Settings::default();
+        let config = HeartbeatConfig::resolve(&settings).expect("resolve");
+        assert!(config.multi_tenant, "multi_tenant should read from env");
+
+        unsafe { std::env::remove_var("HEARTBEAT_MULTI_TENANT") };
     }
 }

--- a/src/config/helpers.rs
+++ b/src/config/helpers.rs
@@ -331,6 +331,99 @@ pub(crate) fn validate_base_url(url: &str, field_name: &str) -> Result<(), Confi
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// DB-first resolution helpers (DB > env > default)
+// ---------------------------------------------------------------------------
+
+/// Log a warning when a DB/TOML setting shadows a set env var.
+///
+/// Only checks real env vars (`std::env::var`), not runtime overrides or
+/// injected vars — those are internal and don't warrant operator warnings.
+/// Values are intentionally NOT logged to avoid leaking sensitive data.
+fn warn_if_db_shadows_env(env_key: &str) {
+    if std::env::var(env_key).is_ok_and(|v| !v.is_empty()) {
+        tracing::warn!(
+            env_key = %env_key,
+            "{env_key} env var is set but a DB or TOML setting takes priority. \
+             Remove the setting from DB/TOML to use the env var."
+        );
+    }
+}
+
+/// Resolve with DB > env > default priority for concrete settings fields.
+///
+/// If `settings_val != default_val`, the settings value wins (it was explicitly
+/// set in DB or TOML). Otherwise falls back to `optional_env(env_key)`, then
+/// `default_val`.
+///
+/// **Limitation:** Uses `settings_val != default_val` as a heuristic for
+/// "was this field explicitly set." If a user deliberately sets a DB value
+/// equal to the default, it's indistinguishable from "unset" and the env
+/// var will win. This matches `merge_from()` semantics and is acceptable
+/// since setting a value to its default is effectively a no-op.
+pub(crate) fn db_first_or_default<T>(
+    settings_val: &T,
+    default_val: &T,
+    env_key: &str,
+) -> Result<T, ConfigError>
+where
+    T: std::str::FromStr + Clone + PartialEq + std::fmt::Display,
+    T::Err: std::fmt::Display,
+{
+    if settings_val != default_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(settings_val.clone());
+    }
+    parse_optional_env(env_key, default_val.clone())
+}
+
+/// Resolve a bool with DB > env > default priority.
+pub(crate) fn db_first_bool(
+    settings_val: bool,
+    default_val: bool,
+    env_key: &str,
+) -> Result<bool, ConfigError> {
+    if settings_val != default_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(settings_val);
+    }
+    parse_bool_env(env_key, default_val)
+}
+
+/// Resolve an `Option<String>` with DB > env priority (no hardcoded default).
+///
+/// Non-empty `Some` means DB set it; `None` or empty falls back to env.
+pub(crate) fn db_first_optional_string(
+    settings_val: &Option<String>,
+    env_key: &str,
+) -> Result<Option<String>, ConfigError> {
+    if let Some(val) = settings_val
+        && !val.is_empty()
+    {
+        warn_if_db_shadows_env(env_key);
+        return Ok(Some(val.clone()));
+    }
+    optional_env(env_key)
+}
+
+/// Resolve an `Option<T>` with DB > env priority (no hardcoded default).
+///
+/// `Some(v)` means DB set it; `None` falls back to env.
+pub(crate) fn db_first_option<T>(
+    settings_val: &Option<T>,
+    env_key: &str,
+) -> Result<Option<T>, ConfigError>
+where
+    T: std::str::FromStr + Clone + std::fmt::Display,
+    T::Err: std::fmt::Display,
+{
+    if let Some(val) = settings_val {
+        warn_if_db_shadows_env(env_key);
+        return Ok(Some(val.clone()));
+    }
+    parse_option_env(env_key)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -518,5 +611,145 @@ mod tests {
             err.contains("failed to resolve"),
             "Expected DNS resolution failure, got: {err}"
         );
+    }
+
+    // --- db_first_* helper tests ---
+
+    #[test]
+    fn db_first_or_default_prefers_settings_over_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_1";
+        // SAFETY: under ENV_MUTEX
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let result: String =
+            db_first_or_default(&"from-db".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(result, "from-db", "DB value should win over env");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_or_default_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_2";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        // settings_val == default_val → treated as "unset"
+        let result: String =
+            db_first_or_default(&"default".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(
+            result, "from-env",
+            "env should win when settings at default"
+        );
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_or_default_uses_default_when_neither_set() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_3";
+        unsafe { std::env::remove_var(key) };
+
+        let result: String =
+            db_first_or_default(&"default".to_string(), &"default".to_string(), key)
+                .expect("should resolve");
+        assert_eq!(result, "default");
+    }
+
+    #[test]
+    fn db_first_bool_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_BOOL_1";
+        unsafe { std::env::set_var(key, "false") };
+
+        let result = db_first_bool(true, false, key).expect("should resolve");
+        assert!(result, "DB true should win over env false");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_bool_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_BOOL_2";
+        unsafe { std::env::set_var(key, "true") };
+
+        // settings == default → falls back to env
+        let result = db_first_bool(false, false, key).expect("should resolve");
+        assert!(result, "env should win when settings at default");
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_1";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let val = Some("from-db".to_string());
+        let result = db_first_optional_string(&val, key).expect("should resolve");
+        assert_eq!(result, Some("from-db".to_string()));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_2";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let result = db_first_optional_string(&None, key).expect("should resolve");
+        assert_eq!(result, Some("from-env".to_string()));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_optional_string_empty_treated_as_unset() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_3";
+        unsafe { std::env::set_var(key, "from-env") };
+
+        let val = Some(String::new());
+        let result = db_first_optional_string(&val, key).expect("should resolve");
+        assert_eq!(
+            result,
+            Some("from-env".to_string()),
+            "empty string should be treated as unset"
+        );
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_option_prefers_settings() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_T_1";
+        unsafe { std::env::set_var(key, "99") };
+
+        let val: Option<u64> = Some(42);
+        let result = db_first_option(&val, key).expect("should resolve");
+        assert_eq!(result, Some(42));
+
+        unsafe { std::env::remove_var(key) };
+    }
+
+    #[test]
+    fn db_first_option_falls_back_to_env() {
+        let _guard = lock_env();
+        let key = "IRONCLAW_TEST_DB_FIRST_OPT_T_2";
+        unsafe { std::env::set_var(key, "99") };
+
+        let val: Option<u64> = None;
+        let result = db_first_option(&val, key).expect("should resolve");
+        assert_eq!(result, Some(99));
+
+        unsafe { std::env::remove_var(key) };
     }
 }

--- a/src/config/hygiene.rs
+++ b/src/config/hygiene.rs
@@ -1,6 +1,7 @@
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Memory hygiene configuration.
 ///
@@ -30,15 +31,27 @@ impl Default for HygieneConfig {
 }
 
 impl HygieneConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::HygieneSettings::default();
+        let hs = &settings.hygiene;
+
         Ok(Self {
-            enabled: parse_bool_env("MEMORY_HYGIENE_ENABLED", true)?,
-            daily_retention_days: parse_optional_env("MEMORY_HYGIENE_DAILY_RETENTION_DAYS", 30)?,
-            conversation_retention_days: parse_optional_env(
-                "MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS",
-                7,
+            enabled: db_first_bool(hs.enabled, defaults.enabled, "MEMORY_HYGIENE_ENABLED")?,
+            daily_retention_days: db_first_or_default(
+                &hs.daily_retention_days,
+                &defaults.daily_retention_days,
+                "MEMORY_HYGIENE_DAILY_RETENTION_DAYS",
             )?,
-            cadence_hours: parse_optional_env("MEMORY_HYGIENE_CADENCE_HOURS", 12)?,
+            conversation_retention_days: db_first_or_default(
+                &hs.conversation_retention_days,
+                &defaults.conversation_retention_days,
+                "MEMORY_HYGIENE_CONVERSATION_RETENTION_DAYS",
+            )?,
+            cadence_hours: db_first_or_default(
+                &hs.cadence_hours,
+                &defaults.cadence_hours,
+                "MEMORY_HYGIENE_CADENCE_HOURS",
+            )?,
         })
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ mod heartbeat;
 pub(crate) mod helpers;
 mod hygiene;
 pub(crate) mod llm;
+pub mod profile;
 pub mod relay;
 mod routines;
 mod safety;
@@ -152,6 +153,7 @@ impl Config {
             tunnel: TunnelConfig::default(),
             channels: ChannelsConfig {
                 cli: CliConfig { enabled: false },
+                cli_mode: None,
                 http: None,
                 gateway: None,
                 signal: None,
@@ -222,8 +224,9 @@ impl Config {
         let _ = dotenvy::dotenv();
         crate::bootstrap::load_ironclaw_env();
 
-        // Start with TOML config as a base (lowest priority among the two).
+        // Start with defaults, apply deployment profile, then TOML overlay.
         let mut settings = Settings::default();
+        profile::apply_profile(&mut settings)?;
         Self::apply_toml_overlay(&mut settings, toml_path)?;
 
         // Overlay DB settings on top so DB values win over TOML.
@@ -325,8 +328,9 @@ impl Config {
         secrets: Option<&(dyn crate::secrets::SecretsStore + Send + Sync)>,
     ) -> Result<(), ConfigError> {
         let mut settings = if let Some(store) = store {
-            // TOML as base, then DB on top (DB wins).
+            // Profile as base, then TOML, then DB on top (DB wins).
             let mut s = Settings::default();
+            profile::apply_profile(&mut s)?;
             Self::apply_toml_overlay(&mut s, toml_path)?;
             if let Ok(map) = store.get_all_settings(user_id).await {
                 let db_settings = Settings::from_db_map(&map);
@@ -334,7 +338,9 @@ impl Config {
             }
             s
         } else {
-            Settings::default()
+            let mut s = Settings::default();
+            profile::apply_profile(&mut s)?;
+            s
         };
 
         // Hydrate API keys from encrypted secrets store into the settings
@@ -397,6 +403,7 @@ pub(crate) fn load_bootstrap_settings(
     crate::bootstrap::load_ironclaw_env();
 
     let mut settings = Settings::load();
+    profile::apply_profile(&mut settings)?;
     Config::apply_toml_overlay(&mut settings, toml_path)?;
     Ok(settings)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,10 +1,19 @@
 //! Configuration for IronClaw.
 //!
-//! Settings are loaded from env vars, the DB settings table, TOML config,
-//! and built-in defaults. Priority varies by subsystem:
+//! Settings are loaded with priority: **DB/TOML > env > default**.
 //!
-//! - **LLM settings** (backend, model, api_key, base_url): DB > env > default
-//! - **Most other settings** (agent, channels, tunnel, …): env > DB > default
+//! DB and TOML are merged into a single `Settings` struct before
+//! resolution (DB wins over TOML when both set the same field).
+//! Resolvers then check settings before env vars.
+//!
+//! For concrete (non-`Option`) fields, a settings value equal to the
+//! built-in default is treated as "unset" and falls through to env.
+//!
+//! Exceptions:
+//! - Bootstrap configs (database, secrets): env-only (DB not yet available)
+//! - Security-sensitive fields (allow_local_tools, allow_full_access,
+//!   cost limits, auth tokens): env-only
+//! - API keys: env/secrets store only
 //!
 //! `DATABASE_URL` lives in `~/.ironclaw/.env` (loaded via dotenvy early
 //! in startup).
@@ -191,9 +200,9 @@ impl Config {
 
     /// Load configuration from environment variables and the database.
     ///
-    /// TOML is loaded first as a base, then DB values are merged on top
-    /// (DB wins over TOML). Individual subsystem resolvers then apply
-    /// their own env-vs-DB priority — see module docs for details.
+    /// Priority: DB/TOML > env > default. TOML is loaded first as a
+    /// base, then DB values are merged on top. Subsystem resolvers check
+    /// the merged settings before env vars (except bootstrap/security fields).
     pub async fn from_db(
         store: &(dyn crate::db::SettingsStore + Sync),
         user_id: &str,
@@ -203,9 +212,8 @@ impl Config {
 
     /// Load from DB with an optional TOML config file overlay.
     ///
-    /// TOML is loaded first as a base, then DB values are merged on top
-    /// (DB wins over TOML). Per-subsystem resolvers then decide whether
-    /// env vars or DB values take final precedence — see module docs.
+    /// Priority: DB/TOML > env > default. TOML is loaded as the base,
+    /// then DB values are merged on top. See module docs for exceptions.
     pub async fn from_db_with_toml(
         store: &(dyn crate::db::SettingsStore + Sync),
         user_id: &str,
@@ -366,13 +374,13 @@ impl Config {
             secrets: SecretsConfig::resolve().await?,
             builder: BuilderModeConfig::resolve(settings)?,
             heartbeat: HeartbeatConfig::resolve(settings)?,
-            hygiene: HygieneConfig::resolve()?,
-            routines: RoutineConfig::resolve()?,
+            hygiene: HygieneConfig::resolve(settings)?,
+            routines: RoutineConfig::resolve(settings)?,
             sandbox: SandboxModeConfig::resolve(settings)?,
             claude_code: ClaudeCodeConfig::resolve(settings)?,
-            skills: SkillsConfig::resolve()?,
+            skills: SkillsConfig::resolve(settings)?,
             transcription: TranscriptionConfig::resolve(settings)?,
-            search: WorkspaceSearchConfig::resolve()?,
+            search: WorkspaceSearchConfig::resolve(settings)?,
             workspace,
             observability: crate::observability::ObservabilityConfig {
                 backend: std::env::var("OBSERVABILITY_BACKEND").unwrap_or_else(|_| "none".into()),

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -1,0 +1,306 @@
+//! Deployment profiles — TOML-based configuration presets.
+//!
+//! A profile is a partial `Settings` TOML file that gets merged onto defaults
+//! before config.toml and database overlays. This lets users (or ops teams)
+//! select a deployment shape with a single env var:
+//!
+//! ```bash
+//! IRONCLAW_PROFILE=server ironclaw
+//! ```
+//!
+//! **Lookup order** for `IRONCLAW_PROFILE=foo`:
+//! 1. `~/.ironclaw/profiles/foo.toml`  (user-defined, highest priority)
+//! 2. Built-in profiles embedded in the binary
+//!
+//! Users can create any profile name they want — just drop a TOML file in the
+//! profiles directory.
+//!
+//! **Built-in profiles:** `local`, `local-sandbox`, `server`, `server-multitenant`.
+
+use std::path::PathBuf;
+
+use crate::bootstrap::ironclaw_base_dir;
+use crate::config::helpers::optional_env;
+use crate::error::ConfigError;
+use crate::settings::Settings;
+
+// Built-in profile TOML files, embedded at compile time.
+const BUILTIN_LOCAL: &str = include_str!("../../profiles/local.toml");
+const BUILTIN_LOCAL_SANDBOX: &str = include_str!("../../profiles/local-sandbox.toml");
+const BUILTIN_SERVER: &str = include_str!("../../profiles/server.toml");
+const BUILTIN_SERVER_MULTITENANT: &str = include_str!("../../profiles/server-multitenant.toml");
+
+/// Known built-in profile names and their embedded TOML content.
+const BUILTIN_PROFILES: &[(&str, &str)] = &[
+    ("local", BUILTIN_LOCAL),
+    ("local-sandbox", BUILTIN_LOCAL_SANDBOX),
+    ("server", BUILTIN_SERVER),
+    ("server-multitenant", BUILTIN_SERVER_MULTITENANT),
+];
+
+/// Directory under the IronClaw base dir where user-defined profiles live.
+const PROFILES_DIR: &str = "profiles";
+
+/// Information about an available profile.
+#[derive(Debug, Clone)]
+pub struct ProfileInfo {
+    /// Profile name (e.g. "server", "my-custom-profile").
+    pub name: String,
+    /// Whether this is a built-in profile.
+    pub builtin: bool,
+    /// Path to the TOML file (None for built-in profiles without a user override).
+    pub path: Option<PathBuf>,
+}
+
+/// Read `IRONCLAW_PROFILE` and merge the profile onto `settings`.
+///
+/// If the env var is unset or empty, this is a no-op. If set to an unknown
+/// name with no user-defined file, returns an error.
+pub fn apply_profile(settings: &mut Settings) -> Result<(), ConfigError> {
+    let name = match optional_env("IRONCLAW_PROFILE")? {
+        Some(n) if !n.is_empty() => n,
+        _ => return Ok(()),
+    };
+
+    let profile_settings = load_profile(&name)?;
+    settings.merge_from(&profile_settings);
+
+    tracing::debug!("Applied deployment profile: {name}");
+    Ok(())
+}
+
+/// Load a profile by name, checking user directory first, then built-ins.
+fn load_profile(name: &str) -> Result<Settings, ConfigError> {
+    // 1. Check user-defined profiles directory.
+    let user_path = user_profiles_dir().join(format!("{name}.toml"));
+    if user_path.is_file() {
+        return Settings::load_toml(&user_path)
+            .map_err(ConfigError::ParseError)?
+            .ok_or(ConfigError::InvalidValue {
+                key: "IRONCLAW_PROFILE".to_string(),
+                message: format!(
+                    "profile file exists but could not be loaded: {}",
+                    user_path.display()
+                ),
+            });
+    }
+
+    // 2. Check built-in profiles.
+    let normalized = name.to_ascii_lowercase();
+    for &(builtin_name, toml_content) in BUILTIN_PROFILES {
+        if builtin_name == normalized {
+            let profile: Settings = toml::from_str(toml_content).map_err(|e| {
+                ConfigError::ParseError(format!(
+                    "failed to parse built-in profile '{builtin_name}': {e}"
+                ))
+            })?;
+            return Ok(profile);
+        }
+    }
+
+    // 3. Not found anywhere.
+    let available: Vec<&str> = BUILTIN_PROFILES.iter().map(|(n, _)| *n).collect();
+    Err(ConfigError::InvalidValue {
+        key: "IRONCLAW_PROFILE".to_string(),
+        message: format!(
+            "unknown profile '{name}'. Built-in profiles: {}. \
+             You can also create a custom profile at {}",
+            available.join(", "),
+            user_path.display(),
+        ),
+    })
+}
+
+/// List all available profiles (built-in + user-defined).
+pub fn list_profiles() -> Vec<ProfileInfo> {
+    let mut profiles = Vec::new();
+
+    // Built-in profiles.
+    for &(name, _) in BUILTIN_PROFILES {
+        profiles.push(ProfileInfo {
+            name: name.to_string(),
+            builtin: true,
+            path: None,
+        });
+    }
+
+    // User-defined profiles.
+    let user_dir = user_profiles_dir();
+    if let Ok(entries) = std::fs::read_dir(&user_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().is_some_and(|ext| ext == "toml")
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            {
+                let name = stem.to_string();
+                // If this overrides a built-in, update that entry instead of adding duplicate.
+                if let Some(existing) = profiles.iter_mut().find(|p| p.name == name) {
+                    existing.path = Some(path);
+                } else {
+                    profiles.push(ProfileInfo {
+                        name,
+                        builtin: false,
+                        path: Some(path),
+                    });
+                }
+            }
+        }
+    }
+
+    profiles
+}
+
+/// Path to the user-defined profiles directory: `~/.ironclaw/profiles/`.
+fn user_profiles_dir() -> PathBuf {
+    ironclaw_base_dir().join(PROFILES_DIR)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+
+    #[test]
+    fn no_profile_is_noop() {
+        let _guard = lock_env();
+        // Ensure IRONCLAW_PROFILE is not set.
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        let mut settings = Settings::default();
+        let original = settings.clone();
+        apply_profile(&mut settings).expect("no profile should be a no-op");
+
+        // Settings should be unchanged.
+        let orig_json = serde_json::to_value(&original).unwrap();
+        let new_json = serde_json::to_value(&settings).unwrap();
+        assert_eq!(orig_json, new_json);
+    }
+
+    #[test]
+    fn unknown_profile_errors() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "nonexistent-xyz-987") };
+
+        let mut settings = Settings::default();
+        let result = apply_profile(&mut settings);
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("nonexistent-xyz-987"),
+            "error should mention the profile name: {err}"
+        );
+        assert!(
+            err.contains("local"),
+            "error should list built-in profiles: {err}"
+        );
+    }
+
+    #[test]
+    fn local_profile_disables_gateway() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "local") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("local profile should load");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert!(!settings.channels.gateway_enabled);
+        assert!(!settings.sandbox.enabled);
+        assert!(!settings.heartbeat.enabled);
+        assert!(!settings.routines.enabled);
+        assert!(!settings.hygiene.enabled);
+        assert_eq!(settings.channels.cli_mode.as_deref(), Some("tui"));
+        assert_eq!(settings.database_backend.as_deref(), Some("libsql"));
+    }
+
+    #[test]
+    fn server_profile_enables_postgres() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "server") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("server profile should load");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert_eq!(settings.database_backend.as_deref(), Some("postgres"));
+        assert!(settings.sandbox.enabled);
+        assert!(settings.heartbeat.enabled);
+        assert!(settings.hygiene.enabled);
+    }
+
+    #[test]
+    fn server_multitenant_sets_higher_parallelism() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "server-multitenant") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("server-multitenant profile should load");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert_eq!(settings.agent.max_parallel_jobs, 10);
+        assert_eq!(settings.database_backend.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn local_sandbox_enables_sandbox() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "local-sandbox") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("local-sandbox profile should load");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert!(settings.sandbox.enabled);
+        assert_eq!(settings.sandbox.policy, "readonly");
+        assert!(!settings.channels.gateway_enabled);
+    }
+
+    #[test]
+    fn case_insensitive_profile_name() {
+        let _guard = lock_env();
+        unsafe { std::env::set_var("IRONCLAW_PROFILE", "SERVER") };
+
+        let mut settings = Settings::default();
+        apply_profile(&mut settings).expect("case-insensitive should work");
+
+        unsafe { std::env::remove_var("IRONCLAW_PROFILE") };
+
+        assert_eq!(settings.database_backend.as_deref(), Some("postgres"));
+    }
+
+    #[test]
+    fn list_profiles_includes_builtins() {
+        let profiles = list_profiles();
+        let names: Vec<&str> = profiles.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"local"));
+        assert!(names.contains(&"local-sandbox"));
+        assert!(names.contains(&"server"));
+        assert!(names.contains(&"server-multitenant"));
+    }
+
+    #[test]
+    fn user_profile_overrides_builtin() {
+        let _guard = lock_env();
+
+        // Create a temporary user profile.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let profile_path = tmp.path().join("local.toml");
+        std::fs::write(
+            &profile_path,
+            "database_backend = \"postgres\"\n\n[heartbeat]\nenabled = true\n",
+        )
+        .unwrap();
+
+        // Load it directly via load_profile logic (simulating user dir).
+        let loaded: Settings = Settings::load_toml(&profile_path).unwrap().unwrap();
+        assert_eq!(loaded.database_backend.as_deref(), Some("postgres"));
+        assert!(loaded.heartbeat.enabled);
+    }
+}

--- a/src/config/routines.rs
+++ b/src/config/routines.rs
@@ -1,5 +1,6 @@
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Routines configuration.
 #[derive(Debug, Clone)]
@@ -35,15 +36,42 @@ impl Default for RoutineConfig {
 }
 
 impl RoutineConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
-        let max_iterations: u32 = parse_optional_env("ROUTINES_LIGHTWEIGHT_MAX_ITERATIONS", 3)?;
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::RoutineSettings::default();
+        let rs = &settings.routines;
+
+        let max_iterations: u32 = db_first_or_default(
+            &rs.lightweight_max_iterations,
+            &defaults.lightweight_max_iterations,
+            "ROUTINES_LIGHTWEIGHT_MAX_ITERATIONS",
+        )?;
         Ok(Self {
-            enabled: parse_bool_env("ROUTINES_ENABLED", true)?,
-            cron_check_interval_secs: parse_optional_env("ROUTINES_CRON_INTERVAL", 15)?,
-            max_concurrent_routines: parse_optional_env("ROUTINES_MAX_CONCURRENT", 10)?,
-            default_cooldown_secs: parse_optional_env("ROUTINES_DEFAULT_COOLDOWN", 300)?,
-            max_lightweight_tokens: parse_optional_env("ROUTINES_MAX_TOKENS", 4096)?,
-            lightweight_tools_enabled: parse_bool_env("ROUTINES_LIGHTWEIGHT_TOOLS", true)?,
+            enabled: db_first_bool(rs.enabled, defaults.enabled, "ROUTINES_ENABLED")?,
+            cron_check_interval_secs: db_first_or_default(
+                &rs.cron_check_interval_secs,
+                &defaults.cron_check_interval_secs,
+                "ROUTINES_CRON_INTERVAL",
+            )?,
+            max_concurrent_routines: db_first_or_default(
+                &rs.max_concurrent_routines,
+                &defaults.max_concurrent_routines,
+                "ROUTINES_MAX_CONCURRENT",
+            )?,
+            default_cooldown_secs: db_first_or_default(
+                &rs.default_cooldown_secs,
+                &defaults.default_cooldown_secs,
+                "ROUTINES_DEFAULT_COOLDOWN",
+            )?,
+            max_lightweight_tokens: db_first_or_default(
+                &rs.max_lightweight_tokens,
+                &defaults.max_lightweight_tokens,
+                "ROUTINES_MAX_TOKENS",
+            )?,
+            lightweight_tools_enabled: db_first_bool(
+                rs.lightweight_tools_enabled,
+                defaults.lightweight_tools_enabled,
+                "ROUTINES_LIGHTWEIGHT_TOOLS",
+            )?,
             lightweight_max_iterations: max_iterations.min(5), // cap at 5
         })
     }

--- a/src/config/safety.rs
+++ b/src/config/safety.rs
@@ -1,4 +1,4 @@
-use crate::config::helpers::{parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default};
 use crate::error::ConfigError;
 
 pub use ironclaw_safety::SafetyConfig;
@@ -7,11 +7,17 @@ pub(crate) fn resolve_safety_config(
     settings: &crate::settings::Settings,
 ) -> Result<SafetyConfig, ConfigError> {
     let ss = &settings.safety;
+    let defaults = crate::settings::SafetySettings::default();
     Ok(SafetyConfig {
-        max_output_length: parse_optional_env("SAFETY_MAX_OUTPUT_LENGTH", ss.max_output_length)?,
-        injection_check_enabled: parse_bool_env(
-            "SAFETY_INJECTION_CHECK_ENABLED",
+        max_output_length: db_first_or_default(
+            &ss.max_output_length,
+            &defaults.max_output_length,
+            "SAFETY_MAX_OUTPUT_LENGTH",
+        )?,
+        injection_check_enabled: db_first_bool(
             ss.injection_check_enabled,
+            defaults.injection_check_enabled,
+            "SAFETY_INJECTION_CHECK_ENABLED",
         )?,
     })
 }
@@ -35,9 +41,10 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
+        // Non-default value simulates an explicit DB/TOML setting
         settings.safety.max_output_length = 42;
 
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
@@ -45,6 +52,25 @@ mod tests {
         let cfg = resolve_safety_config(&settings).expect("resolve");
         unsafe { std::env::remove_var("SAFETY_MAX_OUTPUT_LENGTH") };
 
+        // DB value (42) wins over env value (7)
+        assert_eq!(cfg.max_output_length, 42);
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        // Settings left at defaults — no explicit DB/TOML override
+        let settings = Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SAFETY_MAX_OUTPUT_LENGTH", "7") };
+        unsafe { std::env::set_var("SAFETY_INJECTION_CHECK_ENABLED", "false") };
+        let cfg = resolve_safety_config(&settings).expect("resolve");
+        unsafe { std::env::remove_var("SAFETY_MAX_OUTPUT_LENGTH") };
+        unsafe { std::env::remove_var("SAFETY_INJECTION_CHECK_ENABLED") };
+
+        // Env values win when settings are at their defaults
         assert_eq!(cfg.max_output_length, 7);
+        assert!(!cfg.injection_check_enabled);
     }
 }

--- a/src/config/sandbox.rs
+++ b/src/config/sandbox.rs
@@ -1,4 +1,7 @@
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env, parse_string_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_bool_env, parse_optional_env,
+    parse_string_env,
+};
 use crate::error::ConfigError;
 
 /// Docker sandbox configuration.
@@ -54,16 +57,16 @@ impl Default for SandboxModeConfig {
 impl SandboxModeConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ss = &settings.sandbox;
+        let defaults = crate::settings::SandboxSettings::default();
 
-        let extra_domains = optional_env("SANDBOX_EXTRA_DOMAINS")?
-            .map(|s| s.split(',').map(|d| d.trim().to_string()).collect())
-            .unwrap_or_else(|| {
-                if ss.extra_allowed_domains.is_empty() {
-                    Vec::new()
-                } else {
-                    ss.extra_allowed_domains.clone()
-                }
-            });
+        // extra_allowed_domains: DB wins if non-empty, otherwise env, otherwise empty.
+        let extra_domains = if !ss.extra_allowed_domains.is_empty() {
+            ss.extra_allowed_domains.clone()
+        } else {
+            optional_env("SANDBOX_EXTRA_DOMAINS")?
+                .map(|s| s.split(',').map(|d| d.trim().to_string()).collect())
+                .unwrap_or_default()
+        };
 
         // reaper/orphan fields have no Settings counterpart — env > default only.
         let reaper_interval_secs: u64 = parse_optional_env("SANDBOX_REAPER_INTERVAL_SECS", 300)?;
@@ -85,15 +88,31 @@ impl SandboxModeConfig {
         }
 
         Ok(Self {
-            enabled: parse_bool_env("SANDBOX_ENABLED", ss.enabled)?,
-            policy: parse_string_env("SANDBOX_POLICY", ss.policy.clone())?,
-            // allow_full_access has no Settings counterpart — env > default only.
+            enabled: db_first_bool(ss.enabled, defaults.enabled, "SANDBOX_ENABLED")?,
+            policy: db_first_or_default(&ss.policy, &defaults.policy, "SANDBOX_POLICY")?,
+            // allow_full_access has no Settings counterpart — env > default only (security).
             allow_full_access: parse_bool_env("SANDBOX_ALLOW_FULL_ACCESS", false)?,
-            timeout_secs: parse_optional_env("SANDBOX_TIMEOUT_SECS", ss.timeout_secs)?,
-            memory_limit_mb: parse_optional_env("SANDBOX_MEMORY_LIMIT_MB", ss.memory_limit_mb)?,
-            cpu_shares: parse_optional_env("SANDBOX_CPU_SHARES", ss.cpu_shares)?,
-            image: parse_string_env("SANDBOX_IMAGE", ss.image.clone())?,
-            auto_pull_image: parse_bool_env("SANDBOX_AUTO_PULL", ss.auto_pull_image)?,
+            timeout_secs: db_first_or_default(
+                &ss.timeout_secs,
+                &defaults.timeout_secs,
+                "SANDBOX_TIMEOUT_SECS",
+            )?,
+            memory_limit_mb: db_first_or_default(
+                &ss.memory_limit_mb,
+                &defaults.memory_limit_mb,
+                "SANDBOX_MEMORY_LIMIT_MB",
+            )?,
+            cpu_shares: db_first_or_default(
+                &ss.cpu_shares,
+                &defaults.cpu_shares,
+                "SANDBOX_CPU_SHARES",
+            )?,
+            image: db_first_or_default(&ss.image, &defaults.image, "SANDBOX_IMAGE")?,
+            auto_pull_image: db_first_bool(
+                ss.auto_pull_image,
+                defaults.auto_pull_image,
+                "SANDBOX_AUTO_PULL",
+            )?,
             extra_allowed_domains: extra_domains,
             reaper_interval_secs,
             orphan_threshold_secs,
@@ -264,19 +283,28 @@ impl ClaudeCodeConfig {
     }
 
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
+        let ss = &settings.sandbox;
         let defaults = Self::default();
         Ok(Self {
-            // Use settings.sandbox.claude_code_enabled as fallback (written by setup wizard).
-            enabled: parse_bool_env("CLAUDE_CODE_ENABLED", settings.sandbox.claude_code_enabled)?,
+            enabled: db_first_bool(
+                ss.claude_code_enabled,
+                defaults.enabled,
+                "CLAUDE_CODE_ENABLED",
+            )?,
+            // config_dir has no Settings counterpart — env > default only.
             config_dir: optional_env("CLAUDE_CONFIG_DIR")?
                 .map(std::path::PathBuf::from)
                 .unwrap_or(defaults.config_dir),
+            // model has no Settings counterpart — env > default only.
             model: parse_string_env("CLAUDE_CODE_MODEL", defaults.model)?,
+            // max_turns has no Settings counterpart — env > default only.
             max_turns: parse_optional_env("CLAUDE_CODE_MAX_TURNS", defaults.max_turns)?,
+            // memory_limit_mb has no Settings counterpart — env > default only.
             memory_limit_mb: parse_optional_env(
                 "CLAUDE_CODE_MEMORY_LIMIT_MB",
                 defaults.memory_limit_mb,
             )?,
+            // allowed_tools has no Settings counterpart — env > default only.
             allowed_tools: optional_env("CLAUDE_CODE_ALLOWED_TOOLS")?
                 .map(|s| {
                     s.split(',')
@@ -607,7 +635,7 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_env_overrides_settings() {
+    fn sandbox_db_settings_override_env() {
         let _guard = crate::config::helpers::lock_env();
         let mut settings = crate::settings::Settings::default();
         settings.sandbox.timeout_secs = 999;
@@ -617,7 +645,26 @@ mod tests {
         let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("SANDBOX_TIMEOUT_SECS") };
 
-        assert_eq!(cfg.timeout_secs, 5);
+        // DB value (999) wins over env (5) under DB-first priority.
+        assert_eq!(cfg.timeout_secs, 999);
+    }
+
+    #[test]
+    fn sandbox_env_used_when_no_db_setting() {
+        let _guard = crate::config::helpers::lock_env();
+        // Default settings — all fields at their defaults, so DB is "unset".
+        let settings = crate::settings::Settings::default();
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("SANDBOX_TIMEOUT_SECS", "42") };
+        unsafe { std::env::set_var("SANDBOX_MEMORY_LIMIT_MB", "512") };
+        let cfg = SandboxModeConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("SANDBOX_TIMEOUT_SECS") };
+        unsafe { std::env::remove_var("SANDBOX_MEMORY_LIMIT_MB") };
+
+        // Env values win when settings are at their defaults.
+        assert_eq!(cfg.timeout_secs, 42);
+        assert_eq!(cfg.memory_limit_mb, 512);
     }
 
     // ── ClaudeCodeConfig settings fallback tests ────────────────────
@@ -641,7 +688,7 @@ mod tests {
     }
 
     #[test]
-    fn claude_code_env_overrides_settings() {
+    fn claude_code_db_settings_override_env() {
         let _guard = crate::config::helpers::lock_env();
         let mut settings = crate::settings::Settings::default();
         settings.sandbox.claude_code_enabled = true;
@@ -651,7 +698,8 @@ mod tests {
         let cfg = ClaudeCodeConfig::resolve(&settings).expect("resolve");
         unsafe { std::env::remove_var("CLAUDE_CODE_ENABLED") };
 
-        assert!(!cfg.enabled);
+        // DB value (true) wins over env (false) under DB-first priority.
+        assert!(cfg.enabled);
     }
 
     #[test]

--- a/src/config/search.rs
+++ b/src/config/search.rs
@@ -1,5 +1,6 @@
-use crate::config::helpers::{optional_env, parse_optional_env};
+use crate::config::helpers::{db_first_option, db_first_or_default, parse_optional_env};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 use crate::workspace::FusionStrategy;
 
 /// Workspace search configuration resolved from environment variables.
@@ -33,30 +34,41 @@ impl Default for WorkspaceSearchConfig {
 }
 
 impl WorkspaceSearchConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
-        let fusion_strategy = match optional_env("SEARCH_FUSION_STRATEGY")? {
-            Some(s) => match s.to_lowercase().as_str() {
-                "rrf" => FusionStrategy::Rrf,
-                "weighted" => FusionStrategy::WeightedScore,
-                other => {
-                    return Err(ConfigError::InvalidValue {
-                        key: "SEARCH_FUSION_STRATEGY".to_string(),
-                        message: format!("must be 'rrf' or 'weighted', got '{other}'"),
-                    });
-                }
-            },
-            None => FusionStrategy::default(),
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::SearchSettings::default();
+        let ss = &settings.search;
+
+        // Resolve fusion_strategy string via DB-first, then parse into enum.
+        let strategy_str = db_first_or_default(
+            &ss.fusion_strategy,
+            &defaults.fusion_strategy,
+            "SEARCH_FUSION_STRATEGY",
+        )?;
+        let fusion_strategy = match strategy_str.to_lowercase().as_str() {
+            "rrf" => FusionStrategy::Rrf,
+            "weighted" => FusionStrategy::WeightedScore,
+            other => {
+                return Err(ConfigError::InvalidValue {
+                    key: "SEARCH_FUSION_STRATEGY".to_string(),
+                    message: format!("must be 'rrf' or 'weighted', got '{other}'"),
+                });
+            }
         };
 
-        let rrf_k = parse_optional_env("SEARCH_RRF_K", 60u32)?;
+        let rrf_k = db_first_or_default(&ss.rrf_k, &defaults.rrf_k, "SEARCH_RRF_K")?;
 
         // Per-strategy weight defaults: RRF uses 0.5/0.5, weighted uses 0.3/0.7 (vector-biased).
         let (default_fts, default_vec) = match fusion_strategy {
             FusionStrategy::Rrf => (0.5f32, 0.5f32),
             FusionStrategy::WeightedScore => (0.3f32, 0.7f32),
         };
-        let fts_weight = parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?;
-        let vector_weight = parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?;
+
+        // Weights: DB (Some) > env > per-strategy default.
+        // Uses db_first_option for shadow warnings when DB overrides env.
+        let fts_weight = db_first_option(&ss.fts_weight, "SEARCH_FTS_WEIGHT")?
+            .unwrap_or(parse_optional_env("SEARCH_FTS_WEIGHT", default_fts)?);
+        let vector_weight = db_first_option(&ss.vector_weight, "SEARCH_VECTOR_WEIGHT")?
+            .unwrap_or(parse_optional_env("SEARCH_VECTOR_WEIGHT", default_vec)?);
 
         if !fts_weight.is_finite() || fts_weight < 0.0 {
             return Err(ConfigError::InvalidValue {
@@ -109,7 +121,8 @@ mod tests {
         let _guard = lock_env();
         clear_search_env();
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
         assert_eq!(config.rrf_k, 60);
         assert!((config.fts_weight - 0.5).abs() < 0.001);
@@ -117,7 +130,35 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides() {
+    fn db_settings_override_env() {
+        let _guard = lock_env();
+        clear_search_env();
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("SEARCH_FUSION_STRATEGY", "rrf");
+            std::env::set_var("SEARCH_RRF_K", "30");
+            std::env::set_var("SEARCH_FTS_WEIGHT", "0.9");
+            std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.1");
+        }
+
+        let mut settings = Settings::default();
+        settings.search.fusion_strategy = "weighted".to_string();
+        settings.search.rrf_k = 42;
+        settings.search.fts_weight = Some(0.4);
+        settings.search.vector_weight = Some(0.6);
+
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
+        assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
+        assert_eq!(config.rrf_k, 42);
+        assert!((config.fts_weight - 0.4).abs() < 0.001);
+        assert!((config.vector_weight - 0.6).abs() < 0.001);
+
+        clear_search_env();
+    }
+
+    #[test]
+    fn env_fallback_when_settings_at_default() {
         let _guard = lock_env();
         clear_search_env();
 
@@ -129,7 +170,8 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.1");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         assert_eq!(config.rrf_k, 30);
         assert!((config.fts_weight - 0.9).abs() < 0.001);
@@ -148,7 +190,8 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "bm25");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let settings = Settings::default();
+        let result = WorkspaceSearchConfig::resolve(&settings);
         assert!(result.is_err());
 
         clear_search_env();
@@ -164,7 +207,8 @@ mod tests {
             std::env::set_var("SEARCH_FUSION_STRATEGY", "weighted");
         }
 
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::WeightedScore);
         // Weighted mode should default to 0.3 FTS / 0.7 vector
         assert!((config.fts_weight - 0.3).abs() < 0.001);
@@ -185,7 +229,8 @@ mod tests {
             std::env::set_var("SEARCH_VECTOR_WEIGHT", "0.0");
         }
 
-        let result = WorkspaceSearchConfig::resolve();
+        let settings = Settings::default();
+        let result = WorkspaceSearchConfig::resolve(&settings);
         assert!(result.is_err());
 
         clear_search_env();
@@ -203,7 +248,8 @@ mod tests {
         }
 
         // RRF ignores weights, so both=0 is fine
-        let config = WorkspaceSearchConfig::resolve().expect("should resolve");
+        let settings = Settings::default();
+        let config = WorkspaceSearchConfig::resolve(&settings).expect("should resolve");
         assert_eq!(config.fusion_strategy, FusionStrategy::Rrf);
 
         clear_search_env();

--- a/src/config/skills.rs
+++ b/src/config/skills.rs
@@ -1,8 +1,11 @@
 use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{
+    db_first_bool, db_first_or_default, optional_env, parse_optional_env,
+};
 use crate::error::ConfigError;
+use crate::settings::Settings;
 
 /// Skills system configuration.
 #[derive(Debug, Clone)]
@@ -48,17 +51,29 @@ fn default_installed_skills_dir() -> PathBuf {
 }
 
 impl SkillsConfig {
-    pub(crate) fn resolve() -> Result<Self, ConfigError> {
+    pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
+        let defaults = crate::settings::SkillsSettings::default();
+        let ss = &settings.skills;
+
         Ok(Self {
-            enabled: parse_bool_env("SKILLS_ENABLED", true)?,
+            enabled: db_first_bool(ss.enabled, defaults.enabled, "SKILLS_ENABLED")?,
+            // local_dir and installed_dir are env-only (filesystem paths, no settings counterpart)
             local_dir: optional_env("SKILLS_DIR")?
                 .map(PathBuf::from)
                 .unwrap_or_else(default_skills_dir),
             installed_dir: optional_env("SKILLS_INSTALLED_DIR")?
                 .map(PathBuf::from)
                 .unwrap_or_else(default_installed_skills_dir),
-            max_active_skills: parse_optional_env("SKILLS_MAX_ACTIVE", 3)?,
-            max_context_tokens: parse_optional_env("SKILLS_MAX_CONTEXT_TOKENS", 4000)?,
+            max_active_skills: db_first_or_default(
+                &ss.max_active_skills,
+                &defaults.max_active_skills,
+                "SKILLS_MAX_ACTIVE",
+            )?,
+            max_context_tokens: db_first_or_default(
+                &ss.max_context_tokens,
+                &defaults.max_context_tokens,
+                "SKILLS_MAX_CONTEXT_TOKENS",
+            )?,
             max_scan_depth: parse_optional_env("SKILLS_MAX_SCAN_DEPTH", 3)?,
         })
     }

--- a/src/config/transcription.rs
+++ b/src/config/transcription.rs
@@ -39,10 +39,11 @@ impl Default for TranscriptionConfig {
 
 impl TranscriptionConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
-        let enabled = parse_bool_env(
-            "TRANSCRIPTION_ENABLED",
-            settings.transcription.as_ref().is_some_and(|t| t.enabled),
-        )?;
+        // Tri-state: Some(true/false) = explicit DB value, None = unset (fall back to env).
+        let enabled = match settings.transcription.as_ref().map(|t| t.enabled) {
+            Some(db_enabled) => db_enabled,
+            None => parse_bool_env("TRANSCRIPTION_ENABLED", false)?,
+        };
 
         let provider =
             optional_env("TRANSCRIPTION_PROVIDER")?.unwrap_or_else(|| "openai".to_string());

--- a/src/config/tunnel.rs
+++ b/src/config/tunnel.rs
@@ -1,11 +1,13 @@
-use crate::config::helpers::optional_env;
+use crate::config::helpers::{db_first_bool, db_first_optional_string, optional_env};
 use crate::error::ConfigError;
-use crate::settings::Settings;
+use crate::settings::{Settings, TunnelSettings};
 
 /// Tunnel configuration for exposing the agent to the internet.
 ///
 /// Used by channels and tools that need public webhook endpoints.
 /// The tunnel URL is shared across all channels (Telegram, Slack, etc.).
+///
+/// Resolution priority: DB/settings > env var > default.
 ///
 /// Two modes:
 /// - **Static URL** (`TUNNEL_URL`): set the public URL directly (manual tunnel)
@@ -25,8 +27,10 @@ pub struct TunnelConfig {
 
 impl TunnelConfig {
     pub(crate) fn resolve(settings: &Settings) -> Result<Self, ConfigError> {
-        let public_url = optional_env("TUNNEL_URL")?
-            .or_else(|| settings.tunnel.public_url.clone().filter(|s| !s.is_empty()));
+        let defaults = TunnelSettings::default();
+
+        // Priority: DB/settings > env > default.
+        let public_url = db_first_optional_string(&settings.tunnel.public_url, "TUNNEL_URL")?;
 
         if let Some(ref url) = public_url
             && !url.starts_with("https://")
@@ -38,9 +42,8 @@ impl TunnelConfig {
         }
 
         // Resolve managed tunnel provider config.
-        // Priority: env var > settings > default (none).
-        let provider_name = optional_env("TUNNEL_PROVIDER")?
-            .or_else(|| settings.tunnel.provider.clone())
+        // Priority: DB/settings > env > default (none).
+        let provider_name = db_first_optional_string(&settings.tunnel.provider, "TUNNEL_PROVIDER")?
             .unwrap_or_default();
 
         let provider = if provider_name.is_empty() || provider_name == "none" {
@@ -48,38 +51,64 @@ impl TunnelConfig {
         } else {
             Some(crate::tunnel::TunnelProviderConfig {
                 provider: provider_name.clone(),
-                cloudflare: optional_env("TUNNEL_CF_TOKEN")?
-                    .or_else(|| settings.tunnel.cf_token.clone())
-                    .map(|token| crate::tunnel::CloudflareTunnelConfig { token }),
+                // Security: tunnel auth tokens are env-only (sensitive credentials).
+                cloudflare: {
+                    if settings.tunnel.cf_token.is_some() {
+                        tracing::warn!(
+                            "tunnel.cf_token is set in DB/TOML but is now env-only \
+                             (TUNNEL_CF_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("TUNNEL_CF_TOKEN")?
+                        .map(|token| crate::tunnel::CloudflareTunnelConfig { token })
+                },
                 tailscale: Some(crate::tunnel::TailscaleTunnelConfig {
-                    funnel: optional_env("TUNNEL_TS_FUNNEL")?
-                        .map(|s| s == "true" || s == "1")
-                        .unwrap_or(settings.tunnel.ts_funnel),
-                    hostname: optional_env("TUNNEL_TS_HOSTNAME")?
-                        .or_else(|| settings.tunnel.ts_hostname.clone()),
+                    funnel: db_first_bool(
+                        settings.tunnel.ts_funnel,
+                        defaults.ts_funnel,
+                        "TUNNEL_TS_FUNNEL",
+                    )?,
+                    hostname: db_first_optional_string(
+                        &settings.tunnel.ts_hostname,
+                        "TUNNEL_TS_HOSTNAME",
+                    )?,
                 }),
                 ngrok: {
-                    let ngrok_domain = optional_env("TUNNEL_NGROK_DOMAIN")?
-                        .or_else(|| settings.tunnel.ngrok_domain.clone());
-                    optional_env("TUNNEL_NGROK_TOKEN")?
-                        .or_else(|| settings.tunnel.ngrok_token.clone())
-                        .map(|auth_token| crate::tunnel::NgrokTunnelConfig {
+                    let ngrok_domain = db_first_optional_string(
+                        &settings.tunnel.ngrok_domain,
+                        "TUNNEL_NGROK_DOMAIN",
+                    )?;
+                    if settings.tunnel.ngrok_token.is_some() {
+                        tracing::warn!(
+                            "tunnel.ngrok_token is set in DB/TOML but is now env-only \
+                             (TUNNEL_NGROK_TOKEN). Remove it from DB/TOML settings."
+                        );
+                    }
+                    optional_env("TUNNEL_NGROK_TOKEN")?.map(|auth_token| {
+                        crate::tunnel::NgrokTunnelConfig {
                             auth_token,
                             domain: ngrok_domain,
-                        })
+                        }
+                    })
                 },
                 custom: {
-                    let health_url = optional_env("TUNNEL_CUSTOM_HEALTH_URL")?
-                        .or_else(|| settings.tunnel.custom_health_url.clone());
-                    let url_pattern = optional_env("TUNNEL_CUSTOM_URL_PATTERN")?
-                        .or_else(|| settings.tunnel.custom_url_pattern.clone());
-                    optional_env("TUNNEL_CUSTOM_COMMAND")?
-                        .or_else(|| settings.tunnel.custom_command.clone())
-                        .map(|start_command| crate::tunnel::CustomTunnelConfig {
-                            start_command,
-                            health_url,
-                            url_pattern,
-                        })
+                    let health_url = db_first_optional_string(
+                        &settings.tunnel.custom_health_url,
+                        "TUNNEL_CUSTOM_HEALTH_URL",
+                    )?;
+                    let url_pattern = db_first_optional_string(
+                        &settings.tunnel.custom_url_pattern,
+                        "TUNNEL_CUSTOM_URL_PATTERN",
+                    )?;
+                    db_first_optional_string(
+                        &settings.tunnel.custom_command,
+                        "TUNNEL_CUSTOM_COMMAND",
+                    )?
+                    .map(|start_command| crate::tunnel::CustomTunnelConfig {
+                        start_command,
+                        health_url,
+                        url_pattern,
+                    })
                 },
             })
         };

--- a/src/config/wasm.rs
+++ b/src/config/wasm.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use crate::bootstrap::ironclaw_base_dir;
-use crate::config::helpers::{optional_env, parse_bool_env, parse_optional_env};
+use crate::config::helpers::{db_first_bool, db_first_or_default, optional_env};
 use crate::error::ConfigError;
 
 /// WASM sandbox configuration.
@@ -46,28 +46,41 @@ fn default_tools_dir() -> PathBuf {
 impl WasmConfig {
     pub(crate) fn resolve(settings: &crate::settings::Settings) -> Result<Self, ConfigError> {
         let ws = &settings.wasm;
+        let defaults = crate::settings::WasmSettings::default();
         Ok(Self {
-            enabled: parse_bool_env("WASM_ENABLED", ws.enabled)?,
-            tools_dir: optional_env("WASM_TOOLS_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| ws.tools_dir.clone())
-                .unwrap_or_else(default_tools_dir),
-            default_memory_limit: parse_optional_env(
+            enabled: db_first_bool(ws.enabled, defaults.enabled, "WASM_ENABLED")?,
+            tools_dir: if let Some(ref dir) = ws.tools_dir {
+                dir.clone()
+            } else {
+                optional_env("WASM_TOOLS_DIR")?
+                    .map(PathBuf::from)
+                    .unwrap_or_else(default_tools_dir)
+            },
+            default_memory_limit: db_first_or_default(
+                &ws.default_memory_limit,
+                &defaults.default_memory_limit,
                 "WASM_DEFAULT_MEMORY_LIMIT",
-                ws.default_memory_limit,
             )?,
-            default_timeout_secs: parse_optional_env(
+            default_timeout_secs: db_first_or_default(
+                &ws.default_timeout_secs,
+                &defaults.default_timeout_secs,
                 "WASM_DEFAULT_TIMEOUT_SECS",
-                ws.default_timeout_secs,
             )?,
-            default_fuel_limit: parse_optional_env(
+            default_fuel_limit: db_first_or_default(
+                &ws.default_fuel_limit,
+                &defaults.default_fuel_limit,
                 "WASM_DEFAULT_FUEL_LIMIT",
-                ws.default_fuel_limit,
             )?,
-            cache_compiled: parse_bool_env("WASM_CACHE_COMPILED", ws.cache_compiled)?,
-            cache_dir: optional_env("WASM_CACHE_DIR")?
-                .map(PathBuf::from)
-                .or_else(|| ws.cache_dir.clone()),
+            cache_compiled: db_first_bool(
+                ws.cache_compiled,
+                defaults.cache_compiled,
+                "WASM_CACHE_COMPILED",
+            )?,
+            cache_dir: if let Some(ref dir) = ws.cache_dir {
+                Some(dir.clone())
+            } else {
+                optional_env("WASM_CACHE_DIR")?.map(PathBuf::from)
+            },
         })
     }
 
@@ -111,10 +124,23 @@ mod tests {
     }
 
     #[test]
-    fn env_overrides_settings() {
+    fn db_settings_override_env() {
         let _guard = lock_env();
         let mut settings = Settings::default();
         settings.wasm.default_fuel_limit = 42;
+
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("WASM_DEFAULT_FUEL_LIMIT", "7") };
+        let cfg = WasmConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("WASM_DEFAULT_FUEL_LIMIT") };
+
+        assert_eq!(cfg.default_fuel_limit, 42);
+    }
+
+    #[test]
+    fn env_used_when_no_db_setting() {
+        let _guard = lock_env();
+        let settings = Settings::default();
 
         // SAFETY: Under ENV_MUTEX, no concurrent env access.
         unsafe { std::env::set_var("WASM_DEFAULT_FUEL_LIMIT", "7") };

--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -10,6 +10,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::llm::recording::HttpInterceptor;
+use crate::tools::ApprovalContext;
 
 /// Error returned when a job exceeds its token budget.
 #[derive(Debug, thiserror::Error)]
@@ -199,6 +200,12 @@ pub struct JobContext {
     pub tool_output_stash: Arc<tokio::sync::RwLock<HashMap<String, String>>>,
     /// User's preferred timezone (IANA name, e.g. "America/New_York"). Defaults to "UTC".
     pub user_timezone: String,
+    /// Approval context for tool execution in this job.
+    ///
+    /// When set, tools check this context before executing to determine
+    /// if they're allowed to run in autonomous/non-interactive contexts.
+    #[serde(skip)]
+    pub approval_context: Option<ApprovalContext>,
 }
 
 impl JobContext {
@@ -240,6 +247,7 @@ impl JobContext {
             metadata: serde_json::Value::Null,
             tool_output_stash: Arc::new(tokio::sync::RwLock::new(HashMap::new())),
             user_timezone: "UTC".to_string(),
+            approval_context: None,
         }
     }
 
@@ -252,6 +260,12 @@ impl JobContext {
     /// Set the channel-specific requester/actor ID.
     pub fn with_requester_id(mut self, requester_id: impl Into<String>) -> Self {
         self.requester_id = Some(requester_id.into());
+        self
+    }
+
+    /// Set the approval context on this context.
+    pub fn with_approval_context(mut self, ctx: ApprovalContext) -> Self {
+        self.approval_context = Some(ctx);
         self
     }
 
@@ -366,6 +380,9 @@ impl JobContext {
 
 impl Default for JobContext {
     fn default() -> Self {
+        // Default has no approval_context - safer default that requires explicit
+        // opt-in for autonomous execution. Code that creates JobContext directly
+        // must use with_approval_context() to enable autonomous tool use.
         Self::with_user("default", "Untitled", "No description")
     }
 }

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -67,19 +67,20 @@ impl ConversationStore for LibSqlBackend {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         let conn = self.connect().await?;
         let now = fmt_ts(&Utc::now());
         let affected = conn
             .execute(
             r#"
-                INSERT INTO conversations (id, channel, user_id, thread_id, started_at, last_activity)
-                VALUES (?1, ?2, ?3, ?4, ?5, ?5)
+                INSERT INTO conversations (id, channel, user_id, thread_id, source_channel, started_at, last_activity)
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?6)
                 ON CONFLICT (id) DO UPDATE SET last_activity = excluded.last_activity
                 WHERE conversations.user_id = excluded.user_id
                   AND conversations.channel = excluded.channel
                 "#,
-            params![id.to_string(), channel, user_id, opt_text(thread_id), now],
+            params![id.to_string(), channel, user_id, opt_text(thread_id), opt_text(source_channel), now],
         )
             .await
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
@@ -600,6 +601,28 @@ impl ConversationStore for LibSqlBackend {
             .map_err(|e| DatabaseError::Query(e.to_string()))?;
         Ok(found.is_some())
     }
+
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT source_channel FROM conversations WHERE id = ?1",
+                params![conversation_id.to_string()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(row) => Ok(get_opt_text(&row, 0)),
+            None => Ok(None),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -723,6 +746,113 @@ mod tests {
         assert_eq!(
             id1, id2,
             "Expected same heartbeat conversation on repeated calls"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-src-chan";
+
+        // Create conversation with a source_channel
+        let created = backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("telegram"))
+            .await
+            .unwrap();
+        assert!(created, "first ensure should create");
+
+        // Read it back
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            source.as_deref(),
+            Some("telegram"),
+            "source_channel should round-trip through DB"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_none_round_trip() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_none.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-no-src";
+
+        // Create conversation without source_channel
+        backend
+            .ensure_conversation(conv_id, "http", user_id, None, None)
+            .await
+            .unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert!(
+            source.is_none(),
+            "None source_channel should persist as NULL"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_not_found() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_404.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(Uuid::new_v4())
+            .await
+            .unwrap();
+        assert!(
+            source.is_none(),
+            "non-existent conversation should return None"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_source_channel_not_overwritten_on_upsert() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_source_channel_upsert.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-upsert";
+
+        // First insert with source_channel = "telegram"
+        backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("telegram"))
+            .await
+            .unwrap();
+
+        // Upsert same conversation (same user/channel) — source_channel should
+        // NOT be overwritten because the ON CONFLICT clause only updates
+        // last_activity.
+        backend
+            .ensure_conversation(conv_id, "telegram", user_id, None, Some("different"))
+            .await
+            .unwrap();
+
+        let source = backend
+            .get_conversation_source_channel(conv_id)
+            .await
+            .unwrap();
+        assert_eq!(
+            source.as_deref(),
+            Some("telegram"),
+            "upsert should not overwrite original source_channel"
         );
     }
 }

--- a/src/db/libsql/jobs.rs
+++ b/src/db/libsql/jobs.rs
@@ -134,6 +134,10 @@ impl JobStore for LibSqlBackend {
                     // TODO(#661): persist user_timezone in agent_jobs table so
                     // background/routine jobs retain the session's timezone context.
                     user_timezone: "UTC".to_string(),
+                    // TODO(#1125): approval_context is #[serde(skip)] so it's lost on
+                    // DB restore. Tools that were allowed before restart will be blocked
+                    // until the scheduler re-sets the context on the next dispatch.
+                    approval_context: None,
                 }))
             }
             None => Ok(None),

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -787,7 +787,45 @@ CREATE INDEX IF NOT EXISTS idx_api_tokens_user ON api_tokens(user_id);
 CREATE INDEX IF NOT EXISTS idx_api_tokens_hash ON api_tokens(token_hash);
 "#,
     ),
+    (
+        16,
+        "conversation_source_channel",
+        // Add source_channel to conversations for cross-channel approval authorization.
+        // Marked as idempotent (see IDEMPOTENT_ADD_COLUMN_MIGRATIONS below)
+        // because SQLite does not support IF NOT EXISTS for ADD COLUMN.
+        // The runner checks pragma_table_info before executing the ALTER.
+        r#"
+ALTER TABLE conversations ADD COLUMN source_channel TEXT;
+"#,
+    ),
 ];
+
+/// Migrations whose ADD COLUMN should be skipped when the column already
+/// exists (e.g. because the base SCHEMA was updated to include it).
+/// Each entry is `(version, table_name, column_name)`.
+const IDEMPOTENT_ADD_COLUMN_MIGRATIONS: &[(i64, &str, &str)] =
+    &[(16, "conversations", "source_channel")];
+
+/// Check whether `table` already contains `column` via `pragma_table_info`.
+async fn column_exists(
+    conn: &libsql::Connection,
+    table: &str,
+    column: &str,
+) -> Result<bool, crate::error::DatabaseError> {
+    use crate::error::DatabaseError;
+
+    let sql = format!(
+        "SELECT 1 FROM pragma_table_info('{}') WHERE name = ?1",
+        table
+    );
+    let mut rows = conn
+        .query(&sql, libsql::params![column])
+        .await
+        .map_err(|e| {
+            DatabaseError::Migration(format!("Failed to check column {table}.{column}: {e}"))
+        })?;
+    Ok(rows.next().await.ok().flatten().is_some())
+}
 
 /// Run incremental migrations that haven't been applied yet.
 ///
@@ -813,6 +851,18 @@ pub async fn run_incremental(conn: &libsql::Connection) -> Result<(), crate::err
             continue; // Already applied
         }
 
+        // For ADD COLUMN migrations, skip the ALTER if the column already
+        // exists (e.g. because the base SCHEMA was updated to include it)
+        // and just record the migration as applied.
+        let skip_sql = if let Some(&(_, table, column)) = IDEMPOTENT_ADD_COLUMN_MIGRATIONS
+            .iter()
+            .find(|(v, _, _)| *v == version)
+        {
+            column_exists(conn, table, column).await?
+        } else {
+            false
+        };
+
         // Wrap migration + recording in a transaction for atomicity.
         // If the process crashes mid-migration, the transaction rolls back
         // and the migration will be retried on next startup.
@@ -822,9 +872,19 @@ pub async fn run_incremental(conn: &libsql::Connection) -> Result<(), crate::err
             ))
         })?;
 
-        tx.execute_batch(sql).await.map_err(|e| {
-            DatabaseError::Migration(format!("libSQL migration V{version} ({name}) failed: {e}"))
-        })?;
+        if skip_sql {
+            tracing::debug!(
+                version,
+                name,
+                "libSQL: column already exists, recording migration as applied"
+            );
+        } else {
+            tx.execute_batch(sql).await.map_err(|e| {
+                DatabaseError::Migration(format!(
+                    "libSQL migration V{version} ({name}) failed: {e}"
+                ))
+            })?;
+        }
 
         // Record as applied (inside the same transaction)
         tx.execute(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -373,6 +373,7 @@ pub trait ConversationStore: Send + Sync {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError>;
     async fn list_conversations_with_preview(
         &self,
@@ -438,6 +439,11 @@ pub trait ConversationStore: Send + Sync {
         conversation_id: Uuid,
         user_id: &str,
     ) -> Result<bool, DatabaseError>;
+    /// Get the source_channel for a conversation (the channel that created it).
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError>;
 }
 
 #[async_trait]

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -99,9 +99,10 @@ impl ConversationStore for PgBackend {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         self.store
-            .ensure_conversation(id, channel, user_id, thread_id)
+            .ensure_conversation(id, channel, user_id, thread_id, source_channel)
             .await
     }
 
@@ -220,6 +221,15 @@ impl ConversationStore for PgBackend {
     ) -> Result<bool, DatabaseError> {
         self.store
             .conversation_belongs_to_user(conversation_id, user_id)
+            .await
+    }
+
+    async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        self.store
+            .get_conversation_source_channel(conversation_id)
             .await
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1585,19 +1585,20 @@ impl Store {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         let conn = self.conn().await?;
         let affected = conn
             .execute(
                 r#"
-            INSERT INTO conversations (id, channel, user_id, thread_id)
-            VALUES ($1, $2, $3, $4)
+            INSERT INTO conversations (id, channel, user_id, thread_id, source_channel)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (id) DO UPDATE
             SET last_activity = NOW()
             WHERE conversations.user_id = EXCLUDED.user_id
               AND conversations.channel = EXCLUDED.channel
             "#,
-                &[&id, &channel, &user_id, &thread_id],
+                &[&id, &channel, &user_id, &thread_id, &source_channel],
             )
             .await?;
         Ok(affected > 0)
@@ -1915,6 +1916,21 @@ impl Store {
             )
             .await?;
         Ok(row.is_some())
+    }
+
+    /// Get the source_channel for a conversation.
+    pub async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                "SELECT source_channel FROM conversations WHERE id = $1",
+                &[&conversation_id],
+            )
+            .await?;
+        Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
     }
 
     /// Load messages for a conversation with cursor-based pagination.

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -258,6 +258,10 @@ impl Store {
                     // TODO(#661): persist user_timezone in agent_jobs table so
                     // background/routine jobs retain the session's timezone context.
                     user_timezone: "UTC".to_string(),
+                    // TODO(#1125): approval_context is #[serde(skip)] so it's lost on
+                    // DB restore. Tools that were allowed before restart will be blocked
+                    // until the scheduler re-sets the context on the next dispatch.
+                    approval_context: None,
                 }))
             }
             None => Ok(None),
@@ -1581,19 +1585,20 @@ impl Store {
         channel: &str,
         user_id: &str,
         thread_id: Option<&str>,
+        source_channel: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         let conn = self.conn().await?;
         let affected = conn
             .execute(
                 r#"
-            INSERT INTO conversations (id, channel, user_id, thread_id)
-            VALUES ($1, $2, $3, $4)
+            INSERT INTO conversations (id, channel, user_id, thread_id, source_channel)
+            VALUES ($1, $2, $3, $4, $5)
             ON CONFLICT (id) DO UPDATE
             SET last_activity = NOW()
             WHERE conversations.user_id = EXCLUDED.user_id
               AND conversations.channel = EXCLUDED.channel
             "#,
-                &[&id, &channel, &user_id, &thread_id],
+                &[&id, &channel, &user_id, &thread_id, &source_channel],
             )
             .await?;
         Ok(affected > 0)
@@ -1911,6 +1916,21 @@ impl Store {
             )
             .await?;
         Ok(row.is_some())
+    }
+
+    /// Get the source_channel for a conversation.
+    pub async fn get_conversation_source_channel(
+        &self,
+        conversation_id: Uuid,
+    ) -> Result<Option<String>, DatabaseError> {
+        let conn = self.conn().await?;
+        let row = conn
+            .query_opt(
+                "SELECT source_channel FROM conversations WHERE id = $1",
+                &[&conversation_id],
+            )
+            .await?;
+        Ok(row.and_then(|r| r.get::<_, Option<String>>(0)))
     }
 
     /// Load messages for a conversation with cursor-based pagination.

--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::net::TcpListener;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -921,7 +922,14 @@ pub struct GeminiOauthProvider {
     http_client: Client,
     /// Latest response metadata (updated after each request).
     last_response_meta: std::sync::Mutex<GeminiResponseMeta>,
+    /// Captured thought signatures keyed by tool-call ID. Gemini 3.x models
+    /// require these echoed back on `functionCall` parts when replaying history.
+    /// Populated from responses, consumed when building the next request.
+    thought_signatures: std::sync::Mutex<HashMap<String, String>>,
 }
+
+/// Parsed Gemini response: (completion, tool_calls, thought_signatures_by_call_id).
+type GeminiParsedResponse = (CompletionResponse, Vec<ToolCall>, HashMap<String, String>);
 
 impl GeminiOauthProvider {
     pub fn new(config: GeminiOauthConfig) -> Result<Self, LlmError> {
@@ -939,6 +947,7 @@ impl GeminiOauthProvider {
             cred_manager,
             http_client,
             last_response_meta: std::sync::Mutex::new(GeminiResponseMeta::default()),
+            thought_signatures: std::sync::Mutex::new(HashMap::new()),
         })
     }
 
@@ -1062,8 +1071,21 @@ impl GeminiOauthProvider {
 
     /// Count tokens for the given messages using the Gemini countTokens API.
     pub async fn count_tokens(&self, messages: &[ChatMessage]) -> Result<u32, LlmError> {
-        let req =
-            Self::to_gemini_request(messages, None, None, None, None, None, &self.config.model);
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let req = Self::to_gemini_request(
+            messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            &self.config.model,
+            &sigs,
+        );
         let contents = req
             .get("contents")
             .cloned()
@@ -1589,6 +1611,7 @@ impl GeminiOauthProvider {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn to_gemini_request(
         messages: &[ChatMessage],
         tools: Option<&[ToolDefinition]>,
@@ -1597,6 +1620,7 @@ impl GeminiOauthProvider {
         stop_sequences: Option<&[String]>,
         tool_choice: Option<&str>,
         model: &str,
+        thought_sigs: &HashMap<String, String>,
     ) -> serde_json::Value {
         let mut contents = Vec::new();
 
@@ -1621,12 +1645,24 @@ impl GeminiOauthProvider {
                     }
                     if let Some(ref calls) = msg.tool_calls {
                         for call in calls {
-                            parts.push(serde_json::json!({
+                            let mut part = serde_json::json!({
                                 "functionCall": {
                                     "name": call.name,
                                     "args": call.arguments
                                 }
-                            }));
+                            });
+                            // Echo back the real thoughtSignature if captured from a
+                            // prior Gemini response. ensure_thought_signatures() will
+                            // fill in synthetic placeholders for any gaps.
+                            if let Some(sig) = thought_sigs.get(&call.id)
+                                && let Some(obj) = part.as_object_mut()
+                            {
+                                obj.insert(
+                                    "thoughtSignature".to_string(),
+                                    serde_json::Value::String(sig.clone()),
+                                );
+                            }
+                            parts.push(part);
                         }
                     }
                     // Fallback: if no parts at all, add empty text to avoid
@@ -1855,9 +1891,8 @@ impl GeminiOauthProvider {
         req
     }
 
-    fn from_gemini_response(
-        body: serde_json::Value,
-    ) -> Result<(CompletionResponse, Vec<ToolCall>), LlmError> {
+    /// Parsed Gemini response: (completion, tool_calls, thought_signatures_by_call_id).
+    fn from_gemini_response(body: serde_json::Value) -> Result<GeminiParsedResponse, LlmError> {
         let candidate = body
             .get("candidates")
             .and_then(|c| c.as_array())
@@ -1874,6 +1909,7 @@ impl GeminiOauthProvider {
 
         let mut text_content = String::new();
         let mut tool_calls = Vec::new();
+        let mut thought_sigs = HashMap::new();
 
         if let Some(parts) = parts {
             for part in parts {
@@ -1892,6 +1928,11 @@ impl GeminiOauthProvider {
                         .and_then(|i| i.as_str())
                         .map(|s| s.to_string())
                         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+                    // Capture thoughtSignature (sibling of functionCall in the part)
+                    // so it can be echoed back when replaying history.
+                    if let Some(sig) = part.get("thoughtSignature").and_then(|s| s.as_str()) {
+                        thought_sigs.insert(id.clone(), sig.to_string());
+                    }
 
                     tool_calls.push(ToolCall {
                         id,
@@ -2003,6 +2044,7 @@ impl GeminiOauthProvider {
                 cache_creation_input_tokens: 0,
             },
             tool_calls,
+            thought_sigs,
         ))
     }
 }
@@ -2041,6 +2083,11 @@ impl LlmProvider for GeminiOauthProvider {
     }
 
     async fn complete(&self, request: CompletionRequest) -> Result<CompletionResponse, LlmError> {
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let req_json = Self::to_gemini_request(
             &request.messages,
             None,
@@ -2049,9 +2096,10 @@ impl LlmProvider for GeminiOauthProvider {
             request.stop_sequences.as_deref(),
             None,
             &self.config.model,
+            &sigs,
         );
         let resp_json = self.send_request(&req_json).await?;
-        let (response, _tool_calls) = Self::from_gemini_response(resp_json)?;
+        let (response, _tool_calls, _new_sigs) = Self::from_gemini_response(resp_json)?;
         Ok(response)
     }
 
@@ -2065,6 +2113,11 @@ impl LlmProvider for GeminiOauthProvider {
             Some(request.tools.as_slice())
         };
 
+        let sigs = self
+            .thought_signatures
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let req_json = Self::to_gemini_request(
             &request.messages,
             tool_defs,
@@ -2073,9 +2126,29 @@ impl LlmProvider for GeminiOauthProvider {
             request.stop_sequences.as_deref(),
             request.tool_choice.as_deref(),
             &self.config.model,
+            &sigs,
         );
         let resp_json = self.send_request(&req_json).await?;
-        let (response, tool_calls) = Self::from_gemini_response(resp_json)?;
+        let (response, tool_calls, new_sigs) = Self::from_gemini_response(resp_json)?;
+        // Store captured thought signatures, pruning stale entries to prevent
+        // unbounded growth over long-running processes. Only keep IDs that
+        // appear in the conversation history or the just-received response.
+        {
+            let mut sigs = self
+                .thought_signatures
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            sigs.extend(new_sigs);
+            let live_ids: std::collections::HashSet<&str> = request
+                .messages
+                .iter()
+                .filter_map(|m| m.tool_calls.as_ref())
+                .flatten()
+                .map(|tc| tc.id.as_str())
+                .chain(tool_calls.iter().map(|tc| tc.id.as_str()))
+                .collect();
+            sigs.retain(|id, _| live_ids.contains(id.as_str()));
+        }
 
         Ok(crate::llm::provider::ToolCompletionResponse {
             content: if response.content.is_empty() {
@@ -2218,6 +2291,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let decls = &req["tools"][0]["functionDeclarations"];
@@ -2240,6 +2314,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let contents = req["contents"].as_array().unwrap();
@@ -2265,7 +2340,7 @@ mod tests {
             }
         });
 
-        let (resp, tool_calls) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        let (resp, tool_calls, _sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
 
         assert_eq!(resp.content, "Hello world");
         assert_eq!(resp.input_tokens, 10);
@@ -2293,7 +2368,7 @@ mod tests {
             }
         });
 
-        let (resp, tool_calls) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        let (resp, tool_calls, _sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
 
         assert!(resp.content.is_empty());
         assert_eq!(tool_calls.len(), 1);
@@ -2313,6 +2388,7 @@ mod tests {
             None,
             None,
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
 
         let gen_cfg = &req["generationConfig"];
@@ -2333,6 +2409,7 @@ mod tests {
             None,
             None,
             "gemini-3-flash-preview",
+            &HashMap::new(),
         );
 
         let thinking = &req["generationConfig"]["thinkingConfig"];
@@ -2353,6 +2430,7 @@ mod tests {
             None,
             None,
             "gemini-2.5-flash-thinking",
+            &HashMap::new(),
         );
 
         let thinking = &req["generationConfig"]["thinkingConfig"];
@@ -2376,6 +2454,7 @@ mod tests {
             Some(&stops),
             None,
             "gemini-2.5-flash",
+            &HashMap::new(),
         );
 
         let gen_cfg = &req["generationConfig"];
@@ -2403,6 +2482,7 @@ mod tests {
             None,
             Some("auto"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_auto["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2417,6 +2497,7 @@ mod tests {
             None,
             Some("required"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_req["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2431,6 +2512,7 @@ mod tests {
             None,
             Some("none"),
             "gemini-2.0-flash",
+            &HashMap::new(),
         );
         assert_eq!(
             req_none["toolConfig"]["functionCallingConfig"]["mode"],
@@ -2500,6 +2582,7 @@ mod tests {
             None,
             None,
             "gemini-1.5-flash",
+            &HashMap::new(),
         );
 
         let system_instruction = req
@@ -2613,5 +2696,134 @@ mod tests {
             .count();
 
         assert_eq!(signed_calls, 2); // safety: test-only assertion
+    }
+
+    #[test]
+    fn test_from_gemini_response_captures_thought_signature() {
+        let body = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "thoughtSignature": "abc123sig",
+                        "functionCall": {
+                            "name": "read_file",
+                            "args": { "path": "/tmp/test.txt" }
+                        }
+                    }]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 10,
+                "candidatesTokenCount": 5
+            }
+        });
+
+        let (_resp, tool_calls, sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert_eq!(
+            sigs.get(&tool_calls[0].id).map(|s| s.as_str()),
+            Some("abc123sig")
+        );
+    }
+
+    #[test]
+    fn test_from_gemini_response_no_thought_signature_yields_none() {
+        let body = serde_json::json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{
+                        "functionCall": {
+                            "name": "echo",
+                            "args": {}
+                        }
+                    }]
+                },
+                "finishReason": "STOP"
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 5,
+                "candidatesTokenCount": 3
+            }
+        });
+
+        let (_resp, tool_calls, sigs) = GeminiOauthProvider::from_gemini_response(body).unwrap();
+        assert_eq!(tool_calls.len(), 1);
+        assert!(!sigs.contains_key(&tool_calls[0].id));
+    }
+
+    #[test]
+    fn test_to_gemini_request_echoes_thought_signature_on_function_call() {
+        let messages = vec![
+            ChatMessage::user("call a tool"),
+            ChatMessage::assistant_with_tool_calls(
+                None,
+                vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "read_file".to_string(),
+                    arguments: serde_json::json!({"path": "/tmp/x"}),
+                    reasoning: None,
+                }],
+            ),
+            ChatMessage::tool_result("call_1", "read_file", r#"{"output":"hello"}"#),
+        ];
+
+        let mut sigs = HashMap::new();
+        sigs.insert("call_1".to_string(), "sig_from_gemini".to_string());
+
+        let req = GeminiOauthProvider::to_gemini_request(
+            &messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "gemini-3-flash-preview",
+            &sigs,
+        );
+
+        let contents = req["contents"].as_array().unwrap();
+        // The model turn (index 1) should have the thoughtSignature on its functionCall part.
+        let model_turn = &contents[1];
+        assert_eq!(model_turn["role"], "model");
+        let fc_part = &model_turn["parts"][0];
+        assert!(fc_part.get("functionCall").is_some());
+        assert_eq!(fc_part["thoughtSignature"], "sig_from_gemini");
+    }
+
+    #[test]
+    fn test_to_gemini_request_omits_thought_signature_when_none() {
+        let messages = vec![
+            ChatMessage::user("call a tool"),
+            ChatMessage::assistant_with_tool_calls(
+                None,
+                vec![ToolCall {
+                    id: "call_1".to_string(),
+                    name: "echo".to_string(),
+                    arguments: serde_json::json!({}),
+                    reasoning: None,
+                }],
+            ),
+            ChatMessage::tool_result("call_1", "echo", r#"{"output":"ok"}"#),
+        ];
+
+        let empty_sigs = HashMap::new();
+        let req = GeminiOauthProvider::to_gemini_request(
+            &messages,
+            None,
+            None,
+            None,
+            None,
+            None,
+            "gemini-2.0-flash",
+            &empty_sigs,
+        );
+
+        let contents = req["contents"].as_array().unwrap();
+        let model_turn = &contents[1];
+        let fc_part = &model_turn["parts"][0];
+        assert!(fc_part.get("functionCall").is_some());
+        // No thoughtSignature should be present when there is no captured signature for this call ID.
+        assert!(fc_part.get("thoughtSignature").is_none());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -449,6 +449,7 @@ async fn async_main() -> anyhow::Result<()> {
             &components.secrets_store,
             components.extension_manager.as_ref(),
             components.db.as_ref(),
+            &channel_names,
         )
         .await;
 

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -16,6 +16,11 @@ use crate::error::OrchestratorError;
 use crate::orchestrator::auth::{CredentialGrant, TokenStore};
 use crate::sandbox::connect_docker;
 
+/// Path to the master worker MCP config on the host.
+const WORKER_MCP_CONFIG_PATH: &str = "/opt/ironclaw/config/worker/mcp-servers.json";
+
+use ironclaw_common::MAX_WORKER_ITERATIONS;
+
 /// Which mode a sandbox container runs in.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JobMode {
@@ -38,6 +43,19 @@ impl std::fmt::Display for JobMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.as_str())
     }
+}
+
+/// Parameters for creating a container job, bundled to avoid positional
+/// argument proliferation on `create_job` / `execute_sandbox`.
+#[derive(Debug, Clone, Default)]
+pub struct JobCreationParams {
+    /// Credential grants for the worker (served via `/credentials`).
+    pub credential_grants: Vec<CredentialGrant>,
+    /// Optional filter: which MCP servers to mount into the container.
+    /// `None` = full master config, `Some([])` = no MCP, `Some(["name"])` = filtered.
+    pub mcp_servers: Option<Vec<String>>,
+    /// Optional cap on worker agent loop iterations (clamped to 1..=500 server-side).
+    pub max_iterations: Option<u32>,
 }
 
 /// Configuration for the container job manager.
@@ -66,6 +84,9 @@ pub struct ContainerJobConfig {
     pub claude_code_memory_limit_mb: u64,
     /// Allowed tool patterns for Claude Code (passed as CLAUDE_CODE_ALLOWED_TOOLS env var).
     pub claude_code_allowed_tools: Vec<String>,
+    /// Whether per-job MCP server filtering is enabled.
+    /// When false, `mcp_servers` param on `create_job` is ignored.
+    pub mcp_per_job_enabled: bool,
 }
 
 impl Default for ContainerJobConfig {
@@ -81,6 +102,7 @@ impl Default for ContainerJobConfig {
             claude_code_max_turns: 50,
             claude_code_memory_limit_mb: 4096,
             claude_code_allowed_tools: crate::config::ClaudeCodeConfig::default().allowed_tools,
+            mcp_per_job_enabled: false,
         }
     }
 }
@@ -254,14 +276,14 @@ impl ContainerJobManager {
         task: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
+        params: JobCreationParams,
     ) -> Result<String, OrchestratorError> {
         // Generate auth token (stored in TokenStore, never logged)
         let token = self.token_store.create_token(job_id).await;
 
         // Store credential grants (revoked automatically when the token is revoked)
         self.token_store
-            .store_grants(job_id, credential_grants)
+            .store_grants(job_id, params.credential_grants)
             .await;
 
         // Record the handle
@@ -282,7 +304,14 @@ impl ContainerJobManager {
         // Run the actual container creation. On any failure, revoke the token
         // and remove the handle so we don't leak resources.
         match self
-            .create_job_inner(job_id, &token, project_dir, mode)
+            .create_job_inner(
+                job_id,
+                &token,
+                project_dir,
+                mode,
+                params.mcp_servers,
+                params.max_iterations,
+            )
             .await
         {
             Ok(()) => Ok(token),
@@ -301,6 +330,8 @@ impl ContainerJobManager {
         token: &str,
         project_dir: Option<PathBuf>,
         mode: JobMode,
+        mcp_servers: Option<Vec<String>>,
+        max_iterations: Option<u32>,
     ) -> Result<(), OrchestratorError> {
         // Connect to Docker (reuses cached connection)
         let docker = self.docker().await?;
@@ -329,6 +360,42 @@ impl ContainerJobManager {
             let canonical = validate_bind_mount_path(dir, job_id)?;
             binds.push(format!("{}:/workspace:rw", canonical.display()));
             env_vec.push("IRONCLAW_WORKSPACE=/workspace".to_string());
+        }
+
+        // Inject max_iterations if specified (only for Worker mode — ClaudeCode uses max_turns).
+        // Server-side clamp ensures the cap is enforced even if the tool parsing
+        // layer is bypassed (e.g., direct API call via the web restart handler).
+        if let Some(iters) = max_iterations
+            && mode == JobMode::Worker
+        {
+            let capped = iters.clamp(1, MAX_WORKER_ITERATIONS);
+            env_vec.push(format!("IRONCLAW_MAX_ITERATIONS={}", capped));
+        }
+
+        // Mount per-job MCP config when the feature is enabled.
+        if self.config.mcp_per_job_enabled {
+            let mcp_config_host = std::path::Path::new(WORKER_MCP_CONFIG_PATH);
+            match generate_worker_mcp_config(mcp_config_host, mcp_servers.as_deref(), job_id)
+                .await?
+            {
+                Some(config_path) => {
+                    binds.push(format!(
+                        "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
+                        config_path.display()
+                    ));
+                    tracing::debug!(
+                        job_id = %job_id,
+                        filtered = mcp_servers.is_some(),
+                        "Mounted MCP config into container"
+                    );
+                }
+                None => {
+                    tracing::debug!(
+                        job_id = %job_id,
+                        "No MCP config to mount (master missing or empty filter list)"
+                    );
+                }
+            }
         }
 
         // Claude Code mode: auth + tool allowlist.
@@ -579,6 +646,23 @@ impl ContainerJobManager {
 
     /// Remove a completed job handle from memory (called after result is read).
     pub async fn cleanup_job(&self, job_id: Uuid) {
+        // Clean up per-job MCP config temp file if one was written.
+        // Use remove_file directly — avoids TOCTOU race with exists() check.
+        let tmp_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
+        match std::fs::remove_file(&tmp_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {} // No temp file — normal
+            Err(e) => {
+                tracing::warn!(
+                    job_id = %job_id,
+                    error = %e,
+                    "Failed to remove per-job MCP config temp file"
+                );
+            }
+        }
+
         self.containers.write().await.remove(&job_id);
     }
 
@@ -608,6 +692,132 @@ impl ContainerJobManager {
     /// Get a reference to the token store.
     pub fn token_store(&self) -> &TokenStore {
         &self.token_store
+    }
+}
+
+/// Generate a per-job MCP config file, optionally filtering to specific servers.
+///
+/// - `None` → mount the full master config as-is
+/// - `Some([])` → no MCP config (no mount)
+/// - `Some(["serpstat"])` → filtered config with only matching servers
+///
+/// Temp files are written to `<temp_dir>/ironclaw-mcp-configs/` and cleaned up
+/// in `cleanup_job`.
+async fn generate_worker_mcp_config(
+    master_path: &std::path::Path,
+    server_names: Option<&[String]>,
+    job_id: Uuid,
+) -> Result<Option<std::path::PathBuf>, OrchestratorError> {
+    if !tokio::fs::try_exists(master_path).await.unwrap_or(false) {
+        return Ok(None);
+    }
+
+    match server_names {
+        // No filter → use master config as-is
+        None => Ok(Some(master_path.to_path_buf())),
+
+        // Empty list → no MCP
+        Some([]) => Ok(None),
+
+        // Filter to specific servers
+        Some(names) => {
+            // Validate server names: reject path separators, null bytes, and
+            // excessively long names to prevent misuse if names are ever used
+            // in file paths or shell commands.
+            for name in names {
+                if name.len() > 128
+                    || name.contains('/')
+                    || name.contains('\\')
+                    || name.contains('\0')
+                {
+                    return Err(OrchestratorError::ContainerCreationFailed {
+                        job_id,
+                        reason: format!("invalid MCP server name: {:?}", name),
+                    });
+                }
+            }
+
+            let content = tokio::fs::read_to_string(master_path).await.map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to read master MCP config: {e}"),
+                }
+            })?;
+
+            let master: serde_json::Value = serde_json::from_str(&content).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to parse master MCP config: {e}"),
+                }
+            })?;
+
+            let servers = master["servers"]
+                .as_array()
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|s| {
+                    let name_matches = s["name"]
+                        .as_str()
+                        .map(|n| names.iter().any(|req| req.eq_ignore_ascii_case(n)))
+                        .unwrap_or(false);
+                    let is_enabled = s["enabled"].as_bool().unwrap_or(true);
+                    name_matches && is_enabled
+                })
+                .collect::<Vec<_>>();
+
+            if servers.is_empty() {
+                tracing::warn!(
+                    job_id = %job_id,
+                    requested = ?names,
+                    "No matching MCP servers found in master config; skipping MCP mount"
+                );
+                return Ok(None);
+            }
+
+            let schema_version = master
+                .get("schema_version")
+                .cloned()
+                .unwrap_or(serde_json::json!(1));
+            let filtered = serde_json::json!({
+                "servers": servers,
+                "schema_version": schema_version
+            });
+
+            let tmp_dir = std::env::temp_dir().join("ironclaw-mcp-configs");
+            tokio::fs::create_dir_all(&tmp_dir).await.map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to create MCP config temp dir: {e}"),
+                }
+            })?;
+
+            // Restrict directory permissions to owner-only (0o700) to prevent
+            // other users on the host from reading filtered MCP configs.
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt;
+                let _ =
+                    tokio::fs::set_permissions(&tmp_dir, std::fs::Permissions::from_mode(0o700))
+                        .await;
+            }
+
+            let tmp_path = tmp_dir.join(format!("{}.json", job_id));
+            let config_json = serde_json::to_string_pretty(&filtered).map_err(|e| {
+                OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to serialize filtered MCP config: {e}"),
+                }
+            })?;
+            tokio::fs::write(&tmp_path, config_json)
+                .await
+                .map_err(|e| OrchestratorError::ContainerCreationFailed {
+                    job_id,
+                    reason: format!("failed to write per-job MCP config: {e}"),
+                })?;
+
+            Ok(Some(tmp_path))
+        }
     }
 }
 
@@ -704,5 +914,309 @@ mod tests {
         let handle = mgr.get_handle(job_id).await.unwrap();
         assert_eq!(handle.worker_iteration, 3);
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 3"));
+    }
+
+    // ── generate_worker_mcp_config tests ────────────────────────────
+
+    #[tokio::test]
+    async fn test_mcp_config_none_filter_returns_master_path() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), None, Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), Some(tmp.path().to_path_buf()));
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_empty_filter_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers":[]}"#).unwrap();
+        let result = generate_worker_mcp_config(tmp.path(), Some(&[]), Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_missing_master_returns_none() {
+        let result = generate_worker_mcp_config(
+            std::path::Path::new("/nonexistent/mcp.json"),
+            None,
+            Uuid::new_v4(),
+        )
+        .await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_filters_to_named_servers() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":1,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"disabled","enabled":false,"url":"http://localhost:9999"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string(), "disabled".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        // "disabled" should be excluded because enabled=false
+        assert_eq!(servers.len(), 1);
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert_eq!(content["schema_version"], 1);
+
+        // cleanup
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_no_match_returns_none() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["nonexistent".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), Uuid::new_v4()).await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_case_insensitive_match() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"Serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("case-insensitive match should work");
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[test]
+    fn test_max_iterations_env_var_injected() {
+        // Verify the IRONCLAW_MAX_ITERATIONS env var name matches what the
+        // worker CLI reads via clap's `env` attribute.
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        // We can't test actual container creation without Docker, but we can
+        // verify the env var name matches the clap definition.
+        // The clap definition uses: #[arg(long, env = "IRONCLAW_MAX_ITERATIONS")]
+        // The create_job_inner injects: format!("IRONCLAW_MAX_ITERATIONS={}", iters)
+        // This test ensures the constant isn't accidentally changed in either place.
+        let env_var_in_job = "IRONCLAW_MAX_ITERATIONS";
+        let source = include_str!("../cli/mod.rs");
+        assert!(
+            source.contains(&format!("env = \"{}\"", env_var_in_job)),
+            "cli/mod.rs must have env = \"IRONCLAW_MAX_ITERATIONS\" on the max_iterations arg"
+        );
+        drop(mgr);
+    }
+
+    #[test]
+    fn test_max_iterations_not_injected_for_claude_code() {
+        // ClaudeCode mode uses its own `max_turns`, not IRONCLAW_MAX_ITERATIONS.
+        // Verify the gate in create_job_inner only injects for Worker mode.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("mode == JobMode::Worker"),
+            "create_job_inner must gate IRONCLAW_MAX_ITERATIONS on JobMode::Worker \
+             (ClaudeCode has its own max_turns)"
+        );
+    }
+
+    #[test]
+    fn test_server_side_max_iterations_clamp() {
+        // Verify the server-side clamp uses the same constant as worker/job.rs
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("iters.clamp(1, MAX_WORKER_ITERATIONS)"),
+            "create_job_inner must clamp max_iterations server-side using MAX_WORKER_ITERATIONS"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_server_name_validation_rejects_path_separators() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        // Path separator should be rejected
+        let names = vec!["../../etc/passwd".to_string()];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Null byte should be rejected
+        let names = vec!["test\0evil".to_string()];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Excessively long name should be rejected
+        let names = vec!["a".repeat(129)];
+        assert!(
+            generate_worker_mcp_config(tmp.path(), Some(&names), job_id)
+                .await
+                .is_err()
+        );
+
+        // Valid name should pass
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        assert!(result.is_ok());
+    }
+
+    // ── Regression tests (CI-required) ────────────────────────────────
+
+    #[tokio::test]
+    async fn test_filtered_config_contains_only_requested_server() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"schema_version":2,"servers":[
+                {"name":"serpstat","enabled":true,"url":"http://localhost:8062"},
+                {"name":"notion","enabled":true,"url":"http://localhost:8063"},
+                {"name":"archon","enabled":true,"url":"http://localhost:8064"}
+            ]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let content: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
+        let servers = content["servers"].as_array().unwrap();
+
+        assert_eq!(servers.len(), 1, "only serpstat should be present");
+        assert_eq!(servers[0]["name"], "serpstat");
+        assert!(
+            !servers.iter().any(|s| s["name"] == "notion"),
+            "notion must not leak into filtered config"
+        );
+        assert!(
+            !servers.iter().any(|s| s["name"] == "archon"),
+            "archon must not leak into filtered config"
+        );
+        assert_eq!(
+            content["schema_version"], 2,
+            "schema_version must be preserved"
+        );
+
+        let _ = std::fs::remove_file(&out_path);
+    }
+
+    #[tokio::test]
+    async fn test_feature_flag_disabled_skips_mcp_filtering() {
+        // When MCP_PER_JOB_ENABLED is false (the default), the mcp_servers
+        // parameter should be ignored and no filtered config should be created.
+        let config = ContainerJobConfig::default();
+        assert!(
+            !config.mcp_per_job_enabled,
+            "mcp_per_job_enabled must default to false"
+        );
+
+        // Verify the gate in create_job_inner: the mcp_per_job_enabled field
+        // controls whether generate_worker_mcp_config is called at all.
+        let source = include_str!("job_manager.rs");
+        assert!(
+            source.contains("if self.config.mcp_per_job_enabled"),
+            "create_job_inner must gate MCP filtering on config.mcp_per_job_enabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_temp_file_cleanup_removes_per_job_config() {
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"serpstat","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["serpstat".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+        assert!(
+            out_path.exists(),
+            "temp config file should exist after creation"
+        );
+
+        // Simulate what cleanup_job does
+        let expected_path = std::env::temp_dir()
+            .join("ironclaw-mcp-configs")
+            .join(format!("{}.json", job_id));
+        assert_eq!(
+            out_path, expected_path,
+            "temp path must match cleanup expectation"
+        );
+        std::fs::remove_file(&out_path).unwrap();
+        assert!(!out_path.exists(), "temp file should be gone after cleanup");
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_job_is_idempotent() {
+        let config = ContainerJobConfig::default();
+        let mgr = ContainerJobManager::new(config, TokenStore::new());
+        let job_id = Uuid::new_v4();
+
+        // cleanup_job should not panic or error when called for a job
+        // that has no temp file and no container handle.
+        mgr.cleanup_job(job_id).await;
+        // Second call should also be fine (idempotent).
+        mgr.cleanup_job(job_id).await;
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_temp_dir_has_restrictive_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let job_id = Uuid::new_v4();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{"servers":[{"name":"test","enabled":true}]}"#,
+        )
+        .unwrap();
+
+        let names = vec!["test".to_string()];
+        let result = generate_worker_mcp_config(tmp.path(), Some(&names), job_id).await;
+        let out_path = result.unwrap().expect("should produce a filtered config");
+
+        let dir_path = out_path.parent().unwrap();
+        let mode = std::fs::metadata(dir_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "ironclaw-mcp-configs dir must be 0700, got {:o}",
+            mode
+        );
+
+        let _ = std::fs::remove_file(&out_path);
     }
 }

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -122,6 +122,9 @@ pub async fn setup_orchestrator(
             claude_code_max_turns: config.claude_code.max_turns,
             claude_code_memory_limit_mb: config.claude_code.memory_limit_mb,
             claude_code_allowed_tools: config.claude_code.allowed_tools.clone(),
+            mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
+                .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
+                .unwrap_or(false),
         };
         let jm = Arc::new(ContainerJobManager::new(job_config, token_store.clone()));
 

--- a/src/sandbox/container.rs
+++ b/src/sandbox/container.rs
@@ -98,6 +98,18 @@ impl ContainerRunner {
         }
     }
 
+    /// Create a runner for image-only operations (exists / pull / build).
+    ///
+    /// `proxy_port` is unused for image operations, so this avoids requiring
+    /// a real port number when the caller only needs to check or build images.
+    pub fn for_image_ops(docker: Docker, image: String) -> Self {
+        Self {
+            docker,
+            image,
+            proxy_port: 0,
+        }
+    }
+
     /// Check if the Docker daemon is available.
     pub async fn is_available(&self) -> bool {
         self.docker.ping().await.is_ok()
@@ -137,6 +149,141 @@ impl ContainerRunner {
         }
 
         tracing::info!("Successfully pulled image: {}", self.image);
+        Ok(())
+    }
+
+    /// Build the sandbox image from a Dockerfile.
+    ///
+    /// This is used when the image is not available from a registry and needs
+    /// to be built locally from source.
+    ///
+    /// # Security
+    ///
+    /// The `dockerfile_path` MUST point to a trusted Dockerfile. Docker builds
+    /// execute arbitrary `RUN` commands from the Dockerfile, which is a code
+    /// execution vector. Callers must ensure the path is not user-controlled
+    /// and points to a known, safe Dockerfile (e.g., bundled with the application).
+    pub async fn build_image(&self, dockerfile_path: &Path) -> Result<()> {
+        use tokio::io::AsyncBufReadExt;
+        use tokio::process::Command;
+
+        const MAX_STDERR_CAPTURE: usize = 4096;
+
+        // Canonicalize so the -f path is absolute and context_dir is its parent.
+        // This avoids the bug where a relative path like "docker/sandbox.Dockerfile"
+        // would be resolved twice (once for context_dir, once by docker -f).
+        let canonical =
+            dockerfile_path
+                .canonicalize()
+                .map_err(|e| SandboxError::ContainerCreationFailed {
+                    reason: format!(
+                        "cannot resolve Dockerfile path '{}': {}",
+                        dockerfile_path.display(),
+                        e
+                    ),
+                })?;
+
+        let context_dir =
+            canonical
+                .parent()
+                .ok_or_else(|| SandboxError::ContainerCreationFailed {
+                    reason: format!(
+                        "Dockerfile path '{}' has no parent directory",
+                        canonical.display()
+                    ),
+                })?;
+
+        tracing::info!(
+            "Building sandbox image from {}: {}",
+            canonical.display(),
+            self.image
+        );
+
+        let mut child = Command::new("docker")
+            .arg("build")
+            .arg("-f")
+            .arg(&canonical)
+            .arg("-t")
+            .arg(&self.image)
+            .arg(".")
+            .current_dir(context_dir)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .map_err(|e| SandboxError::ContainerCreationFailed {
+                reason: format!("failed to run docker build: {}", e),
+            })?;
+
+        // Both streams are piped above, so take() returns Some.
+        let mut stdout_lines = tokio::io::BufReader::new(child.stdout.take().ok_or_else(|| {
+            SandboxError::ContainerCreationFailed {
+                reason: "stdout pipe missing".to_string(),
+            }
+        })?)
+        .lines();
+        let mut stderr_lines = tokio::io::BufReader::new(child.stderr.take().ok_or_else(|| {
+            SandboxError::ContainerCreationFailed {
+                reason: "stderr pipe missing".to_string(),
+            }
+        })?)
+        .lines();
+
+        let mut stderr_capture = String::new();
+        let mut stdout_done = false;
+        let mut stderr_done = false;
+
+        while !stdout_done || !stderr_done {
+            tokio::select! {
+                line = stdout_lines.next_line(), if !stdout_done => {
+                    match line {
+                        Ok(Some(line)) => tracing::info!("[docker build] {}", line),
+                        Ok(None) => stdout_done = true,
+                        Err(e) => {
+                            tracing::warn!("Error reading docker build stdout: {}", e);
+                            stdout_done = true;
+                        }
+                    }
+                },
+                line = stderr_lines.next_line(), if !stderr_done => {
+                    match line {
+                        Ok(Some(line)) => {
+                            tracing::info!("[docker build] {}", line);
+                            if stderr_capture.len() < MAX_STDERR_CAPTURE {
+                                stderr_capture.push_str(&line);
+                                stderr_capture.push('\n');
+                            }
+                        }
+                        Ok(None) => stderr_done = true,
+                        Err(e) => {
+                            tracing::warn!("Error reading docker build stderr: {}", e);
+                            stderr_done = true;
+                        }
+                    }
+                },
+            }
+        }
+
+        let status = child
+            .wait()
+            .await
+            .map_err(|e| SandboxError::ContainerCreationFailed {
+                reason: format!("docker build wait failed: {}", e),
+            })?;
+
+        if !status.success() {
+            let code = status
+                .code()
+                .map_or("unknown".to_string(), |c| c.to_string());
+            return Err(SandboxError::ContainerCreationFailed {
+                reason: format!(
+                    "docker build failed (exit {}): {}",
+                    code,
+                    stderr_capture.trim_end()
+                ),
+            });
+        }
+
+        tracing::info!("Successfully built image: {}", self.image);
         Ok(())
     }
 
@@ -615,6 +762,22 @@ mod tests {
         assert!(candidates.contains(&PathBuf::from("/home/tester/.colima/default/docker.sock")));
         assert!(candidates.contains(&PathBuf::from("/home/tester/.rd/docker.sock")));
         assert!(candidates.contains(&PathBuf::from("/run/user/1000/docker.sock")));
+    }
+
+    #[tokio::test]
+    async fn build_image_rejects_nonexistent_dockerfile() {
+        // The behavior under test (Dockerfile path canonicalization) happens
+        // before any Docker daemon call, so we don't need a reachable daemon.
+        let docker = Docker::connect_with_http_defaults().unwrap();
+        let runner = ContainerRunner::for_image_ops(docker, "test-nonexistent:latest".to_string());
+        let dir = tempfile::tempdir().unwrap();
+        let bad_path = dir.path().join("definitely-does-not-exist.Dockerfile");
+        let err = runner.build_image(&bad_path).await.unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("cannot resolve Dockerfile path"),
+            "expected path resolution error, got: {msg}"
+        );
     }
 
     #[tokio::test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -408,6 +408,10 @@ pub struct ChannelSettings {
     /// Directory containing WASM channel modules.
     #[serde(default)]
     pub wasm_channels_dir: Option<PathBuf>,
+
+    /// CLI mode: "tui" for rich terminal UI, empty/absent for simple REPL.
+    #[serde(default)]
+    pub cli_mode: Option<String>,
 }
 
 impl Default for ChannelSettings {
@@ -433,6 +437,7 @@ impl Default for ChannelSettings {
             wasm_channels: Vec::new(),
             wasm_channels_enabled: true,
             wasm_channels_dir: None,
+            cli_mode: None,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -201,6 +201,22 @@ pub struct Settings {
     #[serde(default)]
     pub builder: BuilderSettings,
 
+    /// Routine scheduling and execution configuration.
+    #[serde(default)]
+    pub routines: RoutineSettings,
+
+    /// Skills system configuration.
+    #[serde(default)]
+    pub skills: SkillsSettings,
+
+    /// Memory hygiene configuration.
+    #[serde(default)]
+    pub hygiene: HygieneSettings,
+
+    /// Workspace search fusion configuration.
+    #[serde(default)]
+    pub search: SearchSettings,
+
     /// Transcription configuration.
     #[serde(default)]
     pub transcription: Option<TranscriptionSettings>,
@@ -791,6 +807,188 @@ impl Default for BuilderSettings {
     }
 }
 
+/// Routine scheduling and execution configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoutineSettings {
+    /// Whether the routines system is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// How often (seconds) to poll for cron routines that need firing.
+    #[serde(default = "default_routine_cron_interval")]
+    pub cron_check_interval_secs: u64,
+
+    /// Max routines executing concurrently.
+    #[serde(default = "default_routine_max_concurrent")]
+    pub max_concurrent_routines: usize,
+
+    /// Default cooldown between fires (seconds).
+    #[serde(default = "default_routine_cooldown")]
+    pub default_cooldown_secs: u64,
+
+    /// Max output tokens for lightweight routine LLM calls.
+    #[serde(default = "default_routine_max_tokens")]
+    pub max_lightweight_tokens: u32,
+
+    /// Enable tool execution in lightweight routines.
+    #[serde(default = "default_true")]
+    pub lightweight_tools_enabled: bool,
+
+    /// Max tool iterations for lightweight routines.
+    #[serde(default = "default_routine_max_iterations")]
+    pub lightweight_max_iterations: u32,
+}
+
+fn default_routine_cron_interval() -> u64 {
+    15
+}
+
+fn default_routine_max_concurrent() -> usize {
+    10
+}
+
+fn default_routine_cooldown() -> u64 {
+    300
+}
+
+fn default_routine_max_tokens() -> u32 {
+    4096
+}
+
+fn default_routine_max_iterations() -> u32 {
+    3
+}
+
+impl Default for RoutineSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            cron_check_interval_secs: default_routine_cron_interval(),
+            max_concurrent_routines: default_routine_max_concurrent(),
+            default_cooldown_secs: default_routine_cooldown(),
+            max_lightweight_tokens: default_routine_max_tokens(),
+            lightweight_tools_enabled: true,
+            lightweight_max_iterations: default_routine_max_iterations(),
+        }
+    }
+}
+
+/// Skills system configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SkillsSettings {
+    /// Whether the skills system is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Maximum number of skills that can be active simultaneously.
+    #[serde(default = "default_skills_max_active")]
+    pub max_active_skills: usize,
+
+    /// Maximum total context tokens allocated to skill prompts.
+    #[serde(default = "default_skills_max_context_tokens")]
+    pub max_context_tokens: usize,
+}
+
+fn default_skills_max_active() -> usize {
+    3
+}
+
+fn default_skills_max_context_tokens() -> usize {
+    4000
+}
+
+impl Default for SkillsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            max_active_skills: default_skills_max_active(),
+            max_context_tokens: default_skills_max_context_tokens(),
+        }
+    }
+}
+
+/// Memory hygiene configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HygieneSettings {
+    /// Whether hygiene is enabled.
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+
+    /// Days before `daily/` documents are deleted.
+    #[serde(default = "default_hygiene_daily_retention")]
+    pub daily_retention_days: u32,
+
+    /// Days before `conversations/` documents are deleted.
+    #[serde(default = "default_hygiene_conversation_retention")]
+    pub conversation_retention_days: u32,
+
+    /// Minimum hours between hygiene passes.
+    #[serde(default = "default_hygiene_cadence_hours")]
+    pub cadence_hours: u32,
+}
+
+fn default_hygiene_daily_retention() -> u32 {
+    30
+}
+
+fn default_hygiene_conversation_retention() -> u32 {
+    7
+}
+
+fn default_hygiene_cadence_hours() -> u32 {
+    12
+}
+
+impl Default for HygieneSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            daily_retention_days: default_hygiene_daily_retention(),
+            conversation_retention_days: default_hygiene_conversation_retention(),
+            cadence_hours: default_hygiene_cadence_hours(),
+        }
+    }
+}
+
+/// Workspace search fusion configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchSettings {
+    /// Fusion strategy: "rrf" or "weighted".
+    #[serde(default = "default_search_fusion_strategy")]
+    pub fusion_strategy: String,
+
+    /// RRF constant k.
+    #[serde(default = "default_search_rrf_k")]
+    pub rrf_k: u32,
+
+    /// FTS weight for fusion. `None` = use per-strategy default.
+    #[serde(default)]
+    pub fts_weight: Option<f32>,
+
+    /// Vector weight for fusion. `None` = use per-strategy default.
+    #[serde(default)]
+    pub vector_weight: Option<f32>,
+}
+
+fn default_search_fusion_strategy() -> String {
+    "rrf".to_string()
+}
+
+fn default_search_rrf_k() -> u32 {
+    60
+}
+
+impl Default for SearchSettings {
+    fn default() -> Self {
+        Self {
+            fusion_strategy: default_search_fusion_strategy(),
+            rrf_k: default_search_rrf_k(),
+            fts_weight: None,
+            vector_weight: None,
+        }
+    }
+}
+
 /// Transcription pipeline settings.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TranscriptionSettings {
@@ -907,8 +1105,9 @@ impl Settings {
         let content = format!(
             "# IronClaw configuration file.\n\
              #\n\
-             # Priority varies by subsystem. LLM: DB > env > this file > defaults.\n\
-             # Most others: env > DB > this file > defaults.\n\
+             # Priority: DB settings > env vars > this file > defaults.\n\
+             # A DB value equal to the built-in default is treated as unset.\n\
+             # Exceptions: bootstrap and security-sensitive fields are env-only.\n\
              # Uncomment and edit values to override defaults.\n\
              # Run `ironclaw config init` to regenerate this file.\n\
              #\n\

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -349,7 +349,7 @@ key first, then falls back to the standard env var.
 **Telegram special case** (`setup_telegram`):
 - Validates bot token via Telegram `getMe` API
 - Owner binding: polls `getUpdates` for 120s to capture sender's user ID
-- Optional webhook secret generation
+- Optional webhook secret auto-generation for webhook mode
 
 **SecretsContext creation** (`init_secrets_context`):
 1. Check `self.secrets_crypto` (set in Step 2) → use if available

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -65,6 +65,9 @@ pub enum SetupError {
 
     #[error("User cancelled")]
     Cancelled,
+
+    #[error("Sandbox error: {0}")]
+    Sandbox(#[from] crate::sandbox::error::SandboxError),
 }
 
 impl From<crate::setup::channels::ChannelSetupError> for SetupError {
@@ -2859,6 +2862,9 @@ impl SetupWizard {
             crate::sandbox::detect::DockerStatus::Available => {
                 self.settings.sandbox.enabled = true;
                 print_success("Docker is installed and running. Sandbox enabled.");
+
+                // Check if the worker image exists
+                self.ensure_worker_image().await?;
             }
             crate::sandbox::detect::DockerStatus::NotInstalled
             | crate::sandbox::detect::DockerStatus::NotRunning => {
@@ -2888,6 +2894,8 @@ impl SetupWizard {
                         } else {
                             "Docker is now running. Sandbox enabled."
                         });
+                        // Check if the worker image exists
+                        self.ensure_worker_image().await?;
                     } else {
                         self.settings.sandbox.enabled = false;
                         print_info(if not_installed {
@@ -2969,6 +2977,113 @@ impl SetupWizard {
                 self.settings.sandbox.claude_code_enabled = false;
                 print_info("Claude Code disabled. Enable with CLAUDE_CODE_ENABLED=true later.");
             }
+        }
+
+        Ok(())
+    }
+
+    /// Ensure the sandbox worker Docker image exists, building it if necessary.
+    async fn ensure_worker_image(&mut self) -> Result<(), SetupError> {
+        use crate::sandbox::container::{ContainerRunner, connect_docker};
+
+        let image_name = self.settings.sandbox.image.clone();
+        let docker = match connect_docker().await {
+            Ok(d) => d,
+            Err(e) => {
+                // check_docker() may report Available (via CLI fallback) even when
+                // connect_docker() fails (e.g. on Windows). Don't hard-fail setup.
+                print_info(&format!(
+                    "Could not connect to Docker API to verify image: {}",
+                    e
+                ));
+                print_info("Image check skipped. The image will be pulled at first job run.");
+                return Ok(());
+            }
+        };
+        let runner = ContainerRunner::for_image_ops(docker, image_name.clone());
+
+        if runner.image_exists().await {
+            print_success(&format!("Worker image '{}' found.", image_name));
+            return Ok(());
+        }
+
+        println!();
+        print_info(&format!("Worker image '{}' not found.", image_name));
+        print_info("This image is required for sandboxed job execution.");
+        println!();
+
+        // Images that contain '/' look like registry references (e.g.
+        // "ghcr.io/nearai/ironclaw-worker:v1"). For those, or when
+        // auto_pull_image is enabled, attempt a pull before offering a
+        // local build — the runtime would do the same thing via
+        // SandboxManager::ensure_ready().
+        let is_registry_image = image_name.contains('/');
+        if is_registry_image || self.settings.sandbox.auto_pull_image {
+            print_info(&format!("Attempting to pull '{}'...", image_name));
+            match runner.pull_image().await {
+                Ok(()) => {
+                    print_success(&format!("Successfully pulled image '{}'.", image_name));
+                    return Ok(());
+                }
+                Err(e) => {
+                    if is_registry_image {
+                        // Registry image that can't be pulled — don't offer local build.
+                        print_error(&format!("Failed to pull image: {}", e));
+                        print_info("Ensure the image is published and accessible, or set");
+                        print_info("SANDBOX_IMAGE to a local image name and try again.");
+                        return Ok(());
+                    }
+                    print_info(&format!(
+                        "Pull failed ({}). Checking for local Dockerfile...",
+                        e
+                    ));
+                }
+            }
+        }
+
+        // Only offer local build for default-style local images.
+        let dockerfile_path = std::path::PathBuf::from("Dockerfile.worker");
+
+        if dockerfile_path.exists() {
+            print_info(&format!(
+                "Found Dockerfile at: {}",
+                dockerfile_path.display()
+            ));
+            if confirm(
+                "Build the worker image now? (this may take a few minutes)",
+                true,
+            )
+            .map_err(SetupError::Io)?
+            {
+                print_info("Building worker image... This may take a few minutes.");
+                match runner.build_image(&dockerfile_path).await {
+                    Ok(()) => {
+                        print_success(&format!("Successfully built image '{}'.", image_name));
+                    }
+                    Err(e) => {
+                        print_error(&format!("Failed to build image: {}", e));
+                        print_info("You can build it manually later with:");
+                        print_info(&format!(
+                            "  docker build -f Dockerfile.worker -t {} .",
+                            image_name
+                        ));
+                    }
+                }
+            } else {
+                print_info("Skipped image build. Build it manually with:");
+                print_info(&format!(
+                    "  docker build -f Dockerfile.worker -t {} .",
+                    image_name
+                ));
+            }
+        } else {
+            print_info("No Dockerfile.worker found in current directory.");
+            print_info("To use Docker sandbox, build the worker image manually:");
+            print_info(&format!(
+                "  docker build -f Dockerfile.worker -t {} .",
+                image_name
+            ));
+            print_info("or clone the IronClaw repository and build from source.");
         }
 
         Ok(())

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -278,7 +278,7 @@ impl TenantScope {
         thread_id: Option<&str>,
     ) -> Result<bool, DatabaseError> {
         self.inner
-            .ensure_conversation(id, channel, &self.user_id, thread_id)
+            .ensure_conversation(id, channel, &self.user_id, thread_id, Some(channel))
             .await
     }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -753,7 +753,7 @@ mod tests {
 
         // ensure_conversation should create the row.
         assert!(
-            db.ensure_conversation(conv_id, "web", "carol", None)
+            db.ensure_conversation(conv_id, "web", "carol", None, Some("web"))
                 .await
                 .expect("ensure first"),
             "first ensure_conversation should create the row"
@@ -761,7 +761,7 @@ mod tests {
 
         // Calling again with the same ID should not error.
         assert!(
-            db.ensure_conversation(conv_id, "web", "carol", None)
+            db.ensure_conversation(conv_id, "web", "carol", None, Some("web"))
                 .await
                 .expect("ensure second (idempotent)"),
             "second ensure_conversation should touch owned row"
@@ -806,7 +806,7 @@ mod tests {
         tokio::time::sleep(std::time::Duration::from_millis(25)).await;
 
         assert!(
-            !db.ensure_conversation(conv_id, "web", "mallory", None)
+            !db.ensure_conversation(conv_id, "web", "mallory", None, None)
                 .await
                 .expect("foreign ensure should not error"),
             "foreign ensure_conversation should report not ensured"

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -43,8 +43,79 @@ use crate::error::ToolError as AgentToolError;
 use crate::llm::{
     ChatMessage, LlmProvider, Reasoning, ReasoningContext, RespondResult, ToolDefinition,
 };
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+use crate::tools::tool::{
+    ApprovalContext, ApprovalRequirement, Tool, ToolError, ToolOutput, check_approval_in_context,
+};
 use crate::tools::{ToolRegistry, prepare_tool_params};
+
+/// Deserialize `dependencies` from either a list of strings, a list of objects,
+/// or a flat object map.  LLMs often produce TOML-style inline tables
+/// (`{"ureq": {"version": "2"}}`) instead of simple strings (`"ureq = \"2\""`);
+/// this normalises all variants to `Vec<"name = \"version\"">`  strings.
+fn deserialize_dependencies<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    use serde_json::Value;
+
+    let val = Value::deserialize(deserializer)?;
+    match val {
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::String(s) => out.push(s),
+                    Value::Object(map) => {
+                        for (name, spec) in map {
+                            if let Some(dep) = flatten_dep(&name, &spec) {
+                                out.push(dep);
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(de::Error::custom(format!(
+                            "expected string or object in dependencies array, got {other}"
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Value::Object(map) => {
+            let out: Vec<String> = map
+                .into_iter()
+                .filter_map(|(name, spec)| flatten_dep(&name, &spec))
+                .collect();
+            Ok(out)
+        }
+        Value::Null => Ok(Vec::new()),
+        other => Err(de::Error::custom(format!(
+            "expected array or object for dependencies, got {other}"
+        ))),
+    }
+}
+
+/// Flatten a dependency entry like `("ureq", "2")` or `("serde", {"version":"1","features":["derive"]})`
+/// into a TOML-compatible string like `ureq = "2"` or `serde = { version = "1", features = ["derive"] }`.
+/// Returns `None` for values that cannot produce valid TOML (null, bool, array, number).
+fn flatten_dep(name: &str, spec: &serde_json::Value) -> Option<String> {
+    match spec {
+        serde_json::Value::String(version) => Some(format!("{name} = \"{version}\"")),
+        serde_json::Value::Object(map) => {
+            let parts: Vec<String> = map.iter().map(|(k, v)| format!("{k} = {v}")).collect();
+            Some(format!("{name} = {{ {} }}", parts.join(", ")))
+        }
+        _ => {
+            tracing::warn!(
+                name,
+                ?spec,
+                "Skipping dependency with unsupported value type"
+            );
+            None
+        }
+    }
+}
 
 fn process_builder_tool_result(
     tool_name: &str,
@@ -78,6 +149,7 @@ pub struct BuildRequirement {
     /// Expected output format.
     pub output_spec: Option<String>,
     /// External dependencies needed.
+    #[serde(default, deserialize_with = "deserialize_dependencies")]
     pub dependencies: Vec<String>,
     /// Security/capability requirements (for WASM tools).
     pub capabilities: Vec<String>,
@@ -793,8 +865,22 @@ Create alongside the .wasm file to grant capabilities:
             })?;
         let normalized_params = prepare_tool_params(tool.as_ref(), params);
 
-        // Execute with a dummy context (build tools don't need job context)
-        let ctx = JobContext::default();
+        // Create context with build-specific approval permissions.
+        // Note: shell commands (cargo, npm, pip, etc.) handle network access
+        // for dependency fetching, so we don't need to grant direct http tool access.
+        let ctx =
+            JobContext::default().with_approval_context(ApprovalContext::autonomous_with_tools([
+                "shell".into(),
+                "read_file".into(),
+                "write_file".into(),
+                "list_dir".into(),
+                "apply_patch".into(),
+            ]));
+
+        // Check approval before executing (bypasses worker check, so we do it here)
+        let requirement = tool.requires_approval(&normalized_params);
+        check_approval_in_context(&ctx, tool_name, requirement)?;
+
         tool.execute(normalized_params, &ctx).await
     }
 
@@ -1218,6 +1304,59 @@ mod tests {
         assert!(deserialized.output_spec.is_none());
         assert!(deserialized.dependencies.is_empty());
         assert!(deserialized.capabilities.is_empty());
+    }
+
+    /// Regression test for #1640: LLM returns dependencies as inline tables
+    /// (`{"ureq": {"version": "2"}}`) instead of simple strings.
+    #[test]
+    fn test_build_requirement_deserialize_inline_table_deps() {
+        let json = r#"{
+            "name": "gh-search",
+            "description": "Search GitHub repos",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": [
+                {"ureq": {"version": "2"}},
+                {"serde": {"version": "1", "features": ["derive"]}}
+            ],
+            "capabilities": ["http"]
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies[0].starts_with("ureq = "));
+        assert!(req.dependencies[1].starts_with("serde = "));
+    }
+
+    /// Dependencies as a flat object map (`{"ureq": "2", "serde_json": "1"}`).
+    #[test]
+    fn test_build_requirement_deserialize_object_map_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": {"ureq": "2", "serde_json": "1"},
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies.iter().any(|d| d.contains("ureq")));
+        assert!(req.dependencies.iter().any(|d| d.contains("serde_json")));
+    }
+
+    /// Null or missing dependencies should deserialize to empty vec.
+    #[test]
+    fn test_build_requirement_deserialize_null_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "script",
+            "language": "bash",
+            "dependencies": null,
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert!(req.dependencies.is_empty());
     }
 
     #[test]

--- a/src/tools/builder/core.rs
+++ b/src/tools/builder/core.rs
@@ -48,6 +48,75 @@ use crate::tools::tool::{
 };
 use crate::tools::{ToolRegistry, prepare_tool_params};
 
+/// Deserialize `dependencies` from either a list of strings, a list of objects,
+/// or a flat object map.  LLMs often produce TOML-style inline tables
+/// (`{"ureq": {"version": "2"}}`) instead of simple strings (`"ureq = \"2\""`);
+/// this normalises all variants to `Vec<"name = \"version\"">`  strings.
+fn deserialize_dependencies<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de;
+    use serde_json::Value;
+
+    let val = Value::deserialize(deserializer)?;
+    match val {
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for item in arr {
+                match item {
+                    Value::String(s) => out.push(s),
+                    Value::Object(map) => {
+                        for (name, spec) in map {
+                            if let Some(dep) = flatten_dep(&name, &spec) {
+                                out.push(dep);
+                            }
+                        }
+                    }
+                    other => {
+                        return Err(de::Error::custom(format!(
+                            "expected string or object in dependencies array, got {other}"
+                        )));
+                    }
+                }
+            }
+            Ok(out)
+        }
+        Value::Object(map) => {
+            let out: Vec<String> = map
+                .into_iter()
+                .filter_map(|(name, spec)| flatten_dep(&name, &spec))
+                .collect();
+            Ok(out)
+        }
+        Value::Null => Ok(Vec::new()),
+        other => Err(de::Error::custom(format!(
+            "expected array or object for dependencies, got {other}"
+        ))),
+    }
+}
+
+/// Flatten a dependency entry like `("ureq", "2")` or `("serde", {"version":"1","features":["derive"]})`
+/// into a TOML-compatible string like `ureq = "2"` or `serde = { version = "1", features = ["derive"] }`.
+/// Returns `None` for values that cannot produce valid TOML (null, bool, array, number).
+fn flatten_dep(name: &str, spec: &serde_json::Value) -> Option<String> {
+    match spec {
+        serde_json::Value::String(version) => Some(format!("{name} = \"{version}\"")),
+        serde_json::Value::Object(map) => {
+            let parts: Vec<String> = map.iter().map(|(k, v)| format!("{k} = {v}")).collect();
+            Some(format!("{name} = {{ {} }}", parts.join(", ")))
+        }
+        _ => {
+            tracing::warn!(
+                name,
+                ?spec,
+                "Skipping dependency with unsupported value type"
+            );
+            None
+        }
+    }
+}
+
 fn process_builder_tool_result(
     tool_name: &str,
     tool_call_id: &str,
@@ -80,6 +149,7 @@ pub struct BuildRequirement {
     /// Expected output format.
     pub output_spec: Option<String>,
     /// External dependencies needed.
+    #[serde(default, deserialize_with = "deserialize_dependencies")]
     pub dependencies: Vec<String>,
     /// Security/capability requirements (for WASM tools).
     pub capabilities: Vec<String>,
@@ -1234,6 +1304,59 @@ mod tests {
         assert!(deserialized.output_spec.is_none());
         assert!(deserialized.dependencies.is_empty());
         assert!(deserialized.capabilities.is_empty());
+    }
+
+    /// Regression test for #1640: LLM returns dependencies as inline tables
+    /// (`{"ureq": {"version": "2"}}`) instead of simple strings.
+    #[test]
+    fn test_build_requirement_deserialize_inline_table_deps() {
+        let json = r#"{
+            "name": "gh-search",
+            "description": "Search GitHub repos",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": [
+                {"ureq": {"version": "2"}},
+                {"serde": {"version": "1", "features": ["derive"]}}
+            ],
+            "capabilities": ["http"]
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies[0].starts_with("ureq = "));
+        assert!(req.dependencies[1].starts_with("serde = "));
+    }
+
+    /// Dependencies as a flat object map (`{"ureq": "2", "serde_json": "1"}`).
+    #[test]
+    fn test_build_requirement_deserialize_object_map_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "wasm_tool",
+            "language": "rust",
+            "dependencies": {"ureq": "2", "serde_json": "1"},
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert_eq!(req.dependencies.len(), 2);
+        assert!(req.dependencies.iter().any(|d| d.contains("ureq")));
+        assert!(req.dependencies.iter().any(|d| d.contains("serde_json")));
+    }
+
+    /// Null or missing dependencies should deserialize to empty vec.
+    #[test]
+    fn test_build_requirement_deserialize_null_deps() {
+        let json = r#"{
+            "name": "tool",
+            "description": "A tool",
+            "software_type": "script",
+            "language": "bash",
+            "dependencies": null,
+            "capabilities": []
+        }"#;
+        let req: BuildRequirement = serde_json::from_str(json).unwrap();
+        assert!(req.dependencies.is_empty());
     }
 
     #[test]

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -21,7 +21,7 @@ use crate::context::{ContextManager, JobContext, JobState};
 use crate::db::Database;
 use crate::history::SandboxJobRecord;
 use crate::orchestrator::auth::CredentialGrant;
-use crate::orchestrator::job_manager::{ContainerJobManager, JobMode};
+use crate::orchestrator::job_manager::{ContainerJobManager, JobCreationParams, JobMode};
 use crate::secrets::SecretsStore;
 use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
 use ironclaw_common::AppEvent;
@@ -361,7 +361,7 @@ impl CreateJobTool {
         explicit_dir: Option<PathBuf>,
         wait: bool,
         mode: JobMode,
-        credential_grants: Vec<CredentialGrant>,
+        params: JobCreationParams,
         ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
@@ -376,7 +376,7 @@ impl CreateJobTool {
         let project_dir_str = project_dir.display().to_string();
 
         // Serialize credential grants so restarts can reload them.
-        let credential_grants_json = match serde_json::to_string(&credential_grants) {
+        let credential_grants_json = match serde_json::to_string(&params.credential_grants) {
             Ok(json) => json,
             Err(e) => {
                 tracing::warn!(
@@ -431,7 +431,7 @@ impl CreateJobTool {
 
         // Create the container job with the pre-determined job_id.
         let _token = jm
-            .create_job(job_id, task, Some(project_dir), mode, credential_grants)
+            .create_job(job_id, task, Some(project_dir), mode, params)
             .await
             .map_err(|e| {
                 self.update_status(
@@ -849,6 +849,18 @@ impl Tool for CreateJobTool {
                                         secrets store (via 'ironclaw tool auth' or web UI). Example: \
                                         {\"github_token\": \"GITHUB_TOKEN\", \"npm_token\": \"NPM_TOKEN\"}",
                         "additionalProperties": { "type": "string" }
+                    },
+                    "mcp_servers": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Optional list of MCP server names to make available in the container. \
+                                        If omitted, the full master config is mounted. If empty, no MCP servers \
+                                        are available. Only effective when MCP_PER_JOB_ENABLED=true."
+                    },
+                    "max_iterations": {
+                        "type": "integer",
+                        "description": "Maximum number of agent loop iterations for the worker. \
+                                        Defaults to 50, capped at 500. Use lower values for simple tasks."
                     }
                 },
                 "required": ["title", "description"]
@@ -909,10 +921,44 @@ impl Tool for CreateJobTool {
             // Parse and validate credential grants
             let credential_grants = self.parse_credentials(&params, &ctx.user_id).await?;
 
+            // Parse optional MCP server filter and iteration cap.
+            // Validate types: warn if present but wrong type so callers know why it was ignored.
+            let mcp_servers: Option<Vec<String>> = match params.get("mcp_servers") {
+                Some(v) if v.is_array() => v.as_array().map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                }),
+                Some(_) => {
+                    tracing::warn!("mcp_servers parameter is not an array — ignoring");
+                    None
+                }
+                None => None,
+            };
+            let max_iterations: Option<u32> = match params.get("max_iterations") {
+                Some(v) if v.is_u64() || v.is_i64() => v.as_u64().map(|n| n.clamp(1, 500) as u32),
+                Some(_) => {
+                    tracing::warn!("max_iterations parameter is not a number — ignoring");
+                    None
+                }
+                None => None,
+            };
+
             // Combine title and description into the task prompt for the sub-agent.
             let task = format!("{}\n\n{}", title, description);
-            self.execute_sandbox(&task, explicit_dir, wait, mode, credential_grants, ctx)
-                .await
+            self.execute_sandbox(
+                &task,
+                explicit_dir,
+                wait,
+                mode,
+                JobCreationParams {
+                    credential_grants,
+                    mcp_servers,
+                    max_iterations,
+                },
+                ctx,
+            )
+            .await
         } else {
             self.execute_local(title, description, ctx).await
         }
@@ -1568,7 +1614,7 @@ mod tests {
                 None,
                 false,
                 JobMode::Worker,
-                vec![],
+                JobCreationParams::default(),
                 &JobContext::default(),
             )
             .await;

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -205,11 +205,11 @@ impl Tool for MessageTool {
                 },
                 "channel": {
                     "type": "string",
-                    "description": "Target channel (defaults to current channel if omitted)"
+                    "description": "Transport/integration name: 'slack-relay', 'telegram', 'signal', 'gateway'. This is NOT a Slack channel ID — use target for that. Defaults to current channel if omitted."
                 },
                 "target": {
                     "type": "string",
-                    "description": "Recipient: E.164 phone, group ID, chat ID (defaults to current sender/group if omitted)"
+                    "description": "Recipient within the transport. Slack: channel ID (C0...), user ID (U0...), or #channel-name. Telegram: chat ID. Signal: E.164 phone or group ID. Defaults to current conversation target if omitted."
                 },
                 "attachments": {
                     "type": "array",

--- a/src/tools/builtin/routine.rs
+++ b/src/tools/builtin/routine.rs
@@ -1178,8 +1178,22 @@ impl Tool for RoutineCreateTool {
                 dedup_window: None,
             },
             notify: NotifyConfig {
-                channel: normalized.delivery.channel.clone(),
-                user: normalized.delivery.user.clone(),
+                // Fall back to the current conversation's channel/target when
+                // the LLM omits delivery params, so routines created from
+                // e.g. a Slack channel know where to send results.
+                channel: normalized.delivery.channel.clone().or_else(|| {
+                    ctx.metadata
+                        .get("notify_channel")
+                        .and_then(|v| v.as_str())
+                        .map(ToOwned::to_owned)
+                }),
+                user: normalized.delivery.user.clone().or_else(|| {
+                    ctx.metadata
+                        .get("notify_user")
+                        .and_then(|v| v.as_str())
+                        .filter(|v| *v != "default")
+                        .map(ToOwned::to_owned)
+                }),
                 ..NotifyConfig::default()
             },
             last_run_at: None,
@@ -2611,6 +2625,28 @@ mod tests {
         assert!(
             schema_property(&schema, "source").is_object(),
             "event_emit discovery schema should keep source alias",
+        );
+    }
+
+    /// Regression: routine_create must fall back to ctx.metadata for delivery
+    /// config when the LLM omits delivery.channel/user. This verifies the
+    /// parsing layer returns None so the execute path triggers the fallback.
+    #[test]
+    fn routine_create_omitted_delivery_enables_context_fallback() {
+        let params = serde_json::json!({
+            "name": "ping-every-5",
+            "prompt": "Send Ping in this channel.",
+            "request": { "kind": "cron", "schedule": "*/5 * * * *" }
+        });
+
+        let parsed = parse_routine_create_request(&params).expect("parse");
+        assert!(
+            parsed.delivery.channel.is_none(),
+            "omitted delivery.channel should be None so execute() falls back to ctx.metadata",
+        );
+        assert!(
+            parsed.delivery.user.is_none(),
+            "omitted delivery.user should be None so execute() falls back to ctx.metadata",
         );
     }
 

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -855,7 +855,8 @@ impl Tool for ShellTool {
                 },
                 "timeout": {
                     "type": "integer",
-                    "description": "Timeout in seconds (optional, default 120)"
+                    "description": "Timeout in seconds (optional, default 120)",
+                    "minimum": 1
                 }
             },
             "required": ["command"]
@@ -869,8 +870,41 @@ impl Tool for ShellTool {
     ) -> Result<ToolOutput, ToolError> {
         let command = require_str(&params, "command")?;
 
-        let workdir = params.get("workdir").and_then(|v| v.as_str());
-        let timeout = params.get("timeout").and_then(|v| v.as_u64());
+        let workdir = match params.get("workdir") {
+            None => None,
+            Some(v) if v.is_null() => None,
+            Some(v) => {
+                let s = v.as_str().ok_or_else(|| {
+                    ToolError::InvalidParameters("workdir must be a string".to_string())
+                })?;
+                let trimmed = s.trim();
+                if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                }
+            }
+        };
+
+        let timeout = match params.get("timeout") {
+            None => None,
+            Some(v) if v.is_null() => None,
+            Some(v) => {
+                let n = v.as_u64().ok_or_else(|| {
+                    ToolError::InvalidParameters(
+                        "timeout must be a positive integer number of seconds".to_string(),
+                    )
+                })?;
+
+                if n == 0 {
+                    return Err(ToolError::InvalidParameters(
+                        "timeout must be greater than 0".to_string(),
+                    ));
+                }
+
+                Some(n)
+            }
+        };
 
         let start = std::time::Instant::now();
         let (output, exit_code) = self
@@ -952,16 +986,159 @@ fn truncate_for_error(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use tempfile::TempDir;
+
+    async fn execute_shell(
+        tool: &ShellTool,
+        params: serde_json::Value,
+    ) -> Result<ToolOutput, ToolError> {
+        tool.execute(params, &JobContext::default()).await
+    }
+
+    fn assert_invalid_parameters(result: Result<ToolOutput, ToolError>, expected_message: &str) {
+        match result {
+            Err(ToolError::InvalidParameters(message)) => {
+                assert_eq!(message, expected_message);
+            }
+            Err(other) => panic!("expected InvalidParameters, got {other:?}"),
+            Ok(output) => panic!("expected InvalidParameters, got success: {output:?}"),
+        }
+    }
 
     #[tokio::test]
     async fn test_echo_command() {
         let tool = ShellTool::new();
-        let ctx = JobContext::default();
-
-        let result = tool
-            .execute(serde_json::json!({"command": "echo hello"}), &ctx)
+        let result = execute_shell(&tool, serde_json::json!({"command": "echo hello"}))
             .await
             .unwrap();
+
+        let output = result.result.get("output").unwrap().as_str().unwrap();
+        assert!(output.contains("hello"));
+        assert_eq!(result.result.get("exit_code").unwrap().as_i64().unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_execute_treats_blank_workdir_as_none() {
+        let temp_dir = TempDir::new().unwrap();
+        let tool = ShellTool::new().with_working_dir(temp_dir.path().to_path_buf());
+
+        for workdir in ["", "   "] {
+            let result = execute_shell(
+                &tool,
+                serde_json::json!({
+                    "command": "pwd",
+                    "workdir": workdir
+                }),
+            )
+            .await
+            .unwrap();
+
+            let output = result
+                .result
+                .get("output")
+                .unwrap()
+                .as_str()
+                .unwrap()
+                .trim();
+            let output_path = PathBuf::from(output).canonicalize().unwrap();
+            let expected_path = temp_dir.path().canonicalize().unwrap();
+            assert_eq!(output_path, expected_path);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_non_string_workdir() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "pwd",
+                "workdir": 42
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(result, "workdir must be a string");
+    }
+
+    #[tokio::test]
+    async fn test_execute_treats_missing_or_null_timeout_as_none() {
+        let tool = ShellTool::new();
+
+        for params in [
+            serde_json::json!({"command": "echo hello"}),
+            serde_json::json!({"command": "echo hello", "timeout": null}),
+        ] {
+            let result = execute_shell(&tool, params).await.unwrap();
+            let output = result.result.get("output").unwrap().as_str().unwrap();
+            assert!(output.contains("hello"));
+            assert_eq!(result.result.get("exit_code").unwrap().as_i64().unwrap(), 0);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_non_numeric_timeout_string() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": "abc"
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(
+            result,
+            "timeout must be a positive integer number of seconds",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_zero_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 0
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(result, "timeout must be greater than 0");
+    }
+
+    #[tokio::test]
+    async fn test_execute_rejects_float_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 3.5
+            }),
+        )
+        .await;
+
+        assert_invalid_parameters(
+            result,
+            "timeout must be a positive integer number of seconds",
+        );
+    }
+
+    #[tokio::test]
+    async fn test_execute_accepts_valid_timeout() {
+        let tool = ShellTool::new();
+        let result = execute_shell(
+            &tool,
+            serde_json::json!({
+                "command": "echo hello",
+                "timeout": 30
+            }),
+        )
+        .await
+        .unwrap();
 
         let output = result.result.get("output").unwrap().as_str().unwrap();
         assert!(output.contains("hello"));

--- a/src/tools/mcp/protocol.rs
+++ b/src/tools/mcp/protocol.rs
@@ -46,7 +46,12 @@ fn default_input_schema() -> serde_json::Value {
 }
 
 /// Annotations for an MCP tool that provide hints about its behavior.
+///
+/// The MCP specification uses camelCase for annotation field names
+/// (e.g. `destructiveHint`, `readOnlyHint`). The `rename_all` attribute
+/// ensures correct deserialization from spec-compliant servers.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct McpToolAnnotations {
     /// Hint that this tool performs destructive operations that cannot be undone.
     /// Tools with this hint set to true should require user approval before execution.
@@ -606,6 +611,32 @@ mod tests {
             annotations: None,
         };
         assert!(!tool.requires_approval());
+    }
+
+    #[test]
+    fn test_annotations_deserialize_camel_case_from_mcp_spec() {
+        // MCP spec uses camelCase for annotation fields (destructiveHint, readOnlyHint, etc.).
+        // Without #[serde(rename_all = "camelCase")] on McpToolAnnotations, serde silently
+        // defaults all fields to false and destructive tools bypass approval.
+        let json = serde_json::json!({
+            "name": "pods_delete",
+            "description": "Delete a pod",
+            "inputSchema": {"type": "object"},
+            "annotations": {
+                "destructiveHint": true,
+                "readOnlyHint": false,
+                "sideEffectsHint": true
+            }
+        });
+        let tool: McpTool = serde_json::from_value(json).expect("deserialize");
+        assert!(
+            tool.requires_approval(),
+            "tools with destructiveHint: true must require approval"
+        );
+        let ann = tool.annotations.unwrap();
+        assert!(ann.destructive_hint);
+        assert!(!ann.read_only_hint);
+        assert!(ann.side_effects_hint);
     }
 
     #[test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -35,5 +35,5 @@ pub use rate_limiter::RateLimiter;
 pub use registry::ToolRegistry;
 pub use tool::{
     ApprovalContext, ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput,
-    ToolRateLimitConfig, redact_params, validate_tool_schema,
+    ToolRateLimitConfig, check_approval_in_context, redact_params, validate_tool_schema,
 };

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -25,7 +25,7 @@ use crate::tools::builtin::{
     ToolUpgradeTool, WriteFileTool,
 };
 use crate::tools::rate_limiter::RateLimiter;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolDomain};
+use crate::tools::tool::{ApprovalRequirement, Tool, ToolDiscoverySummary, ToolDomain};
 use crate::tools::wasm::{
     Capabilities, OAuthRefreshConfig, ResourceLimits, SharedCredentialRegistry, WasmError,
     WasmStorageError, WasmToolRuntime, WasmToolStore, WasmToolWrapper,
@@ -674,6 +674,9 @@ impl ToolRegistry {
         if let Some(s) = reg.schema {
             wrapper = wrapper.with_schema(s);
         }
+        if let Some(summary) = reg.discovery_summary {
+            wrapper = wrapper.with_discovery_summary(summary);
+        }
         if let Some(store) = reg.secrets_store {
             wrapper = wrapper.with_secrets_store(store);
         }
@@ -748,6 +751,7 @@ impl ToolRegistry {
             limits: None,
             description: Some(&tool_with_binary.tool.description),
             schema: Some(tool_with_binary.tool.parameters_schema.clone()),
+            discovery_summary: None,
             secrets_store: self.secrets_store.clone(),
             oauth_refresh: None,
         })
@@ -791,6 +795,8 @@ pub struct WasmToolRegistration<'a> {
     pub description: Option<&'a str>,
     /// Optional parameter schema override.
     pub schema: Option<serde_json::Value>,
+    /// Optional curated discovery guidance for `tool_info(detail: "summary")`.
+    pub discovery_summary: Option<ToolDiscoverySummary>,
     /// Secrets store for credential injection at request time.
     pub secrets_store: Option<Arc<dyn SecretsStore + Send + Sync>>,
     /// OAuth refresh configuration for auto-refreshing expired tokens.

--- a/src/tools/tool.rs
+++ b/src/tools/tool.rs
@@ -59,9 +59,18 @@ impl ApprovalContext {
     }
 
     /// Check whether a tool invocation is blocked in this context.
-    pub fn is_blocked(&self, tool_name: &str, _requirement: ApprovalRequirement) -> bool {
+    ///
+    /// - `Never` tools are always allowed (no approval needed).
+    /// - `UnlessAutoApproved` tools are allowed in autonomous contexts
+    ///   (autonomous execution implies auto-approve).
+    /// - `Always` tools are only allowed if explicitly listed in `allowed_tools`.
+    pub fn is_blocked(&self, tool_name: &str, requirement: ApprovalRequirement) -> bool {
         match self {
-            Self::Autonomous { allowed_tools } => !allowed_tools.contains(tool_name),
+            Self::Autonomous { allowed_tools } => match requirement {
+                ApprovalRequirement::Never => false,
+                ApprovalRequirement::UnlessAutoApproved => false,
+                ApprovalRequirement::Always => !allowed_tools.contains(tool_name),
+            },
         }
     }
 
@@ -445,6 +454,53 @@ pub fn require_param<'a>(
     params
         .get(name)
         .ok_or_else(|| ToolError::InvalidParameters(format!("missing '{}' parameter", name)))
+}
+
+/// Check if a tool invocation is allowed based on the job's approval context.
+///
+/// This helper function should be called by tools that execute sub-tools
+/// (like the builder) to ensure proper approval checking is done even when
+/// bypassing the worker's normal approval flow.
+///
+/// Returns `Ok(())` if the tool is allowed, `Err(ToolError::NotAuthorized)` if blocked.
+///
+/// # Security semantics
+///
+/// When `approval_context` is `None`, this function uses **legacy blocking behavior**:
+/// - `Never` tools: allowed
+/// - `UnlessAutoApproved` tools: blocked (require interactive approval)
+/// - `Always` tools: blocked (require explicit approval)
+///
+/// This matches the worker-level `ApprovalContext::is_blocked_or_default()` semantics
+/// to prevent privilege escalation.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// # use ironclaw::context::JobContext;
+/// # use ironclaw::tools::{Tool, ToolError, ToolOutput, check_approval_in_context};
+/// # use serde_json::Value;
+/// async fn execute(&self, params: Value, ctx: &JobContext) -> Result<ToolOutput, ToolError> {
+///     // If this tool executes sub-tools, check their approval first
+///     check_approval_in_context(ctx, "sub_tool_name", self.requires_approval(&params))?;
+///
+///     // ... rest of implementation
+///     # todo!()
+/// }
+/// ```
+pub fn check_approval_in_context(
+    ctx: &crate::context::JobContext,
+    tool_name: &str,
+    requirement: ApprovalRequirement,
+) -> Result<(), ToolError> {
+    // Match worker-level approval semantics exactly to prevent inconsistency
+    if ApprovalContext::is_blocked_or_default(&ctx.approval_context, tool_name, requirement) {
+        return Err(ToolError::NotAuthorized(format!(
+            "Tool '{}' requires approval in this context",
+            tool_name
+        )));
+    }
+    Ok(())
 }
 
 /// Replace sensitive parameter values with `"[REDACTED]"`.
@@ -1006,10 +1062,12 @@ mod tests {
     }
 
     #[test]
-    fn test_approval_context_autonomous_blocks_tools_not_in_scope() {
+    fn test_approval_context_autonomous_blocks_always_but_allows_soft() {
         let ctx = ApprovalContext::autonomous();
-        assert!(ctx.is_blocked("shell", ApprovalRequirement::Never));
-        assert!(ctx.is_blocked("shell", ApprovalRequirement::UnlessAutoApproved));
+        // Never and UnlessAutoApproved are always allowed in autonomous context
+        assert!(!ctx.is_blocked("shell", ApprovalRequirement::Never));
+        assert!(!ctx.is_blocked("shell", ApprovalRequirement::UnlessAutoApproved));
+        // Always tools are blocked unless explicitly listed
         assert!(ctx.is_blocked("shell", ApprovalRequirement::Always));
     }
 
@@ -1024,9 +1082,12 @@ mod tests {
     }
 
     #[test]
-    fn test_approval_context_blocks_never_when_not_in_scope() {
+    fn test_approval_context_never_always_passes() {
         let ctx = ApprovalContext::autonomous();
-        assert!(ctx.is_blocked("any_tool", ApprovalRequirement::Never));
+        assert!(
+            !ctx.is_blocked("any_tool", ApprovalRequirement::Never),
+            "Never tools should always be allowed regardless of allowlist"
+        );
     }
 
     #[test]
@@ -1064,7 +1125,8 @@ mod tests {
             "other",
             ApprovalRequirement::Always
         ));
-        assert!(ApprovalContext::is_blocked_or_default(
+        // UnlessAutoApproved is allowed in autonomous context (auto-approved)
+        assert!(!ApprovalContext::is_blocked_or_default(
             &ctx,
             "any",
             ApprovalRequirement::UnlessAutoApproved

--- a/src/tools/wasm/capabilities_schema.rs
+++ b/src/tools/wasm/capabilities_schema.rs
@@ -33,6 +33,7 @@ use std::time::Duration;
 use serde::{Deserialize, Serialize};
 
 use crate::secrets::{CredentialLocation, CredentialMapping};
+use crate::tools::tool::ToolDiscoverySummary;
 use crate::tools::wasm::{
     Capabilities, EndpointPattern, HttpCapability, RateLimitConfig, SecretsCapability,
     ToolInvokeCapability, WebhookCapability, WorkspaceCapability,
@@ -46,6 +47,10 @@ pub struct CapabilitiesFile {
     /// If omitted, a generic fallback is used (with a warning).
     #[serde(default)]
     pub description: Option<String>,
+
+    /// Optional curated guidance surfaced by `tool_info(detail: "summary")`.
+    #[serde(default)]
+    pub discovery_summary: Option<ToolDiscoverySummary>,
 
     /// Extension version (semver).
     #[serde(default)]
@@ -154,6 +159,7 @@ impl CapabilitiesFile {
         if let Some(inner) = self.capabilities.take() {
             let inner = inner.resolve_nested_inner(depth + 1);
             self.description = self.description.or(inner.description);
+            self.discovery_summary = self.discovery_summary.or(inner.discovery_summary);
             self.http = self.http.or(inner.http);
             self.secrets = self.secrets.or(inner.secrets);
             self.tool_invoke = self.tool_invoke.or(inner.tool_invoke);
@@ -1528,6 +1534,28 @@ mod tests {
             caps.description.as_deref(),
             Some("Outer description wins"),
             "Outer description should take precedence over inner"
+        );
+    }
+
+    #[test]
+    fn test_discovery_summary_promoted_from_nested_capabilities() {
+        let json = r#"{
+            "capabilities": {
+                "discovery_summary": {
+                    "always_required": ["action"],
+                    "notes": ["Use tool_info for full schema"]
+                }
+            }
+        }"#;
+
+        let caps = CapabilitiesFile::from_json(json).unwrap();
+        let summary = caps
+            .discovery_summary
+            .expect("discovery summary should be promoted");
+        assert_eq!(summary.always_required, vec!["action".to_string()]);
+        assert_eq!(
+            summary.notes,
+            vec!["Use tool_info for full schema".to_string()]
         );
     }
 

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -128,48 +128,50 @@ impl WasmToolLoader {
         // capabilities file — it is auto-derived from the WASM module's
         // schema() export at prepare time (see WasmToolSchemas::compact_schema),
         // so no schema override is needed here.
-        let (capabilities, oauth_refresh, description) = if let Some(cap_path) = capabilities_path {
-            if cap_path.exists() {
-                let cap_bytes = fs::read(cap_path).await?;
-                let cap_file = CapabilitiesFile::from_bytes(&cap_bytes)
-                    .map_err(|e| WasmLoadError::InvalidCapabilities(e.to_string()))?;
-                cap_file.validate(name);
+        let (capabilities, oauth_refresh, description, discovery_summary) =
+            if let Some(cap_path) = capabilities_path {
+                if cap_path.exists() {
+                    let cap_bytes = fs::read(cap_path).await?;
+                    let cap_file = CapabilitiesFile::from_bytes(&cap_bytes)
+                        .map_err(|e| WasmLoadError::InvalidCapabilities(e.to_string()))?;
+                    cap_file.validate(name);
 
-                // Check WIT version compatibility
-                check_wit_version_compat(
-                    name,
-                    cap_file.wit_version.as_deref(),
-                    crate::tools::wasm::WIT_TOOL_VERSION,
-                )?;
+                    // Check WIT version compatibility
+                    check_wit_version_compat(
+                        name,
+                        cap_file.wit_version.as_deref(),
+                        crate::tools::wasm::WIT_TOOL_VERSION,
+                    )?;
 
-                let caps = cap_file.to_capabilities();
-                let oauth = resolve_oauth_refresh_config(&cap_file);
-                let desc = cap_file.description.clone();
-                if desc.is_none() {
+                    let caps = cap_file.to_capabilities();
+                    let oauth = resolve_oauth_refresh_config(&cap_file);
+                    let desc = cap_file.description.clone();
+                    let summary = cap_file.discovery_summary.clone();
+                    if desc.is_none() {
+                        tracing::warn!(
+                            tool = name,
+                            path = %cap_path.display(),
+                            "Capabilities file missing \"description\" field; \
+                             tool will use generic fallback description"
+                        );
+                    }
+                    (caps, oauth, desc, summary)
+                } else {
                     tracing::warn!(
                         tool = name,
                         path = %cap_path.display(),
-                        "Capabilities file missing \"description\" field; \
-                         tool will use generic fallback description"
+                        "Capabilities file not found, using default (no permissions)"
                     );
+                    (Capabilities::default(), None, None, None)
                 }
-                (caps, oauth, desc)
             } else {
                 tracing::warn!(
                     tool = name,
-                    path = %cap_path.display(),
-                    "Capabilities file not found, using default (no permissions)"
-                );
-                (Capabilities::default(), None, None)
-            }
-        } else {
-            tracing::warn!(
-                tool = name,
-                "No capabilities file for WASM tool; \
+                    "No capabilities file for WASM tool; \
                      tool will use generic fallback description"
-            );
-            (Capabilities::default(), None, None)
-        };
+                );
+                (Capabilities::default(), None, None, None)
+            };
 
         // Register the tool
         self.registry
@@ -181,6 +183,7 @@ impl WasmToolLoader {
                 limits: None,
                 description: description.as_deref(),
                 schema: None,
+                discovery_summary,
                 secrets_store: self.secrets_store.clone(),
                 oauth_refresh,
             })

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -20,7 +20,7 @@ use crate::context::JobContext;
 use crate::llm::recording::{HttpExchangeRequest, HttpExchangeResponse, HttpInterceptor};
 use crate::safety::LeakDetector;
 use crate::secrets::{DecryptedSecret, SecretsStore};
-use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use crate::tools::tool::{Tool, ToolDiscoverySummary, ToolError, ToolOutput};
 use crate::tools::wasm::capabilities::Capabilities;
 use crate::tools::wasm::credential_injector::{
     InjectedCredentials, host_matches_pattern, inject_credential,
@@ -585,6 +585,8 @@ pub struct WasmToolWrapper {
     description: String,
     /// Compact and discovery schemas for this tool.
     schemas: WasmToolSchemas,
+    /// Optional curated discovery guidance surfaced by `tool_info`.
+    discovery_summary: Option<ToolDiscoverySummary>,
     /// Injected credentials for HTTP requests (e.g., OAuth tokens).
     /// Keys are placeholder names like "GOOGLE_ACCESS_TOKEN".
     credentials: HashMap<String, String>,
@@ -836,6 +838,7 @@ impl WasmToolWrapper {
         Self {
             description: prepared.description.clone(),
             schemas: WasmToolSchemas::new(prepared.schema.clone()),
+            discovery_summary: None,
             runtime,
             prepared,
             capabilities,
@@ -879,6 +882,12 @@ impl WasmToolWrapper {
         } else {
             self.schemas = self.schemas.with_override(schema);
         }
+        self
+    }
+
+    /// Override the curated discovery summary.
+    pub fn with_discovery_summary(mut self, summary: ToolDiscoverySummary) -> Self {
+        self.discovery_summary = Some(summary);
         self
     }
 
@@ -1098,6 +1107,10 @@ impl Tool for WasmToolWrapper {
         self.schemas.discovery()
     }
 
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        self.discovery_summary.clone()
+    }
+
     /// Compose the tool schema for LLM function calling.
     ///
     /// When the advertised schema is permissive (no typed properties), appends
@@ -1149,6 +1162,7 @@ impl Tool for WasmToolWrapper {
         let capabilities = self.capabilities.clone();
         let description = self.description.clone();
         let schemas = self.schemas.clone();
+        let discovery_summary = self.discovery_summary.clone();
         let credentials = self.credentials.clone();
 
         // Execute in blocking task with timeout
@@ -1159,6 +1173,7 @@ impl Tool for WasmToolWrapper {
                 capabilities,
                 description,
                 schemas,
+                discovery_summary,
                 credentials,
                 secrets_store: None, // Not needed in blocking task
                 oauth_refresh: None, // Already used above for pre-refresh
@@ -3056,6 +3071,27 @@ mod tests {
             })
         );
         assert_eq!(wrapper.discovery_schema(), typed_schema); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_wrapper_returns_curated_discovery_summary() {
+        let runtime = Arc::new(WasmToolRuntime::new(WasmRuntimeConfig::for_testing()).unwrap()); // safety: test-only setup
+        let prepared = runtime
+            .prepare("github", b"\0asm\x0d\0\x01\0", None)
+            .await
+            .unwrap(); // safety: test-only setup
+
+        let summary = crate::tools::tool::ToolDiscoverySummary {
+            always_required: vec!["action".into()],
+            notes: vec!["Use tool_info for the full schema".into()],
+            ..crate::tools::tool::ToolDiscoverySummary::default()
+        };
+
+        let wrapper =
+            super::WasmToolWrapper::new(Arc::clone(&runtime), prepared, Capabilities::default())
+                .with_discovery_summary(summary.clone());
+
+        assert_eq!(wrapper.discovery_summary(), Some(summary));
     }
 
     #[test]

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -407,6 +407,7 @@ mod tests {
     fn base_channels() -> crate::config::ChannelsConfig {
         crate::config::ChannelsConfig {
             cli: crate::config::CliConfig { enabled: false },
+            cli_mode: None,
             http: None,
             gateway: None,
             signal: None,

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -30,9 +30,7 @@ use crate::safety::SafetyLayer;
 use crate::tenant::AdminScope;
 use crate::tools::execute::process_tool_result;
 use crate::tools::rate_limiter::RateLimitResult;
-use crate::tools::{
-    ApprovalContext, ToolRegistry, autonomous_unavailable_error, prepare_tool_params, redact_params,
-};
+use crate::tools::{ApprovalContext, ToolRegistry, prepare_tool_params, redact_params};
 use crate::worker::autonomous_recovery::{
     AutonomousRecoveryAction, AutonomousRecoveryState, EMPTY_TOOL_COMPLETION_FAILURE,
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
@@ -318,7 +316,6 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         reasoning: &Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
-        const MAX_WORKER_ITERATIONS: usize = 500;
         let max_iterations = self
             .context_manager()
             .get_context(self.job_id)
@@ -326,7 +323,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .ok()
             .and_then(|ctx| ctx.metadata.get("max_iterations").and_then(|v| v.as_u64()))
             .unwrap_or(50) as usize;
-        let max_iterations = max_iterations.min(MAX_WORKER_ITERATIONS);
+        let max_iterations = max_iterations.min(ironclaw_common::MAX_WORKER_ITERATIONS as usize);
 
         // Initial tool definitions for planning (will be refreshed in loop)
         reason_ctx.available_tools = self.tools().tool_definitions().await;
@@ -511,20 +508,52 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
 
         let normalized_params = prepare_tool_params(tool.as_ref(), params);
 
-        // Fetch job context early so we have the real user_id for approval, hooks,
-        // and rate limiting decisions.
+        // Fetch job context early for approval checking and other needs
         let mut job_ctx = deps.context_manager.get_context(job_id).await?;
+
+        // Check approval: additive semantics - BOTH job-level AND worker-level must approve
+        let requirement = tool.requires_approval(&normalized_params);
+
+        // Check job-level approval context (if set by tools like the builder)
+        let job_level_blocked = job_ctx
+            .approval_context
+            .as_ref()
+            .map(|ctx| ctx.is_blocked(tool_name, requirement))
+            .unwrap_or(false);
+
+        // Check worker-level approval context (set by scheduler for autonomous jobs)
+        let worker_level_blocked =
+            ApprovalContext::is_blocked_or_default(&deps.approval_context, tool_name, requirement);
+
+        // Tool is blocked if EITHER level blocks it (additive/intersection semantics)
+        // This maintains defense in depth: job-level cannot bypass worker-level restrictions
+        if job_level_blocked || worker_level_blocked {
+            let reason = if job_level_blocked && worker_level_blocked {
+                format!(
+                    "Tool '{}' is blocked by both job-level and worker-level approval context",
+                    tool_name
+                )
+            } else if job_level_blocked {
+                format!(
+                    "Tool '{}' is not in the job-level allowed tools list",
+                    tool_name
+                )
+            } else {
+                format!(
+                    "Tool '{}' is not available for autonomous execution",
+                    tool_name
+                )
+            };
+            return Err(crate::error::ToolError::AutonomousUnavailable {
+                name: tool_name.to_string(),
+                reason,
+            }
+            .into());
+        }
+
         // Propagate http_interceptor for trace recording/replay
         if job_ctx.http_interceptor.is_none() {
             job_ctx.http_interceptor = deps.http_interceptor.clone();
-        }
-
-        // Check approval: use context-aware check if available, else block all non-Never tools
-        let requirement = tool.requires_approval(&normalized_params);
-        let blocked =
-            ApprovalContext::is_blocked_or_default(&deps.approval_context, tool_name, requirement);
-        if blocked {
-            return Err(autonomous_unavailable_error(tool_name, &job_ctx.user_id).into());
         }
 
         // Check per-tool rate limit before running hooks or executing (cheaper check first)
@@ -2171,6 +2200,105 @@ mod tests {
             Err(Error::Tool(crate::error::ToolError::AutonomousUnavailable { name, .. }))
                 if name == "always_approval"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_semantics_both_levels_must_approve() {
+        // Test additive semantics: BOTH job-level AND worker-level must approve
+        // If either blocks, the tool is blocked (defense in depth)
+
+        // Scenario 1: Worker-level allows, job-level blocks → BLOCKED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level allows the tool
+            Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                "always_approval".to_string(),
+            ])),
+        )
+        .await;
+
+        // Set job-level context to block the tool (by not listing it)
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context = Some(crate::tools::ApprovalContext::autonomous());
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_err(),
+            "Tool should be blocked when job-level doesn't allow it, \
+             even if worker-level does (additive semantics)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_worker_block_overrides_job_allow() {
+        // Scenario 2: Job-level allows, worker-level blocks → BLOCKED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level does NOT allow the tool
+            Some(crate::tools::ApprovalContext::autonomous()),
+        )
+        .await;
+
+        // Set job-level context to allow the tool
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context =
+                    Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                        "always_approval".to_string(),
+                    ]));
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_err(),
+            "Tool should be blocked when worker-level doesn't allow it, \
+             even if job-level does (additive semantics)"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_additive_approval_both_levels_allow() {
+        // Scenario 3: Both levels allow → ALLOWED
+        let worker = make_worker_with_approval(
+            vec![Arc::new(AlwaysApprovalTool)],
+            // Worker-level allows
+            Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                "always_approval".to_string(),
+            ])),
+        )
+        .await;
+
+        // Job-level also allows
+        worker
+            .context_manager()
+            .update_context(worker.job_id, |ctx| {
+                ctx.approval_context =
+                    Some(crate::tools::ApprovalContext::autonomous_with_tools([
+                        "always_approval".to_string(),
+                    ]));
+            })
+            .await
+            .unwrap();
+
+        let result = worker
+            .execute_tool("always_approval", &serde_json::json!({}))
+            .await;
+        assert!(
+            result.is_ok(),
+            "Tool should be allowed when both job-level and worker-level allow it"
+        );
     }
 
     #[tokio::test]

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -316,7 +316,6 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
         reasoning: &Reasoning,
         reason_ctx: &mut ReasoningContext,
     ) -> Result<(), Error> {
-        const MAX_WORKER_ITERATIONS: usize = 500;
         let max_iterations = self
             .context_manager()
             .get_context(self.job_id)
@@ -324,7 +323,7 @@ Report when the job is complete or if you encounter issues you cannot resolve."#
             .ok()
             .and_then(|ctx| ctx.metadata.get("max_iterations").and_then(|v| v.as_u64()))
             .unwrap_or(50) as usize;
-        let max_iterations = max_iterations.min(MAX_WORKER_ITERATIONS);
+        let max_iterations = max_iterations.min(ironclaw_common::MAX_WORKER_ITERATIONS as usize);
 
         // Initial tool definitions for planning (will be refreshed in loop)
         reason_ctx.available_tools = self.tools().tool_definitions().await;

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -444,6 +444,200 @@ async def hosted_oauth_refresh_server(
 
 
 @pytest.fixture(scope="session")
+async def loop_limited_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance with a low tool-iteration limit."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-loop-limit-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "openai_compatible",
+            "LLM_BASE_URL": mock_llm_server,
+            "LLM_MODEL": "mock-model",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "loop-limited.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+            "AGENT_MAX_TOOL_ITERATIONS": "2",
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"loop-limited ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
+async def length_preserving_server(
+    ironclaw_binary,
+    mock_llm_server,
+    wasm_tools_dir,
+):
+    """Start an isolated ironclaw instance using the NearAI provider path."""
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-length-home-")
+
+    try:
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_tmpdir.name,
+            "IRONCLAW_BASE_DIR": os.path.join(home_tmpdir.name, ".ironclaw"),
+            "RUST_LOG": "ironclaw=info",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "HTTP_WEBHOOK_SECRET": HTTP_WEBHOOK_SECRET,
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "nearai",
+            "NEARAI_BASE_URL": mock_llm_server,
+            "NEARAI_MODEL": "mock-model",
+            "NEARAI_API_KEY": "mock-nearai-key",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "length-preserving.db"),
+            "SANDBOX_ENABLED": "false",
+            "SKILLS_ENABLED": "true",
+            "ROUTINES_ENABLED": "true",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": _WASM_CHANNELS_TMPDIR.name,
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_OAUTH_CALLBACK_URL": "https://oauth.test.example/oauth/callback",
+            "IRONCLAW_OAUTH_EXCHANGE_URL": mock_llm_server,
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            ironclaw_binary, "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield base_url
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"length-preserving ironclaw server failed to start on port {gateway_port} "
+                f"(returncode={returncode}).\nstderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+    finally:
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+
+
+@pytest.fixture(scope="session")
 async def extension_cleanup_server(
     ironclaw_binary,
     mock_llm_server,
@@ -672,6 +866,28 @@ async def page(ironclaw_server, browser):
     pg = await context.new_page()
     await pg.goto(f"{ironclaw_server}/?token={AUTH_TOKEN}")
     # Wait for the app to initialize (auth screen hidden, SSE connected)
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def loop_limited_page(loop_limited_server, browser):
+    """Fresh Playwright page bound to the low-iteration gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{loop_limited_server}/?token={AUTH_TOKEN}")
+    await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    yield pg
+    await context.close()
+
+
+@pytest.fixture
+async def length_preserving_page(length_preserving_server, browser):
+    """Fresh Playwright page bound to the length-preserving gateway fixture."""
+    context = await browser.new_context(viewport={"width": 1280, "height": 720})
+    pg = await context.new_page()
+    await pg.goto(f"{length_preserving_server}/?token={AUTH_TOKEN}")
     await pg.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     yield pg
     await context.close()

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -26,6 +26,7 @@ SEL = {
     "chat_messages": "#chat-messages",
     "message_user": "#chat-messages .message.user",
     "message_assistant": "#chat-messages .message.assistant",
+    "message_system": "#chat-messages .message.system",
     # Skills
     "skill_search_input": "#skill-search-input",
     "skill_search_results": "#skill-search-results",
@@ -180,6 +181,75 @@ async def api_post(base_url: str, path: str, **kwargs) -> httpx.Response:
             timeout=kwargs.pop("timeout", 10),
             **kwargs,
         )
+
+
+async def send_chat_and_wait_for_terminal_message(
+    page,
+    message: str,
+    *,
+    timeout: int = 30000,
+) -> dict[str, str]:
+    """Send a chat message and wait for the next terminal visible outcome.
+
+    Returns a dict with:
+    - ``role``: ``assistant`` or ``system``
+    - ``text``: rendered text of the newest terminal message
+    """
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    assistant_sel = SEL["message_assistant"]
+    system_sel = SEL["message_system"]
+    before_assistant = await page.locator(assistant_sel).count()
+    before_system = await page.locator(system_sel).count()
+
+    await chat_input.fill(message)
+    await chat_input.press("Enter")
+
+    handle = await page.wait_for_function(
+        """({
+            assistantSelector,
+            systemSelector,
+            chatInputSelector,
+            assistantCount,
+            systemCount,
+        }) => {
+            const input = document.querySelector(chatInputSelector);
+            const systems = document.querySelectorAll(systemSelector);
+            if (systems.length > systemCount) {
+                const last = systems[systems.length - 1];
+                const content = last.querySelector('.message-content');
+                return {
+                    role: 'system',
+                    text: ((content && content.innerText) || last.innerText || '').trim(),
+                };
+            }
+
+            const assistants = document.querySelectorAll(assistantSelector);
+            if (assistants.length > assistantCount && input && !input.disabled) {
+                const last = assistants[assistants.length - 1];
+                const content = last.querySelector('.message-content');
+                const text = ((content && content.innerText) || last.innerText || '').trim();
+                if (text.length > 0 && !last.hasAttribute('data-streaming')) {
+                    return {
+                        role: 'assistant',
+                        text,
+                    };
+                }
+            }
+
+            return null;
+        }""",
+        arg={
+            "assistantSelector": assistant_sel,
+            "systemSelector": system_sel,
+            "chatInputSelector": SEL["chat_input"],
+            "assistantCount": before_assistant,
+            "systemCount": before_system,
+        },
+        timeout=timeout,
+    )
+    return await handle.json_value()
 
 
 def signed_http_webhook_headers(body: bytes) -> dict[str, str]:

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -14,6 +14,7 @@ import uuid
 from aiohttp import web
 
 CANNED_RESPONSES = [
+    (re.compile(r"empty routine response", re.IGNORECASE), ""),
     (re.compile(r"hello|hi|hey", re.IGNORECASE), "Hello! How can I help you today?"),
     (re.compile(r"2\s*\+\s*2|two plus two", re.IGNORECASE), "The answer is 4."),
     (re.compile(r"skill|install", re.IGNORECASE), "I can help you with skills management."),
@@ -23,8 +24,21 @@ CANNED_RESPONSES = [
 ]
 DEFAULT_RESPONSE = "I understand your request."
 
+TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
+TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
+    r"issue 1780 truncated tool call",
+    re.IGNORECASE,
+)
+EMPTY_REPLY_TRIGGER = re.compile(r"issue 1780 empty reply", re.IGNORECASE)
+LOOP_FOREVER_TRIGGER = re.compile(r"issue 1780 loop forever", re.IGNORECASE)
+
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
+    (
+        re.compile(r"loop until cap", re.IGNORECASE),
+        "echo",
+        lambda _: {"message": "loop-until-cap"},
+    ),
     (
         re.compile(r"make approval post (?P<label>[a-z0-9_-]+)", re.IGNORECASE),
         "http",
@@ -66,6 +80,21 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create failing lightweight owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Failing lightweight routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Empty routine response for {m.group('name')}.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
             re.IGNORECASE,
         ),
@@ -80,8 +109,41 @@ TOOL_CALL_PATTERNS = [
     ),
     (
         re.compile(
+            r"create looping full[- ]job owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Looping full-job routine {m.group('name')}",
+            "trigger_type": "manual",
+            "prompt": f"Loop until cap for {m.group('name')}.",
+            "action_type": "full_job",
+            "max_iterations": 1,
+        },
+    ),
+    (
+        re.compile(
+            r"create cron owner routine (?P<name>[a-z0-9][a-z0-9_-]*)",
+            re.IGNORECASE,
+        ),
+        "routine_create",
+        lambda m: {
+            "name": m.group("name"),
+            "description": f"Cron routine {m.group('name')}",
+            "trigger_type": "cron",
+            "schedule": "0 */5 * * * *",
+            "timezone": "UTC",
+            "prompt": f"Confirm that cron routine {m.group('name')} executed.",
+            "action_type": "lightweight",
+            "use_tools": False,
+        },
+    ),
+    (
+        re.compile(
             r"create event routine (?P<name>[a-z0-9][a-z0-9_-]*) "
-            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)",
+            r"channel (?P<channel>[a-z0-9_-]+) pattern (?P<pattern>[a-z0-9_|-]+)"
+            r"(?: cooldown (?P<cooldown>\d+))?",
             re.IGNORECASE,
         ),
         "routine_create",
@@ -94,7 +156,7 @@ TOOL_CALL_PATTERNS = [
             "prompt": f"Acknowledge that {m.group('name')} fired.",
             "action_type": "lightweight",
             "use_tools": False,
-            "cooldown_secs": 0,
+            "cooldown_secs": int(m.group("cooldown") or 0),
         },
     ),
     (
@@ -114,16 +176,36 @@ def _new_oauth_state() -> dict:
     }
 
 
+def _message_text(msg: dict) -> str:
+    content = msg.get("content") or ""
+    if isinstance(content, list):
+        content = " ".join(
+            p.get("text") or "" for p in content if p.get("type") == "text"
+        )
+    return content
+
+
 def _last_user_content(messages: list[dict]) -> str:
     for msg in reversed(messages):
         if msg.get("role") == "user":
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                content = " ".join(
-                    p.get("text", "") for p in content if p.get("type") == "text"
-                )
-            return content
+            return _message_text(msg)
     return ""
+
+def _conversation_has_user_trigger(messages: list[dict], pattern: re.Pattern[str]) -> bool:
+    for msg in messages:
+        if msg.get("role") == "user" and pattern.search(_message_text(msg)):
+            return True
+    return False
+
+
+def _job_contains_marker(messages: list[dict], marker: str) -> bool:
+    marker_lower = marker.lower()
+    for msg in messages:
+        if msg.get("role") != "user":
+            continue
+        if marker_lower in _message_text(msg).lower():
+            return True
+    return False
 
 
 def _is_job_mode(messages: list[dict]) -> bool:
@@ -152,6 +234,25 @@ def match_job_response(messages: list[dict], has_tools: bool) -> dict | None:
 
     last_user = _last_user_content(messages)
     tool_result_count = _count_tool_results(messages)
+    loop_until_cap = _job_contains_marker(messages, "loop until cap")
+
+    if loop_until_cap and "create a plan" in last_user.lower():
+        return {"text": json.dumps({
+            "goal": "Keep iterating until the worker hits the iteration cap",
+            "actions": [],
+            "estimated_cost": 0.001,
+            "estimated_time_secs": 5,
+            "confidence": 0.8,
+        })}
+
+    if loop_until_cap and "all planned actions have been executed" in last_user.lower():
+        return {"text": "loop until cap still requires more work"}
+
+    if loop_until_cap and has_tools:
+        return {"tool_call": {
+            "tool_name": "echo",
+            "arguments": {"message": "loop-until-cap"},
+        }}
 
     # Planning call (no tools available = complete() not complete_with_tools())
     if "create a plan" in last_user.lower():
@@ -259,6 +360,82 @@ async def _send_sse(resp: web.StreamResponse, data: dict):
     await resp.write(f"data: {json.dumps(data)}\n\n".encode())
 
 
+def match_special_response(messages: list[dict], has_tools: bool) -> dict | None:
+    """Deterministic issue-specific responses for agent-loop recovery tests."""
+    last_user = _last_user_content(messages)
+
+    if _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        if has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "echo",
+                    "arguments": {"message": "loop-iteration"},
+                },
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after hitting the tool iteration limit.",
+        }
+
+    if _conversation_has_user_trigger(messages, TRUNCATED_TOOL_CALL_TRIGGER):
+        if TRUNCATED_TOOL_CALL_TRIGGER.search(last_user) and has_tools:
+            return {
+                "type": "truncated_tool_call",
+                "tool_call": {
+                    "tool_name": "time",
+                    "arguments": {},
+                },
+                "content": "Attempting a tool call but the response was truncated.",
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after discarding a truncated tool call.",
+        }
+
+    if TOOL_FAILURE_TRIGGER.search(last_user) and has_tools:
+        return {
+            "type": "tool_call",
+            "tool_call": {
+                "tool_name": "time",
+                "arguments": {"operation": "broken-operation"},
+            },
+        }
+
+    if EMPTY_REPLY_TRIGGER.search(last_user):
+        return {"type": "empty_text"}
+
+    return None
+
+
+async def _dispatch_special_response(
+    request: web.Request,
+    cid: str,
+    stream: bool,
+    special: dict,
+) -> web.StreamResponse | web.Response:
+    if special["type"] == "tool_call":
+        tc = special["tool_call"]
+        if not stream:
+            return _tool_call_response(cid, tc)
+        return await _stream_tool_call(request, cid, tc)
+    if special["type"] == "truncated_tool_call":
+        tc = special["tool_call"]
+        content = special["content"]
+        if not stream:
+            return _truncated_tool_call_response(cid, tc, content)
+        return await _stream_truncated_tool_call(request, cid, tc, content)
+    if special["type"] == "empty_text":
+        if not stream:
+            return _text_response(cid, "")
+        return await _stream_text(request, cid, "")
+
+    text = special["text"]
+    if not stream:
+        return _text_response(cid, text)
+    return await _stream_text(request, cid, text)
+
+
 async def chat_completions(request: web.Request) -> web.StreamResponse:
     """Handle POST /v1/chat/completions and /chat/completions."""
     body = await request.json()
@@ -280,6 +457,12 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
 
+    # Special chat-loop recovery cases that intentionally override the normal
+    # tool-result summary path (for example, the looping case).
+    special = match_special_response(messages, has_tools)
+    if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        return await _dispatch_special_response(request, cid, stream, special)
+
     # Tool result in messages -> text summary
     tr = _find_tool_result(messages)
     if tr:
@@ -287,6 +470,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if not stream:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
+
+    if special:
+        return await _dispatch_special_response(request, cid, stream, special)
 
     # Tool-call pattern match
     tc = match_tool_call(messages, has_tools)
@@ -322,6 +508,28 @@ def _tool_call_response(cid: str, tc: dict) -> web.Response:
                             "function": {"name": tc["tool_name"],
                                          "arguments": json.dumps(tc["arguments"])}}],
         }, "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    })
+
+
+def _truncated_tool_call_response(cid: str, tc: dict, content: str) -> web.Response:
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+    return web.json_response({
+        "id": cid,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "mock-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": f"{content}\n<tool_call>{tool_tag}</tool_call>",
+            },
+            "finish_reason": "length",
+        }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     })
 
@@ -364,6 +572,39 @@ async def _stream_tool_call(request: web.Request, cid: str, tc: dict) -> web.Str
     # Final chunk: finish reason
     chunk["choices"][0]["delta"] = {}
     chunk["choices"][0]["finish_reason"] = "tool_calls"
+    await _send_sse(resp, chunk)
+    await resp.write(b"data: [DONE]\n\n")
+    return resp
+
+
+async def _stream_truncated_tool_call(
+    request: web.Request,
+    cid: str,
+    tc: dict,
+    content: str,
+) -> web.StreamResponse:
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type": "text/event-stream", "Cache-Control": "no-cache"})
+    await resp.prepare(request)
+    base = _make_base(cid)
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+
+    chunk = {**base, "choices": [{"index": 0, "delta": {
+        "role": "assistant",
+        "content": content,
+    }, "finish_reason": None}]}
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {
+        "content": f"\n<tool_call>{tool_tag}</tool_call>",
+    }
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {}
+    chunk["choices"][0]["finish_reason"] = "length"
     await _send_sse(resp, chunk)
     await resp.write(b"data: [DONE]\n\n")
     return resp

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -24,6 +24,14 @@ CANNED_RESPONSES = [
 ]
 DEFAULT_RESPONSE = "I understand your request."
 
+TOOL_FAILURE_TRIGGER = re.compile(r"issue 1780 tool failure", re.IGNORECASE)
+TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
+    r"issue 1780 truncated tool call",
+    re.IGNORECASE,
+)
+EMPTY_REPLY_TRIGGER = re.compile(r"issue 1780 empty reply", re.IGNORECASE)
+LOOP_FOREVER_TRIGGER = re.compile(r"issue 1780 loop forever", re.IGNORECASE)
+
 TOOL_CALL_PATTERNS = [
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
     (
@@ -168,16 +176,26 @@ def _new_oauth_state() -> dict:
     }
 
 
+def _message_text(msg: dict) -> str:
+    content = msg.get("content") or ""
+    if isinstance(content, list):
+        content = " ".join(
+            p.get("text") or "" for p in content if p.get("type") == "text"
+        )
+    return content
+
+
 def _last_user_content(messages: list[dict]) -> str:
     for msg in reversed(messages):
         if msg.get("role") == "user":
-            content = msg.get("content", "")
-            if isinstance(content, list):
-                content = " ".join(
-                    p.get("text", "") for p in content if p.get("type") == "text"
-                )
-            return content
+            return _message_text(msg)
     return ""
+
+def _conversation_has_user_trigger(messages: list[dict], pattern: re.Pattern[str]) -> bool:
+    for msg in messages:
+        if msg.get("role") == "user" and pattern.search(_message_text(msg)):
+            return True
+    return False
 
 
 def _job_contains_marker(messages: list[dict], marker: str) -> bool:
@@ -185,12 +203,7 @@ def _job_contains_marker(messages: list[dict], marker: str) -> bool:
     for msg in messages:
         if msg.get("role") != "user":
             continue
-        content = msg.get("content", "")
-        if isinstance(content, list):
-            content = " ".join(
-                p.get("text", "") for p in content if p.get("type") == "text"
-            )
-        if marker_lower in str(content).lower():
+        if marker_lower in _message_text(msg).lower():
             return True
     return False
 
@@ -347,6 +360,82 @@ async def _send_sse(resp: web.StreamResponse, data: dict):
     await resp.write(f"data: {json.dumps(data)}\n\n".encode())
 
 
+def match_special_response(messages: list[dict], has_tools: bool) -> dict | None:
+    """Deterministic issue-specific responses for agent-loop recovery tests."""
+    last_user = _last_user_content(messages)
+
+    if _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        if has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {
+                    "tool_name": "echo",
+                    "arguments": {"message": "loop-iteration"},
+                },
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after hitting the tool iteration limit.",
+        }
+
+    if _conversation_has_user_trigger(messages, TRUNCATED_TOOL_CALL_TRIGGER):
+        if TRUNCATED_TOOL_CALL_TRIGGER.search(last_user) and has_tools:
+            return {
+                "type": "truncated_tool_call",
+                "tool_call": {
+                    "tool_name": "time",
+                    "arguments": {},
+                },
+                "content": "Attempting a tool call but the response was truncated.",
+            }
+        return {
+            "type": "text",
+            "text": "Recovered after discarding a truncated tool call.",
+        }
+
+    if TOOL_FAILURE_TRIGGER.search(last_user) and has_tools:
+        return {
+            "type": "tool_call",
+            "tool_call": {
+                "tool_name": "time",
+                "arguments": {"operation": "broken-operation"},
+            },
+        }
+
+    if EMPTY_REPLY_TRIGGER.search(last_user):
+        return {"type": "empty_text"}
+
+    return None
+
+
+async def _dispatch_special_response(
+    request: web.Request,
+    cid: str,
+    stream: bool,
+    special: dict,
+) -> web.StreamResponse | web.Response:
+    if special["type"] == "tool_call":
+        tc = special["tool_call"]
+        if not stream:
+            return _tool_call_response(cid, tc)
+        return await _stream_tool_call(request, cid, tc)
+    if special["type"] == "truncated_tool_call":
+        tc = special["tool_call"]
+        content = special["content"]
+        if not stream:
+            return _truncated_tool_call_response(cid, tc, content)
+        return await _stream_truncated_tool_call(request, cid, tc, content)
+    if special["type"] == "empty_text":
+        if not stream:
+            return _text_response(cid, "")
+        return await _stream_text(request, cid, "")
+
+    text = special["text"]
+    if not stream:
+        return _text_response(cid, text)
+    return await _stream_text(request, cid, text)
+
+
 async def chat_completions(request: web.Request) -> web.StreamResponse:
     """Handle POST /v1/chat/completions and /chat/completions."""
     body = await request.json()
@@ -368,6 +457,12 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
 
+    # Special chat-loop recovery cases that intentionally override the normal
+    # tool-result summary path (for example, the looping case).
+    special = match_special_response(messages, has_tools)
+    if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        return await _dispatch_special_response(request, cid, stream, special)
+
     # Tool result in messages -> text summary
     tr = _find_tool_result(messages)
     if tr:
@@ -375,6 +470,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
         if not stream:
             return _text_response(cid, text)
         return await _stream_text(request, cid, text)
+
+    if special:
+        return await _dispatch_special_response(request, cid, stream, special)
 
     # Tool-call pattern match
     tc = match_tool_call(messages, has_tools)
@@ -410,6 +508,28 @@ def _tool_call_response(cid: str, tc: dict) -> web.Response:
                             "function": {"name": tc["tool_name"],
                                          "arguments": json.dumps(tc["arguments"])}}],
         }, "finish_reason": "tool_calls"}],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    })
+
+
+def _truncated_tool_call_response(cid: str, tc: dict, content: str) -> web.Response:
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+    return web.json_response({
+        "id": cid,
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "model": "mock-model",
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": f"{content}\n<tool_call>{tool_tag}</tool_call>",
+            },
+            "finish_reason": "length",
+        }],
         "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
     })
 
@@ -452,6 +572,39 @@ async def _stream_tool_call(request: web.Request, cid: str, tc: dict) -> web.Str
     # Final chunk: finish reason
     chunk["choices"][0]["delta"] = {}
     chunk["choices"][0]["finish_reason"] = "tool_calls"
+    await _send_sse(resp, chunk)
+    await resp.write(b"data: [DONE]\n\n")
+    return resp
+
+
+async def _stream_truncated_tool_call(
+    request: web.Request,
+    cid: str,
+    tc: dict,
+    content: str,
+) -> web.StreamResponse:
+    resp = web.StreamResponse(status=200, headers={
+        "Content-Type": "text/event-stream", "Cache-Control": "no-cache"})
+    await resp.prepare(request)
+    base = _make_base(cid)
+    tool_tag = json.dumps({
+        "name": tc["tool_name"],
+        "arguments": tc["arguments"],
+    })
+
+    chunk = {**base, "choices": [{"index": 0, "delta": {
+        "role": "assistant",
+        "content": content,
+    }, "finish_reason": None}]}
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {
+        "content": f"\n<tool_call>{tool_tag}</tool_call>",
+    }
+    await _send_sse(resp, chunk)
+
+    chunk["choices"][0]["delta"] = {}
+    chunk["choices"][0]["finish_reason"] = "length"
     await _send_sse(resp, chunk)
     await resp.write(b"data: [DONE]\n\n")
     return resp

--- a/tests/e2e/scenarios/test_agent_loop_recovery.py
+++ b/tests/e2e/scenarios/test_agent_loop_recovery.py
@@ -1,0 +1,77 @@
+"""Agent-loop recovery regressions for issue #1780."""
+
+from helpers import SEL, send_chat_and_wait_for_terminal_message
+
+
+async def _create_new_thread(page) -> None:
+    previous_thread = await page.evaluate("() => currentThreadId")
+    await page.evaluate("createNewThread()")
+    await page.wait_for_function(
+        """(prevThread) => {
+            return !!currentThreadId
+                && currentThreadId !== prevThread
+                && document.querySelectorAll('#chat-messages .message').length === 0;
+        }""",
+        arg=previous_thread,
+        timeout=10000,
+    )
+
+
+async def test_tool_failure_recovery_shows_final_response(page):
+    """A failed tool call should surface a final assistant response and not hang."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 tool failure",
+    )
+
+    assert result["role"] == "assistant", result
+    text = result["text"].lower()
+    assert "time tool returned" in text, result
+    assert (
+        "unknown operation" in text
+        or "broken-operation" in text
+        or "error" in text
+    ), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_truncated_tool_call_is_discarded_gracefully(length_preserving_page):
+    """A length-truncated tool call should be ignored and the turn should recover."""
+    await _create_new_thread(length_preserving_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        length_preserving_page,
+        "issue 1780 truncated tool call",
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after discarding a truncated tool call" in result["text"].lower(), result
+    assert await length_preserving_page.locator(SEL["approval_card"]).count() == 0
+    assert await length_preserving_page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_empty_reply_uses_chat_fallback(page):
+    """An empty LLM reply should terminate visibly instead of hanging."""
+    await _create_new_thread(page)
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "issue 1780 empty reply",
+    )
+
+    assert "error:" in result["text"].lower(), result
+    assert "empty" in result["text"].lower(), result
+    assert await page.locator(SEL["chat_input"]).is_enabled()
+
+
+async def test_looping_tool_calls_terminate_under_low_iteration_limit(loop_limited_page):
+    """A looping tool-call pattern should terminate once force-text kicks in."""
+    await _create_new_thread(loop_limited_page)
+    result = await send_chat_and_wait_for_terminal_message(
+        loop_limited_page,
+        "issue 1780 loop forever",
+        timeout=20000,
+    )
+
+    assert result["role"] == "assistant", result
+    assert "recovered after hitting the tool iteration limit" in result["text"].lower(), result
+    assert await loop_limited_page.locator(SEL["chat_input"]).is_enabled()

--- a/tests/e2e/scenarios/test_routine_event_batch.py
+++ b/tests/e2e/scenarios/test_routine_event_batch.py
@@ -7,7 +7,7 @@ import uuid
 import httpx
 import pytest
 
-from helpers import AUTH_TOKEN, SEL, signed_http_webhook_headers
+from helpers import AUTH_TOKEN, SEL, api_post, signed_http_webhook_headers
 
 
 async def _send_chat_message(page, message: str) -> None:
@@ -39,11 +39,15 @@ async def _create_event_routine(
     name: str,
     pattern: str,
     channel: str = "http",
+    cooldown_secs: int | None = None,
 ) -> dict:
     """Create an event routine through chat and return its API record."""
+    message = f"create event routine {name} channel {channel} pattern {pattern}"
+    if cooldown_secs is not None:
+        message += f" cooldown {cooldown_secs}"
     await _send_chat_message(
         page,
-        f"create event routine {name} channel {channel} pattern {pattern}",
+        message,
     )
     return await _wait_for_routine(base_url, name)
 
@@ -54,13 +58,14 @@ async def _post_http_message(
     content: str,
     sender_id: str | None = None,
     thread_id: str | None = None,
+    wait_for_response: bool = True,
 ) -> dict:
     """Send a signed HTTP-channel message and return the JSON body."""
     payload = {
         "user_id": sender_id or f"sender-{uuid.uuid4().hex[:8]}",
         "thread_id": thread_id or f"thread-{uuid.uuid4().hex[:8]}",
         "content": content,
-        "wait_for_response": True,
+        "wait_for_response": wait_for_response,
     }
     body = json.dumps(payload).encode("utf-8")
 
@@ -75,7 +80,10 @@ async def _post_http_message(
     assert response.status_code == 200, (
         f"HTTP webhook failed: {response.status_code} {response.text[:400]}"
     )
-    return response.json()
+    data = response.json()
+    if wait_for_response:
+        assert data.get("response"), f"Expected synchronous response body, got: {data}"
+    return data
 
 
 async def _wait_for_routine(base_url: str, name: str, timeout: float = 20.0) -> dict:
@@ -138,6 +146,17 @@ async def _wait_for_completed_run(
             return runs[0]
         await asyncio.sleep(0.5)
     raise AssertionError(f"Routine '{routine_id}' did not complete within {timeout}s")
+
+
+async def _toggle_routine(base_url: str, routine_id: str, enabled: bool) -> dict:
+    """Toggle a routine through the routines API."""
+    response = await api_post(
+        base_url,
+        f"/api/routines/{routine_id}/toggle",
+        json={"enabled": enabled},
+    )
+    response.raise_for_status()
+    return response.json()
 
 
 @pytest.mark.asyncio
@@ -314,4 +333,85 @@ async def test_routine_execution_history_is_available(
 
     assert completed_run["id"]
     assert completed_run["started_at"]
+    assert completed_run["status"].lower() == "attention"
+
+
+@pytest.mark.asyncio
+async def test_event_trigger_respects_cooldown(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Rapid matching events should not re-fire a routine within cooldown."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="alert",
+        cooldown_secs=30,
+    )
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: primary incident",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    first_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert first_run["status"].lower() == "attention"
+
+    await _post_http_message(
+        http_channel_server,
+        content="alert: follow-up incident",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+
+    runs = await _get_routine_runs(ironclaw_server, routine["id"])
+    assert len(runs) == 1, f"Cooldown should suppress duplicate fire, got runs={runs}"
+
+
+@pytest.mark.asyncio
+async def test_event_routine_can_be_paused_and_resumed(
+    page,
+    ironclaw_server,
+    http_channel_server,
+):
+    """Disabled routines should not fire until they are re-enabled."""
+    routine = await _create_event_routine(
+        page,
+        ironclaw_server,
+        name=f"evt-{uuid.uuid4().hex[:8]}",
+        pattern="resume",
+    )
+
+    disabled = await _toggle_routine(ironclaw_server, routine["id"], False)
+    assert disabled["status"] == "disabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await asyncio.sleep(2)
+    assert await _get_routine_runs(ironclaw_server, routine["id"]) == []
+
+    enabled = await _toggle_routine(ironclaw_server, routine["id"], True)
+    assert enabled["status"] == "enabled"
+
+    await _post_http_message(
+        http_channel_server,
+        content="resume this routine",
+        wait_for_response=False,
+    )
+    await _wait_for_run_count(
+        ironclaw_server,
+        routine["id"],
+        expected_at_least=1,
+    )
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
     assert completed_run["status"].lower() == "attention"

--- a/tests/e2e/scenarios/test_routine_full_job.py
+++ b/tests/e2e/scenarios/test_routine_full_job.py
@@ -25,15 +25,61 @@ async def _send_chat_message(page, message: str) -> None:
     await chat_input.fill(message)
     await chat_input.press("Enter")
 
-    await page.wait_for_function(
-        """({ selector, expectedCount }) => {
-            return document.querySelectorAll(selector).length >= expectedCount;
-        }""",
-        arg={
-            "selector": SEL["message_assistant"],
-            "expectedCount": before_count + 1,
-        },
-        timeout=30000,
+    wait_args = {
+        "selector": SEL["message_assistant"],
+        "expectedCount": before_count + 1,
+    }
+
+    async def _wait_for_assistant() -> None:
+        await page.wait_for_function(
+            """({ selector, expectedCount }) => {
+                return document.querySelectorAll(selector).length >= expectedCount;
+            }""",
+            arg=wait_args,
+            timeout=30000,
+        )
+
+    async def _wait_for_approval():
+        approval_card = page.locator(SEL["approval_card"]).last
+        await approval_card.wait_for(
+            state="visible",
+            timeout=30000,
+        )
+        return approval_card
+
+    assistant_task = asyncio.create_task(_wait_for_assistant())
+    approval_task = asyncio.create_task(_wait_for_approval())
+
+    done, pending = await asyncio.wait(
+        {assistant_task, approval_task},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
+
+    for task in pending:
+        task.cancel()
+    if pending:
+        await asyncio.gather(*pending, return_exceptions=True)
+
+    if assistant_task in done and assistant_task.exception() is None:
+        await assistant_task
+        return
+
+    if approval_task not in done or approval_task.exception() is not None:
+        await assistant_task
+        return
+
+    approval_card = await approval_task
+    await approval_card.locator("button.approve").click()
+    await _wait_for_assistant()
+
+
+async def _open_tab(page, tab: str) -> None:
+    """Switch to a visible top-level tab."""
+    button = page.locator(SEL["tab_button"].format(tab=tab))
+    await button.click()
+    await page.locator(SEL["tab_panel"].format(tab=tab)).wait_for(
+        state="visible",
+        timeout=5000,
     )
 
 
@@ -131,3 +177,65 @@ async def test_full_job_routine_completes_with_tools(page, ironclaw_server):
         assert job["state"].lower() in success_states, (
             f"Expected job state in {success_states}, got '{job['state']}'"
         )
+
+
+async def test_cron_routine_appears_and_can_be_manually_triggered(page, ironclaw_server):
+    """Cron routines should expose schedule metadata and support manual trigger."""
+    name = f"cron-{uuid.uuid4().hex[:8]}"
+
+    await _send_chat_message(page, f"create cron owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    assert routine["trigger_type"] == "cron"
+    assert routine["trigger_raw"] == "0 */5 * * * * *"
+    assert routine["next_fire_at"], f"Expected next_fire_at on cron routine: {routine}"
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    trigger_cell_text = await row.locator("td").nth(1).inner_text()
+    assert trigger_cell_text.strip() == routine["trigger_summary"]
+
+    resp = await api_post(ironclaw_server, f"/api/routines/{routine['id']}/trigger")
+    resp.raise_for_status()
+    assert resp.json()["status"] == "triggered"
+
+    completed_run = await _wait_for_completed_run(ironclaw_server, routine["id"])
+    assert completed_run["trigger_type"] == "manual"
+    assert completed_run["status"].lower() == "attention"
+
+
+async def test_failed_routine_is_visible_in_ui(page, ironclaw_server):
+    """A failed routine should surface failed state and error text in the UI."""
+    name = f"fail-{uuid.uuid4().hex[:8]}"
+    failure_reason = "Response contained no message or tool call"
+
+    await _send_chat_message(page, f"create failing lightweight owner routine {name}")
+    routine = await _wait_for_routine(ironclaw_server, name)
+
+    trigger_response = await api_post(
+        ironclaw_server,
+        f"/api/routines/{routine['id']}/trigger",
+    )
+    trigger_response.raise_for_status()
+    assert trigger_response.json()["status"] == "triggered"
+
+    failed_run = await _wait_for_completed_run(ironclaw_server, routine["id"], timeout=60)
+    assert failed_run["status"].lower() == "failed", failed_run
+    assert failure_reason in failed_run["result_summary"]
+
+    await _open_tab(page, "routines")
+    row = page.locator(SEL["routine_row"]).filter(has_text=name).first
+    await row.wait_for(state="visible", timeout=15000)
+    await row.click()
+
+    detail = page.locator("#routine-detail")
+    await detail.wait_for(state="visible", timeout=10000)
+    await detail.locator(".badge.failed").first.wait_for(state="visible", timeout=10000)
+    assert "failing" in (await detail.locator(".badge.failed").first.inner_text()).lower()
+
+    recent_run_row = detail.locator("table.routines-table tbody tr").first
+    await recent_run_row.wait_for(state="visible", timeout=10000)
+    recent_run_text = await recent_run_row.inner_text()
+    assert "failed" in recent_run_text.lower()
+    assert failure_reason in recent_run_text

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -1,7 +1,8 @@
 """Scenario 6: Tool approval overlay UI behavior."""
 
-import pytest
-from helpers import SEL
+import asyncio
+
+from helpers import SEL, api_get, api_post
 
 
 INJECT_APPROVAL_JS = """
@@ -10,6 +11,60 @@ INJECT_APPROVAL_JS = """
     showApproval(data);
 }
 """
+
+
+async def _create_thread(base_url: str) -> str:
+    response = await api_post(base_url, "/api/chat/thread/new", timeout=15)
+    assert response.status_code == 200, response.text
+    return response.json()["id"]
+
+
+async def _send_chat_message(base_url: str, thread_id: str, content: str) -> None:
+    response = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={"content": content, "thread_id": thread_id},
+        timeout=30,
+    )
+    assert response.status_code == 202, response.text
+
+
+async def _wait_for_history(
+    base_url: str,
+    thread_id: str,
+    *,
+    expect_pending: bool | None = None,
+    response_fragment: str | None = None,
+    turn_count_at_least: int | None = None,
+    timeout: float = 20.0,
+) -> dict:
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        response = await api_get(
+            base_url,
+            f"/api/chat/history?thread_id={thread_id}",
+            timeout=10,
+        )
+        assert response.status_code == 200, response.text
+        history = response.json()
+        pending = history.get("pending_approval")
+        turns = history.get("turns", [])
+        latest_response = turns[-1].get("response") if turns else None
+
+        pending_ok = expect_pending is None or bool(pending) == expect_pending
+        response_ok = response_fragment is None or (
+            latest_response is not None and response_fragment in latest_response
+        )
+        turns_ok = turn_count_at_least is None or len(turns) >= turn_count_at_least
+        if pending_ok and response_ok and turns_ok:
+            return history
+
+        await asyncio.sleep(0.25)
+
+    raise AssertionError(
+        f"Timed out waiting for history state: expect_pending={expect_pending}, "
+        f"response_fragment={response_fragment!r}"
+    )
 
 
 async def test_approval_card_appears(page):
@@ -186,3 +241,73 @@ async def test_waiting_for_approval_message_no_error_prefix(page):
     assert "HTTP requests to external APIs" in msg_text, (
         f"Expected tool description in message. Got: {msg_text!r}"
     )
+
+
+async def test_chat_reply_approve_resumes_pending_tool(ironclaw_server):
+    """A plain chat reply of 'approve' should resume the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-chat")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "approve")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    assert history.get("pending_approval") is None
+    assert history["turns"][-1]["response"] is not None
+
+
+async def test_chat_reply_deny_rejects_pending_tool(ironclaw_server):
+    """A plain chat reply of 'deny' should reject the pending tool call."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-denied")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "deny")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="was rejected",
+        turn_count_at_least=1,
+    )
+
+    response_text = history["turns"][-1]["response"]
+    assert response_text is not None
+    assert "Tool 'http' was rejected" in response_text
+
+
+async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
+    """A plain chat reply of 'always' should auto-approve the same tool next time."""
+    thread_id = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-a")
+    await _wait_for_history(ironclaw_server, thread_id, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_id, "always")
+    await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=1,
+    )
+
+    await _send_chat_message(ironclaw_server, thread_id, "make approval post approval-always-b")
+    history = await _wait_for_history(
+        ironclaw_server,
+        thread_id,
+        expect_pending=False,
+        response_fragment="The http tool returned:",
+        turn_count_at_least=2,
+    )
+
+    assert history.get("pending_approval") is None
+    assert len(history["turns"]) >= 2

--- a/tests/e2e_thread_id_isolation.rs
+++ b/tests/e2e_thread_id_isolation.rs
@@ -48,7 +48,13 @@ mod tests {
         let store = rig.database();
         assert!(
             store
-                .ensure_conversation(foreign_thread_id, "gateway", "victim-user", None)
+                .ensure_conversation(
+                    foreign_thread_id,
+                    "gateway",
+                    "victim-user",
+                    None,
+                    Some("gateway")
+                )
                 .await
                 .expect("failed to create victim conversation"),
             "test setup failed: victim conversation was not created"

--- a/tests/e2e_wasm_github_coercion.rs
+++ b/tests/e2e_wasm_github_coercion.rs
@@ -46,6 +46,37 @@ mod tests {
         }
     }
 
+    fn github_exchange(
+        method: &str,
+        url: &str,
+        body: Option<String>,
+        response_body: &str,
+    ) -> HttpExchange {
+        HttpExchange {
+            request: HttpExchangeRequest {
+                method: method.to_string(),
+                url: url.to_string(),
+                headers: vec![],
+                body,
+            },
+            response: github_ok(response_body),
+        }
+    }
+
+    async fn run_trace(trace: LlmTrace, prompt: &str) {
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
+            .build()
+            .await;
+
+        rig.send_message(prompt).await;
+        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
+        rig.verify_trace_expects(&trace, &responses);
+
+        rig.shutdown();
+    }
+
     /// LLM sends `limit: "50"` (string) to `list_issues`. Coercion converts it
     /// to integer, and the WASM tool must call `GET /repos/.../issues?...&per_page=50`.
     #[tokio::test]
@@ -110,18 +141,7 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
-
-        rig.send_message("List issues in nearai/ironclaw with limit 50")
-            .await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
-
-        rig.shutdown();
+        run_trace(trace, "List issues in nearai/ironclaw with limit 50").await;
     }
 
     /// LLM sends `issue_number: "42"` (string) to `get_issue`. Coercion converts
@@ -186,17 +206,7 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
-
-        rig.send_message("Get issue 42 from nearai/ironclaw").await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
-
-        rig.shutdown();
+        run_trace(trace, "Get issue 42 from nearai/ironclaw").await;
     }
 
     /// LLM sends `limit: "25"` (string) to `list_pull_requests`. URL must
@@ -262,16 +272,449 @@ mod tests {
             steps: Vec::new(),
         };
 
-        let rig = TestRigBuilder::new()
-            .with_trace(trace.clone())
-            .with_wasm_tool("github", GITHUB_WASM, Some(GITHUB_CAPS.into()))
-            .build()
-            .await;
+        run_trace(trace, "List PRs in nearai/ironclaw").await;
+    }
 
-        rig.send_message("List PRs in nearai/ironclaw").await;
-        let responses = rig.wait_for_responses(1, Duration::from_secs(15)).await;
-        rig.verify_trace_expects(&trace, &responses);
+    /// LLM sends pagination as strings to `search_code`. Coercion converts them
+    /// to integers, and the tool must construct the expected search query.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_search_code_coerces_string_pagination() {
+        let expected_url = "https://api.github.com/search/code?q=repo%3Anearai%2Fironclaw%20path%3Asrc%20Tool&per_page=10&page=2&sort=indexed&order=desc";
 
-        rig.shutdown();
+        let trace = LlmTrace {
+            model_name: "test-wasm-coercion-search-code".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Search code in nearai/ironclaw".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_4".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "search_code",
+                                    "query": "repo:nearai/ironclaw path:src Tool",
+                                    "limit": "10",
+                                    "page": "2",
+                                    "sort": "indexed",
+                                    "order": "desc"
+                                }),
+                            }],
+                            input_tokens: 120,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Found matching code results.".to_string(),
+                            input_tokens: 180,
+                            output_tokens: 12,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "GET",
+                expected_url,
+                None,
+                r#"{"total_count":1,"items":[{"name":"lib.rs","path":"src/lib.rs"}]}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Search code in nearai/ironclaw").await;
+    }
+
+    /// `create_repo` must target the org repos endpoint and send the expected
+    /// JSON body for repository creation.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_repo_posts_expected_payload() {
+        let expected_url = "https://api.github.com/orgs/nearai/repos";
+        let expected_body = json!({
+            "name": "github-tool-replay",
+            "private": true,
+            "auto_init": true,
+            "description": "Replay-created repo",
+            "gitignore_template": "Rust",
+            "license_template": "mit"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-repo".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a private repo for nearai".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_5".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_repo",
+                                    "name": "github-tool-replay",
+                                    "description": "Replay-created repo",
+                                    "private": true,
+                                    "auto_init": true,
+                                    "gitignore_template": "Rust",
+                                    "license_template": "mit",
+                                    "org": "nearai"
+                                }),
+                            }],
+                            input_tokens: 110,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Repository created.".to_string(),
+                            input_tokens: 150,
+                            output_tokens: 12,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "POST",
+                expected_url,
+                Some(expected_body),
+                r#"{"name":"github-tool-replay","private":true}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a private repo for nearai").await;
+    }
+
+    /// `create_branch` should fetch the source ref SHA and then create the new
+    /// branch ref in a second request.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_branch_replays_two_step_ref_flow() {
+        let source_ref_url = "https://api.github.com/repos/nearai/ironclaw/git/ref/heads/main";
+        let create_ref_url = "https://api.github.com/repos/nearai/ironclaw/git/refs";
+        let create_ref_body = json!({
+            "ref": "refs/heads/feature/replay-test",
+            "sha": "abc123def4567890abc123def4567890abc123de"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-branch".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a replay branch from main".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_6".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_branch",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "branch": "feature/replay-test",
+                                    "from_ref": "main"
+                                }),
+                            }],
+                            input_tokens: 100,
+                            output_tokens: 35,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Branch created.".to_string(),
+                            input_tokens: 145,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![
+                github_exchange(
+                    "GET",
+                    source_ref_url,
+                    None,
+                    r#"{"ref":"refs/heads/main","object":{"sha":"abc123def4567890abc123def4567890abc123de"}}"#,
+                ),
+                github_exchange(
+                    "POST",
+                    create_ref_url,
+                    Some(create_ref_body),
+                    r#"{"ref":"refs/heads/feature/replay-test"}"#,
+                ),
+            ],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a replay branch from main").await;
+    }
+
+    /// `create_or_update_file` must target the contents API and send base64
+    /// encoded file contents in the request body.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_or_update_file_puts_contents_payload() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/contents/docs/replay.md";
+        let expected_body = json!({
+            "message": "Add replay doc",
+            "content": "IyBSZXBsYXkgZG9jCg==",
+            "branch": "feature/replay-test",
+            "committer": {
+                "name": "IronClaw Bot",
+                "email": "bot@example.com"
+            }
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-or-update-file".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Write docs/replay.md".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_7".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_or_update_file",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "path": "docs/replay.md",
+                                    "message": "Add replay doc",
+                                    "content": "# Replay doc\n",
+                                    "branch": "feature/replay-test",
+                                    "committer": {
+                                        "name": "IronClaw Bot",
+                                        "email": "bot@example.com"
+                                    }
+                                }),
+                            }],
+                            input_tokens: 120,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "File written.".to_string(),
+                            input_tokens: 160,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "PUT",
+                expected_url,
+                Some(expected_body),
+                r#"{"content":{"path":"docs/replay.md"},"commit":{"sha":"deadbeef"}}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Write docs/replay.md").await;
+    }
+
+    /// `delete_file` must call DELETE on the contents endpoint with the blob SHA
+    /// and commit metadata in the request body.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_delete_file_deletes_contents_with_sha() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/contents/docs/replay.md";
+        let expected_body = json!({
+            "message": "Remove replay doc",
+            "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            "branch": "feature/replay-test"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-delete-file".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Delete docs/replay.md".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_8".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "delete_file",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "path": "docs/replay.md",
+                                    "message": "Remove replay doc",
+                                    "sha": "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                                    "branch": "feature/replay-test"
+                                }),
+                            }],
+                            input_tokens: 110,
+                            output_tokens: 36,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "File deleted.".to_string(),
+                            input_tokens: 150,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "DELETE",
+                expected_url,
+                Some(expected_body),
+                r#"{"commit":{"sha":"feedface"}}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Delete docs/replay.md").await;
+    }
+
+    /// `create_release` should post release metadata to the releases endpoint.
+    #[tokio::test]
+    #[ignore] // requires pre-compiled WASM binary
+    async fn wasm_github_create_release_posts_expected_payload() {
+        let expected_url = "https://api.github.com/repos/nearai/ironclaw/releases";
+        let expected_body = json!({
+            "tag_name": "v1.2.3",
+            "draft": false,
+            "prerelease": true,
+            "generate_release_notes": true,
+            "target_commitish": "main",
+            "name": "Replay Release",
+            "body": "Generated during replay testing"
+        })
+        .to_string();
+
+        let trace = LlmTrace {
+            model_name: "test-wasm-create-release".to_string(),
+            turns: vec![crate::support::trace_llm::TraceTurn {
+                user_input: "Create a prerelease".to_string(),
+                steps: vec![
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::ToolCalls {
+                            tool_calls: vec![TraceToolCall {
+                                id: "call_gh_9".to_string(),
+                                name: "github".to_string(),
+                                arguments: json!({
+                                    "action": "create_release",
+                                    "owner": "nearai",
+                                    "repo": "ironclaw",
+                                    "tag_name": "v1.2.3",
+                                    "target_commitish": "main",
+                                    "name": "Replay Release",
+                                    "body": "Generated during replay testing",
+                                    "draft": false,
+                                    "prerelease": true,
+                                    "generate_release_notes": true
+                                }),
+                            }],
+                            input_tokens: 125,
+                            output_tokens: 40,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                    TraceStep {
+                        request_hint: None,
+                        response: TraceResponse::Text {
+                            content: "Release created.".to_string(),
+                            input_tokens: 170,
+                            output_tokens: 10,
+                        },
+                        expected_tool_results: Vec::new(),
+                    },
+                ],
+                expects: TraceExpects::default(),
+            }],
+            memory_snapshot: Vec::new(),
+            http_exchanges: vec![github_exchange(
+                "POST",
+                expected_url,
+                Some(expected_body),
+                r#"{"id":1,"tag_name":"v1.2.3"}"#,
+            )],
+            expects: TraceExpects {
+                tools_used: vec!["github".to_string()],
+                all_tools_succeeded: Some(true),
+                max_tool_calls: Some(1),
+                min_responses: Some(1),
+                ..Default::default()
+            },
+            steps: Vec::new(),
+        };
+
+        run_trace(trace, "Create a prerelease").await;
     }
 }

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -70,6 +70,10 @@ mod tests {
                         "event_source": "github",
                         "event_type": "issue.opened",
                         "event_filters": {"repository": "nearai/ironclaw"},
+                        // This test fires the same routine via event_emit and then the
+                        // webhook endpoint back-to-back, so cooldown must not suppress
+                        // the second path.
+                        "cooldown_secs": 0,
                         "action_type": "lightweight",
                         "prompt": "Summarize webhook and report issue number"
                     }),

--- a/tests/gateway_workflow_integration.rs
+++ b/tests/gateway_workflow_integration.rs
@@ -11,19 +11,49 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod tests {
+    use std::sync::Arc;
     use std::time::Duration;
 
+    use async_trait::async_trait;
     use chrono::Utc;
     use ironclaw::agent::routine::{
         NotifyConfig, Routine, RoutineAction, RoutineGuardrails, Trigger,
         reset_routine_verification_state, routine_verification_fingerprint,
     };
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{Tool, ToolError, ToolOutput};
     use uuid::Uuid;
 
     use crate::support::gateway_workflow_harness::GatewayWorkflowHarness;
     use crate::support::mock_openai_server::{
         MockOpenAiResponse, MockOpenAiRule, MockOpenAiServerBuilder, MockToolCall,
     };
+
+    struct BlockingTool;
+
+    #[async_trait]
+    impl Tool for BlockingTool {
+        fn name(&self) -> &str {
+            "block_once"
+        }
+
+        fn description(&self) -> &str {
+            "Sleeps long enough for cancellation-path integration tests"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type":"object"})
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            tokio::time::sleep(Duration::from_secs(30)).await;
+            Ok(ToolOutput::text("block complete", Duration::from_secs(30)))
+        }
+    }
 
     #[tokio::test]
     async fn gateway_workflow_harness_chat_and_webhook() {
@@ -40,6 +70,10 @@ mod tests {
                         "event_source": "github",
                         "event_type": "issue.opened",
                         "event_filters": {"repository": "nearai/ironclaw"},
+                        // This test fires the same routine via event_emit and then the
+                        // webhook endpoint back-to-back, so cooldown must not suppress
+                        // the second path.
+                        "cooldown_secs": 0,
                         "action_type": "lightweight",
                         "prompt": "Summarize webhook and report issue number"
                     }),
@@ -551,6 +585,166 @@ mod tests {
         assert_eq!(
             after_count, before_count,
             "run count should not increase for disabled routine"
+        );
+
+        harness.shutdown().await;
+        mock.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn cancelling_running_full_job_routine_finalizes_run() {
+        let mock = MockOpenAiServerBuilder::new()
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "create blocking routine",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_create_blocking_1",
+                    "routine_create",
+                    serde_json::json!({
+                        "name": "wf-cancel-full-job",
+                        "description": "Full-job cancellation regression test",
+                        "trigger_type": "manual",
+                        "action_type": "full_job",
+                        "prompt": "Use block_once then finish.",
+                        "max_iterations": 10
+                    }),
+                )]),
+            ))
+            .with_rule(MockOpenAiRule::on_user_contains(
+                "use block_once then finish",
+                MockOpenAiResponse::ToolCalls(vec![MockToolCall::new(
+                    "call_block_once_1",
+                    "block_once",
+                    serde_json::json!({}),
+                )]),
+            ))
+            .with_default_response(MockOpenAiResponse::Text("ack".to_string()))
+            .start()
+            .await;
+
+        let harness =
+            GatewayWorkflowHarness::start_openai_compatible(&mock.openai_base_url(), "mock-model")
+                .await;
+        harness.register_tool(Arc::new(BlockingTool)).await;
+
+        let thread_id = harness.create_thread().await;
+        harness
+            .send_chat(&thread_id, "create blocking routine")
+            .await;
+        harness
+            .wait_for_turns(&thread_id, 1, Duration::from_secs(10))
+            .await;
+
+        let routine = harness
+            .routine_by_name("wf-cancel-full-job")
+            .await
+            .expect("blocking full-job routine should exist");
+        let routine_id = routine["id"].as_str().expect("routine id missing");
+
+        let trigger = harness
+            .client
+            .post(format!(
+                "{}/api/routines/{routine_id}/trigger",
+                harness.base_url()
+            ))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("trigger request failed")
+            .error_for_status()
+            .expect("trigger non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid trigger response");
+        assert_eq!(trigger["status"].as_str(), Some("triggered"));
+
+        let mut job_id = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            if let Some(found_job_id) = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .and_then(|run| run["job_id"].as_str())
+            {
+                job_id = Some(found_job_id.to_string());
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let job_id = job_id.expect("routine run should be linked to a job");
+
+        let mut saw_job_execution_request = false;
+        for _ in 0..50 {
+            if mock.requests().await.len() >= 2 {
+                saw_job_execution_request = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(
+            saw_job_execution_request,
+            "job should issue an execution LLM request before cancellation"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        let cancel_response = harness
+            .client
+            .post(format!("{}/api/jobs/{job_id}/cancel", harness.base_url()))
+            .bearer_auth(&harness.auth_token)
+            .send()
+            .await
+            .expect("cancel request failed")
+            .error_for_status()
+            .expect("cancel non-2xx")
+            .json::<serde_json::Value>()
+            .await
+            .expect("invalid cancel response");
+        assert_eq!(cancel_response["status"].as_str(), Some("cancelled"));
+
+        let mut final_job = None;
+        for _ in 0..100 {
+            let job = harness
+                .client
+                .get(format!("{}/api/jobs/{job_id}", harness.base_url()))
+                .bearer_auth(&harness.auth_token)
+                .send()
+                .await
+                .expect("final job detail request failed")
+                .error_for_status()
+                .expect("final job detail non-2xx")
+                .json::<serde_json::Value>()
+                .await
+                .expect("invalid final job detail");
+            if job["state"].as_str() == Some("cancelled") {
+                final_job = Some(job);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_job = final_job.expect("job should reach cancelled state");
+        assert_eq!(final_job["state"].as_str(), Some("cancelled"));
+
+        let mut final_run = None;
+        for _ in 0..100 {
+            let runs = harness.routine_runs(routine_id).await;
+            let run = runs["runs"]
+                .as_array()
+                .and_then(|runs| runs.first())
+                .cloned()
+                .expect("routine run should exist");
+            if run["status"].as_str() != Some("running") {
+                final_run = Some(run);
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        let final_run = final_run.expect("routine run should reach terminal state");
+        assert_eq!(final_run["status"].as_str(), Some("failed"));
+        assert_eq!(final_run["job_id"].as_str(), Some(job_id.as_str()));
+        assert!(
+            final_run["result_summary"]
+                .as_str()
+                .is_some_and(|summary| summary.contains("finished (failed)")),
+            "expected failed routine summary, got {final_run}"
         );
 
         harness.shutdown().await;

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -488,6 +488,15 @@ impl GatewayWorkflowHarness {
             .expect("invalid routine runs response")
     }
 
+    pub async fn register_tool(&self, tool: Arc<dyn Tool>) {
+        let registry = self
+            .gateway_state
+            .tool_registry
+            .as_ref()
+            .expect("tool registry should be available");
+        registry.register(tool).await;
+    }
+
     pub async fn github_webhook(
         &self,
         event: &str,

--- a/tests/tool_approval_context.rs
+++ b/tests/tool_approval_context.rs
@@ -1,0 +1,287 @@
+//! Tests for tool approval context propagation.
+//!
+//! Verifies that:
+//! - JobContext carries approval_context through the execution chain
+//! - Builder sub-tools use proper approval checks
+//! - Worker checks job-level approval context
+
+use ironclaw::context::JobContext;
+use ironclaw::tools::{
+    ApprovalContext, ApprovalRequirement, Tool, ToolError, ToolOutput, check_approval_in_context,
+};
+
+/// A simple test tool that requires approval.
+#[derive(Debug)]
+struct TestTool {
+    approval_req: ApprovalRequirement,
+}
+
+#[async_trait::async_trait]
+impl Tool for TestTool {
+    fn name(&self) -> &str {
+        "test_tool"
+    }
+
+    fn description(&self) -> &str {
+        "A test tool for approval checking"
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({
+            "type": "object",
+            "properties": {},
+        })
+    }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        Ok(ToolOutput::text("ok", std::time::Duration::from_millis(1)))
+    }
+
+    fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+        self.approval_req
+    }
+}
+
+#[test]
+fn test_job_context_default_has_no_approval_context() {
+    let ctx = JobContext::default();
+    assert!(
+        ctx.approval_context.is_none(),
+        "JobContext::default() should NOT have approval_context set for security"
+    );
+}
+
+#[test]
+fn test_job_context_with_approval_context() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    assert!(ctx.approval_context.is_some());
+}
+
+#[test]
+fn test_approval_context_autonomous_allows_unless_auto_approved() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::UnlessAutoApproved,
+    };
+
+    // Check should pass for UnlessAutoApproved in autonomous context
+    check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("UnlessAutoApproved should be allowed in autonomous context");
+}
+
+#[test]
+fn test_approval_context_autonomous_blocks_always() {
+    let ctx =
+        JobContext::new("Test", "Test job").with_approval_context(ApprovalContext::autonomous());
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // Check should fail for Always in autonomous context without explicit allow
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "Always should be blocked in autonomous context"
+    );
+    assert!(matches!(result, Err(ToolError::NotAuthorized(_))));
+}
+
+#[test]
+fn test_approval_context_autonomous_with_tools_allows_specific() {
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools(["shell".to_string(), "read_file".to_string()]),
+    );
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // shell should be allowed (explicitly listed)
+    check_approval_in_context(
+        &ctx,
+        "shell",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Listed tool should be allowed");
+
+    // read_file should be allowed (explicitly listed)
+    check_approval_in_context(
+        &ctx,
+        "read_file",
+        tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Listed tool should be allowed");
+
+    // write_file should be blocked (not listed)
+    let result = check_approval_in_context(
+        &ctx,
+        "write_file",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(result.is_err(), "Non-listed Always tool should be blocked");
+}
+
+#[test]
+fn test_builder_tools_approval_context() {
+    // Verify the builder creates the correct approval context
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools([
+            "shell".into(),
+            "read_file".into(),
+            "write_file".into(),
+            "list_dir".into(),
+            "apply_patch".into(),
+        ]),
+    );
+
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+
+    // All build tools should be allowed
+    for tool_name in &[
+        "shell",
+        "read_file",
+        "write_file",
+        "list_dir",
+        "apply_patch",
+    ] {
+        check_approval_in_context(
+            &ctx,
+            tool_name,
+            tool.requires_approval(&serde_json::json!({})),
+        )
+        .unwrap_or_else(|e| panic!("Builder tool '{}' should be allowed, got: {}", tool_name, e));
+    }
+
+    // Non-build tools should be blocked
+    let result = check_approval_in_context(
+        &ctx,
+        "create_job",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(result.is_err(), "Non-build Always tool should be blocked");
+}
+
+#[test]
+fn test_default_context_blocks_non_never_tools() {
+    // JobContext::default() has no approval_context, which should block
+    // all non-Never tools (secure default)
+    let ctx = JobContext::default();
+
+    let tool = TestTool {
+        approval_req: ApprovalRequirement::UnlessAutoApproved,
+    };
+
+    // UnlessAutoApproved should be blocked with no approval_context
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "UnlessAutoApproved should be blocked with no approval_context"
+    );
+
+    let always_tool = TestTool {
+        approval_req: ApprovalRequirement::Always,
+    };
+    let result = check_approval_in_context(
+        &ctx,
+        "test_tool",
+        always_tool.requires_approval(&serde_json::json!({})),
+    );
+    assert!(
+        result.is_err(),
+        "Always should be blocked with no approval_context"
+    );
+
+    // Never should still be allowed
+    let never_tool = TestTool {
+        approval_req: ApprovalRequirement::Never,
+    };
+    check_approval_in_context(
+        &ctx,
+        "test_tool",
+        never_tool.requires_approval(&serde_json::json!({})),
+    )
+    .expect("Never should be allowed even with no approval_context");
+}
+
+#[test]
+fn test_never_tools_allowed_in_additive_model() {
+    // Never tools (echo, time, etc.) should always be allowed regardless of
+    // approval context configuration - they don't need to be in the allowlist.
+    let ctx = JobContext::new("Test", "Test job").with_approval_context(
+        ApprovalContext::autonomous_with_tools(["shell".to_string()]),
+    );
+
+    // A Never tool not in the allowlist should still be allowed
+    check_approval_in_context(&ctx, "echo", ApprovalRequirement::Never)
+        .expect("Never tools should pass without being in the allowlist");
+
+    // And of course a Never tool in the allowlist should also be allowed
+    check_approval_in_context(&ctx, "shell", ApprovalRequirement::Never)
+        .expect("Never tools in the allowlist should also pass");
+
+    // But an Always tool not in the allowlist should be blocked
+    let result = check_approval_in_context(&ctx, "echo", ApprovalRequirement::Always);
+    assert!(
+        result.is_err(),
+        "Always tools NOT in allowlist should be blocked"
+    );
+}
+
+#[test]
+fn test_builder_execute_build_tool_blocks_unlisted_tool() {
+    // The builder creates a context with specific allowed tools.
+    // Tools NOT in the builder's allowlist should be blocked.
+    let builder_ctx = JobContext::new("Build", "Building software").with_approval_context(
+        ApprovalContext::autonomous_with_tools([
+            "shell".into(),
+            "read_file".into(),
+            "write_file".into(),
+            "list_dir".into(),
+            "apply_patch".into(),
+        ]),
+    );
+
+    // Builder-allowed tools should pass
+    for tool_name in &[
+        "shell",
+        "read_file",
+        "write_file",
+        "list_dir",
+        "apply_patch",
+    ] {
+        check_approval_in_context(&builder_ctx, tool_name, ApprovalRequirement::Always)
+            .unwrap_or_else(|e| {
+                panic!("Builder tool '{}' should be allowed, got: {}", tool_name, e)
+            });
+    }
+
+    // Tools NOT in builder's allowlist should be blocked (e.g., http, create_job, message)
+    for tool_name in &["http", "create_job", "message", "secret_save"] {
+        let result =
+            check_approval_in_context(&builder_ctx, tool_name, ApprovalRequirement::Always);
+        assert!(
+            result.is_err(),
+            "Tool '{}' should be blocked by builder context (not in allowlist)",
+            tool_name
+        );
+    }
+}

--- a/tools-src/github/Cargo.toml
+++ b/tools-src/github/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "github-tool"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 description = "GitHub integration tool for IronClaw (WASM component)"
 license = "MIT OR Apache-2.0"
 publish = false
 
 [dependencies]
+base64 = "0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 wit-bindgen = "0.41.0"

--- a/tools-src/github/README.md
+++ b/tools-src/github/README.md
@@ -1,13 +1,17 @@
 # GitHub Tool for IronClaw
 
-WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
+WASM tool for GitHub integration. It covers repositories, issues, pull requests,
+search, branches, file reads and writes, releases, and workflows.
 
 ## Features
 
-- **Repository Info** - Get repo details, list user repos
+- **Repositories** - Get repo details, list user repos, create repositories
+- **Search** - Search repositories, code, and issues/PRs
+- **Branches** - List branches and create new branches from an existing ref
 - **Issues** - List/create/get issues, list/add issue comments
 - **Pull Requests** - List/create/get PRs, review files, create reviews, list/reply review comments, merge PRs
-- **File Content** - Read files from repos
+- **File Content** - Read files and create/update/delete repository files
+- **Releases** - List releases and create new releases
 - **Workflows** - Trigger GitHub Actions, check run status
 
 ## Setup
@@ -29,6 +33,18 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "action": "get_repo",
   "owner": "nearai",
   "repo": "ironclaw"
+}
+```
+
+### Create Repository
+
+```json
+{
+  "action": "create_repo",
+  "name": "infra-playground",
+  "description": "Scratch repo for release automation",
+  "private": true,
+  "auto_init": true
 }
 ```
 
@@ -66,6 +82,26 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "repo": "ironclaw",
   "state": "open",
   "limit": 5
+}
+```
+
+### Search Code
+
+```json
+{
+  "action": "search_code",
+  "query": "repo:nearai/ironclaw tool_info",
+  "limit": 5
+}
+```
+
+### Search Issues and Pull Requests
+
+```json
+{
+  "action": "search_issues_pull_requests",
+  "query": "repo:nearai/ironclaw is:pr label:bug",
+  "limit": 10
 }
 ```
 
@@ -187,6 +223,81 @@ WASM tool for GitHub integration - manage repos, issues, PRs, and workflows.
   "repo": "ironclaw",
   "path": "README.md",
   "ref": "main"
+}
+```
+
+### Create or Update a File
+
+```json
+{
+  "action": "create_or_update_file",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "path": "docs/example.txt",
+  "message": "docs: add example",
+  "content": "Hello from IronClaw"
+}
+```
+
+When updating an existing file, include the current blob `sha`.
+
+### Delete a File
+
+```json
+{
+  "action": "delete_file",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "path": "docs/example.txt",
+  "message": "docs: remove example",
+  "sha": "0123456789abcdef0123456789abcdef01234567"
+}
+```
+
+### List Branches
+
+```json
+{
+  "action": "list_branches",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "limit": 20
+}
+```
+
+### Create Branch
+
+```json
+{
+  "action": "create_branch",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "branch": "feature/github-tool-audit",
+  "from_ref": "main"
+}
+```
+
+### List Releases
+
+```json
+{
+  "action": "list_releases",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "limit": 10
+}
+```
+
+### Create Release
+
+```json
+{
+  "action": "create_release",
+  "owner": "nearai",
+  "repo": "ironclaw",
+  "tag_name": "v1.2.3",
+  "name": "v1.2.3",
+  "generate_release_notes": true
 }
 ```
 

--- a/tools-src/github/github-tool.capabilities.json
+++ b/tools-src/github/github-tool.capabilities.json
@@ -1,7 +1,45 @@
 {
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
-  "description": "Manage GitHub repositories, issues, pull requests, reviews, and workflows. Supports listing, creating, commenting, merging PRs, and triggering GitHub Actions.",
+  "description": "Manage GitHub repositories, issues, pull requests, search, branches, file reads and writes, releases, and workflows.",
+  "discovery_summary": {
+    "always_required": [
+      "action"
+    ],
+    "conditional_requirements": [
+      "Repository-scoped actions require `owner` and `repo`.",
+      "Search actions require `query`.",
+      "File write actions require `path` and `message`; updates additionally need `sha`.",
+      "Workflow dispatch requires `workflow_id` and `ref`.",
+      "Branch creation requires `branch` and `from_ref`."
+    ],
+    "notes": [
+      "Use `tool_info(name: \"github\", detail: \"schema\")` for the full action schema before guessing fields.",
+      "Supported families: repositories, issues, pull requests, reviews/comments, search, branches, code reads, file writes, releases, workflow dispatch/runs, and webhook normalization.",
+      "Not supported yet: forks, labels, milestones, projects, org/team admin, GraphQL, release asset uploads, and repository deletion."
+    ],
+    "examples": [
+      {
+        "action": "create_repo",
+        "name": "infra-playground",
+        "private": true,
+        "auto_init": true
+      },
+      {
+        "action": "search_code",
+        "query": "repo:nearai/ironclaw tool_info",
+        "limit": 5
+      },
+      {
+        "action": "create_or_update_file",
+        "owner": "nearai",
+        "repo": "ironclaw",
+        "path": "docs/example.txt",
+        "message": "docs: add example",
+        "content": "Hello from IronClaw"
+      }
+    ]
+  },
   "capabilities": {
     "webhook": {
       "hmac_secret_name": "github_webhook_secret",
@@ -16,7 +54,8 @@
           "methods": [
             "GET",
             "POST",
-            "PUT"
+            "PUT",
+            "DELETE"
           ]
         }
       ],

--- a/tools-src/github/src/lib.rs
+++ b/tools-src/github/src/lib.rs
@@ -20,6 +20,8 @@ wit_bindgen::generate!({
 
 use std::collections::HashMap;
 
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine as _;
 use serde::{Deserialize, Serialize};
 
 const MAX_TEXT_LENGTH: usize = 65536;
@@ -63,7 +65,129 @@ fn url_encode_query(s: &str) -> String {
 /// Validate that a path segment doesn't contain dangerous characters.
 /// Returns true if the segment is safe to use.
 fn validate_path_segment(s: &str) -> bool {
-    !s.is_empty() && !s.contains('/') && !s.contains("..") && !s.contains('?') && !s.contains('#')
+    !s.is_empty()
+        && !s.contains('/')
+        && !s.contains("..")
+        && !s.contains('?')
+        && !s.contains('#')
+        && !s.chars().any(|c| c.is_control() || c.is_whitespace())
+}
+
+fn validate_repo_path(path: &str) -> Result<(), String> {
+    validate_input_length(path, "path")?;
+    for segment in path.split('/') {
+        if segment == ".." {
+            return Err("Invalid path: path traversal not allowed".into());
+        }
+        if segment.is_empty() {
+            return Err("Invalid path: empty segment not allowed".into());
+        }
+    }
+    Ok(())
+}
+
+fn encode_repo_path(path: &str) -> String {
+    path.split('/')
+        .map(url_encode_path)
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn validate_git_ref(ref_name: &str, field_name: &str) -> Result<(), String> {
+    if ref_name.is_empty() {
+        return Err(format!("Invalid {field_name}: cannot be empty"));
+    }
+    if ref_name.contains("..")
+        || ref_name.contains(':')
+        || ref_name.contains('?')
+        || ref_name.contains('[')
+        || ref_name.contains('\\')
+        || ref_name.contains('^')
+        || ref_name.contains('~')
+        || ref_name.contains("@{")
+        || ref_name.contains("//")
+        || ref_name.starts_with('/')
+        || ref_name.ends_with('/')
+        || ref_name.starts_with('.')
+        || ref_name.ends_with('.')
+        || ref_name.ends_with(".lock")
+        || ref_name.chars().any(|c| c.is_control() || c == ' ')
+    {
+        return Err(format!(
+            "Invalid {field_name}: must be a valid branch, tag, or ref name"
+        ));
+    }
+    Ok(())
+}
+
+fn normalize_ref_lookup(ref_name: &str) -> Result<String, String> {
+    validate_git_ref(ref_name, "from_ref")?;
+    if let Some(stripped) = ref_name.strip_prefix("refs/heads/") {
+        return Ok(format!("heads/{stripped}"));
+    }
+    if let Some(stripped) = ref_name.strip_prefix("refs/tags/") {
+        return Ok(format!("tags/{stripped}"));
+    }
+    if ref_name.starts_with("refs/") {
+        return Err(
+            "Unsupported from_ref: only refs/heads/* and refs/tags/* are supported".to_string(),
+        );
+    }
+    if ref_name.starts_with("heads/") || ref_name.starts_with("tags/") {
+        return Ok(ref_name.to_string());
+    }
+    Ok(format!("heads/{ref_name}"))
+}
+
+fn normalize_branch_ref(branch: &str) -> Result<String, String> {
+    validate_git_ref(branch, "branch")?;
+    if branch.starts_with("refs/heads/") {
+        return Ok(branch.to_string());
+    }
+    if branch.starts_with("refs/") {
+        return Err("Invalid branch ref: only refs/heads/* is allowed".to_string());
+    }
+    let branch = branch.strip_prefix("heads/").unwrap_or(branch);
+    if branch.starts_with("tags/") {
+        return Err("Invalid branch ref: tags/* is not a branch".to_string());
+    }
+    Ok(format!("refs/heads/{branch}"))
+}
+
+fn append_search_params(
+    path: &mut String,
+    page: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<(), String> {
+    if let Some(p) = page {
+        path.push_str(&format!("&page={p}"));
+    }
+    if let Some(sort) = sort {
+        validate_input_length(sort, "sort")?;
+        path.push_str("&sort=");
+        path.push_str(&url_encode_query(sort));
+    }
+    if let Some(order) = order {
+        if !matches!(order, "asc" | "desc") {
+            return Err("Invalid order: must be 'asc' or 'desc'".into());
+        }
+        path.push_str("&order=");
+        path.push_str(order);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct GitCommitIdentity {
+    name: String,
+    email: String,
+}
+
+fn validate_commit_identity(identity: &GitCommitIdentity, field_name: &str) -> Result<(), String> {
+    validate_input_length(&identity.name, &format!("{field_name}.name"))?;
+    validate_input_length(&identity.email, &format!("{field_name}.email"))?;
+    Ok(())
 }
 
 struct GitHubTool;
@@ -73,6 +197,16 @@ struct GitHubTool;
 enum GitHubAction {
     #[serde(rename = "get_repo")]
     GetRepo { owner: String, repo: String },
+    #[serde(rename = "create_repo")]
+    CreateRepo {
+        name: String,
+        description: Option<String>,
+        private: Option<bool>,
+        auto_init: Option<bool>,
+        gitignore_template: Option<String>,
+        license_template: Option<String>,
+        org: Option<String>,
+    },
     #[serde(rename = "list_issues")]
     ListIssues {
         owner: String,
@@ -192,12 +326,93 @@ enum GitHubAction {
         page: Option<u32>,
         limit: Option<u32>,
     },
+    #[serde(rename = "search_repositories")]
+    SearchRepositories {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "search_code")]
+    SearchCode {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "search_issues_pull_requests")]
+    SearchIssuesPullRequests {
+        query: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+        sort: Option<String>,
+        order: Option<String>,
+    },
+    #[serde(rename = "list_branches")]
+    ListBranches {
+        owner: String,
+        repo: String,
+        protected: Option<bool>,
+        page: Option<u32>,
+        limit: Option<u32>,
+    },
+    #[serde(rename = "create_branch")]
+    CreateBranch {
+        owner: String,
+        repo: String,
+        branch: String,
+        from_ref: String,
+    },
     #[serde(rename = "get_file_content")]
     GetFileContent {
         owner: String,
         repo: String,
         path: String,
         r#ref: Option<String>,
+    },
+    #[serde(rename = "create_or_update_file")]
+    CreateOrUpdateFile {
+        owner: String,
+        repo: String,
+        path: String,
+        message: String,
+        content: String,
+        sha: Option<String>,
+        branch: Option<String>,
+        committer: Option<GitCommitIdentity>,
+        author: Option<GitCommitIdentity>,
+    },
+    #[serde(rename = "delete_file")]
+    DeleteFile {
+        owner: String,
+        repo: String,
+        path: String,
+        message: String,
+        sha: String,
+        branch: Option<String>,
+        committer: Option<GitCommitIdentity>,
+        author: Option<GitCommitIdentity>,
+    },
+    #[serde(rename = "list_releases")]
+    ListReleases {
+        owner: String,
+        repo: String,
+        page: Option<u32>,
+        limit: Option<u32>,
+    },
+    #[serde(rename = "create_release")]
+    CreateRelease {
+        owner: String,
+        repo: String,
+        tag_name: String,
+        target_commitish: Option<String>,
+        name: Option<String>,
+        body: Option<String>,
+        draft: Option<bool>,
+        prerelease: Option<bool>,
+        generate_release_notes: Option<bool>,
     },
     #[serde(rename = "trigger_workflow")]
     TriggerWorkflow {
@@ -259,9 +474,8 @@ impl exports::near::agent::tool::Guest for GitHubTool {
     }
 
     fn description() -> String {
-        "GitHub integration for managing repositories, issues, pull requests, \
-         and workflows. Supports reading repo info, listing/creating issues, \
-         reviewing PRs, and triggering GitHub Actions. \
+        "GitHub integration for repositories, issues, pull requests, search, \
+         branches, file reads and writes, releases, and workflows. \
          Authentication is handled via the 'github_token' secret injected by the host."
             .to_string()
     }
@@ -277,6 +491,23 @@ fn execute_inner(params: &str) -> Result<String, String> {
 
     match action {
         GitHubAction::GetRepo { owner, repo } => get_repo(&owner, &repo),
+        GitHubAction::CreateRepo {
+            name,
+            description,
+            private,
+            auto_init,
+            gitignore_template,
+            license_template,
+            org,
+        } => create_repo(
+            &name,
+            description.as_deref(),
+            private.unwrap_or(false),
+            auto_init.unwrap_or(false),
+            gitignore_template.as_deref(),
+            license_template.as_deref(),
+            org.as_deref(),
+        ),
         GitHubAction::ListIssues {
             owner,
             repo,
@@ -393,12 +624,113 @@ fn execute_inner(params: &str) -> Result<String, String> {
             page,
             limit,
         } => list_repos(&username, page, limit),
+        GitHubAction::SearchRepositories {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_repositories(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::SearchCode {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_code(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::SearchIssuesPullRequests {
+            query,
+            page,
+            limit,
+            sort,
+            order,
+        } => search_issues_pull_requests(&query, page, limit, sort.as_deref(), order.as_deref()),
+        GitHubAction::ListBranches {
+            owner,
+            repo,
+            protected,
+            page,
+            limit,
+        } => list_branches(&owner, &repo, protected, page, limit),
+        GitHubAction::CreateBranch {
+            owner,
+            repo,
+            branch,
+            from_ref,
+        } => create_branch(&owner, &repo, &branch, &from_ref),
         GitHubAction::GetFileContent {
             owner,
             repo,
             path,
             r#ref,
         } => get_file_content(&owner, &repo, &path, r#ref.as_deref()),
+        GitHubAction::CreateOrUpdateFile {
+            owner,
+            repo,
+            path,
+            message,
+            content,
+            sha,
+            branch,
+            committer,
+            author,
+        } => create_or_update_file(
+            &owner,
+            &repo,
+            &path,
+            &message,
+            &content,
+            sha.as_deref(),
+            branch.as_deref(),
+            committer,
+            author,
+        ),
+        GitHubAction::DeleteFile {
+            owner,
+            repo,
+            path,
+            message,
+            sha,
+            branch,
+            committer,
+            author,
+        } => delete_file(
+            &owner,
+            &repo,
+            &path,
+            &message,
+            &sha,
+            branch.as_deref(),
+            committer,
+            author,
+        ),
+        GitHubAction::ListReleases {
+            owner,
+            repo,
+            page,
+            limit,
+        } => list_releases(&owner, &repo, page, limit),
+        GitHubAction::CreateRelease {
+            owner,
+            repo,
+            tag_name,
+            target_commitish,
+            name,
+            body,
+            draft,
+            prerelease,
+            generate_release_notes,
+        } => create_release(
+            &owner,
+            &repo,
+            &tag_name,
+            target_commitish.as_deref(),
+            name.as_deref(),
+            body.as_deref(),
+            draft.unwrap_or(false),
+            prerelease.unwrap_or(false),
+            generate_release_notes.unwrap_or(false),
+        ),
         GitHubAction::TriggerWorkflow {
             owner,
             repo,
@@ -435,7 +767,7 @@ fn github_request(method: &str, path: &str, body: Option<String>) -> Result<Stri
     // via the `http-wrapper` proxy based on the `github_token` secret.
     let headers = serde_json::json!({
         "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28",
+        "X-GitHub-Api-Version": "2026-03-10",
         "User-Agent": "IronClaw-GitHub-Tool"
     });
 
@@ -533,6 +865,58 @@ fn get_repo(owner: &str, repo: &str) -> Result<String, String> {
         &format!("/repos/{}/{}", encoded_owner, encoded_repo),
         None,
     )
+}
+
+fn create_repo(
+    name: &str,
+    description: Option<&str>,
+    private: bool,
+    auto_init: bool,
+    gitignore_template: Option<&str>,
+    license_template: Option<&str>,
+    org: Option<&str>,
+) -> Result<String, String> {
+    if !validate_path_segment(name) {
+        return Err("Invalid repository name".into());
+    }
+    validate_input_length(name, "name")?;
+    if let Some(description) = description {
+        validate_input_length(description, "description")?;
+    }
+    if let Some(template) = gitignore_template {
+        validate_input_length(template, "gitignore_template")?;
+    }
+    if let Some(template) = license_template {
+        validate_input_length(template, "license_template")?;
+    }
+    if let Some(org) = org {
+        if !validate_path_segment(org) {
+            return Err("Invalid org name".into());
+        }
+    }
+
+    let path = if let Some(org) = org {
+        format!("/orgs/{}/repos", url_encode_path(org))
+    } else {
+        "/user/repos".to_string()
+    };
+
+    let mut req_body = serde_json::json!({
+        "name": name,
+        "private": private,
+        "auto_init": auto_init,
+    });
+    if let Some(description) = description {
+        req_body["description"] = serde_json::json!(description);
+    }
+    if let Some(template) = gitignore_template {
+        req_body["gitignore_template"] = serde_json::json!(template);
+    }
+    if let Some(template) = license_template {
+        req_body["license_template"] = serde_json::json!(template);
+    }
+
+    github_request("POST", &path, Some(req_body.to_string()))
 }
 
 fn list_issues(
@@ -916,6 +1300,119 @@ fn list_repos(username: &str, page: Option<u32>, limit: Option<u32>) -> Result<S
     github_request("GET", &path, None)
 }
 
+fn search_repositories(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/repositories?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn search_code(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/code?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn search_issues_pull_requests(
+    query: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+    sort: Option<&str>,
+    order: Option<&str>,
+) -> Result<String, String> {
+    validate_input_length(query, "query")?;
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/search/issues?q={}&per_page={}",
+        url_encode_query(query),
+        limit
+    );
+    append_search_params(&mut path, page, sort, order)?;
+    github_request("GET", &path, None)
+}
+
+fn list_branches(
+    owner: &str,
+    repo: &str,
+    protected: Option<bool>,
+    page: Option<u32>,
+    limit: Option<u32>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/repos/{}/{}/branches?per_page={}",
+        encoded_owner, encoded_repo, limit
+    );
+    if let Some(protected) = protected {
+        path.push_str("&protected=");
+        path.push_str(if protected { "true" } else { "false" });
+    }
+    if let Some(page) = page {
+        path.push_str(&format!("&page={page}"));
+    }
+    github_request("GET", &path, None)
+}
+
+fn create_branch(owner: &str, repo: &str, branch: &str, from_ref: &str) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_input_length(branch, "branch")?;
+    validate_input_length(from_ref, "from_ref")?;
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let source_ref = normalize_ref_lookup(from_ref)?;
+    let source_path = format!(
+        "/repos/{}/{}/git/ref/{}",
+        encoded_owner,
+        encoded_repo,
+        encode_repo_path(&source_ref)
+    );
+    let source_ref_resp = github_request("GET", &source_path, None)?;
+    let source_ref_json: serde_json::Value = serde_json::from_str(&source_ref_resp)
+        .map_err(|e| format!("Invalid GitHub response for source ref: {e}"))?;
+    let sha = source_ref_json
+        .pointer("/object/sha")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| "Source ref response missing object.sha".to_string())?;
+
+    let req_body = serde_json::json!({
+        "ref": normalize_branch_ref(branch)?,
+        "sha": sha,
+    });
+    let path = format!("/repos/{}/{}/git/refs", encoded_owner, encoded_repo);
+    github_request("POST", &path, Some(req_body.to_string()))
+}
+
 fn get_file_content(
     owner: &str,
     repo: &str,
@@ -925,29 +1422,14 @@ fn get_file_content(
     if !validate_path_segment(owner) || !validate_path_segment(repo) {
         return Err("Invalid owner or repo name".into());
     }
-    // Validate path segments - reject path traversal attempts and empty segments
-    for segment in path.split('/') {
-        if segment == ".." {
-            return Err("Invalid path: path traversal not allowed".into());
-        }
-        if segment.is_empty() {
-            return Err("Invalid path: empty segment not allowed".into());
-        }
-    }
+    validate_repo_path(path)?;
     // Validate ref if provided
     if let Some(r#ref) = r#ref {
-        if r#ref.contains("..") || r#ref.contains(':') {
-            return Err("Invalid ref: must be a valid branch, tag, or commit SHA".into());
-        }
+        validate_git_ref(r#ref, "ref")?;
     }
     let encoded_owner = url_encode_path(owner);
     let encoded_repo = url_encode_path(repo);
-    // Path can contain slashes, so we encode each segment separately
-    let encoded_path = path
-        .split('/')
-        .map(url_encode_path)
-        .collect::<Vec<_>>()
-        .join("/");
+    let encoded_path = encode_repo_path(path);
 
     let url_path = if let Some(r#ref) = r#ref {
         let encoded_ref = url_encode_query(r#ref);
@@ -962,6 +1444,186 @@ fn get_file_content(
         )
     };
     github_request("GET", &url_path, None)
+}
+
+fn create_or_update_file(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    message: &str,
+    content: &str,
+    sha: Option<&str>,
+    branch: Option<&str>,
+    committer: Option<GitCommitIdentity>,
+    author: Option<GitCommitIdentity>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_repo_path(path)?;
+    validate_input_length(message, "message")?;
+    validate_input_length(content, "content")?;
+    if let Some(branch) = branch {
+        validate_git_ref(branch, "branch")?;
+    }
+    if let Some(sha) = sha {
+        validate_input_length(sha, "sha")?;
+    }
+    if let Some(committer) = &committer {
+        validate_commit_identity(committer, "committer")?;
+    }
+    if let Some(author) = &author {
+        validate_commit_identity(author, "author")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let encoded_path = encode_repo_path(path);
+    let mut req_body = serde_json::json!({
+        "message": message,
+        "content": BASE64_STANDARD.encode(content.as_bytes()),
+    });
+    if let Some(sha) = sha {
+        req_body["sha"] = serde_json::json!(sha);
+    }
+    if let Some(branch) = branch {
+        req_body["branch"] = serde_json::json!(branch);
+    }
+    if let Some(committer) = committer {
+        req_body["committer"] =
+            serde_json::to_value(committer).map_err(|e| format!("Invalid committer: {e}"))?;
+    }
+    if let Some(author) = author {
+        req_body["author"] =
+            serde_json::to_value(author).map_err(|e| format!("Invalid author: {e}"))?;
+    }
+
+    let path = format!(
+        "/repos/{}/{}/contents/{}",
+        encoded_owner, encoded_repo, encoded_path
+    );
+    github_request("PUT", &path, Some(req_body.to_string()))
+}
+
+fn delete_file(
+    owner: &str,
+    repo: &str,
+    path: &str,
+    message: &str,
+    sha: &str,
+    branch: Option<&str>,
+    committer: Option<GitCommitIdentity>,
+    author: Option<GitCommitIdentity>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_repo_path(path)?;
+    validate_input_length(message, "message")?;
+    validate_input_length(sha, "sha")?;
+    if let Some(branch) = branch {
+        validate_git_ref(branch, "branch")?;
+    }
+    if let Some(committer) = &committer {
+        validate_commit_identity(committer, "committer")?;
+    }
+    if let Some(author) = &author {
+        validate_commit_identity(author, "author")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let encoded_path = encode_repo_path(path);
+    let mut req_body = serde_json::json!({
+        "message": message,
+        "sha": sha,
+    });
+    if let Some(branch) = branch {
+        req_body["branch"] = serde_json::json!(branch);
+    }
+    if let Some(committer) = committer {
+        req_body["committer"] =
+            serde_json::to_value(committer).map_err(|e| format!("Invalid committer: {e}"))?;
+    }
+    if let Some(author) = author {
+        req_body["author"] =
+            serde_json::to_value(author).map_err(|e| format!("Invalid author: {e}"))?;
+    }
+
+    let path = format!(
+        "/repos/{}/{}/contents/{}",
+        encoded_owner, encoded_repo, encoded_path
+    );
+    github_request("DELETE", &path, Some(req_body.to_string()))
+}
+
+fn list_releases(
+    owner: &str,
+    repo: &str,
+    page: Option<u32>,
+    limit: Option<u32>,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let limit = limit.unwrap_or(30).min(100);
+    let mut path = format!(
+        "/repos/{}/{}/releases?per_page={}",
+        encoded_owner, encoded_repo, limit
+    );
+    if let Some(page) = page {
+        path.push_str(&format!("&page={page}"));
+    }
+    github_request("GET", &path, None)
+}
+
+fn create_release(
+    owner: &str,
+    repo: &str,
+    tag_name: &str,
+    target_commitish: Option<&str>,
+    name: Option<&str>,
+    body: Option<&str>,
+    draft: bool,
+    prerelease: bool,
+    generate_release_notes: bool,
+) -> Result<String, String> {
+    if !validate_path_segment(owner) || !validate_path_segment(repo) {
+        return Err("Invalid owner or repo name".into());
+    }
+    validate_git_ref(tag_name, "tag_name")?;
+    if let Some(target_commitish) = target_commitish {
+        validate_git_ref(target_commitish, "target_commitish")?;
+    }
+    if let Some(name) = name {
+        validate_input_length(name, "name")?;
+    }
+    if let Some(body) = body {
+        validate_input_length(body, "body")?;
+    }
+
+    let encoded_owner = url_encode_path(owner);
+    let encoded_repo = url_encode_path(repo);
+    let path = format!("/repos/{}/{}/releases", encoded_owner, encoded_repo);
+    let mut req_body = serde_json::json!({
+        "tag_name": tag_name,
+        "draft": draft,
+        "prerelease": prerelease,
+        "generate_release_notes": generate_release_notes,
+    });
+    if let Some(target_commitish) = target_commitish {
+        req_body["target_commitish"] = serde_json::json!(target_commitish);
+    }
+    if let Some(name) = name {
+        req_body["name"] = serde_json::json!(name);
+    }
+    if let Some(body) = body {
+        req_body["body"] = serde_json::json!(body);
+    }
+
+    github_request("POST", &path, Some(req_body.to_string()))
 }
 
 fn trigger_workflow(
@@ -1288,6 +1950,19 @@ const SCHEMA: &str = r#"{
         },
         {
             "properties": {
+                "action": { "const": "create_repo" },
+                "name": { "type": "string", "description": "New repository name" },
+                "description": { "type": "string" },
+                "private": { "type": "boolean", "default": false },
+                "auto_init": { "type": "boolean", "default": false },
+                "gitignore_template": { "type": "string" },
+                "license_template": { "type": "string" },
+                "org": { "type": "string", "description": "Optional organization name; omit to create under the authenticated user" }
+            },
+            "required": ["action", "name"]
+        },
+        {
+            "properties": {
                 "action": { "const": "list_issues" },
                 "owner": { "type": "string" },
                 "repo": { "type": "string" },
@@ -1446,9 +2121,64 @@ const SCHEMA: &str = r#"{
             "properties": {
                 "action": { "const": "list_repos" },
                 "username": { "type": "string" },
+                "page": { "type": "integer" },
                 "limit": { "type": "integer", "default": 30 }
             },
             "required": ["action", "username"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_repositories" },
+                "query": { "type": "string", "description": "GitHub repository search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_code" },
+                "query": { "type": "string", "description": "GitHub code search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "search_issues_pull_requests" },
+                "query": { "type": "string", "description": "GitHub issue/PR search query" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 },
+                "sort": { "type": "string" },
+                "order": { "type": "string", "enum": ["asc", "desc"] }
+            },
+            "required": ["action", "query"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_branches" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "protected": { "type": "boolean" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 }
+            },
+            "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_branch" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "branch": { "type": "string", "description": "New branch name" },
+                "from_ref": { "type": "string", "description": "Source branch or tag to branch from" }
+            },
+            "required": ["action", "owner", "repo", "branch", "from_ref"]
         },
         {
             "properties": {
@@ -1459,6 +2189,88 @@ const SCHEMA: &str = r#"{
                 "ref": { "type": "string", "description": "Branch/commit (default: default branch)" }
             },
             "required": ["action", "owner", "repo", "path"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_or_update_file" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "path": { "type": "string", "description": "File path in repo" },
+                "message": { "type": "string", "description": "Commit message" },
+                "content": { "type": "string", "description": "Raw UTF-8 file content; the tool base64-encodes it for GitHub" },
+                "sha": { "type": "string", "description": "Required when updating an existing file" },
+                "branch": { "type": "string" },
+                "committer": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                },
+                "author": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                }
+            },
+            "required": ["action", "owner", "repo", "path", "message", "content"]
+        },
+        {
+            "properties": {
+                "action": { "const": "delete_file" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "path": { "type": "string", "description": "File path in repo" },
+                "message": { "type": "string", "description": "Commit message" },
+                "sha": { "type": "string", "description": "Blob SHA of the file to delete" },
+                "branch": { "type": "string" },
+                "committer": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                },
+                "author": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "email": { "type": "string" }
+                    },
+                    "required": ["name", "email"]
+                }
+            },
+            "required": ["action", "owner", "repo", "path", "message", "sha"]
+        },
+        {
+            "properties": {
+                "action": { "const": "list_releases" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "page": { "type": "integer" },
+                "limit": { "type": "integer", "default": 30 }
+            },
+            "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "create_release" },
+                "owner": { "type": "string" },
+                "repo": { "type": "string" },
+                "tag_name": { "type": "string" },
+                "target_commitish": { "type": "string" },
+                "name": { "type": "string" },
+                "body": { "type": "string" },
+                "draft": { "type": "boolean", "default": false },
+                "prerelease": { "type": "boolean", "default": false },
+                "generate_release_notes": { "type": "boolean", "default": false }
+            },
+            "required": ["action", "owner", "repo", "tag_name"]
         },
         {
             "properties": {
@@ -1480,6 +2292,26 @@ const SCHEMA: &str = r#"{
                 "limit": { "type": "integer", "default": 30 }
             },
             "required": ["action", "owner", "repo"]
+        },
+        {
+            "properties": {
+                "action": { "const": "handle_webhook" },
+                "webhook": {
+                    "type": "object",
+                    "properties": {
+                        "headers": {
+                            "type": "object",
+                            "additionalProperties": { "type": "string" }
+                        },
+                        "body_json": {
+                            "type": "object",
+                            "description": "Parsed GitHub webhook JSON payload"
+                        }
+                    },
+                    "required": ["headers", "body_json"]
+                }
+            },
+            "required": ["action", "webhook"]
         }
     ]
 }"#;
@@ -1489,6 +2321,61 @@ export!(GitHubTool);
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn schema_actions() -> std::collections::HashSet<String> {
+        let schema: serde_json::Value =
+            serde_json::from_str(SCHEMA).expect("schema should be valid JSON");
+        schema["oneOf"]
+            .as_array()
+            .expect("schema.oneOf should be an array")
+            .iter()
+            .filter_map(|variant| {
+                variant
+                    .pointer("/properties/action/const")
+                    .and_then(|v| v.as_str())
+                    .map(str::to_string)
+            })
+            .collect()
+    }
+
+    fn supported_actions() -> std::collections::HashSet<String> {
+        [
+            "get_repo",
+            "create_repo",
+            "list_issues",
+            "create_issue",
+            "get_issue",
+            "list_issue_comments",
+            "create_issue_comment",
+            "list_pull_requests",
+            "create_pull_request",
+            "get_pull_request",
+            "get_pull_request_files",
+            "create_pr_review",
+            "list_pull_request_comments",
+            "reply_pull_request_comment",
+            "get_pull_request_reviews",
+            "get_combined_status",
+            "merge_pull_request",
+            "list_repos",
+            "search_repositories",
+            "search_code",
+            "search_issues_pull_requests",
+            "list_branches",
+            "create_branch",
+            "get_file_content",
+            "create_or_update_file",
+            "delete_file",
+            "list_releases",
+            "create_release",
+            "trigger_workflow",
+            "get_workflow_runs",
+            "handle_webhook",
+        ]
+        .into_iter()
+        .map(str::to_string)
+        .collect()
+    }
 
     #[test]
     fn test_url_encode_path() {
@@ -1500,10 +2387,12 @@ mod tests {
     #[test]
     fn test_validate_path_segment() {
         assert!(validate_path_segment("foo"));
+        assert!(validate_path_segment("foo-bar_123.baz"));
         assert!(!validate_path_segment(""));
         assert!(!validate_path_segment("foo/bar"));
         assert!(!validate_path_segment(".."));
-        // Empty segments are handled in get_file_content logic, not here
+        assert!(!validate_path_segment("foo bar"));
+        assert!(!validate_path_segment("foo\nbar"));
     }
 
     #[test]
@@ -1654,5 +2543,151 @@ mod tests {
                 .and_then(|v| v.as_i64()),
             Some(42)
         );
+    }
+
+    #[test]
+    fn test_validate_git_ref_rejects_bad_names() {
+        assert!(validate_git_ref("feature/test", "branch").is_ok());
+        assert!(validate_git_ref("release/v1.2.3", "branch").is_ok());
+        assert!(validate_git_ref("bad ref", "branch").is_err());
+        assert!(validate_git_ref("../main", "branch").is_err());
+        assert!(validate_git_ref("refs/heads/main.lock", "branch").is_err());
+    }
+
+    #[test]
+    fn test_normalize_ref_lookup_and_branch_ref() {
+        assert_eq!(
+            normalize_ref_lookup("main").expect("main should normalize"),
+            "heads/main"
+        );
+        assert_eq!(
+            normalize_ref_lookup("refs/tags/v1.0.0").expect("tag ref should normalize"),
+            "tags/v1.0.0"
+        );
+        assert_eq!(
+            normalize_branch_ref("feature/github-tool-audit").expect("branch ref should normalize"),
+            "refs/heads/feature/github-tool-audit"
+        );
+        assert_eq!(
+            normalize_branch_ref("refs/heads/main").expect("qualified branch ref should pass"),
+            "refs/heads/main"
+        );
+        assert!(normalize_ref_lookup("refs/pull/123/head").is_err());
+        assert!(normalize_branch_ref("refs/tags/v1.0.0").is_err());
+        assert!(normalize_branch_ref("tags/v1.0.0").is_err());
+    }
+
+    #[test]
+    fn test_validate_repo_path_enforces_length_limit() {
+        let long_path = format!("dir/{}", "a".repeat(MAX_TEXT_LENGTH));
+        assert!(validate_repo_path("docs/readme.md").is_ok());
+        assert!(validate_repo_path(&long_path).is_err());
+    }
+
+    #[test]
+    fn test_validate_commit_identity_enforces_length_limit() {
+        let identity = GitCommitIdentity {
+            name: "IronClaw Bot".to_string(),
+            email: "bot@example.com".to_string(),
+        };
+        assert!(validate_commit_identity(&identity, "committer").is_ok());
+
+        let too_long = GitCommitIdentity {
+            name: "a".repeat(MAX_TEXT_LENGTH + 1),
+            email: "bot@example.com".to_string(),
+        };
+        assert!(validate_commit_identity(&too_long, "committer").is_err());
+    }
+
+    #[test]
+    fn test_schema_includes_new_core_actions() {
+        let actions = schema_actions();
+        for action in [
+            "create_repo",
+            "search_repositories",
+            "search_code",
+            "search_issues_pull_requests",
+            "list_branches",
+            "create_branch",
+            "create_or_update_file",
+            "delete_file",
+            "list_releases",
+            "create_release",
+        ] {
+            assert!(
+                actions.contains(action),
+                "schema should include action {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_matches_supported_action_set() {
+        assert_eq!(schema_actions(), supported_actions());
+    }
+
+    #[test]
+    fn test_readme_examples_only_reference_supported_actions() {
+        let actions = schema_actions();
+        let readme = include_str!("../README.md");
+        let mut referenced = Vec::new();
+
+        for line in readme.lines() {
+            let Some((_, rhs)) = line.split_once("\"action\":") else {
+                continue;
+            };
+            let rhs = rhs.trim();
+            let Some(rest) = rhs.strip_prefix('"') else {
+                continue;
+            };
+            let Some(action) = rest.split('"').next() else {
+                continue;
+            };
+            referenced.push(action.to_string());
+        }
+
+        assert!(
+            !referenced.is_empty(),
+            "README should contain action examples"
+        );
+        for action in referenced {
+            assert!(
+                actions.contains(&action),
+                "README references unsupported action {action}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_registry_description_claims_are_supported() {
+        let actions = schema_actions();
+        let manifest: serde_json::Value =
+            serde_json::from_str(include_str!("../../../registry/tools/github.json"))
+                .expect("registry manifest should parse");
+        let description = manifest["description"]
+            .as_str()
+            .expect("registry manifest should have a description")
+            .to_ascii_lowercase();
+
+        if description.contains("search") {
+            assert!(
+                actions.contains("search_repositories")
+                    && actions.contains("search_code")
+                    && actions.contains("search_issues_pull_requests"),
+                "registry search claim should map to implemented search actions"
+            );
+        }
+        if description.contains("releases") {
+            assert!(
+                actions.contains("list_releases") && actions.contains("create_release"),
+                "registry releases claim should map to implemented release actions"
+            );
+        }
+        if description.contains("file writes") {
+            assert!(
+                actions.contains("create_or_update_file") && actions.contains("delete_file"),
+                "registry file write claim should map to implemented content actions"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `IRONCLAW_PROFILE` env var to apply pre-baked configuration presets via TOML files
- Ships 4 built-in profiles: `local`, `local-sandbox`, `server`, `server-multitenant`
- Users can create custom profiles at `~/.ironclaw/profiles/<name>.toml` (e.g. "github-developer", "multi-tenant-financial")
- Profiles merge onto Settings defaults **before** config.toml and DB overlays, so individual settings always win
- Adds `cli_mode` field to `ChannelSettings` so profiles can set TUI mode without requiring the `CLI_MODE` env var

### Resolution chain
```
Settings::default() → profile → config.toml → DB settings → env vars (security-sensitive)
```

### Built-in profiles

| Profile | Use case |
|---------|----------|
| `local` | Solo dev: libSQL, sandbox off, gateway off, TUI mode, heartbeat/routines/hygiene off |
| `local-sandbox` | Same as local + Docker sandbox (readonly policy) |
| `server` | Single-user server: postgres, sandbox on, heartbeat on, hygiene on |
| `server-multitenant` | Multi-user SaaS: server + 10 parallel jobs |

### Usage
```bash
IRONCLAW_PROFILE=local ironclaw           # built-in profile
IRONCLAW_PROFILE=my-custom ironclaw       # ~/.ironclaw/profiles/my-custom.toml
```

## Test plan

- [x] `cargo check --all-features` — compiles cleanly
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test` — all existing tests pass
- [x] 8 new unit tests in `src/config/profile.rs` covering: no-op when unset, unknown profile error, each built-in profile's fields, case-insensitive names, user profile override, list_profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)