### PR TITLE
feat(cli): add `ironclaw profile list` subcommand

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@
 //! - Managing routines (`routines list`, `routines create`, `routines edit`, ...)
 //! - Managing OS service (`service install`, `service start`, `service stop`)
 //! - Listing configured channels (`channels list`)
+//! - Listing deployment profiles (`profile list`)
 //! - Active health diagnostics (`doctor`)
 //! - Viewing gateway logs (`logs`)
 //! - Checking system health (`status`)
@@ -28,6 +29,7 @@ mod mcp;
 pub mod memory;
 mod models;
 mod pairing;
+mod profile;
 mod registry;
 mod routines;
 mod service;
@@ -49,6 +51,7 @@ pub use memory::MemoryCommand;
 pub use memory::run_memory_command_with_db;
 pub use models::{ModelsCommand, run_models_command};
 pub use pairing::{PairingCommand, run_pairing_command, run_pairing_command_with_store};
+pub use profile::{ProfileCommand, run_profile_command};
 pub use registry::{RegistryCommand, run_registry_command};
 pub use routines::{RoutinesCommand, run_routines_command};
 pub use service::{ServiceCommand, run_service_command};
@@ -203,6 +206,14 @@ pub enum Command {
         long_about = "Approve or manage pairing requests.\nExamples:\n  ironclaw pairing list telegram\n  ironclaw pairing approve telegram ABC12345"
     )]
     Pairing(PairingCommand),
+
+    /// Manage deployment profiles
+    #[command(
+        subcommand,
+        about = "Manage deployment profiles",
+        long_about = "List available deployment profiles and see which is active.\nExamples:\n  ironclaw profile list\n  ironclaw profile list --json"
+    )]
+    Profile(ProfileCommand),
 
     /// Manage OS service (launchd / systemd)
     #[command(

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -4,7 +4,7 @@
 
 use clap::Subcommand;
 
