### PR TITLE
fix(ci): bump 5 channel versions + fix lifetime desync in panics check

### DIFF
--- a/registry/channels/discord.json
+++ b/registry/channels/discord.json
@@ -2,7 +2,7 @@
   "name": "discord",
   "display_name": "Discord Channel",
   "kind": "channel",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Discord",
   "keywords": [

--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -2,7 +2,7 @@
   "name": "slack",
   "display_name": "Slack Channel",
   "kind": "channel",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Slack",
   "keywords": [

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [

--- a/registry/channels/whatsapp.json
+++ b/registry/channels/whatsapp.json
@@ -2,7 +2,7 @@
   "name": "whatsapp",
   "display_name": "WhatsApp Channel",
   "kind": "channel",
-  "version": "0.2.0",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through WhatsApp",
   "keywords": [

--- a/scripts/check_no_panics.py
+++ b/scripts/check_no_panics.py
@@ -123,9 +123,25 @@ def sanitize_line(line: str, state: LexerState) -> str:
             i += 1
             continue
         if ch == "'":
-            # This can misclassify lifetimes like `'a` as char literals. That only
-            # risks false negatives by masking later code on the same line.
-            state.in_char = True
+            # Distinguish char literals ('x', '\n') from lifetime annotations
+            # ('a, 'static).  Lifetimes are an apostrophe followed by an ASCII
+            # letter or underscore and then a non-apostrophe (identifiers, not
+            # closing-quote).  Misclassifying a lifetime as a char literal
+            # blanks the rest of the line, hiding braces and causing the
+            # brace-depth tracker to desync across the whole file.
+            if nxt and (nxt.isalpha() or nxt == "_"):
+                # Peek past the identifier to see if it's 'x' (char) or 'ident (lifetime).
+                j = i + 2
+                while j < len(chars) and (chars[j].isalnum() or chars[j] == "_"):
+                    j += 1
+                if j < len(chars) and chars[j] == "'":
+                    # Closing quote found -> char literal like 'a' or 'ab' (invalid but safe to skip).
+                    state.in_char = True
+                else:
+                    # No closing quote -> lifetime annotation; skip the apostrophe.
+                    out[i] = " "
+            else:
+                state.in_char = True
             i += 1
             continue
 
@@ -346,6 +362,33 @@ class CheckNoPanicsTests(unittest.TestCase):
                 self.assertTrue(contexts[2])
                 self.assertFalse(contexts[4])
                 self.assertFalse(contexts[5])
+
+    def test_lifetime_annotations_do_not_desync_braces(self) -> None:
+        """Lifetime annotations ('a, 'static) must not be parsed as char literals.
+
+        If they are, the sanitizer blanks the rest of the line — including any
+        opening brace — and the brace-depth tracker desyncs.  This caused
+        false positives in large test modules (e.g. server.rs).
+        """
+        lines = [
+            "#[cfg(test)]\n",
+            "mod tests {\n",
+            "    fn set_env_var(key: &'static str) -> Guard {\n",
+            "        let original = std::env::var(key).ok();\n",
+            "        Guard { key, original }\n",
+            "    }\n",
+            "    fn later_helper() {\n",
+            '        value.expect("should be test context");\n',
+            "    }\n",
+            "}\n",
+        ]
+
+        contexts = line_test_contexts(lines)
+
+        # All lines inside mod tests must be test context, even after
+        # a function signature containing a lifetime annotation.
+        self.assertTrue(contexts[2], "fn with 'static should be test context")
+        self.assertTrue(contexts[7], "later helper should still be test context")
 
     def test_named_tests_module_marks_context(self) -> None:
         lines = [


### PR DESCRIPTION
## Summary

- Bump registry versions for 5 WASM channels whose source changed but versions weren't updated
- Fix a bug in `scripts/check_no_panics.py` where Rust lifetime annotations (`'static`, `'a`) caused false positive panic violations

Addresses CI failures from #1893 (tracked in [this comment](https://github.com/nearai/ironclaw/pull/1893#issuecomment-4227314436)).

## Change Type

- [x] Bug fix
- [x] CI/Infrastructure

## Linked Issue

Fixes CI failures from #1893

## Version Bumps

| Channel | Old | New | Reason |
|---------|-----|-----|--------|
| discord | 0.2.2 | 0.2.3 | Pairing message UX improvement |
| feishu | 0.1.4 | 0.2.0 | Pairing flow refactor + multi-tenancy |
| slack | 0.2.2 | 0.3.0 | New broadcast feature (`on_broadcast()`) |
| telegram | 0.2.6 | 0.2.8 | Webhook dedup + configurable polling |
| whatsapp | 0.2.0 | 0.2.2 | Pairing message UX improvement |

## Panics Check Fix

**Root cause:** The `sanitize_line()` lexer in `check_no_panics.py` treated Rust lifetime annotations (`'static`, `'a`) as char literal openings. This blanked the rest of the line — including any `{` — causing the brace-depth tracker to desync across the entire file. In `server.rs` (6500+ lines), the `mod tests` block at line 3829 appeared to "close" at line 4501 due to a missing `{` on `fn set_env_var(key: &'static str)`, making lines 4502-6568 falsely classified as production code.

**Fix:** Distinguish lifetimes from char literals by peeking past the identifier: if no closing `'` follows, it's a lifetime (skip the apostrophe); if a closing `'` is found, it's a char literal (enter char mode as before).

**Regression test added:** `test_lifetime_annotations_do_not_desync_braces`

## Validation

- [x] `python3 scripts/check_no_panics.py --self-test` — 5/5 tests pass
- [x] Verified `server.rs:6378-6387` and `http_security.rs:253-275` now correctly detected as test context

## Security Impact

None

## Database Impact

None

## Blast Radius

- Registry JSON metadata only (no code changes)
- CI script fix (Python, not Rust)

## Rollback Plan

Revert the commit.

---

**Review track**: A (CI/chore)

🤖 Generated with [Claude Code](https://claude.com/claude-code)