### PR TITLE
fix(test): case-insensitive hint matching in TraceLlm

### DIFF
--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -408,7 +408,11 @@ fn step_matches(step: &TraceStep, last_user_content: Option<&str>) -> bool {
     match step_hint(step) {
         None => true,
         Some(hint) => last_user_content
-            .map(|content| content.contains(hint))
+            .map(|content| {
+                content
+                    .to_ascii_lowercase()
+                    .contains(&hint.to_ascii_lowercase())
+            })
             .unwrap_or(false),
     }
 }

--- a/tests/support_unit_tests.rs
+++ b/tests/support_unit_tests.rs
@@ -549,6 +549,54 @@ mod trace_llm_tests {
         assert_eq!(llm.hint_mismatches(), 2);
     }
 
+    /// Hint matching must be case-insensitive: a hint of "write" should match
+    /// a user message starting with "Write". Regression test for the bug where
+    /// case-sensitive `contains` left hinted steps permanently stuck at the
+    /// queue head while unhinted steps were consumed out of order.
+    #[tokio::test]
+    async fn hint_matching_is_case_insensitive() {
+        let trace = LlmTrace::single_turn(
+            "test-model",
+            "Write a file",
+            vec![
+                TraceStep {
+                    request_hint: Some(RequestHint {
+                        last_user_message_contains: Some("write".to_string()),
+                        min_message_count: None,
+                    }),
+                    response: TraceResponse::Text {
+                        content: "hinted step".to_string(),
+                        input_tokens: 10,
+                        output_tokens: 5,
+                    },
+                    expected_tool_results: Vec::new(),
+                },
+                TraceStep {
+                    request_hint: None,
+                    response: TraceResponse::Text {
+                        content: "unhinted step".to_string(),
+                        input_tokens: 10,
+                        output_tokens: 5,
+                    },
+                    expected_tool_results: Vec::new(),
+                },
+            ],
+        );
+        let llm = TraceLlm::from_trace(trace);
+
+        // The hinted step should match "Write" (capital W) against hint "write".
+        let resp = llm
+            .complete_with_tools(make_request("Write a file"))
+            .await
+            .unwrap();
+        assert_eq!(
+            resp.content.as_deref(),
+            Some("hinted step"),
+            "hinted step should be selected (case-insensitive match)"
+        );
+        assert_eq!(llm.hint_mismatches(), 0);
+    }
+
     #[tokio::test]
     async fn from_json_file() {
         let fixture_path = concat!(


### PR DESCRIPTION
## Summary

- `step_matches()` in `tests/support/trace_llm.rs` used case-sensitive `String::contains()` for hint matching
- Fixture hints use lowercase (`"write"`, `"save"`) but test messages use title case (`"Write..."`, `"Save..."`)
- This caused hinted steps to get permanently stuck at the queue head while unhinted steps were consumed out of order via scan fallback
- Broke `tool_error_recovery` (1 vs 2 `write_file` calls) and `workspace_semantic_search` (2 vs 3 `memory_write` calls)
- Fix: use `to_ascii_lowercase()` on both sides of the `contains` check

## Test plan

- [x] `cargo test --test e2e_advanced_traces -- --test-threads=1` — all 14 tests pass
- [x] `cargo test --test support_unit_tests -- hint` — 3 tests pass (including new regression test)
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)