### PR TITLE
feat(web): add scroll-to-bottom arrow in gateway chat

### DIFF
--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -3068,7 +3068,8 @@ chatInput.addEventListener('blur', () => {
   setTimeout(hideSlashAutocomplete, 150);
 });
 
-// Infinite scroll: load older messages when scrolled near the top
+// Infinite scroll: load older messages when scrolled near the top.
+// Also toggles the scroll-to-bottom button when the user has scrolled up.
 document.getElementById('chat-messages').addEventListener('scroll', function () {
   if (this.scrollTop < 100 && hasMore && !loadingOlder) {
     loadingOlder = true;
@@ -3080,6 +3081,16 @@ document.getElementById('chat-messages').addEventListener('scroll', function () 
     this.insertBefore(spinner, this.firstChild);
     loadHistory(oldestTimestamp);
   }
+  const btn = document.getElementById('scroll-to-bottom-btn');
+  if (btn) {
+    const distanceFromBottom = this.scrollHeight - this.scrollTop - this.clientHeight;
+    btn.style.display = distanceFromBottom > 200 ? 'flex' : 'none';
+  }
+});
+
+document.getElementById('scroll-to-bottom-btn').addEventListener('click', () => {
+  const container = document.getElementById('chat-messages');
+  container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
 });
 
 function autoResizeTextarea(el) {

--- a/src/channels/web/static/app.js
+++ b/src/channels/web/static/app.js
@@ -3070,28 +3070,51 @@ chatInput.addEventListener('blur', () => {
 
 // Infinite scroll: load older messages when scrolled near the top.
 // Also toggles the scroll-to-bottom button when the user has scrolled up.
+// The handler is rAF-throttled so rapid scroll events coalesce into at most
+// one layout read per frame.
+let _scrollRafPending = false;
 document.getElementById('chat-messages').addEventListener('scroll', function () {
-  if (this.scrollTop < 100 && hasMore && !loadingOlder) {
+  const container = this;
+  if (container.scrollTop < 100 && hasMore && !loadingOlder) {
     loadingOlder = true;
     // Show spinner at top
     const spinner = document.createElement('div');
     spinner.id = 'scroll-load-spinner';
     spinner.className = 'scroll-load-spinner';
     spinner.innerHTML = '<div class="spinner"></div> Loading older messages...';
-    this.insertBefore(spinner, this.firstChild);
+    container.insertBefore(spinner, container.firstChild);
     loadHistory(oldestTimestamp);
   }
-  const btn = document.getElementById('scroll-to-bottom-btn');
-  if (btn) {
-    const distanceFromBottom = this.scrollHeight - this.scrollTop - this.clientHeight;
+  if (_scrollRafPending) return;
+  _scrollRafPending = true;
+  requestAnimationFrame(() => {
+    _scrollRafPending = false;
+    const btn = document.getElementById('scroll-to-bottom-btn');
+    if (!btn) return;
+    const distanceFromBottom = container.scrollHeight - container.scrollTop - container.clientHeight;
     btn.style.display = distanceFromBottom > 200 ? 'flex' : 'none';
-  }
+  });
 });
 
 document.getElementById('scroll-to-bottom-btn').addEventListener('click', () => {
   const container = document.getElementById('chat-messages');
   container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
 });
+
+// Keep the scroll-to-bottom button anchored just above the chat input,
+// even when the textarea grows to multiple lines.
+(() => {
+  const input = document.querySelector('.chat-container .chat-input');
+  const container = document.querySelector('.chat-container');
+  if (!input || !container || typeof ResizeObserver === 'undefined') return;
+  const ro = new ResizeObserver((entries) => {
+    for (const entry of entries) {
+      const h = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+      container.style.setProperty('--chat-input-height', `${Math.ceil(h)}px`);
+    }
+  });
+  ro.observe(input);
+})();
 
 function autoResizeTextarea(el) {
   const prev = el.offsetHeight;

--- a/src/channels/web/static/i18n/en.js
+++ b/src/channels/web/static/i18n/en.js
@@ -119,6 +119,7 @@ I18n.register('en', {
   'chat.conversations': 'Conversations',
   'chat.send': 'Send',
   'chat.attachImages': 'Attach Images',
+  'chat.scrollToBottom': 'Scroll to bottom',
   'chat.empty': 'Select a file to view content',
   'chat.loading': 'Loading...',
   'chat.loadingOlder': 'Loading older messages...',

--- a/src/channels/web/static/i18n/ko.js
+++ b/src/channels/web/static/i18n/ko.js
@@ -119,6 +119,7 @@ I18n.register('ko', {
   'chat.conversations': '대화',
   'chat.send': '보내기',
   'chat.attachImages': '이미지 첨부',
+  'chat.scrollToBottom': '맨 아래로 스크롤',
   'chat.empty': '내용을 보려면 파일을 선택하세요',
   'chat.loading': '로딩 중...',
   'chat.loadingOlder': '이전 메시지 로드 중...',

--- a/src/channels/web/static/i18n/zh-CN.js
+++ b/src/channels/web/static/i18n/zh-CN.js
@@ -119,6 +119,7 @@ I18n.register('zh-CN', {
   'chat.conversations': '对话列表',
   'chat.send': '发送',
   'chat.attachImages': '附加图片',
+  'chat.scrollToBottom': '滚动到底部',
   'chat.empty': '选择文件查看内容',
   'chat.loading': '加载中...',
   'chat.loadingOlder': '加载更早的消息...',

--- a/src/channels/web/static/index.html
+++ b/src/channels/web/static/index.html
@@ -241,6 +241,9 @@
       </div>
       <div class="chat-container">
         <div class="chat-messages" id="chat-messages"></div>
+        <button class="scroll-to-bottom-btn" id="scroll-to-bottom-btn" style="display:none"
+          data-i18n="chat.scrollToBottom" data-i18n-attr="title" title="Scroll to bottom"
+          aria-label="Scroll to bottom">&#x2304;</button>
         <div id="slash-autocomplete" class="slash-autocomplete" style="display:none"></div>
         <div id="suggestion-chips" class="suggestion-chips" style="display:none"></div>
         <div class="chat-input">

--- a/src/channels/web/static/index.html
+++ b/src/channels/web/static/index.html
@@ -242,8 +242,9 @@
       <div class="chat-container">
         <div class="chat-messages" id="chat-messages"></div>
         <button class="scroll-to-bottom-btn" id="scroll-to-bottom-btn" style="display:none"
-          data-i18n="chat.scrollToBottom" data-i18n-attr="title" title="Scroll to bottom"
-          aria-label="Scroll to bottom">&#x2304;</button>
+          data-i18n="chat.scrollToBottom" data-i18n-attr="aria-label"
+          data-i18n-title="chat.scrollToBottom"
+          title="Scroll to bottom" aria-label="Scroll to bottom">&#x2304;</button>
         <div id="slash-autocomplete" class="slash-autocomplete" style="display:none"></div>
         <div id="suggestion-chips" class="suggestion-chips" style="display:none"></div>
         <div class="chat-input">

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -965,7 +965,7 @@ body {
 .scroll-to-bottom-btn {
   position: absolute;
   right: var(--space-4);
-  bottom: 96px;
+  bottom: calc(var(--chat-input-height, 72px) + var(--space-3));
   width: 28px;
   height: 28px;
   padding: 0;

--- a/src/channels/web/static/style.css
+++ b/src/channels/web/static/style.css
@@ -959,6 +959,34 @@ body {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  position: relative;
+}
+
+.scroll-to-bottom-btn {
+  position: absolute;
+  right: var(--space-4);
+  bottom: 96px;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-muted, var(--text));
+  font-size: 22px;
+  line-height: 1;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10;
+  opacity: 0.55;
+  transition: opacity 150ms ease, transform 150ms ease, color 150ms ease;
+}
+
+.scroll-to-bottom-btn:hover {
+  opacity: 1;
+  color: var(--text);
+  transform: translateY(2px);
 }
 
 .chat-messages {


### PR DESCRIPTION
## Summary
- Adds a subtle chevron in the bottom-right of the gateway chat message area that appears when the user has scrolled more than 200px above the bottom.
- Clicking smooth-scrolls back to the latest message.
- i18n strings added for en/ko/zh-CN.

## Test plan
- [ ] Open gateway, scroll up in a long conversation — arrow appears bottom-right.
- [ ] Click arrow — smooth scrolls to bottom, arrow hides.
- [ ] Scroll all the way down manually — arrow hides.
- [ ] Hover — arrow darkens and nudges down slightly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)