### PR TITLE
feat: add conversation_id to LLM request metadata

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -633,7 +633,10 @@ async fn handle_llm_complete(
             let mut m = HashMap::new();
             m.insert("thread_id".to_string(), thread.id.0.to_string());
             m.insert("user_id".to_string(), thread.user_id.clone());
-            if let Some(conv_id) = thread.metadata.get("conversation_id").and_then(|v| v.as_str())
+            if let Some(conv_id) = thread
+                .metadata
+                .get("conversation_id")
+                .and_then(|v| v.as_str())
             {
                 m.insert("conversation_id".to_string(), conv_id.to_string());
             }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -629,7 +629,16 @@ async fn handle_llm_complete(
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
         depth: thread.config.depth,
-        metadata: HashMap::new(),
+        metadata: {
+            let mut m = HashMap::new();
+            m.insert("thread_id".to_string(), thread.id.0.to_string());
+            m.insert("user_id".to_string(), thread.user_id.clone());
+            if let Some(conv_id) = thread.metadata.get("conversation_id").and_then(|v| v.as_str())
+            {
+                m.insert("conversation_id".to_string(), conv_id.to_string());
+            }
+            m
+        },
     };
 
     match deps.llm.complete(&messages, &actions, &config).await {

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -1233,7 +1233,14 @@ mod tests {
         let project = ProjectId::new();
 
         let tid = cm
-            .handle_user_message(conv_id, "Hello", project, "u1", ThreadConfig::default(), None)
+            .handle_user_message(
+                conv_id,
+                "Hello",
+                project,
+                "u1",
+                ThreadConfig::default(),
+                None,
+            )
             .await
             .unwrap();
 
@@ -1300,14 +1307,24 @@ mod tests {
         let project = ProjectId::new();
 
         let tid = cm
-            .handle_user_message(conv_id, "Hello", project, "u1", ThreadConfig::default(), None)
+            .handle_user_message(
+                conv_id,
+                "Hello",
+                project,
+                "u1",
+                ThreadConfig::default(),
+                None,
+            )
             .await
             .unwrap();
 
         let _ = tm.join_thread(tid).await;
 
         let captured = llm.captured.lock().unwrap();
-        assert!(!captured.is_empty(), "LLM should have been called at least once");
+        assert!(
+            !captured.is_empty(),
+            "LLM should have been called at least once"
+        );
         let meta = &captured[0];
         assert_eq!(
             meta.get("conversation_id").unwrap(),

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -303,6 +303,12 @@ impl ConversationManager {
                         serde_json::Value::String(tz.to_string()),
                     );
                 }
+                // Stable conversation ID for stateful LLM backends (session
+                // routing, prompt caching, cost attribution).
+                initial_metadata.insert(
+                    "conversation_id".into(),
+                    serde_json::Value::String(conversation_id.0.to_string()),
+                );
 
                 // Spawn new foreground thread with conversation history.
                 self.thread_manager
@@ -1205,5 +1211,162 @@ mod tests {
             result.is_err(),
             "expected Err for unknown conversation, got Ok"
         );
+    }
+
+    #[tokio::test]
+    async fn thread_metadata_includes_conversation_id() {
+        let store = Arc::new(MockStore::new());
+        let tm = Arc::new(ThreadManager::new(
+            Arc::new(MockLlm(Mutex::new(vec![LlmOutput {
+                response: LlmResponse::Text("hi".into()),
+                usage: TokenUsage::default(),
+            }]))),
+            Arc::new(MockEffects),
+            store.clone(),
+            Arc::new(CapabilityRegistry::new()),
+            Arc::new(LeaseManager::new()),
+            Arc::new(PolicyEngine::new()),
+        ));
+        let cm = ConversationManager::new(Arc::clone(&tm), store.clone());
+
+        let conv_id = cm.get_or_create_conversation("web", "u1").await.unwrap();
+        let project = ProjectId::new();
+
+        let tid = cm
+            .handle_user_message(conv_id, "Hello", project, "u1", ThreadConfig::default(), None)
+            .await
+            .unwrap();
+
+        // The spawned thread must carry the conversation_id in its metadata
+        let thread = store.load_thread(tid).await.unwrap().unwrap();
+        let stored = thread
+            .metadata
+            .get("conversation_id")
+            .and_then(|v| v.as_str())
+            .unwrap();
+        assert_eq!(stored, conv_id.0.to_string());
+
+        // Let thread finish so we don't leak the task
+        let _ = tm.join_thread(tid).await;
+    }
+
+    /// A mock LLM that captures the LlmCallConfig metadata from each call.
+    struct CapturingMockLlm {
+        captured: Mutex<Vec<HashMap<String, String>>>,
+    }
+
+    impl CapturingMockLlm {
+        fn new() -> Self {
+            Self {
+                captured: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for CapturingMockLlm {
+        async fn complete(
+            &self,
+            _: &[ThreadMessage],
+            _: &[ActionDef],
+            config: &LlmCallConfig,
+        ) -> Result<LlmOutput, EngineError> {
+            self.captured.lock().unwrap().push(config.metadata.clone());
+            Ok(LlmOutput {
+                response: LlmResponse::Text("ok".into()),
+                usage: TokenUsage::default(),
+            })
+        }
+        fn model_name(&self) -> &str {
+            "capturing-mock"
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_call_receives_conversation_id_in_metadata() {
+        let store = Arc::new(MockStore::new());
+        let llm = Arc::new(CapturingMockLlm::new());
+        let tm = Arc::new(ThreadManager::new(
+            llm.clone(),
+            Arc::new(MockEffects),
+            store.clone(),
+            Arc::new(CapabilityRegistry::new()),
+            Arc::new(LeaseManager::new()),
+            Arc::new(PolicyEngine::new()),
+        ));
+        let cm = ConversationManager::new(Arc::clone(&tm), store.clone());
+
+        let conv_id = cm.get_or_create_conversation("web", "u1").await.unwrap();
+        let project = ProjectId::new();
+
+        let tid = cm
+            .handle_user_message(conv_id, "Hello", project, "u1", ThreadConfig::default(), None)
+            .await
+            .unwrap();
+
+        let _ = tm.join_thread(tid).await;
+
+        let captured = llm.captured.lock().unwrap();
+        assert!(!captured.is_empty(), "LLM should have been called at least once");
+        let meta = &captured[0];
+        assert_eq!(
+            meta.get("conversation_id").unwrap(),
+            &conv_id.0.to_string(),
+            "LLM metadata must include stable conversation_id"
+        );
+        assert_eq!(
+            meta.get("thread_id").unwrap(),
+            &tid.0.to_string(),
+            "LLM metadata must include thread_id"
+        );
+        assert_eq!(
+            meta.get("user_id").unwrap(),
+            "u1",
+            "LLM metadata must include user_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn llm_metadata_omits_conversation_id_when_absent() {
+        // When a thread is spawned directly (not via ConversationManager),
+        // conversation_id should not appear in the LLM metadata.
+        let store: Arc<dyn Store> = Arc::new(MockStore::new());
+        let llm = Arc::new(CapturingMockLlm::new());
+        let tm = Arc::new(ThreadManager::new(
+            llm.clone(),
+            Arc::new(MockEffects),
+            store.clone(),
+            Arc::new(CapabilityRegistry::new()),
+            Arc::new(LeaseManager::new()),
+            Arc::new(PolicyEngine::new()),
+        ));
+
+        let project = ProjectId::new();
+        let tid = tm
+            .spawn_thread_with_history(
+                "test",
+                ThreadType::Foreground,
+                project,
+                ThreadConfig::default(),
+                None,
+                "u1",
+                vec![ThreadMessage::user("hi")],
+                serde_json::Map::new(), // no initial_metadata
+            )
+            .await
+            .unwrap();
+
+        let _ = tm.join_thread(tid).await;
+
+        let captured = llm.captured.lock().unwrap();
+        assert!(!captured.is_empty());
+        let meta = &captured[0];
+        assert!(
+            !meta.contains_key("conversation_id"),
+            "conversation_id should be absent when thread has no conversation metadata"
+        );
+        // thread_id and user_id should still be present
+        assert!(meta.contains_key("thread_id"));
+        assert!(meta.contains_key("user_id"));
     }
 }

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -1687,9 +1687,7 @@ mod tests {
         assert!(req.additional_params.is_none());
     }
 
-    fn make_metadata(
-        pairs: &[(&str, &str)],
-    ) -> std::collections::HashMap<String, String> {
+    fn make_metadata(pairs: &[(&str, &str)]) -> std::collections::HashMap<String, String> {
         pairs
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
@@ -1718,10 +1716,7 @@ mod tests {
     #[test]
     fn test_inject_user_routing_falls_back_to_thread_id() {
         let mut req = make_rig_request(None);
-        let meta = make_metadata(&[
-            ("user_id", "andrew"),
-            ("thread_id", "thread-uuid-456"),
-        ]);
+        let meta = make_metadata(&[("user_id", "andrew"), ("thread_id", "thread-uuid-456")]);
         inject_user_routing(&mut req, &meta);
 
         let params = req
@@ -1746,19 +1741,13 @@ mod tests {
         let mut req = make_rig_request(Some(serde_json::json!({
             "model": "gpt-4o",
         })));
-        let meta = make_metadata(&[
-            ("user_id", "grace"),
-            ("conversation_id", "conv-789"),
-        ]);
+        let meta = make_metadata(&[("user_id", "grace"), ("conversation_id", "conv-789")]);
         inject_user_routing(&mut req, &meta);
 
         let params = req.additional_params.expect("should remain Some");
         let obj = params.as_object().expect("should be object");
         assert_eq!(obj.get("model"), Some(&serde_json::json!("gpt-4o")));
-        assert_eq!(
-            obj.get("user"),
-            Some(&serde_json::json!("grace:conv-789"))
-        );
+        assert_eq!(obj.get("user"), Some(&serde_json::json!("grace:conv-789")));
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -619,6 +619,51 @@ fn build_rig_request(
 /// handling of duplicate JSON keys (most Python/Go servers use last-key-wins,
 /// but this is not guaranteed by the JSON spec). The `effective_model_name()`
 /// trait method should be consulted to determine the model actually used.
+/// When `metadata` contains `user_id` and/or `thread_id`/`conversation_id`,
+/// encodes them as `"{user_id}:{id}"` in the OpenAI `user` field. Prefers
+/// `conversation_id` (stable across turns) over `thread_id` (per-turn engine
+/// ID). This lets OpenAI-compatible backends extract routing context without
+/// needing per-request custom HTTP headers.
+///
+/// If neither key is present, this is a no-op.
+fn inject_user_routing(
+    rig_req: &mut RigRequest,
+    metadata: &std::collections::HashMap<String, String>,
+) {
+    let user_id = metadata.get("user_id").map(String::as_str).unwrap_or("");
+    // Prefer conversation_id (stable across turns) over thread_id (per-turn engine ID).
+    let conv_id = metadata
+        .get("conversation_id")
+        .map(String::as_str)
+        .unwrap_or("");
+    let session_id = if conv_id.is_empty() {
+        metadata.get("thread_id").map(String::as_str).unwrap_or("")
+    } else {
+        conv_id
+    };
+    if user_id.is_empty() && session_id.is_empty() {
+        return;
+    }
+    // Format: "user_id:session_id" when both present, just the non-empty
+    // part when one is missing. Avoids ambiguous ":uuid" or "user:" prefixes.
+    let user_value = match (user_id.is_empty(), session_id.is_empty()) {
+        (false, false) => format!("{user_id}:{session_id}"),
+        (true, false) => session_id.to_string(),
+        (false, true) => user_id.to_string(),
+        (true, true) => unreachable!(), // guarded above
+    };
+    match rig_req.additional_params {
+        Some(ref mut params) => {
+            if let Some(obj) = params.as_object_mut() {
+                obj.insert("user".to_string(), serde_json::json!(user_value));
+            }
+        }
+        None => {
+            rig_req.additional_params = Some(serde_json::json!({ "user": user_value }));
+        }
+    }
+}
+
 fn inject_model_override(rig_req: &mut RigRequest, model_override: Option<&str>) {
     let Some(model) = model_override else {
         return;
@@ -688,6 +733,7 @@ where
         )?;
 
         inject_model_override(&mut rig_req, model_override.as_deref());
+        inject_user_routing(&mut rig_req, &request.metadata);
 
         let response =
             self.model
@@ -750,6 +796,7 @@ where
         )?;
 
         inject_model_override(&mut rig_req, model_override.as_deref());
+        inject_user_routing(&mut rig_req, &request.metadata);
 
         let response =
             self.model
@@ -1638,5 +1685,103 @@ mod tests {
         let mut req = make_rig_request(None);
         inject_model_override(&mut req, None);
         assert!(req.additional_params.is_none());
+    }
+
+    fn make_metadata(
+        pairs: &[(&str, &str)],
+    ) -> std::collections::HashMap<String, String> {
+        pairs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn test_inject_user_routing_prefers_conversation_id() {
+        let mut req = make_rig_request(None);
+        let meta = make_metadata(&[
+            ("user_id", "andrew"),
+            ("thread_id", "old-thread-uuid"),
+            ("conversation_id", "stable-conv-123"),
+        ]);
+        inject_user_routing(&mut req, &meta);
+
+        let params = req
+            .additional_params
+            .expect("additional_params should be Some");
+        assert_eq!(
+            params,
+            serde_json::json!({ "user": "andrew:stable-conv-123" })
+        );
+    }
+
+    #[test]
+    fn test_inject_user_routing_falls_back_to_thread_id() {
+        let mut req = make_rig_request(None);
+        let meta = make_metadata(&[
+            ("user_id", "andrew"),
+            ("thread_id", "thread-uuid-456"),
+        ]);
+        inject_user_routing(&mut req, &meta);
+
+        let params = req
+            .additional_params
+            .expect("additional_params should be Some");
+        assert_eq!(
+            params,
+            serde_json::json!({ "user": "andrew:thread-uuid-456" })
+        );
+    }
+
+    #[test]
+    fn test_inject_user_routing_noop_when_empty() {
+        let mut req = make_rig_request(None);
+        let meta = std::collections::HashMap::new();
+        inject_user_routing(&mut req, &meta);
+        assert!(req.additional_params.is_none());
+    }
+
+    #[test]
+    fn test_inject_user_routing_preserves_existing_params() {
+        let mut req = make_rig_request(Some(serde_json::json!({
+            "model": "gpt-4o",
+        })));
+        let meta = make_metadata(&[
+            ("user_id", "grace"),
+            ("conversation_id", "conv-789"),
+        ]);
+        inject_user_routing(&mut req, &meta);
+
+        let params = req.additional_params.expect("should remain Some");
+        let obj = params.as_object().expect("should be object");
+        assert_eq!(obj.get("model"), Some(&serde_json::json!("gpt-4o")));
+        assert_eq!(
+            obj.get("user"),
+            Some(&serde_json::json!("grace:conv-789"))
+        );
+    }
+
+    #[test]
+    fn test_inject_user_routing_user_id_only() {
+        let mut req = make_rig_request(None);
+        let meta = make_metadata(&[("user_id", "andrew")]);
+        inject_user_routing(&mut req, &meta);
+
+        let params = req
+            .additional_params
+            .expect("additional_params should be Some");
+        assert_eq!(params, serde_json::json!({ "user": "andrew" }));
+    }
+
+    #[test]
+    fn test_inject_user_routing_conversation_id_only() {
+        let mut req = make_rig_request(None);
+        let meta = make_metadata(&[("conversation_id", "conv-abc")]);
+        inject_user_routing(&mut req, &meta);
+
+        let params = req
+            .additional_params
+            .expect("additional_params should be Some");
+        assert_eq!(params, serde_json::json!({ "user": "conv-abc" }));
     }
 }


### PR DESCRIPTION
## Summary
Add stable `conversation_id` to LLM request metadata so stateful backends can route by conversation instead of by ephemeral engine thread IDs.

## Problem
`LlmCallConfig.metadata` (v2 engine) was always an empty HashMap. The OpenAI `user` field was never set. Stateful OpenAI-compatible backends (proxies, session-based providers) need a stable conversation ID for session routing, prompt caching, and cost attribution.

Concrete scenario: an OpenAI-compatible proxy uses the `user` field for session affinity. Each turn gets a new thread ID, so the proxy treats every turn as a new session. Prompt cache is never reused, adding 15-20s cold starts per turn.

## Solution
Three changes, all backward-compatible:

**1. Stamp conversation_id on thread metadata** (`crates/ironclaw_engine/src/runtime/conversation.rs`)
- Add `conversation_id` (the `ConversationId` UUID) to `initial_metadata` when spawning new threads
- Applied before the executor's background task starts (avoids the `set_thread_metadata` race documented in the code)
- Follows the existing pattern for `source_channel` and `user_timezone`

**2. Populate LlmCallConfig.metadata** (`crates/ironclaw_engine/src/executor/orchestrator.rs`)
- Build the metadata HashMap with `thread_id`, `user_id` (from thread fields), and `conversation_id` (from thread.metadata)
- Previously always `HashMap::new()` (empty)

**3. Inject user routing** (`src/llm/rig_adapter.rs`)
- New `inject_user_routing()` encodes `"{user_id}:{session_id}"` in the OpenAI `user` field
- Prefers `conversation_id` (stable) over `thread_id` (per-turn), falls back gracefully
- Called in both `complete()` and `complete_with_tools()`

## Test plan

**Unit tests (9 new, all passing):**

Rig adapter (6 tests):
- `test_inject_user_routing_prefers_conversation_id` — conversation_id wins over thread_id
- `test_inject_user_routing_falls_back_to_thread_id` — uses thread_id when no conversation_id
- `test_inject_user_routing_noop_when_empty` — empty metadata, no additional_params
- `test_inject_user_routing_preserves_existing_params` — model override preserved
- `test_inject_user_routing_user_id_only` — partial metadata still produces output
- `test_inject_user_routing_conversation_id_only` — partial metadata still produces output

Engine pipeline tests (3 tests, using a capturing LLM mock):
- `thread_metadata_includes_conversation_id` — ConversationManager stamps conversation_id on spawned thread
- `llm_call_receives_conversation_id_in_metadata` — full pipeline: conversation_id flows from ConversationManager through orchestrator to LlmCallConfig
- `llm_metadata_omits_conversation_id_when_absent` — backward compat: threads spawned without conversation context omit conversation_id

**Engine tests:** All 340 ironclaw_engine tests pass (337 existing + 3 new).

**Manual validation** (repro script with mock OpenAI server):

```bash
#!/usr/bin/env bash
# Usage: ./test-conversation-id.sh /path/to/ironclaw
set -euo pipefail

BINARY="${1:?Usage: $0 /path/to/ironclaw}"
PORT=3013
GW_PORT=3014
TOKEN=test-tok
TD=$(mktemp -d)
LOG="$TD/llm.log"

trap 'kill $MOCK $IC 2>/dev/null; rm -rf "$TD"' EXIT

python3 -c "
import http.server, json
LOG='$LOG'
class H(http.server.BaseHTTPRequestHandler):
    def do_POST(self):
        body = self.rfile.read(int(self.headers['Content-Length'])).decode()
        open(LOG,'a').write(body+'\n')
        r = json.dumps({'id':'x','object':'chat.completion','choices':[{'index':0,'message':{'role':'assistant','content':'OK'},'finish_reason':'stop'}],'usage':{'prompt_tokens':1,'completion_tokens':1,'total_tokens':2}}).encode()
        self.send_response(200); self.send_header('Content-Type','application/json'); self.send_header('Content-Length',len(r)); self.end_headers(); self.wfile.write(r)
    def log_message(self,*a): pass
http.server.HTTPServer(('127.0.0.1',$PORT),H).serve_forever()
" &
MOCK=$!; sleep 0.3

IRONCLAW_BASE_DIR="$TD/home" ONBOARD_COMPLETED=true \
SECRETS_MASTER_KEY=0000000000000000000000000000000000000000000000000000000000000000 \
LLM_BACKEND=openai_compatible LLM_BASE_URL="http://127.0.0.1:$PORT/v1" \
LLM_API_KEY=k LLM_MODEL=m DATABASE_BACKEND=sqlite LIBSQL_PATH="$TD/test.db" \
HTTP_PORT=3015 HTTP_WEBHOOK_SECRET=test-secret \
GATEWAY_ENABLED=true GATEWAY_AUTH_TOKEN=$TOKEN \
GATEWAY_HOST=127.0.0.1 GATEWAY_PORT=$GW_PORT \
"$BINARY" --no-onboard >"$TD/ic.log" 2>&1 &
IC=$!

for _ in $(seq 30); do
  curl -sf "http://127.0.0.1:$GW_PORT/api/health" >/dev/null 2>&1 && break; sleep 1
done

API="http://127.0.0.1:$GW_PORT/api/chat/send"
curl -sf -X POST "$API" -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" -d '{"content":"Hello"}' >/dev/null || true
sleep 2
curl -sf -X POST "$API" -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" -d '{"content":"Hi again"}' >/dev/null || true
sleep 1

echo "user fields in LLM requests:"
grep -oE '"user":"[^"]*"' "$LOG" 2>/dev/null || echo "(none)"
```

Before (staging): `(none)` — no user field set.
After (feature branch): same conversation UUID across all turns.

## Scope
- `src/llm/rig_adapter.rs` (+138 lines, mostly tests) — inject_user_routing + 6 tests
- `crates/ironclaw_engine/src/runtime/conversation.rs` (+6 lines code, +157 lines tests) — stamp conversation_id + 3 pipeline tests
- `crates/ironclaw_engine/src/executor/orchestrator.rs` (+11 lines) — populate LlmCallConfig.metadata
- **Provider coverage:** RigAdapter only (covers openai_compatible, openai, anthropic, ollama, tinfoil). Non-rig providers use their own auth for tenant identification. A trait-level decorator could extend coverage in a follow-up.
- **Blast radius:** Low. Metadata is opaque; providers that don't read `user` are unaffected.
- **Breaking changes:** None. The `user` field was not previously set.