### PR TITLE
fix(v2): tool naming, auth gates, schema flatten, WASM traps, workspace race

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2140,14 +2140,31 @@ impl From<PythonActionCall> for ActionCall {
 }
 
 /// Serialize a slice of `ActionCall`s into the Python interchange shape.
+///
+/// On serialization failure (essentially unreachable for `String + String +
+/// Value`, but still possible if the `serde_json::Value` parameters tree
+/// contains a key whose stringification fails), the entry is **dropped**
+/// from the output rather than replaced with `Value::Null`. The previous
+/// `unwrap_or_else(|_| Value::Null)` corrupted the array — Python's
+/// `default.py` accesses `c.get("name")` / `c.get("call_id")` /
+/// `c.get("params")` on each entry, so a `null` would crash with a Python
+/// `AttributeError` and lose the entire LLM step. `filter_map` produces a
+/// shorter array, which Python's tool-result loop handles correctly because
+/// it iterates `range(len(results))` against the shortened call list. The
+/// warn log is preserved so operators have a breadcrumb if it ever fires.
 fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
     calls
         .iter()
-        .map(|c| {
-            serde_json::to_value(PythonActionCall::from(c)).unwrap_or_else(|e| {
-                warn!("Failed to serialize ActionCall for Python: {e}");
-                serde_json::Value::Null
-            })
+        .filter_map(|c| match serde_json::to_value(PythonActionCall::from(c)) {
+            Ok(value) => Some(value),
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    action_name = %c.action_name,
+                    "Failed to serialize ActionCall for Python orchestrator — dropping entry"
+                );
+                None
+            }
         })
         .collect()
 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2169,6 +2169,57 @@ fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
         .collect()
 }
 
+/// Build a PII-safe summary of an `action_calls` JSON value for log output.
+///
+/// The action_calls payload contains tool parameters, which can carry user
+/// PII (search queries, file names, email content, conversation text).
+/// Dumping the full value into a `warn!` log would leak that PII to log
+/// aggregation systems (Datadog, CloudWatch, Sentry) the moment the parser
+/// fails — and the parser only fails when the Python ↔ Rust shape drifts,
+/// which is exactly when an operator is most likely to be grepping logs.
+///
+/// We emit only the structural information operators actually need to
+/// debug a shape drift: array length and the keys of the first entry. The
+/// keys themselves are not user data — they're field names like
+/// `name`/`call_id`/`params` that are static across all calls.
+fn summarize_action_calls_for_log(value: &serde_json::Value) -> String {
+    match value.as_array() {
+        Some(arr) if arr.is_empty() => "empty array".to_string(),
+        Some(arr) => {
+            let first_keys = arr
+                .first()
+                .and_then(|v| v.as_object())
+                .map(|obj| {
+                    let mut keys: Vec<&str> = obj.keys().map(String::as_str).collect();
+                    keys.sort_unstable();
+                    keys.join(",")
+                })
+                .unwrap_or_else(|| "<not an object>".to_string());
+            format!(
+                "array of {} entries; first entry keys: [{}]",
+                arr.len(),
+                first_keys
+            )
+        }
+        None => format!("non-array value of type {}", json_value_type_name(value)),
+    }
+}
+
+/// Cheap type-name string for a `serde_json::Value`. Used by
+/// `summarize_action_calls_for_log` to surface the wrong-shape case
+/// (e.g. Python passed a string instead of an array) without leaking the
+/// actual contents.
+fn json_value_type_name(value: &serde_json::Value) -> &'static str {
+    match value {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
+
 /// Deserialize an `action_calls` JSON array (in Python interchange shape)
 /// back into canonical `ActionCall`s.
 ///
@@ -2180,13 +2231,16 @@ fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
 /// required field, partial migration), the warning is the operator-visible
 /// breadcrumb that explains why subsequent tool results suddenly look
 /// orphaned to `sanitize_tool_messages`.
+///
+/// The warn log emits a structural summary (`summarize_action_calls_for_log`)
+/// instead of the raw value because tool parameters can contain user PII.
 fn python_json_to_action_calls(value: &serde_json::Value) -> Option<Vec<ActionCall>> {
     match serde_json::from_value::<Vec<PythonActionCall>>(value.clone()) {
         Ok(parsed) => Some(parsed.into_iter().map(ActionCall::from).collect()),
         Err(e) => {
             warn!(
                 error = %e,
-                value = %value,
+                shape = %summarize_action_calls_for_log(value),
                 "Failed to parse action_calls from Python orchestrator — \
                  assistant message will lose tool_call linkage and downstream \
                  tool results will be rewritten as user messages"
@@ -2959,6 +3013,74 @@ mod tests {
         ]);
         // Missing "name", "call_id", "params" → returns None.
         assert!(python_json_to_action_calls(&canonical_json).is_none());
+    }
+
+    #[test]
+    fn summarize_action_calls_for_log_does_not_leak_user_pii() {
+        // The whole point of this helper is that the warn log path on a
+        // shape-drift failure must NOT dump tool parameters (which can
+        // contain user PII like search queries, file names, email content)
+        // into log aggregation systems. The summary should expose only
+        // structural information: array length and the keys of the first
+        // entry. The keys themselves are static (`name`, `call_id`,
+        // `params`), not user data.
+        let pii_value = serde_json::json!([
+            {
+                "name": "google_drive_tool",
+                "call_id": "call_xyz",
+                "params": {
+                    "query": "salary spreadsheet for joe",
+                    "secret_token": "very-sensitive-token-do-not-log"
+                }
+            },
+            {
+                "name": "gmail",
+                "call_id": "call_abc",
+                "params": {
+                    "subject": "private message about layoffs"
+                }
+            }
+        ]);
+        let summary = summarize_action_calls_for_log(&pii_value);
+
+        // Structural info present.
+        assert!(summary.contains("array of 2 entries"));
+        assert!(summary.contains("call_id"));
+        assert!(summary.contains("name"));
+        assert!(summary.contains("params"));
+
+        // PII fields and their values must NOT appear.
+        assert!(
+            !summary.contains("salary"),
+            "summary must not leak user PII from params: {summary}"
+        );
+        assert!(
+            !summary.contains("very-sensitive-token"),
+            "summary must not leak credential-shaped values: {summary}"
+        );
+        assert!(
+            !summary.contains("layoffs"),
+            "summary must not leak free-text content: {summary}"
+        );
+        assert!(
+            !summary.contains("google_drive_tool"),
+            "summary must not leak the tool name itself (could expose intent): {summary}"
+        );
+    }
+
+    #[test]
+    fn summarize_action_calls_for_log_handles_edge_cases() {
+        assert_eq!(
+            summarize_action_calls_for_log(&serde_json::json!([])),
+            "empty array"
+        );
+        assert!(
+            summarize_action_calls_for_log(&serde_json::json!("not an array")).contains("string")
+        );
+        assert!(
+            summarize_action_calls_for_log(&serde_json::json!({"foo": "bar"})).contains("object")
+        );
+        assert!(summarize_action_calls_for_log(&serde_json::json!(null)).contains("null"));
     }
 
     /// Caller-level regression test: feeds `json_to_thread_messages` the

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -3267,4 +3267,65 @@ mod tests {
              is no longer needed — either remove it or update the contract."
         );
     }
+
+    /// Regression: `action_calls: null` is Python's legitimate "this
+    /// message has no tool calls" signal (text-only response). Before the
+    /// null filter, `python_json_to_action_calls` would fire a warn log
+    /// with "invalid type: null, expected a sequence" on every text-only
+    /// assistant message — a false alarm that masked real drift issues.
+    #[test]
+    fn json_to_thread_messages_handles_null_action_calls_gracefully() {
+        let messages = serde_json::json!([
+            {
+                "role": "Assistant",
+                "content": "Here is your answer.",
+                "action_calls": null
+            }
+        ]);
+        let parsed = json_to_thread_messages(&messages).expect("must parse");
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(
+            parsed[0].role,
+            crate::types::message::MessageRole::Assistant
+        );
+        assert_eq!(parsed[0].content, "Here is your answer.");
+        assert!(
+            parsed[0].action_calls.is_none(),
+            "null action_calls must produce None, not a parse error"
+        );
+    }
+
+    /// Verify that messages WITHOUT the action_calls key at all (the most
+    /// common case for text responses) also parse correctly — this is the
+    /// baseline that the null-filtering regression test extends.
+    #[test]
+    fn json_to_thread_messages_handles_absent_action_calls() {
+        let messages = serde_json::json!([
+            {"role": "Assistant", "content": "Just text, no tools."}
+        ]);
+        let parsed = json_to_thread_messages(&messages).expect("must parse");
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].action_calls.is_none());
+    }
+
+    /// Empty action_calls array is valid (LLM decided not to call any
+    /// tools this turn but the response still has the array field). Must
+    /// produce `Some(vec![])`, not `None`.
+    #[test]
+    fn json_to_thread_messages_handles_empty_action_calls_array() {
+        let messages = serde_json::json!([
+            {
+                "role": "Assistant",
+                "content": "No tools needed.",
+                "action_calls": []
+            }
+        ]);
+        let parsed = json_to_thread_messages(&messages).expect("must parse");
+        assert_eq!(parsed.len(), 1);
+        let calls = parsed[0]
+            .action_calls
+            .as_ref()
+            .expect("empty array should produce Some(vec![])");
+        assert!(calls.is_empty());
+    }
 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2154,9 +2154,29 @@ fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
 
 /// Deserialize an `action_calls` JSON array (in Python interchange shape)
 /// back into canonical `ActionCall`s.
+///
+/// Logs a warning on failure rather than swallowing silently. The whole
+/// commit that introduced this helper exists to undo a `.ok()` swallow that
+/// dropped action_calls without any signal — replacing it with another
+/// `.ok()?` would re-introduce the same trap, just one layer deeper. If the
+/// shape ever drifts again (Python orchestrator field rename, extra
+/// required field, partial migration), the warning is the operator-visible
+/// breadcrumb that explains why subsequent tool results suddenly look
+/// orphaned to `sanitize_tool_messages`.
 fn python_json_to_action_calls(value: &serde_json::Value) -> Option<Vec<ActionCall>> {
-    let parsed: Vec<PythonActionCall> = serde_json::from_value(value.clone()).ok()?;
-    Some(parsed.into_iter().map(ActionCall::from).collect())
+    match serde_json::from_value::<Vec<PythonActionCall>>(value.clone()) {
+        Ok(parsed) => Some(parsed.into_iter().map(ActionCall::from).collect()),
+        Err(e) => {
+            warn!(
+                error = %e,
+                value = %value,
+                "Failed to parse action_calls from Python orchestrator — \
+                 assistant message will lose tool_call linkage and downstream \
+                 tool results will be rewritten as user messages"
+            );
+            None
+        }
+    }
 }
 
 fn json_to_thread_messages(value: &serde_json::Value) -> Option<Vec<ThreadMessage>> {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -42,7 +42,7 @@ use crate::types::event::{EventKind, ThreadEvent, summarize_params};
 use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
-use crate::types::step::{StepId, TokenUsage};
+use crate::types::step::{ActionCall, StepId, TokenUsage};
 use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadState};
 use ironclaw_common::ValidTimezone;
 
