### PR TITLE
fix(engine): admin skills visible to all tenants via system_project_id

### DIFF
--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -34,7 +34,7 @@ pub use types::event::{EventId, EventKind, ThreadEvent};
 pub use types::memory::{DocId, DocType, MemoryDoc};
 pub use types::message::{MessageRole, ThreadMessage};
 pub use types::mission::{Mission, MissionCadence, MissionId, MissionStatus};
-pub use types::project::{Project, ProjectId};
+pub use types::project::{Project, ProjectId, system_project_id};
 pub use types::provenance::Provenance;
 pub use types::step::{
     ActionCall, ActionResult, ExecutionTier, LlmResponse, Step, StepId, StepStatus, TokenUsage,
@@ -104,7 +104,7 @@ pub(crate) mod tests {
     use crate::types::event::ThreadEvent;
     use crate::types::memory::{DocId, MemoryDoc};
     use crate::types::mission::{Mission, MissionId, MissionStatus};
-    use crate::types::project::{Project, ProjectId};
+    use crate::types::project::{Project, ProjectId, system_project_id};
     use crate::types::step::Step;
     use crate::types::thread::{Thread, ThreadId, ThreadState};
 
@@ -528,5 +528,78 @@ pub(crate) mod tests {
             .await
             .unwrap();
         assert_eq!(docs.len(), 2);
+    }
+
+    /// Regression test for issue #2084.
+    ///
+    /// Admin skills live in `system_project_id()`. A tenant whose thread runs
+    /// in a different per-user project must still see those skills via
+    /// `list_shared_memory_docs` / `list_memory_docs_with_shared`.
+    #[tokio::test]
+    async fn admin_skills_in_system_project_visible_to_all_tenants() {
+        use crate::types::memory::DocType;
+        use crate::types::shared_owner_id;
+
+        // Admin installs a skill into the system project.
+        let admin_skill = MemoryDoc::new(
+            system_project_id(),
+            shared_owner_id(),
+            DocType::Skill,
+            "skill:admin-tool",
+            "# Admin Tool\nDo admin things.",
+        );
+
+        // Alice has her own skill in her own project.
+        let alice_project = ProjectId::new();
+        let alice_skill = MemoryDoc::new(
+            alice_project,
+            "alice",
+            DocType::Skill,
+            "skill:alice-tool",
+            "# Alice Tool\nAlice's personal skill.",
+        );
+
+        // Bob's thread runs in yet another project.
+        let bob_project = ProjectId::new();
+
+        let store = InMemoryStore::with_docs(vec![admin_skill.clone(), alice_skill.clone()]);
+
+        // Bob sees admin skill via list_shared_memory_docs from his project.
+        let shared = store
+            .list_shared_memory_docs(bob_project)
+            .await
+            .unwrap();
+        assert!(
+            shared.iter().any(|d| d.id == admin_skill.id),
+            "Bob should see admin skill from system project"
+        );
+
+        // Bob does NOT see Alice's personal skill.
+        assert!(
+            !shared.iter().any(|d| d.id == alice_skill.id),
+            "Bob should not see Alice's personal skill"
+        );
+
+        // Alice sees both her own skill and the admin skill.
+        let alice_docs = store
+            .list_memory_docs_with_shared(alice_project, "alice")
+            .await
+            .unwrap();
+        assert!(
+            alice_docs.iter().any(|d| d.id == admin_skill.id),
+            "Alice should see admin skill"
+        );
+        assert!(
+            alice_docs.iter().any(|d| d.id == alice_skill.id),
+            "Alice should see her own skill"
+        );
+
+        // Bob's full doc list (own + shared) includes admin skill, not Alice's.
+        let bob_docs = store
+            .list_memory_docs_with_shared(bob_project, "bob")
+            .await
+            .unwrap();
+        assert!(bob_docs.iter().any(|d| d.id == admin_skill.id));
+        assert!(!bob_docs.iter().any(|d| d.id == alice_skill.id));
     }
 }

--- a/crates/ironclaw_engine/src/traits/store.rs
+++ b/crates/ironclaw_engine/src/traits/store.rs
@@ -9,7 +9,7 @@ use crate::types::error::EngineError;
 use crate::types::event::ThreadEvent;
 use crate::types::memory::{DocId, MemoryDoc};
 use crate::types::mission::{Mission, MissionId, MissionStatus};
-use crate::types::project::{Project, ProjectId};
+use crate::types::project::{Project, ProjectId, system_project_id};
 use crate::types::step::Step;
 use crate::types::thread::{Thread, ThreadId, ThreadState};
 use crate::types::{is_shared_owner, shared_owner_candidates};
@@ -120,9 +120,16 @@ pub trait Store: Send + Sync {
         &self,
         project_id: ProjectId,
     ) -> Result<Vec<MemoryDoc>, EngineError> {
+        let sys = system_project_id();
         let mut docs = Vec::new();
         for owner_id in shared_owner_candidates() {
             docs.extend(self.list_memory_docs(project_id, owner_id).await?);
+            // Always include the system project — admin-installed skills live
+            // here and must be visible to all tenants regardless of which
+            // per-user project their thread runs in.
+            if project_id != sys {
+                docs.extend(self.list_memory_docs(sys, owner_id).await?);
+            }
         }
         docs.sort_by_key(|doc| doc.id.0);
         docs.dedup_by_key(|doc| doc.id);

--- a/crates/ironclaw_engine/src/types/project.rs
+++ b/crates/ironclaw_engine/src/types/project.rs
@@ -25,6 +25,17 @@ impl Default for ProjectId {
     }
 }
 
+/// The global system project — a stable, well-known project where
+/// admin-installed shared skills live. Using `Uuid::nil()` means it requires
+/// no database row: every `Store` implementation can query it via the normal
+/// `list_memory_docs(system_project_id(), user_id)` path.
+///
+/// Skills in this project are visible to all users regardless of which
+/// per-user project their thread runs in.
+pub fn system_project_id() -> ProjectId {
+    ProjectId(Uuid::nil())
+}
+
 /// A project — the unit of context scoping.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Project {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -783,6 +783,7 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
             match crate::bridge::skill_migration::migrate_v1_skill_list(
                 &skills_snapshot,
                 &store_dyn,
+                owner_id,
                 project_id,
             )
             .await
@@ -3291,6 +3292,24 @@ async fn migrate_legacy_user_ids(store: &Arc<dyn ironclaw_engine::Store>, owner_
                 doc.updated_at = chrono::Utc::now();
                 let _ = store.save_memory_doc(&doc).await;
             }
+        }
+    }
+
+    // Upgrade path: docs in the system project that were serialized before
+    // project_id/user_id were written to frontmatter will be loaded with
+    // user_id = "legacy". Skill docs there belong to the shared/admin space,
+    // not to any individual owner, so stamp them with shared_owner_id().
+    let sys = ironclaw_engine::system_project_id();
+    if let Ok(legacy) = store.list_memory_docs(sys, "legacy").await {
+        for mut doc in legacy {
+            let correct_owner = if doc.doc_type == ironclaw_engine::DocType::Skill {
+                ironclaw_engine::types::shared_owner_id().to_string()
+            } else {
+                owner_id.to_string()
+            };
+            doc.user_id = correct_owner;
+            doc.updated_at = chrono::Utc::now();
+            let _ = store.save_memory_doc(&doc).await;
         }
     }
 

