### PR TITLE
fix(oauth): use localhost for redirect URI when bound to 0.0.0.0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -770,7 +770,15 @@ async fn async_main() -> anyhow::Result<()> {
                 .tunnel
                 .public_url
                 .clone()
-                .unwrap_or_else(|| format!("http://{}:{}", gw_config.host, gw_config.port));
+                .unwrap_or_else(|| {
+                    // 0.0.0.0 / [::] are valid bind addresses but not valid
+                    // OAuth redirect hosts — use localhost instead.
+                    let host = match gw_config.host.as_str() {
+                        "0.0.0.0" | "::" | "[::]" => "localhost",
+                        other => other,
+                    };
+                    format!("http://{}:{}", host, gw_config.port)
+                });
             ext_mgr.enable_gateway_mode(gw_base).await;
             gw = gw.with_extension_manager(Arc::clone(ext_mgr));
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -770,15 +770,7 @@ async fn async_main() -> anyhow::Result<()> {
                 .tunnel
                 .public_url
                 .clone()
-                .unwrap_or_else(|| {
-                    // 0.0.0.0 / [::] are valid bind addresses but not valid
-                    // OAuth redirect hosts — use localhost instead.
-                    let host = match gw_config.host.as_str() {
-                        "0.0.0.0" | "::" | "[::]" => "localhost",
-                        other => other,
-                    };
-                    format!("http://{}:{}", host, gw_config.port)
-                });
+                .unwrap_or_else(|| oauth_base_url(&gw_config.host, gw_config.port));
             ext_mgr.enable_gateway_mode(gw_base).await;
             gw = gw.with_extension_manager(Arc::clone(ext_mgr));
         }
@@ -1448,4 +1440,46 @@ async fn async_main() -> anyhow::Result<()> {
     tracing::debug!("Agent shutdown complete");
 
     Ok(())
+}
+
+/// Build the OAuth base URL from the gateway bind address and port.
+///
+/// Unspecified addresses (`0.0.0.0`, `::`, `[::]`) are mapped to `localhost`
+/// because they are valid bind addresses but not valid OAuth redirect hosts.
+fn oauth_base_url(host: &str, port: u16) -> String {
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    let is_unspecified = trimmed
+        .parse::<std::net::IpAddr>()
+        .map_or(false, |ip| ip.is_unspecified());
+    if is_unspecified {
+        format!("http://localhost:{}", port)
+    } else {
+        format!("http://{}:{}", host, port)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn oauth_base_url_maps_unspecified_to_localhost() {
+        assert_eq!(oauth_base_url("0.0.0.0", 3033), "http://localhost:3033");
+        assert_eq!(oauth_base_url("::", 3033), "http://localhost:3033");
+        assert_eq!(oauth_base_url("[::]", 3033), "http://localhost:3033");
+        assert_eq!(
+            oauth_base_url("0:0:0:0:0:0:0:0", 3033),
+            "http://localhost:3033"
+        );
+    }
+
+    #[test]
+    fn oauth_base_url_preserves_explicit_host() {
+        assert_eq!(oauth_base_url("127.0.0.1", 3000), "http://127.0.0.1:3000");
+        assert_eq!(
+            oauth_base_url("my-server.example.com", 8080),
+            "http://my-server.example.com:8080"
+        );
+        assert_eq!(oauth_base_url("::1", 3000), "http://::1:3000");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1450,7 +1450,7 @@ fn oauth_base_url(host: &str, port: u16) -> String {
     let trimmed = host.trim_start_matches('[').trim_end_matches(']');
     let is_unspecified = trimmed
         .parse::<std::net::IpAddr>()
-        .map_or(false, |ip| ip.is_unspecified());
+        .is_ok_and(|ip| ip.is_unspecified());
     if is_unspecified {
         format!("http://localhost:{}", port)
     } else {


### PR DESCRIPTION
## Summary
- When `GATEWAY_HOST=0.0.0.0` and no `TUNNEL_PUBLIC_URL` is set, the extension OAuth redirect URI was built as `http://0.0.0.0:<port>/oauth/callback`, which Google rejects as invalid
- Map unspecified bind addresses (`0.0.0.0`, `::`, `[::]`) to `localhost` when constructing the gateway base URL, matching the social-login flow's existing fallback

## Test plan
- [ ] Set `GATEWAY_HOST=0.0.0.0` with no `TUNNEL_PUBLIC_URL`, trigger extension OAuth — redirect URI should use `localhost`
- [ ] Set `GATEWAY_HOST=127.0.0.1` — redirect URI should use `127.0.0.1` (unchanged)
- [ ] Set `TUNNEL_PUBLIC_URL=https://example.com` — redirect URI should use the tunnel URL (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)