### PR TITLE
fix(tools): normalize hyphens to underscores in MCP/WASM tool names

### DIFF
--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -223,7 +223,7 @@ impl WasmChannelLoader {
             }
 
             let name = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(n) => n.to_string(),
+                Some(n) => n.replace('-', "_"),
                 None => {
                     results.errors.push((
                         path.clone(),
@@ -233,6 +233,8 @@ impl WasmChannelLoader {
                 }
             };
 
+            // Look up capabilities using the original filename (before
+            // hyphen normalization) so existing sidecar files are found.
             let cap_path = path.with_extension("capabilities.json");
             let has_cap = cap_path.exists();
             channel_entries.push((name, path, if has_cap { Some(cap_path) } else { None }));

--- a/src/channels/wasm/loader.rs
+++ b/src/channels/wasm/loader.rs
@@ -384,7 +384,7 @@ pub async fn discover_channels(
         }
 
         let name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(n) => n.to_string(),
+            Some(n) => n.replace('-', "_"),
             None => continue,
         };
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -5181,10 +5181,7 @@ impl ExtensionManager {
             .await
             .map_err(|e| ExtensionError::ActivationFailed(e.to_string()))?;
 
-        let tool_names: Vec<String> = mcp_tools
-            .iter()
-            .map(|t| format!("{}_{}", name, t.name))
-            .collect();
+        let tool_names: Vec<String> = tool_impls.iter().map(|t| t.name().to_string()).collect();
 
         for tool in tool_impls {
             self.tool_registry.register(tool).await;

--- a/src/tools/mcp/auth.rs
+++ b/src/tools/mcp/auth.rs
@@ -1194,7 +1194,16 @@ pub async fn is_authenticated(
     .await
     {
         Ok(Some(_)) => true,
-        Ok(None) => false,
+        Ok(None) => {
+            // Fall back to legacy (pre-hyphen-normalization) secret name
+            // so existing users with tokens stored under hyphenated server
+            // names are not forced to re-authenticate after upgrade.
+            if let Some(legacy_name) = server_config.legacy_token_secret_name() {
+                secrets.get_decrypted(user_id, &legacy_name).await.is_ok()
+            } else {
+                false
+            }
+        }
         Err(error) => {
             tracing::warn!(server = %server_config.name, error = %error, "Failed to read access token");
             false

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -126,7 +126,7 @@ impl McpClient {
     ///
     /// Use this when you have a configured server name but no authentication.
     pub fn new_with_name(server_name: impl Into<String>, server_url: impl Into<String>) -> Self {
-        let name: String = server_name.into();
+        let name: String = server_name.into().replace('-', "_");
         let url: String = server_url.into();
         let transport = Arc::new(HttpMcpTransport::new(url.clone(), name.clone()));
 
@@ -819,7 +819,7 @@ mod tests {
     #[test]
     fn test_new_with_name_uses_custom_name() {
         let client = McpClient::new_with_name("my-server", "http://localhost:8080");
-        assert_eq!(client.server_name(), "my-server");
+        assert_eq!(client.server_name(), "my_server");
         assert_eq!(client.server_url(), "http://localhost:8080");
         assert_eq!(client.user_id, "<unset>");
         assert!(client.session_manager.is_none());
@@ -846,7 +846,7 @@ mod tests {
         client.next_request_id();
         let cloned = client.clone();
         assert_eq!(cloned.server_url(), "http://localhost:5555");
-        assert_eq!(cloned.server_name(), "cloned-server");
+        assert_eq!(cloned.server_name(), "cloned_server");
         assert_eq!(cloned.user_id, "<unset>");
         assert_eq!(cloned.next_id.load(Ordering::SeqCst), 3);
     }

--- a/src/tools/mcp/client.rs
+++ b/src/tools/mcp/client.rs
@@ -599,7 +599,7 @@ impl McpClient {
         Ok(mcp_tools
             .into_iter()
             .map(|t| {
-                let prefixed_name = format!("{}_{}", self.server_name, t.name);
+                let prefixed_name = format!("{}_{}", self.server_name, t.name).replace('-', "_");
                 Arc::new(McpToolWrapper {
                     tool: t,
                     prefixed_name,
@@ -1381,6 +1381,34 @@ mod tests {
         };
         let approval = wrapper.requires_approval(&serde_json::json!({}));
         assert_eq!(approval, ApprovalRequirement::Never);
+    }
+
+    /// Regression test: MCP tool prefixed names must normalise hyphens to
+    /// underscores so that LLM providers that strip hyphens can still resolve
+    /// tool calls back to the registered name.
+    #[tokio::test]
+    async fn test_create_tools_normalises_hyphens_in_prefixed_name() {
+        // Build a client whose server_name contains no hyphens (factory
+        // already normalises it) and feed it a tool list with hyphenated
+        // tool names — the prefixed name must be fully underscored.
+        let client = McpClient::new_with_name("notion", "http://localhost:9999");
+
+        // Manually populate the tools cache with a hyphenated tool name.
+        let hyphenated_tool = McpTool {
+            name: "notion-search".to_string(),
+            description: "Search".to_string(),
+            input_schema: serde_json::json!({"type": "object"}),
+            annotations: None,
+        };
+        *client.tools_cache.write().await = Some(vec![hyphenated_tool]);
+
+        let tools = client.create_tools().await.expect("create_tools");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(
+            tools[0].name(),
+            "notion_notion_search",
+            "Hyphens in MCP tool names must be replaced with underscores"
+        );
     }
 
     // Regression test: empty/whitespace-only tokens must not produce a

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -275,6 +275,21 @@ impl McpServerConfig {
         format!("{}_refresh_token", self.token_secret_name())
     }
 
+    /// Legacy secret name for access tokens (pre-hyphen-normalization).
+    ///
+    /// Before the factory normalised server names (hyphens→underscores),
+    /// tokens were stored under the original hyphenated name.  Used as a
+    /// fallback during lookup to avoid forcing re-auth on existing users.
+    /// Returns `None` when the name contains no underscores (nothing to
+    /// reverse).
+    pub fn legacy_token_secret_name(&self) -> Option<String> {
+        let hyphenated = self.name.replace('_', "-");
+        if hyphenated == self.name {
+            return None;
+        }
+        Some(format!("mcp_{}_access_token", hyphenated))
+    }
+
     /// Legacy secret name for refresh tokens (pre-v0.22).
     ///
     /// Earlier versions stored refresh tokens as `mcp_{name}_refresh_token`

--- a/src/tools/mcp/factory.rs
+++ b/src/tools/mcp/factory.rs
@@ -26,12 +26,18 @@ pub enum McpFactoryError {
 /// Create an `McpClient` from a server configuration, dispatching on the
 /// effective transport type.
 pub async fn create_client_from_config(
-    server: McpServerConfig,
+    mut server: McpServerConfig,
     session_manager: &Arc<McpSessionManager>,
     process_manager: &Arc<McpProcessManager>,
     secrets: Option<Arc<dyn SecretsStore + Send + Sync>>,
     user_id: &str,
 ) -> Result<McpClient, McpFactoryError> {
+    // Normalize hyphens to underscores in the server name so that all code
+    // paths (Stdio, Unix, HTTP, OAuth) produce consistently underscore-only
+    // tool prefixes.  This must happen before any branch so that the OAuth
+    // early-return via `McpClient::new_authenticated(server, ..)` also
+    // receives the normalised name.
+    server.name = server.name.replace('-', "_");
     let server_name = server.name.clone();
 
     match server.effective_transport() {
@@ -99,11 +105,11 @@ pub async fn create_client_from_config(
             // the client (via `with_session_manager`) is not enough — the
             // transport must know about it to read/write the header.
             let transport = Arc::new(
-                HttpMcpTransport::new(server.url.clone(), server.name.clone())
+                HttpMcpTransport::new(server.url.clone(), server_name.clone())
                     .with_session_manager(Arc::clone(session_manager)),
             );
             Ok(McpClient::new_with_transport(
-                server.name.clone(),
+                server_name,
                 transport,
                 Some(Arc::clone(session_manager)),
                 secrets,
@@ -371,7 +377,9 @@ mod tests {
 
         // Pre-create a session entry so that update_session_id has something to update.
         // In production, the MCP initialize handshake calls get_or_create before responses arrive.
-        session_manager.get_or_create("session-test", &url).await;
+        // Use the normalised server name (hyphens → underscores) that the factory applies.
+        let normalised_name = "session_test";
+        session_manager.get_or_create(normalised_name, &url).await;
 
         // Send a request through the client's transport to trigger session capture.
         use crate::tools::mcp::protocol::McpRequest;
@@ -389,11 +397,37 @@ mod tests {
             .expect("request should succeed");
 
         // Verify the session manager captured the session ID from the response.
-        let captured = session_manager.get_session_id("session-test").await;
+        let captured = session_manager.get_session_id(normalised_name).await;
         assert_eq!(
             captured.as_deref(),
             Some(SESSION_ID),
             "transport must capture Mcp-Session-Id into session manager"
+        );
+    }
+
+    /// Regression test: factory must normalise hyphens in server names so
+    /// the McpClient.server_name is always underscore-only, matching the
+    /// canonicalised name used by ExtensionManager::activate_mcp().
+    #[tokio::test]
+    async fn test_factory_normalises_server_name_hyphens() {
+        let server = McpServerConfig::new("my-mcp-server", "http://localhost:9999");
+        let session_manager = Arc::new(McpSessionManager::new());
+        let process_manager = Arc::new(McpProcessManager::new());
+
+        let client = create_client_from_config(
+            server,
+            &session_manager,
+            &process_manager,
+            None,
+            "test-user",
+        )
+        .await
+        .expect("factory should succeed");
+
+        assert_eq!(
+            client.server_name(),
+            "my_mcp_server",
+            "Hyphens in server name must be replaced with underscores"
         );
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -278,15 +278,45 @@ impl ToolRegistry {
         }
     }
 
-    /// Unregister a tool.
+    /// Resolve a tool name to the key under which it is registered,
+    /// trying the exact name first, then hyphen→underscore and
+    /// underscore→hyphen aliases.
+    fn resolve_key(tools: &HashMap<String, Arc<dyn Tool>>, name: &str) -> Option<String> {
+        if tools.contains_key(name) {
+            return Some(name.to_string());
+        }
+        // Reverse alias: hyphens → underscores (LLM normalization)
+        let underscore_alias = name.replace('-', "_");
+        if underscore_alias != name && tools.contains_key(&underscore_alias) {
+            return Some(underscore_alias);
+        }
+        // Legacy alias: underscores → hyphens (older WASM extensions)
+        let hyphen_alias = name.replace('_', "-");
+        if hyphen_alias != name && tools.contains_key(&hyphen_alias) {
+            return Some(hyphen_alias);
+        }
+        None
+    }
+
+    /// Unregister a tool.  Uses the same alias resolution as `get()` so
+    /// callers that pass hyphenated names still find underscore-registered
+    /// tools.
     pub async fn unregister(&self, name: &str) -> Option<Arc<dyn Tool>> {
-        self.tools.write().await.remove(name)
+        let mut tools = self.tools.write().await;
+        let key = Self::resolve_key(&tools, name)?;
+        tools.remove(&key)
     }
 
     /// Get a tool by name.
+    ///
+    /// Falls back to a hyphen→underscore alias when the exact name is not
+    /// found, so that tool calls from LLM providers that normalise hyphens
+    /// (e.g. `notion_notion_search` vs the registered `notion_notion-search`)
+    /// still resolve correctly.
     pub async fn get(&self, name: &str) -> Option<Arc<dyn Tool>> {
         let tools = self.tools.read().await;
-        tools.get(name).map(Arc::clone)
+        let key = Self::resolve_key(&tools, name)?;
+        tools.get(&key).map(Arc::clone)
     }
 
     /// Resolve a caller-provided action/tool name to the registered tool id.
@@ -320,7 +350,7 @@ impl ToolRegistry {
 
     /// Check if a tool exists.
     pub async fn has(&self, name: &str) -> bool {
-        self.tools.read().await.contains_key(name)
+        self.get(name).await.is_some()
     }
 
     /// List tool names visible in the current engine version.
@@ -1548,5 +1578,79 @@ mod tests {
 
         assert!(names.contains(&"echo"));
         assert!(!names.contains(&"v1_only_stub"));
+    }
+
+    /// Regression test: tool names with hyphens must be resolvable when the
+    /// LLM provider normalises hyphens to underscores (nearai/ironclaw#NNN).
+    #[tokio::test]
+    async fn get_resolves_hyphen_to_underscore_alias() {
+        let registry = ToolRegistry::new();
+        registry.register(Arc::new(EchoTool)).await;
+
+        // Register a tool whose name contains underscores (the normalised
+        // form produced by the MCP prefixed-name fix).
+        struct UnderscoreTool;
+        #[async_trait::async_trait]
+        impl Tool for UnderscoreTool {
+            fn name(&self) -> &str {
+                "notion_notion_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(UnderscoreTool)).await;
+
+        // Exact match works
+        assert!(registry.get("notion_notion_search").await.is_some());
+        // Hyphenated variant resolves via alias
+        assert!(registry.get("notion_notion-search").await.is_some());
+        // has() also resolves
+        assert!(registry.has("notion_notion-search").await);
+        // Completely wrong name still fails
+        assert!(registry.get("nonexistent_tool").await.is_none());
+    }
+
+    /// Regression test: legacy underscore→hyphen alias still works.
+    #[tokio::test]
+    async fn get_resolves_underscore_to_hyphen_alias() {
+        let registry = ToolRegistry::new();
+
+        struct HyphenTool;
+        #[async_trait::async_trait]
+        impl Tool for HyphenTool {
+            fn name(&self) -> &str {
+                "my-old-tool"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(HyphenTool)).await;
+
+        // Exact hyphenated match works
+        assert!(registry.get("my-old-tool").await.is_some());
+        // Underscored variant resolves via legacy alias
+        assert!(registry.get("my_old_tool").await.is_some());
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -321,30 +321,27 @@ impl ToolRegistry {
 
     /// Resolve a caller-provided action/tool name to the registered tool id.
     ///
-    /// The runtime is converging on `snake_case` names. Hyphenated names remain
-    /// accepted here only as a compatibility alias for older installed tools.
+    /// Tries exact match first, then hyphen→underscore (LLM normalization),
+    /// then underscore→hyphen (legacy WASM extensions).
     pub async fn resolve_name(&self, name: &str) -> Option<String> {
         let tools = self.tools.read().await;
-        if tools.contains_key(name) {
-            return Some(name.to_string());
-        }
-        crate::extensions::naming::legacy_extension_alias(name)
-            .filter(|alias| tools.contains_key(alias))
+        Self::resolve_key(&tools, name)
     }
 
     pub async fn get_resolved(&self, name: &str) -> Option<(String, Arc<dyn Tool>)> {
-        let resolved = self.resolve_name(name).await?;
-        let tool = self.get(&resolved).await?;
-        Some((resolved, tool))
+        let tools = self.tools.read().await;
+        let key = Self::resolve_key(&tools, name)?;
+        let tool = tools.get(&key).map(Arc::clone)?;
+        Some((key, tool))
     }
 
     /// Resolve a tool/action name to its owning provider extension, when the
     /// action is extension-backed.
     pub async fn provider_extension_for_tool(&self, name: &str) -> Option<String> {
-        let resolved = self.resolve_name(name).await?;
         let tools = self.tools.read().await;
+        let key = Self::resolve_key(&tools, name)?;
         tools
-            .get(&resolved)
+            .get(&key)
             .and_then(|tool| tool.provider_extension().map(ToOwned::to_owned))
     }
 
@@ -430,7 +427,10 @@ impl ToolRegistry {
         let tools = self.tools.read().await;
         names
             .iter()
-            .filter_map(|name| tools.get(*name).map(Self::tool_definition))
+            .filter_map(|name| {
+                let key = Self::resolve_key(&tools, name)?;
+                tools.get(&key).map(Self::tool_definition)
+            })
             .collect()
     }
 
@@ -1652,5 +1652,74 @@ mod tests {
         assert!(registry.get("my-old-tool").await.is_some());
         // Underscored variant resolves via legacy alias
         assert!(registry.get("my_old_tool").await.is_some());
+    }
+
+    /// Regression test: get_resolved must use resolve_key so that dispatch,
+    /// approval gate, and effect adapter all resolve hyphenated names.
+    #[tokio::test]
+    async fn get_resolved_hyphen_to_underscore() {
+        let registry = ToolRegistry::new();
+
+        struct UnderscoreTool;
+        #[async_trait::async_trait]
+        impl Tool for UnderscoreTool {
+            fn name(&self) -> &str {
+                "notion_notion_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(UnderscoreTool)).await;
+
+        let (key, _) = registry
+            .get_resolved("notion_notion-search")
+            .await
+            .expect("get_resolved must resolve hyphenated name to underscore registration");
+        assert_eq!(key, "notion_notion_search");
+    }
+
+    /// Regression test: unregister with alias resolution.
+    #[tokio::test]
+    async fn unregister_resolves_hyphen_alias() {
+        let registry = ToolRegistry::new();
+
+        struct TestTool;
+        #[async_trait::async_trait]
+        impl Tool for TestTool {
+            fn name(&self) -> &str {
+                "my_mcp_search"
+            }
+            fn description(&self) -> &str {
+                "test"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+        registry.register(Arc::new(TestTool)).await;
+        assert!(registry.has("my_mcp_search").await);
+
+        // Unregister using hyphenated alias
+        let removed = registry.unregister("my-mcp-search").await;
+        assert!(removed.is_some(), "unregister must resolve hyphen alias");
+        assert!(!registry.has("my_mcp_search").await, "tool should be gone");
     }
 }

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -258,7 +258,7 @@ impl WasmToolLoader {
             }
 
             let name = match path.file_stem().and_then(|s| s.to_str()) {
-                Some(n) => n.to_string(),
+                Some(n) => n.replace('-', "_"),
                 None => {
                     results.errors.push((
                         path.clone(),
@@ -268,6 +268,8 @@ impl WasmToolLoader {
                 }
             };
 
+            // Look up capabilities using the original filename (before
+            // hyphen normalization) so existing sidecar files are found.
             let cap_path = path.with_extension("capabilities.json");
             let has_cap = cap_path.exists();
             tool_entries.push((name, path, if has_cap { Some(cap_path) } else { None }));
@@ -549,7 +551,7 @@ fn tools_src_dir() -> PathBuf {
 /// - `tools-src/<name>/target/wasm32-wasip2/release/<crate_name>_tool.wasm`
 /// - `tools-src/<name>/<name>-tool.capabilities.json`
 ///
-/// Returns a map of install-name (e.g. "gmail-tool") to paths.
+/// Returns a map of install-name (e.g. "gmail_tool") to paths.
 pub async fn discover_dev_tools() -> Result<HashMap<String, DiscoveredTool>, std::io::Error> {
     let src_dir = tools_src_dir();
     let mut tools = HashMap::new();
@@ -572,7 +574,7 @@ pub async fn discover_dev_tools() -> Result<HashMap<String, DiscoveredTool>, std
 
         // Convention: crate name uses underscores, directory uses hyphens
         let crate_name = dir_name.replace('-', "_");
-        let install_name = format!("{}-tool", dir_name);
+        let install_name = format!("{}_tool", crate_name);
 
         let wasm_path = wasm_artifact_path(&path, &format!("{}_tool", crate_name));
 

--- a/src/tools/wasm/loader.rs
+++ b/src/tools/wasm/loader.rs
@@ -701,7 +701,7 @@ pub async fn discover_tools(dir: &Path) -> Result<HashMap<String, DiscoveredTool
         }
 
         let name = match path.file_stem().and_then(|s| s.to_str()) {
-            Some(n) => n.to_string(),
+            Some(n) => n.replace('-', "_"),
             None => continue,
         };
 
@@ -887,11 +887,11 @@ mod tests {
         // If build artifacts exist, they should be discovered.
         let tools = super::discover_dev_tools().await.unwrap();
 
-        // If any tools have been built, they should appear with "-tool" suffix
+        // If any tools have been built, they should appear with "_tool" suffix
         for (name, discovered) in &tools {
             assert!(
-                name.ends_with("-tool"),
-                "Dev tool name should end with -tool: {}",
+                name.ends_with("_tool"),
+                "Dev tool name should end with _tool: {}",
                 name
             );
             assert!(


### PR DESCRIPTION
## Summary

- **Bug**: LLM providers (NEAR AI, OpenAI) normalize tool names by converting hyphens to underscores. MCP tools were registered with mixed hyphen/underscore names (e.g. `notion_notion-search`), so when the LLM called back with `notion_notion_search`, dispatch failed with "Tool not found". This broke **all** MCP tool calls through affected providers.
- **Fix**: Normalize hyphens→underscores at every tool name construction site (MCP factory, MCP client, WASM loaders), and add bidirectional alias resolution in the tool registry as defense-in-depth.
- Derives `tool_names` in `activate_mcp` from registered tool impls (single source of truth)
- Adds 4 regression tests covering MCP prefixed names, factory server name normalization, and bidirectional registry alias resolution

## Files Changed

| File | Change |
|------|--------|
| `src/tools/mcp/factory.rs` | Normalize `server.name` before any branch (including OAuth early-return) |
| `src/tools/mcp/client.rs` | `.replace('-', "_")` on prefixed tool names in `create_tools()` |
| `src/tools/registry.rs` | Extract `resolve_key()` helper; `get()`/`has()`/`unregister()` all use bidirectional alias resolution |
| `src/tools/wasm/loader.rs` | `load_from_dir` normalizes hyphenated filenames; dev tool `install_name` uses underscore convention |
| `src/channels/wasm/loader.rs` | `load_from_dir` normalizes hyphenated channel filenames |
| `src/extensions/manager.rs` | `tool_names` derived from `tool_impls` instead of re-deriving normalization |

## Test plan

- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib` — 4037 passed, 0 failed (on pre-rebase branch; CI will verify on staging)
- [x] 4 new regression tests: `get_resolves_hyphen_to_underscore_alias`, `get_resolves_underscore_to_hyphen_alias`, `test_create_tools_normalises_hyphens_in_prefixed_name`, `test_factory_normalises_server_name_hyphens`
- [ ] Manual: Connect Notion MCP → `tool_list` shows underscored names → tool calls succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)