### PR TITLE
fix(llm): auto-append /v1 to LLM_BASE_URL for openai_compatible (#1934)

### DIFF
--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -285,7 +285,8 @@ fn create_openai_compat_from_registry(
 
     let mut builder = openai::Client::builder().api_key(&api_key);
     if !config.base_url.is_empty() {
-        builder = builder.base_url(&config.base_url);
+        let normalized = normalize_openai_base_url(&config.base_url);
+        builder = builder.base_url(&normalized);
     }
     if !extra_headers.is_empty() {
         builder = builder.http_headers(extra_headers);
@@ -707,6 +708,21 @@ pub fn create_gemini_oauth_provider(config: &LlmConfig) -> Result<Arc<dyn LlmPro
     Ok(Arc::new(provider))
 }
 
+/// Normalize an OpenAI-compatible base URL to ensure it ends with `/v1`.
+///
+/// Local model servers (MLX, vLLM, llama.cpp) expect requests at `/v1/chat/completions`,
+/// but rig-core's openai client appends `/chat/completions` directly to the base URL.
+/// This function ensures the `/v1` path segment is present so requests reach the
+/// correct endpoint regardless of whether the user included it.
+fn normalize_openai_base_url(url: &str) -> String {
+    let trimmed = url.trim_end_matches('/');
+    if trimmed.ends_with("/v1") {
+        trimmed.to_string()
+    } else {
+        format!("{}/v1", trimmed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -866,5 +882,61 @@ mod tests {
         // None when nothing configured
         let config = test_llm_config();
         assert_eq!(config.cheap_model_name(), None);
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_appends_v1_when_missing() {
+        assert_eq!(
+            normalize_openai_base_url("http://localhost:8080"),
+            "http://localhost:8080/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_strips_trailing_slash_then_appends_v1() {
+        assert_eq!(
+            normalize_openai_base_url("http://localhost:8080/"),
+            "http://localhost:8080/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_preserves_existing_v1() {
+        assert_eq!(
+            normalize_openai_base_url("http://localhost:8080/v1"),
+            "http://localhost:8080/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_preserves_v1_with_trailing_slash() {
+        assert_eq!(
+            normalize_openai_base_url("http://localhost:8080/v1/"),
+            "http://localhost:8080/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_with_path_prefix() {
+        assert_eq!(
+            normalize_openai_base_url("https://proxy.example.com/llm"),
+            "https://proxy.example.com/llm/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_with_path_prefix_and_v1() {
+        assert_eq!(
+            normalize_openai_base_url("https://proxy.example.com/llm/v1"),
+            "https://proxy.example.com/llm/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_multiple_trailing_slashes() {
+        assert_eq!(
+            normalize_openai_base_url("http://localhost:8080///"),
+            "http://localhost:8080/v1"
+        );
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -245,9 +245,13 @@ async fn create_bedrock_provider(config: &LlmConfig) -> Result<Arc<dyn LlmProvid
     Ok(Arc::new(provider))
 }
 
-fn create_openai_compat_from_registry(
+/// Build the rig-core OpenAI-compatible `CompletionsClient` for a registry
+/// provider config. Extracted from `create_openai_compat_from_registry` so
+/// tests can drive the exact construction path (including base URL
+/// normalization) and inspect the resulting client's base URL.
+fn build_openai_compat_client(
     config: &RegistryProviderConfig,
-) -> Result<Arc<dyn LlmProvider>, LlmError> {
+) -> Result<rig::providers::openai::CompletionsClient, LlmError> {
     use rig::providers::openai;
 
     let mut extra_headers = reqwest::header::HeaderMap::new();
@@ -300,7 +304,13 @@ fn create_openai_compat_from_registry(
     // Use CompletionsClient (Chat Completions API) instead of the default
     // Client (Responses API). The Responses API path in rig-core handles
     // tool results differently, which breaks IronClaw's tool call flow.
-    let client = client.completions_api();
+    Ok(client.completions_api())
+}
+
+fn create_openai_compat_from_registry(
+    config: &RegistryProviderConfig,
+) -> Result<Arc<dyn LlmProvider>, LlmError> {
+    let client = build_openai_compat_client(config)?;
     let model = client.completion_model(&config.model);
 
     tracing::debug!(
@@ -937,6 +947,80 @@ mod tests {
         assert_eq!(
             normalize_openai_base_url("http://localhost:8080///"),
             "http://localhost:8080/v1"
+        );
+    }
+
+    // ---- Caller-level tests for the openai_compatible provider factory ----
+    //
+    // These tests drive `build_openai_compat_client` — the shared builder used
+    // by `create_openai_compat_from_registry` — and inspect the base URL on
+    // the constructed rig-core client. The helper-level
+    // `normalize_openai_base_url` tests above only cover string normalization;
+    // these assert that the normalization is actually threaded through to the
+    // client that ends up serving real requests, for both a bare local
+    // endpoint and an already-versioned custom endpoint.
+
+    fn registry_config_for_base_url(base_url: &str) -> RegistryProviderConfig {
+        use crate::llm::config::CacheRetention;
+        use crate::llm::registry::ProviderProtocol;
+        use secrecy::SecretString;
+
+        RegistryProviderConfig {
+            protocol: ProviderProtocol::OpenAiCompletions,
+            provider_id: "test_openai_compat".to_string(),
+            api_key: Some(SecretString::from("test-key".to_string())),
+            base_url: base_url.to_string(),
+            model: "test-model".to_string(),
+            extra_headers: Vec::new(),
+            oauth_token: None,
+            is_codex_chatgpt: false,
+            refresh_token: None,
+            auth_path: None,
+            cache_retention: CacheRetention::default(),
+            unsupported_params: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn test_openai_compat_factory_appends_v1_for_bare_local_base_url() {
+        // Bare local endpoint (MLX, vLLM, llama.cpp style): factory must
+        // append /v1 so rig-core's `/chat/completions` lands at
+        // `/v1/chat/completions`.
+        let config = registry_config_for_base_url("http://localhost:8080");
+        let client = build_openai_compat_client(&config)
+            .expect("build_openai_compat_client should succeed for bare local URL");
+        assert_eq!(
+            client.base_url(),
+            "http://localhost:8080/v1",
+            "bare local base URL should have /v1 appended by the factory"
+        );
+    }
+
+    #[test]
+    fn test_openai_compat_factory_preserves_already_versioned_custom_base_url() {
+        // Custom proxy that already includes /v1: factory must NOT
+        // double-suffix to /v1/v1.
+        let config = registry_config_for_base_url("https://custom.proxy.example.com/v1");
+        let client = build_openai_compat_client(&config)
+            .expect("build_openai_compat_client should succeed for pre-versioned URL");
+        assert_eq!(
+            client.base_url(),
+            "https://custom.proxy.example.com/v1",
+            "pre-versioned custom base URL must not be double-suffixed"
+        );
+    }
+
+    #[test]
+    fn test_openai_compat_factory_strips_trailing_slash_on_versioned_url() {
+        // Regression guard for the `/v1/` -> `/v1` trimming path at the
+        // caller level.
+        let config = registry_config_for_base_url("https://custom.proxy.example.com/v1/");
+        let client = build_openai_compat_client(&config)
+            .expect("build_openai_compat_client should succeed for trailing-slash URL");
+        assert_eq!(
+            client.base_url(),
+            "https://custom.proxy.example.com/v1",
+            "trailing slash after /v1 should be stripped, not double-suffixed"
         );
     }
 }

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -316,7 +316,8 @@ fn create_openai_compat_from_registry(
     tracing::debug!(
         provider = %config.provider_id,
         model = %config.model,
-        base_url = %config.base_url,
+        original_base_url = %config.base_url,
+        normalized_base_url = %client.base_url(),
         "Using OpenAI-compatible provider"
     );
 
@@ -726,7 +727,7 @@ pub fn create_gemini_oauth_provider(config: &LlmConfig) -> Result<Arc<dyn LlmPro
 /// correct endpoint regardless of whether the user included it.
 fn normalize_openai_base_url(url: &str) -> String {
     let trimmed = url.trim_end_matches('/');
-    if trimmed.ends_with("/v1") {
+    if trimmed.rsplit_once('/').map(|(_, last)| last) == Some("v1") {
         trimmed.to_string()
     } else {
         format!("{}/v1", trimmed)
@@ -939,6 +940,23 @@ mod tests {
         assert_eq!(
             normalize_openai_base_url("https://proxy.example.com/llm/v1"),
             "https://proxy.example.com/llm/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_no_false_positive_on_apiv1() {
+        // "/apiv1" ends with "v1" but the last path segment is "apiv1", not "v1".
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/apiv1"),
+            "https://example.com/apiv1/v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_openai_base_url_no_false_positive_on_myv1() {
+        assert_eq!(
+            normalize_openai_base_url("https://example.com/myv1"),
+            "https://example.com/myv1/v1"
         );
     }
 


### PR DESCRIPTION
## Summary
Fixes #1934. Local model servers (MLX, vLLM, llama.cpp) returned 404 when `LLM_BASE_URL` lacked a `/v1` suffix because rig-core's openai client appends `/chat/completions` directly to the base URL.

- Added `normalize_openai_base_url()` in `src/llm/mod.rs` that auto-appends `/v1` when not already present
- Applied in `create_openai_compat_from_registry()`
- 7 unit tests covering bare URL, trailing slash, already-has-`/v1`, path prefixes, etc.

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-features` zero warnings
- [x] All tests pass
- [ ] Manual: `LLM_BACKEND=openai_compatible LLM_BASE_URL=http://localhost:8080 ironclaw` succeeds against a local server

🤖 Generated with [Claude Code](https://claude.com/claude-code)