--- a/src/bridge/skill_migration.rs
+++ b/src/bridge/skill_migration.rs
@@ -4,6 +4,12 @@
 //! v2 `MemoryDoc` with `DocType::Skill` and structured `V2SkillMetadata`.
 //! The migration is idempotent: skills with unchanged content_hash are skipped.
 //!
+//! **Ownership model:**
+//! - `Bundled` / `Installed` skills are admin-installed and go into the global
+//!   `system_project_id()` under `shared_owner_id()`. Every tenant sees them.
+//! - `User` / `Workspace` skills belong to the owner and go into their own
+//!   project under `owner_id`. Other tenants do not see them.
+//!
 //! **Remove after v1 migration is complete.** Once all users are on ENGINE_V2
 //! and SKILL.md files are authored directly as v2 MemoryDocs (or via the
 //! skill-extraction mission), this one-time migration code is unnecessary.
@@ -12,6 +18,7 @@
 
 use std::sync::Arc;
 
+use ironclaw_engine::system_project_id;
 use ironclaw_engine::traits::store::Store;
 use ironclaw_engine::types::error::EngineError;
 use ironclaw_engine::types::memory::{DocType, MemoryDoc};
@@ -31,25 +38,36 @@ use ironclaw_skills::v2::{SkillMetrics, V2SkillMetadata, V2SkillSource};
 pub async fn migrate_v1_skills(
     v1_registry: &SkillRegistry,
     store: &Arc<dyn Store>,
-    project_id: ProjectId,
+    owner_id: &str,
+    tenant_project_id: ProjectId,
 ) -> Result<usize, EngineError> {
-    migrate_v1_skill_list(v1_registry.skills(), store, project_id).await
+    migrate_v1_skill_list(v1_registry.skills(), store, owner_id, tenant_project_id).await
 }
 
 /// Migrate a snapshot of v1 skills to v2 MemoryDocs.
 ///
 /// Takes a pre-cloned slice of skills (to avoid holding a lock across await).
