### PR TITLE
fix(secrets): auto-generate master key with file fallback when keychain unavailable (#1820)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -44,7 +44,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -63,9 +63,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.10.2"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c56a59cf6315e99f874d2c1f96c69d2da5ffe0087d211297fc4a41f849770a2"
+checksum = "10eeef5e80864f9c3c148a3f395c3e35a66d37ec7561c7845b2bffae8e841759"
 dependencies = [
  "agent-client-protocol-schema",
  "anyhow",
@@ -80,9 +80,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0497b9a95a404e35799904835c57c6f8c69b9d08ccfd3cb5b7d746425cd6789"
+checksum = "ca68e7e55681ce56546c0cecc6bc8f20493d24b44c6d93ec46174f310730bba2"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -375,9 +375,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -573,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.128.0"
+version = "1.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949d34a5c329ed83e7146d2fc1ffc06473fdc9bcbc5fa3d3534abeb950569c5"
+checksum = "c710f0b7dbd906047724ec892afc0de0b92c7484ba25f499a91563e0417a96d6"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -685,11 +685,11 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac",
+ "hmac 0.12.1",
  "http 0.2.12",
  "http 1.4.0",
  "percent-encoding",
- "sha2",
+ "sha2 0.10.9",
  "time",
  "tracing",
 ]
@@ -753,13 +753,13 @@ dependencies = [
  "http 1.4.0",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.24.2",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.8",
  "hyper-util",
  "pin-project-lite",
  "rustls 0.21.12",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -929,7 +929,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit 0.8.4",
@@ -1097,16 +1097,16 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "4d2d5991425dfd0785aed03aedcf0b321d61975c9b5b3689c774a2610ae0b51e"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -1116,6 +1116,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1155,14 +1164,14 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-named-pipe",
- "hyper-rustls 0.27.7",
+ "hyper-rustls 0.27.8",
  "hyper-util",
  "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -1438,9 +1447,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.58"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1468,6 +1477,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.0",
+]
 
 [[package]]
 name = "chrono"
@@ -1526,7 +1546,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
 ]
 
@@ -1565,9 +1585,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.6.0"
+version = "4.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c9f1dde76b736e3681f28cec9d5a61299cbaae0fce80a68e43724ad56031eb"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
 dependencies = [
  "clap",
 ]
@@ -1607,6 +1627,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "cobs"
@@ -1682,6 +1708,12 @@ name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "const-random"
@@ -1777,6 +1809,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -2143,6 +2184,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2175,15 +2225,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -2291,7 +2350,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der_derive",
  "flagset",
  "zeroize",
@@ -2375,9 +2434,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -2515,7 +2586,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2706,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"
@@ -3096,6 +3167,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.0",
  "wasip2",
  "wasip3",
 ]
@@ -3112,13 +3184,13 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -3140,7 +3212,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3159,7 +3231,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -3230,6 +3302,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
 name = "hashlink"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3276,7 +3354,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -3285,7 +3363,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3429,6 +3516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3454,9 +3550,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3469,7 +3565,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -3482,7 +3577,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3525,16 +3620,15 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
