### PR TITLE
feat(railway): build staging target with pre-bundled WASM extensions

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "dockerfile"
+dockerfilePath = "Dockerfile"
+target = "runtime-staging"
+
+[deploy]
+healthcheckPath = "/api/health"
+healthcheckTimeout = 300
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

- Adds `railway.toml` with `target = "runtime-staging"` so Railway builds the Docker target that includes all pre-built WASM tool/channel extensions
- Depends on the `runtime-staging` Dockerfile target added in #2210

Without this, Railway runs a bare `docker build .` which builds the last stage (`runtime` — no extensions). With `target = "runtime-staging"`, Railway builds the staging target that includes `.wasm` files in `~/.ironclaw/{tools,channels}/`.

## Test plan

- [ ] Push to staging and confirm Railway triggers a deploy
- [ ] Check Railway build logs for `=== Building ... ===` lines from the wasm-builder stage
- [ ] Verify the app at `ironclaw-production-near-ai.up.railway.app` is healthy via `/api/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)