+///
+/// - Admin skills (`Bundled`/`Installed`) → `system_project_id()`, `user_id = "__shared__"`
+/// - Tenant skills (`User`/`Workspace`)   → `tenant_project_id`, `user_id = owner_id`
 pub async fn migrate_v1_skill_list(
     v1_skills: &[LoadedSkill],
     store: &Arc<dyn Store>,
-    project_id: ProjectId,
+    owner_id: &str,
+    tenant_project_id: ProjectId,
 ) -> Result<usize, EngineError> {
     if v1_skills.is_empty() {
         return Ok(0);
     }
 
-    // Load existing skill docs to check for duplicates by content_hash
-    let existing_docs = store.list_shared_memory_docs(project_id).await?;
+    // Load existing docs from both locations to check for duplicates by content_hash.
+    let sys = system_project_id();
+    let mut existing_docs = store.list_shared_memory_docs(sys).await?;
+    existing_docs.extend(
+        store
+            .list_memory_docs(tenant_project_id, owner_id)
+            .await?,
+    );
     let existing_hashes: std::collections::HashSet<String> = existing_docs
         .iter()
         .filter(|d| d.doc_type == DocType::Skill)
@@ -64,7 +82,7 @@ pub async fn migrate_v1_skill_list(
     let mut migrated = 0;
 
     for skill in v1_skills {
-        // Skip if content hasn't changed (idempotent)
+        // Skip if content hasn't changed (idempotent).
         if existing_hashes.contains(&skill.content_hash) {
             tracing::debug!(
                 skill = %skill.name(),
@@ -73,13 +91,15 @@ pub async fn migrate_v1_skill_list(
             continue;
         }
 
-        let doc = v1_skill_to_memory_doc(skill, project_id);
+        let doc = v1_skill_to_memory_doc(skill, owner_id, tenant_project_id);
         store.save_memory_doc(&doc).await?;
         migrated += 1;
 
         tracing::debug!(
             skill = %skill.name(),
             doc_id = %doc.id.0,
+            project_id = %doc.project_id.0,
+            user_id = %doc.user_id,
             "migrated v1 skill to v2 MemoryDoc"
         );
     }
@@ -92,12 +112,22 @@ pub async fn migrate_v1_skill_list(
 }
 
 /// Convert a single v1 `LoadedSkill` to a v2 `MemoryDoc`.
-fn v1_skill_to_memory_doc(skill: &LoadedSkill, project_id: ProjectId) -> MemoryDoc {
-    let v2_source = match &skill.source {
-        SkillSource::Workspace(_) | SkillSource::User(_) | SkillSource::Installed(_) => {
-            V2SkillSource::Migrated
+///
+/// Routing:
+/// - `Bundled` / `Installed` → admin skill → system project, shared owner
+/// - `User` / `Workspace`    → tenant skill → owner's project, owner's user_id
+fn v1_skill_to_memory_doc(
+    skill: &LoadedSkill,
+    owner_id: &str,
+    tenant_project_id: ProjectId,
+) -> MemoryDoc {
+    let (project_id, user_id) = match &skill.source {
+        SkillSource::Bundled(_) | SkillSource::Installed(_) => {
+            (system_project_id(), shared_owner_id().to_string())
         }
-        SkillSource::Bundled(_) => V2SkillSource::Migrated,
+        SkillSource::User(_) | SkillSource::Workspace(_) => {
+            (tenant_project_id, owner_id.to_string())
+        }
     };
 
     let meta = V2SkillMetadata {
@@ -105,9 +135,9 @@ fn v1_skill_to_memory_doc(skill: &LoadedSkill, project_id: ProjectId) -> MemoryD
         version: 1,
         description: skill.manifest.description.clone(),
         activation: skill.manifest.activation.clone(),
-        source: v2_source,
+        source: V2SkillSource::Migrated,
         trust: skill.trust,
-        code_snippets: vec![], // v1 skills are prompt-only
+        code_snippets: vec![],
         metrics: SkillMetrics::default(),
         parent_version: None,
         revisions: vec![],
@@ -117,7 +147,7 @@ fn v1_skill_to_memory_doc(skill: &LoadedSkill, project_id: ProjectId) -> MemoryD
 
     let mut doc = MemoryDoc::new(
         project_id,
-        shared_owner_id(),
+        user_id,
         DocType::Skill,
         format!("skill:{}", skill.manifest.name),
         &skill.prompt_content,
@@ -133,7 +163,7 @@ mod tests {
     use ironclaw_skills::types::{ActivationCriteria, SkillManifest, SkillTrust};
     use std::path::PathBuf;
 
-    fn make_v1_skill(name: &str, content: &str) -> LoadedSkill {
+    fn make_skill(name: &str, content: &str, source: SkillSource) -> LoadedSkill {
         LoadedSkill {
             manifest: SkillManifest {
                 name: name.to_string(),
@@ -148,7 +178,7 @@ mod tests {
             },
             prompt_content: content.to_string(),
             trust: SkillTrust::Trusted,
-            source: SkillSource::User(PathBuf::from("/tmp/test")), // safety: dummy path in test, not used for I/O
+            source,
             content_hash: ironclaw_skills::compute_hash(content),
             compiled_patterns: vec![],
             lowercased_keywords: vec!["test".to_string()],
@@ -158,23 +188,59 @@ mod tests {
     }
 
     #[test]
-    fn test_v1_skill_converts_to_memory_doc() {
-        let skill = make_v1_skill("test-skill", "Test prompt content");
-        let project_id = ProjectId::new();
-        let doc = v1_skill_to_memory_doc(&skill, project_id);
+    fn bundled_skill_goes_to_system_project() {
+        let skill = make_skill(
+            "admin-skill",
+            "Admin prompt",
+            SkillSource::Bundled(PathBuf::from("/bundled")),
+        );
+        let tenant_project = ProjectId::new();
+        let doc = v1_skill_to_memory_doc(&skill, "alice", tenant_project);
 
+        assert_eq!(doc.project_id, system_project_id());
+        assert_eq!(doc.user_id, shared_owner_id());
         assert_eq!(doc.doc_type, DocType::Skill);
-        assert_eq!(doc.title, "skill:test-skill");
-        assert_eq!(doc.content, "Test prompt content");
-        assert_eq!(doc.project_id, project_id);
-        assert!(doc.tags.contains(&"migrated_from_v1".to_string()));
+    }
 
-        let meta: V2SkillMetadata = serde_json::from_value(doc.metadata).unwrap();
-        assert_eq!(meta.name, "test-skill");
-        assert_eq!(meta.version, 1);
-        assert_eq!(meta.source, V2SkillSource::Migrated);
-        assert_eq!(meta.trust, SkillTrust::Trusted);
-        assert!(meta.code_snippets.is_empty());
-        assert!(!meta.content_hash.is_empty());
+    #[test]
+    fn installed_skill_goes_to_system_project() {
+        let skill = make_skill(
+            "installed-skill",
+            "Installed prompt",
+            SkillSource::Installed(PathBuf::from("/installed")),
+        );
+        let tenant_project = ProjectId::new();
+        let doc = v1_skill_to_memory_doc(&skill, "alice", tenant_project);
+
+        assert_eq!(doc.project_id, system_project_id());
+        assert_eq!(doc.user_id, shared_owner_id());
+    }
+
+    #[test]
+    fn user_skill_goes_to_tenant_project() {
+        let skill = make_skill(
+            "my-skill",
+            "Personal prompt",
+            SkillSource::User(PathBuf::from("/home/alice/.ironclaw/skills/my-skill")),
+        );
+        let tenant_project = ProjectId::new();
+        let doc = v1_skill_to_memory_doc(&skill, "alice", tenant_project);
+
+        assert_eq!(doc.project_id, tenant_project);
+        assert_eq!(doc.user_id, "alice");
+    }
+
+    #[test]
+    fn workspace_skill_goes_to_tenant_project() {
+        let skill = make_skill(
+            "ws-skill",
+            "Workspace prompt",
+            SkillSource::Workspace(PathBuf::from("/workspace/skills/ws-skill")),
+        );
+        let tenant_project = ProjectId::new();
+        let doc = v1_skill_to_memory_doc(&skill, "bob", tenant_project);
+
+        assert_eq!(doc.project_id, tenant_project);
+        assert_eq!(doc.user_id, "bob");
     }
 }

--- a/src/bridge/store_adapter.rs
+++ b/src/bridge/store_adapter.rs
@@ -728,18 +728,28 @@ fn slugify(title: &str, id: &str) -> String {
 
 // ── Frontmatter serialization ───────────────────────────────
 
+/// Escape a string for use as a YAML double-quoted scalar.
+fn yaml_escape(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "\\r")
+}
+
 /// Serialize a MemoryDoc as YAML frontmatter + markdown content.
 fn serialize_knowledge_doc(doc: &MemoryDoc) -> String {
     let mut frontmatter = String::from("---\n");
     frontmatter.push_str(&format!("id: \"{}\"\n", doc.id.0));
+    frontmatter.push_str(&format!("project_id: \"{}\"\n", doc.project_id.0));
+    frontmatter.push_str(&format!("user_id: \"{}\"\n", yaml_escape(&doc.user_id)));
     frontmatter.push_str(&format!("doc_type: \"{:?}\"\n", doc.doc_type));
-    frontmatter.push_str(&format!("title: \"{}\"\n", doc.title.replace('"', "\\\"")));
+    frontmatter.push_str(&format!("title: \"{}\"\n", yaml_escape(&doc.title)));
     if !doc.tags.is_empty() {
         frontmatter.push_str(&format!(
             "tags: [{}]\n",
             doc.tags
                 .iter()
-                .map(|t| format!("\"{t}\""))
+                .map(|t| format!("\"{}\"", yaml_escape(t)))
                 .collect::<Vec<_>>()
                 .join(", ")
         ));
@@ -832,11 +842,28 @@ fn deserialize_knowledge_doc(content: &str) -> Option<MemoryDoc> {
         .cloned()
         .unwrap_or(serde_json::json!({}));
 
-    // project_id is not in frontmatter — use nil UUID (assigned at load time)
+    // project_id: present in new docs; older docs default to system_project_id()
+    // (Uuid::nil()) which is where shared/admin skills were stored before this
+    // field was added to the frontmatter.
+    let project_id = yaml
+        .get("project_id")
+        .and_then(|v| v.as_str())
+        .and_then(|s| uuid::Uuid::parse_str(s).ok())
+        .map(ProjectId)
+        .unwrap_or_else(ironclaw_engine::system_project_id);
+
+    // user_id: present in new docs; older docs default to "legacy" so that
+    // migrate_legacy_user_ids() can stamp them with the correct owner.
+    let user_id = yaml
+        .get("user_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("legacy")
+        .to_string();
+
     Some(MemoryDoc {
         id: DocId(id),
-        project_id: ProjectId(uuid::Uuid::nil()),
-        user_id: "legacy".to_string(),
+        project_id,
+        user_id,
         doc_type,
         title,
         content: body.to_string(),


### PR DESCRIPTION
## Summary

- Introduced `system_project_id()` (Uuid::nil) as a stable well-known project for admin-installed shared skills, requiring no database row
- Fixed skill migration so `Bundled`/`Installed` skills go to the system project under `shared_owner_id()`, while `User`/`Workspace` skills stay in the tenant's own project
- Extended `list_shared_memory_docs` to always include the system project, making admin skills visible to all tenants regardless of which per-user project their thread runs in
- Added `project_id` and `user_id` fields to YAML frontmatter serialization, with a `"legacy"` fallback and upgrade-path migration to stamp pre-existing docs with correct ownership
- Added a regression test covering the multi-tenant visibility contract (Bob sees admin skills, not Alice's personal skills)

## Change Type

- [x] Bug fix

## Linked Issue

Closes #2084

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `admin_skills_in_system_project_visible_to_all_tenants`, `bundled_skill_goes_to_system_project`, `installed_skill_goes_to_system_project`, `user_skill_goes_to_tenant_project`, `workspace_skill_goes_to_tenant_project`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None. Changes are scoped to in-memory skill visibility and YAML frontmatter; no permissions, secrets, network, or sandbox policy changes.

## Database Impact

No migrations. The system project uses `Uuid::nil()` — no DB row required. The `project_id`/`user_id` fields are now serialized to YAML frontmatter in the flat-file store; existing docs missing these fields fall back gracefully via `deserialize_knowledge_doc`.

## Blast Radius

- `ironclaw_engine`: `Store::list_shared_memory_docs` now queries the system project in addition to the per-user project — one extra DB/store read per call.
- `src/bridge/skill_migration.rs`: migration routing changed; `Bundled`/`Installed` skills will be re-migrated into the system project on next startup if they were previously stored in the tenant project (content-hash dedup prevents double-migration for unchanged skills).
- `src/bridge/store_adapter.rs`: YAML frontmatter now includes `project_id`/`user_id`; older docs without these fields get `system_project_id()` and `"legacy"` as defaults, then are upgraded by `migrate_legacy_user_ids`.
- No API surface changes.

## Rollback Plan

Revert the commit. Skills previously stored in the system project will remain there but `list_shared_memory_docs` will stop including them for non-system tenants. Bundled/Installed skills will be re-migrated into the tenant project on next startup by the pre-fix migration code. No data loss — `MemoryDoc` rows are never deleted per the data retention policy.

## Review Follow-Through

- The extra `list_memory_docs(sys, owner_id)` call inside `list_shared_memory_docs` iterates once per `shared_owner_candidates()` entry — worth confirming this stays fast under load or caching is acceptable.
- `migrate_legacy_user_ids` now processes system-project docs with `user_id = "legacy"`; reviewer should confirm the fallback owner assignment (`shared_owner_id()` for skills, `owner_id` for everything else) matches intent for non-skill doc types.

---

**Review track**: B (feature/maintainer-requested refactor)
