### PR TITLE
fix: include Completed and Submitted in is_terminal()

### DIFF
--- a/src/context/state.rs
+++ b/src/context/state.rs
@@ -76,7 +76,10 @@ impl JobState {
 
     /// Check if this is a terminal state.
     pub fn is_terminal(&self) -> bool {
-        matches!(self, Self::Accepted | Self::Failed | Self::Cancelled)
+        matches!(
+            self,
+            Self::Accepted | Self::Completed | Self::Submitted | Self::Failed | Self::Cancelled
+        )
     }
 
     /// Check if the job is active (not terminal).
@@ -485,9 +488,13 @@ mod tests {
     #[test]
     fn test_terminal_states() {
         assert!(JobState::Accepted.is_terminal());
+        assert!(JobState::Completed.is_terminal());
+        assert!(JobState::Submitted.is_terminal());
         assert!(JobState::Failed.is_terminal());
         assert!(JobState::Cancelled.is_terminal());
+        assert!(!JobState::Pending.is_terminal());
         assert!(!JobState::InProgress.is_terminal());
+        assert!(!JobState::Stuck.is_terminal());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`JobState::is_terminal()` returns `false` for `Completed` and `Submitted`, even though both are terminal states that should not be polled or retried. This causes `FullJobWatcher` to poll indefinitely for jobs that reach either state.

The bug is self-documenting — `is_parallel_blocking()` already notes:

> "Completed and Submitted jobs are in the state machine but are no longer actively executing."

Yet `is_terminal()` only matches `Accepted | Failed | Cancelled`.

## Fix

Add `Completed` and `Submitted` to the `is_terminal()` match, and add corresponding test assertions for all non-terminal states (`Pending`, `InProgress`, `Stuck`).

## Test plan

- [ ] `cargo test` — updated `test_terminal_states` asserts `Completed` and `Submitted` are terminal, and `Pending`/`InProgress`/`Stuck` are not
- [ ] Verify `FullJobWatcher` stops polling when a job reaches `Completed` or `Submitted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)