### PR TITLE
fix(ci): unblock v0.25.0 release — fix tag filter and publish config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ permissions:
 on:
   push:
     tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
+      - 'ironclaw-v[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,11 +116,11 @@ jsonschema = { version = "0.45", default-features = false }
 ironclaw_common = { path = "crates/ironclaw_common", version = "0.2.0" }
 
 # Safety/sanitization
-ironclaw_engine = { path = "crates/ironclaw_engine", version = "0.1.0" }
-ironclaw_gateway = { path = "crates/ironclaw_gateway", version = "0.1.0" }
+ironclaw_engine = { path = "crates/ironclaw_engine" }
+ironclaw_gateway = { path = "crates/ironclaw_gateway" }
 ironclaw_safety = { path = "crates/ironclaw_safety", version = "0.2.1" }
 ironclaw_skills = { path = "crates/ironclaw_skills", version = "0.1.0" }
-ironclaw_tui = { path = "crates/ironclaw_tui", version = "0.1.0", optional = true }
+ironclaw_tui = { path = "crates/ironclaw_tui", optional = true }
 regex = "1"
 aho-corasick = "1"
 

--- a/crates/ironclaw_gateway/Cargo.toml
+++ b/crates/ironclaw_gateway/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 rust-version = "1.92"
 description = "Gateway frontend assets, layout configuration, and widget extension system for IronClaw"
 license = "MIT OR Apache-2.0"
+publish = false
 
 [package.metadata.dist]
 dist = false

--- a/crates/ironclaw_tui/Cargo.toml
+++ b/crates/ironclaw_tui/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["NEAR AI <support@near.ai>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://github.com/nearai/ironclaw"
 repository = "https://github.com/nearai/ironclaw"
+publish = false
 
 [features]
 default = ["clipboard"]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,2 +1,28 @@
 [workspace]
+# GitHub Releases are created by cargo-dist (release.yml), not release-plz.
+# release-plz only creates git tags and publishes to crates.io.
 git_release_enable = false
+
+# ── Main binary ─────────────────────────────────────────────
+# Cannot publish to crates.io because ironclaw_engine depends on `monty`
+# (git-only, not on crates.io). Still create git tags so cargo-dist builds
+# binaries and creates GitHub Releases.
+[[package]]
+name = "ironclaw"
+publish = false
+
+# ── Internal crates (not useful standalone) ─────────────────
+[[package]]
+name = "ironclaw_engine"
+publish = false
+release = false
+
+[[package]]
+name = "ironclaw_tui"
+publish = false
+release = false
+
+[[package]]
+name = "ironclaw_gateway"
+publish = false
+release = false


### PR DESCRIPTION
## Summary

- Narrow `release.yml` tag pattern from `**[0-9]+.[0-9]+.[0-9]+*` to `ironclaw-v[0-9]+.[0-9]+.[0-9]+*` — prevents sub-crate tags from triggering cargo-dist binary builds
- Configure release-plz to skip crates.io publish for `ironclaw` (`publish = false`) while still creating git tags that trigger cargo-dist
- Mark `ironclaw_engine`, `ironclaw_tui`, `ironclaw_gateway` as non-releasable in `release-plz.toml`
- Add `publish = false` to tui and gateway `Cargo.toml` files
- Remove `version` fields from non-publishable path deps in root `Cargo.toml`

### What was broken

1. **`ironclaw_tui-v0.1.0` stole the "Latest" badge** — sub-crate tags matched the catch-all pattern in `release.yml`, triggering cargo-dist which created a bogus GitHub Release (fixed manually: deleted release, restored Latest to v0.24.0)
2. **v0.25.0 can't publish to crates.io** — `ironclaw_engine` depends on `monty` via a git dep (crates.io forbids git deps), so `cargo publish` for the main crate fails
3. **Sub-crate tags triggering full cargo-dist runs** — wasting CI and creating confusing releases

### What happens after merge

1. release-plz sees `ironclaw` at v0.25.0 with no tag → creates `ironclaw-v0.25.0` tag (skips crates.io)
2. Tag matches new pattern → cargo-dist builds binaries for all 7 targets + WASM extensions
3. GitHub Release created with all artifacts

### Trade-off

`cargo install ironclaw` stops working for v0.25.0+ (blocked by monty git dep in ironclaw_engine). Users install via the shell/npm installer from GitHub Releases. This can be restored if/when monty is published to crates.io.

## Test plan

- [x] `cargo check --all` passes
- [x] `cargo clippy --all --all-targets --all-features` clean
- [x] 349 engine tests pass
- [x] release-plz config validated (parses without error)
- [x] Tag pattern verified: `ironclaw-v*` matches main releases, rejects sub-crate tags
- [ ] After merge: verify release-plz creates `ironclaw-v0.25.0` tag
- [ ] After tag: verify cargo-dist creates GitHub Release with binary artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)