### PR TITLE
fix(bridge): sanitize auth_url on engine v2 path (#2206)

### DIFF
--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1306,15 +1306,7 @@ fn normalize_extension_name(value: Option<&str>) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-/// Only allow `https://` URLs for auth/setup links to prevent scheme injection
-/// (e.g. `javascript:`, `file://`). Host validation is explicitly out of scope:
-/// the URL source is a trusted local extension tool result, and display-side
-/// rendering controls where the user is actually navigated.
-fn sanitize_auth_url(url: Option<&str>) -> Option<String> {
-    url.map(str::trim)
-        .filter(|u| u.starts_with("https://"))
-        .map(ToOwned::to_owned)
-}
+pub(super) use crate::auth::oauth::sanitize_auth_url;
 
 pub(super) fn auth_instructions_or_default(instructions: Option<&str>) -> String {
     instructions
@@ -1692,8 +1684,7 @@ mod tests {
 
     use super::{
         capture_auth_prompt, check_auth_required, extract_auth_prompt, parse_auth_result,
-        persist_selected_auth_prompt, restore_selected_auth_prompt, sanitize_auth_url,
-        selected_model_override,
+        persist_selected_auth_prompt, restore_selected_auth_prompt, selected_model_override,
     };
     use crate::agent::session::PendingAuthPrompt;
 
@@ -2413,23 +2404,9 @@ mod tests {
         assert!(extract_auth_prompt("tool_activate", &result).is_none());
     }
 
-    #[test]
-    fn test_sanitize_auth_url_rejects_non_https_schemes() {
-        assert!(sanitize_auth_url(Some("javascript:alert(1)")).is_none());
-        assert!(sanitize_auth_url(Some("file:///etc/passwd")).is_none());
-        assert!(sanitize_auth_url(Some("http://example.com")).is_none());
-        assert!(sanitize_auth_url(Some("data:text/html,<h1>")).is_none());
-        assert!(sanitize_auth_url(Some("")).is_none());
-        assert!(sanitize_auth_url(None).is_none());
-    }
-
-    #[test]
-    fn test_sanitize_auth_url_allows_https() {
-        assert_eq!(
-            sanitize_auth_url(Some("https://accounts.google.com/o/oauth2/auth")),
-            Some("https://accounts.google.com/o/oauth2/auth".to_string())
-        );
-    }
+    // Helper-level sanitize_auth_url tests live alongside the helper itself
+    // in `crate::auth::oauth`. The test below covers the parse_auth_result
+    // wiring (i.e. that the helper is actually applied at the call site).
 
     #[test]
     fn test_parse_auth_result_strips_non_https_urls() {

--- a/src/auth/oauth.rs
+++ b/src/auth/oauth.rs
@@ -32,6 +32,52 @@ pub use crate::llm::oauth_helpers::{
 
 // ── Shared OAuth flow steps ─────────────────────────────────────────
 
+/// Only allow `https://` URLs for auth/setup links to prevent scheme injection
+/// (e.g. `javascript:`, `file://`). Host validation is explicitly out of scope:
+/// the URL source is a trusted local extension tool result, and display-side
+/// rendering controls where the user is actually navigated.
+///
+/// Both the v1 dispatcher (`src/agent/dispatcher.rs`) and the v2 effect adapter
+/// (`src/bridge/effect_adapter.rs`) call this on every `auth_url` extracted
+/// from `tool_activate`/`tool_auth` output before surfacing it to the client.
+/// Keeping the helper in one place ensures the v1/v2 invariants stay symmetric.
+pub(crate) fn sanitize_auth_url(url: Option<&str>) -> Option<String> {
+    url.map(str::trim)
+        .filter(|u| u.starts_with("https://"))
+        .map(ToOwned::to_owned)
+}
+
+#[cfg(test)]
+mod sanitize_tests {
+    use super::sanitize_auth_url;
+
+    #[test]
+    fn rejects_non_https_schemes() {
+        assert!(sanitize_auth_url(Some("javascript:alert(1)")).is_none());
+        assert!(sanitize_auth_url(Some("file:///etc/passwd")).is_none());
+        assert!(sanitize_auth_url(Some("http://example.com")).is_none());
+        assert!(sanitize_auth_url(Some("data:text/html,<h1>")).is_none());
+        assert!(sanitize_auth_url(Some("")).is_none());
+        assert!(sanitize_auth_url(None).is_none());
+    }
+
+    #[test]
+    fn allows_https() {
+        assert_eq!(
+            sanitize_auth_url(Some("https://accounts.google.com/o/oauth2/auth")),
+            Some("https://accounts.google.com/o/oauth2/auth".to_string())
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_before_validating_scheme() {
+        assert_eq!(
+            sanitize_auth_url(Some("  https://example.com/auth  ")),
+            Some("https://example.com/auth".to_string())
+        );
+    }
+}
+
 /// Truncate `body` to at most `max_bytes` UTF-8 bytes, walking back to the
 /// nearest char boundary so the result is always a valid `&str`. Appends
 /// `"..."` when truncation actually happens. Used to bound any

--- a/src/bridge/auth_manager.rs
+++ b/src/bridge/auth_manager.rs
@@ -296,8 +296,9 @@ impl AuthManager {
                 ToolReadiness::NeedsAuth {
                     credential_name: described.credential_name,
                     instructions,
-                    auth_url: crate::auth::oauth::sanitize_auth_url(auth.auth_url())
-                        .or(described.auth_url),
+                    auth_url: crate::auth::oauth::sanitize_auth_url(auth.auth_url()).or_else(
+                        || crate::auth::oauth::sanitize_auth_url(described.auth_url.as_deref()),
+                    ),
                 }
             }
             Ok(crate::extensions::EnsureReadyOutcome::NeedsSetup { instructions, .. }) => {

--- a/src/bridge/auth_manager.rs
+++ b/src/bridge/auth_manager.rs
@@ -296,9 +296,7 @@ impl AuthManager {
                 ToolReadiness::NeedsAuth {
                     credential_name: described.credential_name,
                     instructions,
-                    auth_url: auth
-                        .auth_url()
-                        .map(ToOwned::to_owned)
+                    auth_url: crate::auth::oauth::sanitize_auth_url(auth.auth_url())
                         .or(described.auth_url),
                 }
             }
@@ -378,7 +376,7 @@ impl AuthManager {
                         .instructions()
                         .unwrap_or("Complete authentication to continue.")
                         .to_string(),
-                    auth_url: auth.auth_url().map(ToOwned::to_owned),
+                    auth_url: crate::auth::oauth::sanitize_auth_url(auth.auth_url()),
                 }),
                 Ok(crate::extensions::EnsureReadyOutcome::NeedsSetup { instructions, .. }) => {
                     Ok(LatentActionExecution::NeedsSetup {

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -19,6 +19,7 @@ use ironclaw_engine::{
     ActionDef, ActionResult, CapabilityLease, EffectExecutor, EngineError, ThreadExecutionContext,
 };
 
+use crate::auth::oauth::sanitize_auth_url;
 use crate::bridge::auth_manager::{AuthCheckResult, AuthManager};
 use crate::bridge::router::synthetic_action_call_id;
 use crate::context::JobContext;
@@ -166,10 +167,9 @@ impl EffectBridgeAdapter {
                         .and_then(|v| v.as_str())
                         .unwrap_or("Complete authentication to continue.")
                         .to_string(),
-                    auth_url: output_value
-                        .get("auth_url")
-                        .and_then(|v| v.as_str())
-                        .map(|s| s.to_string()),
+                    auth_url: sanitize_auth_url(
+                        output_value.get("auth_url").and_then(|v| v.as_str()),
+                    ),
                 },
                 None,
             )),
@@ -667,7 +667,7 @@ impl EffectBridgeAdapter {
                             instructions: cred.setup_instructions.clone().unwrap_or_else(|| {
                                 format!("Provide your {} token", cred.credential_name)
                             }),
-                            auth_url: cred.auth_url.clone(),
+                            auth_url: sanitize_auth_url(cred.auth_url.as_deref()),
                         },
                         None,
                     ));
@@ -708,7 +708,7 @@ impl EffectBridgeAdapter {
                             instructions: instructions.unwrap_or_else(|| {
                                 format!("Authenticate '{}' to continue.", provider_extension)
                             }),
-                            auth_url,
+                            auth_url: sanitize_auth_url(auth_url.as_deref()),
                         },
                         None,
                     ));
@@ -885,7 +885,7 @@ impl EffectBridgeAdapter {
                                     instructions: instructions.unwrap_or_else(|| {
                                         auth_mgr.get_setup_instructions_or_default(&credential_name)
                                     }),
-                                    auth_url,
+                                    auth_url: sanitize_auth_url(auth_url.as_deref()),
                                 },
                                 Some(output_value),
                             ));
@@ -1817,6 +1817,184 @@ mod tests {
             )
             .await;
         assert!(matches!(third, Err(EngineError::GatePaused { .. })));
+    }
+
+    /// Regression for nearai/ironclaw#2206: a `tool_activate`/`tool_auth`
+    /// extension result containing a non-https `auth_url` (e.g.
+    /// `javascript:alert(1)`) must be sanitized to `None` before it reaches
+    /// `ResumeKind::Authentication` and is forwarded onto the gate stream.
+    ///
+    /// This test deliberately drives `EffectBridgeAdapter::execute_action`
+    /// (the call site) instead of `auth_gate_from_extension_result` in
+    /// isolation, per the "Test Through the Caller, Not Just the Helper"
+    /// rule in `.claude/rules/testing.md`.
+    #[tokio::test]
+    async fn auth_gate_strips_non_https_auth_url_from_tool_activate_output() {
+        use ironclaw_safety::SafetyConfig;
+
+        struct OAuthPromptTool;
+
+        #[async_trait]
+        impl Tool for OAuthPromptTool {
+            fn name(&self) -> &str {
+                "tool_activate"
+            }
+
+            fn description(&self) -> &str {
+                "Test stub for tool_activate that returns a malicious auth_url"
+            }
+
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                Ok(ToolOutput::success(
+                    serde_json::json!({
+                        "status": "awaiting_authorization",
+                        "name": "evil_ext",
+                        "instructions": "Complete sign-in",
+                        "auth_url": "javascript:alert(1)",
+                    }),
+                    std::time::Duration::from_millis(1),
+                ))
+            }
+
+            fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+                ApprovalRequirement::Never
+            }
+        }
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(OAuthPromptTool)).await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        );
+
+        let result = adapter
+            .execute_action(
+                "tool_activate",
+                serde_json::json!({}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_auth_url_sanitize"),
+                ),
+            )
+            .await;
+
+        match result {
+            Err(EngineError::GatePaused {
+                gate_name,
+                resume_kind,
+                ..
+            }) => {
+                assert_eq!(gate_name, "authentication");
+                match *resume_kind {
+                    ironclaw_engine::ResumeKind::Authentication { auth_url, .. } => {
+                        assert!(
+                            auth_url.is_none(),
+                            "javascript: auth_url must be stripped before reaching ResumeKind, got {auth_url:?}"
+                        );
+                    }
+                    other => panic!("expected Authentication resume kind, got {other:?}"),
+                }
+            }
+            other => {
+                panic!("expected GatePaused(authentication), got {other:?}")
+            }
+        }
+    }
+
+    /// Sibling regression: a well-formed `https://` auth_url must still
+    /// flow through unmodified. Guards against an over-eager sanitizer.
+    #[tokio::test]
+    async fn auth_gate_preserves_https_auth_url_from_tool_activate_output() {
+        use ironclaw_safety::SafetyConfig;
+
+        struct OAuthPromptTool;
+
+        #[async_trait]
+        impl Tool for OAuthPromptTool {
+            fn name(&self) -> &str {
+                "tool_activate"
+            }
+
+            fn description(&self) -> &str {
+                "Test stub for tool_activate that returns a valid auth_url"
+            }
+
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &JobContext,
+            ) -> Result<ToolOutput, ToolError> {
+                Ok(ToolOutput::success(
+                    serde_json::json!({
+                        "status": "awaiting_authorization",
+                        "name": "good_ext",
+                        "instructions": "Complete sign-in",
+                        "auth_url": "https://accounts.google.com/o/oauth2/auth",
+                    }),
+                    std::time::Duration::from_millis(1),
+                ))
+            }
+
+            fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+                ApprovalRequirement::Never
+            }
+        }
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(OAuthPromptTool)).await;
+
+        let adapter = EffectBridgeAdapter::new(
+            tools,
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        );
+
+        let result = adapter
+            .execute_action(
+                "tool_activate",
+                serde_json::json!({}),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_auth_url_passthrough"),
+                ),
+            )
+            .await;
+
+        match result {
+            Err(EngineError::GatePaused { resume_kind, .. }) => match *resume_kind {
+                ironclaw_engine::ResumeKind::Authentication { auth_url, .. } => {
+                    assert_eq!(
+                        auth_url.as_deref(),
+                        Some("https://accounts.google.com/o/oauth2/auth"),
+                    );
+                }
+                other => panic!("expected Authentication resume kind, got {other:?}"),
+            },
+            other => panic!("expected GatePaused(authentication), got {other:?}"),
+        }
     }
 
     // ── routine→mission alias tests ────────────────────────────

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -595,7 +595,7 @@ impl EffectBridgeAdapter {
                         ironclaw_engine::ResumeKind::Authentication {
                             credential_name,
                             instructions,
-                            auth_url,
+                            auth_url: sanitize_auth_url(auth_url.as_deref()),
                         },
                         None,
                     ));