-use crate::config::profile::{list_profiles, ProfileInfo, BUILTIN_PROFILES};
+use crate::config::profile::{BUILTIN_PROFILES, ProfileInfo, list_profiles};
 
 #[derive(Subcommand, Debug, Clone)]
 pub enum ProfileCommand {
@@ -62,8 +62,13 @@ fn builtin_description(name: &str) -> Option<String> {
 
 /// Read the description from a user-defined profile TOML file.
 fn user_profile_description(path: &std::path::Path) -> Option<String> {
-    let content = std::fs::read_to_string(path).ok()?;
-    extract_description(&content)
+    match std::fs::read_to_string(path) {
+        Ok(content) => extract_description(&content),
+        Err(e) => {
+            tracing::warn!(path = %path.display(), error = %e, "Failed to read user profile for description");
+            None
+        }
+    }
 }
 
 /// Get the description for a profile, checking built-in first then file.
@@ -84,21 +89,25 @@ fn cmd_list(json: bool) -> anyhow::Result<()> {
         .map(|s| s.to_ascii_lowercase());
 
     if json {
-        let entries: Vec<serde_json::Value> = profiles
+        #[derive(serde::Serialize)]
+        struct ProfileEntry<'a> {
+            name: &'a str,
+            builtin: bool,
+            active: bool,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            path: Option<String>,
+            #[serde(skip_serializing_if = "Option::is_none")]
+            description: Option<String>,
+        }
+
+        let entries: Vec<ProfileEntry> = profiles
             .iter()
-            .map(|p| {
-                let mut v = serde_json::json!({
-                    "name": p.name,
-                    "builtin": p.builtin,
-                    "active": active_name.as_deref() == Some(p.name.as_str()),
-                });
-                if let Some(path) = &p.path {
-                    v["path"] = serde_json::Value::String(path.display().to_string());
-                }
-                if let Some(desc) = profile_description(p) {
-                    v["description"] = serde_json::Value::String(desc);
-                }
-                v
+            .map(|p| ProfileEntry {
+                name: &p.name,
+                builtin: p.builtin,
+                active: active_name.as_deref() == Some(p.name.as_str()),
+                path: p.path.as_ref().map(|path| path.display().to_string()),
+                description: profile_description(p),
             })
             .collect();
         println!(

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -1,0 +1,202 @@
+//! Profile management CLI commands.
+//!
+//! Lists available deployment profiles and shows which one is active.
+
+use clap::Subcommand;
+
+use crate::config::profile::{list_profiles, ProfileInfo, BUILTIN_PROFILES};
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ProfileCommand {
+    /// List all available deployment profiles
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Run the profile CLI subcommand.
+pub async fn run_profile_command(cmd: ProfileCommand) -> anyhow::Result<()> {
+    match cmd {
+        ProfileCommand::List { json } => cmd_list(json),
+    }
+}
+
+/// Extract a one-line description from a profile's TOML comment header.
+///
+/// Built-in profiles have a header like:
+/// ```text
+/// # IronClaw Profile: local
+/// #
+/// # Stripped-down configuration for solo developers working locally.
+/// ```
+///
+/// We skip the title line and blank comment lines, then take the first
+/// non-empty comment line as the description.
+fn extract_description(toml_content: &str) -> Option<String> {
+    let mut lines = toml_content.lines();
+    // Skip the `# IronClaw Profile: <name>` title line.
+    lines.next()?;
+
+    for line in lines {
+        let trimmed = line.trim();
+        if !trimmed.starts_with('#') {
+            break;
+        }
+        let comment = trimmed.trim_start_matches('#').trim();
+        if !comment.is_empty() {
+            return Some(comment.to_string());
+        }
+    }
+    None
+}
+
+/// Get the description for a built-in profile by name.
+fn builtin_description(name: &str) -> Option<String> {
+    BUILTIN_PROFILES
+        .iter()
+        .find(|(n, _)| *n == name)
+        .and_then(|(_, toml)| extract_description(toml))
+}
+
+/// Read the description from a user-defined profile TOML file.
+fn user_profile_description(path: &std::path::Path) -> Option<String> {
+    let content = std::fs::read_to_string(path).ok()?;
+    extract_description(&content)
+}
+
+/// Get the description for a profile, checking built-in first then file.
+fn profile_description(info: &ProfileInfo) -> Option<String> {
+    if info.builtin {
+        builtin_description(&info.name)
+    } else {
+        info.path.as_deref().and_then(user_profile_description)
+    }
+}
+
+/// List all available profiles.
+fn cmd_list(json: bool) -> anyhow::Result<()> {
+    let profiles = list_profiles();
+    let active_name = std::env::var("IRONCLAW_PROFILE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase());
+
+    if json {
+        let entries: Vec<serde_json::Value> = profiles
+            .iter()
+            .map(|p| {
+                let mut v = serde_json::json!({
+                    "name": p.name,
+                    "builtin": p.builtin,
+                    "active": active_name.as_deref() == Some(p.name.as_str()),
+                });
+                if let Some(path) = &p.path {
+                    v["path"] = serde_json::Value::String(path.display().to_string());
+                }
+                if let Some(desc) = profile_description(p) {
+                    v["description"] = serde_json::Value::String(desc);
+                }
+                v
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&entries).unwrap_or_else(|_| "[]".to_string())
+        );
+        return Ok(());
+    }
+
+    // Human-readable output.
+    println!("Available deployment profiles:\n");
+
+    for p in &profiles {
+        let active = if active_name.as_deref() == Some(p.name.as_str()) {
+            " (active)"
+        } else {
+            ""
+        };
+        let kind = if p.builtin { "built-in" } else { "custom" };
+        let desc = profile_description(p).unwrap_or_default();
+
+        println!("  {:<24} {:<10}{}", p.name, kind, active);
+        if !desc.is_empty() {
+            println!("    {desc}");
+        }
+        if let Some(path) = &p.path {
+            println!("    path: {}", path.display());
+        }
+    }
+
+    println!();
+    if active_name.is_none() {
+        println!("No profile is currently active.");
+        println!("Set IRONCLAW_PROFILE=<name> to activate one.");
+    }
+    println!("\nCustom profiles can be added to ~/.ironclaw/profiles/");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_description_from_builtin() {
+        let toml = "# IronClaw Profile: local\n#\n# A short description.\n#\ndatabase_backend = \"libsql\"\n";
+        assert_eq!(
+            extract_description(toml),
+            Some("A short description.".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_description_skips_blank_comments() {
+        let toml = "# IronClaw Profile: foo\n#\n#\n# Real description.\n";
+        assert_eq!(
+            extract_description(toml),
+            Some("Real description.".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_description_none_when_no_comments() {
+        let toml = "database_backend = \"libsql\"\n";
+        assert_eq!(extract_description(toml), None);
+    }
+
+    #[test]
+    fn builtin_descriptions_exist() {
+        for &(name, _) in BUILTIN_PROFILES {
+            assert!(
+                builtin_description(name).is_some(),
+                "built-in profile '{name}' should have a description"
+            );
+        }
+    }
+
+    #[test]
+    fn user_profile_description_from_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("custom.toml");
+        std::fs::write(
+            &path,
+            "# IronClaw Profile: custom\n#\n# My custom profile.\n\ndatabase_backend = \"postgres\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            user_profile_description(&path),
+            Some("My custom profile.".to_string())
+        );
+    }
+
+    #[test]
+    fn user_profile_description_missing_file() {
+        assert_eq!(
+            user_profile_description(std::path::Path::new("/nonexistent/profile.toml")),
+            None
+        );
+    }
+}

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -1,6 +1,5 @@
 ---
 source: src/cli/mod.rs
-assertion_line: 422
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -18,6 +17,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -1,6 +1,5 @@
 ---
 source: src/cli/mod.rs
-assertion_line: 461
 expression: help
 ---
 IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
@@ -21,6 +20,7 @@ Commands:
   mcp         Manage MCP servers
   memory      Manage workspace memory
   pairing     Manage DM pairing
+  profile     Manage deployment profiles
   service     Manage OS service
   skills      Manage skills
   hooks       Manage lifecycle hooks

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -31,7 +31,7 @@ const BUILTIN_SERVER: &str = include_str!("../../profiles/server.toml");
 const BUILTIN_SERVER_MULTITENANT: &str = include_str!("../../profiles/server-multitenant.toml");
 
 /// Known built-in profile names and their embedded TOML content.
-const BUILTIN_PROFILES: &[(&str, &str)] = &[
+pub(crate) const BUILTIN_PROFILES: &[(&str, &str)] = &[
     ("local", BUILTIN_LOCAL),
     ("local-sandbox", BUILTIN_LOCAL_SANDBOX),
     ("server", BUILTIN_SERVER),

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,8 @@ use ironclaw::{
         web::log_layer::LogBroadcaster,
     },
     cli::{
-        Cli, Command, run_mcp_command, run_pairing_command, run_service_command,
-        run_status_command, run_tool_command,
+        Cli, Command, run_mcp_command, run_pairing_command, run_profile_command,
+        run_service_command, run_status_command, run_tool_command,
     },
     config::Config,
     hooks::bootstrap_hooks,
@@ -123,6 +123,10 @@ async fn async_main() -> anyhow::Result<()> {
         Some(Command::Pairing(pairing_cmd)) => {
             init_cli_tracing();
             return run_pairing_command(pairing_cmd.clone()).await;
+        }
+        Some(Command::Profile(profile_cmd)) => {
+            init_cli_tracing();
+            return run_profile_command(profile_cmd.clone()).await;
         }
         Some(Command::Service(service_cmd)) => {
             init_cli_tracing();


### PR DESCRIPTION
## Summary

- Adds `ironclaw profile list` CLI subcommand that lists all available deployment profiles (built-in + user-defined from `~/.ironclaw/profiles/`)
- Shows a one-line description extracted from each profile's TOML header comments
- Indicates which profile is currently active via `IRONCLAW_PROFILE` env var
- Supports `--json` flag for machine-readable output

Closes #2271

## Changes

| File | What |
|------|------|
| `src/cli/profile.rs` | **New** — `ProfileCommand` enum, `run_profile_command()`, description extraction, unit tests |
| `src/cli/mod.rs` | Register `profile` module, add `Profile(ProfileCommand)` to `Command` enum |
| `src/main.rs` | Add dispatch arm for `Command::Profile` |
| `src/config/profile.rs` | Widen `BUILTIN_PROFILES` visibility to `pub(crate)` for description extraction |
| `src/cli/snapshots/*.snap` | Updated insta snapshots for new command in help text |

## Test plan

- [x] `cargo check` — compiles cleanly
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test -p ironclaw --lib cli::profile` — 6 unit tests pass
- [x] `cargo test -p ironclaw --lib cli::tests` — insta snapshot tests pass
- [x] `cargo test -p ironclaw --lib profile` — all 42 profile-related tests pass
- [ ] Manual: `ironclaw profile list` and `ironclaw profile list --json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)