### PR TITLE
fix(config): skip NEARAI URL DNS validation when nearai backend not selected (#1826)

### DIFF
--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -2198,6 +2198,46 @@ mod tests {
         }
     }
 
+    /// Positive companion to `non_nearai_backend_skips_nearai_url_validation`
+    /// (#1826): when the backend IS `nearai`, an unresolvable NEARAI_AUTH_URL
+    /// must still trigger the validation failure the original fix preserved —
+    /// proving the guard only short-circuits when nearai is inactive, never
+    /// when it's the selected backend.
+    #[test]
+    fn nearai_backend_enforces_nearai_url_validation() {
+        let _guard = lock_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            // Point auth URL at a hostname that will never resolve.
+            std::env::set_var("NEARAI_AUTH_URL", "https://does-not-exist.invalid");
+            std::env::remove_var("NEARAI_BASE_URL");
+            std::env::remove_var("NEARAI_API_KEY");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("nearai".to_string()),
+            ..Default::default()
+        };
+
+        // Must fail — nearai is active, so the unreachable auth URL is a
+        // real misconfiguration that validate_base_url should surface.
+        let err = LlmConfig::resolve(&settings).expect_err(
+            "resolve must fail when nearai is active and NEARAI_AUTH_URL \
+             is unresolvable (#1826 companion)",
+        );
+        let msg = err.to_string();
+        assert!(
+            msg.contains("NEARAI_AUTH_URL"),
+            "expected error to mention NEARAI_AUTH_URL, got: {msg}"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("NEARAI_AUTH_URL");
+        }
+    }
+
     #[test]
     fn registry_provider_override_base_url_wins_over_env() {
         let _guard = lock_env();

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -134,10 +134,14 @@ impl LlmConfig {
             );
         }
 
-        // Session config (used by NearAI provider for OAuth/session-token auth)
+        // Session config (used by NearAI provider for OAuth/session-token auth).
+        // Only validate (DNS-resolve) the auth URL when nearai is the active
+        // backend — otherwise startup fails if the hostname is unreachable (#1826).
         let nearai_auth_url = optional_env("NEARAI_AUTH_URL")?
             .unwrap_or_else(|| "https://private.near.ai".to_string());
-        validate_base_url(&nearai_auth_url, "NEARAI_AUTH_URL")?;
+        if is_nearai {
+            validate_base_url(&nearai_auth_url, "NEARAI_AUTH_URL")?;
+        }
         let session = SessionConfig {
             auth_base_url: nearai_auth_url,
             session_path: optional_env("NEARAI_SESSION_PATH")?
@@ -172,7 +176,10 @@ impl LlmConfig {
         } else {
             "https://private.near.ai".to_string()
         };
-        validate_base_url(&nearai_base_url, "NEARAI_BASE_URL")?;
+        // Only DNS-resolve the base URL when nearai is active (#1826).
+        if is_nearai {
+            validate_base_url(&nearai_base_url, "NEARAI_BASE_URL")?;
+        }
         let nearai = NearAiConfig {
             model: nearai_model,
             cheap_model: optional_env("NEARAI_CHEAP_MODEL")?,
@@ -2155,6 +2162,40 @@ mod tests {
             cfg.nearai.base_url, "https://cloud-api.near.ai",
             "With API key, should default to cloud-api.near.ai"
         );
+    }
+
+    /// Regression test for #1826: when the backend is NOT nearai, config
+    /// resolution must succeed even if NEARAI_AUTH_URL points to an
+    /// unresolvable hostname (no DNS lookup should be attempted).
+    #[test]
+    fn non_nearai_backend_skips_nearai_url_validation() {
+        let _guard = lock_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            // Point auth/base URLs at a hostname that will never resolve.
+            std::env::set_var("NEARAI_AUTH_URL", "https://does-not-exist.invalid");
+            std::env::set_var("NEARAI_BASE_URL", "https://also-unresolvable.invalid");
+            std::env::remove_var("NEARAI_API_KEY");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai".to_string()),
+            ..Default::default()
+        };
+
+        // Must not fail — the unreachable NEARAI URLs should be ignored.
+        let cfg = LlmConfig::resolve(&settings).expect(
+            "resolve must succeed when nearai is not the backend, \
+             even with unreachable NEARAI_AUTH_URL (#1826)",
+        );
+        assert_eq!(cfg.backend, "openai");
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("NEARAI_AUTH_URL");
+            std::env::remove_var("NEARAI_BASE_URL");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Fixes #1826. `LlmConfig::resolve()` unconditionally called `validate_base_url()` for `NEARAI_AUTH_URL` and `NEARAI_BASE_URL`, performing blocking DNS resolution via `to_socket_addrs()`. When DNS for `private.near.ai` failed, startup failed even when the user wasn't using the nearai backend.

- Wrapped both `validate_base_url()` calls inside `if is_nearai { ... }` guards
- URLs still get default values; DNS only attempted at runtime when nearai is selected
- Regression test uses RFC 6761 `.invalid` hostnames

## Test plan
- [x] `cargo fmt`, `cargo clippy --all --all-features` zero warnings
- [x] All 57 LLM config tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)