### PR TITLE
fix(docker): make runtime-staging the default Docker target for Railway

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -194,7 +194,7 @@ jobs:
           ref: ${{ inputs.ref || github.sha }}
           persist-credentials: false
       - name: Build Docker image
-        run: docker build -t ironclaw-test:ci .
+        run: docker build --target runtime -t ironclaw-test:ci .
 
   version-check:
     name: Version Bump Check

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # database reopen), so we use glibc.
 #
 # Build:
-#   docker build --platform linux/amd64 -t ironclaw:latest .
+#   docker build --platform linux/amd64 --target runtime -t ironclaw:latest .
 #
 # Run:
 #   docker run --env-file .env -p 3000:3000 ironclaw:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,9 +67,18 @@ COPY providers.json providers.json
 RUN cargo build --profile dist --bin ironclaw
 
 # Stage 4b: Build all WASM extensions from source (only used by runtime-staging)
-FROM builder AS wasm-builder
+#
+# Inherits from chef (not builder) so WASM extensions only rebuild when
+# tools-src/, channels-src/, registry/, or wit/ change — not on every
+# src/ edit. The extensions are standalone crates with their own lockfiles.
+FROM chef AS wasm-builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
+
+COPY tools-src/ tools-src/
+COPY channels-src/ channels-src/
+COPY registry/ registry/
+COPY wit/ wit/
 
 RUN set -eux; \
     mkdir -p /app/wasm-bundles/tools /app/wasm-bundles/channels; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,10 +68,8 @@ RUN cargo build --profile dist --bin ironclaw
 
 # Stage 4b: Build all WASM extensions from source (only used by runtime-staging)
 FROM builder AS wasm-builder
-ARG CACHE_BUST
 
 RUN apt-get update && apt-get install -y --no-install-recommends jq && rm -rf /var/lib/apt/lists/*
-RUN echo "cache-bust=${CACHE_BUST}"
 
 RUN set -eux; \
     mkdir -p /app/wasm-bundles/tools /app/wasm-bundles/channels; \
@@ -133,12 +131,14 @@ ENV RUST_LOG=ironclaw=info
 
 ENTRYPOINT ["ironclaw"]
 
-# Stage 5b: Staging runtime (with pre-built WASM extensions)
+# Stage 5b: Production runtime (no pre-bundled extensions)
+FROM runtime-base AS runtime
+USER ironclaw
+
+# Stage 5c: Staging runtime (with pre-built WASM extensions)
+# Last stage = default target. Railway doesn't support --target, so this
+# must be last for Railway deploys. CI uses explicit --target flags.
 FROM runtime-base AS runtime-staging
 COPY --from=wasm-builder --chown=ironclaw:ironclaw /app/wasm-bundles/tools/ /home/ironclaw/.ironclaw/tools/
 COPY --from=wasm-builder --chown=ironclaw:ironclaw /app/wasm-bundles/channels/ /home/ironclaw/.ironclaw/channels/
-USER ironclaw
-
-# Stage 5c: Production runtime (default — no pre-bundled extensions)
-FROM runtime-base AS runtime
 USER ironclaw

--- a/railway.toml
+++ b/railway.toml
@@ -1,7 +1,6 @@
 [build]
 builder = "dockerfile"
 dockerfilePath = "Dockerfile"
-target = "runtime-staging"
 
 [deploy]
 healthcheckPath = "/api/health"


### PR DESCRIPTION
## Summary
- Reorder Dockerfile stages so `runtime-staging` is last (default target)
- Remove unsupported `target` field from railway.toml
- Revert CACHE_BUST arg (no longer needed)

## Context
Railway's `railway.toml` doesn't support a `target` field ([docs](https://docs.railway.com/config-as-code/reference)) — it was silently ignored, so Railway always built the last Dockerfile stage (`runtime`, no WASM extensions). The `wasm-builder` stage never ran.

Fix: make `runtime-staging` the last stage so Railway builds it by default. CI is unaffected — `docker.yml` uses explicit `--target` flags.

Closes #2242

## Test plan
- [ ] Merge to staging and verify Railway build log shows `wasm-builder` stage (should see "Building github...", "Building slack...", etc.)
- [ ] Build takes several minutes (not seconds)
- [ ] After deploy, check WASM tools loaded: `curl -H "Authorization: Bearer <token>" .../api/extensions/tools` should show github, gmail, etc.
- [ ] Healthcheck passes
- [ ] CI docker.yml still works (uses explicit `--target runtime` for production)

🤖 Generated with [Claude Code](https://claude.com/claude-code)