### PR TITLE
fix(gateway): scope chat approvals to the active thread

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -1175,8 +1175,9 @@ function sendMessage() {
       autoResizeTextarea(input);
       input.focus();
       const requestId = approvalCard.getAttribute('data-request-id');
+      const threadId = approvalCard.getAttribute('data-thread-id');
       if (requestId) {
-        sendApprovalAction(requestId, action);
+        sendApprovalAction(requestId, action, threadId);
       }
       return;
     }
@@ -1416,12 +1417,14 @@ function filterSlashCommands(value) {
   }
 }
 
-function sendApprovalAction(requestId, action) {
+function sendApprovalAction(requestId, action, threadId) {
+  const card = document.querySelector('.approval-card[data-request-id="' + requestId + '"]');
+  const targetThreadId = threadId || (card ? card.getAttribute('data-thread-id') : null) || currentThreadId;
   apiFetch('/api/chat/gate/resolve', {
     method: 'POST',
     body: {
       request_id: requestId,
-      thread_id: currentThreadId,
+      thread_id: targetThreadId,
       resolution: action === 'deny' ? 'denied' : 'approved',
       always: action === 'always',
     },
@@ -1430,7 +1433,6 @@ function sendApprovalAction(requestId, action) {
   });
 
   // Disable buttons and show confirmation on the card
-  const card = document.querySelector('.approval-card[data-request-id="' + requestId + '"]');
   if (card) {
     const buttons = card.querySelectorAll('.approval-actions button');
     buttons.forEach((btn) => {
@@ -2172,19 +2174,19 @@ function showApproval(data) {
   const approveBtn = document.createElement('button');
   approveBtn.className = 'approve';
   approveBtn.textContent = I18n.t('approval.approve');
-  approveBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'approve'));
+  approveBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'approve', cardThreadId));
 
   const denyBtn = document.createElement('button');
   denyBtn.className = 'deny';
   denyBtn.textContent = I18n.t('approval.deny');
-  denyBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'deny'));
+  denyBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'deny', cardThreadId));
 
   actions.appendChild(approveBtn);
   if (data.allow_always !== false) {
     const alwaysBtn = document.createElement('button');
     alwaysBtn.className = 'always';
     alwaysBtn.textContent = I18n.t('approval.always');
-    alwaysBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'always'));
+    alwaysBtn.addEventListener('click', () => sendApprovalAction(data.request_id, 'always', cardThreadId));
     actions.appendChild(alwaysBtn);
   }
   actions.appendChild(denyBtn);

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1164,11 +1164,21 @@ pub async fn handle_approval(
         .as_ref()
         .ok_or_else(|| engine_err("init", "engine state is empty"))?;
 
-    // Don't pass the v1 thread_id as a hint — the v1 session uses different
-    // UUIDs from the engine.  The user_id alone is sufficient for single-user
-    // deployments; ambiguity resolution kicks in for multi-user.
-    let pending = match resolve_pending_gate_for_user(&state.pending_gates, &message.user_id, None)
-        .await
+    // Scope explicit approval replies to the active gateway conversation when
+    // available so `/approve` cannot resume an unrelated pending gate owned by
+    // another thread, such as a background routine. Other channels still use
+    // legacy thread IDs that do not map 1:1 to engine conversation scopes.
+    let thread_scope = if message.channel == "gateway" {
+        message.conversation_scope()
+    } else {
+        None
+    };
+    let pending = match resolve_pending_gate_for_user(
+        &state.pending_gates,
+        &message.user_id,
+        thread_scope,
+    )
+    .await
     {
         PendingGateResolution::Resolved(p) => p,
         PendingGateResolution::None => {
@@ -4468,6 +4478,49 @@ mod tests {
             gate.resume_kind,
             ironclaw_engine::ResumeKind::Authentication { .. }
         ));
+    }
+
+    #[tokio::test]
+    async fn handle_approval_ignores_pending_gate_from_different_thread() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let state = make_expected_test_state(store);
+            let pending_thread_id = ironclaw_engine::ThreadId::new();
+            let active_thread_id = ironclaw_engine::ThreadId::new();
+            let pending = sample_pending_gate(
+                "alice",
+                pending_thread_id,
+                ironclaw_engine::ResumeKind::Approval { allow_always: true },
+            );
+            state
+                .pending_gates
+                .insert(pending)
+                .await
+                .expect("insert pending gate");
+
+            *lock.write().await = Some(state);
+
+            let (agent, _statuses) = make_router_test_agent(None).await;
+            let message = IncomingMessage::new("gateway", "alice", "/approve")
+                .with_thread(active_thread_id.to_string());
+
+            let result = handle_approval(&agent, &message, true, false)
+                .await
+                .expect("handle approval");
+
+            assert_eq!(
+                result.as_deref(),
+                Some("No pending approval for this thread.")
+            );
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome
     }
 
     #[test]

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -1,6 +1,7 @@
 """Scenario 6: Tool approval overlay UI behavior."""
 
 import asyncio