@@ -3565,7 +3659,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -3586,7 +3680,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3619,12 +3713,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -3632,9 +3727,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -3645,9 +3740,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -3659,15 +3754,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -3679,15 +3774,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -3772,12 +3867,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -3803,9 +3898,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.1"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99322078b2c076829a1db959d49da554fabc4342257fc0ba5a070a1eb3a01cd8"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -3856,9 +3951,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -3900,10 +3995,10 @@ dependencies = [
  "glob",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "html-to-markdown-rs",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "iana-time-zone",
  "insta",
@@ -3933,7 +4028,7 @@ dependencies = [
  "rig-core",
  "rust_decimal",
  "rust_decimal_macros",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
  "rustyline",
  "secrecy",
@@ -3943,7 +4038,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "tar",
  "tempfile",
@@ -3971,6 +4066,7 @@ dependencies = [
  "wasmtime-wasi",
  "webpki-roots 0.26.11",
  "zbus",
+ "zeroize",
  "zip",
 ]
 
@@ -3998,7 +4094,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -4039,7 +4135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4202,9 +4298,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc4c90f45aa2e6eacbe8645f77fdea542ac97a494bcd117a67df9ff4d611f995"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -4225,9 +4321,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f29616f6e19415398eb186964fb7cbbeef572c79bede3622a8277667924bbe3"
+checksum = "257eb0e588b76827bbddc9e73945a9743693dd2adeaee9da26420f93cfedb798"
 dependencies = [
  "ahash 0.8.12",
  "bytecount",
@@ -4275,7 +4371,7 @@ dependencies = [
  "crc",
  "cssparser",
  "html5ever 0.38.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "precomputed-hash",
  "selectors 0.35.0",
 ]
@@ -4354,9 +4450,9 @@ checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.185"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
 name = "libloading"
@@ -4376,14 +4472,14 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -4469,7 +4565,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cc",
  "fallible-iterator 0.3.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "memchr",
  "phf 0.11.3",
@@ -4542,9 +4638,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -4575,10 +4671,10 @@ checksum = "c5c8ecfc6c72051981c0459f75ccc585e7ff67c70829560cda8e647882a9abff"
 dependencies = [
  "encoding_rs",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "nom",
  "rangemap",
  "time",
@@ -4714,7 +4810,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -4804,7 +4910,7 @@ dependencies = [
  "chrono",
  "fancy-regex",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "jiter",
  "libm",
@@ -5086,7 +5192,7 @@ checksum = "271638cd5fa9cca89c4c304675ca658efc4e64a66c716b7cfe1afb4b9611dbbc"
 dependencies = [
  "crc32fast",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -5164,11 +5270,11 @@ dependencies = [
 
 [[package]]
 name = "ordermap"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfa78c92071bbd3628c22b1a964f7e0eb201dc1456555db072beb1662ecd6715"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5320,7 +5426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5330,7 +5436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -5508,9 +5614,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -5580,7 +5686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -5612,27 +5718,27 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.10"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac",
- "md-5",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
  "memchr",
- "rand 0.9.2",
- "sha2",
+ "rand 0.10.1",
+ "sha2 0.11.0",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
  "bytes",
  "chrono",
@@ -5651,9 +5757,9 @@ checksum = "78451badbdaebaf17f053fd9152b3ffb33b516104eacb45e7864aaa9c712f306"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -5705,7 +5811,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.8+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -5899,7 +6005,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5916,10 +6022,10 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash 2.1.2",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -6014,12 +6120,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.0",
 ]
 
 [[package]]
@@ -6059,6 +6176,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
 
 [[package]]
 name = "rand_xoshiro"
@@ -6118,9 +6241,9 @@ dependencies = [
 
 [[package]]
 name = "readabilityrs"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3eb174b0af6c181a87d68b42800806657bfbdf88b566f819aaadb9d2a7b7699d"
+checksum = "d90c6e1dad698d9f3c80a8d91bc0efc8c2397cb5ca4bbffb9c0fb88a9a66e6b8"
 dependencies = [
  "bitflags 2.11.0",
  "kuchikikiki",
@@ -6154,9 +6277,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -6205,9 +6328,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.45.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a618c14f8ba29d8193bb55e2bf13e4fb2b1115313ecb7ae94b43100c7ac7d5"
+checksum = "e2f38748ceca8d0b0013e60f534d94a6e23dfd89fd2a88318fc5a2d04fda1010"
 dependencies = [
  "ahash 0.8.12",
  "fluent-uri",
@@ -6336,8 +6459,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls 0.27.7",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.8",
  "hyper-util",
  "js-sys",
  "log",
@@ -6346,7 +6469,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "serde",
@@ -6627,15 +6750,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -6707,9 +6830,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -6880,7 +7003,7 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "zbus",
 ]
 
@@ -6960,9 +7083,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -7084,7 +7207,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -7111,7 +7234,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -7124,7 +7247,7 @@ version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59e2dd588bf1597a252c3b920e0143eb99b0f76e4e082f4c92ce34fbc9e71ddd"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "libyml",
  "memchr",
@@ -7149,8 +7272,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -7166,8 +7289,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -7798,9 +7932,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -7854,9 +7988,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -7882,9 +8016,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7893,9 +8027,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7910,7 +8044,7 @@ dependencies = [
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand 0.9.2",
+ "rand 0.10.1",
  "socket2 0.6.3",
  "tokio",
  "tokio-util",
@@ -7923,9 +8057,9 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27d684bad428a0f2481f42241f821db42c54e2dc81d8c00db8536c506b0a0144"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "ring",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
  "tokio-postgres",
  "tokio-rustls 0.26.4",
@@ -7959,7 +8093,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -8009,7 +8143,7 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.38",
  "rustls-native-certs 0.8.3",
  "rustls-pki-types",
  "tokio",
@@ -8061,7 +8195,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -8090,9 +8224,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -8103,7 +8237,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -8113,23 +8247,23 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.8+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16bff38f1d86c47f9ff0647e6838d7bb362522bdf44006c7068c2b1e606f1f3c"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -8415,8 +8549,8 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
- "rustls 0.23.37",
+ "rand 0.9.3",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
@@ -8434,7 +8568,7 @@ dependencies = [
  "http 1.4.0",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.3",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -8583,7 +8717,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -8752,9 +8886,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6523d69017b7633e396a89c5efab138161ed5aafcbc8d3e5c5a42ae38f50495a"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -8766,9 +8900,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.65"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1faf851e778dfa54db7cd438b70758eba9755cb47403f3496edd7c8fc212f0"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -8776,9 +8910,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3a6c758eb2f701ed3d052ff5737f5bfe6614326ea7f3bbac7156192dc32e67"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8786,9 +8920,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "921de2737904886b52bcbb237301552d05969a6f9c40d261eb0533c8b055fedf"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -8799,9 +8933,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.115"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a93e946af942b58934c604527337bad9ae33ba1d5c6900bbb41c2c07c2364a93"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -8815,7 +8949,7 @@ dependencies = [
  "anyhow",
  "heck",
  "im-rc",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "petgraph",
  "serde",
@@ -8848,13 +8982,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.246.2",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -8880,7 +9024,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -8892,9 +9036,20 @@ checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.246.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
+dependencies = [
+ "bitflags 2.11.0",
+ "indexmap 2.14.0",
+ "semver",
 ]
 
 [[package]]
@@ -8974,7 +9129,7 @@ dependencies = [
  "cranelift-entity",
  "gimli",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "object",
  "postcard",
@@ -8982,7 +9137,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "target-lexicon",
  "wasm-encoder 0.245.1",
@@ -9005,7 +9160,7 @@ dependencies = [
  "rustix 1.1.4",
  "serde",
  "serde_derive",
- "sha2",
+ "sha2 0.10.9",
  "toml 0.9.12+spec-1.1.0",
  "wasmtime-environ",
  "windows-sys 0.61.2",
@@ -9161,7 +9316,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.11.0",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wit-parser 0.245.1",
 ]
 
@@ -9219,31 +9374,31 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "245.0.1"
+version = "246.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cf1149285569120b8ce39db8b465e8a2b55c34cbb586bd977e43e2bc7300bf"
+checksum = "fe3fe8e3bf88ad96d031b4181ddbd64634b17cb0d06dfc3de589ef43591a9a62"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.245.1",
+ "wasm-encoder 0.246.2",
 ]
 
 [[package]]
 name = "wat"
-version = "1.245.1"
+version = "1.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd48d1679b6858988cb96b154dda0ec5bbb09275b71db46057be37332d5477be"
+checksum = "4bd7fda1199b94fff395c2d19a153f05dbe7807630316fa9673367666fd2ad8c"
 dependencies = [
- "wast 245.0.1",
+ "wast 246.0.2",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.92"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84cde8507f4d7cfcb1185b8cb5890c494ffea65edbe1ba82cfd63661c805ed94"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9722,9 +9877,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -9767,7 +9922,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -9798,7 +9953,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -9817,7 +9972,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -9836,7 +9991,7 @@ dependencies = [
  "anyhow",
  "hashbrown 0.16.1",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -9860,9 +10015,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -9896,7 +10051,7 @@ version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "der",
  "spki",
  "tls_codec",
@@ -9936,9 +10091,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9947,9 +10102,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10063,18 +10218,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10104,9 +10259,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -10115,9 +10270,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -10126,9 +10281,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10146,7 +10301,7 @@ dependencies = [
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "thiserror 2.0.18",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ semver = "1"
 
 # Secrecy for sensitive values
 secrecy = { version = "0.10", features = ["serde"] }
+zeroize = "1"
 
 # URL parsing and encoding
 url = "2"

--- a/src/channels/web/handlers/settings.rs
+++ b/src/channels/web/handlers/settings.rs
@@ -423,7 +423,11 @@ fn require_secrets_store(
     match state.secrets_store.as_ref() {
         Some(s) => Ok(Some(s)),
         None if has_real_keys => {
-            tracing::error!("Cannot store API keys: secrets store is not available");
+            tracing::error!(
+                "Cannot store API keys: secrets store is not available. \
+                 Set the SECRETS_MASTER_KEY environment variable or ensure a database \
+                 backend (PostgreSQL or libSQL) is configured."
+            );
             Err(StatusCode::SERVICE_UNAVAILABLE)
         }
         None => Ok(None),

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -616,6 +616,9 @@ fn check_secrets(settings: &Settings) -> CheckResult {
                 )
             }
         }
+        crate::settings::KeySource::File => {
+            CheckResult::Pass("master key source: file (~/.ironclaw/master.key)".into())
+        }
         crate::settings::KeySource::None => {
             CheckResult::Skip("secrets not configured (run `ironclaw onboard`)".into())
         }

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -2,6 +2,7 @@ use secrecy::{ExposeSecret, SecretString};
 
 use crate::config::helpers::optional_env;
 use crate::error::ConfigError;
+use crate::secrets::keychain::{Keystore, KeystoreError, OsKeystore};
 
 /// Secrets management configuration.
 #[derive(Clone, Default)]
@@ -31,25 +32,98 @@ impl SecretsConfig {
     /// If neither source has a key, auto-generate one and persist it to the
     /// keychain (preferred) or a file at `~/.ironclaw/master.key` (fallback).
     /// This ensures the secrets store is always available without manual setup.
+    ///
+    /// # Keystore failure semantics
+    ///
+    /// The OS keychain is probed via the [`Keystore`] abstraction, which
+    /// distinguishes `NotFound` ("store is reachable but has no entry" --
+    /// a legitimate signal to fall back or generate) from `Unavailable`
+    /// ("store is locked / D-Bus down / permission denied" -- a transient
+    /// failure that MUST NOT be treated as NotFound). A transient failure
+    /// propagates as a startup error rather than silently rotating the
+    /// master key and stranding any previously-encrypted secrets.
     pub(crate) async fn resolve() -> Result<Self, ConfigError> {
+        Self::resolve_with_keystore(
+            &OsKeystore,
+            &Self::master_key_file_path(),
+            /* allow_keystore_persist = */ true,
+        )
+        .await
+    }
+
+    /// Testable core of [`Self::resolve`]. Isolates the keystore
+    /// abstraction and file-fallback path so caller-level tests can
+    /// simulate first-boot, reuse, NotFound-with-file, and transient
+    /// failure modes deterministically.
+    ///
+    /// `allow_keystore_persist` controls whether newly-generated keys
+    /// may be written to the keystore; tests disable this to force the
+    /// file-fallback path.
+    pub(crate) async fn resolve_with_keystore<K: Keystore + ?Sized>(
+        keystore: &K,
+        master_key_file: &std::path::Path,
+        allow_keystore_persist: bool,
+    ) -> Result<Self, ConfigError> {
         use crate::settings::KeySource;
 
         let (master_key, source) = if let Some(env_key) = optional_env("SECRETS_MASTER_KEY")? {
             (Some(SecretString::from(env_key)), KeySource::Env)
         } else {
-            // Probe the OS keychain; if a key is stored, use it
-            match crate::secrets::keychain::get_master_key().await {
+            match keystore.get_master_key().await {
                 Ok(key_bytes) => {
+                    // Key present in keychain -- reuse it. Never rotate.
                     let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
                     (Some(SecretString::from(key_hex)), KeySource::Keychain)
                 }
-                Err(_) => {
-                    // Try loading from the file-based fallback
-                    match Self::load_master_key_file() {
+                Err(KeystoreError::NotFound) => {
+                    // Keychain is reachable and authoritatively reports
+                    // no entry. Safe to fall back to file, or generate.
+                    match Self::load_master_key_from_path(master_key_file) {
                         Some(key_hex) => (Some(SecretString::from(key_hex)), KeySource::File),
                         None => {
-                            // No key anywhere — auto-generate and persist
-                            Self::auto_generate_master_key().await
+                            Self::auto_generate_master_key(
+                                keystore,
+                                master_key_file,
+                                allow_keystore_persist,
+                            )
+                            .await
+                        }
+                    }
+                }
+                Err(KeystoreError::Unavailable { reason }) => {
+                    // Transient failure (locked, D-Bus down, permission
+                    // denied, etc.). If a file-based key already exists,
+                    // use it -- that's the key we'd regenerate to anyway
+                    // and preserving it avoids stranding secrets the
+                    // next time the keychain comes back.
+                    //
+                    // If there is NO existing key anywhere, we MUST NOT
+                    // silently generate a new one: doing so could strand
+                    // previously-encrypted secrets that were keyed from
+                    // the real keychain value we couldn't read. Propagate
+                    // the error and fail to start.
+                    match Self::load_master_key_from_path(master_key_file) {
+                        Some(key_hex) => {
+                            tracing::warn!(
+                                "OS keystore unavailable ({reason}); using existing \
+                                 file-based master key at {}",
+                                master_key_file.display()
+                            );
+                            (Some(SecretString::from(key_hex)), KeySource::File)
+                        }
+                        None => {
+                            return Err(ConfigError::InvalidValue {
+                                key: "SECRETS_MASTER_KEY".to_string(),
+                                message: format!(
+                                    "OS keystore is unavailable ({reason}) and no \
+                                     master.key file fallback exists. Refusing to \
+                                     auto-generate a new master key because doing so \
+                                     would silently strand any previously-encrypted \
+                                     secrets once the keystore becomes reachable \
+                                     again. Set SECRETS_MASTER_KEY explicitly, unlock \
+                                     the keystore, or place a master.key file."
+                                ),
+                            });
                         }
                     }
                 }
@@ -76,27 +150,28 @@ impl SecretsConfig {
 
     /// Auto-generate a master key and try to persist it.
     ///
-    /// Tries the OS keychain first; falls back to `~/.ironclaw/master.key`.
-    async fn auto_generate_master_key() -> (Option<SecretString>, crate::settings::KeySource) {
+    /// Tries the OS keystore first (when `allow_keystore_persist` is
+    /// true); falls back to `master_key_file`.
+    async fn auto_generate_master_key<K: Keystore + ?Sized>(
+        keystore: &K,
+        master_key_file: &std::path::Path,
+        allow_keystore_persist: bool,
+    ) -> (Option<SecretString>, crate::settings::KeySource) {
         use crate::settings::KeySource;
 
         let key_bytes = crate::secrets::keychain::generate_master_key();
         let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
 
-        // Try storing in the OS keychain
-        if crate::secrets::keychain::store_master_key(&key_bytes)
-            .await
-            .is_ok()
-        {
+        if allow_keystore_persist && keystore.store_master_key(&key_bytes).await.is_ok() {
             tracing::debug!("Auto-generated secrets master key and stored in OS keychain");
             return (Some(SecretString::from(key_hex)), KeySource::Keychain);
         }
 
-        // Keychain unavailable — persist to file
-        if Self::save_master_key_file(&key_hex) {
+        // Keychain unavailable -- persist to file
+        if Self::save_master_key_to_path(&key_hex, master_key_file) {
             tracing::debug!(
                 "Auto-generated secrets master key and stored in {}",
-                Self::master_key_file_path().display()
+                master_key_file.display()
             );
             return (Some(SecretString::from(key_hex)), KeySource::File);
         }
@@ -111,11 +186,6 @@ impl SecretsConfig {
     /// Path to the file-based master key fallback.
     fn master_key_file_path() -> std::path::PathBuf {
         crate::bootstrap::ironclaw_base_dir().join("master.key")
-    }
-
-    /// Load the master key from the file-based fallback.
-    fn load_master_key_file() -> Option<String> {
-        Self::load_master_key_from_path(&Self::master_key_file_path())
     }
 
     /// Load and validate a master key from a specific file path.
@@ -134,11 +204,6 @@ impl SecretsConfig {
             }
             Err(_) => None,
         }
-    }
-
-    /// Save the master key to the file-based fallback with restrictive permissions.
-    fn save_master_key_file(key_hex: &str) -> bool {
-        Self::save_master_key_to_path(key_hex, &Self::master_key_file_path())
     }
 
     /// Save the master key to a specific file path with restrictive permissions.
@@ -197,7 +262,319 @@ impl SecretsConfig {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Mutex, OnceLock};
+
     use super::*;
+    use crate::settings::KeySource;
+
+    /// Serialize all tests in this module that mutate `SECRETS_MASTER_KEY`.
+    /// `std::env::set_var`/`remove_var` are process-global, so without
+    /// this lock `cargo test`'s parallel scheduler races and flakes the
+    /// env-guarded tests.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Deterministic keystore stub for caller-level tests. Lets each test
+    /// inject a specific response (present / NotFound / transient
+    /// Unavailable) and observes whether the resolver attempts to
+    /// persist a newly-generated key.
+    struct TestKeystore {
+        /// Response to return from `get_master_key`.
+        get_response: Mutex<Result<Vec<u8>, KeystoreError>>,
+        /// If present, `store_master_key` records the stored bytes here.
+        /// Tests assert on this to detect silent rotation.
+        stored: Mutex<Option<Vec<u8>>>,
+        /// If true, `store_master_key` fails with Unavailable.
+        store_fails: bool,
+    }
+
+    impl TestKeystore {
+        fn new(get_response: Result<Vec<u8>, KeystoreError>) -> Self {
+            Self {
+                get_response: Mutex::new(get_response),
+                stored: Mutex::new(None),
+                store_fails: false,
+            }
+        }
+
+        fn with_store_failing(mut self) -> Self {
+            self.store_fails = true;
+            self
+        }
+
+        fn stored_key(&self) -> Option<Vec<u8>> {
+            self.stored.lock().ok().and_then(|g| g.clone())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Keystore for TestKeystore {
+        async fn get_master_key(&self) -> Result<Vec<u8>, KeystoreError> {
+            let guard = self
+                .get_response
+                .lock()
+                .map_err(|_| KeystoreError::Unavailable {
+                    reason: "test mutex poisoned".to_string(),
+                })?;
+            guard.clone()
+        }
+
+        async fn store_master_key(&self, key: &[u8]) -> Result<(), KeystoreError> {
+            if self.store_fails {
+                return Err(KeystoreError::Unavailable {
+                    reason: "test: store unavailable".to_string(),
+                });
+            }
+            if let Ok(mut guard) = self.stored.lock() {
+                *guard = Some(key.to_vec());
+            }
+            Ok(())
+        }
+    }
+
+    /// Guard that clears `SECRETS_MASTER_KEY` for the duration of a
+    /// test so env-var bleed-through from the host cannot mask bugs in
+    /// the keystore fallback path. Restores on drop.
+    struct EnvGuard {
+        prior: Option<String>,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvGuard {
+        fn new() -> Self {
+            let lock = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+            let prior = std::env::var("SECRETS_MASTER_KEY").ok();
+            // SAFETY: tests are single-threaded per `#[tokio::test]` task
+            // but env mutation is process-global. The `cargo test`
+            // harness may run these concurrently with other tests that
+            // also touch SECRETS_MASTER_KEY. We accept that risk here
+            // because (a) no other test in this module touches this var
+            // and (b) we only need it cleared for the body of one test.
+            unsafe {
+                std::env::remove_var("SECRETS_MASTER_KEY");
+            }
+            Self { prior, _lock: lock }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: see `EnvGuard::new`.
+            unsafe {
+                if let Some(ref v) = self.prior {
+                    std::env::set_var("SECRETS_MASTER_KEY", v);
+                } else {
+                    std::env::remove_var("SECRETS_MASTER_KEY");
+                }
+            }
+        }
+    }
+
+    // ========================================================================
+    // Caller-level tests: drive SecretsConfig::resolve_with_keystore through
+    // all the branches that a real startup would hit. These cover the
+    // data-loss bug addressed in PR #2312: a transient keychain outage must
+    // NEVER silently rotate the master key.
+    // ========================================================================
+
+    #[tokio::test]
+    async fn first_boot_no_key_anywhere_generates_and_persists() {
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        let keystore = TestKeystore::new(Err(KeystoreError::NotFound));
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("first boot should succeed");
+
+        assert!(
+            cfg.master_key.is_some(),
+            "should generate a key on first boot"
+        );
+        assert_eq!(cfg.source, KeySource::Keychain);
+        // Generated key must have been persisted to the keystore.
+        let stored = keystore
+            .stored_key()
+            .expect("keystore should have been written");
+        assert_eq!(stored.len(), 32, "32-byte AES-256 key");
+    }
+
+    #[tokio::test]
+    async fn key_already_in_keychain_is_reused_not_rotated() {
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        // Pre-existing key in the keychain.
+        let existing = vec![0x42u8; 32];
+        let keystore = TestKeystore::new(Ok(existing.clone()));
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("key reuse should succeed");
+
+        let expected_hex: String = existing.iter().map(|b| format!("{:02x}", b)).collect();
+        assert_eq!(
+            cfg.master_key
+                .as_ref()
+                .map(|k| k.expose_secret().to_string()),
+            Some(expected_hex)
+        );
+        assert_eq!(cfg.source, KeySource::Keychain);
+        // Reuse path must NOT call store_master_key.
+        assert!(
+            keystore.stored_key().is_none(),
+            "must not overwrite an existing key"
+        );
+    }
+
+    #[tokio::test]
+    async fn notfound_with_file_fallback_present_loads_from_file() {
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        let file_key_hex = "a".repeat(64);
+        std::fs::write(&file_path, &file_key_hex).unwrap();
+
+        let keystore = TestKeystore::new(Err(KeystoreError::NotFound));
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("file fallback should succeed");
+
+        assert_eq!(
+            cfg.master_key
+                .as_ref()
+                .map(|k| k.expose_secret().to_string()),
+            Some(file_key_hex)
+        );
+        assert_eq!(cfg.source, KeySource::File);
+        assert!(
+            keystore.stored_key().is_none(),
+            "must not regenerate when a file-based key exists"
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_keystore_failure_with_existing_file_loads_file() {
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        // The file-based fallback already holds a key.
+        let file_key_hex = "b".repeat(64);
+        std::fs::write(&file_path, &file_key_hex).unwrap();
+
+        // Keychain is transiently broken (locked, dbus down, etc).
+        let keystore = TestKeystore::new(Err(KeystoreError::Unavailable {
+            reason: "secret-service unavailable".to_string(),
+        }));
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("transient failure with existing file should succeed");
+
+        // MUST use the existing file key -- the bug this test guards
+        // against is silently regenerating and losing previously
+        // encrypted secrets.
+        assert_eq!(
+            cfg.master_key
+                .as_ref()
+                .map(|k| k.expose_secret().to_string()),
+            Some(file_key_hex)
+        );
+        assert_eq!(cfg.source, KeySource::File);
+        assert!(
+            keystore.stored_key().is_none(),
+            "must NOT regenerate or overwrite on transient failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn transient_keystore_failure_with_no_existing_key_errors() {
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        let keystore = TestKeystore::new(Err(KeystoreError::Unavailable {
+            reason: "keychain locked".to_string(),
+        }));
+
+        let result = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true).await;
+
+        // Must propagate the error. Silently generating a new key here
+        // is the data-loss bug: once the keychain comes back online with
+        // a pre-existing key, any secrets encrypted under the silently-
+        // generated replacement are stranded.
+        match result {
+            Err(ConfigError::InvalidValue { key, message }) => {
+                assert_eq!(key, "SECRETS_MASTER_KEY");
+                assert!(message.contains("unavailable"));
+            }
+            other => panic!("expected InvalidValue error, got {other:?}"),
+        }
+        // Must not have written a new key to the file fallback either.
+        assert!(
+            !file_path.exists(),
+            "must NOT create a new master.key file on transient failure"
+        );
+        assert!(
+            keystore.stored_key().is_none(),
+            "must NOT write a new key to the keystore on transient failure"
+        );
+    }
+
+    #[tokio::test]
+    async fn env_var_override_bypasses_keystore_even_on_transient_failure() {
+        // When SECRETS_MASTER_KEY is set, the env var wins unconditionally.
+        // This is the CI/Docker escape hatch.
+        let _env = EnvGuard::new();
+        // SAFETY: single env var write, guarded by EnvGuard::drop.
+        unsafe {
+            std::env::set_var("SECRETS_MASTER_KEY", "c".repeat(64));
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        let keystore = TestKeystore::new(Err(KeystoreError::Unavailable {
+            reason: "should not be consulted".to_string(),
+        }));
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("env override should succeed even with a broken keystore");
+
+        assert_eq!(cfg.source, KeySource::Env);
+        assert!(cfg.master_key.is_some());
+    }
+
+    #[tokio::test]
+    async fn first_boot_keystore_persist_denied_falls_back_to_file() {
+        // Keystore reports NotFound on read but rejects writes (e.g.
+        // macOS keychain in read-only mode). Must persist the newly
+        // generated key to the file fallback instead.
+        let _env = EnvGuard::new();
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("master.key");
+
+        let keystore = TestKeystore::new(Err(KeystoreError::NotFound)).with_store_failing();
+
+        let cfg = SecretsConfig::resolve_with_keystore(&keystore, &file_path, true)
+            .await
+            .expect("file fallback persist should succeed");
+
+        assert_eq!(cfg.source, KeySource::File);
+        assert!(
+            file_path.exists(),
+            "master.key file should have been written"
+        );
+    }
 
     #[test]
     fn test_save_and_load_master_key_file_roundtrip() {

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,4 +1,5 @@
 use secrecy::{ExposeSecret, SecretString};
+use zeroize::Zeroizing;
 
 use crate::config::helpers::optional_env;
 use crate::error::ConfigError;
@@ -72,8 +73,12 @@ impl SecretsConfig {
             match keystore.get_master_key().await {
                 Ok(key_bytes) => {
                     // Key present in keychain -- reuse it. Never rotate.
-                    let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
-                    (Some(SecretString::from(key_hex)), KeySource::Keychain)
+                    let key_hex: Zeroizing<String> =
+                        Zeroizing::new(key_bytes.iter().map(|b| format!("{:02x}", b)).collect());
+                    (
+                        Some(SecretString::from(key_hex.as_str().to_owned())),
+                        KeySource::Keychain,
+                    )
                 }
                 Err(KeystoreError::NotFound) => {
                     // Keychain is reachable and authoritatively reports
@@ -104,10 +109,9 @@ impl SecretsConfig {
                     // the error and fail to start.
                     match Self::load_master_key_from_path(master_key_file) {
                         Some(key_hex) => {
-                            tracing::warn!(
-                                "OS keystore unavailable ({reason}); using existing \
-                                 file-based master key at {}",
-                                master_key_file.display()
+                            tracing::debug!(
+                                "OS keystore unavailable ({reason}); \
+                                 using existing file-based master key"
                             );
                             (Some(SecretString::from(key_hex)), KeySource::File)
                         }
@@ -160,23 +164,36 @@ impl SecretsConfig {
         use crate::settings::KeySource;
 
         let key_bytes = crate::secrets::keychain::generate_master_key();
-        let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+        let key_hex: Zeroizing<String> =
+            Zeroizing::new(key_bytes.iter().map(|b| format!("{:02x}", b)).collect());
 
         if allow_keystore_persist && keystore.store_master_key(&key_bytes).await.is_ok() {
             tracing::debug!("Auto-generated secrets master key and stored in OS keychain");
-            return (Some(SecretString::from(key_hex)), KeySource::Keychain);
-        }
-
-        // Keychain unavailable -- persist to file
-        if Self::save_master_key_to_path(&key_hex, master_key_file) {
-            tracing::debug!(
-                "Auto-generated secrets master key and stored in {}",
-                master_key_file.display()
+            return (
+                Some(SecretString::from(key_hex.as_str().to_owned())),
+                KeySource::Keychain,
             );
-            return (Some(SecretString::from(key_hex)), KeySource::File);
         }
 
-        tracing::warn!(
+        // Keychain unavailable -- persist to file.
+        // save_master_key_to_path uses create_new, so it returns false if
+        // another process already created the file (TOCTOU race). In that
+        // case, load the winner's key.
+        if Self::save_master_key_to_path(&key_hex, master_key_file) {
+            tracing::debug!("Auto-generated secrets master key and stored to file");
+            return (
+                Some(SecretString::from(key_hex.as_str().to_owned())),
+                KeySource::File,
+            );
+        }
+
+        // Check if another process won the race and created the file.
+        if let Some(existing_hex) = Self::load_master_key_from_path(master_key_file) {
+            tracing::debug!("Loaded master key created by concurrent process");
+            return (Some(SecretString::from(existing_hex)), KeySource::File);
+        }
+
+        tracing::debug!(
             "Failed to persist auto-generated master key to keychain or file. \
              Set SECRETS_MASTER_KEY env var to enable the secrets store."
         );
@@ -193,11 +210,12 @@ impl SecretsConfig {
         match std::fs::read_to_string(path) {
             Ok(contents) => {
                 let trimmed = contents.trim().to_string();
-                if trimmed.len() >= 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+                if trimmed.len() == 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
                     Some(trimmed)
                 } else {
-                    tracing::warn!(
-                        "master.key file exists but contains invalid data (expected 64+ hex chars)"
+                    tracing::debug!(
+                        "master.key file exists but contains invalid data \
+                         (expected exactly 64 hex chars)"
                     );
                     None
                 }
@@ -216,14 +234,16 @@ impl SecretsConfig {
             return false;
         }
 
-        // Write with restrictive permissions (owner read/write only)
+        // Write with restrictive permissions (owner read/write only).
+        // Use create_new to prevent TOCTOU race: if two processes race to
+        // generate a key on first boot, only one wins; the loser loads the
+        // winner's key instead of overwriting it.
         #[cfg(unix)]
         {
             use std::os::unix::fs::OpenOptionsExt;
             match std::fs::OpenOptions::new()
                 .write(true)
-                .create(true)
-                .truncate(true)
+                .create_new(true)
                 .mode(0o600)
                 .open(path)
             {
@@ -235,6 +255,13 @@ impl SecretsConfig {
                     }
                     true
                 }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    // Another process won the race -- load their key.
+                    tracing::debug!(
+                        "master.key already exists (concurrent creation); loading existing"
+                    );
+                    false
+                }
                 Err(e) => {
                     tracing::debug!("Failed to create master.key: {e}");
                     false
@@ -244,8 +271,29 @@ impl SecretsConfig {
 
         #[cfg(not(unix))]
         {
-            match std::fs::write(path, key_hex) {
-                Ok(()) => true,
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    if let Err(e) = file.write_all(key_hex.as_bytes()) {
+                        tracing::debug!("Failed to write master.key: {e}");
+                        return false;
+                    }
+                    tracing::debug!(
+                        "File permissions are not restricted on this platform; \
+                         consider using SECRETS_MASTER_KEY env var for production"
+                    );
+                    true
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    tracing::debug!(
+                        "master.key already exists (concurrent creation); loading existing"
+                    );
+                    false
+                }
                 Err(e) => {
                     tracing::debug!("Failed to write master.key: {e}");
                     false
@@ -655,5 +703,46 @@ mod tests {
 
         let loaded = SecretsConfig::load_master_key_from_path(&path);
         assert_eq!(loaded, Some(key_hex));
+    }
+
+    #[test]
+    fn test_load_master_key_rejects_oversized_key() {
+        // 128 hex chars = 64 bytes, but AES-256 requires exactly 32 bytes = 64 hex chars.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+        let oversized = "a".repeat(128);
+        std::fs::write(&path, &oversized).unwrap();
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert!(
+            loaded.is_none(),
+            "128 hex chars (64 bytes) should be rejected; only exactly 64 hex chars allowed"
+        );
+    }
+
+    #[test]
+    fn test_concurrent_first_boot_create_new_exclusivity() {
+        // Simulate two processes racing to create the master.key file.
+        // Only the first writer should succeed; the second gets AlreadyExists.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+
+        let key_a = "a".repeat(64);
+        let key_b = "b".repeat(64);
+
+        // First writer wins.
+        assert!(
+            SecretsConfig::save_master_key_to_path(&key_a, &path),
+            "first writer should succeed"
+        );
+        // Second writer should fail (create_new returns AlreadyExists).
+        assert!(
+            !SecretsConfig::save_master_key_to_path(&key_b, &path),
+            "second writer should fail due to create_new exclusivity"
+        );
+
+        // The file should contain the first writer's key, not the second's.
+        let loaded = SecretsConfig::load_master_key_from_path(&path).unwrap();
+        assert_eq!(loaded, key_a, "first writer's key must survive the race");
     }
 }

--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -28,7 +28,9 @@ impl SecretsConfig {
     /// Auto-detect secrets master key from env var, then OS keychain.
     ///
     /// Sequential probe: SECRETS_MASTER_KEY env var first, then OS keychain.
-    /// No saved "source" needed; just try each source in order.
+    /// If neither source has a key, auto-generate one and persist it to the
+    /// keychain (preferred) or a file at `~/.ironclaw/master.key` (fallback).
+    /// This ensures the secrets store is always available without manual setup.
     pub(crate) async fn resolve() -> Result<Self, ConfigError> {
         use crate::settings::KeySource;
 
@@ -41,7 +43,16 @@ impl SecretsConfig {
                     let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
                     (Some(SecretString::from(key_hex)), KeySource::Keychain)
                 }
-                Err(_) => (None, KeySource::None),
+                Err(_) => {
+                    // Try loading from the file-based fallback
+                    match Self::load_master_key_file() {
+                        Some(key_hex) => (Some(SecretString::from(key_hex)), KeySource::File),
+                        None => {
+                            // No key anywhere — auto-generate and persist
+                            Self::auto_generate_master_key().await
+                        }
+                    }
+                }
             }
         };
 
@@ -63,8 +74,209 @@ impl SecretsConfig {
         })
     }
 
+    /// Auto-generate a master key and try to persist it.
+    ///
+    /// Tries the OS keychain first; falls back to `~/.ironclaw/master.key`.
+    async fn auto_generate_master_key() -> (Option<SecretString>, crate::settings::KeySource) {
+        use crate::settings::KeySource;
+
+        let key_bytes = crate::secrets::keychain::generate_master_key();
+        let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+
+        // Try storing in the OS keychain
+        if crate::secrets::keychain::store_master_key(&key_bytes)
+            .await
+            .is_ok()
+        {
+            tracing::debug!("Auto-generated secrets master key and stored in OS keychain");
+            return (Some(SecretString::from(key_hex)), KeySource::Keychain);
+        }
+
+        // Keychain unavailable — persist to file
+        if Self::save_master_key_file(&key_hex) {
+            tracing::debug!(
+                "Auto-generated secrets master key and stored in {}",
+                Self::master_key_file_path().display()
+            );
+            return (Some(SecretString::from(key_hex)), KeySource::File);
+        }
+
+        tracing::warn!(
+            "Failed to persist auto-generated master key to keychain or file. \
+             Set SECRETS_MASTER_KEY env var to enable the secrets store."
+        );
+        (None, KeySource::None)
+    }
+
+    /// Path to the file-based master key fallback.
+    fn master_key_file_path() -> std::path::PathBuf {
+        crate::bootstrap::ironclaw_base_dir().join("master.key")
+    }
+
+    /// Load the master key from the file-based fallback.
+    fn load_master_key_file() -> Option<String> {
+        Self::load_master_key_from_path(&Self::master_key_file_path())
+    }
+
+    /// Load and validate a master key from a specific file path.
+    fn load_master_key_from_path(path: &std::path::Path) -> Option<String> {
+        match std::fs::read_to_string(path) {
+            Ok(contents) => {
+                let trimmed = contents.trim().to_string();
+                if trimmed.len() >= 64 && trimmed.chars().all(|c| c.is_ascii_hexdigit()) {
+                    Some(trimmed)
+                } else {
+                    tracing::warn!(
+                        "master.key file exists but contains invalid data (expected 64+ hex chars)"
+                    );
+                    None
+                }
+            }
+            Err(_) => None,
+        }
+    }
+
+    /// Save the master key to the file-based fallback with restrictive permissions.
+    fn save_master_key_file(key_hex: &str) -> bool {
+        Self::save_master_key_to_path(key_hex, &Self::master_key_file_path())
+    }
+
+    /// Save the master key to a specific file path with restrictive permissions.
+    fn save_master_key_to_path(key_hex: &str, path: &std::path::Path) -> bool {
+        // Ensure parent directory exists
+        if let Some(parent) = path.parent()
+            && let Err(e) = std::fs::create_dir_all(parent)
+        {
+            tracing::debug!("Cannot create directory for master.key: {e}");
+            return false;
+        }
+
+        // Write with restrictive permissions (owner read/write only)
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            match std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .mode(0o600)
+                .open(path)
+            {
+                Ok(mut file) => {
+                    use std::io::Write;
+                    if let Err(e) = file.write_all(key_hex.as_bytes()) {
+                        tracing::debug!("Failed to write master.key: {e}");
+                        return false;
+                    }
+                    true
+                }
+                Err(e) => {
+                    tracing::debug!("Failed to create master.key: {e}");
+                    false
+                }
+            }
+        }
+
+        #[cfg(not(unix))]
+        {
+            match std::fs::write(path, key_hex) {
+                Ok(()) => true,
+                Err(e) => {
+                    tracing::debug!("Failed to write master.key: {e}");
+                    false
+                }
+            }
+        }
+    }
+
     /// Get the master key if configured.
     pub fn master_key(&self) -> Option<&SecretString> {
         self.master_key.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_save_and_load_master_key_file_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+
+        let key_hex = "a".repeat(64); // valid 32-byte hex key
+        assert!(SecretsConfig::save_master_key_to_path(&key_hex, &path));
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert_eq!(loaded, Some(key_hex));
+    }
+
+    #[test]
+    fn test_load_master_key_file_rejects_short_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+        std::fs::write(&path, "abcd1234").unwrap();
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_load_master_key_file_rejects_non_hex() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+        // 64 chars but not all hex
+        let bad_key = format!("{}zzzz", "a".repeat(60));
+        std::fs::write(&path, &bad_key).unwrap();
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_load_master_key_file_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nonexistent.key");
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert!(loaded.is_none());
+    }
+
+    #[test]
+    fn test_load_master_key_file_trims_whitespace() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+        let key_hex = "b".repeat(64);
+        std::fs::write(&path, format!("  {key_hex}  \n")).unwrap();
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert_eq!(loaded, Some(key_hex));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_master_key_file_permissions() {
+        use std::os::unix::fs::MetadataExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("master.key");
+
+        let key_hex = "c".repeat(64);
+        assert!(SecretsConfig::save_master_key_to_path(&key_hex, &path));
+
+        let metadata = std::fs::metadata(&path).unwrap();
+        assert_eq!(metadata.mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn test_save_master_key_creates_parent_dirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("nested").join("dir").join("master.key");
+
+        let key_hex = "d".repeat(64);
+        assert!(SecretsConfig::save_master_key_to_path(&key_hex, &path));
+
+        let loaded = SecretsConfig::load_master_key_from_path(&path);
+        assert_eq!(loaded, Some(key_hex));
     }
 }

--- a/src/secrets/keychain.rs
+++ b/src/secrets/keychain.rs
@@ -119,6 +119,19 @@ mod platform {
     /// macOS `errSecItemNotFound` status code.
     /// See <https://developer.apple.com/documentation/security/errsecitemnotfound>.
     const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+    /// macOS `errSecNoSuchKeychain` -- the keychain itself doesn't exist.
+    const ERR_SEC_NO_SUCH_KEYCHAIN: i32 = -25294;
+    /// macOS `errSecNoSuchAttr` -- the attribute doesn't exist.
+    const ERR_SEC_NO_SUCH_ATTR: i32 = -25303;
+
+    /// Returns true if the Security.framework error code indicates the
+    /// key genuinely does not exist (as opposed to a transient failure).
+    fn is_not_found_code(code: i32) -> bool {
+        matches!(
+            code,
+            ERR_SEC_ITEM_NOT_FOUND | ERR_SEC_NO_SUCH_KEYCHAIN | ERR_SEC_NO_SUCH_ATTR
+        )
+    }
 
     /// Typed variant of `get_master_key` that distinguishes NotFound from
     /// transient/unavailable errors.
@@ -133,7 +146,7 @@ mod platform {
                     reason: e.to_string(),
                 })
             }
-            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => Err(KeystoreError::NotFound),
+            Err(e) if is_not_found_code(e.code()) => Err(KeystoreError::NotFound),
             Err(e) => Err(KeystoreError::Unavailable {
                 reason: format!("keychain error (code {}): {}", e.code(), e),
             }),

--- a/src/secrets/keychain.rs
+++ b/src/secrets/keychain.rs
@@ -27,6 +27,68 @@ const SERVICE_NAME: &str = "ironclaw";
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 const MASTER_KEY_ACCOUNT: &str = "master_key";
 
+/// Keystore error distinguishing "no key stored" from "store unavailable".
+///
+/// This distinction is load-bearing for master-key handling: a `NotFound`
+/// is a legitimate signal that we should fall back to file or generate a
+/// new key, but an `Unavailable` (keychain locked, D-Bus down, permission
+/// denied, transient crash) must NEVER be treated as `NotFound` -- doing
+/// so would silently rotate the master key and strand previously
+/// encrypted secrets.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum KeystoreError {
+    /// The keystore is reachable and reports that no entry exists.
+    #[error("keystore entry not found")]
+    NotFound,
+
+    /// The keystore is unavailable, locked, permission-denied, or
+    /// otherwise transiently broken. The caller MUST NOT rotate or
+    /// regenerate keys in response to this error.
+    #[error("keystore unavailable: {reason}")]
+    Unavailable { reason: String },
+}
+
+impl From<KeystoreError> for SecretError {
+    fn from(err: KeystoreError) -> Self {
+        SecretError::KeychainError(err.to_string())
+    }
+}
+
+/// Abstraction over the OS keystore used for master-key storage.
+///
+/// This trait exists so that `SecretsConfig::resolve()` can be tested
+/// with a deterministic stub. Production code uses [`OsKeystore`], which
+/// wraps the platform-specific implementation and maps raw errors to
+/// [`KeystoreError::NotFound`] vs [`KeystoreError::Unavailable`].
+#[async_trait::async_trait]
+pub trait Keystore: Send + Sync {
+    /// Fetch the master key bytes. `NotFound` means "no entry"; any
+    /// other error must surface as `Unavailable`.
+    async fn get_master_key(&self) -> Result<Vec<u8>, KeystoreError>;
+
+    /// Store the master key bytes.
+    async fn store_master_key(&self, key: &[u8]) -> Result<(), KeystoreError>;
+}
+
+/// Production keystore backed by the OS keychain / secret-service.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct OsKeystore;
+
+#[async_trait::async_trait]
+impl Keystore for OsKeystore {
+    async fn get_master_key(&self) -> Result<Vec<u8>, KeystoreError> {
+        platform::get_master_key_typed().await
+    }
+
+    async fn store_master_key(&self, key: &[u8]) -> Result<(), KeystoreError> {
+        platform::store_master_key(key)
+            .await
+            .map_err(|e| KeystoreError::Unavailable {
+                reason: e.to_string(),
+            })
+    }
+}
+
 /// Generate a random 32-byte master key.
 pub fn generate_master_key() -> Vec<u8> {
     use rand::RngCore;
@@ -53,6 +115,30 @@ mod platform {
     };
 
     use super::*;
+
+    /// macOS `errSecItemNotFound` status code.
+    /// See <https://developer.apple.com/documentation/security/errsecitemnotfound>.
+    const ERR_SEC_ITEM_NOT_FOUND: i32 = -25300;
+
+    /// Typed variant of `get_master_key` that distinguishes NotFound from
+    /// transient/unavailable errors.
+    pub async fn get_master_key_typed() -> Result<Vec<u8>, KeystoreError> {
+        match get_generic_password(SERVICE_NAME, MASTER_KEY_ACCOUNT) {
+            Ok(password) => {
+                let hex_str =
+                    String::from_utf8(password).map_err(|_| KeystoreError::Unavailable {
+                        reason: "invalid UTF-8 in keychain entry".to_string(),
+                    })?;
+                hex_to_bytes(&hex_str).map_err(|e| KeystoreError::Unavailable {
+                    reason: e.to_string(),
+                })
+            }
+            Err(e) if e.code() == ERR_SEC_ITEM_NOT_FOUND => Err(KeystoreError::NotFound),
+            Err(e) => Err(KeystoreError::Unavailable {
+                reason: format!("keychain error (code {}): {}", e.code(), e),
+            }),
+        }
+    }
 
     /// Store the master key in the macOS Keychain.
     pub async fn store_master_key(key: &[u8]) -> Result<(), SecretError> {
@@ -98,6 +184,57 @@ mod platform {
     use secret_service::{EncryptionType, SecretService};
 
     use super::*;
+
+    /// Typed variant of `get_master_key` that distinguishes NotFound (empty
+    /// search result from a reachable secret-service) from transient /
+    /// unavailable errors (D-Bus down, collection locked, dbus permission
+    /// denied, etc.).
+    pub async fn get_master_key_typed() -> Result<Vec<u8>, KeystoreError> {
+        let ss = SecretService::connect(EncryptionType::Dh)
+            .await
+            .map_err(|e| KeystoreError::Unavailable {
+                reason: format!("failed to connect to secret service: {e}"),
+            })?;
+
+        let items = ss
+            .search_items(
+                [("service", SERVICE_NAME), ("account", MASTER_KEY_ACCOUNT)]
+                    .into_iter()
+                    .collect(),
+            )
+            .await
+            .map_err(|e| KeystoreError::Unavailable {
+                reason: format!("failed to search secret service: {e}"),
+            })?;
+
+        let item = match items.unlocked.first().or(items.locked.first()) {
+            Some(item) => item,
+            None => return Err(KeystoreError::NotFound),
+        };
+
+        if item.is_locked().await.unwrap_or(true) {
+            item.unlock()
+                .await
+                .map_err(|e| KeystoreError::Unavailable {
+                    reason: format!("failed to unlock secret: {e}"),
+                })?;
+        }
+
+        let secret = item
+            .get_secret()
+            .await
+            .map_err(|e| KeystoreError::Unavailable {
+                reason: format!("failed to read secret: {e}"),
+            })?;
+
+        let hex_str = String::from_utf8(secret).map_err(|_| KeystoreError::Unavailable {
+            reason: "invalid UTF-8 in secret-service entry".to_string(),
+        })?;
+
+        hex_to_bytes(&hex_str).map_err(|e| KeystoreError::Unavailable {
+            reason: e.to_string(),
+        })
+    }
 
     /// Store the master key in the Linux secret service (GNOME Keyring, KWallet).
     pub async fn store_master_key(key: &[u8]) -> Result<(), SecretError> {
@@ -235,6 +372,13 @@ mod platform {
 #[cfg(not(any(target_os = "macos", target_os = "linux")))]
 mod platform {
     use super::*;
+
+    /// On unsupported platforms there is no OS keystore. Report
+    /// `NotFound` so the caller falls through to the file-based
+    /// fallback, which is the only persistence path available here.
+    pub async fn get_master_key_typed() -> Result<Vec<u8>, KeystoreError> {
+        Err(KeystoreError::NotFound)
+    }
 
     pub async fn store_master_key(_key: &[u8]) -> Result<(), SecretError> {
         Err(SecretError::KeychainError(

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -249,7 +249,10 @@ pub enum KeySource {
     /// (fallback when OS keychain is unavailable).
     File,
     /// Not configured (secrets features disabled).
+    /// `#[serde(other)]` ensures unknown variants (e.g. `"file"` read by
+    /// an older binary) gracefully degrade instead of failing to deserialize.
     #[default]
+    #[serde(other)]
     None,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -245,6 +245,9 @@ pub enum KeySource {
     Keychain,
     /// User provides via SECRETS_MASTER_KEY env var.
     Env,
+    /// Auto-generated key stored in `~/.ironclaw/master.key` file
+    /// (fallback when OS keychain is unavailable).
+    File,
     /// Not configured (secrets features disabled).
     #[default]
     None,

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -3536,6 +3536,7 @@ impl SetupWizard {
         let security_display = match self.settings.secrets_master_key_source {
             KeySource::Keychain => "OS keychain",
             KeySource::Env => "environment variable",
+            KeySource::File => "file (~/.ironclaw/master.key)",
             KeySource::None => "disabled",
         };
         println!(


### PR DESCRIPTION
## Summary
Fixes #1820. When neither `SECRETS_MASTER_KEY` env var nor an OS keychain entry existed (headless Linux, skipped onboarding), `SecretsConfig::resolve()` returned `master_key: None`, the secrets store was never created, and configuring API keys failed with "secrets store is not available".

- `SecretsConfig::resolve()` now auto-generates a 32-byte master key when none is found
- Tries OS keychain first; falls back to `~/.ironclaw/master.key` (0o600)
- New `KeySource::File` variant handled in doctor/setup/settings handlers
- File-based fallback validates 64+ hex chars, trims whitespace
- 7 regression tests (round-trip, invalid data, permissions, missing files)

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-features` zero warnings
- [x] Unit tests pass
- [ ] Manual: on a system without keychain, verify API keys can be configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)