### PR DESCRIPTION
## Summary

Closes #2206. The engine-v2 effect adapter forwarded `auth_url` from `tool_activate`/`tool_auth` output (and from the v2 pre-flight auth gates) directly into `ResumeKind::Authentication` without scheme validation, leaving the v2 path open to `javascript:`, `file://`, `http://`, and `data:` URLs from a buggy or compromised local extension. The v1 dispatcher already had a private `sanitize_auth_url` helper from #2038; v2 was the asymmetry.

- Promoted `sanitize_auth_url` to `crate::auth::oauth` as `pub(crate)`, dropped the private copy in `agent::dispatcher`, and re-exported it so the v1 invariant is unchanged.
- Applied it at every v2 site that builds an `auth_url` from runtime data:
  - `effect_adapter::auth_gate_from_extension_result` (post-exec)
  - `effect_adapter` `tool_install` post-readiness branch
  - `effect_adapter` `check_action_auth` pre-flight gate
  - `effect_adapter` `check_tool_readiness` pre-flight gate
  - `auth_manager::check_tool_readiness` (extension `auth.auth_url()`)
  - `auth_manager::execute_latent_extension_action`
- Host validation stays out of scope, matching v1's documented invariant.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 4520 passed
- [x] New regression `bridge::effect_adapter::tests::auth_gate_strips_non_https_auth_url_from_tool_activate_output` drives `EffectBridgeAdapter::execute_action` with an `OAuthPromptTool` stub returning `auth_url: "javascript:alert(1)"` and asserts the resulting `ResumeKind::Authentication.auth_url` is `None` (per the "Test Through the Caller, Not Just the Helper" rule in `.claude/rules/testing.md`).
- [x] Sibling test `auth_gate_preserves_https_auth_url_from_tool_activate_output` guards against an over-eager sanitizer by asserting a well-formed `https://` URL still flows through.
- [x] Helper-level tests live next to the helper in `crate::auth::oauth::sanitize_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)