+import json
 
 from helpers import SEL, api_get, api_post, send_chat_and_wait_for_terminal_message
 
@@ -692,3 +693,102 @@ async def test_approval_card_from_other_thread_not_intercepted(page):
     assert await card.locator(".approval-resolved").count() == 0, (
         "Approval card from another thread should NOT be resolved"
     )
+
+
+async def test_approval_card_button_posts_card_thread_id(page):
+    """Clicking an approval card must post the card's thread_id, not the active thread."""
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    captured = {}
+
+    async def handle_gate_resolve(route):
+        captured["body"] = json.loads(route.request.post_data or "{}")
+        await route.fulfill(status=200, content_type="application/json", body='{"ok":true}')
+
+    await page.route("**/api/chat/gate/resolve", handle_gate_resolve)
+
+    await page.evaluate("""
+        showApproval({
+            request_id: 'test-button-thread-id',
+            thread_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            tool_name: 'http',
+            description: 'From another thread',
+        })
+    """)
+
+    card = page.locator('.approval-card[data-request-id="test-button-thread-id"]')
+    await card.wait_for(state="visible", timeout=5000)
+    await card.locator("button.approve").click()
+
+    for _ in range(20):
+        if "body" in captured:
+            break
+        await page.wait_for_timeout(100)
+    else:
+        raise AssertionError("Expected /api/chat/gate/resolve request to be captured")
+
+    assert captured["body"]["request_id"] == "test-button-thread-id"
+    assert captured["body"]["thread_id"] == "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    assert captured["body"]["resolution"] == "approved"
+    assert captured["body"]["always"] is False
+
+
+async def test_slash_approve_does_not_intercept_other_thread_card(page):
+    """Typing '/approve' must not resolve an approval card from another thread."""
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    await page.evaluate("""
+        showApproval({
+            request_id: 'test-other-thread-slash',
+            thread_id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+            tool_name: 'http',
+            description: 'From another thread',
+        })
+    """)
+
+    card = page.locator('.approval-card[data-request-id="test-other-thread-slash"]')
+    await card.wait_for(state="visible", timeout=5000)
+
+    result = await send_chat_and_wait_for_terminal_message(page, "/approve", timeout=15000)
+
+    assert result["role"] == "assistant", (
+        f"Expected assistant response, got {result['role']}: {result['text']!r}"
+    )
+    assert await card.locator(".approval-resolved").count() == 0, (
+        "Approval card from another thread should NOT be resolved by /approve"
+    )
+
+
+async def test_slash_approve_is_thread_scoped_api(ironclaw_server):
+    """Sending '/approve' in thread A must not resolve a pending gate in thread B."""
+    thread_a = await _create_thread(ironclaw_server)
+    thread_b = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(
+        ironclaw_server,
+        thread_b,
+        "make approval post slash-approve-thread-scope",
+    )
+    await _wait_for_history(ironclaw_server, thread_b, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_a, "/approve")
+    await asyncio.sleep(1.0)
+
+    history_a = await _wait_for_history(
+        ironclaw_server,
+        thread_a,
+        expect_pending=False,
+        timeout=5.0,
+    )
+    assert history_a.get("pending_gate") is None
+
+    history_b = await _wait_for_history(
+        ironclaw_server,
+        thread_b,
+        expect_pending=True,
+        turn_count_at_least=1,
+        timeout=5.0,
+    )
+    assert history_b.get("pending_gate") is not None


### PR DESCRIPTION
## Summary
- scope gateway slash-approve resolution to the active thread so chat approvals cannot resume unrelated background gates
- send approval actions with the approval card thread id instead of always using the currently selected thread
- add backend and e2e regressions for cross-thread slash-approve and wrong-thread approval cards

## Verification
- cargo test handle_approval_ignores_pending_gate_from_different_thread --lib
- uv run --project tests/e2e pytest -q tests/e2e/scenarios/test_tool_approval.py -k approval_card_button_posts_card_thread_id\ or\ slash_approve_does_not_intercept_other_thread_card\ or\ slash_approve_is_thread_scoped_api

Fixes #2238