### PR TITLE
feat(jobs): MCP client support in sandboxed container workers

### DIFF
--- a/src/orchestrator/api.rs
+++ b/src/orchestrator/api.rs
@@ -75,6 +75,18 @@ impl OrchestratorApi {
             .route("/worker/{job_id}/event", post(job_event_handler))
             .route("/worker/{job_id}/prompt", get(get_prompt_handler))
             .route("/worker/{job_id}/credentials", get(get_credentials_handler))
+            .route(
+                "/worker/{job_id}/mcp/secrets/get",
+                post(mcp_secret_get_handler),
+            )
+            .route(
+                "/worker/{job_id}/mcp/secrets/exists",
+                post(mcp_secret_exists_handler),
+            )
+            .route(
+                "/worker/{job_id}/mcp/secrets/create",
+                post(mcp_secret_create_handler),
+            )
             .route_layer(axum::middleware::from_fn_with_state(
                 state.token_store.clone(),
                 worker_auth_middleware,
@@ -496,6 +508,120 @@ async fn get_credentials_handler(
         StatusCode::OK,
         Json(serde_json::to_value(&credentials).unwrap_or(serde_json::Value::Null)),
     ))
+}
+
+// -- MCP secrets proxy handlers --
+
+#[derive(Debug, Deserialize)]
+struct McpSecretRequest {
+    name: String,
+}
+
+// No Debug — `value` contains a plaintext secret.
+#[derive(Deserialize)]
+struct McpSecretCreateRequest {
+    name: String,
+    value: String,
+    #[serde(default)]
+    expires_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Validate allowlist + resolve secrets store (shared guard for all MCP secret endpoints).
+async fn require_mcp_secrets_access<'a>(
+    state: &'a OrchestratorState,
+    job_id: Uuid,
+    secret_name: &str,
+) -> Result<&'a (dyn SecretsStore + Send + Sync), StatusCode> {
+    if !state
+        .token_store
+        .is_mcp_secret_allowed(job_id, secret_name)
+        .await
+    {
+        return Err(StatusCode::FORBIDDEN);
+    }
+    state
+        .secrets_store
+        .as_deref()
+        .ok_or(StatusCode::SERVICE_UNAVAILABLE)
+}
+
+async fn mcp_secret_get_handler(
+    State(state): State<OrchestratorState>,
+    Path(job_id): Path<Uuid>,
+    Json(req): Json<McpSecretRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let secrets = require_mcp_secrets_access(&state, job_id, &req.name).await?;
+
+    let decrypted = secrets
+        .get_decrypted(&state.user_id, &req.name)
+        .await
+        .map_err(|e| {
+            tracing::debug!(
+                job_id = %job_id,
+                name = %req.name,
+                "MCP secret lookup failed: {e}"
+            );
+            StatusCode::NOT_FOUND
+        })?;
+
+    // Record usage for audit trail (best-effort, matching get_credentials_handler)
+    if let Ok(secret) = secrets.get(&state.user_id, &req.name).await
+        && let Err(e) = secrets.record_usage(secret.id).await
+    {
+        tracing::warn!(
+            job_id = %job_id,
+            name = %req.name,
+            "Failed to record MCP secret usage: {e}"
+        );
+    }
+
+    Ok(Json(serde_json::json!({ "value": decrypted.expose() })))
+}
+
+async fn mcp_secret_exists_handler(
+    State(state): State<OrchestratorState>,
+    Path(job_id): Path<Uuid>,
+    Json(req): Json<McpSecretRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let secrets = require_mcp_secrets_access(&state, job_id, &req.name).await?;
+
+    let exists = match secrets.exists(&state.user_id, &req.name).await {
+        Ok(e) => e,
+        Err(e) => {
+            tracing::debug!(
+                job_id = %job_id,
+                name = %req.name,
+                "MCP secret exists check failed: {e}"
+            );
+            false
+        }
+    };
+
+    Ok(Json(serde_json::json!({ "exists": exists })))
+}
+
+async fn mcp_secret_create_handler(
+    State(state): State<OrchestratorState>,
+    Path(job_id): Path<Uuid>,
+    Json(req): Json<McpSecretCreateRequest>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let secrets = require_mcp_secrets_access(&state, job_id, &req.name).await?;
+
+    let mut params = crate::secrets::CreateSecretParams::new(req.name.clone(), &req.value);
+    if let Some(expires_at) = req.expires_at {
+        params = params.with_expiry(expires_at);
+    }
+
+    secrets.create(&state.user_id, params).await.map_err(|e| {
+        tracing::error!(
+            job_id = %job_id,
+            name = %req.name,
+            "Failed to create MCP secret: {e}"
+        );
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+
+    Ok(Json(serde_json::json!({ "ok": true })))
 }
 
 fn format_finish_reason(reason: crate::llm::FinishReason) -> String {
@@ -987,5 +1113,251 @@ mod tests {
         let handle = jm.get_handle(job_id).await.unwrap();
         assert_eq!(handle.worker_iteration, 5);
         assert_eq!(handle.last_worker_status.as_deref(), Some("Iteration 5"));
+    }
+
+    // -- MCP secrets proxy tests --
+
+    fn test_state_with_secrets() -> (OrchestratorState, TokenStore) {
+        use crate::testing::credentials::test_secrets_store;
+        let secrets_store = Arc::new(test_secrets_store());
+        let token_store = TokenStore::new();
+        let jm = ContainerJobManager::new(ContainerJobConfig::default(), token_store.clone());
+        let state = OrchestratorState {
+            llm: Arc::new(StubLlm::default()),
+            job_manager: Arc::new(jm),
+            token_store: token_store.clone(),
+            job_event_tx: None,
+            prompt_queue: Arc::new(Mutex::new(HashMap::new())),
+            store: None,
+            secrets_store: Some(secrets_store),
+            user_id: "<unset>".to_string(),
+            job_owner_cache: Arc::new(std::sync::RwLock::new(HashMap::new())),
+        };
+        (state, token_store)
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_get_rejects_non_allowlisted_name() {
+        let (state, token_store) = test_state_with_secrets();
+        let job_id = Uuid::new_v4();
+        let token = token_store.create_token(job_id).await;
+        // No allowlist stored → all names rejected
+        let router = OrchestratorApi::router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/get", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"GITHUB_TOKEN"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_get_returns_decrypted_value() {
+        use secrecy::SecretString;
+        let (state, token_store) = test_state_with_secrets();
+        let job_id = Uuid::new_v4();
+        let token = token_store.create_token(job_id).await;
+
+        // Store the allowlist
+        let allowlist: std::collections::HashSet<String> =
+            ["mcp_test_access_token".to_string()].into();
+        token_store
+            .store_mcp_secret_allowlist(job_id, allowlist)
+            .await;
+
+        // Create the secret
+        state
+            .secrets_store
+            .as_ref()
+            .unwrap()
+            .create(
+                "<unset>",
+                crate::secrets::CreateSecretParams {
+                    name: "mcp_test_access_token".to_string(),
+                    value: SecretString::from("my-oauth-token".to_string()),
+                    provider: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let router = OrchestratorApi::router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/get", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"mcp_test_access_token"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["value"], "my-oauth-token");
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_exists_returns_correct_result() {
+        let (state, token_store) = test_state_with_secrets();
+        let job_id = Uuid::new_v4();
+        let token = token_store.create_token(job_id).await;
+
+        let allowlist: std::collections::HashSet<String> =
+            ["mcp_test_access_token".to_string()].into();
+        token_store
+            .store_mcp_secret_allowlist(job_id, allowlist)
+            .await;
+
+        let router = OrchestratorApi::router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/exists", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"mcp_test_access_token"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        // Secret doesn't exist yet, should return false
+        assert_eq!(json["exists"], false); // safety: test assertion
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_exists_returns_true_after_create() {
+        use secrecy::SecretString;
+        let (state, token_store) = test_state_with_secrets();
+        let job_id = Uuid::new_v4();
+        let token = token_store.create_token(job_id).await;
+
+        let allowlist: std::collections::HashSet<String> =
+            ["mcp_test_access_token".to_string()].into();
+        token_store
+            .store_mcp_secret_allowlist(job_id, allowlist)
+            .await;
+
+        // Create the secret via the store directly
+        state
+            .secrets_store
+            .as_ref()
+            .unwrap()
+            .create(
+                "<unset>",
+                crate::secrets::CreateSecretParams {
+                    name: "mcp_test_access_token".to_string(),
+                    value: SecretString::from("some-value".to_string()),
+                    provider: None,
+                    expires_at: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        let router = OrchestratorApi::router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/exists", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"mcp_test_access_token"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["exists"], true);
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_returns_503_without_store() {
+        let state = test_state(); // no secrets store
+        let job_id = Uuid::new_v4();
+        let token = state.token_store.create_token(job_id).await;
+
+        // Even with an allowlist, 503 if no secrets store
+        let allowlist: std::collections::HashSet<String> =
+            ["mcp_test_access_token".to_string()].into();
+        state
+            .token_store
+            .store_mcp_secret_allowlist(job_id, allowlist)
+            .await;
+
+        let router = OrchestratorApi::router(state);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/get", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"mcp_test_access_token"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    #[tokio::test]
+    async fn mcp_secrets_create_stores_and_retrieves() {
+        let (state, token_store) = test_state_with_secrets();
+        let job_id = Uuid::new_v4();
+        let token = token_store.create_token(job_id).await;
+
+        let allowlist: std::collections::HashSet<String> =
+            ["mcp_test_access_token".to_string()].into();
+        token_store
+            .store_mcp_secret_allowlist(job_id, allowlist)
+            .await;
+
+        let router = OrchestratorApi::router(state);
+
+        // Create a secret via the create endpoint
+        let create_req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/create", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(
+                r#"{"name":"mcp_test_access_token","value":"fresh-token"}"#,
+            ))
+            .unwrap();
+
+        let resp = router.clone().oneshot(create_req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["ok"], true);
+
+        // Retrieve via the get endpoint
+        let get_req = Request::builder()
+            .method("POST")
+            .uri(format!("/worker/{}/mcp/secrets/get", job_id))
+            .header("Authorization", format!("Bearer {}", token))
+            .header("Content-Type", "application/json")
+            .body(Body::from(r#"{"name":"mcp_test_access_token"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(get_req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["value"], "fresh-token");
     }
 }

--- a/src/orchestrator/auth.rs
+++ b/src/orchestrator/auth.rs
@@ -7,7 +7,7 @@
 //! - A token for Job A cannot access endpoints for Job B
 //! - Credential grants are per-job: only secrets explicitly granted are accessible
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use axum::extract::{Request, State};
@@ -38,6 +38,9 @@ pub struct TokenStore {
     tokens: Arc<RwLock<HashMap<Uuid, String>>>,
     /// Maps job_id -> granted credentials. Revoked alongside the token.
     credential_grants: Arc<RwLock<HashMap<Uuid, Vec<CredentialGrant>>>>,
+    /// Maps job_id -> exhaustive set of MCP secret names the job may access.
+    /// Computed at job creation from the mounted MCP server configs.
+    mcp_secret_allowlist: Arc<RwLock<HashMap<Uuid, HashSet<String>>>>,
 }
 
 impl TokenStore {
@@ -45,6 +48,7 @@ impl TokenStore {
         Self {
             tokens: Arc::new(RwLock::new(HashMap::new())),
             credential_grants: Arc::new(RwLock::new(HashMap::new())),
+            mcp_secret_allowlist: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -65,10 +69,11 @@ impl TokenStore {
             .unwrap_or(false)
     }
 
-    /// Remove a token and its credential grants (on container cleanup).
+    /// Remove a token, credential grants, and MCP secret allowlist (on container cleanup).
     pub async fn revoke(&self, job_id: Uuid) {
         self.tokens.write().await.remove(&job_id);
         self.credential_grants.write().await.remove(&job_id);
+        self.mcp_secret_allowlist.write().await.remove(&job_id);
     }
 
     /// Get the number of active tokens (for diagnostics).
@@ -86,6 +91,27 @@ impl TokenStore {
     /// Retrieve credential grants for a job.
     pub async fn get_grants(&self, job_id: Uuid) -> Option<Vec<CredentialGrant>> {
         self.credential_grants.read().await.get(&job_id).cloned()
+    }
+
+    /// Store the exhaustive set of MCP secret names a job is allowed to access.
+    /// Computed at job creation from the mounted MCP server configs.
+    pub async fn store_mcp_secret_allowlist(&self, job_id: Uuid, allowlist: HashSet<String>) {
+        if !allowlist.is_empty() {
+            self.mcp_secret_allowlist
+                .write()
+                .await
+                .insert(job_id, allowlist);
+        }
+    }
+
+    /// Check whether a secret name is in the job's MCP secret allowlist.
+    pub async fn is_mcp_secret_allowed(&self, job_id: Uuid, secret_name: &str) -> bool {
+        self.mcp_secret_allowlist
+            .read()
+            .await
+            .get(&job_id)
+            .map(|allowlist| allowlist.contains(secret_name))
+            .unwrap_or(false)
     }
 }
 
@@ -254,6 +280,79 @@ mod tests {
 
         // Empty vec should not create an entry
         assert!(store.get_grants(job_id).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_secret_allowlist_store_and_check() {
+        let store = TokenStore::new();
+        let job_id = Uuid::new_v4();
+
+        assert!(
+            !store
+                .is_mcp_secret_allowed(job_id, "mcp_serpstat_access_token")
+                .await
+        );
+
+        let allowlist: HashSet<String> = [
+            "mcp_serpstat_access_token".to_string(),
+            "mcp_serpstat_access_token_refresh_token".to_string(),
+        ]
+        .into();
+
+        store.store_mcp_secret_allowlist(job_id, allowlist).await;
+
+        assert!(
+            store
+                .is_mcp_secret_allowed(job_id, "mcp_serpstat_access_token")
+                .await
+        );
+        assert!(
+            store
+                .is_mcp_secret_allowed(job_id, "mcp_serpstat_access_token_refresh_token")
+                .await
+        );
+        assert!(
+            !store
+                .is_mcp_secret_allowed(job_id, "mcp_github_access_token")
+                .await
+        );
+        assert!(!store.is_mcp_secret_allowed(job_id, "GITHUB_TOKEN").await);
+    }
+
+    #[tokio::test]
+    async fn test_mcp_secret_allowlist_revoked_on_cleanup() {
+        let store = TokenStore::new();
+        let job_id = Uuid::new_v4();
+
+        let _token = store.create_token(job_id).await;
+        let allowlist: HashSet<String> = ["mcp_test_access_token".to_string()].into();
+        store.store_mcp_secret_allowlist(job_id, allowlist).await;
+
+        assert!(
+            store
+                .is_mcp_secret_allowed(job_id, "mcp_test_access_token")
+                .await
+        );
+
+        store.revoke(job_id).await;
+
+        assert!(
+            !store
+                .is_mcp_secret_allowed(job_id, "mcp_test_access_token")
+                .await
+        );
+    }
+
+    #[tokio::test]
+    async fn test_mcp_secret_allowlist_empty_not_stored() {
+        let store = TokenStore::new();
+        let job_id = Uuid::new_v4();
+
+        store
+            .store_mcp_secret_allowlist(job_id, HashSet::new())
+            .await;
+
+        assert!(!store.is_mcp_secret_allowed(job_id, "anything").await);
     }
 
     #[tokio::test]

--- a/src/orchestrator/job_manager.rs
+++ b/src/orchestrator/job_manager.rs
@@ -3,7 +3,7 @@
 //! Extends the existing `SandboxManager` infrastructure to support persistent
 //! containers with their own agent loops (as opposed to ephemeral per-command containers).
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -103,6 +103,8 @@ pub struct ContainerJobConfig {
     /// Whether per-job MCP server filtering is enabled.
     /// When false, `mcp_servers` param on `create_job` is ignored.
     pub mcp_per_job_enabled: bool,
+    /// User ID for secret lookups (single-tenant, typically "default" or from config.owner_id).
+    pub user_id: String,
     /// Whether Claude Code sandbox mode is available (from CLAUDE_CODE_ENABLED).
     pub claude_code_enabled: bool,
     /// Whether ACP agent mode is available (from ACP_ENABLED).
@@ -125,6 +127,7 @@ impl Default for ContainerJobConfig {
             acp_memory_limit_mb: 4096,
             acp_timeout_secs: 1800,
             mcp_per_job_enabled: false,
+            user_id: "default".to_string(),
             claude_code_enabled: false,
             acp_enabled: false,
         }
@@ -434,6 +437,7 @@ impl ContainerJobManager {
             format!("IRONCLAW_WORKER_TOKEN={}", token),
             format!("IRONCLAW_JOB_ID={}", job_id),
             format!("IRONCLAW_ORCHESTRATOR_URL={}", orchestrator_url),
+            format!("IRONCLAW_USER_ID={}", self.config.user_id),
         ];
 
         // Build volume mounts (validate project_dir stays within ~/.ironclaw/projects/)
@@ -467,11 +471,19 @@ impl ContainerJobManager {
             )
             .await?
             {
-                Some(config_path) => {
+                Some((config_path, filtered_config)) => {
                     binds.push(format!(
                         "{}:/home/sandbox/.ironclaw/mcp-servers.json:ro",
                         config_path.display()
                     ));
+
+                    let allowlist = compute_mcp_secret_allowlist(filtered_config, job_id);
+                    if !allowlist.is_empty() {
+                        self.token_store
+                            .store_mcp_secret_allowlist(job_id, allowlist)
+                            .await;
+                    }
+
                     tracing::debug!(
                         job_id = %job_id,
                         filtered = mcp_servers.is_some(),
@@ -831,7 +843,7 @@ async fn generate_worker_mcp_config(
     master: Option<&serde_json::Value>,
     server_names: Option<&[String]>,
     job_id: Uuid,
-) -> Result<Option<std::path::PathBuf>, OrchestratorError> {
+) -> Result<Option<(std::path::PathBuf, serde_json::Value)>, OrchestratorError> {
     let Some(master) = master else {
         return Ok(None);
     };
@@ -958,7 +970,38 @@ async fn generate_worker_mcp_config(
             reason: format!("failed to write per-job MCP config: {e}"),
         })?;
 
-    Ok(Some(tmp_path))
+    Ok(Some((tmp_path, filtered)))
+}
+
+/// Compute the exhaustive set of MCP secret names for a filtered config value.
+///
+/// For each OAuth-capable server, produces the 5 canonical secret names
+/// (access token, refresh token, legacy refresh, client_id, client_secret).
+/// Returns an empty set if the config cannot be parsed or has no OAuth servers.
+fn compute_mcp_secret_allowlist(config_value: serde_json::Value, job_id: Uuid) -> HashSet<String> {
+    let servers_file: crate::tools::mcp::config::McpServersFile =
+        match serde_json::from_value(config_value) {
+            Ok(f) => f,
+            Err(e) => {
+                tracing::debug!(
+                    job_id = %job_id,
+                    "Failed to parse MCP config for secret allowlist: {e}"
+                );
+                return HashSet::new();
+            }
+        };
+
+    let mut allowlist = HashSet::new();
+    for server in servers_file.enabled_servers() {
+        if server.requires_auth() {
+            allowlist.insert(server.token_secret_name());
+            allowlist.insert(server.refresh_token_secret_name());
+            allowlist.insert(server.legacy_refresh_token_secret_name());
+            allowlist.insert(server.client_id_secret_name());
+            allowlist.insert(server.client_secret_secret_name());
+        }
+    }
+    allowlist
 }
 
 #[cfg(test)]
@@ -1184,7 +1227,7 @@ mod tests {
             ]}"#,
         );
         let result = generate_worker_mcp_config(Some(&master), None, job_id).await;
-        let out_path = result.unwrap().expect("should write a temp config"); // safety: test fixture
+        let (out_path, _) = result.unwrap().expect("should write a temp config"); // safety: test fixture
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap(); // safety: test fixture
         let servers = content["servers"].as_array().unwrap(); // safety: test fixture
@@ -1236,7 +1279,7 @@ mod tests {
 
         let names = vec!["serpstat".to_string(), "disabled".to_string()];
         let result = generate_worker_mcp_config(Some(&master), Some(&names), job_id).await;
-        let out_path = result.unwrap().expect("should produce a filtered config");
+        let (out_path, _) = result.unwrap().expect("should produce a filtered config");
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
@@ -1265,7 +1308,7 @@ mod tests {
         let master = master_value(r#"{"servers":[{"name":"Serpstat","enabled":true}]}"#);
         let names = vec!["serpstat".to_string()];
         let result = generate_worker_mcp_config(Some(&master), Some(&names), job_id).await;
-        let out_path = result.unwrap().expect("case-insensitive match should work");
+        let (out_path, _) = result.unwrap().expect("case-insensitive match should work");
         let _ = std::fs::remove_file(&out_path);
     }
 
@@ -1361,7 +1404,7 @@ mod tests {
 
         let names = vec!["serpstat".to_string()];
         let result = generate_worker_mcp_config(Some(&master), Some(&names), job_id).await;
-        let out_path = result.unwrap().expect("should produce a filtered config");
+        let (out_path, _) = result.unwrap().expect("should produce a filtered config");
 
         let content: serde_json::Value =
             serde_json::from_str(&std::fs::read_to_string(&out_path).unwrap()).unwrap();
@@ -1411,7 +1454,7 @@ mod tests {
 
         let names = vec!["serpstat".to_string()];
         let result = generate_worker_mcp_config(Some(&master), Some(&names), job_id).await;
-        let out_path = result.unwrap().expect("should produce a filtered config");
+        let (out_path, _) = result.unwrap().expect("should produce a filtered config");
         assert!(
             out_path.exists(),
             "temp config file should exist after creation"
@@ -1452,7 +1495,7 @@ mod tests {
 
         let names = vec!["test".to_string()];
         let result = generate_worker_mcp_config(Some(&master), Some(&names), job_id).await;
-        let out_path = result.unwrap().expect("should produce a filtered config");
+        let (out_path, _) = result.unwrap().expect("should produce a filtered config");
 
         let dir_path = out_path.parent().unwrap();
         let mode = std::fs::metadata(dir_path).unwrap().permissions().mode() & 0o777;
@@ -1486,7 +1529,7 @@ mod tests {
         });
 
         let result = generate_worker_mcp_config(Some(&master), None, job_id).await;
-        let out_path = result.unwrap().expect(
+        let (out_path, _) = result.unwrap().expect(
             // safety: test fixture
             "DB-loaded master with no filter must produce a mountable config — \
              pre-fix this would silently fall back to None on installs where \

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -127,6 +127,7 @@ pub async fn setup_orchestrator(
             mcp_per_job_enabled: std::env::var("MCP_PER_JOB_ENABLED")
                 .map(|v| v.eq_ignore_ascii_case("true") || v == "1")
                 .unwrap_or(false),
+            user_id: config.owner_id.clone(),
             claude_code_enabled: config.claude_code.enabled,
             acp_enabled: config.acp.enabled,
         };

--- a/src/worker/api.rs
+++ b/src/worker/api.rs
@@ -399,6 +399,48 @@ impl WorkerHttpClient {
             })
     }
 
+    /// Get a decrypted MCP secret from the orchestrator.
+    pub async fn mcp_secret_get(&self, name: &str) -> Result<String, WorkerError> {
+        let body = serde_json::json!({ "name": name });
+        let resp: serde_json::Value = self
+            .post_json("mcp/secrets/get", &body, "mcp secret get")
+            .await?;
+        resp["value"]
+            .as_str()
+            .map(|s| s.to_string())
+            .ok_or_else(|| WorkerError::SecretResolveFailed {
+                secret_name: name.to_string(),
+                reason: "missing 'value' in response".to_string(),
+            })
+    }
+
+    /// Check if an MCP secret exists on the orchestrator.
+    pub async fn mcp_secret_exists(&self, name: &str) -> Result<bool, WorkerError> {
+        let body = serde_json::json!({ "name": name });
+        let resp: serde_json::Value = self
+            .post_json("mcp/secrets/exists", &body, "mcp secret exists")
+            .await?;
+        Ok(resp["exists"].as_bool().unwrap_or(false))
+    }
+
+    /// Create/update an MCP secret on the orchestrator.
+    pub async fn mcp_secret_create(
+        &self,
+        name: &str,
+        value: &str,
+        expires_at: Option<chrono::DateTime<chrono::Utc>>,
+    ) -> Result<(), WorkerError> {
+        let body = serde_json::json!({
+            "name": name,
+            "value": value,
+            "expires_at": expires_at,
+        });
+        let _: serde_json::Value = self
+            .post_json("mcp/secrets/create", &body, "mcp secret create")
+            .await?;
+        Ok(())
+    }
+
     /// Signal job completion to the orchestrator.
     pub async fn report_complete(&self, report: &CompletionReport) -> Result<(), WorkerError> {
         let _: serde_json::Value = self

--- a/src/worker/container.rs
+++ b/src/worker/container.rs
@@ -22,15 +22,23 @@ use crate::config::SafetyConfig;
 use crate::context::JobContext;
 use crate::error::WorkerError;
 use crate::llm::{ChatMessage, LlmProvider, Reasoning, ReasoningContext, ResponseMetadata};
+use crate::secrets::SecretsStore;
 use crate::tools::ToolRegistry;
 use crate::tools::execute::{execute_tool_simple, process_tool_result};
+use crate::tools::mcp::config::load_mcp_servers_from;
+use crate::tools::mcp::create_client_from_config;
+use crate::tools::mcp::{McpProcessManager, McpSessionManager};
 use crate::worker::api::{CompletionReport, JobEventPayload, StatusUpdate, WorkerHttpClient};
 use crate::worker::autonomous_recovery::{
     AutonomousRecoveryAction, AutonomousRecoveryState, EMPTY_TOOL_COMPLETION_FAILURE,
     EMPTY_TOOL_COMPLETION_NUDGE, FORCE_TEXT_RECOVERY_PROMPT,
 };
 use crate::worker::proxy_llm::ProxyLlmProvider;
+use crate::worker::proxy_secrets::ProxySecretsStore;
 use ironclaw_safety::SafetyLayer;
+
+/// Default path where the orchestrator mounts MCP config inside the container.
+const DEFAULT_MCP_CONFIG_PATH: &str = "/home/sandbox/.ironclaw/mcp-servers.json";
 
 /// Configuration for the worker runtime.
 pub struct WorkerConfig {
@@ -133,6 +141,17 @@ impl WorkerRuntime {
             );
         }
 
+        // Initialize MCP tools from the mounted config (non-fatal).
+        let proxy_secrets: Option<Arc<dyn SecretsStore + Send + Sync>> =
+            Some(Arc::new(ProxySecretsStore::new(Arc::clone(&self.client))));
+        let user_id = std::env::var("IRONCLAW_USER_ID").unwrap_or_else(|_| "default".to_string());
+        let mcp_config_path = std::env::var("IRONCLAW_MCP_CONFIG_PATH")
+            .map(std::path::PathBuf::from)
+            .unwrap_or_else(|_| std::path::PathBuf::from(DEFAULT_MCP_CONFIG_PATH));
+
+        let (mcp_tool_count, mcp_process_manager) =
+            load_mcp_tools(&mcp_config_path, &self.tools, proxy_secrets, &user_id).await;
+
         // Report that we're starting
         self.client
             .report_status(&StatusUpdate {
@@ -148,18 +167,27 @@ impl WorkerRuntime {
         // Build initial context
         let mut reason_ctx = ReasoningContext::new().with_job(&job.description);
 
+        let mcp_note = if mcp_tool_count > 0 {
+            format!(
+                "\nYou also have {} MCP tool(s) for external service integration.",
+                mcp_tool_count
+            )
+        } else {
+            String::new()
+        };
+
         reason_ctx.messages.push(ChatMessage::system(format!(
             r#"You are an autonomous agent running inside a Docker container.
 
 Job: {}
 Description: {}
 
-You have tools for shell commands, file operations, and code editing.
+You have tools for shell commands, file operations, and code editing.{}
 Work independently to complete this job. When finished, your final message MUST include the phrase "The job is complete" to signal termination."#,
-            job.title, job.description
+            job.title, job.description, mcp_note
         )));
 
-        // Load tool definitions
+        // Load tool definitions (includes MCP tools if any were registered above)
         reason_ctx.available_tools = self.tools.tool_definitions().await;
 
         // Shared iteration tracker — read after the loop to report accurate counts.
@@ -299,6 +327,11 @@ Work independently to complete this job. When finished, your final message MUST 
             }
         }
 
+        // Clean up MCP stdio processes (nice-to-have; Docker kills them on container stop).
+        if let Some(pm) = mcp_process_manager {
+            pm.shutdown_all().await;
+        }
+
         Ok(())
     }
 
@@ -311,6 +344,72 @@ Work independently to complete this job. When finished, your final message MUST 
             })
             .await;
     }
+}
+
+/// Load MCP tools from a config file into the tool registry.
+///
+/// Returns `(tools_loaded, process_manager)`. All failures are logged at
+/// `debug!` level and never propagate — the worker continues with dev tools only.
+async fn load_mcp_tools(
+    config_path: &std::path::Path,
+    tools: &ToolRegistry,
+    secrets: Option<Arc<dyn SecretsStore + Send + Sync>>,
+    user_id: &str,
+) -> (usize, Option<Arc<McpProcessManager>>) {
+    let servers_file = match load_mcp_servers_from(config_path).await {
+        Ok(f) if f.servers.is_empty() => {
+            tracing::debug!("No MCP servers configured at {}", config_path.display());
+            return (0, None);
+        }
+        Ok(f) => f,
+        Err(e) => {
+            tracing::debug!("No MCP config at {}: {e}", config_path.display());
+            return (0, None);
+        }
+    };
+
+    let session_mgr = Arc::new(McpSessionManager::new());
+    let process_mgr = Arc::new(McpProcessManager::new());
+    let mut total_tools = 0usize;
+
+    for server in servers_file.enabled_servers() {
+        let server_name = server.name.clone();
+        let client = match create_client_from_config(
+            server.clone(),
+            &session_mgr,
+            &process_mgr,
+            secrets.clone(),
+            user_id,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::debug!("Failed to create MCP client for '{}': {e}", server_name);
+                continue;
+            }
+        };
+
+        let tool_impls = match client.create_tools().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to load tools from MCP server '{}': {e}",
+                    server_name
+                );
+                continue;
+            }
+        };
+
+        let count = tool_impls.len();
+        for tool in tool_impls {
+            tools.register(tool).await;
+        }
+        total_tools += count;
+        tracing::debug!("Loaded {count} tool(s) from MCP server '{server_name}'");
+    }
+
+    (total_tools, Some(process_mgr))
 }
 
 /// Container delegate: implements `LoopDelegate` for the Docker container context.
@@ -603,6 +702,7 @@ impl LoopDelegate for ContainerDelegate {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::agent::agentic_loop::truncate_for_preview;
 
     #[test]
@@ -627,5 +727,59 @@ mod tests {
         let result = truncate_for_preview("é is fancy", 1);
         // Should truncate to 0 chars (can't fit "é" in 1 byte)
         assert_eq!(result, "...");
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_missing_returns_zero() {
+        let tools = Arc::new(ToolRegistry::new());
+        let nonexistent = std::path::Path::new("/nonexistent/mcp-servers.json");
+        let (count, pm) = load_mcp_tools(nonexistent, &tools, None, "test").await;
+        assert_eq!(count, 0);
+        assert!(pm.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_invalid_json_returns_zero() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), "not valid json!!!").unwrap();
+
+        let tools = Arc::new(ToolRegistry::new());
+        let (count, pm) = load_mcp_tools(tmp.path(), &tools, None, "test").await;
+        assert_eq!(count, 0);
+        assert!(pm.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_config_empty_servers_returns_zero() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), r#"{"servers": [], "schema_version": 1}"#).unwrap();
+
+        let tools = Arc::new(ToolRegistry::new());
+        let (count, pm) = load_mcp_tools(tmp.path(), &tools, None, "test").await;
+        assert_eq!(count, 0);
+        // Empty server list short-circuits before creating process manager.
+        assert!(pm.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mcp_unreachable_server_continues_gracefully() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            r#"{
+                "servers": [
+                    {"name": "unreachable", "url": "http://127.0.0.1:1", "enabled": true}
+                ],
+                "schema_version": 1
+            }"#,
+        )
+        .unwrap();
+
+        let tools = Arc::new(ToolRegistry::new());
+        let (count, pm) = load_mcp_tools(tmp.path(), &tools, None, "test").await;
+        // MCP client creation may succeed (it's lazy) but create_tools will fail.
+        // Either way, no tools should be registered.
+        assert_eq!(count, 0);
+        assert!(pm.is_some());
     }
 }

--- a/src/worker/mod.rs
+++ b/src/worker/mod.rs
@@ -31,6 +31,7 @@ pub mod claude_bridge;
 pub mod container;
 pub mod job;
 pub mod proxy_llm;
+pub mod proxy_secrets;
 
 pub use acp_bridge::AcpBridgeRuntime;
 pub use api::WorkerHttpClient;

--- a/src/worker/proxy_secrets.rs
+++ b/src/worker/proxy_secrets.rs
@@ -1,0 +1,185 @@
+//! Proxy `SecretsStore` that delegates to the orchestrator via HTTP.
+//!
+//! Used inside container workers to give MCP OAuth clients access to
+//! the host's secrets store without exposing it directly. Only the
+//! subset of `SecretsStore` methods needed by the MCP token lifecycle
+//! (`get_decrypted`, `exists`, `create`) are implemented; the rest
+//! return sensible defaults.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use secrecy::ExposeSecret;
+use uuid::Uuid;
+
+use crate::secrets::{
+    CreateSecretParams, DecryptedSecret, Secret, SecretError, SecretRef, SecretsStore,
+};
+use crate::worker::api::WorkerHttpClient;
+
+/// A `SecretsStore` that proxies read/write operations to the orchestrator
+/// via the `/worker/{job_id}/mcp/secrets/*` endpoints.
+pub struct ProxySecretsStore {
+    client: Arc<WorkerHttpClient>,
+}
+
+impl ProxySecretsStore {
+    pub fn new(client: Arc<WorkerHttpClient>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl SecretsStore for ProxySecretsStore {
+    async fn create(
+        &self,
+        _user_id: &str,
+        params: CreateSecretParams,
+    ) -> Result<Secret, SecretError> {
+        self.client
+            .mcp_secret_create(
+                &params.name,
+                params.value.expose_secret(),
+                params.expires_at,
+            )
+            .await
+            .map_err(|e| classify_worker_error(&params.name, e))?;
+
+        // Return a minimal Secret — the caller only needs confirmation, not the full record.
+        Ok(Secret {
+            id: Uuid::new_v4(),
+            user_id: String::new(),
+            name: params.name,
+            encrypted_value: Vec::new(),
+            key_salt: Vec::new(),
+            provider: params.provider,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            last_used_at: None,
+            expires_at: params.expires_at,
+            usage_count: 0,
+        })
+    }
+
+    async fn get(&self, _user_id: &str, name: &str) -> Result<Secret, SecretError> {
+        // Not implemented — MCP OAuth flow only uses get_decrypted.
+        Err(SecretError::NotFound(name.to_string()))
+    }
+
+    async fn get_decrypted(
+        &self,
+        _user_id: &str,
+        name: &str,
+    ) -> Result<DecryptedSecret, SecretError> {
+        let value = self
+            .client
+            .mcp_secret_get(name)
+            .await
+            .map_err(|e| classify_worker_error(name, e))?;
+
+        DecryptedSecret::from_bytes(value.into_bytes())
+    }
+
+    async fn exists(&self, _user_id: &str, name: &str) -> Result<bool, SecretError> {
+        self.client
+            .mcp_secret_exists(name)
+            .await
+            .map_err(|e| classify_worker_error(name, e))
+    }
+
+    async fn list(&self, _user_id: &str) -> Result<Vec<SecretRef>, SecretError> {
+        Ok(vec![])
+    }
+
+    async fn delete(&self, _user_id: &str, _name: &str) -> Result<bool, SecretError> {
+        Ok(false)
+    }
+
+    async fn record_usage(&self, _secret_id: Uuid) -> Result<(), SecretError> {
+        Ok(())
+    }
+
+    async fn is_accessible(
+        &self,
+        _user_id: &str,
+        _secret_name: &str,
+        _allowed_secrets: &[String],
+    ) -> Result<bool, SecretError> {
+        // In container context, access control is handled by the orchestrator's allowlist.
+        Ok(true)
+    }
+}
+
+/// Map a `WorkerError` to the appropriate `SecretError` variant based on the
+/// HTTP status code embedded in the error message.
+fn classify_worker_error(name: &str, e: crate::error::WorkerError) -> SecretError {
+    let msg = e.to_string();
+    if msg.contains("returned 403") {
+        SecretError::AccessDenied
+    } else if msg.contains("returned 404") {
+        SecretError::NotFound(name.to_string())
+    } else if msg.contains("returned 503") {
+        SecretError::Database("secrets store unavailable".to_string())
+    } else {
+        SecretError::Database(format!("{}: {}", name, msg))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn proxy_secrets_store_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ProxySecretsStore>();
+    }
+
+    #[test]
+    fn classify_403_maps_to_access_denied() {
+        let err = crate::error::WorkerError::LlmProxyFailed {
+            reason: "mcp secret get: orchestrator returned 403 Forbidden: ".to_string(),
+        };
+        let result = classify_worker_error("my_secret", err);
+        assert!(matches!(result, SecretError::AccessDenied));
+    }
+
+    #[test]
+    fn classify_404_maps_to_not_found() {
+        let err = crate::error::WorkerError::LlmProxyFailed {
+            reason: "mcp secret get: orchestrator returned 404 Not Found: ".to_string(),
+        };
+        let result = classify_worker_error("my_secret", err);
+        assert!(matches!(result, SecretError::NotFound(ref name) if name == "my_secret"));
+    }
+
+    #[test]
+    fn classify_503_maps_to_unavailable() {
+        let err = crate::error::WorkerError::LlmProxyFailed {
+            reason: "mcp secret get: orchestrator returned 503 Service Unavailable: ".to_string(),
+        };
+        let result = classify_worker_error("my_secret", err);
+        assert!(
+            matches!(result, SecretError::Database(ref msg) if msg == "secrets store unavailable")
+        );
+    }
+
+    #[test]
+    fn classify_other_maps_to_database_with_name() {
+        let err = crate::error::WorkerError::LlmProxyFailed {
+            reason: "mcp secret get: connection refused".to_string(),
+        };
+        let result = classify_worker_error("my_secret", err);
+        assert!(matches!(result, SecretError::Database(ref msg) if msg.starts_with("my_secret:")));
+    }
+
+    #[test]
+    fn classify_body_containing_403_does_not_misclassify() {
+        // Body contains "403" but the status is 500 — should NOT match AccessDenied.
+        let err = crate::error::WorkerError::LlmProxyFailed {
+            reason: "mcp secret get: orchestrator returned 500 Internal Server Error: error code 403 in upstream".to_string(),
+        };
+        let result = classify_worker_error("my_secret", err);
+        assert!(matches!(result, SecretError::Database(_)));
+    }
+}


### PR DESCRIPTION
## Summary

- Wire up MCP client lifecycle inside Docker container workers so sandboxed jobs can use MCP tools (including OAuth-authenticated servers)
- Add `ProxySecretsStore` that proxies secrets operations to the orchestrator, enabling MCP OAuth token refresh inside containers
- Add 3 new orchestrator endpoints (`/mcp/secrets/{get,exists,create}`) gated by per-job exact-match `HashSet` allowlist
- Make `mcp_config_path` configurable and inject `IRONCLAW_USER_ID` into container env

Closes #2180

## Security model

Closed-world allowlist: at job creation, the orchestrator pre-computes the exhaustive set of permitted MCP secret names (5 per OAuth server) from the mounted config. The `HashSet` is stored in `TokenStore` and checked on every request — no prefix matching, no string parsing. Revoked automatically on job cleanup.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib` — 4352 passed, 0 failed
- [x] Manual: create sandboxed job with `mcp_servers` param, verify MCP tools appear in agent loop
- [x] Manual: create sandboxed job with OAuth MCP server, verify token refresh works