### PR TITLE
fix(docs): explain in more details `activation` block & installation steps for skills

### DIFF
--- a/docs/capabilities/skills.mdx
+++ b/docs/capabilities/skills.mdx
@@ -68,7 +68,7 @@ Skills pass through four stages before injection:
     | `patterns`           | Regex patterns. Each match adds significant weight — use for intent-specific phrases.           |
     | `tags`               | Short labels for broad domain matching (e.g. `blockchain`, `cli`).                             |
     | `exclude_keywords`   | Veto list — if any appear in the message, the skill scores zero regardless of other matches.    |
-    | `max_context_tokens` | Token budget this skill may consume per turn. Omitting it leaves the skill with a 1-token budget, effectively excluding it. |
+    | `max_context_tokens` | Token budget this skill may consume per turn. Omitting it leaves the skill with a 2000-token budget, effectively excluding it. |
 
     <Tip>
     If a skill appears in `ironclaw skills list` but the agent doesn't use it, the most common cause is a missing or empty `activation` block.

--- a/docs/capabilities/skills.mdx
+++ b/docs/capabilities/skills.mdx
@@ -35,6 +35,45 @@ Skills pass through four stages before injection:
 
   <Step title="Score">
     Each gated skill is scored against the current message using a deterministic algorithm: keyword matches, tag overlaps, and regex pattern matches. Higher scores indicate stronger relevance.
+
+    Scoring is fully deterministic — no LLM involved. A skill must declare its activation criteria in the frontmatter so the scorer knows what to match.
+
+    <Warning>
+    A skill without an `activation` block scores zero on every message and is never injected.
+    </Warning>
+
+    ```yaml
+    ---
+    name: my-skill
+    version: 0.1.0
+    description: Short description shown in skill list
+    activation:
+      keywords:
+        - deploy
+        - rollback
+      patterns:
+        - "deploy to.*production"
+        - "rollback.*release"
+      tags:
+        - devops
+      exclude_keywords:
+        - dry-run
+      max_context_tokens: 2000
+    ---
+    ```
+
+    | Field                | Purpose                                                                                         |
+    |----------------------|-------------------------------------------------------------------------------------------------|
+    | `keywords`           | Word or phrase matches. Exact word match scores higher than substring.                          |
+    | `patterns`           | Regex patterns. Each match adds significant weight — use for intent-specific phrases.           |
+    | `tags`               | Short labels for broad domain matching (e.g. `blockchain`, `cli`).                             |
+    | `exclude_keywords`   | Veto list — if any appear in the message, the skill scores zero regardless of other matches.    |
+    | `max_context_tokens` | Token budget this skill may consume per turn. Omitting it leaves the skill with a 1-token budget, effectively excluding it. |
+
+    <Tip>
+    If a skill appears in `ironclaw skills list` but the agent doesn't use it, the most common cause is a missing or empty `activation` block.
+    </Tip>
+
   </Step>
 
   <Step title="Budget">
@@ -72,6 +111,22 @@ IronClaw discovers skills from three locations, checked in order:
 | `~/.ironclaw/installed_skills/` | Installed | Registry-installed skills from ClawHub                      |
 
 Skills in trusted directories are loaded as-is. Skills in `installed_skills/` have their tool access capped by the attenuation layer regardless of what they declare.
+
+Each skill lives in its own subdirectory named after the skill:
+
+```
+~/.ironclaw/skills/
+└── my-skill/
+    └── SKILL.md
+```
+
+To verify that a skill was picked up correctly:
+
+```bash
+ironclaw skills list
+```
+
+A correctly installed skill appears with its name, version, and trust level. If a skill is missing from the list, check the directory structure and SKILL.md validity.
 
 ---
 


### PR DESCRIPTION
## Summary

<!-- 2-5 bullet points: what changed and why -->

The skills doc was missing concrete installation instructions (correct path and how to verify) and an explanation of why the `activation` block is required for the agent to ever pick up a skill.

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
