### PR TITLE
feat(docker): pre-bundle WASM extensions in staging image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,4 +5,3 @@ target/
 *.md
 !CLAUDE.md
 node_modules/
-tools-src/

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -85,6 +85,13 @@ jobs:
           echo "tags=${TAGS}" >> "$GITHUB_OUTPUT"
           echo "worker_tags=${WORKER_TAGS}" >> "$GITHUB_OUTPUT"
 
+          # Staging builds get pre-bundled WASM extensions
+          if [[ "${EVENT_NAME}" == "schedule" || "${INPUT_TAG}" == "staging" ]]; then
+            echo "target=runtime-staging" >> "$GITHUB_OUTPUT"
+          else
+            echo "target=runtime" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
@@ -100,6 +107,7 @@ jobs:
           context: .
           push: true
           tags: ${{ steps.tags.outputs.tags }}
+          target: ${{ steps.tags.outputs.target }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,8 +84,13 @@ RUN set -eux; \
       # Telegram is embedded in the binary at build time; skip it
       [ "$ext_name" = "telegram" ] && continue; \
       echo "=== Building $ext_name from $source_dir ==="; \
-      CARGO_TARGET_DIR=/app/target cargo build --release --target wasm32-wasip2 \
-        --manifest-path "$source_dir/Cargo.toml" || { echo "WARN: build failed for $ext_name"; continue; }; \
+      if [ -f "$source_dir/Cargo.lock" ]; then \
+        CARGO_TARGET_DIR=/app/target cargo build --locked --release --target wasm32-wasip2 \
+          --manifest-path "$source_dir/Cargo.toml" || { echo "WARN: build failed for $ext_name"; continue; }; \
+      else \
+        CARGO_TARGET_DIR=/app/target cargo build --release --target wasm32-wasip2 \
+          --manifest-path "$source_dir/Cargo.toml" || { echo "WARN: build failed for $ext_name"; continue; }; \
+      fi; \
       wasm_artifact=$(echo "${crate_name}" | tr '-' '_'); \
       raw_wasm="/app/target/wasm32-wasip2/release/${wasm_artifact}.wasm"; \
       [ -f "$raw_wasm" ] || continue; \
@@ -126,13 +131,12 @@ ENV RUST_LOG=ironclaw=info
 
 ENTRYPOINT ["ironclaw"]
 
-# Stage 5b: Production runtime (no pre-bundled extensions)
-FROM runtime-base AS runtime
+# Stage 5b: Staging runtime (with pre-built WASM extensions)
+FROM runtime-base AS runtime-staging
+COPY --from=wasm-builder --chown=ironclaw:ironclaw /app/wasm-bundles/tools/ /home/ironclaw/.ironclaw/tools/
+COPY --from=wasm-builder --chown=ironclaw:ironclaw /app/wasm-bundles/channels/ /home/ironclaw/.ironclaw/channels/
 USER ironclaw
 
-# Stage 5c: Staging runtime (with pre-built WASM extensions)
-FROM runtime-base AS runtime-staging
-COPY --from=wasm-builder /app/wasm-bundles/tools/ /home/ironclaw/.ironclaw/tools/
-COPY --from=wasm-builder /app/wasm-bundles/channels/ /home/ironclaw/.ironclaw/channels/
-RUN chown -R ironclaw:ironclaw /home/ironclaw/.ironclaw/tools /home/ironclaw/.ironclaw/channels
+# Stage 5c: Production runtime (default — no pre-bundled extensions)
+FROM runtime-base AS runtime
 USER ironclaw

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ COPY tests/ tests/
 COPY migrations/ migrations/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
+COPY tools-src/ tools-src/
 COPY wit/ wit/
 COPY providers.json providers.json
 
@@ -59,13 +60,51 @@ COPY tests/ tests/
 COPY migrations/ migrations/
 COPY registry/ registry/
 COPY channels-src/ channels-src/
+COPY tools-src/ tools-src/
 COPY wit/ wit/
 COPY providers.json providers.json
 
 RUN cargo build --profile dist --bin ironclaw
 
-# Stage 5: Minimal runtime
-FROM debian:bookworm-slim
+# Stage 4b: Build all WASM extensions from source (only used by runtime-staging)
+FROM builder AS wasm-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
+
+RUN set -eux; \
+    mkdir -p /app/wasm-bundles/tools /app/wasm-bundles/channels; \
+    for manifest in registry/tools/*.json registry/channels/*.json; do \
+      [ -f "$manifest" ] || continue; \
+      kind=$(jq -r '.kind' "$manifest"); \
+      ext_name=$(jq -r '.name' "$manifest"); \
+      source_dir=$(jq -r '.source.dir' "$manifest"); \
+      caps_file=$(jq -r '.source.capabilities' "$manifest"); \
+      crate_name=$(jq -r '.source.crate_name' "$manifest"); \
+      [ -d "$source_dir" ] || continue; \
+      # Telegram is embedded in the binary at build time; skip it
+      [ "$ext_name" = "telegram" ] && continue; \
+      echo "=== Building $ext_name from $source_dir ==="; \
+      CARGO_TARGET_DIR=/app/target cargo build --release --target wasm32-wasip2 \
+        --manifest-path "$source_dir/Cargo.toml" || { echo "WARN: build failed for $ext_name"; continue; }; \
+      wasm_artifact=$(echo "${crate_name}" | tr '-' '_'); \
+      raw_wasm="/app/target/wasm32-wasip2/release/${wasm_artifact}.wasm"; \
+      [ -f "$raw_wasm" ] || continue; \
+      dest_dir="/app/wasm-bundles/tools"; \
+      [ "$kind" = "channel" ] && dest_dir="/app/wasm-bundles/channels"; \
+      wasm-tools component new "$raw_wasm" -o "$dest_dir/${ext_name}.wasm" 2>/dev/null \
+        || cp "$raw_wasm" "$dest_dir/${ext_name}.wasm"; \
+      wasm-tools strip "$dest_dir/${ext_name}.wasm" -o "$dest_dir/${ext_name}.wasm.tmp" 2>/dev/null \
+        && mv "$dest_dir/${ext_name}.wasm.tmp" "$dest_dir/${ext_name}.wasm" \
+        || true; \
+      [ -f "$source_dir/$caps_file" ] && cp "$source_dir/$caps_file" "$dest_dir/${ext_name}.capabilities.json"; \
+      echo "  -> $dest_dir/${ext_name}.wasm"; \
+    done; \
+    count=$(find /app/wasm-bundles -name '*.wasm' | wc -l); \
+    echo "Built $count WASM extensions"; \
+    [ "$count" -gt 0 ] || { echo "ERROR: No WASM extensions were built"; exit 1; }
+
+# Stage 5a: Shared runtime base
+FROM debian:bookworm-slim AS runtime-base
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends ca-certificates \
@@ -80,10 +119,20 @@ RUN useradd -m -d /home/ironclaw -u 1000 ironclaw \
     && mkdir -p /home/ironclaw/.ironclaw \
     && chown -R ironclaw:ironclaw /home/ironclaw
 WORKDIR /home/ironclaw
-USER ironclaw
 
 EXPOSE 3000
 
 ENV RUST_LOG=ironclaw=info
 
 ENTRYPOINT ["ironclaw"]
+
+# Stage 5b: Production runtime (no pre-bundled extensions)
+FROM runtime-base AS runtime
+USER ironclaw
+
+# Stage 5c: Staging runtime (with pre-built WASM extensions)
+FROM runtime-base AS runtime-staging
+COPY --from=wasm-builder /app/wasm-bundles/tools/ /home/ironclaw/.ironclaw/tools/
+COPY --from=wasm-builder /app/wasm-bundles/channels/ /home/ironclaw/.ironclaw/channels/
+RUN chown -R ironclaw:ironclaw /home/ironclaw/.ironclaw/tools /home/ironclaw/.ironclaw/channels
+USER ironclaw


### PR DESCRIPTION
## Summary

- Adds a `wasm-builder` Docker stage that builds all registry tool/channel WASM extensions from source
- Splits the runtime into `runtime-base` / `runtime` (production) / `runtime-staging` (with extensions)
- `docker.yml` passes `--target runtime-staging` for staging builds only; production builds skip the wasm-builder stage entirely (zero overhead)
- `ironclaw-dind` inherits the pre-bundled extensions automatically via `FROM nearaidev/ironclaw:staging` — no changes needed there

**Key details:**
- Uses `jq` for reliable JSON manifest parsing (matching `release.yml`)
- Skips Telegram (already embedded in the binary by `build.rs`)
- Uses shared `CARGO_TARGET_DIR=/app/target` to reuse pre-warmed deps from the main build
- Strips debug info via temp file to avoid in-place clobber
- Fails the build if zero extensions are produced

## Test plan

- [ ] `docker build --platform linux/amd64 --target runtime-staging -t ironclaw:staging-test .` succeeds and includes `.wasm` files in `/home/ironclaw/.ironclaw/{tools,channels}/`
- [ ] `docker build --platform linux/amd64 --target runtime -t ironclaw:prod-test .` succeeds with no pre-bundled extensions
- [ ] Trigger manual `docker.yml` dispatch with `tag=staging` and verify extensions are included
- [ ] Verify scheduled staging build produces image with extensions

🤖 Generated with [Claude Code](https://claude.com/claude-code)