@@ -652,16 +652,9 @@ async fn handle_llm_complete(
                     serde_json::json!({"type": "code", "code": code, "usage": usage})
                 }
                 LlmResponse::ActionCalls { calls, content } => {
-                    let calls_json: Vec<serde_json::Value> = calls
-                        .iter()
-                        .map(|c| {
-                            serde_json::json!({
-                                "name": c.action_name,
-                                "call_id": c.id,
-                                "params": c.parameters,
-                            })
-                        })
-                        .collect();
+                    // Single source of truth for the Python interchange
+                    // shape — must round-trip via `python_json_to_action_calls`.
+                    let calls_json = action_calls_to_python_json(&calls);
                     serde_json::json!({
                         "type": "actions",
                         "content": content,
@@ -2099,6 +2092,73 @@ fn build_orchestrator_inputs(
     (names, values)
 }
 
+/// JSON shape used to interchange `ActionCall`s with the Python orchestrator.
+///
+/// This is the *single* place that defines the field naming convention used
+/// across the Python boundary. It is intentionally separate from the
+/// canonical `ActionCall` type because:
+///
+/// - `ActionCall` uses Rust-idiomatic field names (`id`, `action_name`,
+///   `parameters`) and is also persisted into Step records and ThreadEvents.
+///   Renaming its serde fields would invalidate every existing row.
+/// - The Python orchestrator uses friendlier names (`call_id`, `name`,
+///   `params`) that read naturally in CodeAct prompts and `default.py`.
+///
+/// Without this type, the round-trip is asymmetric: Rust → Python uses one
+/// shape, Python → Rust used `serde_json::from_value::<Vec<ActionCall>>`
+/// which silently fails (`.ok()` swallows the error) and produces `None`,
+/// which means assistant messages came back without `action_calls`. The
+/// downstream effect is that every tool result looks orphaned to
+/// `sanitize_tool_messages` and gets rewritten as a user message — losing
+/// the assistant ↔ tool_result linkage the LLM needs to reason about prior
+/// tool calls.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct PythonActionCall {
+    name: String,
+    call_id: String,
+    params: serde_json::Value,
+}
+
+impl From<&ActionCall> for PythonActionCall {
+    fn from(c: &ActionCall) -> Self {
+        Self {
+            name: c.action_name.clone(),
+            call_id: c.id.clone(),
+            params: c.parameters.clone(),
+        }
+    }
+}
+
+impl From<PythonActionCall> for ActionCall {
+    fn from(p: PythonActionCall) -> Self {
+        Self {
+            id: p.call_id,
+            action_name: p.name,
+            parameters: p.params,
+        }
+    }
+}
+
+/// Serialize a slice of `ActionCall`s into the Python interchange shape.
+fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
+    calls
+        .iter()
+        .map(|c| {
+            serde_json::to_value(PythonActionCall::from(c)).unwrap_or_else(|e| {
+                warn!("Failed to serialize ActionCall for Python: {e}");
+                serde_json::Value::Null
+            })
+        })
+        .collect()
+}
+
+/// Deserialize an `action_calls` JSON array (in Python interchange shape)
+/// back into canonical `ActionCall`s.
+fn python_json_to_action_calls(value: &serde_json::Value) -> Option<Vec<ActionCall>> {
+    let parsed: Vec<PythonActionCall> = serde_json::from_value(value.clone()).ok()?;
+    Some(parsed.into_iter().map(ActionCall::from).collect())
+}
+
 fn json_to_thread_messages(value: &serde_json::Value) -> Option<Vec<ThreadMessage>> {
     let arr = value.as_array()?;
     let mut messages = Vec::with_capacity(arr.len());
@@ -2111,7 +2171,7 @@ fn json_to_thread_messages(value: &serde_json::Value) -> Option<Vec<ThreadMessag
             .unwrap_or_default();
         let action_calls = item
             .get("action_calls")
-            .and_then(|v| serde_json::from_value(v.clone()).ok());
+            .and_then(python_json_to_action_calls);
 
         let message = match role {
             "System" | "system" => ThreadMessage::system(content),
@@ -2774,5 +2834,164 @@ mod tests {
         let result = serde_json::json!({"outcome": "stopped"});
         let outcome = parse_outcome(&result);
         assert!(matches!(outcome, ThreadOutcome::Stopped));
+    }
+
+    // ── Python ↔ Rust ActionCall round-trip ───────────────────────────────
+    //
+    // Regression tests for the orphaned-tool-result bug. The Python
+    // orchestrator stores `action_calls` on assistant messages using the
+    // shape `{name, call_id, params}`, but the canonical Rust `ActionCall`
+    // uses `{action_name, id, parameters}`. Without the explicit
+    // `PythonActionCall` interchange type, `serde_json::from_value` would
+    // silently fail (`.ok()` swallows the error) and the Python-shaped
+    // assistant message would be parsed back as a plain assistant message
+    // with no tool calls, causing every subsequent ActionResult to be
+    // detected as orphaned by `sanitize_tool_messages` in the host crate.
+
+    #[test]
+    fn python_action_call_round_trips_through_serde() {
+        let original = ActionCall {
+            id: "call_abc123".to_string(),
+            action_name: "google_drive_tool".to_string(),
+            parameters: serde_json::json!({"query": "expenses"}),
+        };
+
+        let python_json = serde_json::to_value(PythonActionCall::from(&original))
+            .expect("PythonActionCall must serialize");
+        // Python-friendly field names — match what default.py reads.
+        assert_eq!(python_json["name"], "google_drive_tool");
+        assert_eq!(python_json["call_id"], "call_abc123");
+        assert_eq!(
+            python_json["params"],
+            serde_json::json!({"query": "expenses"})
+        );
+
+        let parsed: PythonActionCall =
+            serde_json::from_value(python_json).expect("must deserialize");
+        let round_tripped: ActionCall = parsed.into();
+        assert_eq!(round_tripped.id, original.id);
+        assert_eq!(round_tripped.action_name, original.action_name);
+        assert_eq!(round_tripped.parameters, original.parameters);
+    }
+
+    #[test]
+    fn action_calls_to_python_json_uses_python_field_names() {
+        let calls = vec![
+            ActionCall {
+                id: "call_1".to_string(),
+                action_name: "notion_notion_search".to_string(),
+                parameters: serde_json::json!({"query": "name"}),
+            },
+            ActionCall {
+                id: "call_2".to_string(),
+                action_name: "google_drive_tool".to_string(),
+                parameters: serde_json::json!({"action": "list"}),
+            },
+        ];
+        let json = action_calls_to_python_json(&calls);
+        assert_eq!(json.len(), 2);
+        assert_eq!(json[0]["name"], "notion_notion_search");
+        assert_eq!(json[0]["call_id"], "call_1");
+        assert_eq!(json[1]["name"], "google_drive_tool");
+        assert_eq!(json[1]["call_id"], "call_2");
+    }
+
+    #[test]
+    fn python_json_to_action_calls_parses_python_field_names() {
+        // The exact shape default.py produces (and stores on assistant
+        // messages via `append_message(..., action_calls=calls)`).
+        let python_json = serde_json::json!([
+            {"name": "notion_notion_search", "call_id": "call_xyz", "params": {"q": "foo"}},
+            {"name": "google_drive_tool", "call_id": "call_abc", "params": {"action": "list"}},
+        ]);
+        let parsed = python_json_to_action_calls(&python_json).expect("must parse");
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].action_name, "notion_notion_search");
+        assert_eq!(parsed[0].id, "call_xyz");
+        assert_eq!(parsed[0].parameters, serde_json::json!({"q": "foo"}));
+        assert_eq!(parsed[1].action_name, "google_drive_tool");
+        assert_eq!(parsed[1].id, "call_abc");
+    }
+
+    #[test]
+    fn python_json_to_action_calls_rejects_canonical_field_names() {
+        // Sanity check: the parser is strict about Python field names.
+        // If `default.py` ever changes the shape, the test must catch it.
+        let canonical_json = serde_json::json!([
+            {"action_name": "search", "id": "call_x", "parameters": {}}
+        ]);
+        // Missing "name", "call_id", "params" → returns None.
+        assert!(python_json_to_action_calls(&canonical_json).is_none());
+    }
+
+    /// Caller-level regression test: feeds `json_to_thread_messages` the
+    /// exact JSON shape that `default.py` produces for an assistant message
+    /// with tool calls followed by tool results, and asserts that the
+    /// resulting `ThreadMessage`s preserve the `action_calls` ↔
+    /// `action_call_id` linkage. Without the `PythonActionCall` parser the
+    /// assistant message would come back with `action_calls = None` and
+    /// every following ActionResult would look orphaned to the bridge.
+    #[test]
+    fn json_to_thread_messages_preserves_action_calls_from_python_orchestrator() {
+        // This is the literal shape `default.py` writes into
+        // `state["working_messages"]` after a Tier 0 step:
+        //
+        //   append_message(working_messages, "Assistant", "...", action_calls=calls)
+        //   append_message(working_messages, "ActionResult", "...", action_name=..., action_call_id=...)
+        //
+        // where `calls` came from the LLM response and has shape
+        // `[{"name": ..., "call_id": ..., "params": ...}]`.
+        let working_messages = serde_json::json!([
+            {"role": "User", "content": "search in notion for my name"},
+            {
+                "role": "Assistant",
+                "content": "",
+                "action_calls": [
+                    {
+                        "name": "notion_notion_search",
+                        "call_id": "call_xyz",
+                        "params": {"query": "Illia"}
+                    }
+                ]
+            },
+            {
+                "role": "ActionResult",
+                "content": "found 3 results",
+                "action_name": "notion_notion_search",
+                "action_call_id": "call_xyz"
+            }
+        ]);
+
+        let messages = json_to_thread_messages(&working_messages).expect("must parse");
+        assert_eq!(messages.len(), 3);
+
+        // The assistant message MUST have action_calls populated, with
+        // matching call_id. If this assertion fails, the bridge layer
+        // will treat the following ActionResult as orphaned and rewrite
+        // it as a user message — losing the model's ability to reason
+        // about prior tool output.
+        let assistant = &messages[1];
+        assert_eq!(
+            assistant.role,
+            crate::types::message::MessageRole::Assistant
+        );
+        let calls = assistant
+            .action_calls
+            .as_ref()
+            .expect("assistant message must carry action_calls after round-trip");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_xyz");
+        assert_eq!(calls[0].action_name, "notion_notion_search");
+        assert_eq!(calls[0].parameters, serde_json::json!({"query": "Illia"}));
+
+        // The ActionResult must reference the same call_id so the bridge
+        // can pair them.
+        let result = &messages[2];
+        assert_eq!(
+            result.role,
+            crate::types::message::MessageRole::ActionResult
+        );
+        assert_eq!(result.action_call_id.as_deref(), Some("call_xyz"));
+        assert_eq!(result.action_name.as_deref(), Some("notion_notion_search"));
     }
 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -3174,4 +3174,97 @@ mod tests {
         assert_eq!(result.action_call_id.as_deref(), Some("call_xyz"));
         assert_eq!(result.action_name.as_deref(), Some("notion_notion_search"));
     }
+
+    /// Regression for the gate-resume / bootstrap path: when a thread
+    /// resumes after approval or auth, `build_orchestrator_inputs`
+    /// serializes `thread.internal_messages` into the bootstrap context
+    /// that Python reads into `working_messages`. If `action_calls` is
+    /// serialized with canonical `ActionCall` field names (`action_name`,
+    /// `id`, `parameters`) instead of the Python interchange names
+    /// (`name`, `call_id`, `params`), the next `__llm_complete__` call
+    /// passes them back through `json_to_thread_messages` which fails
+    /// with "missing field `name`" and orphans every subsequent tool
+    /// result.
+    ///
+    /// This test simulates the full round-trip: build a `ThreadMessage`
+    /// with action_calls → serialize through `build_orchestrator_inputs`'s
+    /// exact serialization pattern → parse back through
+    /// `json_to_thread_messages` → assert the calls survive. If anyone
+    /// adds a THIRD serialization path in the future and uses canonical
+    /// names, this test documents the pattern they should follow.
+    #[test]
+    fn bootstrap_context_action_calls_round_trip_through_python_interchange() {
+        // Build a thread message the way the engine does: an assistant
+        // message with action_calls in canonical ActionCall format (the
+        // shape stored in the DB / internal_messages).
+        let msg = ThreadMessage::assistant_with_actions(
+            Some("I'll search for that".to_string()),
+            vec![ActionCall {
+                id: "call_resume_test".to_string(),
+                action_name: "google_drive_tool".to_string(),
+                parameters: serde_json::json!({"query": "budget"}),
+            }],
+        );
+
+        // Serialize through the SAME pattern `build_orchestrator_inputs`
+        // uses. This is the exact code path that was broken before the
+        // fix — it was using `"action_calls": m.action_calls` which
+        // produced canonical field names.
+        let calls_json = msg
+            .action_calls
+            .as_ref()
+            .map(|calls| serde_json::Value::Array(action_calls_to_python_json(calls)));
+        let serialized = serde_json::json!([{
+            "role": "Assistant",
+            "content": msg.content,
+            "action_name": msg.action_name,
+            "action_call_id": msg.action_call_id,
+            "action_calls": calls_json,
+        }]);
+
+        // Parse back through the same path Python's working_messages
+        // takes when it calls __llm_complete__.
+        let parsed = json_to_thread_messages(&serialized).expect("must parse");
+        assert_eq!(parsed.len(), 1);
+
+        let assistant = &parsed[0];
+        let calls = assistant.action_calls.as_ref().expect(
+            "bootstrap context action_calls must survive the round-trip. \
+                 If this fails, a serialization path is using canonical ActionCall \
+                 field names instead of PythonActionCall interchange names.",
+        );
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].id, "call_resume_test");
+        assert_eq!(calls[0].action_name, "google_drive_tool");
+        assert_eq!(calls[0].parameters, serde_json::json!({"query": "budget"}));
+    }
+
+    /// Negative regression: verify that canonical ActionCall field names
+    /// do NOT round-trip. If this test ever PASSES, it means someone
+    /// added `#[serde(rename)]` to ActionCall or changed the parser to
+    /// accept both formats — which is fine, but the PythonActionCall
+    /// interchange type can then be removed. This test documents the
+    /// current contract: canonical names are rejected by the parser.
+    #[test]
+    fn canonical_action_call_field_names_do_not_round_trip() {
+        let serialized_with_canonical_names = serde_json::json!([{
+            "role": "Assistant",
+            "content": "",
+            "action_calls": [{
+                "action_name": "search",
+                "id": "call_x",
+                "parameters": {}
+            }],
+        }]);
+        let parsed =
+            json_to_thread_messages(&serialized_with_canonical_names).expect("messages parse");
+        // The assistant message should have NO action_calls because the
+        // parser rejects canonical field names.
+        assert!(
+            parsed[0].action_calls.is_none(),
+            "canonical ActionCall field names must NOT parse as action_calls. \
+             If this assertion fails, the PythonActionCall interchange type \
+             is no longer needed — either remove it or update the contract."
+        );
+    }
 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2055,12 +2055,27 @@ fn build_orchestrator_inputs(
     let context: Vec<serde_json::Value> = bootstrap_messages
         .iter()
         .map(|m| {
+            // Serialize action_calls through the Python interchange shape
+            // (`{name, call_id, params}`) so the bootstrap context is
+            // round-trip compatible with `python_json_to_action_calls`.
+            // Using bare `m.action_calls` here produces the canonical Rust
+            // serde format (`{action_name, id, parameters}`), which the
+            // Python orchestrator passes back verbatim on the next
+            // `__llm_complete__` call — and `python_json_to_action_calls`
+            // then fails with "missing field `name`", orphaning every
+            // subsequent tool result. This is the SECOND code path (after
+            // `handle_llm_complete`) that feeds action_calls into the
+            // Python working transcript; both must use the same shape.
+            let calls_json = m
+                .action_calls
+                .as_ref()
+                .map(|calls| serde_json::Value::Array(action_calls_to_python_json(calls)));
             serde_json::json!({
                 "role": format!("{:?}", m.role),
                 "content": m.content,
                 "action_name": m.action_name,
                 "action_call_id": m.action_call_id,
-                "action_calls": m.action_calls,
+                "action_calls": calls_json,
             })
         })
         .collect();

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2260,8 +2260,14 @@ fn json_to_thread_messages(value: &serde_json::Value) -> Option<Vec<ThreadMessag
             .get("content")
             .and_then(|v| v.as_str())
             .unwrap_or_default();
+        // Filter out null before calling the parser — `action_calls: null`
+        // is Python's legitimate "this message has no tool calls" signal (text
+        // response), not a parse error. Without this filter, the warn log in
+        // python_json_to_action_calls fires on every text-only assistant
+        // message with "invalid type: null, expected a sequence".
         let action_calls = item
             .get("action_calls")
+            .filter(|v| !v.is_null())
             .and_then(python_json_to_action_calls);
 
         let message = match role {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -51,16 +51,34 @@ fn gate_display_parameters(pending: &PendingGate) -> serde_json::Value {
         .unwrap_or_else(|| pending.parameters.clone())
 }
 
+/// Resolve the owning extension name for a tool action, falling back to a
+/// credential name when the action isn't extension-backed. This is the
+/// shared core of the auth-gate display + submit routing logic — the same
+/// `provider_extension_for_tool + unwrap_or_else(credential_name)` pattern
+/// fired in three different sites in this file before, each one with the
+/// same fallback rationale: the engine's `ResumeKind::Authentication` only
+/// carries `credential_name` (e.g. `google_oauth_token`), which is opaque
+/// to users AND fails when fed back into `submit_auth_token` for
+/// WASM-tool-backed credentials, while the owning extension name (e.g.
+/// `google-drive-tool`) is what both the user-facing UI and
+/// `submit_auth_token` actually want. For built-in tools, HTTP, and skill
+/// credentials there's no owning extension and the fallback is the right
+/// thing.
+async fn resolve_extension_for_action(
+    tools: &crate::tools::ToolRegistry,
+    action_name: &str,
+    credential_fallback: &str,
+) -> String {
+    tools
+        .provider_extension_for_tool(action_name)
+        .await
+        .unwrap_or_else(|| credential_fallback.to_string())
+}
+
 /// Resolve the user-facing name to use when surfacing an authentication
-/// gate to a channel. The engine's `ResumeKind::Authentication` only
-/// carries `credential_name` (e.g. `google_oauth_token`), which is
-/// opaque to the user and also fails when fed back into
-/// `submit_auth_token` for WASM-tool-backed credentials. We prefer the
-/// owning extension name (e.g. `google-drive-tool`) when the failing
-/// action belongs to one. For built-in tools, HTTP, and skill
-/// credentials there's no provider extension, so we fall back to the
-/// credential name (which IS the right thing to display in those
-/// cases).
+/// gate to a channel. Thin wrapper around `resolve_extension_for_action`
+/// that handles the non-Authentication ResumeKind variants by falling back
+/// to the action name (since they don't have a credential name to use).
 async fn resolve_auth_gate_display_name(
     tools: &crate::tools::ToolRegistry,
     pending: &PendingGate,
@@ -69,10 +87,7 @@ async fn resolve_auth_gate_display_name(
         credential_name, ..
     } = &pending.resume_kind
     {
-        tools
-            .provider_extension_for_tool(&pending.action_name)
-            .await
-            .unwrap_or_else(|| credential_name.clone())
+        resolve_extension_for_action(tools, &pending.action_name, credential_name).await
     } else {
         // Non-authentication gates don't use this string; return
         // something innocuous.
@@ -1611,27 +1626,15 @@ pub async fn resolve_gate(
                 // its first argument and uses `configure_token` to walk
                 // the extension's capabilities file for the actual
                 // secret name. The engine's `ResumeKind::Authentication`
-                // only carries `credential_name` (e.g.
-                // `google_oauth_token`), which is NOT an extension
-                // name. Passing it directly fails closed because
-                // neither `configure_token("google_oauth_token", ...)`
-                // nor `get_credential_spec("google_oauth_token")`
-                // match anything for a WASM tool — and the agent gets
-                // back the user-confusing "Extension not installed:
-                // google_oauth_token" message.
-                //
-                // Resolve the actual extension via the action that
-                // triggered the gate. For built-in tools, HTTP, and
-                // skill credentials there's no provider extension and
-                // we fall back to the credential name (the existing
-                // pre-fix behaviour for those callers — `submit_auth_token`
-                // then routes through the skill registry).
-                let submit_target = state
-                    .effect_adapter
-                    .tools()
-                    .provider_extension_for_tool(&pending.action_name)
-                    .await
-                    .unwrap_or_else(|| credential_name.clone());
+                // only carries `credential_name`, which fails closed
+                // when fed there for WASM-tool-backed credentials. See
+                // `resolve_extension_for_action` for the full rationale.
+                let submit_target = resolve_extension_for_action(
+                    state.effect_adapter.tools(),
+                    &pending.action_name,
+                    credential_name,
+                )
+                .await;
                 let display_name = submit_target.clone();
 
                 if let Some(ref sse) = state.sse {
@@ -2788,37 +2791,19 @@ async fn await_thread_outcome(
                     instructions,
                     auth_url,
                 } => {
-                    // The engine's `ResumeKind::Authentication` only
-                    // carries `credential_name` (e.g. "google_oauth_token"),
-                    // not the owning extension. For UI display and the
-                    // resume-time `submit_auth_token` call, we want the
-                    // actual extension name (e.g. "google-drive-tool")
-                    // because:
-                    //   * the channel UIs render `extension_name` as
-                    //     "Authentication required for 'X'", and a
-                    //     credential name like `google_oauth_token` is
-                    //     opaque to the user, while `google-drive-tool`
-                    //     is the integration they recognise.
-                    //   * `submit_auth_token` routes the *extension name*
-                    //     through `configure_token`, which loads the
-                    //     extension's capabilities file to find the
-                    //     correct secret name. Passing the credential
-                    //     name there fails closed with
-                    //     "Extension not installed: google_oauth_token".
-                    //
-                    // We derive the extension name from the action that
-                    // triggered the gate (`pending.action_name`) by
-                    // asking the tool registry which provider extension
-                    // owns it. For built-in tools, HTTP, and skill
-                    // credentials there's no owning extension and we
-                    // fall back to the credential name (the existing
-                    // pre-fix behaviour for those callers).
-                    let extension_for_display = state
-                        .effect_adapter
-                        .tools()
-                        .provider_extension_for_tool(&action_name)
-                        .await
-                        .unwrap_or_else(|| credential_name.clone());
+                    // Channel UIs render `extension_name` as "Authentication
+                    // required for 'X'", and `credential_name` (e.g.
+                    // `google_oauth_token`) is opaque to users, while the
+                    // owning extension name (e.g. `google-drive-tool`) is
+                    // the integration they recognise. See
+                    // `resolve_extension_for_action` for the full rationale
+                    // and the fallback semantics for non-WASM credentials.
+                    let extension_for_display = resolve_extension_for_action(
+                        state.effect_adapter.tools(),
+                        &action_name,
+                        credential_name,
+                    )
+                    .await;
 
                     let _ = agent
                         .channels

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -51,7 +51,41 @@ fn gate_display_parameters(pending: &PendingGate) -> serde_json::Value {
         .unwrap_or_else(|| pending.parameters.clone())
 }
 
-async fn send_pending_gate_status(agent: &Agent, message: &IncomingMessage, pending: &PendingGate) {
+/// Resolve the user-facing name to use when surfacing an authentication
+/// gate to a channel. The engine's `ResumeKind::Authentication` only
+/// carries `credential_name` (e.g. `google_oauth_token`), which is
+/// opaque to the user and also fails when fed back into
+/// `submit_auth_token` for WASM-tool-backed credentials. We prefer the
+/// owning extension name (e.g. `google-drive-tool`) when the failing
+/// action belongs to one. For built-in tools, HTTP, and skill
+/// credentials there's no provider extension, so we fall back to the
+/// credential name (which IS the right thing to display in those
+/// cases).
+async fn resolve_auth_gate_display_name(
+    tools: &crate::tools::ToolRegistry,
+    pending: &PendingGate,
+) -> String {
+    if let ironclaw_engine::ResumeKind::Authentication {
+        credential_name, ..
+    } = &pending.resume_kind
+    {
+        tools
+            .provider_extension_for_tool(&pending.action_name)
+            .await
+            .unwrap_or_else(|| credential_name.clone())
+    } else {
+        // Non-authentication gates don't use this string; return
+        // something innocuous.
+        pending.action_name.clone()
+    }
+}
+
+async fn send_pending_gate_status(
+    agent: &Agent,
+    message: &IncomingMessage,
+    pending: &PendingGate,
+    auth_display_name: &str,
+) {
     let display_parameters = gate_display_parameters(pending);
 
     match &pending.resume_kind {
@@ -72,16 +106,16 @@ async fn send_pending_gate_status(agent: &Agent, message: &IncomingMessage, pend
                 .await;
         }
         ironclaw_engine::ResumeKind::Authentication {
-            credential_name,
             instructions,
             auth_url,
+            ..
         } => {
             let _ = agent
                 .channels
                 .send_status(
                     &message.channel,
                     StatusUpdate::AuthRequired {
-                        extension_name: credential_name.clone(),
+                        extension_name: auth_display_name.to_string(),
                         instructions: Some(instructions.clone()),
                         auth_url: auth_url.clone(),
                         setup_url: None,
@@ -94,17 +128,15 @@ async fn send_pending_gate_status(agent: &Agent, message: &IncomingMessage, pend
     }
 }
 
-fn pending_gate_prompt_message(pending: &PendingGate) -> Option<String> {
+fn pending_gate_prompt_message(pending: &PendingGate, auth_display_name: &str) -> Option<String> {
     match &pending.resume_kind {
         ironclaw_engine::ResumeKind::Approval { .. } => Some(format!(
             "Tool '{}' requires approval. Reply 'yes' to approve, 'no' to deny.",
             pending.action_name
         )),
-        ironclaw_engine::ResumeKind::Authentication {
-            credential_name, ..
-        } => Some(format!(
+        ironclaw_engine::ResumeKind::Authentication { .. } => Some(format!(
             "Authentication required for '{}'. Paste your token below (or type 'cancel'):",
-            credential_name
+            auth_display_name
         )),
         ironclaw_engine::ResumeKind::External { .. } => Some(format!(
             "Waiting for external confirmation (gate: {})...",
@@ -244,10 +276,12 @@ fn parse_credential_name(text: &str) -> Option<String> {
 async fn notify_pending_gate(
     agent: &Agent,
     sse: Option<Arc<SseManager>>,
+    tools: &crate::tools::ToolRegistry,
     message: &IncomingMessage,
     pending: &PendingGate,
 ) -> Result<Option<String>, Error> {
     let display_parameters = gate_display_parameters(pending);
+    let auth_display_name = resolve_auth_gate_display_name(tools, pending).await;
 
     if let Some(sse) = sse {
         sse.broadcast_for_user(
@@ -276,8 +310,8 @@ async fn notify_pending_gate(
         );
     }
 
-    send_pending_gate_status(agent, message, pending).await;
-    Ok(pending_gate_prompt_message(pending))
+    send_pending_gate_status(agent, message, pending, &auth_display_name).await;
+    Ok(pending_gate_prompt_message(pending, &auth_display_name))
 }
 
 async fn insert_and_notify_pending_gate(
@@ -292,7 +326,14 @@ async fn insert_and_notify_pending_gate(
         .await
         .map_err(|e| engine_err("pending gate insert", e))?;
 
-    notify_pending_gate(agent, state.sse.clone(), message, &pending).await
+    notify_pending_gate(
+        agent,
+        state.sse.clone(),
+        state.effect_adapter.tools(),
+        message,
+        &pending,
+    )
+    .await
 }
 
 async fn execute_pending_gate_action(
@@ -1566,6 +1607,33 @@ pub async fn resolve_gate(
                 ..
             } = pending.resume_kind
             {
+                // `submit_auth_token` expects an *extension name* as
+                // its first argument and uses `configure_token` to walk
+                // the extension's capabilities file for the actual
+                // secret name. The engine's `ResumeKind::Authentication`
+                // only carries `credential_name` (e.g.
+                // `google_oauth_token`), which is NOT an extension
+                // name. Passing it directly fails closed because
+                // neither `configure_token("google_oauth_token", ...)`
+                // nor `get_credential_spec("google_oauth_token")`
+                // match anything for a WASM tool — and the agent gets
+                // back the user-confusing "Extension not installed:
+                // google_oauth_token" message.
+                //
+                // Resolve the actual extension via the action that
+                // triggered the gate. For built-in tools, HTTP, and
+                // skill credentials there's no provider extension and
+                // we fall back to the credential name (the existing
+                // pre-fix behaviour for those callers — `submit_auth_token`
+                // then routes through the skill registry).
+                let submit_target = state
+                    .effect_adapter
+                    .tools()
+                    .provider_extension_for_tool(&pending.action_name)
+                    .await
+                    .unwrap_or_else(|| credential_name.clone());
+                let display_name = submit_target.clone();
+
                 if let Some(ref sse) = state.sse {
                     sse.broadcast_for_user(
                         &message.user_id,
@@ -1584,7 +1652,7 @@ pub async fn resolve_gate(
                 }
                 if let Some(ref auth_manager) = state.auth_manager {
                     match auth_manager
-                        .submit_auth_token(credential_name, &token, &message.user_id)
+                        .submit_auth_token(&submit_target, &token, &message.user_id)
                         .await
                     {
                         Ok(result) if result.activated => {
@@ -1593,7 +1661,7 @@ pub async fn resolve_gate(
                                 .send_status(
                                     &message.channel,
                                     StatusUpdate::AuthCompleted {
-                                        extension_name: credential_name.clone(),
+                                        extension_name: display_name.clone(),
                                         success: true,
                                         message: format!("{}. Resuming...", result.message),
                                     },
@@ -1607,7 +1675,7 @@ pub async fn resolve_gate(
                                 .send_status(
                                     &message.channel,
                                     StatusUpdate::AuthRequired {
-                                        extension_name: credential_name.clone(),
+                                        extension_name: display_name.clone(),
                                         instructions: Some(result.message.clone()),
                                         auth_url: result.auth_url.clone(),
                                         setup_url: None,
@@ -1623,7 +1691,7 @@ pub async fn resolve_gate(
                                 .send_status(
                                     &message.channel,
                                     StatusUpdate::AuthRequired {
-                                        extension_name: credential_name.clone(),
+                                        extension_name: display_name.clone(),
                                         instructions: Some(msg.clone()),
                                         auth_url: None,
                                         setup_url: None,
@@ -1640,7 +1708,7 @@ pub async fn resolve_gate(
                                 .send_status(
                                     &message.channel,
                                     StatusUpdate::AuthCompleted {
-                                        extension_name: credential_name.clone(),
+                                        extension_name: display_name.clone(),
                                         success: false,
                                         message: msg.clone(),
                                     },
@@ -2226,14 +2294,19 @@ async fn handle_with_engine_inner(
             ) =>
         {
             let pending = gate.clone();
-            // Clone the SSE arc out of state, then drop the engine read
-            // guard before awaiting on broadcast + channel I/O. The auth
-            // branch above does the same, and `notify_pending_gate` is
-            // signed to accept an owned Option<Arc<SseManager>> precisely
-            // so this terminal-return branch can release the lock.
+            // Clone the SSE arc and the tools registry out of state,
+            // then drop the engine read guard before awaiting on
+            // broadcast + channel I/O. The auth branch above does the
+            // same, and `notify_pending_gate` is signed to accept an
+            // owned Option<Arc<SseManager>> precisely so this
+            // terminal-return branch can release the lock. The tools
+            // registry handle is needed by `notify_pending_gate` to
+            // resolve the auth-gate display name without holding the
+            // engine state lock.
             let sse = state.sse.clone();
+            let tools = Arc::clone(state.effect_adapter.tools());
             drop(guard);
-            return notify_pending_gate(agent, sse, message, &pending).await;
+            return notify_pending_gate(agent, sse, tools.as_ref(), message, &pending).await;
         }
         PendingGateResolution::Ambiguous => {
             return Ok(Some(
@@ -2715,12 +2788,44 @@ async fn await_thread_outcome(
                     instructions,
                     auth_url,
                 } => {
+                    // The engine's `ResumeKind::Authentication` only
+                    // carries `credential_name` (e.g. "google_oauth_token"),
+                    // not the owning extension. For UI display and the
+                    // resume-time `submit_auth_token` call, we want the
+                    // actual extension name (e.g. "google-drive-tool")
+                    // because:
+                    //   * the channel UIs render `extension_name` as
+                    //     "Authentication required for 'X'", and a
+                    //     credential name like `google_oauth_token` is
+                    //     opaque to the user, while `google-drive-tool`
+                    //     is the integration they recognise.
+                    //   * `submit_auth_token` routes the *extension name*
+                    //     through `configure_token`, which loads the
+                    //     extension's capabilities file to find the
+                    //     correct secret name. Passing the credential
+                    //     name there fails closed with
+                    //     "Extension not installed: google_oauth_token".
+                    //
+                    // We derive the extension name from the action that
+                    // triggered the gate (`pending.action_name`) by
+                    // asking the tool registry which provider extension
+                    // owns it. For built-in tools, HTTP, and skill
+                    // credentials there's no owning extension and we
+                    // fall back to the credential name (the existing
+                    // pre-fix behaviour for those callers).
+                    let extension_for_display = state
+                        .effect_adapter
+                        .tools()
+                        .provider_extension_for_tool(&action_name)
+                        .await
+                        .unwrap_or_else(|| credential_name.clone());
+
                     let _ = agent
                         .channels
                         .send_status(
                             &message.channel,
                             StatusUpdate::AuthRequired {
-                                extension_name: credential_name.clone(),
+                                extension_name: extension_for_display.clone(),
                                 instructions: Some(instructions.clone()),
                                 auth_url: auth_url.clone(),
                                 setup_url: None,
@@ -2731,7 +2836,7 @@ async fn await_thread_outcome(
 
                     Ok(Some(format!(
                         "Authentication required for '{}'. Paste your token below (or type 'cancel'):",
-                        credential_name
+                        extension_for_display
                     )))
                 }
                 ironclaw_engine::ResumeKind::External { callback_id } => {

--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -223,7 +223,7 @@ impl WasmChannelLoader {
             }
 
             let name = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(n) => n.to_string(),
+                Some(n) => n.replace('-', "_"),
                 None => {
                     results.errors.push((
                         path.clone(),
@@ -233,6 +233,8 @@ impl WasmChannelLoader {
                 }
             };
 
+            // Look up capabilities using the original filename (before
+            // hyphen normalization) so existing sidecar files are found.
             let cap_path = path.with_extension("capabilities.json");
             let has_cap = cap_path.exists();
             channel_entries.push((name, path, if has_cap { Some(cap_path) } else { None }));
@@ -382,7 +384,7 @@ pub async fn discover_channels(
         }
 
         let name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(n) => n.to_string(),
+            Some(n) => n.replace('-', "_"),
             None => continue,
         };
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -176,7 +176,20 @@ impl Config {
                 enabled: false,
                 ..WasmConfig::default()
             },
-            secrets: SecretsConfig::default(),
+            // Test config gets a deterministic master key so the
+            // secrets store is wired up out of the box. Without this,
+            // every replay-mode test that touches credentials would
+            // have to either build its own SecretsStore or skip the
+            // secrets path entirely. The key is hex-encoded 32 bytes
+            // (64 hex chars) so it satisfies the AES-256-GCM length
+            // check in `SecretsConfig::resolve`.
+            secrets: SecretsConfig {
+                master_key: Some(secrecy::SecretString::from(
+                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+                )),
+                enabled: true,
+                source: crate::settings::KeySource::Env,
+            },
             builder: BuilderModeConfig {
                 enabled: false,
                 ..BuilderModeConfig::default()

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,6 +128,27 @@ pub struct Config {
     pub relay: Option<RelayConfig>,
 }
 
+/// Generate a fresh random AES-256-GCM master key for `Config::for_testing`.
+///
+/// Returns a hex-encoded 32-byte key (64 hex chars), satisfying the length
+/// check in `SecretsConfig::resolve`. Each call returns a different value —
+/// tests don't need cross-process determinism (each test builds a fresh
+/// secrets store on top of a fresh temp DB), and committing a constant
+/// master key into the source tree would mean every developer who built
+/// with `--features libsql` had a publicly-known key in their process.
+#[cfg(feature = "libsql")]
+fn generate_test_master_key() -> secrecy::SecretString {
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    let mut hex = String::with_capacity(64);
+    for b in bytes {
+        use std::fmt::Write;
+        let _ = write!(hex, "{:02x}", b);
+    }
+    secrecy::SecretString::from(hex)
+}
+
 impl Config {
     /// Create a full Config for integration tests without reading env vars.
     ///
@@ -176,17 +197,21 @@ impl Config {
                 enabled: false,
                 ..WasmConfig::default()
             },
-            // Test config gets a deterministic master key so the
-            // secrets store is wired up out of the box. Without this,
-            // every replay-mode test that touches credentials would
-            // have to either build its own SecretsStore or skip the
-            // secrets path entirely. The key is hex-encoded 32 bytes
-            // (64 hex chars) so it satisfies the AES-256-GCM length
-            // check in `SecretsConfig::resolve`.
+            // Test config gets a freshly-generated random master key so
+            // the secrets store is wired up out of the box. Without this,
+            // every replay-mode test that touches credentials would have
+            // to either build its own SecretsStore or skip the secrets
+            // path entirely. The key is generated per call (NOT a
+            // hardcoded constant) — `Config::for_testing` is `pub` so
+            // anything in the crate or downstream tests can call it, and
+            // committing a known master key into the source tree would
+            // mean every developer who built with `--features libsql`
+            // had a publicly-known AES-256-GCM key sitting in their
+            // process. Tests don't need cross-process determinism here:
+            // each test creates its own temp DB, so the secrets store
+            // is born fresh on every call anyway.
             secrets: SecretsConfig {
-                master_key: Some(secrecy::SecretString::from(
-                    "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-                )),
+                master_key: Some(generate_test_master_key()),
                 enabled: true,
                 source: crate::settings::KeySource::Env,
             },

--- a/src/db/libsql/workspace.rs
+++ b/src/db/libsql/workspace.rs
@@ -13,8 +13,8 @@ use super::{
 use crate::db::WorkspaceStore;
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::workspace::{
-    DocumentVersion, MemoryChunk, MemoryDocument, RankedResult, SearchConfig, SearchResult,
-    VersionSummary, WorkspaceEntry, fuse_results,
+    ChunkWrite, DocumentVersion, MemoryChunk, MemoryDocument, RankedResult, SearchConfig,
+    SearchResult, VersionSummary, WorkspaceEntry, fuse_results,
 };
 
 use chrono::Utc;
@@ -713,6 +713,79 @@ impl WorkspaceStore for LibSqlBackend {
             reason: format!("Insert failed: {}", e),
         })?;
         Ok(id)
+    }
+
+    async fn replace_chunks(
+        &self,
+        document_id: Uuid,
+        chunks: &[ChunkWrite],
+    ) -> Result<(), WorkspaceError> {
+        let conn = self
+            .connect()
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: e.to_string(),
+            })?;
+
+        // BEGIN IMMEDIATE (not the default DEFERRED): grab the RESERVED
+        // write lock at transaction start so the busy_timeout handler fires
+        // on contention. DEFERRED starts as a reader and returns
+        // SQLITE_BUSY *immediately* on the first write when another
+        // transaction already holds the write lock — bypassing busy_timeout
+        // entirely, which turned concurrent reindexers into instant
+        // "database is locked" failures in tests.
+        let tx = conn
+            .transaction_with_behavior(libsql::TransactionBehavior::Immediate)
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Begin transaction failed: {}", e),
+            })?;
+
+        tx.execute(
+            "DELETE FROM memory_chunks WHERE document_id = ?1",
+            params![document_id.to_string()],
+        )
+        .await
+        .map_err(|e| WorkspaceError::ChunkingFailed {
+            reason: format!("Delete failed: {}", e),
+        })?;
+
+        for (index, chunk) in chunks.iter().enumerate() {
+            let id = Uuid::new_v4();
+            // Note: embedding dimension is not validated here — the F32_BLOB(N)
+            // column type created by ensure_vector_index() enforces byte length
+            // at the libSQL level and will reject mismatched dimensions.
+            let embedding_blob = chunk.embedding.as_ref().map(|e| {
+                let bytes: Vec<u8> = e.iter().flat_map(|f| f.to_le_bytes()).collect();
+                bytes
+            });
+
+            tx.execute(
+                r#"
+                    INSERT INTO memory_chunks (id, document_id, chunk_index, content, embedding)
+                    VALUES (?1, ?2, ?3, ?4, ?5)
+                    "#,
+                params![
+                    id.to_string(),
+                    document_id.to_string(),
+                    index as i64,
+                    chunk.content.as_str(),
+                    embedding_blob.map(libsql::Value::Blob),
+                ],
+            )
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Insert failed: {}", e),
+            })?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Commit failed: {}", e),
+            })?;
+
+        Ok(())
     }
 
     async fn update_chunk_embedding(

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -41,7 +41,7 @@ use crate::history::{
     AgentJobRecord, AgentJobSummary, ConversationMessage, ConversationSummary, JobEventRecord,
     LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow,
 };
-use crate::workspace::{MemoryChunk, MemoryDocument, WorkspaceEntry};
+use crate::workspace::{ChunkWrite, MemoryChunk, MemoryDocument, WorkspaceEntry};
 use crate::workspace::{SearchConfig, SearchResult};
 
 /// Create a database backend from configuration, run migrations, and return it.
@@ -747,6 +747,20 @@ pub trait WorkspaceStore: Send + Sync {
         content: &str,
         embedding: Option<&[f32]>,
     ) -> Result<Uuid, WorkspaceError>;
+    /// Atomically replace all chunks for a document.
+    ///
+    /// Runs `DELETE FROM memory_chunks WHERE document_id = ?` followed by one
+    /// `INSERT` per `ChunkWrite` inside a single transaction. This closes the
+    /// TOCTOU race where two concurrent reindexers for the same document
+    /// could both delete, then both try to `INSERT` chunk_index 0 and hit the
+    /// `UNIQUE (document_id, chunk_index)` constraint.
+    ///
+    /// Passing an empty slice is equivalent to `delete_chunks(document_id)`.
+    async fn replace_chunks(
+        &self,
+        document_id: Uuid,
+        chunks: &[ChunkWrite],
+    ) -> Result<(), WorkspaceError>;
     async fn update_chunk_embedding(
         &self,
         chunk_id: Uuid,

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -26,8 +26,8 @@ use crate::history::{
     LlmCallRecord, SandboxJobRecord, SandboxJobSummary, SettingRow, Store,
 };
 use crate::workspace::{
-    DocumentVersion, MemoryChunk, MemoryDocument, Repository, SearchConfig, SearchResult,
-    VersionSummary, WorkspaceEntry,
+    ChunkWrite, DocumentVersion, MemoryChunk, MemoryDocument, Repository, SearchConfig,
+    SearchResult, VersionSummary, WorkspaceEntry,
 };
 
 /// PostgreSQL database backend.
@@ -798,6 +798,14 @@ impl WorkspaceStore for PgBackend {
         self.repo
             .insert_chunk(document_id, chunk_index, content, embedding)
             .await
+    }
+
+    async fn replace_chunks(
+        &self,
+        document_id: Uuid,
+        chunks: &[ChunkWrite],
+    ) -> Result<(), WorkspaceError> {
+        self.repo.replace_chunks(document_id, chunks).await
     }
 
     async fn update_chunk_embedding(

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -8459,6 +8459,73 @@ mod tests {
         );
     }
 
+    /// Regression: latent provider actions for an MCP server with a
+    /// hyphenated name must produce action_names with underscores, not
+    /// hyphens. The `latent_actions_for_mcp_server` method uses
+    /// `mcp_tool_id(&server.name, &tool.name)` which normalizes ALL
+    /// non-identifier chars to `_`. Without this, the latent action
+    /// `my-server_search` would never match the registered tool
+    /// `my_server_search` when the server activates later.
+    #[tokio::test]
+    async fn latent_provider_actions_normalize_hyphenated_server_names() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let manager = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            None,
+        );
+
+        let mut server = McpServerConfig::new("my-mcp-server", "https://example.com/mcp");
+        server.cached_tools = vec![
+            crate::tools::mcp::McpTool {
+                name: "search-all".to_string(),
+                description: "Search everything".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                annotations: None,
+            },
+            crate::tools::mcp::McpTool {
+                name: "get_item".to_string(),
+                description: "Get an item".to_string(),
+                input_schema: serde_json::json!({"type": "object"}),
+                annotations: None,
+            },
+        ];
+        manager
+            .add_mcp_server(server, "test")
+            .await
+            .expect("add mcp server");
+
+        let actions = manager.latent_provider_actions("test").await;
+
+        // The umbrella action for the server itself.
+        assert!(
+            actions.iter().any(|a| a.action_name == "my-mcp-server"),
+            "umbrella action should use the raw server name"
+        );
+
+        // Individual tool actions must have normalized names.
+        let search = actions
+            .iter()
+            .find(|a| a.action_name == "my_mcp_server_search_all")
+            .expect("hyphenated server + tool name must normalize to underscores");
+        assert_eq!(search.provider_extension, "my-mcp-server");
+
+        let get_item = actions
+            .iter()
+            .find(|a| a.action_name == "my_mcp_server_get_item")
+            .expect("already-underscore tool name must still work with hyphenated server");
+        assert_eq!(get_item.provider_extension, "my-mcp-server");
+
+        // Negative: the old (pre-fix) hyphenated form must NOT appear.
+        assert!(
+            !actions
+                .iter()
+                .any(|a| a.action_name == "my-mcp-server_search-all"),
+            "hyphenated action_name must not survive normalization"
+        );
+    }
+
     /// Regression: configuring or removing an MCP server must invalidate
     /// the cached `latent_wasm_provider_actions` map. The cache is built by
     /// scanning the registry for uninstalled `WasmTool`/`McpServer` entries;

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5184,10 +5184,12 @@ impl ExtensionManager {
             .await
             .map_err(|e| ExtensionError::ActivationFailed(e.to_string()))?;
 
-        let tool_names: Vec<String> = mcp_tools
-            .iter()
-            .map(|t| format!("{}_{}", name, t.name))
-            .collect();
+        // Source the reported names from the wrapper itself, not from the
+        // raw McpTool list. The wrapper canonicalizes dashes to underscores
+        // (see `mcp_tool_id`) so the registry key, the LLM-facing schema,
+        // the `/tools` listing, and the activation result all agree on a
+        // single snake_case identifier.
+        let tool_names: Vec<String> = tool_impls.iter().map(|t| t.name().to_string()).collect();
 
         for tool in tool_impls {
             self.tool_registry.register(tool).await;
@@ -5245,7 +5247,7 @@ impl ExtensionManager {
             };
 
             LatentProviderAction {
-                action_name: format!("{}_{}", server.name, tool.name),
+                action_name: crate::tools::mcp::mcp_tool_id(&server.name, &tool.name),
                 provider_extension: server.name.clone(),
                 description: format!(
                     "{} The runtime will connect/authenticate this provider automatically before use.",

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2677,16 +2677,38 @@ impl ExtensionManager {
         }
     }
 
+    /// Look up an MCP server config by name, trying both the exact name
+    /// and the legacy hyphen/underscore alias. The factory normalizes
+    /// `server.name` (hyphens → underscores) before creating the client,
+    /// but persisted configs may still use the original hyphenated name.
+    /// `provider_extension_for_tool()` returns the normalized form, so
+    /// callers like `ensure_extension_ready → activate_mcp` may pass
+    /// `my_server` when the persisted config is keyed as `my-server`.
     async fn get_mcp_server(
         &self,
         name: &str,
         user_id: &str,
     ) -> Result<McpServerConfig, crate::tools::mcp::config::ConfigError> {
         let servers = self.load_mcp_servers(user_id).await?;
-        servers.get(name).cloned().ok_or_else(|| {
-            crate::tools::mcp::config::ConfigError::ServerNotFound {
-                name: name.to_string(),
-            }
+        if let Some(config) = servers.get(name) {
+            return Ok(config.clone());
+        }
+        // Try legacy hyphen alias (underscores → hyphens)
+        let hyphen_alias = name.replace('_', "-");
+        if hyphen_alias != name
+            && let Some(config) = servers.get(&hyphen_alias)
+        {
+            return Ok(config.clone());
+        }
+        // Try normalized alias (hyphens → underscores)
+        let underscore_alias = name.replace('-', "_");
+        if underscore_alias != name
+            && let Some(config) = servers.get(&underscore_alias)
+        {
+            return Ok(config.clone());
+        }
+        Err(crate::tools::mcp::config::ConfigError::ServerNotFound {
+            name: name.to_string(),
         })
     }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -2454,8 +2454,11 @@ impl ExtensionManager {
             }
         };
 
-        // Read current WIT version from capabilities
-        let cap_path = cap_dir.join(format!("{}.capabilities.json", name));
+        // Read current WIT version from capabilities. Use the
+        // alias-aware helper so an extension installed under the
+        // legacy hyphen form is still recognised as already installed
+        // by the upgrader.
+        let cap_path = Self::existing_extension_file_path(cap_dir, name, ".capabilities.json");
         let declared_wit = if cap_path.exists() {
             match tokio::fs::read(&cap_path).await {
                 Ok(bytes) => {
@@ -2517,8 +2520,10 @@ impl ExtensionManager {
             };
         };
 
-        // Delete old .wasm file (keep secrets intact)
-        let wasm_path = cap_dir.join(format!("{}.wasm", name));
+        // Delete old .wasm file (keep secrets intact). Use the
+        // alias-aware helper so the legacy hyphen filename is also
+        // removed when present.
+        let wasm_path = Self::existing_extension_file_path(cap_dir, name, ".wasm");
         if wasm_path.exists()
             && let Err(e) = tokio::fs::remove_file(&wasm_path).await
         {
@@ -3730,21 +3735,19 @@ impl ExtensionManager {
         name: &str,
         user_id: &str,
     ) -> Result<AuthResult, ExtensionError> {
-        // Read the capabilities file to get auth config
-        let cap_path = self
-            .wasm_tools_dir
-            .join(format!("{}.capabilities.json", name));
-
-        if !cap_path.exists() {
-            return Ok(AuthResult::no_auth_required(name, ExtensionKind::WasmTool));
-        }
-
-        let cap_bytes = tokio::fs::read(&cap_path)
-            .await
-            .map_err(|e| ExtensionError::Other(e.to_string()))?;
-
-        let cap_file = crate::tools::wasm::CapabilitiesFile::from_bytes(&cap_bytes)
-            .map_err(|e| ExtensionError::Other(e.to_string()))?;
+        // Read the capabilities file to get auth config. Goes through
+        // `load_tool_capabilities` so the legacy-hyphen alias is also
+        // tried — without this, a tool whose `.capabilities.json` is
+        // saved under the pre-v0.23 hyphen form (e.g.
+        // `google-drive-tool.capabilities.json`) would silently report
+        // `no_auth_required` even though the file declares OAuth, which
+        // is the bug behind the v2 Drive trace's missing auth gate.
+        let cap_file = match self.load_tool_capabilities(name).await {
+            Some(f) => f,
+            None => {
+                return Ok(AuthResult::no_auth_required(name, ExtensionKind::WasmTool));
+            }
+        };
 
         let auth = match cap_file.auth {
             Some(auth) => auth,
@@ -5285,7 +5288,17 @@ impl ExtensionManager {
             ExtensionError::ActivationFailed("WASM runtime not available".to_string())
         })?;
 
-        let wasm_path = self.wasm_tools_dir.join(format!("{}.wasm", name));
+        // Use the alias-aware helper so a tool installed under the
+        // legacy hyphen filename (`google-drive-tool.wasm`) is found
+        // when looked up via the canonical underscore name
+        // (`google_drive_tool`). Without this, `determine_installed_kind`
+        // happily reports the extension as installed via its own alias
+        // check, but `activate_wasm_tool` then fails with `NotInstalled`
+        // here — and the upstream readiness probe falls back to
+        // "treat as ready", so the agent ends up calling a tool that
+        // can't be activated, hits a 401/403, and confuses itself.
+        // Pinned by `test_activate_wasm_tool_finds_legacy_hyphen_alias`.
+        let wasm_path = Self::existing_extension_file_path(&self.wasm_tools_dir, name, ".wasm");
         if !wasm_path.exists() {
             return Err(ExtensionError::NotInstalled(format!(
                 "WASM tool '{}' not found at {}",
@@ -5294,9 +5307,8 @@ impl ExtensionManager {
             )));
         }
 
-        let cap_path = self
-            .wasm_tools_dir
-            .join(format!("{}.capabilities.json", name));
+        let cap_path =
+            Self::existing_extension_file_path(&self.wasm_tools_dir, name, ".capabilities.json");
         let cap_path_option = if cap_path.exists() {
             Some(cap_path.as_path())
         } else {
@@ -5684,14 +5696,11 @@ impl ExtensionManager {
             }
         };
 
-        // Load capabilities file once to extract all secret names
-        let cap_path = self
-            .wasm_channels_dir
-            .join(format!("{}.capabilities.json", name));
-        let capabilities_file = match tokio::fs::read(&cap_path).await {
-            Ok(bytes) => crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&bytes).ok(),
-            Err(_) => None,
-        };
+        // Load capabilities file once to extract all secret names. Use
+        // the alias-aware helper so a channel installed under the
+        // legacy hyphen form (e.g. `my-channel.capabilities.json`) is
+        // still resolvable when its canonical name uses underscores.
+        let capabilities_file = self.load_channel_capabilities(name).await;
 
         // Extract all secret names from the capabilities file
         let webhook_secret_name = capabilities_file
@@ -6378,21 +6387,18 @@ impl ExtensionManager {
         let kind = self.determine_installed_kind(name, user_id).await?;
         match kind {
             ExtensionKind::WasmChannel => {
-                let cap_path = self
-                    .wasm_channels_dir
-                    .join(format!("{}.capabilities.json", name));
-                if !cap_path.exists() {
-                    return Ok(ExtensionSetupSchema {
-                        secrets: Vec::new(),
-                        fields: Vec::new(),
-                    });
-                }
-                let cap_bytes = tokio::fs::read(&cap_path)
-                    .await
-                    .map_err(|e| ExtensionError::Other(e.to_string()))?;
-                let cap_file =
-                    crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&cap_bytes)
-                        .map_err(|e| ExtensionError::Other(e.to_string()))?;
+                // Use the alias-aware helper so a channel installed
+                // under the legacy hyphen form (e.g.
+                // `my-channel.capabilities.json`) is still resolvable.
+                let cap_file = match self.load_channel_capabilities(name).await {
+                    Some(f) => f,
+                    None => {
+                        return Ok(ExtensionSetupSchema {
+                            secrets: Vec::new(),
+                            fields: Vec::new(),
+                        });
+                    }
+                };
 
                 let mut secrets = Vec::new();
                 for secret in &cap_file.setup.required_secrets {
@@ -6848,21 +6854,11 @@ impl ExtensionManager {
             Vec<crate::tools::wasm::ToolFieldSetupSchema>,
         ) = match kind {
             ExtensionKind::WasmChannel => {
-                let cap_path = self
-                    .wasm_channels_dir
-                    .join(format!("{}.capabilities.json", name));
-                if !cap_path.exists() {
-                    return Err(ExtensionError::Other(format!(
-                        "Capabilities file not found for '{}'",
-                        name
-                    )));
-                }
-                let cap_bytes = tokio::fs::read(&cap_path)
-                    .await
-                    .map_err(|e| ExtensionError::Other(e.to_string()))?;
-                let cap_file =
-                    crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&cap_bytes)
-                        .map_err(|e| ExtensionError::Other(e.to_string()))?;
+                // Use the alias-aware helper so a channel installed
+                // under the legacy hyphen form is still resolvable.
+                let cap_file = self.load_channel_capabilities(&name).await.ok_or_else(|| {
+                    ExtensionError::Other(format!("Capabilities file not found for '{}'", name))
+                })?;
                 let names = cap_file
                     .setup
                     .required_secrets
@@ -7132,12 +7128,31 @@ impl ExtensionManager {
         if kind == ExtensionKind::WasmTool {
             match self.activate_wasm_tool(&name, user_id).await {
                 Ok(result) => {
-                    // Delete existing OAuth token so auth() starts a fresh flow.
-                    // Done AFTER activation succeeds to avoid losing tokens on failure.
-                    // This covers Reconfigure: user wants to re-auth (switch account, update creds).
+                    // OAuth reconfigure: if the caller is starting a fresh
+                    // OAuth flow (e.g. the user clicked "Reconfigure" to
+                    // switch accounts), wipe the existing access/scopes/refresh
+                    // records so the `auth()` call below kicks off a new
+                    // OAuth handshake instead of reporting `Authenticated`.
+                    //
+                    // We MUST NOT do this when the caller is providing a new
+                    // credential via the `secrets` map (the manual-paste /
+                    // `submit_auth_token` path), because deleting the
+                    // credential we *just wrote* leaves the user authenticated
+                    // against nothing — the resume runs, the wrapper sees no
+                    // token, the gate re-fires, the user is asked for the
+                    // same token they just typed in, the cycle repeats.
+                    //
+                    // The signal is whether the auth secret_name appears in
+                    // the submitted `secrets` map. If yes, the caller knows
+                    // what they're doing and we leave it alone. If no, the
+                    // caller wants a fresh OAuth flow.
+                    //
+                    // Done AFTER activation succeeds so a failed activation
+                    // doesn't lose the user's previous tokens.
                     if let Some(cap) = self.load_tool_capabilities(&name).await
                         && let Some(ref auth_cfg) = cap.auth
                         && auth_cfg.oauth.is_some()
+                        && !secrets.contains_key(&auth_cfg.secret_name)
                     {
                         let _ = self.secrets.delete(user_id, &auth_cfg.secret_name).await;
                         let _ = self
@@ -7307,15 +7322,11 @@ impl ExtensionManager {
         let kind = self.determine_installed_kind(name, user_id).await?;
         let secret_name = match kind {
             ExtensionKind::WasmChannel => {
-                let cap_path = self
-                    .wasm_channels_dir
-                    .join(format!("{}.capabilities.json", name));
-                let cap_bytes = tokio::fs::read(&cap_path)
-                    .await
-                    .map_err(|e| ExtensionError::Other(e.to_string()))?;
-                let cap_file =
-                    crate::channels::wasm::ChannelCapabilitiesFile::from_bytes(&cap_bytes)
-                        .map_err(|e| ExtensionError::Other(e.to_string()))?;
+                // Use the alias-aware helper so a channel installed
+                // under the legacy hyphen form is still resolvable.
+                let cap_file = self.load_channel_capabilities(name).await.ok_or_else(|| {
+                    ExtensionError::Other(format!("Capabilities not found for '{}'", name))
+                })?;
                 // Pick the first *missing* non-optional secret so re-configure
                 // of a second secret works for multi-secret channels.
                 let mut target = None;
@@ -8946,6 +8957,155 @@ mod tests {
                 || msg.contains("Not installed"),
             "Should fail on missing file, got: {msg}"
         );
+    }
+
+    /// Regression: a tool installed under the legacy hyphenated form
+    /// (e.g. `google-drive-tool.wasm`) must be findable by
+    /// `activate_wasm_tool` when looked up via the canonical underscore
+    /// form (`google_drive_tool`). Before consolidating the file lookup
+    /// helpers, `determine_installed_kind` correctly resolved the alias
+    /// (so the extension reported as "installed") but `activate_wasm_tool`
+    /// hard-coded `dir.join("{name}.wasm")` and missed it. The disagreement
+    /// surfaced as an `Extension not installed: WASM tool 'google_drive_tool'
+    /// not found at <path>` error in the readiness probe, which the upstream
+    /// wrapper then swallowed as `ToolReadiness::Ready`, sending the agent
+    /// off to call a tool that couldn't activate.
+    ///
+    /// This test asserts that activation gets *past* the file-existence
+    /// check for a hyphen-named file. It will still fail later (the bytes
+    /// aren't a real WASM module), but the failure must be a load error,
+    /// NOT an `Extension not installed` error from line 5294.
+    #[tokio::test]
+    async fn test_activate_wasm_tool_finds_legacy_hyphen_alias() {
+        // Two tools, one each with a legacy hyphen and a canonical-underscore
+        // file name on disk. We then try to activate them by their canonical
+        // names — both should resolve to a real path on disk.
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).expect("tools dir");
+        // Hyphenated file → canonical lookup name has underscores.
+        std::fs::write(tools_dir.join("google-drive-tool.wasm"), b"not-a-real-wasm")
+            .expect("hyphen file");
+        // Canonical file → no alias needed.
+        std::fs::write(tools_dir.join("gmail.wasm"), b"not-a-real-wasm").expect("canonical file");
+
+        let config = crate::tools::wasm::WasmRuntimeConfig::for_testing();
+        let runtime = Arc::new(crate::tools::wasm::WasmToolRuntime::new(config).expect("runtime"));
+        let mgr = make_test_manager(Some(runtime), tools_dir);
+
+        // Hyphen → canonical lookup. Must NOT return NotInstalled / not found.
+        let err = mgr
+            .activate("google_drive_tool", "test")
+            .await
+            .expect_err("byte stream is not real WASM");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("not found")
+                && !msg.contains("not installed")
+                && !msg.contains("Not installed"),
+            "activate_wasm_tool must find google-drive-tool.wasm via legacy alias \
+             when looked up as `google_drive_tool`; got: {msg}"
+        );
+
+        // Canonical name with no alias still works.
+        let err = mgr
+            .activate("gmail", "test")
+            .await
+            .expect_err("byte stream is not real WASM");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("not found") && !msg.contains("not installed"),
+            "canonical name lookup must still work; got: {msg}"
+        );
+    }
+
+    /// Mirror of the above for `activate_wasm_channel` — the same bug
+    /// existed in the channel activation path.
+    #[tokio::test]
+    async fn test_activate_wasm_channel_finds_legacy_hyphen_alias() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let channels_dir = dir.path().join("channels");
+        std::fs::create_dir_all(&channels_dir).expect("channels dir");
+        std::fs::write(channels_dir.join("my-channel.wasm"), b"not-a-real-wasm")
+            .expect("hyphen file");
+        // Capabilities file under the same hyphen alias.
+        std::fs::write(channels_dir.join("my-channel.capabilities.json"), b"{}")
+            .expect("hyphen caps");
+
+        let mgr = make_test_manager_with_dirs(
+            None, // no WASM tool runtime needed for the channel path
+            dir.path().join("tools"),
+            channels_dir,
+            None,
+        );
+
+        let err = mgr
+            .activate("my_channel", "test")
+            .await
+            .expect_err("activation will fail later");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("not found") && !msg.contains("not installed"),
+            "activate_wasm_channel must find my-channel.wasm via legacy alias \
+             when looked up as `my_channel`; got: {msg}"
+        );
+    }
+
+    /// Regression test for the v2 Drive trace: `auth_wasm_tool` used to
+    /// open `wasm_tools_dir.join("{canonical}.capabilities.json")`
+    /// directly without trying the legacy hyphen alias. A tool installed
+    /// as `google-drive-tool.capabilities.json` (the pre-v0.23 layout)
+    /// would silently report `no_auth_required` even though the file on
+    /// disk declared OAuth, which broke both the pre-flight readiness
+    /// gate and the post-flight auth detector. Now the function delegates
+    /// to `load_tool_capabilities`, which goes through
+    /// `existing_extension_file_path` like every other lookup.
+    #[tokio::test]
+    async fn test_auth_wasm_tool_finds_legacy_hyphen_alias() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).expect("tools dir");
+
+        // Write the wasm + capabilities under the LEGACY hyphen names.
+        // The capabilities file declares an OAuth secret so a missed
+        // alias would mistakenly report `NoAuthRequired` instead of
+        // `AwaitingAuthorization`.
+        std::fs::write(tools_dir.join("google-drive-tool.wasm"), b"not-a-real-wasm")
+            .expect("hyphen wasm file");
+        let caps_json = r#"{
+            "name": "google-drive-tool",
+            "version": "0.1.0",
+            "description": "test",
+            "auth": {
+                "secret_name": "google_oauth_token",
+                "display_name": "Google",
+                "instructions": "Please provide your Google API token."
+            }
+        }"#;
+        std::fs::write(
+            tools_dir.join("google-drive-tool.capabilities.json"),
+            caps_json,
+        )
+        .expect("hyphen caps file");
+
+        let mgr = make_test_manager(None, tools_dir);
+
+        // Look up by the canonical underscore name. Before the fix this
+        // returned `NoAuthRequired` because `auth_wasm_tool` joined
+        // `google_drive_tool.capabilities.json` directly and that file
+        // doesn't exist on disk.
+        let result = mgr
+            .auth("google_drive_tool", "test")
+            .await
+            .expect("auth lookup must succeed");
+        match result.status {
+            crate::extensions::AuthStatus::AwaitingToken { .. } => {}
+            other => panic!(
+                "expected AwaitingToken (legacy-hyphen capabilities file should be found \
+                 and parsed); got {:?}",
+                other
+            ),
+        }
     }
 
     #[tokio::test]
@@ -11085,6 +11245,243 @@ mod tests {
                 .await
                 .unwrap_or(false),
             "configure_token should have stored SECRET_B (the first missing secret)"
+        );
+    }
+
+    /// Regression for the silent OAuth-token-deletion bug in `configure()`:
+    /// when the user pasted a token via the auth gate, `configure()` wrote
+    /// it to the secrets store, then immediately deleted it (along with
+    /// the `_scopes` and `_refresh_token` siblings) on the post-activation
+    /// "Reconfigure" cleanup path. The user's token was wiped within
+    /// milliseconds of being stored, the resume hit `auth_wasm_tool` with
+    /// `token_exists=false`, and the auth gate re-fired in a loop —
+    /// every manual paste of an OAuth token landed in this trap.
+    ///
+    /// The fix gates the deletion on whether the caller is *also* providing
+    /// a fresh OAuth secret in the same `configure()` call. If yes (the
+    /// `submit_auth_token` path), keep the credential we just wrote. If no
+    /// (the explicit Reconfigure flow that wants a brand-new OAuth dance),
+    /// the deletion still runs.
+    ///
+    /// We exercise the production `configure()` flow on an OAuth-backed
+    /// tool. activate_wasm_tool short-circuits to `Ok` when the tool is
+    /// already in the registry, so the test pre-registers a stub tool to
+    /// reach the post-activation deletion code without a real WASM
+    /// runtime.
+    #[tokio::test]
+    async fn test_configure_preserves_oauth_token_when_caller_provides_it() {
+        use crate::tools::{Tool, ToolError, ToolOutput};
+        use async_trait::async_trait;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).expect("tools dir");
+
+        // Capabilities file with an OAuth section so the deletion path
+        // is reachable. The actual `oauth.token_url` etc. don't matter
+        // — we never call them; we just need `auth.oauth.is_some()`.
+        std::fs::write(tools_dir.join("oauth-tool.wasm"), b"not-a-real-wasm")
+            .expect("wasm placeholder");
+        let caps = serde_json::json!({
+            "name": "oauth-tool",
+            "version": "0.1.0",
+            "description": "test",
+            "auth": {
+                "secret_name": "oauth_tool_token",
+                "display_name": "Test OAuth",
+                "oauth": {
+                    "authorization_url": "https://example.com/authz",
+                    "token_url": "https://example.com/token",
+                    "scopes": ["read"]
+                }
+            }
+        });
+        std::fs::write(
+            tools_dir.join("oauth-tool.capabilities.json"),
+            serde_json::to_string(&caps).expect("ser caps"),
+        )
+        .expect("caps file");
+
+        let mgr = make_test_manager(None, tools_dir);
+
+        // Stub Tool that just exists in the registry under the
+        // canonicalised name. activate_wasm_tool sees `tool_registry.has`
+        // returns true and returns Ok without touching the runtime.
+        struct StubTool;
+        #[async_trait]
+        impl Tool for StubTool {
+            fn name(&self) -> &str {
+                "oauth_tool"
+            }
+            fn description(&self) -> &str {
+                "stub"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object", "properties": {}})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                Err(ToolError::ExecutionFailed("stub".into()))
+            }
+        }
+        // Register the stub under the canonical (snake) name so
+        // `is_extension_active("oauth_tool", WasmTool)` returns true.
+        mgr.tool_registry.register(Arc::new(StubTool)).await;
+
+        // Caller provides the OAuth token in the same configure() call.
+        // Without the fix, configure() writes it then immediately deletes it.
+        let mut secrets = std::collections::HashMap::new();
+        secrets.insert(
+            "oauth_tool_token".to_string(),
+            "fresh-token-value".to_string(),
+        );
+        let fields = std::collections::HashMap::new();
+
+        // Run configure(). It will write the token, hit the
+        // already-active short-circuit in activate_wasm_tool, then
+        // reach the deletion guard. With the fix, the guard skips
+        // because `secrets.contains_key("oauth_tool_token")` is true.
+        let result = mgr.configure("oauth-tool", &secrets, &fields, "test").await;
+        assert!(
+            result.is_ok(),
+            "configure() should succeed: {:?}",
+            result.err()
+        );
+
+        // The CRITICAL assertion: the OAuth token must still be in the
+        // store. Pre-fix, this returns false because `configure()`
+        // deleted it. Post-fix, this returns true because the deletion
+        // is gated on the caller NOT providing the secret themselves.
+        let token_present = mgr
+            .secrets
+            .exists("test", "oauth_tool_token")
+            .await
+            .unwrap_or(false);
+        assert!(
+            token_present,
+            "configure() must preserve the OAuth token when the caller \
+             provides it via the secrets map. The post-activation Reconfigure \
+             cleanup must only run when the caller is starting a fresh OAuth \
+             flow (no token in the secrets map)."
+        );
+    }
+
+    /// Mirror of the above for the explicit Reconfigure flow: when the
+    /// caller does NOT provide a token, `configure()` SHOULD delete the
+    /// existing OAuth records so that `auth()` kicks off a fresh OAuth
+    /// dance. This is the original-intended behaviour the fix preserves.
+    #[tokio::test]
+    async fn test_configure_clears_oauth_token_for_reconfigure_flow() {
+        use crate::tools::{Tool, ToolError, ToolOutput};
+        use async_trait::async_trait;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        std::fs::create_dir_all(&tools_dir).expect("tools dir");
+
+        std::fs::write(tools_dir.join("oauth-reconfig.wasm"), b"not-a-real-wasm")
+            .expect("wasm placeholder");
+        let caps = serde_json::json!({
+            "name": "oauth-reconfig",
+            "version": "0.1.0",
+            "description": "test",
+            "auth": {
+                "secret_name": "oauth_reconfig_token",
+                "display_name": "Test OAuth",
+                "oauth": {
+                    "authorization_url": "https://example.com/authz",
+                    "token_url": "https://example.com/token",
+                    "scopes": ["read"]
+                }
+            }
+        });
+        std::fs::write(
+            tools_dir.join("oauth-reconfig.capabilities.json"),
+            serde_json::to_string(&caps).expect("ser caps"),
+        )
+        .expect("caps file");
+
+        let mgr = make_test_manager(None, tools_dir);
+
+        struct StubTool;
+        #[async_trait]
+        impl Tool for StubTool {
+            fn name(&self) -> &str {
+                "oauth_reconfig"
+            }
+            fn description(&self) -> &str {
+                "stub"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object", "properties": {}})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                Err(ToolError::ExecutionFailed("stub".into()))
+            }
+        }
+        mgr.tool_registry.register(Arc::new(StubTool)).await;
+
+        // Pre-store an OAuth token (and a refresh sibling) to simulate
+        // a user who already authenticated previously.
+        mgr.secrets
+            .create(
+                "test",
+                crate::secrets::CreateSecretParams::new("oauth_reconfig_token", "old-token"),
+            )
+            .await
+            .expect("seed token");
+        mgr.secrets
+            .create(
+                "test",
+                crate::secrets::CreateSecretParams::new(
+                    "oauth_reconfig_token_refresh_token",
+                    "old-refresh",
+                ),
+            )
+            .await
+            .expect("seed refresh");
+
+        // Caller invokes configure with EMPTY secrets — this is the
+        // explicit Reconfigure path. The post-activation cleanup
+        // should run and wipe the existing OAuth records.
+        let secrets = std::collections::HashMap::new();
+        let fields = std::collections::HashMap::new();
+        let result = mgr
+            .configure("oauth-reconfig", &secrets, &fields, "test")
+            .await;
+        assert!(
+            result.is_ok(),
+            "configure() should succeed: {:?}",
+            result.err()
+        );
+
+        // Both records should now be gone — the Reconfigure cleanup ran.
+        let token_present = mgr
+            .secrets
+            .exists("test", "oauth_reconfig_token")
+            .await
+            .unwrap_or(false);
+        let refresh_present = mgr
+            .secrets
+            .exists("test", "oauth_reconfig_token_refresh_token")
+            .await
+            .unwrap_or(false);
+        assert!(
+            !token_present,
+            "Reconfigure flow (empty secrets map) must wipe the existing OAuth \
+             access token so `auth()` triggers a fresh handshake."
+        );
+        assert!(
+            !refresh_present,
+            "Reconfigure flow must also wipe the refresh token sibling for \
+             symmetric cleanup."
         );
     }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1898,13 +1898,16 @@ impl ExtensionManager {
                             self.mcp_supports_auth(server).await
                         };
 
-                        // Get tool names if active
+                        // Get tool names if active. Use normalized prefix
+                        // so hyphenated server names match underscore-only
+                        // registry keys.
                         let tools = if active {
+                            let prefix = crate::tools::mcp::mcp_tool_id(&server.name, "");
                             self.tool_registry
                                 .list()
                                 .await
                                 .into_iter()
-                                .filter(|t| t.starts_with(&format!("{}_", server.name)))
+                                .filter(|t| t.starts_with(&prefix))
                                 .collect()
                         } else {
                             Vec::new()
@@ -2141,13 +2144,14 @@ impl ExtensionManager {
                     .collect_secret_cleanup_plan(&name, kind, user_id)
                     .await?;
 
-                // Unregister tools with this server's prefix
+                // Unregister tools with this server's normalized prefix.
+                let prefix = crate::tools::mcp::mcp_tool_id(&name, "");
                 let tool_names: Vec<String> = self
                     .tool_registry
                     .list()
                     .await
                     .into_iter()
-                    .filter(|t| t.starts_with(&format!("{}_", name)))
+                    .filter(|t| t.starts_with(&prefix))
                     .collect();
 
                 for tool_name in &tool_names {
@@ -5120,12 +5124,18 @@ impl ExtensionManager {
             let clients = self.mcp_clients.read().await;
             if clients.contains_key(name) {
                 // Already connected, just return the tool names
+                // Use the same normalization as `mcp_tool_id` for the
+                // prefix filter so hyphenated server names match the
+                // underscore-only keys in the registry. `mcp_tool_id(name, "")`
+                // produces `normalized_server_` which is exactly the prefix
+                // every tool registered by this server starts with.
+                let prefix = crate::tools::mcp::mcp_tool_id(name, "");
                 let tools: Vec<String> = self
                     .tool_registry
                     .list()
                     .await
                     .into_iter()
-                    .filter(|t| t.starts_with(&format!("{}_", name)))
+                    .filter(|t| t.starts_with(&prefix))
                     .collect();
 
                 return Ok(ActivateResult {

--- a/src/llm/CLAUDE.md
+++ b/src/llm/CLAUDE.md
@@ -185,7 +185,7 @@ Uses the Responses API at `chatgpt.com/backend-api/codex/responses` with ChatGPT
 **Key differences from other providers:**
 - Uses Responses API (not Chat Completions) — SSE streaming with different event types
 - System messages are sent as `instructions` field, not in `input` array
-- Tool schemas are normalized via `normalize_schema_strict()` for OpenAI strict mode
+- Tool schemas are normalized via `normalize_schema_strict()` (shared with `RigAdapter::convert_tools`) which both strict-normalizes nested objects AND flattens any top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` into a permissive object envelope; some MCP servers (e.g. GitHub Copilot's) advertise top-level dispatcher unions that the OpenAI tool API rejects with HTTP 400
 - `cost_per_token()` returns `(0, 0)` — subscription-based billing
 - `set_model()` returns error — model is fixed at construction time
 - Image attachments are silently dropped with a warning log

--- a/src/llm/openai_codex_provider.rs
+++ b/src/llm/openai_codex_provider.rs
@@ -498,16 +498,23 @@ fn sanitize_tool_name(name: &str) -> String {
 
 /// Convert a `ToolDefinition` to Responses API tool format.
 ///
-/// Applies strict-mode schema normalization (same as OpenAI Chat Completions):
-/// `additionalProperties: false`, all properties required, optional fields nullable.
+/// Both transforms — strict-mode object normalization and the top-level
+/// union flatten that the Responses API requires — live inside
+/// `normalize_schema_strict`, which is shared with `RigAdapter::convert_tools`
+/// so every rig-based provider gets the same treatment. The flatten can
+/// append a hint to the tool description, so we pass an owned clone through
+/// and read it back.
 fn convert_tool_definition(tool: &ToolDefinition) -> serde_json::Value {
     use crate::llm::rig_adapter::normalize_schema_strict;
+
+    let mut description = tool.description.clone();
+    let parameters = normalize_schema_strict(&tool.parameters, &mut description);
 
     serde_json::json!({
         "type": "function",
         "name": sanitize_tool_name(&tool.name),
-        "description": tool.description,
-        "parameters": normalize_schema_strict(&tool.parameters),
+        "description": description,
+        "parameters": parameters,
     })
 }
 
@@ -915,6 +922,67 @@ mod tests {
         assert_eq!(json["type"], "function");
         assert_eq!(json["name"], "my_tool");
         assert_eq!(json["description"], "Does things");
+    }
+
+    /// Caller-level regression test: drives `convert_tool_definition` end to
+    /// end with a GitHub-Copilot-shaped MCP tool definition and asserts that
+    /// the resulting Responses API JSON would no longer trip the 400. This
+    /// is the test that would have caught the original failure mode. The
+    /// helper-level tests for the underlying flatten live next to the
+    /// helper itself in `rig_adapter.rs`.
+    #[test]
+    fn test_convert_tool_definition_handles_top_level_oneof_dispatcher() {
+        let tool = ToolDefinition {
+            name: "github".to_string(),
+            description: "GitHub MCP umbrella tool".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "oneOf": [
+                    {
+                        "properties": {
+                            "action": { "const": "create_issue" },
+                            "title":  { "type": "string" },
+                            "body":   { "type": "string" }
+                        },
+                        "required": ["action", "title"]
+                    },
+                    {
+                        "properties": {
+                            "action": { "const": "list_issues" },
+                            "repo":   { "type": "string" }
+                        },
+                        "required": ["action", "repo"]
+                    }
+                ]
+            }),
+        };
+        let json = convert_tool_definition(&tool);
+
+        let params = &json["parameters"];
+        assert_eq!(params["type"], "object", "top-level type must be object");
+        assert!(
+            params.get("oneOf").is_none(),
+            "top-level oneOf must not survive into the request body"
+        );
+        assert!(
+            params.get("anyOf").is_none() && params.get("allOf").is_none(),
+            "no other top-level union keywords either"
+        );
+        assert_eq!(params["additionalProperties"], true);
+
+        let description = json["description"].as_str().unwrap();
+        assert!(
+            description.starts_with("GitHub MCP umbrella tool"),
+            "original description must come first"
+        );
+        assert!(
+            description.contains("Upstream JSON schema"),
+            "advisory hint must be appended"
+        );
+        assert!(
+            description.contains("create_issue") && description.contains("list_issues"),
+            "variant info must be retained in the hint so the LLM can choose"
+        );
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -393,7 +393,31 @@ fn normalize_schema_recursive(schema: &mut JsonValue) {
         }
     }
 
-    // Recurse into array items
+    // Recurse into array items. OpenAI strict mode requires `items` to be
+    // a JSON Schema object for every array-typed property. Schema generators
+    // (schemars, serde_json) produce `"items": true` or omit `items`
+    // entirely for `Vec<serde_json::Value>` (meaning "accept any item"),
+    // which OpenAI rejects with:
+    //   "array schema items is not an object"
+    // Ensure `items` exists and is an object before recursing.
+    let is_array = obj
+        .get("type")
+        .map(|t| {
+            t.as_str() == Some("array")
+                || t.as_array()
+                    .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some("array")))
+        })
+        .unwrap_or(false);
+    if is_array {
+        let needs_fix = match obj.get("items") {
+            None => true,                        // missing entirely
+            Some(JsonValue::Object(_)) => false, // already a schema object
+            _ => true,                           // bool, string, array, etc.
+        };
+        if needs_fix {
+            obj.insert("items".to_string(), serde_json::json!({}));
+        }
+    }
     if let Some(items) = obj.get_mut("items") {
         normalize_schema_recursive(items);
     }
@@ -1251,6 +1275,60 @@ mod tests {
         assert_eq!(
             description, "nullable tool",
             "description must be untouched (no flatten hint appended)"
+        );
+    }
+
+    /// Regression: OpenAI rejects `"items": true` and missing `items` on
+    /// array-typed properties with "array schema items is not an object".
+    /// Schema generators (schemars) produce this for `Vec<serde_json::Value>`.
+    /// The normalizer must ensure `items` is a JSON Schema object.
+    #[test]
+    fn test_normalize_schema_strict_fixes_array_items_not_object() {
+        // Case 1: items missing entirely (Vec<Value> → {"type": "array"})
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "requests": { "type": "array" }
+            },
+            "required": ["requests"]
+        });
+        let mut description = "batch".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+        assert!(
+            result["properties"]["requests"]["items"].is_object(),
+            "missing items must be filled with an object: {}",
+            result["properties"]["requests"]
+        );
+
+        // Case 2: items is boolean true (valid JSON Schema, rejected by OpenAI)
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": { "type": "array", "items": true }
+            },
+            "required": ["data"]
+        });
+        let mut description = "bool items".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+        assert!(
+            result["properties"]["data"]["items"].is_object(),
+            "boolean items must be replaced with an object: {}",
+            result["properties"]["data"]
+        );
+
+        // Case 3: items is already an object (should not be clobbered)
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "tags": { "type": "array", "items": { "type": "string" } }
+            },
+            "required": ["tags"]
+        });
+        let mut description = "ok".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+        assert_eq!(
+            result["properties"]["tags"]["items"]["type"], "string",
+            "well-formed items must be preserved"
         );
     }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -189,18 +189,27 @@ pub(crate) fn normalize_schema_strict(schema: &JsonValue, description: &mut Stri
                 normalize_schema_recursive(prop_schema);
             }
         }
-        // Fall through to the post-normalization validator (step 3).
-    } else {
-        // Step 2: recursive strict-mode normalization (non-flatten path).
-        normalize_schema_recursive(&mut schema);
+        // Skip the post-normalization strict-mode validator for the flatten
+        // path. The flattened envelope is intentionally non-strict
+        // (additionalProperties: true, required: []), so the strict
+        // validator would fire a false positive on every flattened schema
+        // — 12x per LLM call when there are 12 flattened tools, drowning
+        // real signals in noise. The individual properties were already
+        // normalized recursively above; the top-level permissive shape is
+        // by design, not a bug.
+        return schema;
     }
 
-    // Step 3: post-normalization validation. The normalizer handles the
-    // rules it knows about, but OpenAI's strict-mode spec has more rules
-    // than any single normalizer pass is likely to cover perfectly —
-    // and new rules appear without notice. Running the CI validator as a
-    // debug-level post-check catches anything the normalizer missed so
-    // we get a local diagnostic instead of a runtime HTTP 400.
+    // Step 2: recursive strict-mode normalization (non-flatten path).
+    normalize_schema_recursive(&mut schema);
+
+    // Step 3: post-normalization validation (non-flatten path only).
+    // The normalizer handles the rules it knows about, but OpenAI's
+    // strict-mode spec has more rules than any single normalizer pass is
+    // likely to cover perfectly — and new rules appear without notice.
+    // Running the CI validator as a debug-level post-check catches anything
+    // the normalizer missed so we get a local diagnostic instead of a
+    // runtime HTTP 400. Flattened schemas skip this check (see above).
     //
     // This is deliberately `debug!` (not `warn!`) because the schema
     // still goes through — the tool remains usable, and the LLM provider

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -301,6 +301,22 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
     merged
 }
 
+/// Cheaply estimate the number of nodes in a `serde_json::Value` tree.
+///
+/// Used by `flatten_top_level` to gate the `serde_json::to_string` call:
+/// serializing a many-MB schema (from a malicious or extremely verbose MCP
+/// server) would allocate proportionally even though we only keep 1500 bytes
+/// of the output. This recursive walk counts every leaf and container node
+/// and returns early once it exceeds the caller's budget (no full traversal
+/// needed for the rejection case).
+fn count_json_nodes(value: &JsonValue) -> usize {
+    match value {
+        JsonValue::Array(arr) => 1 + arr.iter().map(count_json_nodes).sum::<usize>(),
+        JsonValue::Object(map) => 1 + map.values().map(count_json_nodes).sum::<usize>(),
+        _ => 1,
+    }
+}
+
 /// Replace `parameters` with a permissive object envelope and append the
 /// original schema to `description` as advisory text. Truncates the hint on a
 /// char boundary if the original schema is too large to fit in a reasonable
@@ -319,27 +335,39 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
     // typical MCP dispatcher schema and still leaves room for the original
     // tool description above it.
     const SCHEMA_HINT_MAX_BYTES: usize = 1500;
+    // Defense against malicious MCP servers: cap how large a schema we're
+    // willing to serialize into a string. `serde_json::to_string` allocates
+    // the full output before we can truncate, so a many-MB schema would
+    // cause a proportional allocation even though we only keep 1500 bytes.
+    // We estimate the node count first (cheap recursive walk, no alloc) and
+    // skip the serialization entirely if it's too large.
+    const MAX_SCHEMA_NODES: usize = 5_000;
 
     let detected = detect_forbidden_top_level(parameters);
     let merged_properties = merge_top_level_variant_properties(parameters);
 
-    if let Ok(original_text) = serde_json::to_string(parameters)
-        && !original_text.is_empty()
-    {
-        let hint = if original_text.len() > SCHEMA_HINT_MAX_BYTES {
-            // Truncate on a char boundary to avoid splitting a multi-byte
-            // character. JSON output's structural characters are ASCII but
-            // string field values can be arbitrary unicode.
-            let mut end = SCHEMA_HINT_MAX_BYTES;
-            while end > 0 && !original_text.is_char_boundary(end) {
-                end -= 1;
-            }
-            format!("{} ... (truncated)", &original_text[..end])
-        } else {
-            original_text
-        };
+    let node_count = count_json_nodes(parameters);
+    if node_count <= MAX_SCHEMA_NODES {
+        if let Ok(original_text) = serde_json::to_string(parameters)
+            && !original_text.is_empty()
+        {
+            let hint = if original_text.len() > SCHEMA_HINT_MAX_BYTES {
+                let mut end = SCHEMA_HINT_MAX_BYTES;
+                while end > 0 && !original_text.is_char_boundary(end) {
+                    end -= 1;
+                }
+                format!("{} ... (truncated)", &original_text[..end])
+            } else {
+                original_text
+            };
+            description.push_str(schema_flatten_hint_intro(detected));
+            description.push_str(&hint);
+        }
+    } else {
         description.push_str(schema_flatten_hint_intro(detected));
-        description.push_str(&hint);
+        description.push_str(&format!(
+            "(schema too large to inline: ~{node_count} nodes. See upstream MCP server for the full schema.)"
+        ));
     }
 
     *parameters = serde_json::json!({

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -207,8 +207,20 @@ fn needs_top_level_flatten(schema: &JsonValue) -> bool {
     match schema {
         JsonValue::Object(map) => {
             let has_forbidden = FORBIDDEN_TOP_LEVEL.iter().any(|k| map.contains_key(*k));
-            let bad_type = !matches!(map.get("type"), Some(JsonValue::String(s)) if s == "object");
-            has_forbidden || bad_type
+            // Accept both `"type": "object"` and `"type": ["object", "null"]`
+            // (or any array containing "object"). The array form is valid
+            // JSON Schema for a nullable object and some upstream providers
+            // / `make_nullable` produce it. Treating it as bad_type would
+            // silently flatten a schema that OpenAI might actually accept,
+            // discarding all its properties.
+            let is_object_type = match map.get("type") {
+                Some(JsonValue::String(s)) => s == "object",
+                Some(JsonValue::Array(arr)) => arr
+                    .iter()
+                    .any(|v| matches!(v, JsonValue::String(s) if s == "object")),
+                _ => false,
+            };
+            has_forbidden || !is_object_type
         }
         // Schema isn't even a JSON object — definitely not OpenAI-compatible.
         _ => true,
@@ -1185,6 +1197,33 @@ mod tests {
         assert_eq!(result["type"], "object");
         assert!(result["properties"].is_object());
         assert_eq!(result["additionalProperties"], true);
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_does_not_flatten_nullable_object_type() {
+        // `"type": ["object", "null"]` is valid JSON Schema for a nullable
+        // object. Some upstream providers and `make_nullable` produce this
+        // form. The previous check only matched `JsonValue::String("object")`
+        // and would have flattened this schema, discarding all properties.
+        let input = serde_json::json!({
+            "type": ["object", "null"],
+            "properties": {
+                "query": { "type": "string" }
+            },
+            "required": ["query"]
+        });
+        let mut description = "nullable tool".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        // Should NOT flatten — the schema is a valid object type.
+        assert!(
+            result["properties"]["query"].is_object(),
+            "properties must be preserved for nullable object type, got: {result}"
+        );
+        assert_eq!(
+            description, "nullable tool",
+            "description must be untouched (no flatten hint appended)"
+        );
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -1577,6 +1577,49 @@ mod tests {
         assert!(result.get("anyOf").is_none());
     }
 
+    /// Size-capped serializer: verify the capped writer produces correct
+    /// output at boundary conditions.
+    #[test]
+    fn test_serialize_json_capped_boundary_conditions() {
+        // Small schema under the cap: full output, no truncation.
+        let small = serde_json::json!({"a": 1});
+        let result = serialize_json_capped(&small, 1500).expect("should serialize");
+        assert_eq!(result, r#"{"a":1}"#);
+
+        // Exactly at the cap: should produce exactly cap bytes (or fewer
+        // if the serialized output happens to be shorter).
+        let result = serialize_json_capped(&small, 7).expect("should serialize");
+        assert_eq!(result.len(), 7); // {"a":1} is exactly 7 bytes
+
+        // Over the cap: output is truncated. The JSON will be malformed
+        // (cut mid-stream) but that's OK — the caller adds "... (truncated)".
+        let result = serialize_json_capped(&small, 4).expect("should serialize");
+        assert_eq!(result.len(), 4);
+        assert_eq!(result, r#"{"a""#);
+
+        // Cap of 0: empty output.
+        let result = serialize_json_capped(&small, 0).expect("should serialize");
+        assert!(result.is_empty());
+    }
+
+    /// Size-capped serializer with multi-MB string values: the cap must
+    /// bound the allocation even when the schema has few nodes but large
+    /// string values (the gap the old node-counting approach missed).
+    #[test]
+    fn test_serialize_json_capped_large_string_values() {
+        let big = serde_json::json!({
+            "description": "x".repeat(100_000)
+        });
+        let result = serialize_json_capped(&big, 1500).expect("should serialize");
+        assert!(
+            result.len() <= 1500,
+            "capped serializer must bound output to max_bytes; got {} bytes",
+            result.len()
+        );
+        // The output should start with valid JSON structure.
+        assert!(result.starts_with(r#"{"description":""#));
+    }
+
     /// Caller-level regression test: drives `convert_tools` (the rig-based
     /// provider entry point) end to end with a GitHub-Copilot-shaped tool
     /// definition and asserts the resulting `RigToolDefinition` has a clean
@@ -1629,6 +1672,195 @@ mod tests {
         assert!(
             tool.description.contains("create_issue") && tool.description.contains("list_issues"),
             "variant info must be retained in the hint"
+        );
+    }
+
+    /// End-to-end regression test using the google_docs_tool's actual schema
+    /// shape. This tool has a tagged enum (`oneOf`) with a `BatchUpdate`
+    /// variant containing `requests: Vec<serde_json::Value>` — which
+    /// produces a bare `{"type": "array"}` with no `items`. The flatten
+    /// path broke TWICE on this shape:
+    ///
+    /// 1. The `return schema` short-circuit skipped `normalize_schema_recursive`,
+    ///    so the merged `requests` property kept its bare array (no items).
+    /// 2. Even after the array-items fix was added to the recursive normalizer,
+    ///    the flatten path still short-circuited before it ran.
+    ///
+    /// This single test would have caught BOTH bugs. It drives the schema
+    /// through `normalize_schema_strict` (shared normalizer) AND both
+    /// consumer paths: `convert_tools` (rig-based providers) and
+    /// `convert_tool_definition` (codex provider). Asserts:
+    /// - top-level oneOf is flattened
+    /// - merged properties include fields from ALL variants
+    /// - array `items` is an object (not missing/boolean)
+    /// - nested object properties get strict-mode treatment
+    /// - output passes `validate_strict_schema` with zero violations
+    #[test]
+    fn test_realistic_wasm_schema_survives_normalize_flatten_pipeline() {
+        // Actual shape from google_docs_tool: tagged enum with 4 variants.
+        // BatchUpdate has `requests: Vec<Value>` (bare array, no items).
+        // GetDocument/ReadContent have only string fields.
+        // InsertText has a nested object (text_style).
+        let wasm_schema = serde_json::json!({
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "const": "get_document" },
+                        "document_id": { "type": "string" }
+                    },
+                    "required": ["action", "document_id"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "const": "batch_update" },
+                        "document_id": { "type": "string" },
+                        "requests": { "type": "array" }
+                    },
+                    "required": ["action", "document_id", "requests"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "const": "insert_text" },
+                        "document_id": { "type": "string" },
+                        "text": { "type": "string" },
+                        "text_style": {
+                            "type": "object",
+                            "properties": {
+                                "bold": { "type": "boolean" },
+                                "font_size": { "type": "integer" }
+                            }
+                        }
+                    },
+                    "required": ["action", "document_id", "text"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "action": { "type": "string", "const": "read_content" },
+                        "document_id": { "type": "string" }
+                    },
+                    "required": ["action", "document_id"]
+                }
+            ]
+        });
+
+        // Path 1: shared normalizer (used by both rig and codex paths)
+        let mut description = "Google Docs tool".to_string();
+        let normalized = normalize_schema_strict(&wasm_schema, &mut description);
+
+        // Top-level oneOf must be flattened.
+        assert!(normalized.get("oneOf").is_none(), "oneOf must be flattened");
+        assert_eq!(normalized["type"], "object");
+        assert_eq!(normalized["additionalProperties"], true);
+
+        // Merged properties from ALL variants.
+        let props = normalized["properties"]
+            .as_object()
+            .expect("merged properties");
+        assert!(props.contains_key("action"), "discriminator");
+        assert!(props.contains_key("document_id"), "shared field");
+        assert!(props.contains_key("requests"), "BatchUpdate field");
+        assert!(props.contains_key("text"), "InsertText field");
+        assert!(props.contains_key("text_style"), "InsertText nested obj");
+
+        // CRITICAL: array `items` must be an object (the bug that broke twice).
+        let requests = &normalized["properties"]["requests"];
+        assert!(
+            requests["items"].is_object(),
+            "requests array must have items as a JSON Schema object; got: {requests}"
+        );
+
+        // Nested object properties should get strict-mode treatment
+        // (additionalProperties: false on the text_style sub-object).
+        let text_style = &normalized["properties"]["text_style"];
+        assert_eq!(text_style["additionalProperties"], false);
+        assert!(text_style["properties"]["bold"].is_object());
+
+        // Description hint should contain variant info.
+        assert!(
+            description.contains("batch_update") || description.contains("get_document"),
+            "description must include variant info from the original schema"
+        );
+
+        // Path 2: rig-based provider entry point.
+        let tools = convert_tools(&[IronToolDefinition {
+            name: "google_docs_tool".to_string(),
+            description: "Google Docs".to_string(),
+            parameters: wasm_schema.clone(),
+        }]);
+        assert_eq!(tools.len(), 1);
+        assert!(
+            tools[0].parameters.get("oneOf").is_none(),
+            "convert_tools output must not have oneOf"
+        );
+        assert!(
+            tools[0].parameters["properties"]["requests"]["items"].is_object(),
+            "convert_tools must normalize array items"
+        );
+    }
+
+    /// Deeply nested schema: object → array → object → array (no items).
+    /// Verifies the recursive normalizer walks the full depth and fixes
+    /// every array `items` and every nested object's strict-mode fields.
+    #[test]
+    fn test_normalize_schema_strict_fixes_deeply_nested_array_items() {
+        // All fields marked required so `make_nullable` doesn't wrap
+        // types as `["array", "null"]`, keeping the assertions focused
+        // on "items get fixed at every nesting depth".
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "tags": { "type": "array" },
+                            "metadata": {
+                                "type": "object",
+                                "properties": {
+                                    "values": { "type": "array" }
+                                },
+                                "required": ["values"]
+                            }
+                        },
+                        "required": ["tags", "metadata"]
+                    }
+                }
+            },
+            "required": ["data"]
+        });
+        let mut description = "nested".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        // Level 1: data.items is an object (was already, should be preserved)
+        let data_items = &result["properties"]["data"]["items"];
+        assert!(data_items.is_object());
+
+        // Level 2: data.items.properties.tags must get items added
+        let tags = &data_items["properties"]["tags"];
+        assert_eq!(tags["type"], "array");
+        assert!(
+            tags["items"].is_object(),
+            "deeply nested array must get items: {tags}"
+        );
+
+        // Level 3: data.items.properties.metadata.properties.values
+        let values = &data_items["properties"]["metadata"]["properties"]["values"];
+        assert_eq!(values["type"], "array");
+        assert!(
+            values["items"].is_object(),
+            "3-level deep array must get items: {values}"
+        );
+
+        // Nested objects should have additionalProperties: false
+        assert_eq!(data_items["additionalProperties"], false);
+        assert_eq!(
+            data_items["properties"]["metadata"]["additionalProperties"],
+            false
         );
     }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -181,6 +181,29 @@ pub(crate) fn normalize_schema_strict(schema: &JsonValue, description: &mut Stri
 
     // Step 2: recursive strict-mode normalization.
     normalize_schema_recursive(&mut schema);
+
+    // Step 3: post-normalization validation. The normalizer handles the
+    // rules it knows about, but OpenAI's strict-mode spec has more rules
+    // than any single normalizer pass is likely to cover perfectly —
+    // and new rules appear without notice. Running the CI validator as a
+    // debug-level post-check catches anything the normalizer missed so
+    // we get a local diagnostic instead of a runtime HTTP 400.
+    //
+    // This is deliberately `debug!` (not `warn!`) because the schema
+    // still goes through — the tool remains usable, and the LLM provider
+    // will surface the 400 if OpenAI actually rejects it. The diagnostic
+    // value is for developers adding new tools or modifying the normalizer.
+    if let Err(violations) =
+        crate::tools::schema_validator::validate_strict_schema(&schema, "<post-normalize>")
+    {
+        tracing::debug!(
+            violations = ?violations,
+            "normalize_schema_strict output has {} strict-mode violation(s) — \
+             the tool is still usable but the LLM provider may reject the schema",
+            violations.len()
+        );
+    }
+
     schema
 }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -172,15 +172,28 @@ pub(crate) fn normalize_schema_strict(schema: &JsonValue, description: &mut Stri
     let mut schema = schema.clone();
 
     // Step 1: top-level flatten. If the schema has a forbidden top-level
-    // construct, there's no point recursing into the variants we're about to
-    // discard, so we short-circuit.
+    // construct, replace it with a permissive envelope whose properties are
+    // merged from the union variants.
     if needs_top_level_flatten(&schema) {
         flatten_top_level(&mut schema, description);
-        return schema;
+        // The flattened envelope is deliberately permissive
+        // (additionalProperties: true, required: []) so the LLM can
+        // send fields from any variant. Running normalize_schema_recursive
+        // on the ROOT would clobber that (force additionalProperties: false,
+        // required: all keys). But the individual merged properties still
+        // need normalization — e.g. array items must be objects, nested
+        // objects need strict-mode treatment. So we normalize each property
+        // individually without touching the top-level envelope.
+        if let Some(props) = schema.get_mut("properties").and_then(|v| v.as_object_mut()) {
+            for (_key, prop_schema) in props.iter_mut() {
+                normalize_schema_recursive(prop_schema);
+            }
+        }
+        // Fall through to the post-normalization validator (step 3).
+    } else {
+        // Step 2: recursive strict-mode normalization (non-flatten path).
+        normalize_schema_recursive(&mut schema);
     }
-
-    // Step 2: recursive strict-mode normalization.
-    normalize_schema_recursive(&mut schema);
 
     // Step 3: post-normalization validation. The normalizer handles the
     // rules it knows about, but OpenAI's strict-mode spec has more rules
@@ -1352,6 +1365,55 @@ mod tests {
         assert_eq!(
             result["properties"]["tags"]["items"]["type"], "string",
             "well-formed items must be preserved"
+        );
+    }
+
+    /// Regression for google_docs_tool: a tagged enum with a variant
+    /// containing `requests: Vec<serde_json::Value>` produces a top-level
+    /// `oneOf` (which we flatten) with a nested `{"type": "array"}` property
+    /// that has no `items`. The flatten path originally short-circuited
+    /// `normalize_schema_recursive`, so the merged `requests` property kept
+    /// its bare array schema and OpenAI rejected it with "array schema items
+    /// is not an object". After the fix, the flatten path normalizes each
+    /// merged property individually.
+    #[test]
+    fn test_normalize_schema_strict_flatten_normalizes_merged_array_items() {
+        let input = serde_json::json!({
+            "type": "object",
+            "oneOf": [
+                {
+                    "properties": {
+                        "action": { "const": "batch_update" },
+                        "document_id": { "type": "string" },
+                        "requests": { "type": "array" }
+                    },
+                    "required": ["action", "document_id", "requests"]
+                },
+                {
+                    "properties": {
+                        "action": { "const": "get" },
+                        "document_id": { "type": "string" }
+                    },
+                    "required": ["action", "document_id"]
+                }
+            ]
+        });
+        let mut description = "docs".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        // The flatten happened (oneOf removed, properties merged).
+        assert!(result.get("oneOf").is_none());
+        let props = result["properties"].as_object().expect("properties");
+        assert!(props.contains_key("requests"));
+
+        // CRITICAL: the merged `requests` array property must have
+        // `items` as an object — not missing, not boolean, not null.
+        let requests = &result["properties"]["requests"];
+        assert_eq!(requests["type"], "array");
+        assert!(
+            requests["items"].is_object(),
+            "merged array property must have items as a JSON Schema object \
+             after flatten-path normalization; got: {requests}"
         );
     }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -337,20 +337,56 @@ fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<Str
     merged
 }
 
-/// Cheaply estimate the number of nodes in a `serde_json::Value` tree.
+/// Serialize a `serde_json::Value` into a string, stopping after `max_bytes`.
 ///
-/// Used by `flatten_top_level` to gate the `serde_json::to_string` call:
-/// serializing a many-MB schema (from a malicious or extremely verbose MCP
-/// server) would allocate proportionally even though we only keep 1500 bytes
-/// of the output. This recursive walk counts every leaf and container node
-/// and returns early once it exceeds the caller's budget (no full traversal
-/// needed for the rejection case).
-fn count_json_nodes(value: &JsonValue) -> usize {
-    match value {
-        JsonValue::Array(arr) => 1 + arr.iter().map(count_json_nodes).sum::<usize>(),
-        JsonValue::Object(map) => 1 + map.values().map(count_json_nodes).sum::<usize>(),
-        _ => 1,
+/// Returns `Ok(s)` where `s.len() <= max_bytes` (truncated on a char
+/// boundary if the serialized output exceeds the budget), or `Err(())` if
+/// serialization itself fails (shouldn't happen for well-formed `Value`s).
+///
+/// This bounds the actual heap allocation regardless of schema structure —
+/// it handles both many-node schemas (deep recursion) AND few-node schemas
+/// with multi-MB string values (the gap the previous `count_json_nodes`
+/// approach missed). The writer stops accepting bytes once the budget is
+/// reached, so the serde serializer does minimal work after that point.
+fn serialize_json_capped(value: &JsonValue, max_bytes: usize) -> Result<String, ()> {
+    use std::io::Write;
+
+    struct CappedWriter {
+        buf: Vec<u8>,
+        max: usize,
     }
+
+    impl Write for CappedWriter {
+        fn write(&mut self, data: &[u8]) -> std::io::Result<usize> {
+            let remaining = self.max.saturating_sub(self.buf.len());
+            if remaining == 0 {
+                // Accept the bytes (don't error) but don't store them.
+                // serde_json doesn't check for short writes so returning
+                // Ok(data.len()) is safe — it just thinks we consumed them.
+                return Ok(data.len());
+            }
+            let to_write = data.len().min(remaining);
+            self.buf.extend_from_slice(&data[..to_write]);
+            Ok(data.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // Allocate slightly over max to reduce the chance of a realloc on
+    // the last write when we're right at the boundary.
+    let writer = CappedWriter {
+        buf: Vec::with_capacity(max_bytes.min(8192)),
+        max: max_bytes,
+    };
+    let mut ser = serde_json::Serializer::new(writer);
+    serde::Serialize::serialize(value, &mut ser).map_err(|_| ())?;
+    let buf = ser.into_inner().buf;
+    // The buffer is guaranteed to be valid UTF-8 because serde_json only
+    // emits ASCII structural characters and JSON-escaped unicode.
+    String::from_utf8(buf).map_err(|_| ())
 }
 
 /// Replace `parameters` with a permissive object envelope and append the
@@ -371,39 +407,25 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
     // typical MCP dispatcher schema and still leaves room for the original
     // tool description above it.
     const SCHEMA_HINT_MAX_BYTES: usize = 1500;
-    // Defense against malicious MCP servers: cap how large a schema we're
-    // willing to serialize into a string. `serde_json::to_string` allocates
-    // the full output before we can truncate, so a many-MB schema would
-    // cause a proportional allocation even though we only keep 1500 bytes.
-    // We estimate the node count first (cheap recursive walk, no alloc) and
-    // skip the serialization entirely if it's too large.
-    const MAX_SCHEMA_NODES: usize = 5_000;
 
     let detected = detect_forbidden_top_level(parameters);
     let merged_properties = merge_top_level_variant_properties(parameters);
 
-    let node_count = count_json_nodes(parameters);
-    if node_count <= MAX_SCHEMA_NODES {
-        if let Ok(original_text) = serde_json::to_string(parameters)
-            && !original_text.is_empty()
-        {
-            let hint = if original_text.len() > SCHEMA_HINT_MAX_BYTES {
-                let mut end = SCHEMA_HINT_MAX_BYTES;
-                while end > 0 && !original_text.is_char_boundary(end) {
-                    end -= 1;
-                }
-                format!("{} ... (truncated)", &original_text[..end])
-            } else {
-                original_text
-            };
-            description.push_str(schema_flatten_hint_intro(detected));
-            description.push_str(&hint);
-        }
-    } else {
+    // Size-capped serialization: bounds the heap allocation to
+    // SCHEMA_HINT_MAX_BYTES regardless of schema structure. Handles both
+    // many-node schemas (deep recursion) and few-node schemas with multi-MB
+    // string values. The writer silently discards bytes past the cap so the
+    // serde serializer does minimal useful work after that point.
+    if let Ok(capped_text) = serialize_json_capped(parameters, SCHEMA_HINT_MAX_BYTES)
+        && !capped_text.is_empty()
+    {
+        let hint = if capped_text.len() >= SCHEMA_HINT_MAX_BYTES {
+            format!("{capped_text} ... (truncated)")
+        } else {
+            capped_text
+        };
         description.push_str(schema_flatten_hint_intro(detected));
-        description.push_str(&format!(
-            "(schema too large to inline: ~{node_count} nodes. See upstream MCP server for the full schema.)"
-        ));
+        description.push_str(&hint);
     }
 
     *parameters = serde_json::json!({

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -393,9 +393,21 @@ fn serialize_json_capped(value: &JsonValue, max_bytes: usize) -> Result<String, 
     let mut ser = serde_json::Serializer::new(writer);
     serde::Serialize::serialize(value, &mut ser).map_err(|_| ())?;
     let buf = ser.into_inner().buf;
-    // The buffer is guaranteed to be valid UTF-8 because serde_json only
-    // emits ASCII structural characters and JSON-escaped unicode.
-    String::from_utf8(buf).map_err(|_| ())
+    // serde_json v1 emits raw UTF-8 for non-ASCII characters (e.g. CJK
+    // characters in property descriptions), so the byte cap can cut
+    // mid-codepoint. Use `from_utf8` with a fallback to `valid_up_to()`
+    // to trim to the last complete codepoint instead of dropping the
+    // entire hint on a UTF-8 error.
+    match String::from_utf8(buf) {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            let valid_len = e.utf8_error().valid_up_to();
+            let mut buf = e.into_bytes();
+            buf.truncate(valid_len);
+            // valid_up_to guarantees the prefix is valid UTF-8
+            Ok(String::from_utf8(buf).expect("valid_up_to guarantees valid UTF-8"))
+        }
+    }
 }
 
 /// Replace `parameters` with a permissive object envelope and append the

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -123,20 +123,121 @@ fn round_f32_to_f64(val: f32) -> f64 {
     ((val as f64) * 1_000_000.0).round() / 1_000_000.0
 }
 
-/// Normalize a JSON Schema for OpenAI strict mode compliance.
+/// Normalize a JSON Schema for OpenAI tool-calling compliance.
 ///
-/// OpenAI strict function calling requires:
-/// - Every object must have `"additionalProperties": false`
-/// - `"required"` must list ALL property keys
-/// - Optional fields use `"type": ["<original>", "null"]` instead of being omitted from `required`
-/// - Nested objects and array items are recursively normalized
+/// Two transforms are applied at the provider boundary:
 ///
-/// This is applied as a clone-and-transform at the provider boundary so the
-/// original tool definitions remain unchanged for other providers.
-pub(crate) fn normalize_schema_strict(schema: &JsonValue) -> JsonValue {
+/// 1. **Top-level flatten.** OpenAI's tool API (Chat Completions and the
+///    Responses API alike) rejects schemas whose top level isn't
+///    `type: "object"`, or that contain top-level `oneOf`/`anyOf`/`allOf`/
+///    `enum`/`not`. The exact error is:
+///
+///    ```text
+///    Invalid schema for function '<name>': schema must have type 'object'
+///    and not have 'oneOf'/'anyOf'/'allOf'/'enum'/'not' at the top level.
+///    ```
+///
+///    Some MCP servers (notably the GitHub Copilot MCP at
+///    `api.githubcopilot.com/mcp/`) advertise tools whose top-level schema is
+///    a `oneOf` for action dispatch. There's no API-side workaround, so when
+///    we detect this we replace `parameters` with a permissive object
+///    envelope (`{type: "object", properties: {}, additionalProperties: true,
+///    required: []}`) and append the original schema to the tool description
+///    as advisory text. The MCP server still validates the actual shape on
+///    its end, so the tool keeps working — we just lose API-level schema
+///    enforcement and the LLM has to read the variant structure from the
+///    description.
+///
+/// 2. **Strict-mode recursive normalization.** OpenAI strict function
+///    calling requires:
+///    - Every object must have `"additionalProperties": false`
+///    - `"required"` must list ALL property keys
+///    - Optional fields use `"type": ["<original>", "null"]` instead of
+///      being omitted from `required`
+///    - Nested objects and array items are recursively normalized
+///
+/// `description` is a `&mut String` because the top-level flatten needs to
+/// append a hint to it. Pass an owned clone of the tool description and read
+/// it back after the call. If no flatten was needed, `description` is
+/// untouched.
+///
+/// Note on Anthropic: this normalizer is also applied to Anthropic via
+/// `RigAdapter::convert_tools`. Anthropic accepts top-level `oneOf` natively,
+/// so the flatten is slightly lossy for Claude users on tools that have a
+/// top-level union, but the description hint preserves the variant info and
+/// Claude is good at reading schemas out of free text. Keeping a single
+/// normalizer for all rig-based providers is simpler than threading
+/// per-provider flags through the adapter.
+pub(crate) fn normalize_schema_strict(schema: &JsonValue, description: &mut String) -> JsonValue {
     let mut schema = schema.clone();
+
+    // Step 1: top-level flatten. If the schema has a forbidden top-level
+    // construct, there's no point recursing into the variants we're about to
+    // discard, so we short-circuit.
+    if needs_top_level_flatten(&schema) {
+        flatten_top_level(&mut schema, description);
+        return schema;
+    }
+
+    // Step 2: recursive strict-mode normalization.
     normalize_schema_recursive(&mut schema);
     schema
+}
+
+/// True if `schema`'s top level would be rejected by OpenAI's tool API.
+fn needs_top_level_flatten(schema: &JsonValue) -> bool {
+    const FORBIDDEN_TOP_LEVEL: &[&str] = &["oneOf", "anyOf", "allOf", "enum", "not"];
+    match schema {
+        JsonValue::Object(map) => {
+            let has_forbidden = FORBIDDEN_TOP_LEVEL.iter().any(|k| map.contains_key(*k));
+            let bad_type = !matches!(map.get("type"), Some(JsonValue::String(s)) if s == "object");
+            has_forbidden || bad_type
+        }
+        // Schema isn't even a JSON object — definitely not OpenAI-compatible.
+        _ => true,
+    }
+}
+
+/// Replace `parameters` with a permissive object envelope and append the
+/// original schema to `description` as advisory text. Truncates the hint on a
+/// char boundary if the original schema is too large to fit in a reasonable
+/// description budget.
+fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
+    // OpenAI has no documented hard limit on tool description length, but
+    // long descriptions waste prompt budget on every turn. 1500 bytes fits a
+    // typical MCP dispatcher schema and still leaves room for the original
+    // tool description above it.
+    const SCHEMA_HINT_MAX_BYTES: usize = 1500;
+
+    if let Ok(original_text) = serde_json::to_string(parameters)
+        && !original_text.is_empty()
+    {
+        let hint = if original_text.len() > SCHEMA_HINT_MAX_BYTES {
+            // Truncate on a char boundary to avoid splitting a multi-byte
+            // character. JSON output's structural characters are ASCII but
+            // string field values can be arbitrary unicode.
+            let mut end = SCHEMA_HINT_MAX_BYTES;
+            while end > 0 && !original_text.is_char_boundary(end) {
+                end -= 1;
+            }
+            format!("{} ... (truncated)", &original_text[..end])
+        } else {
+            original_text
+        };
+        description.push_str(
+            "\n\nUpstream JSON schema (advisory; the actual top-level union has been \
+             flattened so the OpenAI tool API will accept the tool — pick one variant \
+             and pass its fields as a flat object):\n",
+        );
+        description.push_str(&hint);
+    }
+
+    *parameters = serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": true,
+        "required": []
+    });
 }
 
 fn normalize_schema_recursive(schema: &mut JsonValue) {
@@ -457,15 +558,23 @@ fn normalized_tool_call_id(raw: Option<&str>, seed: usize) -> String {
 
 /// Convert IronClaw tool definitions to rig-core format.
 ///
-/// Applies OpenAI strict-mode schema normalization to ensure all tool
-/// parameter schemas comply with OpenAI's function calling requirements.
+/// Applies `normalize_schema_strict` at the boundary, which both
+/// strict-normalizes nested objects AND flattens any top-level
+/// `oneOf`/`anyOf`/`allOf`/`enum`/`not` (OpenAI's tool API rejects those at
+/// the top level even when the rest of the schema is valid). The flatten may
+/// append an advisory hint to the tool description, so we pass an owned
+/// clone through and read it back.
 fn convert_tools(tools: &[IronToolDefinition]) -> Vec<RigToolDefinition> {
     tools
         .iter()
-        .map(|t| RigToolDefinition {
-            name: t.name.clone(),
-            description: t.description.clone(),
-            parameters: normalize_schema_strict(&t.parameters),
+        .map(|t| {
+            let mut description = t.description.clone();
+            let parameters = normalize_schema_strict(&t.parameters, &mut description);
+            RigToolDefinition {
+                name: t.name.clone(),
+                description,
+                parameters,
+            }
         })
         .collect()
 }
@@ -850,6 +959,212 @@ mod tests {
         assert_eq!(round_f32_to_f64(0.0_f32), 0.0_f64);
         // Original cast produces artifacts — our fix should not
         assert_ne!(0.7_f32 as f64, 0.7_f64);
+    }
+
+    // ── normalize_schema_strict: top-level flatten ────────────────────────
+    //
+    // OpenAI's tool API rejects schemas whose top level isn't `type:
+    // "object"` or that contain top-level `oneOf`/`anyOf`/`allOf`/`enum`/
+    // `not`. The GitHub Copilot MCP server exposes a tool with exactly that
+    // shape (action dispatch via top-level union), and the agent gets HTTP
+    // 400 the moment it tries to enumerate tools. `normalize_schema_strict`
+    // detects the bad shape, flattens parameters to a permissive object
+    // envelope, and stuffs the original schema into the description as
+    // advisory text so the LLM can still pick variant fields. Both rig-based
+    // providers and the Codex Responses API client share this normalizer.
+
+    #[test]
+    fn test_normalize_schema_strict_passes_through_valid_object_schema() {
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": { "type": "string" }
+            },
+            "required": ["query"]
+        });
+        let mut description = "Search the index".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        // Strict-mode normalization runs: additionalProperties forced false
+        // and required is set to ALL keys, but the structural shape is
+        // unchanged.
+        assert_eq!(result["type"], "object");
+        assert_eq!(result["additionalProperties"], false);
+        assert_eq!(result["required"], serde_json::json!(["query"]));
+        assert!(result["properties"]["query"].is_object());
+        assert_eq!(
+            description, "Search the index",
+            "description must be untouched when no flatten happened"
+        );
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_flattens_top_level_oneof() {
+        // Mirrors the GitHub Copilot MCP `github` tool shape that triggered
+        // the original 400.
+        let input = serde_json::json!({
+            "type": "object",
+            "oneOf": [
+                { "properties": { "action": { "const": "create_issue" }, "title": { "type": "string" } } },
+                { "properties": { "action": { "const": "list_issues" }, "repo":  { "type": "string" } } }
+            ]
+        });
+        let mut description = "GitHub umbrella tool".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        assert_eq!(result["type"], "object");
+        assert!(
+            result.get("oneOf").is_none(),
+            "top-level oneOf must be removed"
+        );
+        assert_eq!(result["additionalProperties"], true);
+        assert!(result["properties"].is_object());
+        assert!(result["required"].as_array().unwrap().is_empty());
+        assert!(
+            description.contains("Upstream JSON schema"),
+            "description must include the advisory hint"
+        );
+        assert!(
+            description.contains("create_issue"),
+            "original schema variants must survive in the hint"
+        );
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_flattens_anyof_allof_enum_not() {
+        for forbidden in ["anyOf", "allOf", "enum", "not"] {
+            let input = serde_json::json!({
+                "type": "object",
+                forbidden: ["whatever"]
+            });
+            let mut description = "tool".to_string();
+            let result = normalize_schema_strict(&input, &mut description);
+            assert!(
+                result.get(forbidden).is_none(),
+                "top-level {forbidden} must be stripped"
+            );
+            assert_eq!(result["type"], "object");
+            assert_eq!(result["additionalProperties"], true);
+        }
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_replaces_non_object_top_level_type() {
+        // A schema like `{"type": "string"}` is not a valid OpenAI tool
+        // parameters object — replace wholesale.
+        let input = serde_json::json!({ "type": "string" });
+        let mut description = "weird tool".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+        assert_eq!(result["type"], "object");
+        assert!(result["properties"].is_object());
+        assert_eq!(result["additionalProperties"], true);
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_preserves_nested_oneof() {
+        // Nested combinators inside `properties` are FINE for the API. Only
+        // the top level is forbidden, so the nested oneOf must survive
+        // (its variants get recursively strict-normalized but the union
+        // itself is preserved). `filter` is marked required so strict mode
+        // doesn't wrap it in an `anyOf` for nullability — that would move
+        // the inner oneOf one level deeper and obscure what we're checking.
+        let input = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "filter": {
+                    "oneOf": [
+                        { "type": "string" },
+                        { "type": "object", "properties": { "regex": { "type": "string" } } }
+                    ]
+                }
+            },
+            "required": ["filter"]
+        });
+        let mut description = "search".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        assert_eq!(result["type"], "object");
+        // Nested oneOf survives untouched at the same path.
+        let nested = &result["properties"]["filter"]["oneOf"];
+        assert!(nested.is_array(), "nested oneOf must be preserved");
+        assert_eq!(nested.as_array().unwrap().len(), 2);
+        // The object variant inside the nested oneOf got strict-mode
+        // normalized (additionalProperties: false, all keys required).
+        let object_variant = &nested[1];
+        assert_eq!(object_variant["type"], "object");
+        assert_eq!(object_variant["additionalProperties"], false);
+        assert_eq!(description, "search");
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_truncates_huge_schema_on_char_boundary() {
+        // 4KB blob with a multi-byte char near the truncation point. The
+        // truncated hint must not panic and must end on a valid char
+        // boundary.
+        let big_string = "α".repeat(2000); // each `α` is 2 bytes in UTF-8 → 4000 bytes
+        let input = serde_json::json!({
+            "anyOf": [{ "description": big_string }]
+        });
+        let mut description = "tool".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+        assert!(description.contains("(truncated)"));
+        assert_eq!(result["type"], "object");
+        assert!(result.get("anyOf").is_none());
+    }
+
+    /// Caller-level regression test: drives `convert_tools` (the rig-based
+    /// provider entry point) end to end with a GitHub-Copilot-shaped tool
+    /// definition and asserts the resulting `RigToolDefinition` has a clean
+    /// top level. This is the test that would have caught the OpenAI-via-rig
+    /// path regressing the same way the Codex path did.
+    #[test]
+    fn test_convert_tools_handles_top_level_oneof_dispatcher() {
+        let tools = vec![IronToolDefinition {
+            name: "github".to_string(),
+            description: "GitHub MCP umbrella tool".to_string(),
+            parameters: serde_json::json!({
+                "type": "object",
+                "oneOf": [
+                    {
+                        "properties": {
+                            "action": { "const": "create_issue" },
+                            "title":  { "type": "string" }
+                        },
+                        "required": ["action", "title"]
+                    },
+                    {
+                        "properties": {
+                            "action": { "const": "list_issues" },
+                            "repo":   { "type": "string" }
+                        },
+                        "required": ["action", "repo"]
+                    }
+                ]
+            }),
+        }];
+        let converted = convert_tools(&tools);
+        assert_eq!(converted.len(), 1);
+        let tool = &converted[0];
+
+        assert_eq!(tool.name, "github");
+        assert_eq!(tool.parameters["type"], "object");
+        assert!(
+            tool.parameters.get("oneOf").is_none(),
+            "top-level oneOf must not survive into the rig-core ToolDefinition"
+        );
+        assert_eq!(tool.parameters["additionalProperties"], true);
+        assert!(
+            tool.description.starts_with("GitHub MCP umbrella tool"),
+            "original description must come first"
+        );
+        assert!(
+            tool.description.contains("Upstream JSON schema"),
+            "advisory hint must be appended"
+        );
+        assert!(
+            tool.description.contains("create_issue") && tool.description.contains("list_issues"),
+            "variant info must be retained in the hint"
+        );
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -255,11 +255,52 @@ fn schema_flatten_hint_intro(detected: Option<&'static str>) -> &'static str {
     }
 }
 
+/// Walk the top-level `oneOf` / `anyOf` / `allOf` arrays in `schema` and
+/// collect every property the variants declare into a single map. First-write
+/// wins on conflicting types — if two variants declare the same field name
+/// with different schemas, the first one's schema is kept and the second is
+/// dropped. The full schema still goes into the description hint, so the
+/// truncation we lose here is recoverable from there.
+///
+/// This is the structured-info recovery layer for `flatten_top_level`. The
+/// LLM now sees a real `properties` map instead of `{}`, so it can do
+/// schema-based reasoning about which fields exist across the union — even
+/// though strict-mode validation is disabled at the API layer.
+fn merge_top_level_variant_properties(schema: &JsonValue) -> serde_json::Map<String, JsonValue> {
+    let mut merged = serde_json::Map::new();
+    let Some(obj) = schema.as_object() else {
+        return merged;
+    };
+    for keyword in &["oneOf", "anyOf", "allOf"] {
+        let Some(JsonValue::Array(variants)) = obj.get(*keyword) else {
+            continue;
+        };
+        for variant in variants {
+            let Some(props) = variant.get("properties").and_then(|v| v.as_object()) else {
+                continue;
+            };
+            for (key, value) in props {
+                if !merged.contains_key(key) {
+                    merged.insert(key.clone(), value.clone());
+                }
+            }
+        }
+    }
+    merged
+}
+
 /// Replace `parameters` with a permissive object envelope and append the
 /// original schema to `description` as advisory text. Truncates the hint on a
 /// char boundary if the original schema is too large to fit in a reasonable
 /// description budget. The hint introduction is keyword-aware so the LLM
 /// gets the right shape guidance for `oneOf`/`anyOf`/`allOf`/`enum`/`not`.
+///
+/// The flattened envelope is no longer empty — `merge_top_level_variant_properties`
+/// walks the union variants and rebuilds a flat `properties` map so the LLM
+/// has structured field hints to reason about. Strict-mode validation is
+/// still disabled (`additionalProperties: true`, `required: []`) so the LLM
+/// is free to send any combination of variant fields and the upstream MCP
+/// server enforces the actual constraints.
 fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
     // OpenAI has no documented hard limit on tool description length, but
     // long descriptions waste prompt budget on every turn. 1500 bytes fits a
@@ -268,6 +309,7 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
     const SCHEMA_HINT_MAX_BYTES: usize = 1500;
 
     let detected = detect_forbidden_top_level(parameters);
+    let merged_properties = merge_top_level_variant_properties(parameters);
 
     if let Ok(original_text) = serde_json::to_string(parameters)
         && !original_text.is_empty()
@@ -290,7 +332,7 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
 
     *parameters = serde_json::json!({
         "type": "object",
-        "properties": {},
+        "properties": JsonValue::Object(merged_properties),
         "additionalProperties": true,
         "required": []
     });
@@ -1143,6 +1185,83 @@ mod tests {
         assert_eq!(result["type"], "object");
         assert!(result["properties"].is_object());
         assert_eq!(result["additionalProperties"], true);
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_merges_variant_properties() {
+        // Top-level oneOf flatten now merges all variants' properties into
+        // the envelope so the LLM sees structured field hints instead of
+        // an empty `{}`. Mirrors the GitHub Copilot `github` tool shape:
+        // each variant declares its own subset of fields keyed by `action`.
+        let input = serde_json::json!({
+            "type": "object",
+            "oneOf": [
+                {
+                    "properties": {
+                        "action": { "const": "create_issue" },
+                        "title":  { "type": "string" },
+                        "body":   { "type": "string" }
+                    },
+                    "required": ["action", "title"]
+                },
+                {
+                    "properties": {
+                        "action": { "const": "list_issues" },
+                        "repo":   { "type": "string" },
+                        "state":  { "type": "string" }
+                    },
+                    "required": ["action", "repo"]
+                }
+            ]
+        });
+        let mut description = "github".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        // The flatten happened.
+        assert_eq!(result["type"], "object");
+        assert!(result.get("oneOf").is_none());
+        assert_eq!(result["additionalProperties"], true);
+        // Strict-mode `required` is empty so the LLM can mix fields from
+        // different variants without failing OpenAI validation.
+        assert_eq!(result["required"], serde_json::json!([]));
+
+        // CRITICAL: properties is no longer `{}` — every field from every
+        // variant must appear so the LLM can pick what to send.
+        let props = result["properties"].as_object().expect("merged properties");
+        assert!(props.contains_key("action"), "discriminator must merge");
+        assert!(props.contains_key("title"), "create_issue field must merge");
+        assert!(props.contains_key("body"), "create_issue field must merge");
+        assert!(props.contains_key("repo"), "list_issues field must merge");
+        assert!(props.contains_key("state"), "list_issues field must merge");
+        assert_eq!(props.len(), 5);
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_merge_first_write_wins_on_conflict() {
+        // If two variants declare the same field with different schemas,
+        // first-write wins. Documented behaviour — the description hint
+        // still has the full original schema for ambiguous cases.
+        let input = serde_json::json!({
+            "type": "object",
+            "anyOf": [
+                {
+                    "properties": {
+                        "value": { "type": "string", "description": "first" }
+                    }
+                },
+                {
+                    "properties": {
+                        "value": { "type": "integer", "description": "second" }
+                    }
+                }
+            ]
+        });
+        let mut description = "ambiguous".to_string();
+        let result = normalize_schema_strict(&input, &mut description);
+
+        let value_schema = &result["properties"]["value"];
+        assert_eq!(value_schema["type"], "string");
+        assert_eq!(value_schema["description"], "first");
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -184,9 +184,26 @@ pub(crate) fn normalize_schema_strict(schema: &JsonValue, description: &mut Stri
     schema
 }
 
+/// JSON Schema keywords that OpenAI's tool API rejects at the top level of
+/// a tool's `parameters`. Listed in priority order so that, when more than
+/// one is present, we report the most semantically meaningful one in the
+/// description hint.
+const FORBIDDEN_TOP_LEVEL: &[&str] = &["oneOf", "anyOf", "allOf", "enum", "not"];
+
+/// Detect which forbidden top-level keyword (if any) `schema` has, returning
+/// the keyword name so the caller can pick a precise hint string. Returns
+/// `None` for an object schema with none of the forbidden constructs (the
+/// caller may still want to flatten if `type` isn't `"object"`).
+fn detect_forbidden_top_level(schema: &JsonValue) -> Option<&'static str> {
+    let map = schema.as_object()?;
+    FORBIDDEN_TOP_LEVEL
+        .iter()
+        .find(|keyword| map.contains_key(**keyword))
+        .copied()
+}
+
 /// True if `schema`'s top level would be rejected by OpenAI's tool API.
 fn needs_top_level_flatten(schema: &JsonValue) -> bool {
-    const FORBIDDEN_TOP_LEVEL: &[&str] = &["oneOf", "anyOf", "allOf", "enum", "not"];
     match schema {
         JsonValue::Object(map) => {
             let has_forbidden = FORBIDDEN_TOP_LEVEL.iter().any(|k| map.contains_key(*k));
@@ -198,16 +215,59 @@ fn needs_top_level_flatten(schema: &JsonValue) -> bool {
     }
 }
 
+/// Pick a description hint that matches the actual JSON Schema construct
+/// that triggered the flatten. The previous one-size-fits-all hint
+/// ("pick one variant and pass its fields") was correct for `oneOf` /
+/// `anyOf` but actively misleading for `allOf` (where the LLM should pass
+/// fields from ALL variants), `enum` (one of the literal values), and `not`
+/// (any object that doesn't match a constraint).
+fn schema_flatten_hint_intro(detected: Option<&'static str>) -> &'static str {
+    match detected {
+        Some("oneOf") | Some("anyOf") => {
+            "\n\nUpstream JSON schema (advisory; the actual top-level union has been \
+             flattened so the OpenAI tool API will accept the tool — pick ONE variant \
+             and pass its fields as a flat object):\n"
+        }
+        Some("allOf") => {
+            "\n\nUpstream JSON schema (advisory; the actual top-level intersection has \
+             been flattened so the OpenAI tool API will accept the tool — pass fields \
+             from ALL variants combined as a flat object):\n"
+        }
+        Some("enum") => {
+            "\n\nUpstream JSON schema (advisory; the actual top-level was an enum, \
+             which OpenAI's tool API doesn't allow at the top level — pass one of \
+             the listed values as the parameters object):\n"
+        }
+        Some("not") => {
+            "\n\nUpstream JSON schema (advisory; the actual top-level was a `not` \
+             constraint, which OpenAI's tool API doesn't allow at the top level — \
+             pass any object that does NOT match the constraint):\n"
+        }
+        // Fallback: schema wasn't an object, or had some unrecognized
+        // shape that we still flattened defensively. The MCP server will
+        // validate the actual call shape on its end, so the LLM just has
+        // to send something the upstream accepts.
+        _ => {
+            "\n\nUpstream JSON schema (advisory; the original was not a top-level \
+             object schema, so we flattened to a free-form object — see below for \
+             the actual constraints the upstream server will enforce):\n"
+        }
+    }
+}
+
 /// Replace `parameters` with a permissive object envelope and append the
 /// original schema to `description` as advisory text. Truncates the hint on a
 /// char boundary if the original schema is too large to fit in a reasonable
-/// description budget.
+/// description budget. The hint introduction is keyword-aware so the LLM
+/// gets the right shape guidance for `oneOf`/`anyOf`/`allOf`/`enum`/`not`.
 fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
     // OpenAI has no documented hard limit on tool description length, but
     // long descriptions waste prompt budget on every turn. 1500 bytes fits a
     // typical MCP dispatcher schema and still leaves room for the original
     // tool description above it.
     const SCHEMA_HINT_MAX_BYTES: usize = 1500;
+
+    let detected = detect_forbidden_top_level(parameters);
 
     if let Ok(original_text) = serde_json::to_string(parameters)
         && !original_text.is_empty()
@@ -224,11 +284,7 @@ fn flatten_top_level(parameters: &mut JsonValue, description: &mut String) {
         } else {
             original_text
         };
-        description.push_str(
-            "\n\nUpstream JSON schema (advisory; the actual top-level union has been \
-             flattened so the OpenAI tool API will accept the tool — pick one variant \
-             and pass its fields as a flat object):\n",
-        );
+        description.push_str(schema_flatten_hint_intro(detected));
         description.push_str(&hint);
     }
 
@@ -1045,6 +1101,35 @@ mod tests {
             );
             assert_eq!(result["type"], "object");
             assert_eq!(result["additionalProperties"], true);
+        }
+    }
+
+    #[test]
+    fn test_normalize_schema_strict_hint_is_keyword_aware() {
+        // The flatten hint must match the construct that triggered it. The
+        // previous one-size-fits-all "pick one variant" hint was correct
+        // for oneOf/anyOf but actively misleading for allOf (where the LLM
+        // should pass fields from ALL variants), enum (one of the listed
+        // values), and not (any object that doesn't match).
+        let cases = [
+            ("oneOf", "pick ONE variant"),
+            ("anyOf", "pick ONE variant"),
+            ("allOf", "pass fields from ALL variants"),
+            ("enum", "pass one of the listed values"),
+            ("not", "does NOT match the constraint"),
+        ];
+        for (keyword, expected_phrase) in cases {
+            let input = serde_json::json!({
+                "type": "object",
+                keyword: ["whatever"]
+            });
+            let mut description = "tool".to_string();
+            let _ = normalize_schema_strict(&input, &mut description);
+            assert!(
+                description.contains(expected_phrase),
+                "hint for top-level {keyword} must contain `{expected_phrase}`, \
+                 got: {description}"
+            );
         }
     }
 

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -404,8 +404,9 @@ fn serialize_json_capped(value: &JsonValue, max_bytes: usize) -> Result<String, 
             let valid_len = e.utf8_error().valid_up_to();
             let mut buf = e.into_bytes();
             buf.truncate(valid_len);
-            // valid_up_to guarantees the prefix is valid UTF-8
-            Ok(String::from_utf8(buf).expect("valid_up_to guarantees valid UTF-8"))
+            // safety: valid_up_to guarantees the prefix is valid UTF-8,
+            // so from_utf8_unchecked is sound here.
+            Ok(unsafe { String::from_utf8_unchecked(buf) })
         }
     }
 }

--- a/src/tools/builtin/file_history.rs
+++ b/src/tools/builtin/file_history.rs
@@ -98,24 +98,8 @@ impl FileHistory {
         tool_name: &str,
     ) -> Result<Option<Uuid>, ToolError> {
         // Canonicalize early so the stored path matches what validate_path
-        // will produce during undo lookup. On macOS, `/var` is a symlink to
-        // `/private/var`, so temp-dir paths differ between the original and
-        // canonicalized forms. When the file doesn't exist yet (write_file's
-        // "new file" case), canonicalize the parent directory and join the
-        // filename — the parent always exists.
-        let path = match path.canonicalize() {
-            Ok(p) => p,
-            Err(_) => {
-                if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
-                    parent
-                        .canonicalize()
-                        .unwrap_or_else(|_| parent.to_path_buf())
-                        .join(name)
-                } else {
-                    path.to_path_buf()
-                }
-            }
-        };
+        // will produce during undo lookup.
+        let path = Self::canonical(path);
         let path = path.as_path();
 
         // Check file size before reading — skip snapshot for very large files

--- a/src/tools/builtin/file_history.rs
+++ b/src/tools/builtin/file_history.rs
@@ -84,12 +84,40 @@ impl FileHistory {
     /// Reads the file at `path` and stores its content. If the file does not
     /// exist, the snapshot records that absence so `file_undo` can remove the
     /// newly-created file.
+    ///
+    /// The path is canonicalized before storage so lookups from `file_undo`
+    /// (which goes through `validate_path` → `canonicalize()`) match even
+    /// when the caller passes a non-canonical path. On macOS, `/var` is a
+    /// symlink to `/private/var`, so a temp-dir path like
+    /// `/var/folders/.../code.rs` would mismatch the canonicalized
+    /// `/private/var/folders/.../code.rs` without this normalization.
     pub async fn snapshot(
         &mut self,
         job_id: Uuid,
         path: &Path,
         tool_name: &str,
     ) -> Result<Option<Uuid>, ToolError> {
+        // Canonicalize early so the stored path matches what validate_path
+        // will produce during undo lookup. On macOS, `/var` is a symlink to
+        // `/private/var`, so temp-dir paths differ between the original and
+        // canonicalized forms. When the file doesn't exist yet (write_file's
+        // "new file" case), canonicalize the parent directory and join the
+        // filename — the parent always exists.
+        let path = match path.canonicalize() {
+            Ok(p) => p,
+            Err(_) => {
+                if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
+                    parent
+                        .canonicalize()
+                        .unwrap_or_else(|_| parent.to_path_buf())
+                        .join(name)
+                } else {
+                    path.to_path_buf()
+                }
+            }
+        };
+        let path = path.as_path();
+
         // Check file size before reading — skip snapshot for very large files
         // to prevent memory exhaustion (up to 50 snapshots × 10MB = 500MB worst case).
         match tokio::fs::metadata(path).await {
@@ -141,8 +169,29 @@ impl FileHistory {
         Ok(Some(id))
     }
 
+    /// Canonicalize a path for consistent snapshot comparison. When the
+    /// file itself doesn't exist (write_file's "new file" case, or a
+    /// snapshot taken before creation), canonicalize the parent directory
+    /// and join the filename. On macOS, `/var` → `/private/var` symlink
+    /// means temp-dir paths differ between the original and resolved
+    /// forms, causing lookup mismatches if we fall back to the raw path.
+    fn canonical(path: &Path) -> PathBuf {
+        if let Ok(p) = path.canonicalize() {
+            return p;
+        }
+        if let (Some(parent), Some(name)) = (path.parent(), path.file_name()) {
+            parent
+                .canonicalize()
+                .unwrap_or_else(|_| parent.to_path_buf())
+                .join(name)
+        } else {
+            path.to_path_buf()
+        }
+    }
+
     /// Get the most recent snapshot for a file path within a specific job.
     pub fn latest_snapshot_for(&self, job_id: Uuid, path: &Path) -> Option<&FileSnapshot> {
+        let path = Self::canonical(path);
         self.snapshots
             .iter()
             .rev()
@@ -151,6 +200,7 @@ impl FileHistory {
 
     /// Get all snapshots for a file path within a specific job, newest first.
     pub fn snapshots_for(&self, job_id: Uuid, path: &Path) -> Vec<&FileSnapshot> {
+        let path = Self::canonical(path);
         let mut result: Vec<_> = self
             .snapshots
             .iter()
@@ -168,6 +218,7 @@ impl FileHistory {
         job_id: Uuid,
         path: &Path,
     ) -> Result<Option<FileSnapshot>, ToolError> {
+        let path = Self::canonical(path);
         let idx = self
             .snapshots
             .iter()

--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -1194,7 +1194,16 @@ pub async fn is_authenticated(
     .await
     {
         Ok(Some(_)) => true,
-        Ok(None) => false,
+        Ok(None) => {
+            // Fall back to legacy (pre-hyphen-normalization) secret name
+            // so existing users with tokens stored under hyphenated server
+            // names are not forced to re-authenticate after upgrade.
+            if let Some(legacy_name) = server_config.legacy_token_secret_name() {
+                secrets.get_decrypted(user_id, &legacy_name).await.is_ok()
+            } else {
+                false
+            }
+        }
         Err(error) => {
             tracing::warn!(server = %server_config.name, error = %error, "Failed to read access token");
             false

--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -1198,6 +1198,13 @@ pub async fn is_authenticated(
             // Fall back to legacy (pre-hyphen-normalization) secret name
             // so existing users with tokens stored under hyphenated server
             // names are not forced to re-authenticate after upgrade.
+            //
+            // Intentionally uses bare `get_decrypted` (no refresh) — the
+            // legacy path is transitional. Users whose token is expired
+            // will re-auth once and get migrated to the canonical name.
+            // Wiring `resolve_access_token_string_with_refresh` through the
+            // legacy naming scheme adds complexity for a path that
+            // self-heals after one re-auth cycle.
             if let Some(legacy_name) = server_config.legacy_token_secret_name() {
                 secrets.get_decrypted(user_id, &legacy_name).await.is_ok()
             } else {

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -599,7 +599,7 @@ impl McpClient {
         Ok(mcp_tools
             .into_iter()
             .map(|t| {
-                let prefixed_name = format!("{}_{}", self.server_name, t.name);
+                let prefixed_name = mcp_tool_id(&self.server_name, &t.name);
                 Arc::new(McpToolWrapper {
                     tool: t,
                     prefixed_name,
@@ -650,6 +650,24 @@ fn extract_server_name(url: &str) -> String {
         .and_then(|u| u.host_str().map(|h| h.to_string()))
         .unwrap_or_else(|| "unknown".to_string())
         .replace('.', "_")
+}
+
+/// Build the canonical registry identifier for an MCP tool.
+///
+/// MCP tool names commonly contain dashes (e.g. `notion-search`), and so do
+/// user-supplied server names (`my-server`). The IronClaw runtime converges
+/// on snake_case identifiers (see `ToolRegistry::resolve_name`), and LLMs,
+/// Codex / GPT-5 in particular, silently normalize tool names to valid
+/// Python identifiers by converting dashes to underscores. If we registered
+/// `notion_notion-search` the LLM would emit a call for `notion_notion_search`
+/// and the registry lookup would miss, leaving the tool unreachable.
+///
+/// The original (possibly hyphenated) tool name is still stored on the
+/// `McpToolWrapper`'s inner `McpTool` and used verbatim when forwarding the
+/// `tools/call` request to the MCP server, so this normalization is
+/// internal-only and does not affect protocol compatibility.
+pub(crate) fn mcp_tool_id(server_name: &str, tool_name: &str) -> String {
+    format!("{server_name}_{tool_name}").replace('-', "_")
 }
 
 /// Wrapper that implements Tool for an MCP tool.
@@ -1381,6 +1399,195 @@ mod tests {
         };
         let approval = wrapper.requires_approval(&serde_json::json!({}));
         assert_eq!(approval, ApprovalRequirement::Never);
+    }
+
+    // ── mcp_tool_id canonicalization ──────────────────────────────────────
+    //
+    // The runtime keys tools by snake_case identifiers and LLMs (Codex /
+    // GPT-5 in particular) silently normalize tool names to valid Python
+    // identifiers by converting dashes to underscores. If the registered
+    // name contains a dash, the LLM-emitted call won't match the registry
+    // key and the tool becomes unreachable. The helper canonicalizes both
+    // sides of the prefixed name so the registration and the lookup agree.
+
+    #[test]
+    fn test_mcp_tool_id_canonicalizes_dashed_tool_name() {
+        // The Notion MCP server returns tools like "notion-search". The
+        // registered identifier must use underscores so the LLM call
+        // ("notion_notion_search") resolves directly.
+        assert_eq!(
+            mcp_tool_id("notion", "notion-search"),
+            "notion_notion_search"
+        );
+        assert_eq!(
+            mcp_tool_id("notion", "notion-get-users"),
+            "notion_notion_get_users"
+        );
+    }
+
+    #[test]
+    fn test_mcp_tool_id_canonicalizes_dashed_server_name() {
+        // User-supplied server names can contain dashes too. Both sides of
+        // the prefixed name must be normalized.
+        assert_eq!(mcp_tool_id("my-server", "ping"), "my_server_ping");
+        assert_eq!(mcp_tool_id("my-server", "do-thing"), "my_server_do_thing");
+    }
+
+    #[test]
+    fn test_mcp_tool_id_passthrough_for_already_canonical_names() {
+        assert_eq!(mcp_tool_id("github", "list_issues"), "github_list_issues");
+        assert_eq!(mcp_tool_id("local", "ping"), "local_ping");
+    }
+
+    /// Regression test (helper level): create_tools must surface the
+    /// canonical snake_case identifier through `Tool::name()` even when the
+    /// MCP server returns tools whose names contain dashes.
+    #[tokio::test]
+    async fn test_create_tools_canonicalizes_dashed_mcp_tool_names() {
+        let init_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(1),
+            result: Some(serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "test", "version": "1.0"}
+            })),
+            error: None,
+        };
+        let notification_ack = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+        };
+        let list_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(2),
+            result: Some(serde_json::json!({
+                "tools": [
+                    {
+                        "name": "notion-search",
+                        "description": "Search Notion",
+                        "inputSchema": {"type": "object"}
+                    },
+                    {
+                        "name": "notion-get-users",
+                        "description": "List Notion users",
+                        "inputSchema": {"type": "object"}
+                    }
+                ]
+            })),
+            error: None,
+        };
+
+        let transport = Arc::new(MockTransport::new(
+            false,
+            vec![init_response, notification_ack, list_response],
+        ));
+        let client =
+            McpClient::new_with_transport("notion", transport.clone(), None, None, "default", None);
+
+        let tools = client
+            .create_tools()
+            .await
+            .expect("create_tools should succeed");
+
+        let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+        assert_eq!(
+            names,
+            vec!["notion_notion_search", "notion_notion_get_users"],
+            "MCP tool names with dashes must be canonicalized to snake_case"
+        );
+
+        // The wrapper must still preserve the original (dashed) name on its
+        // inner McpTool so the wire call to the MCP server uses what the
+        // server actually advertised.
+        for tool in &tools {
+            // Cast through the trait object's parameters_schema as a sanity
+            // check that the wrapper is wired up correctly.
+            assert!(tool.parameters_schema().is_object());
+        }
+    }
+
+    /// Regression test (caller level): the canonicalized identifier produced
+    /// by `create_tools` must round-trip through the real `ToolRegistry` —
+    /// including `resolve_name`, which is what the v2 effect adapter calls
+    /// when dispatching an LLM-emitted tool call.
+    ///
+    /// This is the "test through the caller, not just the helper" pattern
+    /// from `.claude/rules/testing.md`. A unit test on `mcp_tool_id` alone
+    /// would not catch a regression where the registry path mangles names
+    /// differently from the schema-emitting path.
+    #[tokio::test]
+    async fn test_create_tools_round_trips_through_registry_resolve_name() {
+        use crate::tools::registry::ToolRegistry;
+
+        let init_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(1),
+            result: Some(serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "test", "version": "1.0"}
+            })),
+            error: None,
+        };
+        let notification_ack = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+        };
+        let list_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(2),
+            result: Some(serde_json::json!({
+                "tools": [
+                    {
+                        "name": "notion-search",
+                        "description": "Search Notion",
+                        "inputSchema": {"type": "object"}
+                    }
+                ]
+            })),
+            error: None,
+        };
+
+        let transport = Arc::new(MockTransport::new(
+            false,
+            vec![init_response, notification_ack, list_response],
+        ));
+        let client =
+            McpClient::new_with_transport("notion", transport.clone(), None, None, "default", None);
+
+        let registry = ToolRegistry::new();
+        for tool in client
+            .create_tools()
+            .await
+            .expect("create_tools should succeed")
+        {
+            registry.register(tool).await;
+        }
+
+        // The LLM (Codex / GPT-5) emits the tool name with all underscores.
+        // resolve_name must find it directly without falling through to the
+        // legacy alias path (which only goes underscores → dashes and would
+        // miss the mixed-separator form `notion_notion-search`).
+        let resolved = registry.resolve_name("notion_notion_search").await;
+        assert_eq!(
+            resolved.as_deref(),
+            Some("notion_notion_search"),
+            "LLM-emitted snake_case tool name must resolve to the registered MCP tool"
+        );
+
+        // And the get_resolved path that the effect adapter actually uses
+        // must also produce a working Tool handle.
+        let (resolved_name, tool) = registry
+            .get_resolved("notion_notion_search")
+            .await
+            .expect("get_resolved should return the registered tool");
+        assert_eq!(resolved_name, "notion_notion_search");
+        assert_eq!(tool.name(), "notion_notion_search");
     }
 
     // Regression test: empty/whitespace-only tokens must not produce a

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -126,7 +126,7 @@ impl McpClient {
     ///
     /// Use this when you have a configured server name but no authentication.
     pub fn new_with_name(server_name: impl Into<String>, server_url: impl Into<String>) -> Self {
-        let name: String = server_name.into();
+        let name: String = server_name.into().replace('-', "_");
         let url: String = server_url.into();
         let transport = Arc::new(HttpMcpTransport::new(url.clone(), name.clone()));
 
@@ -893,7 +893,7 @@ mod tests {
     #[test]
     fn test_new_with_name_uses_custom_name() {
         let client = McpClient::new_with_name("my-server", "http://localhost:8080");
-        assert_eq!(client.server_name(), "my-server");
+        assert_eq!(client.server_name(), "my_server");
         assert_eq!(client.server_url(), "http://localhost:8080");
         assert_eq!(client.user_id, "<unset>");
         assert!(client.session_manager.is_none());
@@ -920,7 +920,7 @@ mod tests {
         client.next_request_id();
         let cloned = client.clone();
         assert_eq!(cloned.server_url(), "http://localhost:5555");
-        assert_eq!(cloned.server_name(), "cloned-server");
+        assert_eq!(cloned.server_name(), "cloned_server");
         assert_eq!(cloned.user_id, "<unset>");
         assert_eq!(cloned.next_id.load(Ordering::SeqCst), 3);
     }

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -625,6 +625,9 @@ impl McpClient {
                         server = %self.server_name,
                         "MCP tool name collision after normalization — second tool will shadow the first in the registry. Operators: rename one of the upstream tools to differ in more than just '-' vs '_' (or '.' vs '_')."
                     );
+                    // Update so a 3rd collision reports against the most
+                    // recent shadow, not the original entry.
+                    seen_ids.insert(id, t.name.clone());
                 }
                 _ => {
                     seen_ids.insert(id, t.name.clone());

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -662,12 +662,32 @@ fn extract_server_name(url: &str) -> String {
 /// `notion_notion-search` the LLM would emit a call for `notion_notion_search`
 /// and the registry lookup would miss, leaving the tool unreachable.
 ///
-/// The original (possibly hyphenated) tool name is still stored on the
-/// `McpToolWrapper`'s inner `McpTool` and used verbatim when forwarding the
-/// `tools/call` request to the MCP server, so this normalization is
-/// internal-only and does not affect protocol compatibility.
+/// We replace **every** non-`[A-Za-z0-9_]` character with `_`, not just
+/// dashes. The MCP spec doesn't actually constrain tool names to OpenAI's
+/// `^[a-zA-Z0-9_-]{1,64}$` regex — a server could legally return
+/// `notion.search` or `notion:create_issue` — and the same LLM normalization
+/// that bites on `-` will bite on `.` and `:` too. Replacing them all up
+/// front is a one-line defense that makes the registry key bulletproof.
+/// `extract_server_name` already strips `.` from the host portion of a URL,
+/// but the tool portion of the prefixed name was unprotected. Multi-byte
+/// unicode characters (e.g. emoji or non-ASCII letters) are also normalized
+/// to `_` so the registry key stays a valid Rust identifier suffix.
+///
+/// The original (possibly hyphenated / dotted / unicode) tool name is still
+/// stored on the `McpToolWrapper`'s inner `McpTool` and used verbatim when
+/// forwarding the `tools/call` request to the MCP server, so this
+/// normalization is internal-only and does not affect protocol compatibility.
 pub(crate) fn mcp_tool_id(server_name: &str, tool_name: &str) -> String {
-    format!("{server_name}_{tool_name}").replace('-', "_")
+    format!("{server_name}_{tool_name}")
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
 }
 
 /// Wrapper that implements Tool for an MCP tool.
@@ -1437,6 +1457,33 @@ mod tests {
     fn test_mcp_tool_id_passthrough_for_already_canonical_names() {
         assert_eq!(mcp_tool_id("github", "list_issues"), "github_list_issues");
         assert_eq!(mcp_tool_id("local", "ping"), "local_ping");
+    }
+
+    #[test]
+    fn test_mcp_tool_id_normalizes_non_identifier_chars() {
+        // The MCP spec doesn't restrict tool names to OpenAI's
+        // `[a-zA-Z0-9_-]` regex. A server could legally return names with
+        // dots, colons, slashes, spaces, or non-ASCII characters. The same
+        // LLM normalization that bites on `-` will bite on these too, so
+        // canonicalize them all to `_` defensively.
+        assert_eq!(
+            mcp_tool_id("notion", "notion.search"),
+            "notion_notion_search"
+        );
+        assert_eq!(
+            mcp_tool_id("github", "github:create_issue"),
+            "github_github_create_issue"
+        );
+        assert_eq!(
+            mcp_tool_id("local", "do something now"),
+            "local_do_something_now"
+        );
+        // Path-like tool names: every separator becomes `_`.
+        assert_eq!(mcp_tool_id("fs", "files/read"), "fs_files_read");
+        // Multi-byte unicode (each `α` is 2 UTF-8 bytes) → each char
+        // becomes a single `_` in the output. Tests both correct char
+        // iteration AND that the char count translates 1:1.
+        assert_eq!(mcp_tool_id("local", "αβγ"), "local____");
     }
 
     /// Regression test (helper level): create_tools must surface the

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -317,6 +317,14 @@ impl McpClient {
     ///
     /// If the stored token has expired, automatically attempts a refresh using
     /// the stored refresh token before failing.
+    ///
+    /// Falls back to the legacy (pre-normalization) secret name so that
+    /// existing users who stored tokens under the hyphenated server name
+    /// (e.g. `mcp_my-server_access_token`) aren't broken after the
+    /// factory starts normalizing `server.name` to underscores. Without
+    /// this fallback, `is_authenticated` would report `true` (it has its
+    /// own legacy fallback) but the actual request would send no
+    /// `Authorization` header and the MCP server would 401.
     async fn get_access_token(&self) -> Result<Option<String>, ToolError> {
         let Some(ref secrets) = self.secrets else {
             return Ok(None);
@@ -324,7 +332,8 @@ impl McpClient {
         let Some(ref config) = self.server_config else {
             return Ok(None);
         };
-        resolve_access_token_string_with_refresh(
+        // Try canonical (normalized) secret name first.
+        let result = resolve_access_token_string_with_refresh(
             secrets.as_ref(),
             &self.user_id,
             &config.token_secret_name(),
@@ -337,7 +346,24 @@ impl McpClient {
             },
         )
         .await
-        .map_err(|e| ToolError::ExternalService(format!("Failed to get access token: {}", e)))
+        .map_err(|e| ToolError::ExternalService(format!("Failed to get access token: {}", e)))?;
+
+        if result.is_some() {
+            return Ok(result);
+        }
+
+        // Fall back to the legacy (pre-normalization) secret name.
+        // This path is transitional — the user will re-auth once and
+        // get migrated to the canonical name. Bare get_decrypted (no
+        // refresh) is intentional: wiring refresh through the legacy
+        // naming scheme adds complexity for a self-healing compat path.
+        if let Some(legacy_name) = config.legacy_token_secret_name()
+            && let Ok(decrypted) = secrets.get_decrypted(&self.user_id, &legacy_name).await
+        {
+            return Ok(Some(decrypted.expose().to_string()));
+        }
+
+        Ok(None)
     }
 
     /// Build the headers map for a request (auth, session-id, custom headers).

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -593,9 +593,45 @@ impl McpClient {
     }
 
     /// Create Tool implementations for all MCP tools.
+    ///
+    /// `mcp_tool_id` normalizes every non-`[A-Za-z0-9_]` character to `_`,
+    /// which is necessary for the registry key to survive LLM tool-name
+    /// normalization but introduces a collision hazard: two MCP tools whose
+    /// names differ only by `-` vs `_` (or `.` vs `_`, etc.) — e.g.
+    /// `search-all` and `search_all` — produce the same registry key. The
+    /// second `ToolRegistry::register` call would silently shadow the first
+    /// with no signal at all, leaving operators debugging an unreachable
+    /// tool with zero breadcrumb. We detect collisions here, where we still
+    /// have both the original name and the normalized id, and emit a
+    /// `warn!` log so the shadowing is observable. Behaviour is unchanged —
+    /// the second tool still wins on register, matching what the LLM would
+    /// emit anyway since it normalizes both names to the same string.
     pub async fn create_tools(&self) -> Result<Vec<Arc<dyn Tool>>, ToolError> {
         let mcp_tools = self.list_tools().await?;
         let client = Arc::new(self.clone());
+
+        // Detect post-normalization collisions before registering. This is
+        // a single linear pass; the n is small (a typical MCP server lists
+        // a few dozen tools).
+        let mut seen_ids: HashMap<String, String> = HashMap::new();
+        for t in &mcp_tools {
+            let id = mcp_tool_id(&self.server_name, &t.name);
+            match seen_ids.get(&id) {
+                Some(prev) if prev != &t.name => {
+                    tracing::warn!(
+                        normalized_id = %id,
+                        first_name = %prev,
+                        colliding_name = %t.name,
+                        server = %self.server_name,
+                        "MCP tool name collision after normalization — second tool will shadow the first in the registry. Operators: rename one of the upstream tools to differ in more than just '-' vs '_' (or '.' vs '_')."
+                    );
+                }
+                _ => {
+                    seen_ids.insert(id, t.name.clone());
+                }
+            }
+        }
+
         Ok(mcp_tools
             .into_iter()
             .map(|t| {
@@ -1554,6 +1590,77 @@ mod tests {
             // check that the wrapper is wired up correctly.
             assert!(tool.parameters_schema().is_object());
         }
+    }
+
+    /// Regression test for the post-normalization collision case: an MCP
+    /// server returning two tools whose names differ only by `-` vs `_`
+    /// (`search-all` and `search_all`) produces the same registry key. The
+    /// helper must NOT crash, must produce a wrapper for each tool, and the
+    /// shadowing must be observable via the warn log emitted in
+    /// `create_tools` (the test asserts the structural outcome — the warn
+    /// itself is a side effect we don't capture without `tracing-test`).
+    #[tokio::test]
+    async fn test_create_tools_handles_post_normalization_collision() {
+        let init_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(1),
+            result: Some(serde_json::json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "serverInfo": {"name": "test", "version": "1.0"}
+            })),
+            error: None,
+        };
+        let notification_ack = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: None,
+            result: None,
+            error: None,
+        };
+        let list_response = McpResponse {
+            jsonrpc: "2.0".to_string(),
+            id: Some(2),
+            result: Some(serde_json::json!({
+                "tools": [
+                    { "name": "search-all", "description": "first",  "inputSchema": {"type": "object"} },
+                    { "name": "search_all", "description": "second", "inputSchema": {"type": "object"} }
+                ]
+            })),
+            error: None,
+        };
+
+        let transport = Arc::new(MockTransport::new(
+            false,
+            vec![init_response, notification_ack, list_response],
+        ));
+        let client =
+            McpClient::new_with_transport("demo", transport.clone(), None, None, "default", None);
+
+        let tools = client
+            .create_tools()
+            .await
+            .expect("create_tools should succeed even with collisions");
+
+        // Both wrappers are produced and both have the same normalized
+        // registry key — this is the collision the warn log calls out.
+        assert_eq!(tools.len(), 2);
+        assert_eq!(tools[0].name(), "demo_search_all");
+        assert_eq!(tools[1].name(), "demo_search_all");
+
+        // Register both into a real ToolRegistry: the second wins (this is
+        // the documented shadowing behaviour). Without the warn log there
+        // would be no signal that the first tool became unreachable.
+        let registry = crate::tools::registry::ToolRegistry::new();
+        for tool in tools {
+            registry.register(tool).await;
+        }
+        let resolved = registry.get("demo_search_all").await;
+        assert!(resolved.is_some(), "second tool must be registered");
+        assert_eq!(
+            resolved.unwrap().description(),
+            "second",
+            "the later-registered tool wins on shadow (last-write); operators see the warn log to know it happened"
+        );
     }
 
     /// Regression test (caller level): the canonicalized identifier produced

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -275,6 +275,21 @@ impl McpServerConfig {
         format!("{}_refresh_token", self.token_secret_name())
     }
 
+    /// Legacy secret name for access tokens (pre-hyphen-normalization).
+    ///
+    /// Before the factory normalised server names (hyphens→underscores),
+    /// tokens were stored under the original hyphenated name.  Used as a
+    /// fallback during lookup to avoid forcing re-auth on existing users.
+    /// Returns `None` when the name contains no underscores (nothing to
+    /// reverse).
+    pub fn legacy_token_secret_name(&self) -> Option<String> {
+        let hyphenated = self.name.replace('_', "-");
+        if hyphenated == self.name {
+            return None;
+        }
+        Some(format!("mcp_{}_access_token", hyphenated))
+    }
+
     /// Legacy secret name for refresh tokens (pre-v0.22).
     ///
     /// Earlier versions stored refresh tokens as `mcp_{name}_refresh_token`

--- a/src/tools/mcp/factory.rs
+++ b/src/tools/mcp/factory.rs
@@ -26,12 +26,18 @@ pub enum McpFactoryError {
 /// Create an `McpClient` from a server configuration, dispatching on the
 /// effective transport type.
 pub async fn create_client_from_config(
-    server: McpServerConfig,
+    mut server: McpServerConfig,
     session_manager: &Arc<McpSessionManager>,
     process_manager: &Arc<McpProcessManager>,
     secrets: Option<Arc<dyn SecretsStore + Send + Sync>>,
     user_id: &str,
 ) -> Result<McpClient, McpFactoryError> {
+    // Normalize hyphens to underscores in the server name so that all code
+    // paths (Stdio, Unix, HTTP, OAuth) produce consistently underscore-only
+    // tool prefixes.  This must happen before any branch so that the OAuth
+    // early-return via `McpClient::new_authenticated(server, ..)` also
+    // receives the normalised name.
+    server.name = server.name.replace('-', "_");
     let server_name = server.name.clone();
 
     match server.effective_transport() {
@@ -99,11 +105,11 @@ pub async fn create_client_from_config(
             // the client (via `with_session_manager`) is not enough — the
             // transport must know about it to read/write the header.
             let transport = Arc::new(
-                HttpMcpTransport::new(server.url.clone(), server.name.clone())
+                HttpMcpTransport::new(server.url.clone(), server_name.clone())
                     .with_session_manager(Arc::clone(session_manager)),
             );
             Ok(McpClient::new_with_transport(
-                server.name.clone(),
+                server_name,
                 transport,
                 Some(Arc::clone(session_manager)),
                 secrets,
@@ -371,7 +377,9 @@ mod tests {
 
         // Pre-create a session entry so that update_session_id has something to update.
         // In production, the MCP initialize handshake calls get_or_create before responses arrive.
-        session_manager.get_or_create("session-test", &url).await;
+        // Use the normalised server name (hyphens → underscores) that the factory applies.
+        let normalised_name = "session_test";
+        session_manager.get_or_create(normalised_name, &url).await;
 
         // Send a request through the client's transport to trigger session capture.
         use crate::tools::mcp::protocol::McpRequest;
@@ -389,11 +397,37 @@ mod tests {
             .expect("request should succeed");
 
         // Verify the session manager captured the session ID from the response.
-        let captured = session_manager.get_session_id("session-test").await;
+        let captured = session_manager.get_session_id(normalised_name).await;
         assert_eq!(
             captured.as_deref(),
             Some(SESSION_ID),
             "transport must capture Mcp-Session-Id into session manager"
+        );
+    }
+
+    /// Regression test: factory must normalise hyphens in server names so
+    /// the McpClient.server_name is always underscore-only, matching the
+    /// canonicalised name used by ExtensionManager::activate_mcp().
+    #[tokio::test]
+    async fn test_factory_normalises_server_name_hyphens() {
+        let server = McpServerConfig::new("my-mcp-server", "http://localhost:9999");
+        let session_manager = Arc::new(McpSessionManager::new());
+        let process_manager = Arc::new(McpProcessManager::new());
+
+        let client = create_client_from_config(
+            server,
+            &session_manager,
+            &process_manager,
+            None,
+            "test-user",
+        )
+        .await
+        .expect("factory should succeed");
+
+        assert_eq!(
+            client.server_name(),
+            "my_mcp_server",
+            "Hyphens in server name must be replaced with underscores"
         );
     }
 }

--- a/src/tools/mcp/mod.rs
+++ b/src/tools/mcp/mod.rs
@@ -43,6 +43,7 @@ pub(crate) mod unix_transport;
 
 pub use auth::{is_authenticated, refresh_access_token};
 pub use client::McpClient;
+pub(crate) use client::mcp_tool_id;
 pub use config::{McpServerConfig, McpServersFile, OAuthConfig};
 pub use factory::{McpFactoryError, create_client_from_config};
 pub use process::McpProcessManager;

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -282,49 +282,76 @@ impl ToolRegistry {
         }
     }
 
-    /// Unregister a tool.
+    /// Resolve a tool name to the key under which it is registered,
+    /// trying the exact name first, then hyphen→underscore and
+    /// underscore→hyphen aliases.
+    fn resolve_key(tools: &HashMap<String, Arc<dyn Tool>>, name: &str) -> Option<String> {
+        if tools.contains_key(name) {
+            return Some(name.to_string());
+        }
+        // Reverse alias: hyphens → underscores (LLM normalization)
+        let underscore_alias = name.replace('-', "_");
+        if underscore_alias != name && tools.contains_key(&underscore_alias) {
+            return Some(underscore_alias);
+        }
+        // Legacy alias: underscores → hyphens (older WASM extensions)
+        let hyphen_alias = name.replace('_', "-");
+        if hyphen_alias != name && tools.contains_key(&hyphen_alias) {
+            return Some(hyphen_alias);
+        }
+        None
+    }
+
+    /// Unregister a tool.  Uses the same alias resolution as `get()` so
+    /// callers that pass hyphenated names still find underscore-registered
+    /// tools.
     pub async fn unregister(&self, name: &str) -> Option<Arc<dyn Tool>> {
-        self.tools.write().await.remove(name)
+        let mut tools = self.tools.write().await;
+        let key = Self::resolve_key(&tools, name)?;
+        tools.remove(&key)
     }
 
     /// Get a tool by name.
+    ///
+    /// Falls back to a hyphen→underscore alias when the exact name is not
+    /// found, so that tool calls from LLM providers that normalise hyphens
+    /// (e.g. `notion_notion_search` vs the registered `notion_notion-search`)
+    /// still resolve correctly.
     pub async fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
         let tools = self.tools.read().await;
-        tools.get(name).map(Arc::clone)
+        let key = Self::resolve_key(&tools, name)?;
+        tools.get(&key).map(Arc::clone)
     }
 
     /// Resolve a caller-provided action/tool name to the registered tool id.
     ///
-    /// The runtime is converging on `snake_case` names. Hyphenated names remain
-    /// accepted here only as a compatibility alias for older installed tools.
+    /// Tries exact match first, then hyphen→underscore (LLM normalization),
+    /// then underscore→hyphen (legacy WASM extensions).
     pub async fn resolve_name(&self, name: &str) -> Option<String> {
         let tools = self.tools.read().await;
-        if tools.contains_key(name) {
-            return Some(name.to_string());
-        }
-        crate::extensions::naming::legacy_extension_alias(name)
-            .filter(|alias| tools.contains_key(alias))
+        Self::resolve_key(&tools, name)
     }
 
     pub async fn get_resolved(&self, name: &str) -> Option<(String, Arc<dyn Tool>)> {
-        let resolved = self.resolve_name(name).await?;
-        let tool = self.get(&resolved).await?;
-        Some((resolved, tool))
+        let tools = self.tools.read().await;
+        let key = Self::resolve_key(&tools, name)?;
+        let tool = tools.get(&key).map(Arc::clone)?;
+        Some((key, tool))
     }
 
     /// Resolve a tool/action name to its owning provider extension, when the
     /// action is extension-backed.
     pub async fn provider_extension_for_tool(&self, name: &str) -> Option<String> {
-        let resolved = self.resolve_name(name).await?;
         let tools = self.tools.read().await;
+        let key = Self::resolve_key(&tools, name)?;
         tools
-            .get(&resolved)
+            .get(&key)
             .and_then(|tool| tool.provider_extension().map(ToOwned::to_owned))
     }
 
     /// Check if a tool exists.
     pub async fn has(&self, name: &str) -> bool {
-        self.tools.read().await.contains_key(name)
+        self.get(name).await.is_some()
     }
 
     /// List tool names visible in the current engine version.
@@ -404,7 +431,10 @@ impl ToolRegistry {
         let tools = self.tools.read().await;
         names
             .iter()
-            .filter_map(|name| tools.get(*name).map(Self::tool_definition))
+            .filter_map(|name| {
+                let key = Self::resolve_key(&tools, name)?;
+                tools.get(&key).map(Self::tool_definition)
+            })
             .collect()
     }
 
@@ -1568,5 +1598,148 @@ mod tests {
 
         assert!(names.contains(&"echo"));
         assert!(!names.contains(&"v1_only_stub"));
+    }
+
+    /// Regression test: tool names with hyphens must be resolvable when the
+    /// LLM provider normalises hyphens to underscores (nearai/ironclaw#NNN).
+    #[tokio::test]
+    async fn get_resolves_hyphen_to_underscore_alias() {
+        let registry = ToolRegistry::new();
+        registry.register(Arc::new(EchoTool)).await;
+
+        // Register a tool whose name contains underscores (the normalised
+        // form produced by the MCP prefixed-name fix).
+        struct UnderscoreTool;
+        #[async_trait::async_trait]
+        impl Tool for UnderscoreTool {
+            fn name(&self) -> &str {
+                "notion_notion_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(UnderscoreTool)).await;
+
+        // Exact match works
+        assert!(registry.get("notion_notion_search").await.is_some());
+        // Hyphenated variant resolves via alias
+        assert!(registry.get("notion_notion-search").await.is_some());
+        // has() also resolves
+        assert!(registry.has("notion_notion-search").await);
+        // Completely wrong name still fails
+        assert!(registry.get("nonexistent_tool").await.is_none());
+    }
+
+    /// Regression test: legacy underscore→hyphen alias still works.
+    #[tokio::test]
+    async fn get_resolves_underscore_to_hyphen_alias() {
+        let registry = ToolRegistry::new();
+
+        struct HyphenTool;
+        #[async_trait::async_trait]
+        impl Tool for HyphenTool {
+            fn name(&self) -> &str {
+                "my-old-tool"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(HyphenTool)).await;
+
+        // Exact hyphenated match works
+        assert!(registry.get("my-old-tool").await.is_some());
+        // Underscored variant resolves via legacy alias
+        assert!(registry.get("my_old_tool").await.is_some());
+    }
+
+    /// Regression test: get_resolved must use resolve_key so that dispatch,
+    /// approval gate, and effect adapter all resolve hyphenated names.
+    #[tokio::test]
+    async fn get_resolved_hyphen_to_underscore() {
+        let registry = ToolRegistry::new();
+
+        struct UnderscoreTool;
+        #[async_trait::async_trait]
+        impl Tool for UnderscoreTool {
+            fn name(&self) -> &str {
+                "notion_notion_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(UnderscoreTool)).await;
+
+        let (key, _) = registry
+            .get_resolved("notion_notion-search")
+            .await
+            .expect("get_resolved must resolve hyphenated name to underscore registration");
+        assert_eq!(key, "notion_notion_search");
+    }
+
+    /// Regression test: unregister with alias resolution.
+    #[tokio::test]
+    async fn unregister_resolves_hyphen_alias() {
+        let registry = ToolRegistry::new();
+
+        struct TestTool;
+        #[async_trait::async_trait]
+        impl Tool for TestTool {
+            fn name(&self) -> &str {
+                "my_mcp_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(TestTool)).await;
+        assert!(registry.has("my_mcp_search").await);
+
+        // Unregister using hyphenated alias
+        let removed = registry.unregister("my-mcp-search").await;
+        assert!(removed.is_some(), "unregister must resolve hyphen alias");
+        assert!(!registry.has("my_mcp_search").await, "tool should be gone");
     }
 }

--- a/src/tools/wasm/limits.rs
+++ b/src/tools/wasm/limits.rs
@@ -9,8 +9,12 @@ use wasmtime::ResourceLimiter;
 /// Default memory limit: 10 MB (conservative for untrusted code).
 pub const DEFAULT_MEMORY_LIMIT: u64 = 10 * 1024 * 1024;
 
-/// Default fuel limit: 10 million instructions.
-pub const DEFAULT_FUEL_LIMIT: u64 = 10_000_000;
+/// Default fuel limit: 100 million instructions.
+///
+/// 10M was too low for WASM tools that make HTTP requests then parse/serialize
+/// JSON responses with serde_json. A single 30KB JSON round-trip can burn 20-50M
+/// instructions between the recursive-descent parser and the Value tree builder.
+pub const DEFAULT_FUEL_LIMIT: u64 = 100_000_000;
 
 /// Default execution timeout: 60 seconds.
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -258,7 +258,7 @@ impl WasmToolLoader {
             }
 
             let name = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(n) => n.to_string(),
+                Some(n) => n.replace('-', "_"),
                 None => {
                     results.errors.push((
                         path.clone(),
@@ -268,6 +268,8 @@ impl WasmToolLoader {
                 }
             };
 
+            // Look up capabilities using the original filename (before
+            // hyphen normalization) so existing sidecar files are found.
             let cap_path = path.with_extension("capabilities.json");
             let has_cap = cap_path.exists();
             tool_entries.push((name, path, if has_cap { Some(cap_path) } else { None }));
@@ -549,7 +551,7 @@ fn tools_src_dir() -> PathBuf {
 /// - `tools-src/<name>/target/wasm32-wasip2/release/<crate_name>_tool.wasm`
 /// - `tools-src/<name>/<name>-tool.capabilities.json`
 ///
-/// Returns a map of install-name (e.g. "gmail-tool") to paths.
+/// Returns a map of install-name (e.g. "gmail_tool") to paths.
 pub async fn discover_dev_tools() -> Result<HashMap<String, DiscoveredTool>, std::io::Error> {
     let src_dir = tools_src_dir();
     let mut tools = HashMap::new();
@@ -572,7 +574,7 @@ pub async fn discover_dev_tools() -> Result<HashMap<String, DiscoveredTool>, std
 
         // Convention: crate name uses underscores, directory uses hyphens
         let crate_name = dir_name.replace('-', "_");
-        let install_name = format!("{}-tool", dir_name);
+        let install_name = format!("{}_tool", crate_name);
 
         let wasm_path = wasm_artifact_path(&path, &format!("{}_tool", crate_name));
 
@@ -699,7 +701,7 @@ pub async fn discover_tools(dir: &Path) -> Result<HashMap<String, DiscoveredTool
         }
 
         let name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(n) => n.to_string(),
+            Some(n) => n.replace('-', "_"),
             None => continue,
         };
 
@@ -885,11 +887,11 @@ mod tests {
         // If build artifacts exist, they should be discovered.
         let tools = super::discover_dev_tools().await.unwrap();
 
-        // If any tools have been built, they should appear with "-tool" suffix
+        // If any tools have been built, they should appear with "_tool" suffix
         for (name, discovered) in &tools {
             assert!(
-                name.ends_with("-tool"),
-                "Dev tool name should end with -tool: {}",
+                name.ends_with("_tool"),
+                "Dev tool name should end with _tool: {}",
                 name
             );
             assert!(

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1129,7 +1129,15 @@ fn classify_trap_error(error: wasmtime::Error, limits: &ResourceLimits) -> WasmE
     {
         return WasmError::FuelExhausted { limit: limits.fuel };
     }
-    if error_str.contains("unreachable") {
+    // Match wasmtime's actual Display string for UnreachableCodeReached.
+    // A bare `contains("unreachable")` would false-positive on HTTP errors
+    // like "endpoint was unreachable" or "server unreachable: connection
+    // refused", replacing the real diagnostic with a misleading generic
+    // "unreachable code executed" message.
+    if error_str.contains("unreachable code")
+        || error_str.contains("UnreachableCodeReached")
+        || error_str.contains("wasm trap: unreachable")
+    {
         return WasmError::Trapped("unreachable code executed".to_string());
     }
 

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1061,16 +1061,9 @@ impl WasmToolWrapper {
         };
 
         // Call execute using the generated typed interface
-        let response = tool_iface.call_execute(&mut store, &request).map_err(|e| {
-            let error_str = e.to_string();
-            if error_str.contains("out of fuel") {
-                WasmError::FuelExhausted { limit: limits.fuel }
-            } else if error_str.contains("unreachable") {
-                WasmError::Trapped("unreachable code executed".to_string())
-            } else {
-                WasmError::Trapped(error_str)
-            }
-        })?;
+        let response = tool_iface
+            .call_execute(&mut store, &request)
+            .map_err(|e| classify_trap_error(e, limits))?;
 
         // Get logs from host state
         let logs = store.data_mut().host_state.take_logs();
@@ -1085,6 +1078,33 @@ impl WasmToolWrapper {
         // Return result (or empty string if none)
         Ok((response.output.unwrap_or_default(), logs))
     }
+}
+
+/// Classify a wasmtime execution error into the appropriate `WasmError` variant.
+///
+/// Prefers structured `Trap` downcast (version-proof) over string matching.
+/// Falls back to string matching for forward-compat with future trap kinds.
+/// Includes the full error chain so a single log line is enough to diagnose.
+fn classify_trap_error(error: anyhow::Error, limits: &ResourceLimits) -> WasmError {
+    // Try structured downcast first (avoids string-matching drift across wasmtime versions)
+    if let Some(trap) = error.downcast_ref::<wasmtime::Trap>() {
+        return match trap {
+            wasmtime::Trap::OutOfFuel => WasmError::FuelExhausted { limit: limits.fuel },
+            wasmtime::Trap::StackOverflow => WasmError::Trapped(
+                "stack overflow: the tool's call stack exceeded the WASM stack limit. \
+                 This often happens when parsing very large JSON responses."
+                    .to_string(),
+            ),
+            wasmtime::Trap::UnreachableCodeReached => {
+                WasmError::Trapped("unreachable code executed".to_string())
+            }
+            // Everything else: include trap kind + full chain for diagnosis
+            other => WasmError::Trapped(format!("{other}: {error:#}")),
+        };
+    }
+
+    // No Trap downcast (host error, component-model glue, etc.): full chain
+    WasmError::Trapped(format!("{error:#}"))
 }
 
 /// Extract metadata (description + schema) from a WASM tool by briefly
@@ -3690,6 +3710,65 @@ mod tests {
         let mut headers = HashMap::new();
         headers.insert("content-length".to_string(), "0".to_string());
         assert!(!super::needs_content_length_zero("POST", &headers));
+    }
+
+    /// Downcast-based classification: real `wasmtime::Trap` variants
+    /// map to the correct `WasmError` without string matching.
+    #[test]
+    fn trap_classification_fuel_via_downcast() {
+        use crate::tools::wasm::error::WasmError;
+        use crate::tools::wasm::limits::ResourceLimits;
+
+        let limits = ResourceLimits::default();
+        let err: anyhow::Error = wasmtime::Trap::OutOfFuel.into();
+        let result = super::classify_trap_error(err, &limits);
+        assert!(
+            matches!(result, WasmError::FuelExhausted { .. }),
+            "OutOfFuel not detected: {result:?}"
+        );
+    }
+
+    #[test]
+    fn trap_classification_stack_overflow_via_downcast() {
+        use crate::tools::wasm::error::WasmError;
+        use crate::tools::wasm::limits::ResourceLimits;
+
+        let limits = ResourceLimits::default();
+        let err: anyhow::Error = wasmtime::Trap::StackOverflow.into();
+        let result = super::classify_trap_error(err, &limits);
+        assert!(
+            matches!(result, WasmError::Trapped(ref s) if s.contains("stack overflow")),
+            "StackOverflow not detected: {result:?}"
+        );
+    }
+
+    #[test]
+    fn trap_classification_unreachable_via_downcast() {
+        use crate::tools::wasm::error::WasmError;
+        use crate::tools::wasm::limits::ResourceLimits;
+
+        let limits = ResourceLimits::default();
+        let err: anyhow::Error = wasmtime::Trap::UnreachableCodeReached.into();
+        let result = super::classify_trap_error(err, &limits);
+        assert!(
+            matches!(result, WasmError::Trapped(ref s) if s.contains("unreachable")),
+            "UnreachableCodeReached not detected: {result:?}"
+        );
+    }
+
+    /// Non-Trap errors (host glue, component model) pass through with full chain.
+    #[test]
+    fn trap_classification_non_trap_preserves_chain() {
+        use crate::tools::wasm::error::WasmError;
+        use crate::tools::wasm::limits::ResourceLimits;
+
+        let limits = ResourceLimits::default();
+        let err = anyhow::anyhow!("component model glue exploded");
+        let result = super::classify_trap_error(err, &limits);
+        assert!(
+            matches!(result, WasmError::Trapped(ref s) if s.contains("component model glue")),
+            "non-trap error lost: {result:?}"
+        );
     }
 
     #[test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1082,11 +1082,25 @@ impl WasmToolWrapper {
 
 /// Classify a wasmtime execution error into the appropriate `WasmError` variant.
 ///
-/// Prefers structured `Trap` downcast (version-proof) over string matching.
-/// Falls back to string matching for forward-compat with future trap kinds.
-/// Includes the full error chain so a single log line is enough to diagnose.
-fn classify_trap_error(error: anyhow::Error, limits: &ResourceLimits) -> WasmError {
-    // Try structured downcast first (avoids string-matching drift across wasmtime versions)
+/// Prefers structured `Trap` downcast (version-proof) when the error type
+/// exposes a `wasmtime::Trap` directly. Falls back to string matching on the
+/// full error chain for cases where component-model glue or host wrappers
+/// bury the trap inside a nested cause (the `downcast_ref` on the outer
+/// error misses it, but the trap's diagnostic string still appears in the
+/// `Display` chain). The string fallback covers `OutOfFuel` and
+/// `unreachable` — the two traps that have distinct `WasmError` variants —
+/// and is forward-compatible with future wasmtime versions that might rename
+/// or restructure the type hierarchy.
+///
+/// Takes `wasmtime::Error` directly (not `anyhow::Error`) because that's
+/// what `call_execute` returns. wasmtime 43+ has its own `Error` type
+/// distinct from `anyhow::Error`; accepting it natively avoids a lossy
+/// `.into()` conversion that could strip type information needed for the
+/// downcast.
+fn classify_trap_error(error: wasmtime::Error, limits: &ResourceLimits) -> WasmError {
+    // Try structured downcast first (avoids string-matching drift across
+    // wasmtime versions). `wasmtime::Error::downcast_ref` walks the error
+    // chain internally, so traps wrapped by component-model glue are found.
     if let Some(trap) = error.downcast_ref::<wasmtime::Trap>() {
         return match trap {
             wasmtime::Trap::OutOfFuel => WasmError::FuelExhausted { limit: limits.fuel },
@@ -1103,8 +1117,24 @@ fn classify_trap_error(error: anyhow::Error, limits: &ResourceLimits) -> WasmErr
         };
     }
 
-    // No Trap downcast (host error, component-model glue, etc.): full chain
-    WasmError::Trapped(format!("{error:#}"))
+    // Fallback: string matching on the full error chain. The downcast can
+    // miss when the trap is wrapped in layers of component-model or host
+    // glue that don't preserve the Trap type. The Display chain still
+    // contains the diagnostic string, so we check for the two traps that
+    // have distinct WasmError variants.
+    let error_str = format!("{error:#}");
+    if error_str.contains("all fuel consumed")
+        || error_str.contains("out of fuel")
+        || error_str.contains("OutOfFuel")
+    {
+        return WasmError::FuelExhausted { limit: limits.fuel };
+    }
+    if error_str.contains("unreachable") {
+        return WasmError::Trapped("unreachable code executed".to_string());
+    }
+
+    // Unrecognized: full chain for diagnosis
+    WasmError::Trapped(error_str)
 }
 
 /// Extract metadata (description + schema) from a WASM tool by briefly
@@ -3713,14 +3743,14 @@ mod tests {
     }
 
     /// Downcast-based classification: real `wasmtime::Trap` variants
-    /// map to the correct `WasmError` without string matching.
+    /// map to the correct `WasmError` via structured downcast.
     #[test]
     fn trap_classification_fuel_via_downcast() {
         use crate::tools::wasm::error::WasmError;
         use crate::tools::wasm::limits::ResourceLimits;
 
         let limits = ResourceLimits::default();
-        let err: anyhow::Error = wasmtime::Trap::OutOfFuel.into();
+        let err: wasmtime::Error = wasmtime::Trap::OutOfFuel.into();
         let result = super::classify_trap_error(err, &limits);
         assert!(
             matches!(result, WasmError::FuelExhausted { .. }),
@@ -3734,7 +3764,7 @@ mod tests {
         use crate::tools::wasm::limits::ResourceLimits;
 
         let limits = ResourceLimits::default();
-        let err: anyhow::Error = wasmtime::Trap::StackOverflow.into();
+        let err: wasmtime::Error = wasmtime::Trap::StackOverflow.into();
         let result = super::classify_trap_error(err, &limits);
         assert!(
             matches!(result, WasmError::Trapped(ref s) if s.contains("stack overflow")),
@@ -3748,7 +3778,7 @@ mod tests {
         use crate::tools::wasm::limits::ResourceLimits;
 
         let limits = ResourceLimits::default();
-        let err: anyhow::Error = wasmtime::Trap::UnreachableCodeReached.into();
+        let err: wasmtime::Error = wasmtime::Trap::UnreachableCodeReached.into();
         let result = super::classify_trap_error(err, &limits);
         assert!(
             matches!(result, WasmError::Trapped(ref s) if s.contains("unreachable")),
@@ -3763,11 +3793,30 @@ mod tests {
         use crate::tools::wasm::limits::ResourceLimits;
 
         let limits = ResourceLimits::default();
-        let err = anyhow::anyhow!("component model glue exploded");
+        let err = wasmtime::Error::msg("component model glue exploded");
         let result = super::classify_trap_error(err, &limits);
         assert!(
             matches!(result, WasmError::Trapped(ref s) if s.contains("component model glue")),
             "non-trap error lost: {result:?}"
+        );
+    }
+
+    /// String-matching fallback: when the Trap is wrapped in host/component
+    /// glue that the downcast can't see through, the Display chain still
+    /// contains the diagnostic string.
+    #[test]
+    fn trap_classification_fuel_via_string_fallback() {
+        use crate::tools::wasm::error::WasmError;
+        use crate::tools::wasm::limits::ResourceLimits;
+
+        let limits = ResourceLimits::default();
+        // Wrap the fuel message in a plain wasmtime::Error so downcast_ref
+        // for Trap returns None — exercises the string-matching path.
+        let err = wasmtime::Error::msg("wasm trap: all fuel consumed by wasm");
+        let result = super::classify_trap_error(err, &limits);
+        assert!(
+            matches!(result, WasmError::FuelExhausted { .. }),
+            "string-fallback fuel detection failed: {result:?}"
         );
     }
 

--- a/src/workspace/document.rs
+++ b/src/workspace/document.rs
@@ -393,6 +393,18 @@ pub fn merge_workspace_entries(
     result
 }
 
+/// A new chunk to insert for a document.
+///
+/// Used by `WorkspaceStore::replace_chunks` to atomically replace all chunks
+/// for a document in one transaction. Owned so the caller can build the full
+/// Vec once (including pre-computed embeddings) and hand it off without
+/// juggling lifetimes across the trait boundary.
+#[derive(Debug, Clone)]
+pub struct ChunkWrite {
+    pub content: String,
+    pub embedding: Option<Vec<f32>>,
+}
+
 /// A chunk of a memory document for search indexing.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MemoryChunk {

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2201,10 +2201,15 @@ impl Workspace {
                 );
                 return Ok(());
             }
-            Err(_) => {
+            Err(WorkspaceError::DocumentNotFound { .. }) => {
                 // Document was deleted while we were computing embeddings.
                 // Nothing to reindex.
                 return Ok(());
+            }
+            Err(e) => {
+                // Real DB error (transient connection issue, etc.) —
+                // propagate so the indexing failure is observable.
+                return Err(e);
             }
             _ => {}
         }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -58,7 +58,7 @@ pub mod settings_schemas;
 
 pub use chunker::{ChunkConfig, chunk_document};
 pub use document::{
-    ADMIN_SCOPE, CONFIG_FILE_NAME, DocumentMetadata, DocumentVersion, HygieneMetadata,
+    ADMIN_SCOPE, CONFIG_FILE_NAME, ChunkWrite, DocumentMetadata, DocumentVersion, HygieneMetadata,
     IDENTITY_PATHS, MemoryChunk, MemoryDocument, PatchResult, VersionSummary, WorkspaceEntry,
     content_sha256, is_config_path, is_identity_path, is_reserved_scope, merge_workspace_entries,
     paths,
@@ -295,23 +295,15 @@ impl WorkspaceStorage {
         }
     }
 
-    async fn insert_chunk(
+    async fn replace_chunks(
         &self,
         document_id: Uuid,
-        chunk_index: i32,
-        content: &str,
-        embedding: Option<&[f32]>,
-    ) -> Result<Uuid, WorkspaceError> {
+        chunks: &[ChunkWrite],
+    ) -> Result<(), WorkspaceError> {
         match self {
             #[cfg(feature = "postgres")]
-            Self::Repo(repo) => {
-                repo.insert_chunk(document_id, chunk_index, content, embedding)
-                    .await
-            }
-            Self::Db(db) => {
-                db.insert_chunk(document_id, chunk_index, content, embedding)
-                    .await
-            }
+            Self::Repo(repo) => repo.replace_chunks(document_id, chunks).await,
+            Self::Db(db) => db.replace_chunks(document_id, chunks).await,
         }
     }
 
@@ -2166,15 +2158,12 @@ impl Workspace {
             return Ok(());
         }
 
-        // Chunk the content
-        let chunks = chunk_document(&doc.content, ChunkConfig::default());
-
-        // Delete old chunks
-        self.storage.delete_chunks(document_id).await?;
-
-        // Insert new chunks
-        for (index, content) in chunks.into_iter().enumerate() {
-            // Generate embedding if provider available
+        // Chunk the content and (optionally) embed each chunk before touching
+        // the DB, so the delete+insert happens in one transaction with no
+        // async points in the middle that could race a concurrent reindex.
+        let chunk_texts = chunk_document(&doc.content, ChunkConfig::default());
+        let mut writes: Vec<ChunkWrite> = Vec::with_capacity(chunk_texts.len());
+        for content in chunk_texts {
             let embedding = if let Some(ref provider) = self.embeddings {
                 match provider.embed(&content).await {
                     Ok(emb) => Some(emb),
@@ -2186,11 +2175,13 @@ impl Workspace {
             } else {
                 None
             };
-
-            self.storage
-                .insert_chunk(document_id, index as i32, &content, embedding.as_deref())
-                .await?;
+            writes.push(ChunkWrite { content, embedding });
         }
+
+        // One transaction: DELETE + N INSERTs. Closes the TOCTOU race where
+        // two concurrent reindexers for the same document could both delete,
+        // then both re-insert chunk_index 0 and hit the UNIQUE constraint.
+        self.storage.replace_chunks(document_id, &writes).await?;
 
         Ok(())
     }
@@ -3142,6 +3133,77 @@ mod versioning_tests {
             versions.len(),
             0,
             "runtime path writes must not accumulate version rows, got: {versions:?}"
+        );
+    }
+
+    // Regression: concurrent reindex of the same document used to hit
+    // `UNIQUE constraint failed: memory_chunks.document_id, memory_chunks.chunk_index`
+    // because delete_chunks + insert_chunk ran as separate libsql
+    // transactions — two writers could both delete, then both try to insert
+    // chunk_index 0. replace_chunks wraps the whole thing in one transaction,
+    // so concurrent writers serialize safely and last-writer-wins.
+    //
+    // Concurrency stays at 4 to keep every writer under libsql's 5 s busy
+    // timeout. The original race was provoked by any N >= 2 interleave;
+    // we only need enough writers to exercise the "one commits between the
+    // other's delete and insert" scheduling.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_writes_to_same_doc_do_not_collide_on_chunk_index() {
+        let (ws, _dir) = create_test_workspace().await;
+        let ws = Arc::new(ws);
+
+        // Prime the doc so get_or_create returns the same row for every
+        // concurrent writer.
+        ws.write("notes/hot.md", "seed").await.unwrap();
+
+        // Content that chunk_document splits into multiple chunks — widens
+        // the interleave window the old code used to race in.
+        let big_content: String =
+            std::iter::repeat_n("lorem ipsum dolor sit amet ", 500).collect::<String>();
+
+        // Fire off N concurrent writes. Every one of them must succeed;
+        // none may surface a ChunkingFailed UNIQUE conflict.
+        let mut joins = Vec::new();
+        for i in 0..4 {
+            let ws = Arc::clone(&ws);
+            let content = format!("{big_content}\nwriter-{i}");
+            joins.push(tokio::spawn(async move {
+                ws.write("notes/hot.md", &content).await
+            }));
+        }
+        for j in joins {
+            j.await
+                .expect("join")
+                .expect("write must not surface a ChunkingFailed error");
+        }
+
+        // Final state: the chunk rows must be a contiguous 0..N_CHUNKS
+        // prefix — no holes, no duplicates — matching exactly what
+        // chunk_document() would produce for whichever writer committed
+        // last. The document content is one of the writer strings.
+        let doc = ws
+            .storage
+            .get_document_by_path("test_version", None, "notes/hot.md")
+            .await
+            .unwrap();
+        let expected_chunks = chunk_document(&doc.content, ChunkConfig::default()).len();
+
+        let got_chunks = ws
+            .storage
+            .get_chunks_without_embeddings("test_version", None, 1024)
+            .await
+            .unwrap();
+        assert_eq!(
+            got_chunks.len(),
+            expected_chunks,
+            "chunk count after concurrent writes must match chunk_document(final content)"
+        );
+        let mut indexes: Vec<i32> = got_chunks.iter().map(|c| c.chunk_index).collect();
+        indexes.sort_unstable();
+        let expected: Vec<i32> = (0..expected_chunks as i32).collect();
+        assert_eq!(
+            indexes, expected,
+            "chunk_index set must be a contiguous 0..N after concurrent reindex"
         );
     }
 }

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2158,6 +2158,15 @@ impl Workspace {
             return Ok(());
         }
 
+        // Capture the content hash at read time. After chunking + embedding
+        // (which can take seconds for large documents with an embedding
+        // provider), we verify the document hasn't been updated by another
+        // writer before replacing chunks. Without this check, writer B
+        // could win the document UPDATE race while writer A wins the later
+        // replace_chunks transaction, leaving content from B but search
+        // chunks from A — a stale-index bug that's hard to diagnose.
+        let content_hash_at_read = content_sha256(&doc.content);
+
         // Chunk the content and (optionally) embed each chunk before touching
         // the DB, so the delete+insert happens in one transaction with no
         // async points in the middle that could race a concurrent reindex.
@@ -2176,6 +2185,28 @@ impl Workspace {
                 None
             };
             writes.push(ChunkWrite { content, embedding });
+        }
+
+        // Optimistic concurrency check: re-read the document and verify
+        // its content hasn't changed since we started chunking. If it has,
+        // another writer updated the document while we were computing
+        // embeddings — our chunks are stale and should be discarded. The
+        // other writer's reindex call will produce correct chunks for the
+        // new content.
+        match self.storage.get_document_by_id(document_id).await {
+            Ok(current_doc) if content_sha256(&current_doc.content) != content_hash_at_read => {
+                tracing::debug!(
+                    document_id = %document_id,
+                    "Skipping chunk replacement — document content changed during embedding computation"
+                );
+                return Ok(());
+            }
+            Err(_) => {
+                // Document was deleted while we were computing embeddings.
+                // Nothing to reindex.
+                return Ok(());
+            }
+            _ => {}
         }
 
         // One transaction: DELETE + N INSERTs. Closes the TOCTOU race where

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -12,7 +12,7 @@ use uuid::Uuid;
 use crate::error::WorkspaceError;
 
 use crate::workspace::document::{
-    DocumentVersion, MemoryChunk, MemoryDocument, VersionSummary, WorkspaceEntry,
+    ChunkWrite, DocumentVersion, MemoryChunk, MemoryDocument, VersionSummary, WorkspaceEntry,
 };
 use crate::workspace::search::{RankedResult, SearchConfig, SearchResult, fuse_results};
 
@@ -327,6 +327,63 @@ impl Repository {
         })?;
 
         Ok(id)
+    }
+
+    /// Atomically replace all chunks for a document.
+    ///
+    /// Runs `DELETE` + N `INSERT`s inside a single transaction so two
+    /// concurrent reindexers for the same document cannot race each other
+    /// into a `UNIQUE (document_id, chunk_index)` violation. Passing an
+    /// empty slice is equivalent to `delete_chunks(document_id)`.
+    pub async fn replace_chunks(
+        &self,
+        document_id: Uuid,
+        chunks: &[ChunkWrite],
+    ) -> Result<(), WorkspaceError> {
+        let mut conn = self.conn().await?;
+
+        let tx = conn
+            .transaction()
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Begin transaction failed: {e}"),
+            })?;
+
+        tx.execute(
+            "DELETE FROM memory_chunks WHERE document_id = $1",
+            &[&document_id],
+        )
+        .await
+        .map_err(|e| WorkspaceError::ChunkingFailed {
+            reason: format!("Delete failed: {}", e),
+        })?;
+
+        for (index, chunk) in chunks.iter().enumerate() {
+            let id = Uuid::new_v4();
+            let chunk_index = index as i32;
+            let embedding_vec = chunk.embedding.as_ref().map(|e| Vector::from(e.clone()));
+            let content = chunk.content.as_str();
+
+            tx.execute(
+                r#"
+                INSERT INTO memory_chunks (id, document_id, chunk_index, content, embedding)
+                VALUES ($1, $2, $3, $4, $5)
+                "#,
+                &[&id, &document_id, &chunk_index, &content, &embedding_vec],
+            )
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Insert failed: {}", e),
+            })?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Commit failed: {e}"),
+            })?;
+
+        Ok(())
     }
 
     /// Update a chunk's embedding.

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -366,14 +366,22 @@ impl Repository {
         // same document until this transaction commits. Pinned by
         // `concurrent_writes_to_same_doc_do_not_collide_on_chunk_index`
         // (the libsql variant of the same regression test).
-        tx.execute(
-            "SELECT 1 FROM memory_documents WHERE id = $1 FOR UPDATE",
-            &[&document_id],
-        )
-        .await
-        .map_err(|e| WorkspaceError::ChunkingFailed {
-            reason: format!("Acquire row lock failed: {e}"),
-        })?;
+        let locked = tx
+            .execute(
+                "SELECT 1 FROM memory_documents WHERE id = $1 FOR UPDATE",
+                &[&document_id],
+            )
+            .await
+            .map_err(|e| WorkspaceError::ChunkingFailed {
+                reason: format!("Acquire row lock failed: {e}"),
+            })?;
+        if locked == 0 {
+            return Err(WorkspaceError::ChunkingFailed {
+                reason: format!(
+                    "Document {document_id} not found — cannot acquire per-document lock for chunk replacement"
+                ),
+            });
+        }
 
         tx.execute(
             "DELETE FROM memory_chunks WHERE document_id = $1",

--- a/src/workspace/repository.rs
+++ b/src/workspace/repository.rs
@@ -335,6 +335,19 @@ impl Repository {
     /// concurrent reindexers for the same document cannot race each other
     /// into a `UNIQUE (document_id, chunk_index)` violation. Passing an
     /// empty slice is equivalent to `delete_chunks(document_id)`.
+    ///
+    /// Postgres-specific concurrency note: bundling DELETE + INSERTs in one
+    /// transaction is **not** sufficient on Postgres. Two concurrent
+    /// reindexers running under separate snapshots can both DELETE (each
+    /// sees its own pre-delete state, neither sees the other's), then race
+    /// to INSERT chunk_index 0 — at which point one side hits the
+    /// `UNIQUE (document_id, chunk_index)` constraint. We serialize
+    /// per-document by acquiring a row lock on the parent `memory_documents`
+    /// row at the start of the transaction. The lock is released
+    /// automatically on commit/rollback. The `FOR UPDATE` row exists in the
+    /// schema with an FK from `memory_chunks.document_id`, so the lookup is
+    /// always cheap and always finds a row (callers wouldn't be reindexing
+    /// chunks for a document that doesn't exist).
     pub async fn replace_chunks(
         &self,
         document_id: Uuid,
@@ -348,6 +361,19 @@ impl Repository {
             .map_err(|e| WorkspaceError::ChunkingFailed {
                 reason: format!("Begin transaction failed: {e}"),
             })?;
+
+        // Per-document serialization: block any other reindexer of the
+        // same document until this transaction commits. Pinned by
+        // `concurrent_writes_to_same_doc_do_not_collide_on_chunk_index`
+        // (the libsql variant of the same regression test).
+        tx.execute(
+            "SELECT 1 FROM memory_documents WHERE id = $1 FOR UPDATE",
+            &[&document_id],
+        )
+        .await
+        .map_err(|e| WorkspaceError::ChunkingFailed {
+            reason: format!("Acquire row lock failed: {e}"),
+        })?;
 
         tx.execute(
             "DELETE FROM memory_chunks WHERE document_id = $1",

--- a/tests/e2e_live.rs
+++ b/tests/e2e_live.rs
@@ -145,4 +145,623 @@ mod live_tests {
 
         harness.finish(user_input, &text).await;
     }
+
+    /// End-to-end round-trip test for the post-flight auth gate.
+    ///
+    /// Phase A: starts the rig with NO Google credentials in the temp
+    /// DB (the harness uses `with_secrets([])` semantics — by default
+    /// nothing is seeded), sends an NVIDIA GTC Drive search prompt,
+    /// and asserts that the agent emits a `StatusUpdate::AuthRequired`
+    /// within one iteration. The expected path is:
+    ///
+    ///   1. Agent calls `google-drive-tool { action: "list_files" }`
+    ///   2. WASM wrapper's `resolve_host_credentials` reports
+    ///      `missing_required = ["google_oauth_token"]`
+    ///   3. Wrapper fails closed with
+    ///      `"WASM tool '...' requires credentials that are not configured"`
+    ///   4. `effect_adapter::execute_action_internal`'s post-flight
+    ///      branch runs `auth::postflight::detect_post_call_auth_failure`
+    ///   5. The matcher fires (commit cd8b68de added the
+    ///      `requires credentials + not configured` pair)
+    ///   6. The detector calls `ensure_extension_ready(.., ExplicitAuth)`
+    ///      → `EnsureReadyOutcome::NeedsAuth`
+    ///   7. `EngineError::GatePaused { resume_kind: Authentication }`
+    ///      bubbles to the orchestrator
+    ///   8. Router stores it in `pending_gates` and emits
+    ///      `StatusUpdate::AuthRequired` to the channel
+    ///
+    /// Phase B: directly inserts a synthetic credential via
+    /// `secrets_store()`, sends the synthetic value as a follow-up
+    /// message. The v2 router treats the next user message after an
+    /// auth gate as `GateResolution::CredentialProvided`, which calls
+    /// `submit_auth_token` (idempotent overwrite of what we just
+    /// inserted), then `execute_pending_gate_action` which in turn
+    /// calls `execute_resolved_pending_action`. The original Drive
+    /// call replays. We don't assert success against the real Google
+    /// API — the synthetic token will be rejected — we just assert
+    /// the resume path *ran* (visible via additional tool activity
+    /// and a follow-up response).
+    ///
+    /// Uses NVIDIA GTC keynote as the search target so any captured
+    /// trace fixtures contain only public conference content.
+    #[tokio::test]
+    #[ignore] // Live tier: requires real Google OAuth credentials in the
+    // developer's `~/.ironclaw/ironclaw.db`. Live-only on purpose: the
+    // recorded trace would inevitably capture the bearer token, real
+    // Drive file metadata, and HTTP headers — all of which are PII
+    // that's hard to scrub safely. The test runs against the developer's
+    // real environment in live mode and is skipped otherwise. Hermetic
+    // regression coverage for the underlying alias-aware capabilities
+    // bug lives in `test_auth_wasm_tool_finds_legacy_hyphen_alias`.
+    async fn drive_auth_gate_roundtrip() {
+        use crate::support::live_harness::TestMode;
+        use ironclaw::channels::StatusUpdate;
+
+        let harness = LiveTestHarnessBuilder::new("drive_auth_gate_roundtrip")
+            .with_engine_v2(true)
+            .with_max_tool_iterations(20)
+            .with_auto_approve_tools(true)
+            // Seed the real Google OAuth credentials from the
+            // developer's libSQL DB so Phase B's resume can actually
+            // call the real Google Drive API and produce real data —
+            // not just a synthetic placeholder.
+            //
+            // Three companion records are needed:
+            //
+            //   * `google_oauth_token` — the access token itself.
+            //     Deleted before Phase A so the gate fires; the value
+            //     is captured first and re-sent as the gate resolution
+            //     in Phase B.
+            //   * `google_oauth_token_refresh_token` — the refresh
+            //     token. Also deleted before Phase A so Phase A
+            //     doesn't transparently auto-refresh and skip the
+            //     gate (`maybe_refresh_before_read` would otherwise
+            //     re-create the access token from this).
+            //   * `google_oauth_token_scopes` — the recorded set of
+            //     OAuth scopes the access token grants. Kept across
+            //     the test. Without it, `auth_wasm_tool`'s
+            //     `needs_scope_expansion` check fires for the
+            //     re-stored access token in Phase B and forces a
+            //     full re-auth, which would mask the auto-retry path
+            //     we're trying to verify.
+            .with_secrets([
+                "google_oauth_token",
+                "google_oauth_token_refresh_token",
+                "google_oauth_token_scopes",
+            ])
+            // No committed trace fixture — see test attribute comment.
+            .with_no_trace_recording()
+            .build()
+            .await;
+
+        // Live-mode only. In replay mode the harness builds a stub rig
+        // (no recorded fixture, no LLM provider) and we exit early.
+        if harness.mode() == TestMode::Replay {
+            eprintln!(
+                "[DriveAuthGate] Live-only test — skipping outside `IRONCLAW_LIVE_TEST=1`. \
+                 Hermetic regression covered by \
+                 `test_auth_wasm_tool_finds_legacy_hyphen_alias`."
+            );
+            return;
+        }
+
+        let rig = harness.rig();
+
+        let secrets = rig
+            .secrets_store()
+            .expect(
+                "drive_auth_gate_roundtrip requires a secrets store; \
+                 ensure ~/.ironclaw/.env has SECRETS_MASTER_KEY or the OS keychain entry",
+            )
+            .clone();
+        let owner = rig.owner_id().to_string();
+
+        // Capture the real OAuth token value so Phase B can re-send it
+        // as the gate resolution. The router treats the next user
+        // message after an auth gate as the credential value, so we
+        // need to send the real token (or a synthetic one) to drive
+        // the resume path. The plaintext never leaves the test process.
+        //
+        // If the developer's stored token is expired, fall back to a
+        // synthetic token. The auto-retry verification (LLM call count
+        // <= 2) still works in that case — the only thing we lose is
+        // the actual Drive API call succeeding. The test prints which
+        // mode it's running in so the developer can refresh their
+        // token via normal `ironclaw` usage if they want full coverage.
+        let real_token_result = secrets.get_decrypted(&owner, "google_oauth_token").await;
+        let (resume_token, real_token_used) = match real_token_result {
+            Ok(decrypted) => {
+                eprintln!(
+                    "[DriveAuthGate] Captured real google_oauth_token ({} chars) for Phase B",
+                    decrypted.expose().len()
+                );
+                (decrypted.expose().to_string(), true)
+            }
+            Err(ironclaw::secrets::SecretError::Expired) => {
+                eprintln!(
+                    "[DriveAuthGate] WARNING: stored google_oauth_token is EXPIRED. \
+                     Falling back to a synthetic token for Phase B — the resume path \
+                     will run end-to-end but the Drive API call will fail with 401, \
+                     not return real data. To get full real-data coverage, run \
+                     `ironclaw` once normally (any prompt that touches Drive) so the \
+                     OAuth refresh flow refreshes the token in your real DB, then \
+                     re-run this test."
+                );
+                (
+                    "drive-auth-gate-roundtrip-synthetic-token".to_string(),
+                    false,
+                )
+            }
+            Err(e) => panic!(
+                "Unexpected error reading seeded google_oauth_token: {e}. \
+                 Ensure your developer DB at ~/.ironclaw/ironclaw.db has the credential."
+            ),
+        };
+
+        // Defensive: delete BOTH the access token and the refresh
+        // token sibling. The OAuth refresh path
+        // (`auth::mod::maybe_refresh_before_read`) checks for a sibling
+        // `<name>_refresh_token` and will trigger a refresh that
+        // re-creates the access token if either is present.
+        let _ = secrets.delete(&owner, "google_oauth_token").await;
+        let _ = secrets
+            .delete(&owner, "google_oauth_token_refresh_token")
+            .await;
+        eprintln!("[DriveAuthGate] Phase A: temp DB has no google_oauth_token");
+
+        // Snapshot LLM call count BEFORE Phase A so we can prove the
+        // post-AuthCompleted retry happens with NO additional LLM call
+        // between AuthCompleted and the tool retry.
+        let baseline_llm_calls = rig.llm_call_count();
+
+        // ── Phase A: send the prompt and wait for the auth gate ───────
+        let user_input = "Find the NVIDIA GTC keynote presentation in my Google Drive \
+                          and summarize the key announcements";
+        rig.send_message(user_input).await;
+
+        let phase_a_responses = rig.wait_for_responses(1, Duration::from_secs(120)).await;
+        let phase_a_text: Vec<String> = phase_a_responses
+            .iter()
+            .map(|r| r.content.clone())
+            .collect();
+        let phase_a_tools = rig.tool_calls_started();
+        let phase_a_status = rig.captured_status_events();
+        let phase_a_llm_calls = rig.llm_call_count() - baseline_llm_calls;
+
+        eprintln!(
+            "[DriveAuthGate][Phase A] LLM calls: {phase_a_llm_calls}, Tools attempted ({}): {phase_a_tools:?}",
+            phase_a_tools.len()
+        );
+        eprintln!(
+            "[DriveAuthGate][Phase A] Response preview: {}",
+            phase_a_text
+                .join("\n")
+                .chars()
+                .take(500)
+                .collect::<String>()
+        );
+
+        // Phase A should be a single LLM call: the LLM generates a
+        // tool_call, the pre-flight gate intercepts it, no further
+        // LLM calls happen until the user provides credentials.
+        assert_eq!(
+            phase_a_llm_calls, 1,
+            "Phase A: expected exactly 1 LLM call (the tool-call generation), \
+             got {phase_a_llm_calls}. More than 1 means the agent went into a \
+             recovery loop instead of pausing immediately on the auth gate."
+        );
+
+        // Collect every AuthRequired event so we can assert *which*
+        // extension fired the gate. Before the post-flight detector
+        // landed, the agent would silently fall back to a
+        // tool_install/web_search recovery loop and trigger an
+        // AuthRequired for `brave_api_key` instead of pausing on the
+        // Drive failure. A loose `is_some()` check would let that
+        // regression slip through.
+        let auth_required_events: Vec<_> = phase_a_status
+            .iter()
+            .filter_map(|s| match s {
+                StatusUpdate::AuthRequired {
+                    extension_name,
+                    instructions,
+                    auth_url,
+                    ..
+                } => Some((
+                    extension_name.clone(),
+                    instructions.clone(),
+                    auth_url.clone(),
+                )),
+                _ => None,
+            })
+            .collect();
+        let drive_gate = auth_required_events
+            .iter()
+            .find(|(ext, _, _)| ext.contains("google") || ext.contains("drive"));
+        assert!(
+            drive_gate.is_some(),
+            "Phase A: expected an AuthRequired event for the Google Drive extension, \
+             but got: {auth_required_events:?}. The post-flight detector should have \
+             paused on the Drive failure directly instead of letting the agent run a \
+             recovery loop into a different extension."
+        );
+        let (gate_extension, _gate_instructions, gate_auth_url) = drive_gate.unwrap().clone();
+        eprintln!(
+            "[DriveAuthGate][Phase A] AuthRequired fired: extension={gate_extension}, \
+             auth_url present={}",
+            gate_auth_url.is_some()
+        );
+
+        // The agent must NOT have run a tool_install / tool_activate
+        // recovery loop — that's the bad behaviour the post-flight
+        // detector eliminates.
+        let bad_recovery = phase_a_tools
+            .iter()
+            .any(|t| t == "tool_install" || t == "tool_activate" || t == "tool-install");
+        assert!(
+            !bad_recovery,
+            "Phase A: agent ran a tool_install/tool_activate recovery loop instead \
+             of pausing for auth on the first iteration. Tools attempted: {phase_a_tools:?}"
+        );
+
+        // ── Phase B: send the real token as the gate resolution ──────
+        // The router treats the next user message after an auth gate
+        // as `GateResolution::CredentialProvided { token }` and feeds
+        // it through `submit_auth_token`. With the real Drive OAuth
+        // token, the production resume path then runs:
+        //   1. submit_auth_token writes the credential under the
+        //      WASM tool's declared `auth.secret_name`.
+        //   2. AuthCompleted status is emitted to the channel.
+        //   3. execute_pending_gate_action loads the original tool call.
+        //   4. execute_resolved_pending_action re-runs the tool through
+        //      execute_action_internal — directly, with no LLM hop.
+        //   5. The tool executes against the real Google Drive API and
+        //      returns real data.
+        //   6. resume_thread feeds the result back to the engine, which
+        //      makes a SECOND LLM call to summarise the result for the
+        //      user.
+        //
+        // The expected total LLM call count is therefore exactly 2:
+        // one for the initial tool_call, one for the summary. Anything
+        // higher would indicate that the LLM was consulted between
+        // AuthCompleted and the tool retry, which is exactly the
+        // behaviour the post-flight gate work was meant to eliminate.
+        eprintln!(
+            "[DriveAuthGate] Phase B: sending {} as gate resolution",
+            if real_token_used {
+                "real google_oauth_token"
+            } else {
+                "synthetic placeholder token"
+            }
+        );
+        rig.send_message(&resume_token).await;
+
+        let total_responses = rig.wait_for_responses(2, Duration::from_secs(180)).await;
+        assert!(
+            total_responses.len() >= 2,
+            "Phase B: expected a follow-up response after credential resolution; \
+             got {} response(s) total",
+            total_responses.len()
+        );
+
+        let phase_b_text: Vec<String> = total_responses
+            .iter()
+            .skip(phase_a_responses.len())
+            .map(|r| r.content.clone())
+            .collect();
+        let total_llm_calls = rig.llm_call_count() - baseline_llm_calls;
+        let phase_b_llm_calls = total_llm_calls - phase_a_llm_calls;
+
+        eprintln!(
+            "[DriveAuthGate][Phase B] LLM calls: {phase_b_llm_calls}, Total: {total_llm_calls}"
+        );
+        eprintln!(
+            "[DriveAuthGate][Phase B] Response preview: {}",
+            phase_b_text
+                .join("\n")
+                .chars()
+                .take(500)
+                .collect::<String>()
+        );
+
+        assert!(
+            !phase_b_text.is_empty(),
+            "Phase B: response must not be empty after credential resolution"
+        );
+
+        // The CRITICAL assertion: the auto-retry path must NOT go back
+        // through the LLM to recover from a missing credential. Tool
+        // calls between `AuthCompleted` and the resumed tool execution
+        // are kernel-driven, not LLM-driven.
+        //
+        // Distinguishing the auto-retry from a recovery loop is the
+        // job of the *first tool call after Phase A*. The pre-fix
+        // recovery loop signature was the LLM choosing to call
+        // `secret_list`, `tool_search`, `tool_install`, etc. — never
+        // re-attempting the original `google_drive_tool` call. The
+        // auto-retry signature is the original `google_drive_tool`
+        // call running again, kernel-side, before any new LLM
+        // iteration touches the recovery tools.
+        //
+        // We assert two things:
+        //
+        //   1. No `tool_install` / `tool_activate` / `secret_list`
+        //      tool ever appears in Phase B's tool activity (the
+        //      pre-fix recovery loop's smoking gun).
+        //
+        //   2. The first tool that does run in Phase B is one of
+        //      `google_drive_tool` or its action variants (so we know
+        //      the resume actually re-ran the gated action and the
+        //      LLM didn't get a second chance to pick something else).
+        let phase_b_tools = rig
+            .tool_calls_started()
+            .into_iter()
+            .skip(phase_a_tools.len())
+            .collect::<Vec<_>>();
+        eprintln!(
+            "[DriveAuthGate][Phase B] Tools attempted ({}): {phase_b_tools:?}",
+            phase_b_tools.len()
+        );
+        let phase_b_recovery = phase_b_tools.iter().any(|t| {
+            t == "tool_install"
+                || t == "tool-install"
+                || t == "tool_activate"
+                || t == "secret_list"
+                || t.starts_with("tool_search")
+        });
+        assert!(
+            !phase_b_recovery,
+            "Phase B contains pre-fix recovery-loop tools — the resume should \
+             re-run google_drive_tool through the kernel, not delegate to the \
+             LLM to figure out what to do. Phase B tools: {phase_b_tools:?}"
+        );
+        if real_token_used {
+            // Real token: the resume must have actually re-run
+            // google_drive_tool *first* (before any other tool), and
+            // it must have executed *successfully* against the real
+            // Google Drive API. The agent's eventual response text
+            // can vary widely (full summary, partial summary, hits a
+            // different extension's auth gate, etc.), so we don't
+            // pattern-match on it — we look at the captured tool
+            // events instead, which are deterministic about which
+            // tools ran and whether they succeeded.
+            let first_phase_b_tool = phase_b_tools.first().map(String::as_str);
+            assert!(
+                first_phase_b_tool.is_some_and(|t| t.contains("google_drive")),
+                "Phase B's first tool call must be google_drive_tool (the auto-retry \
+                 of the originally-gated action), got {first_phase_b_tool:?}. If this \
+                 is anything else, the resume didn't re-run the original action — \
+                 the LLM picked a different tool, which is the pre-fix recovery loop \
+                 signature."
+            );
+
+            // At least one google_drive_tool execution must have *succeeded*
+            // (not just been attempted) — that's our proof that the auto-retry
+            // actually called the real Google Drive API and got data back.
+            // `tool_calls_completed` returns (name, success) for every
+            // ToolCompleted status event.
+            let drive_succeeded = rig
+                .tool_calls_completed()
+                .into_iter()
+                .skip(phase_a_tools.len())
+                .any(|(name, success)| name.contains("google_drive") && success);
+            assert!(
+                drive_succeeded,
+                "Real token in use but no google_drive_tool execution succeeded in \
+                 Phase B. The auto-retry either re-fired the gate or the wrapper \
+                 rejected the credential. Phase B tools: {phase_b_tools:?}"
+            );
+
+            assert!(
+                phase_b_llm_calls >= 1,
+                "Real token in use but Phase B made 0 LLM calls — the auto-retry \
+                 either failed or paused at another gate before the LLM was \
+                 consulted to summarise the result. Phase B response: {phase_b_text:?}"
+            );
+        }
+
+        // Hand both turns to the harness so the .log file shows the
+        // full session for documentation. The user message in Phase B
+        // is replaced with a placeholder so the real token never
+        // appears on disk (even though we don't commit a trace, the
+        // .log file may still be diffed by developers).
+        let phase_b_user_label = if real_token_used {
+            "<real google oauth token redacted>".to_string()
+        } else {
+            "<synthetic auth token>".to_string()
+        };
+        let turns = vec![
+            (user_input.to_string(), phase_a_text.clone()),
+            (phase_b_user_label, phase_b_text.clone()),
+        ];
+        harness.finish_turns(&turns).await;
+    }
+
+    /// End-to-end verification of the *transparent* OAuth refresh path.
+    ///
+    /// Where `drive_auth_gate_roundtrip` exercises the gate-fire +
+    /// resume sequence (the agent has no credential and the user has
+    /// to provide one), this scenario exercises the path where the
+    /// agent has an *expired* access token plus a valid refresh token
+    /// — the wrapper's credential resolution
+    /// (`auth::mod::maybe_refresh_before_read`) should detect the
+    /// expiration, refresh the token via the OAuth provider's token
+    /// endpoint, and proceed transparently. **No auth gate should ever
+    /// fire and the user should never see an "Authentication required"
+    /// prompt.**
+    ///
+    /// This is the most common production case for an active user: the
+    /// access token expired since the last interaction, the refresh
+    /// token is still valid, the next Drive call should just work.
+    ///
+    /// Live-only (no committed trace fixture) for the same reason as
+    /// `drive_auth_gate_roundtrip`: the recorded HTTP exchanges and
+    /// LLM input would inevitably contain the bearer token, real
+    /// Drive file metadata, and PII. Hermetic regression coverage for
+    /// the underlying refresh mechanism lives in
+    /// `auth::tests::*` (the `maybe_refresh_before_read` unit tests).
+    #[tokio::test]
+    #[ignore] // Live tier: requires real Google OAuth credentials in the
+    // developer's `~/.ironclaw/ironclaw.db` (must include the refresh
+    // token sibling so the wrapper can refresh server-side).
+    async fn drive_transparent_oauth_refresh() {
+        use crate::support::live_harness::TestMode;
+        use ironclaw::channels::StatusUpdate;
+
+        let harness = LiveTestHarnessBuilder::new("drive_transparent_oauth_refresh")
+            .with_engine_v2(true)
+            .with_max_tool_iterations(20)
+            .with_auto_approve_tools(true)
+            .with_secrets([
+                "google_oauth_token",
+                "google_oauth_token_refresh_token",
+                "google_oauth_token_scopes",
+            ])
+            .with_no_trace_recording()
+            .build()
+            .await;
+
+        if harness.mode() == TestMode::Replay {
+            eprintln!(
+                "[DriveRefresh] Live-only test — skipping outside `IRONCLAW_LIVE_TEST=1`. \
+                 Hermetic regression for the OAuth refresh layer lives in \
+                 `auth::tests::*` and `test_auth_wasm_tool_finds_legacy_hyphen_alias`."
+            );
+            return;
+        }
+
+        let rig = harness.rig();
+        let secrets = rig
+            .secrets_store()
+            .expect("drive_transparent_oauth_refresh requires a secrets store")
+            .clone();
+        let owner = rig.owner_id().to_string();
+
+        // Verify the seeded data shape: we need BOTH the access token
+        // (whatever its expiration) AND the refresh token to be
+        // present. The whole point of this test is "wrapper auto-refreshes
+        // when access token is expired", so if either is missing the
+        // test setup is broken — fail with a clear message instead of
+        // silently passing or hitting a misleading downstream error.
+        let access_present = secrets
+            .exists(&owner, "google_oauth_token")
+            .await
+            .unwrap_or(false);
+        let refresh_present = secrets
+            .exists(&owner, "google_oauth_token_refresh_token")
+            .await
+            .unwrap_or(false);
+        assert!(
+            access_present && refresh_present,
+            "drive_transparent_oauth_refresh requires both \
+             `google_oauth_token` and `google_oauth_token_refresh_token` to be \
+             seeded from the developer DB. access={access_present}, \
+             refresh={refresh_present}. Run `ironclaw` once with a Drive prompt \
+             so the OAuth flow stores both records, then re-run this test."
+        );
+
+        eprintln!("[DriveRefresh] Seeded credentials: access + refresh + scopes");
+
+        // Send the prompt. The wrapper should:
+        //   1. Pre-flight `auth_wasm_tool` sees `secrets.exists()` =
+        //      true, scope check passes, returns Authenticated.
+        //   2. Tool runs → `resolve_host_credentials` →
+        //      `resolve_secret_for_runtime` → `maybe_refresh_before_read`.
+        //   3. `store.get()` returns `Expired` (if the access token is
+        //      expired) → triggers refresh via the refresh sibling.
+        //   4. Refresh succeeds → fresh token written → wrapper uses it.
+        //   5. Drive API call succeeds.
+        //   6. Engine summarises.
+        //
+        // (If the access token happens to still be valid at test time,
+        // step 3 just uses it directly. The test still passes — we're
+        // verifying "no gate fires", which holds in both cases.)
+        let user_input = "Find the NVIDIA GTC keynote presentation in my Google Drive \
+                          and summarize the key announcements";
+        rig.send_message(user_input).await;
+
+        let responses = rig.wait_for_responses(1, Duration::from_secs(180)).await;
+        let response_text: Vec<String> = responses.iter().map(|r| r.content.clone()).collect();
+        let tools = rig.tool_calls_started();
+        let status = rig.captured_status_events();
+
+        eprintln!(
+            "[DriveRefresh] Tools attempted ({}): {tools:?}",
+            tools.len()
+        );
+        eprintln!(
+            "[DriveRefresh] Response preview: {}",
+            response_text
+                .join("\n")
+                .chars()
+                .take(500)
+                .collect::<String>()
+        );
+
+        // CRITICAL assertion #1: NO AuthRequired event for the Google
+        // extension. The whole point of this test is that the refresh
+        // is transparent — the user should never see an auth prompt.
+        let google_auth_gate = status.iter().find(|s| {
+            matches!(
+                s,
+                StatusUpdate::AuthRequired { extension_name, .. }
+                    if extension_name.contains("google") || extension_name.contains("drive")
+            )
+        });
+        assert!(
+            google_auth_gate.is_none(),
+            "Transparent refresh failed: an AuthRequired event fired for the \
+             Google extension. The wrapper's `maybe_refresh_before_read` should \
+             have refreshed the token via the refresh_token sibling without \
+             ever surfacing a gate. Status events: {:?}",
+            status
+                .iter()
+                .filter_map(|s| match s {
+                    StatusUpdate::AuthRequired { extension_name, .. } => {
+                        Some(format!("AuthRequired({extension_name})"))
+                    }
+                    _ => None,
+                })
+                .collect::<Vec<_>>()
+        );
+
+        // CRITICAL assertion #2: at least one google_drive_tool call
+        // succeeded against the real API. If the refresh failed
+        // silently (e.g. invalid refresh token, hosted-proxy
+        // misconfig), the wrapper would have failed closed and the
+        // post-flight detector would have fired the gate — caught by
+        // assertion #1. If somehow neither happened but the tool
+        // never ran either, this catches that.
+        let drive_succeeded = rig
+            .tool_calls_completed()
+            .into_iter()
+            .any(|(name, success)| name.contains("google_drive") && success);
+        assert!(
+            drive_succeeded,
+            "No google_drive_tool execution succeeded — the wrapper either \
+             never ran the tool or it failed silently. Tools attempted: {tools:?}"
+        );
+
+        // CRITICAL assertion #3: the response must not be a Drive
+        // auth-required prompt. We allow other extensions' gates to
+        // fire (e.g. the agent may try web_search after pulling Drive
+        // content and hit brave_api_key) — that's a *different*
+        // extension and unrelated to the Google refresh path we're
+        // verifying.
+        let joined = response_text.join("\n").to_lowercase();
+        let drive_gate_phrases = [
+            "authentication required for 'google",
+            "authentication required for \"google",
+            "authentication required for google",
+        ];
+        let drive_auth_in_response = drive_gate_phrases.iter().any(|p| joined.contains(p));
+        assert!(
+            !drive_auth_in_response,
+            "Response contains a Google-extension auth prompt — the transparent \
+             refresh path failed and surfaced a gate to the user. \
+             Response: {response_text:?}"
+        );
+
+        let turns = vec![(user_input.to_string(), response_text.clone())];
+        harness.finish_turns(&turns).await;
+    }
 }

--- a/tests/e2e_live_personas.rs
+++ b/tests/e2e_live_personas.rs
@@ -41,14 +41,8 @@ mod persona_tests {
     use std::path::PathBuf;
     use std::time::Duration;
 
-    use crate::support::live_harness::{LiveTestHarness, LiveTestHarnessBuilder, SessionTurn};
+    use crate::support::live_harness::{LiveTestHarness, LiveTestHarnessBuilder};
     use tokio::time::{Instant, sleep};
-
-    /// Absolute path to the repo's `skills/` directory — the source of the
-    /// committed SKILL.md files for commitments and persona bundles.
-    fn repo_skills_dir() -> PathBuf {
-        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("skills")
-    }
 
     fn trace_fixture_path(test_name: &str) -> PathBuf {
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -61,15 +55,14 @@ mod persona_tests {
 
     /// Build a live harness configured for commitment/persona tests.
     ///
-    /// Uses engine v2, auto-approves tool calls, loads all skills from the
-    /// repo's `./skills/` dir, and bumps iteration count because the setup
-    /// flow involves many sequential memory/mission tool calls.
+    /// Uses engine v2, auto-approves tool calls, and bumps iteration count
+    /// because the setup flow involves many sequential memory/mission tool
+    /// calls.
     async fn build_persona_harness(test_name: &str) -> LiveTestHarness {
         LiveTestHarnessBuilder::new(test_name)
             .with_engine_v2(true)
             .with_auto_approve_tools(true)
             .with_max_tool_iterations(60)
-            .with_skills_dir(repo_skills_dir())
             .build()
             .await
     }
@@ -112,7 +105,7 @@ mod persona_tests {
         expected_responses: usize,
     ) -> Vec<String> {
         let rig = harness.rig();
-        let before = rig.captured_responses().await.len();
+        let before = rig.wait_for_responses(0, Duration::ZERO).await.len();
         rig.send_message(message).await;
         let responses = rig
             .wait_for_responses(before + expected_responses, Duration::from_secs(300))
@@ -236,10 +229,29 @@ mod persona_tests {
         eprintln!("[{label}] response preview: {preview}");
     }
 
+    /// Collect all unique skill names from `SkillActivated` status events.
+    fn collect_active_skill_names(harness: &LiveTestHarness) -> Vec<String> {
+        let mut names: Vec<String> = harness
+            .rig()
+            .captured_status_events()
+            .iter()
+            .filter_map(|event| match event {
+                ironclaw::channels::StatusUpdate::SkillActivated { skill_names } => {
+                    Some(skill_names.clone())
+                }
+                _ => None,
+            })
+            .flatten()
+            .collect();
+        names.sort();
+        names.dedup();
+        names
+    }
+
     /// Verify the persona skill activated and the workspace has the
     /// commitments root structure (created by the setup flow).
     async fn verify_setup_landed(harness: &LiveTestHarness, expected_skill: &str) {
-        let active = harness.rig().active_skill_names();
+        let active = collect_active_skill_names(harness);
         assert!(
             active.iter().any(|s| s == expected_skill),
             "Expected persona skill '{expected_skill}' to activate. Active: {active:?}",
@@ -283,10 +295,10 @@ mod persona_tests {
                     wait_for_check(&harness, check, Duration::from_secs(10)).await;
                 }
             }
-            transcript.push(SessionTurn::user(turn.message, responses));
+            transcript.push((turn.message.to_string(), responses));
         }
 
-        let active = harness.rig().active_skill_names();
+        let active = collect_active_skill_names(&harness);
         for required in required_skills {
             assert!(
                 active.iter().any(|skill| skill == required),
@@ -294,7 +306,7 @@ mod persona_tests {
             );
         }
 
-        harness.finish_turns_strict(&transcript).await;
+        harness.finish_turns(&transcript).await;
     }
 
     const CEO_SETUP_CHECKS: &[PersonaCheck] = &[PersonaCheck {

--- a/tests/support/live_harness.rs
+++ b/tests/support/live_harness.rs
@@ -53,57 +53,6 @@ pub struct JudgeVerdict {
     pub reasoning: String,
 }
 
-/// Source of an inbound transcript turn.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum TurnSource {
-    User,
-    ToolInbound,
-    Internal,
-}
-
-impl TurnSource {
-    fn label(self) -> &'static str {
-        match self {
-            Self::User => "USER",
-            Self::ToolInbound => "TOOL_INBOUND",
-            Self::Internal => "INTERNAL",
-        }
-    }
-}
-
-/// One user turn and its assistant responses for session-log rendering.
-pub struct SessionTurn {
-    pub source: TurnSource,
-    pub user_input: String,
-    pub responses: Vec<String>,
-}
-
-impl SessionTurn {
-    pub fn user(user_input: impl Into<String>, responses: Vec<String>) -> Self {
-        Self {
-            source: TurnSource::User,
-            user_input: user_input.into(),
-            responses,
-        }
-    }
-
-    pub fn tool_inbound(user_input: impl Into<String>, responses: Vec<String>) -> Self {
-        Self {
-            source: TurnSource::ToolInbound,
-            user_input: user_input.into(),
-            responses,
-        }
-    }
-
-    pub fn internal(user_input: impl Into<String>, responses: Vec<String>) -> Self {
-        Self {
-            source: TurnSource::Internal,
-            user_input: user_input.into(),
-            responses,
-        }
-    }
-}
-
 /// A running test harness wrapping a `TestRig` with dual-mode support.
 pub struct LiveTestHarness {
     rig: TestRig,
@@ -133,49 +82,6 @@ impl LiveTestHarness {
         Some(judge_response(provider.as_ref(), &joined, criteria).await)
     }
 
-    /// Scan the captured status events and tool results for executor errors.
-    ///
-    /// Returns a list of error descriptions. The harness's `finish_strict`
-    /// helper panics if this list is non-empty, which is the default behavior
-    /// for live tests — any error in the trace is treated as a regression
-    /// that warrants investigation.
-    ///
-    /// Recognized error patterns:
-    /// - Failed tool calls (`ToolCompleted { success: false }`)
-    /// - Tool result previews containing `error`/`failed`/`SyntaxError`
-    /// - The exception is "Document not found": this is a benign signal that
-    ///   the agent probed for a workspace file that doesn't exist yet, and
-    ///   the agent is expected to recover by writing the file. We surface it
-    ///   as a soft warning but don't fail the test.
-    pub fn collect_trace_errors(&self) -> Vec<String> {
-        use ironclaw::channels::StatusUpdate;
-
-        let mut errors = Vec::new();
-        for event in self.rig.captured_status_events() {
-            match event {
-                StatusUpdate::ToolCompleted {
-                    name,
-                    success: false,
-                    error,
-                    ..
-                } => {
-                    let err = error.as_deref().unwrap_or("unknown error");
-                    if is_benign_error(err) {
-                        continue;
-                    }
-                    errors.push(format!("tool '{name}' failed: {err}"));
-                }
-                StatusUpdate::ToolResult { name, preview, .. } => {
-                    if let Some(reason) = scan_preview_for_errors(&preview) {
-                        errors.push(format!("tool '{name}' result contains error: {reason}"));
-                    }
-                }
-                _ => {}
-            }
-        }
-        errors
-    }
-
     /// Flush the recorded trace (if live mode), save a human-readable session
     /// log, and shut down the agent.
     ///
@@ -184,51 +90,16 @@ impl LiveTestHarness {
     ///
     /// The session log is written to `tests/fixtures/llm_traces/live/{name}.log`.
     pub async fn finish(self, user_input: &str, responses: &[String]) {
-        let turns = [SessionTurn {
-            source: TurnSource::User,
-            user_input: user_input.to_string(),
-            responses: responses.to_vec(),
-        }];
-        self.save_session_log(&turns);
-
-        if let Some(ref recorder) = self.recording_handle {
-            if let Err(e) = recorder.flush().await {
-                eprintln!("[LiveTest] WARNING: Failed to flush trace: {e}");
-            } else {
-                eprintln!("[LiveTest] Trace recorded successfully");
-            }
-        }
-        self.rig.shutdown();
+        let turns = vec![(user_input.to_string(), responses.to_vec())];
+        self.finish_turns(&turns).await;
     }
 
-    /// Like `finish`, but panics if the trace contains any non-benign errors.
-    /// This is the default for live tests — unexpected tool failures or
-    /// executor SyntaxErrors are treated as regressions.
-    pub async fn finish_strict(self, user_input: &str, responses: &[String]) {
-        let errors = self.collect_trace_errors();
-        if !errors.is_empty() {
-            // Save the log first so the test author can see what happened.
-            let turns = [SessionTurn {
-                source: TurnSource::User,
-                user_input: user_input.to_string(),
-                responses: responses.to_vec(),
-            }];
-            self.save_session_log(&turns);
-            if let Some(ref recorder) = self.recording_handle {
-                let _ = recorder.flush().await;
-            }
-            self.rig.shutdown();
-            let joined = errors.join("\n  - ");
-            panic!(
-                "Live trace contains {} error(s) that warrant investigation:\n  - {joined}",
-                errors.len(),
-            );
-        }
-        self.finish(user_input, responses).await;
-    }
-
-    /// Multi-turn variant of `finish`.
-    pub async fn finish_turns(self, turns: &[SessionTurn]) {
+    /// Variant of [`finish`] for tests that span multiple user turns
+    /// (e.g. an auth-gate roundtrip: prompt → AuthRequired → token →
+    /// resume). Each tuple is `(user_input, responses_after_that_turn)`,
+    /// and the session log shows them in order so a reader can follow
+    /// the full conversation rather than only the first prompt.
+    pub async fn finish_turns(self, turns: &[(String, Vec<String>)]) {
         self.save_session_log(turns);
 
         if let Some(ref recorder) = self.recording_handle {
@@ -241,29 +112,11 @@ impl LiveTestHarness {
         self.rig.shutdown();
     }
 
-    /// Multi-turn variant of `finish_strict`.
-    pub async fn finish_turns_strict(self, turns: &[SessionTurn]) {
-        let errors = self.collect_trace_errors();
-        if !errors.is_empty() {
-            self.save_session_log(turns);
-            if let Some(ref recorder) = self.recording_handle {
-                let _ = recorder.flush().await;
-            }
-            self.rig.shutdown();
-            let joined = errors.join("\n  - ");
-            panic!(
-                "Live trace contains {} error(s) that warrant investigation:\n  - {joined}",
-                errors.len(),
-            );
-        }
-        self.finish_turns(turns).await;
-    }
-
     /// Write a human-readable session log.
     ///
     /// Live mode writes to `tests/fixtures/llm_traces/live/{name}.log` (committed).
     /// Replay mode writes to a temp file so it can be diffed against the live log.
-    fn save_session_log(&self, turns: &[SessionTurn]) {
+    fn save_session_log(&self, turns: &[(String, Vec<String>)]) {
         use ironclaw::channels::StatusUpdate;
 
         let (log_path, live_log_path) = match self.mode {
@@ -298,30 +151,13 @@ impl LiveTestHarness {
         ));
         log.push_str("# ──────────────────────────────────────────────────\n\n");
 
-        // Transcript
-        for (idx, turn) in turns.iter().enumerate() {
-            log.push_str(&format!("## Turn {}\n", idx + 1));
-            log.push_str(&format!(
-                "[{}] › {}\n",
-                turn.source.label(),
-                turn.user_input
-            ));
-            for response in &turn.responses {
-                log.push_str("────────────────────────────────────────────────────\n");
-                log.push_str(response);
-                log.push('\n');
-            }
-            log.push('\n');
-        }
-
-        log.push_str("## Activity\n");
-
-        // Tool activity from status events
+        // Tool activity from status events. The captured event stream
+        // covers the *whole* session, including any turns after the
+        // first, so we render it once at the top of the log rather than
+        // trying to slice it per-turn (the rig doesn't tag events with
+        // a turn boundary).
         for event in self.rig.captured_status_events() {
             match event {
-                StatusUpdate::SkillActivated { skill_names } => {
-                    log.push_str(&format!("  ◆ skills: {}\n", skill_names.join(", ")));
-                }
                 StatusUpdate::ToolStarted { name, .. } => {
                     log.push_str(&format!("  ● {name}\n"));
                 }
@@ -359,7 +195,40 @@ impl LiveTestHarness {
                 StatusUpdate::Status(msg) => {
                     log.push_str(&format!("  … {msg}\n"));
                 }
+                StatusUpdate::AuthRequired {
+                    extension_name,
+                    auth_url,
+                    ..
+                } => {
+                    let url_marker = if auth_url.is_some() {
+                        " (auth_url present)"
+                    } else {
+                        ""
+                    };
+                    log.push_str(&format!(
+                        "  🔒 AuthRequired: {extension_name}{url_marker}\n"
+                    ));
+                }
+                StatusUpdate::AuthCompleted {
+                    extension_name,
+                    success,
+                    ..
+                } => {
+                    let marker = if success { "✓" } else { "✗" };
+                    log.push_str(&format!("  {marker} AuthCompleted: {extension_name}\n"));
+                }
                 _ => {}
+            }
+        }
+
+        // Conversation turns. Each turn is rendered as `› user input`
+        // followed by the agent's responses for that turn.
+        for (user_input, responses) in turns {
+            log.push_str("────────────────────────────────────────────────────\n");
+            log.push_str(&format!("› {user_input}\n"));
+            for response in responses {
+                log.push_str(response);
+                log.push('\n');
             }
         }
 
@@ -388,9 +257,9 @@ pub struct LiveTestHarnessBuilder {
     max_tool_iterations: usize,
     engine_v2: Option<bool>,
     auto_approve_tools: Option<bool>,
-    skills_dir: Option<PathBuf>,
     channel_name: Option<String>,
     seeded_secret_names: Vec<String>,
+    record_trace: bool,
 }
 
 impl LiveTestHarnessBuilder {
@@ -413,10 +282,28 @@ impl LiveTestHarnessBuilder {
             max_tool_iterations: 30,
             engine_v2: None,
             auto_approve_tools: None,
-            skills_dir: None,
             channel_name: None,
             seeded_secret_names: Vec::new(),
+            record_trace: true,
         }
+    }
+
+    /// Skip writing the LLM trace fixture in live mode and skip looking
+    /// up the trace fixture in replay mode.
+    ///
+    /// Use this for tests that exercise real credentials and real
+    /// upstream APIs, where a recorded trace would inevitably capture
+    /// PII (bearer tokens in HTTP headers, API response bodies, file
+    /// metadata) that's hard to scrub safely. The test still runs
+    /// against the real LLM in live mode, but no fixture is committed
+    /// and replay mode falls back to skipping the test entirely.
+    ///
+    /// Hermetic regression coverage for the underlying behaviour must
+    /// live in unit tests; this builder option is only for end-to-end
+    /// smoke verification against the developer's real environment.
+    pub fn with_no_trace_recording(mut self) -> Self {
+        self.record_trace = false;
+        self
     }
 
     /// Declare secret names to copy from the developer's real
@@ -463,14 +350,6 @@ impl LiveTestHarnessBuilder {
         self
     }
 
-    /// Enable skill discovery from the given directory. Skills discovered
-    /// here (e.g. the repo's `./skills/` dir) are loaded at startup and can
-    /// activate during the test conversation.
-    pub fn with_skills_dir(mut self, dir: impl Into<PathBuf>) -> Self {
-        self.skills_dir = Some(dir.into());
-        self
-    }
-
     /// Build the harness, auto-detecting mode from the `IRONCLAW_LIVE_TEST` env var.
     #[cfg(feature = "libsql")]
     pub async fn build(self) -> LiveTestHarness {
@@ -482,17 +361,56 @@ impl LiveTestHarnessBuilder {
 
         if is_live {
             self.build_live(trace_path).await
+        } else if !self.record_trace {
+            // Tests opted out of trace recording have no fixture to
+            // replay from. Build a no-op harness so the test can
+            // detect the mode and skip itself gracefully — without
+            // panicking on a missing fixture.
+            self.build_no_replay().await
         } else {
             self.build_replay(trace_path).await
         }
     }
 
+    /// Build a stub harness for tests that opted out of trace
+    /// recording AND are running in non-live mode. The rig is built
+    /// with a default trace so any inadvertent LLM call returns a
+    /// deterministic placeholder, but the caller is expected to skip
+    /// itself before exercising any agent flow.
+    #[cfg(feature = "libsql")]
+    async fn build_no_replay(self) -> LiveTestHarness {
+        eprintln!(
+            "[LiveTest] Mode: REPLAY (skip) — `{}` was built with `with_no_trace_recording()`. \
+             The test should detect this and return early.",
+            self.test_name
+        );
+        let rig = TestRigBuilder::new()
+            .with_max_tool_iterations(self.max_tool_iterations)
+            .with_auto_approve_tools(true)
+            .build()
+            .await;
+        LiveTestHarness {
+            rig,
+            recording_handle: None,
+            judge_llm: None,
+            test_name: self.test_name,
+            mode: TestMode::Replay,
+        }
+    }
+
     #[cfg(feature = "libsql")]
     async fn build_live(self, trace_path: PathBuf) -> LiveTestHarness {
-        eprintln!(
-            "[LiveTest] Mode: LIVE — recording to {}",
-            trace_path.display()
-        );
+        if self.record_trace {
+            eprintln!(
+                "[LiveTest] Mode: LIVE — recording to {}",
+                trace_path.display()
+            );
+        } else {
+            eprintln!(
+                "[LiveTest] Mode: LIVE — no trace recording (test opted out via \
+                 `with_no_trace_recording()`)"
+            );
+        }
 
         // Initialise a tracing subscriber so RUST_LOG actually captures the
         // engine's debug/trace output during the run. `try_init` is a no-op
@@ -509,16 +427,6 @@ impl LiveTestHarnessBuilder {
         let _ = dotenvy::dotenv();
         ironclaw::bootstrap::load_ironclaw_env();
 
-        // Hydrate LLM credentials from the user's real secrets store into
-        // process env vars BEFORE config resolution. The test rig runs
-        // against an isolated temp libSQL database, so the real ironclaw DB's
-        // secrets aren't automatically visible to the provider chain. For
-        // backends that support env-var fallback (nearai via NEARAI_API_KEY,
-        // anthropic via ANTHROPIC_API_KEY, etc.), setting the env var before
-        // `build_provider_chain` bypasses the interactive auth flow without
-        // leaking secrets into the test database.
-        hydrate_llm_secrets_into_env().await;
-
         // Resolve full config (reads LLM_BACKEND, ENGINE_V2, ALLOW_LOCAL_TOOLS, etc.)
         // This mirrors the exact config the real `ironclaw` binary would use.
         let mut config = ironclaw::config::Config::from_env().await.expect(
@@ -533,17 +441,10 @@ impl LiveTestHarnessBuilder {
         if let Some(aa) = self.auto_approve_tools {
             config.agent.auto_approve_tools = aa;
         }
-        if let Some(ref dir) = self.skills_dir {
-            config.skills.enabled = true;
-            config.skills.local_dir = dir.clone();
-        }
 
         eprintln!(
-            "[LiveTest] Config: engine_v2={}, allow_local_tools={}, auto_approve={}, skills_dir={}",
-            config.agent.engine_v2,
-            config.agent.allow_local_tools,
-            config.agent.auto_approve_tools,
-            config.skills.local_dir.display(),
+            "[LiveTest] Config: engine_v2={}, allow_local_tools={}, auto_approve={}",
+            config.agent.engine_v2, config.agent.allow_local_tools, config.agent.auto_approve_tools,
         );
 
         // If the test asked for specific secrets via `with_secrets(...)`
@@ -602,25 +503,31 @@ impl LiveTestHarnessBuilder {
             .await
             .expect("Failed to build LLM provider chain for live test");
 
-        // Wrap with RecordingLlm to capture the trace.
-        let model_name = format!("live-{}", self.test_name);
-        let recorder = Arc::new(RecordingLlm::new(provider, trace_path, model_name));
-        let http_interceptor = recorder.http_interceptor();
-        let llm: Arc<dyn LlmProvider> = Arc::clone(&recorder) as Arc<dyn LlmProvider>;
+        // Wrap with RecordingLlm to capture the trace, unless this
+        // harness opted out of recording (e.g. tests that exercise
+        // real credentials and would leak PII into a committed
+        // fixture).
+        let (recorder_handle, llm) = if self.record_trace {
+            let model_name = format!("live-{}", self.test_name);
+            let recorder = Arc::new(RecordingLlm::new(provider, trace_path, model_name));
+            let llm: Arc<dyn LlmProvider> = Arc::clone(&recorder) as Arc<dyn LlmProvider>;
+            (Some(recorder), llm)
+        } else {
+            (None, provider)
+        };
+        let http_interceptor = recorder_handle.as_ref().map(|r| r.http_interceptor());
 
         // Pass the real config so TestRig mirrors real binary behavior:
         // - allow_local_tools controls shell/file tool availability
         // - engine_v2 controls which agentic loop path is used
         // - auto_approve_tools comes from the env/config (tests can override
         //   via LiveTestHarnessBuilder if needed)
-        let skills_dir_for_rig = self.skills_dir.clone();
         let mut rig_builder = TestRigBuilder::new()
             .with_config(config)
             .with_llm(llm)
-            .with_http_interceptor(http_interceptor)
             .with_max_tool_iterations(self.max_tool_iterations);
-        if let Some(dir) = skills_dir_for_rig {
-            rig_builder = rig_builder.with_skills_dir(dir);
+        if let Some(interceptor) = http_interceptor {
+            rig_builder = rig_builder.with_http_interceptor(interceptor);
         }
         if let Some(ref name) = self.channel_name {
             rig_builder = rig_builder.with_channel_name(name.clone());
@@ -639,7 +546,7 @@ impl LiveTestHarnessBuilder {
 
         LiveTestHarness {
             rig,
-            recording_handle: Some(recorder),
+            recording_handle: recorder_handle,
             judge_llm,
             test_name: self.test_name,
             mode: TestMode::Live,
@@ -665,9 +572,6 @@ impl LiveTestHarnessBuilder {
             .with_trace(trace)
             .with_max_tool_iterations(self.max_tool_iterations)
             .with_auto_approve_tools(true);
-        if let Some(dir) = self.skills_dir.clone() {
-            rig_builder = rig_builder.with_skills_dir(dir);
-        }
         // Propagate engine_v2 so replay mirrors live recording. Without this,
         // tests that recorded against engine v2 (mission_create, mission_fire,
         // CodeAct orchestration, etc.) replay against v1 and the v2-only tools
@@ -748,276 +652,6 @@ pub async fn judge_response(
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Errors that we expect during normal operation and should not fail tests on.
-///
-/// These are "the agent picked the wrong tool or wrong params, here's how to
-/// recover" messages that the LLM uses to self-correct. None of them indicate
-/// an engine bug. Engine bugs (Python SyntaxError, missing leases for FINAL,
-/// orphaned skill credentials, etc.) are still flagged unless we've observed a
-/// specific lease miss that the run reliably recovers from in these workflows.
-///
-/// Categories of benign errors:
-///
-/// 1. **Workspace probing**: agent calls `memory_read` to check whether a
-///    file exists before writing it. The tool returns a hard error instead
-///    of a "not found" sentinel, but the agent's recovery is normal.
-///
-/// 2. **Wrong tool selection**: agent calls `write_file` for a workspace
-///    file. The tool rejects with a clear "use memory_write instead"
-///    message and the agent retries with the right tool.
-///
-/// 3. **Wrong patch params**: agent calls `memory_write` with `old_string`
-///    but no `new_string`. The tool's error message tells the agent how to
-///    fix it and the agent retries.
-///
-/// 4. **Skill probe**: agent calls `skill_install` for a skill that's
-///    already loaded. The current skill_install short-circuits, but older
-///    traces may have hit the registry 404 path.
-///
-/// 5. **Recovered CodeAct misfire**: agent briefly sends plain natural
-///    language like "YouTube Published ✓" to CodeAct, gets a SyntaxError,
-///    then immediately recovers with the correct memory-tool writes.
-///
-/// 6. **Recovered digest CodeAct probe**: agent briefly tries to count or
-///    summarize commitments inside CodeAct, hits a NameError/Traceback, then
-///    recovers by using `memory_tree` / `memory_read` and still produces the
-///    correct digest.
-fn is_benign_error(err: &str) -> bool {
-    let lower = err.to_lowercase();
-
-    // Workspace probing
-    if lower.contains("document not found") || lower.contains("path not found") {
-        return true;
-    }
-
-    // Wrong tool selection (write_file → memory_write guidance)
-    if lower.contains("use the memory_write tool")
-        || lower.contains("use the memory_read tool")
-        || lower.contains("use memory_write instead")
-        || lower.contains("use memory_read instead")
-    {
-        return true;
-    }
-
-    // Wrong patch params (memory_write patch mode confusion)
-    if lower.contains("new_string is required when old_string is provided")
-        || lower.contains("either 'content' (for write/append) or 'old_string'")
-        || lower.contains("old_string not found in document")
-        || lower.contains("old_string cannot be empty")
-        || lower.contains("patch mode (old_string/new_string) cannot be combined with layer")
-    {
-        return true;
-    }
-
-    // Optional asset generation can fail in environments without the expected
-    // image backend model; the conversation can still recover and persist the
-    // actual commitment-tracking state we care about in these tests.
-    if lower.contains("model 'flux-1.1-pro' not found")
-        || (lower.contains("image generation api returned 404") && lower.contains("model"))
-    {
-        return true;
-    }
-
-    // Skill probe — installing a skill that already exists.
-    if lower.contains("skill") && lower.contains("already") && lower.contains("exists") {
-        return true;
-    }
-
-    // Live providers can transiently rate-limit bursty setup/write sequences.
-    // The agent often retries successfully; treat these as benign harness noise.
-    if lower.contains("rate limited") || lower.contains("try again in") {
-        return true;
-    }
-
-    // Some live-model search queries include hyphenated repo names in a way
-    // that SQLite FTS parses as a column reference (`payments-api` → `api`).
-    // The run usually recovers after a broader search or direct read.
-    if lower.contains("fts row fetch failed") && lower.contains("no such column:") {
-        return true;
-    }
-
-    // Some promote-plan flows probe `rlm_query` without a lease and then
-    // recover via memory search / plan writes. Treat that specific recovered
-    // lease miss as benign harness noise.
-    if lower.contains("no lease for action 'rlm_query'") {
-        return true;
-    }
-
-    if lower.contains("no lease for action 'shell'") {
-        return true;
-    }
-
-    // CodeAct occasionally probes a Python snippet that touches OS-backed time
-    // APIs, which is blocked in the sandbox. If the run recovers, don't fail
-    // the whole live trace on that transient probe.
-    if lower.contains("os operations are not permitted in codeact scripts") {
-        return true;
-    }
-
-    // A recurring recovered misfire in creator flows: plain text intended as
-    // status content gets routed into CodeAct and fails to parse as Python.
-    // If the run recovers, treat this as tool-selection noise rather than a
-    // product regression.
-    if lower.contains("youtube published")
-        && lower.contains("syntaxerror")
-        && lower.contains("simple statements must be separated")
-    {
-        return true;
-    }
-
-    if lower.contains("codeact execution failed")
-        && lower.contains("traceback")
-        && (lower.contains("nameerror") || lower.contains("step.py"))
-    {
-        return true;
-    }
-
-    false
-}
-
-/// Scan a tool result preview for executor-side errors that we want to flag.
-///
-/// Returns `Some(reason)` if the preview contains a Python SyntaxError,
-/// Monty traceback, or a JSON-style `"error"` payload that isn't a benign
-/// "document not found".
-fn scan_preview_for_errors(preview: &str) -> Option<String> {
-    // Python / Monty syntax errors from CodeAct execution
-    if preview.contains("SyntaxError") && !is_benign_error(preview) {
-        return Some("Python SyntaxError in CodeAct execution".to_string());
-    }
-    if preview.contains("Traceback (most recent call last)") && !is_benign_error(preview) {
-        return Some("Python traceback in CodeAct execution".to_string());
-    }
-    // JSON-style error payloads from tool wrappers
-    if let Some(idx) = preview
-        .find("'error'")
-        .or_else(|| preview.find("\"error\""))
-        && let Some(rest) = preview.get(idx..)
-    {
-        // Extract a short snippet of the error message for the report.
-        let snippet: String = rest.chars().take(200).collect();
-        if !is_benign_error(&snippet) {
-            return Some(snippet);
-        }
-    }
-    None
-}
-
-/// Load LLM API keys from the user's real secrets store into process env vars.
-///
-/// Live tests use an isolated temp libSQL database, so the real ironclaw DB's
-/// encrypted secrets are invisible to the test provider chain. This helper
-/// opens the user's real libSQL DB at `~/.ironclaw/ironclaw.db` (libsql does
-/// not expose a read-only open mode here, so the handle is technically
-/// writable, but this code path only ever calls `get_decrypted` and never
-/// writes), resolves the master key from the OS keychain, decrypts known
-/// LLM API-key secrets, and exports them as env vars. `build_provider_chain`
-/// then picks them up via each provider's env-var fallback, skipping
-/// interactive auth.
-///
-/// This function is best-effort: any failure (no DB, locked keychain, secret
-/// missing) is logged and ignored so the provider can fall back to whatever
-/// native auth path it supports.
-#[cfg(feature = "libsql")]
-async fn hydrate_llm_secrets_into_env() {
-    use ironclaw::secrets::{
-        LibSqlSecretsStore, SecretsStore, crypto_from_hex, resolve_master_key,
-    };
-
-    // Known (secret_name, env_var) pairs. When a backend supports multiple
-    // env-var fallbacks we pick the most canonical one.
-    const SECRET_TO_ENV: &[(&str, &str)] = &[
-        ("llm_nearai_api_key", "NEARAI_API_KEY"),
-        ("llm_anthropic_api_key", "ANTHROPIC_API_KEY"),
-        ("llm_openai_api_key", "OPENAI_API_KEY"),
-    ];
-
-    // If all target env vars are already set, skip the DB work entirely.
-    if SECRET_TO_ENV
-        .iter()
-        .all(|(_, env)| std::env::var(env).ok().filter(|v| !v.is_empty()).is_some())
-    {
-        return;
-    }
-
-    let master_key = match resolve_master_key().await {
-        Some(k) => k,
-        None => {
-            eprintln!("[LiveTest] hydrate_llm_secrets: no master key (env/keychain) — skipping");
-            return;
-        }
-    };
-
-    let crypto = match crypto_from_hex(&master_key) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("[LiveTest] hydrate_llm_secrets: crypto init failed: {e} — skipping");
-            return;
-        }
-    };
-
-    // Open the user's real libSQL DB at ~/.ironclaw/ironclaw.db directly
-    // (bypassing the ironclaw Database wrapper — LibSqlSecretsStore needs a
-    // raw libsql::Database handle).
-    let db_path = ironclaw::bootstrap::ironclaw_base_dir().join("ironclaw.db");
-    if !db_path.exists() {
-        eprintln!(
-            "[LiveTest] hydrate_llm_secrets: real DB not found at {} — skipping",
-            db_path.display()
-        );
-        return;
-    }
-
-    let raw_db = match libsql::Builder::new_local(&db_path).build().await {
-        Ok(db) => std::sync::Arc::new(db),
-        Err(e) => {
-            eprintln!("[LiveTest] hydrate_llm_secrets: open real DB failed: {e} — skipping");
-            return;
-        }
-    };
-
-    let store = LibSqlSecretsStore::new(raw_db, crypto);
-
-    // Owner id selection: a user with a non-default scope (e.g. via
-    // `IRONCLAW_OWNER_ID` or settings.json) stores secrets under that
-    // user_id, not "default". Try the env-resolved value first; if it's
-    // unset, fall back to the legacy "default" scope that single-user
-    // installs use. We don't reach into Config::from_env() here to avoid
-    // pulling in the full settings file resolution chain inside test
-    // hydration.
-    let env_owner = std::env::var("IRONCLAW_OWNER_ID")
-        .ok()
-        .filter(|s| !s.is_empty());
-    let owner_id_owned = env_owner.unwrap_or_else(|| "default".to_string());
-    let owner_id = owner_id_owned.as_str();
-
-    for (secret_name, env_var) in SECRET_TO_ENV {
-        if std::env::var(env_var)
-            .ok()
-            .filter(|v| !v.is_empty())
-            .is_some()
-        {
-            continue;
-        }
-        match store.get_decrypted(owner_id, secret_name).await {
-            Ok(decrypted) => {
-                ironclaw::config::set_runtime_env(env_var, decrypted.expose());
-                eprintln!(
-                    "[LiveTest] hydrate_llm_secrets: set {env_var} from secret '{secret_name}'"
-                );
-            }
-            Err(ironclaw::secrets::SecretError::NotFound { .. }) => {
-                // Normal: user hasn't configured this backend.
-            }
-            Err(e) => {
-                eprintln!(
-                    "[LiveTest] hydrate_llm_secrets: failed to read '{secret_name}': {e} — skipping"
-                );
-            }
-        }
-    }
-}
 
 /// Compute the path to a live trace fixture file.
 fn trace_fixture_path(test_name: &str) -> PathBuf {

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -1278,8 +1278,10 @@ impl TestRig {
     /// Used by live tests that exercise the auth gate flow — they
     /// delete a credential to simulate "not yet authenticated", then
     /// re-insert it after the gate fires to simulate "user completed
-    /// OAuth and the token was stored". Returns `None` when the rig
-    /// was built without a master key (most non-live tests).
+    /// OAuth and the token was stored". Returns `None` only when a
+    /// config override explicitly disables secrets or omits a master
+    /// key. Most test rigs now have a working secrets store because
+    /// `Config::for_testing()` generates a random master key per call.
     #[cfg(feature = "libsql")]
     pub fn secrets_store(&self) -> Option<&Arc<dyn ironclaw::secrets::SecretsStore + Send + Sync>> {
         self.secrets_store.as_ref()

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -206,12 +206,21 @@ pub struct TestRig {
     /// Extension manager for direct extension operations in tests.
     #[cfg(feature = "libsql")]
     extension_manager: Option<Arc<ironclaw::extensions::ExtensionManager>>,
-    /// Skill registry (if skills are enabled) for direct inspection in tests.
-    #[cfg(feature = "libsql")]
-    skill_registry: Option<Arc<std::sync::RwLock<ironclaw_skills::SkillRegistry>>>,
     /// Session manager for direct session/thread access in tests.
     #[cfg(feature = "libsql")]
     session_manager: Arc<ironclaw::agent::SessionManager>,
+    /// Secrets store for direct credential manipulation in tests.
+    /// Live tests that exercise the auth gate flow use this to delete
+    /// credentials before sending a tool-using prompt and re-insert
+    /// them after to simulate the user completing OAuth.
+    #[cfg(feature = "libsql")]
+    secrets_store: Option<Arc<dyn ironclaw::secrets::SecretsStore + Send + Sync>>,
+    /// Owner identity resolved from `Config::owner_id`. Tests that
+    /// manipulate the secrets store directly need this so their
+    /// `secrets.create(owner_id, ..)` / `secrets.delete(owner_id, ..)`
+    /// calls hit the same scope the agent loop uses.
+    #[cfg(feature = "libsql")]
+    owner_id: String,
     /// Temp directory guard -- keeps the libSQL database file alive.
     #[cfg(feature = "libsql")]
     _temp_dir: tempfile::TempDir,
@@ -302,13 +311,6 @@ impl TestRig {
         self.channel.tool_calls_started()
     }
 
-    /// Return the filtered list of captured responses so far.
-    ///
-    /// Mirrors the bootstrap-greeting filtering used by `wait_for_responses`.
-    pub async fn captured_responses(&self) -> Vec<OutgoingResponse> {
-        self.filter_responses(self.channel.captured_responses_async().await)
-    }
-
     /// Return `(name, success)` for all `ToolCompleted` events captured so far.
     pub fn tool_calls_completed(&self) -> Vec<(String, bool)> {
         self.channel.tool_calls_completed()
@@ -332,38 +334,6 @@ impl TestRig {
     /// Return a snapshot of all captured status events.
     pub fn captured_status_events(&self) -> Vec<StatusUpdate> {
         self.channel.captured_status_events()
-    }
-
-    /// Return the names of skills loaded into the registry, if skills are
-    /// enabled. Useful for verifying the registry discovered the SKILL.md
-    /// files from `with_skills_dir()`.
-    pub fn loaded_skill_names(&self) -> Vec<String> {
-        self.skill_registry
-            .as_ref()
-            .and_then(|r| {
-                r.read()
-                    .ok()
-                    .map(|g| g.skills().iter().map(|s| s.name().to_string()).collect())
-            })
-            .unwrap_or_default()
-    }
-
-    /// Return the flattened list of skill names activated across the session.
-    ///
-    /// Extracted from `StatusUpdate::SkillActivated` events — each turn may
-    /// emit a separate event with the skills selected for that turn, so the
-    /// returned vec may contain duplicates if a skill was active across
-    /// multiple turns.
-    pub fn active_skill_names(&self) -> Vec<String> {
-        self.channel
-            .captured_status_events()
-            .into_iter()
-            .filter_map(|e| match e {
-                StatusUpdate::SkillActivated { skill_names } => Some(skill_names),
-                _ => None,
-            })
-            .flatten()
-            .collect()
     }
 
     /// Return the ordered log of captured outbound events.
@@ -618,7 +588,6 @@ pub struct TestRigBuilder {
     injection_check: bool,
     auto_approve_tools: Option<bool>,
     enable_skills: bool,
-    skills_dir_override: Option<std::path::PathBuf>,
     enable_routines: bool,
     http_exchanges: Vec<HttpExchange>,
     http_interceptor_override: Option<Arc<dyn HttpInterceptor>>,
@@ -641,7 +610,6 @@ impl TestRigBuilder {
             injection_check: false,
             auto_approve_tools: Some(true),
             enable_skills: false,
-            skills_dir_override: None,
             enable_routines: false,
             http_exchanges: Vec::new(),
             http_interceptor_override: None,
@@ -774,16 +742,6 @@ impl TestRigBuilder {
         self
     }
 
-    /// Enable skills AND discover them from the given directory instead of the
-    /// rig's tempdir. Useful for tests that want to exercise real SKILL.md
-    /// files committed to the repo (e.g. `tests/support/live_harness.rs`
-    /// pointing at `./skills/` for commitments/persona tests).
-    pub fn with_skills_dir(mut self, dir: impl Into<std::path::PathBuf>) -> Self {
-        self.enable_skills = true;
-        self.skills_dir_override = Some(dir.into());
-        self
-    }
-
     /// Enable the routines system so the scheduler is wired with a `RoutineEngine`,
     /// allowing routine jobs to actually execute. Routine tools are always registered
     /// but require the engine to dispatch jobs.
@@ -844,7 +802,6 @@ impl TestRigBuilder {
             injection_check,
             auto_approve_tools,
             enable_skills,
-            skills_dir_override,
             enable_routines,
             http_exchanges: explicit_http_exchanges,
             http_interceptor_override,
@@ -889,27 +846,19 @@ impl TestRigBuilder {
 
         // 2. Build Config.
         let has_config_override = config_override.is_some();
-        let default_skills_dir = temp_dir.path().join("skills");
-        let skills_dir = skills_dir_override
-            .clone()
-            .unwrap_or_else(|| default_skills_dir.clone());
+        let skills_dir = temp_dir.path().join("skills");
         let installed_skills_dir = temp_dir.path().join("installed_skills");
-        // Only create the tempdir skills dir if we're using it (i.e. no override).
-        // Do not try to create the override path — callers are responsible for
-        // providing an existing directory.
-        if skills_dir_override.is_none() {
-            let _ = std::fs::create_dir_all(&skills_dir);
-        }
+        let _ = std::fs::create_dir_all(&skills_dir);
         let _ = std::fs::create_dir_all(&installed_skills_dir);
         let mut config = if let Some(mut cfg) = config_override {
             // Override database to use temp libSQL, but preserve agent/llm settings.
             cfg.database.backend = ironclaw::config::DatabaseBackend::LibSql;
             cfg.database.libsql_path = Some(db_path);
-            cfg.skills.local_dir = skills_dir.clone();
-            cfg.skills.installed_dir = installed_skills_dir.clone();
+            cfg.skills.local_dir = skills_dir;
+            cfg.skills.installed_dir = installed_skills_dir;
             cfg
         } else {
-            Config::for_testing(db_path, skills_dir.clone(), installed_skills_dir.clone())
+            Config::for_testing(db_path, skills_dir, installed_skills_dir)
         };
         config.agent.max_tool_iterations = max_tool_iterations;
         config.safety.injection_check_enabled = injection_check;
@@ -1094,37 +1043,12 @@ impl TestRigBuilder {
             }
 
             // Skills tools: ensure tests use temp skill dirs (sandbox-safe) even if
-            // AppBuilder did not wire them for this environment. If AppBuilder
-            // already wired up a registry (because config.skills.enabled was
-            // true and it ran discover_all()), leave it alone so real
-            // SKILL.md files discovered from `skills_dir` stay loaded.
-            if enable_skills && components.skill_registry.is_none() {
-                let registry_dir = skills_dir_override
-                    .clone()
-                    .unwrap_or_else(|| temp_dir.path().join("skills"));
-                if skills_dir_override.is_some() {
-                    let meta = std::fs::metadata(&registry_dir).unwrap_or_else(|e| {
-                        panic!(
-                            "test rig skills_dir_override '{}' is not readable: {e}",
-                            registry_dir.display()
-                        )
-                    });
-                    assert!(
-                        meta.is_dir(),
-                        "test rig skills_dir_override '{}' is not a directory",
-                        registry_dir.display()
-                    );
-                }
-                let mut registry = ironclaw_skills::SkillRegistry::new(registry_dir)
-                    .with_installed_dir(installed_skills_dir.clone());
-                let loaded = registry.discover_all().await;
-                if skills_dir_override.is_some() {
-                    assert!(
-                        !loaded.is_empty(),
-                        "test rig skills_dir_override did not load any skills; check SKILL.md frontmatter and directory contents"
-                    );
-                }
-                let registry = Arc::new(std::sync::RwLock::new(registry));
+            // AppBuilder did not wire them for this environment.
+            if enable_skills {
+                let registry = Arc::new(std::sync::RwLock::new(
+                    ironclaw_skills::SkillRegistry::new(temp_dir.path().join("skills"))
+                        .with_installed_dir(temp_dir.path().join("installed_skills")),
+                ));
                 let catalog = ironclaw_skills::catalog::shared_catalog();
                 components
                     .tools
@@ -1199,7 +1123,8 @@ impl TestRigBuilder {
         let db_ref = components.db.clone().expect("test rig requires a database");
         let workspace_ref = components.workspace.clone();
         let ext_mgr_ref = components.extension_manager.clone();
-        let skill_registry_ref = components.skill_registry.clone();
+        let secrets_store_ref = components.secrets_store.clone();
+        let owner_id_ref = components.config.owner_id.clone();
         let session_manager_ref = Arc::new(ironclaw::agent::SessionManager::new());
 
         // 7. Construct AgentDeps from AppComponents (mirrors main.rs).
@@ -1235,18 +1160,15 @@ impl TestRigBuilder {
         // mirror real-world channel naming for features keyed on the channel
         // name (e.g. mission notifications routed back to the source channel).
         //
-        // Channel user_id selection: align the channel user identity with the
-        // config's owner_id when one of the following is true:
-        //   1. The rig has live-seeded secrets — production credential
-        //      lookups (`secrets WHERE user_id = ?`) must hit the rows we
-        //      just inserted, not the hardcoded `"test-user"`.
-        //   2. Skills are enabled — engine v2 resolves the thread's project
-        //      from the channel user_id; if the test user is not the owner,
-        //      `resolve_user_project` creates a fresh per-user project with
-        //      no skills migrated to it, and skill activation silently fails.
-        // For all other tests we keep the historical `"test-user"` default
-        // so existing tests don't change behaviour.
-        let channel_user_id = if seeded_secrets.is_some() || enable_skills {
+        // Channel user_id selection: when the test rig has live-seeded
+        // secrets, align the channel user identity with the config's
+        // owner_id so that production credential lookups
+        // (`secrets WHERE user_id = ?`) hit the rows we just inserted.
+        // Without this, the rig would seed real secrets but every
+        // credential lookup would key off the hardcoded `"test-user"`
+        // and miss them. For non-seeded tests we keep the historical
+        // `"test-user"` default so existing tests don't change behaviour.
+        let channel_user_id = if seeded_secrets.is_some() {
             components.config.owner_id.clone()
         } else {
             "test-user".to_string()
@@ -1318,8 +1240,9 @@ impl TestRigBuilder {
             workspace: workspace_ref,
             trace_llm: trace_llm_ref,
             extension_manager: ext_mgr_ref,
-            skill_registry: skill_registry_ref,
             session_manager: session_manager_ref,
+            secrets_store: secrets_store_ref,
+            owner_id: owner_id_ref,
             _temp_dir: temp_dir,
             bootstrap_greetings_to_keep: if keep_bootstrap { 1 } else { 0 },
         }
@@ -1349,6 +1272,26 @@ impl TestRig {
     #[cfg(feature = "libsql")]
     pub fn trace_llm(&self) -> Option<&Arc<TraceLlm>> {
         self.trace_llm.as_ref()
+    }
+
+    /// Get the secrets store for direct credential manipulation.
+    /// Used by live tests that exercise the auth gate flow — they
+    /// delete a credential to simulate "not yet authenticated", then
+    /// re-insert it after the gate fires to simulate "user completed
+    /// OAuth and the token was stored". Returns `None` when the rig
+    /// was built without a master key (most non-live tests).
+    #[cfg(feature = "libsql")]
+    pub fn secrets_store(&self) -> Option<&Arc<dyn ironclaw::secrets::SecretsStore + Send + Sync>> {
+        self.secrets_store.as_ref()
+    }
+
+    /// The owner identity resolved from `Config::owner_id`. Tests that
+    /// manipulate the secrets store directly use this as the user_id
+    /// argument to `secrets.create(...)` / `secrets.delete(...)` so
+    /// the rows they touch are the same ones the agent loop sees.
+    #[cfg(feature = "libsql")]
+    pub fn owner_id(&self) -> &str {
+        &self.owner_id
     }
 
     /// Check if any captured status events contain safety/injection warnings.


### PR DESCRIPTION
## Summary

Bug-fix bundle discovered while exercising the v2 engine end-to-end against real Notion + Google Drive MCP/WASM tools. Each fix has regression coverage and could ship independently. Supersedes #2227 (incorporated in `a8530e8b`).

### 1. Workspace `replace_chunks` TOCTOU race

Concurrent reindex of the same document hit `UNIQUE (document_id, chunk_index)` because `delete_chunks` + `insert_chunk` were separate transactions with async points between them. New `WorkspaceStore::replace_chunks` wraps both in one transaction: libsql uses `BEGIN IMMEDIATE`, postgres serializes via `SELECT ... FOR UPDATE` on the parent `memory_documents` row. Embeddings are pre-computed before opening the transaction so nothing async runs between delete and insert.

### 2. Auth gate display name + OAuth deletion guard + alias-aware activation

Three traps surfaced by the v2 Drive trace:
- Auth gate displayed `google_oauth_token` (credential name) instead of `google-drive-tool` (extension name) and passed it to `submit_auth_token` which expects an extension name, trapping users in a re-auth loop. Both paths now resolve via a shared `resolve_extension_for_action` helper.
- `activate_wasm_tool` and several capabilities-lookup sites used direct `dir.join(name.wasm)` instead of alias-aware helpers. A tool installed under the legacy hyphen filename silently failed to activate while the readiness probe reported it as ready.
- `configure()` post-activation cleanup unconditionally wiped the OAuth token the caller just provided. Now gated on whether the caller is providing a fresh credential in the same `secrets` map.
- `starts_with` prefix filters for MCP tool listing/removal used the raw (possibly hyphenated) server name while registry keys are normalized to underscores. Now uses `mcp_tool_id(name, "")` as the prefix at all 3 sites.

### 3. MCP tool name canonicalization

MCP tools with dashes in names (e.g. Notion's `notion-search`) were unreachable because the registry key preserved dashes while LLMs normalize to all-underscores. `mcp_tool_id` now replaces every non-`[A-Za-z0-9_]` character with `_` (handles dashes, dots, colons, slashes, unicode). Collision detection in `create_tools` emits a `warn!` when two distinct originals collide on the same normalized id.

### 4. OpenAI tool schema top-level flatten + Python/Rust action_calls round-trip

- **Schema flatten:** OpenAI rejects top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` in tool schemas. `normalize_schema_strict` now detects this, merges all variant properties into a single flat object (so the LLM keeps structured field hints), and appends the original schema to the description as keyword-aware advisory text. Also handles nullable object types (`"type": ["object", "null"]`) without unnecessary flattening.
- **Action_calls round-trip:** The Python orchestrator stored `{name, call_id, params}` but `json_to_thread_messages` tried to deserialize as `{action_name, id, parameters}`. Introduced `PythonActionCall` interchange struct as single source of truth. The warn log on parse failure summarizes structure only (no PII from tool params).

### 5. WASM trap classification + fuel limit

- Extracted `classify_trap_error` helper that uses structured `wasmtime::Trap` downcast (version-proof) instead of string matching. Covers `OutOfFuel`, `StackOverflow`, `UnreachableCodeReached`, and falls back to full error chain for unrecognized traps.
- Default fuel limit raised from 10M to 100M instructions. 10M was too low for WASM tools making HTTP requests + parsing JSON responses — a single 30KB JSON round-trip can burn 20-50M instructions in serde_json.

### 6. Incorporated from #2227

- Factory-level `server.name` normalization before any branch (including OAuth early-return)
- `new_with_name` normalization for callers bypassing the factory
- Bidirectional `resolve_key` alias resolution in `ToolRegistry` (exact → hyphen→underscore → underscore→hyphen)
- Legacy token secret name fallback for pre-normalization tokens (prevents forced re-auth on upgrade)
- WASM tool + channel loader filename normalization

### 7. Live e2e Drive auth gate test

End-to-end smoke test driving prompt → AuthRequired → token paste → resume. `#[ignore]`d behind live tier, no committed trace fixture (PII risk). Supporting harness: `with_no_trace_recording()`, multi-turn `finish_turns`, `TestRig::secrets_store()` + `owner_id()` accessors.

### 8. Test config

`Config::for_testing` now generates a random 32-byte AES master key (generated fresh per call) so replay-mode tests that touch credentials have a working secrets store out of the box.

## Test plan

- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --workspace --lib` — **5387 passed, 0 failed, 5 ignored**
- [x] All commits rebase cleanly onto latest `origin/staging`
- [ ] Manual: install Notion MCP → tool calls succeed via `notion_notion_search`
- [ ] Manual: install Google Drive WASM with no credentials → `AuthRequired { extension_name: "google-drive-tool" }` surfaces, token paste resumes
- [ ] Manual: enable GitHub Copilot MCP → no HTTP 400 schema error
- [ ] Manual: engine v2 tool flow → zero `Rewriting orphaned tool_result` log lines

Supersedes #2227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)