### PR TITLE
fix(docker): add CACHE_BUST arg to wasm-builder stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN cargo build --profile dist --bin ironclaw
 
 # Stage 4b: Build all WASM extensions from source (only used by runtime-staging)
 FROM builder AS wasm-builder
+ARG CACHE_BUST
 
 RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Add `ARG CACHE_BUST` to the `wasm-builder` Dockerfile stage so Railway's Docker cache can be invalidated via service variables
- Railway was serving stale cached layers from the old `runtime` target, so the `wasm-builder` stage never ran and WASM extensions were not pre-bundled in the image

## Context
After merging #2219 (railway.toml with `target = "runtime-staging"`), Railway deploys failed because:
1. **Healthcheck port mismatch**: Railway's healthcheck probes the `PORT` env var, but the app reads `GATEWAY_PORT`. Fixed by setting `PORT=3000` in Railway service variables.
2. **Stale Docker cache**: The `wasm-builder` stage never executed — Railway cached layers from previous `runtime` target builds. This `ARG CACHE_BUST` lets us invalidate those layers.

## Usage
Set `CACHE_BUST=1` (or any value) in Railway service variables to force a fresh build of the wasm-builder stage. Change the value to bust cache again in the future. Can be removed after the first successful build.

## Test plan
- [ ] Merge to staging
- [ ] Set `CACHE_BUST=1` in Railway service variables
- [ ] Verify Railway build log shows wasm-builder stage running (should see "Building github...", "Building slack...", etc. and take several minutes)
- [ ] Verify WASM tools are loaded: `curl -H "Authorization: Bearer <token>" https://ironclaw-production-near-ai.up.railway.app/api/extensions/tools` should show WASM tools (github, gmail, etc.)
- [ ] Verify healthcheck passes
- [ ] Optionally remove `CACHE_BUST` env var after successful build

🤖 Generated with [Claude Code](https://claude.com/claude-code)