### PR TITLE
fix(ux): actionable auth errors and improved CLI help for new users (#1852)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -68,9 +68,18 @@ use clap::{ColorChoice, Parser, Subcommand};
 #[command(
     about = "Secure personal AI assistant that protects your data and expands its capabilities"
 )]
-#[command(
-    long_about = "IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.\nExamples:\n  ironclaw run  # Start the agent\n  ironclaw config list  # List configs"
-)]
+#[command(long_about = "IronClaw is a secure AI assistant.\n\n\
+     Getting started:\n  \
+       ironclaw onboard              # Interactive setup wizard (recommended for first run)\n  \
+       ironclaw onboard --quick      # Quick setup: just pick a provider and model\n  \
+       ironclaw models set-provider openai  # Switch to a specific provider\n  \
+       ironclaw doctor               # Check your configuration\n\n\
+     Common commands:\n  \
+       ironclaw run                  # Start the agent\n  \
+       ironclaw config list          # View all settings\n  \
+       ironclaw models status        # Show current provider and model\n  \
+       ironclaw models list          # List available providers\n\n\
+     Use 'ironclaw <subcommand> --help' for details on any command.")]
 #[command(version)]
 #[command(color = ColorChoice::Auto)] // Enable auto-color for help (if the terminal supports it)
 pub struct Cli {
@@ -117,8 +126,16 @@ pub enum Command {
 
     /// Interactive onboarding wizard
     #[command(
-        about = "Run interactive setup wizard",
-        long_about = "Guides through initial configuration.\nExamples:\n  ironclaw onboard --skip-auth  # Skip auth step\n  ironclaw onboard --channels-only  # Reconfigure channels\n  ironclaw onboard --provider-only  # Change LLM provider and model"
+        about = "Run interactive setup wizard (start here if new to IronClaw)",
+        long_about = "Guides you through configuring IronClaw step by step.\n\n\
+         This is the recommended way to set up your LLM provider, API keys,\n\
+         database, and channels. Run it again any time to change settings.\n\n\
+         Examples:\n  \
+           ironclaw onboard                    # Full setup wizard\n  \
+           ironclaw onboard --quick            # Quick: just provider + model\n  \
+           ironclaw onboard --step provider    # Change only the LLM provider\n  \
+           ironclaw onboard --step channels    # Reconfigure messaging channels\n  \
+           ironclaw onboard --step provider,model  # Change provider and model"
     )]
     Onboard {
         /// Skip authentication (use existing session)
@@ -145,8 +162,16 @@ pub enum Command {
     /// Manage configuration settings
     #[command(
         subcommand,
-        about = "Manage app configs",
-        long_about = "Commands for listing, getting, and setting configurations.\nExample: ironclaw config list"
+        about = "Manage app configuration settings",
+        long_about = "View and modify IronClaw settings (stored in database and config.toml).\n\n\
+         For LLM provider/model changes, use `ironclaw models` instead.\n\n\
+         Examples:\n  \
+           ironclaw config list              # List all settings\n  \
+           ironclaw config list -f agent     # Filter by prefix\n  \
+           ironclaw config get agent.name    # Get a specific value\n  \
+           ironclaw config set agent.name my-bot  # Change a value\n  \
+           ironclaw config init              # Generate config.toml\n  \
+           ironclaw config path              # Show where settings are stored"
     )]
     Config(ConfigCommand),
 
@@ -243,14 +268,25 @@ pub enum Command {
     #[command(
         subcommand,
         about = "Manage LLM providers and models",
-        long_about = "List providers, view current configuration, and set active provider/model.\nExamples:\n  ironclaw models list\n  ironclaw models list openai --verbose\n  ironclaw models status\n  ironclaw models set gpt-4o\n  ironclaw models set-provider anthropic --model claude-sonnet-4-6-20250514"
+        long_about = "List providers, view current configuration, and set active provider/model.\n\n\
+         Use this to switch between AI providers without re-running the full setup wizard.\n\n\
+         Examples:\n  \
+           ironclaw models list                          # List all providers\n  \
+           ironclaw models list openai --verbose         # Show details for OpenAI\n  \
+           ironclaw models status                        # Show current provider/model\n  \
+           ironclaw models set gpt-4o                    # Change model\n  \
+           ironclaw models set-provider anthropic        # Switch to Anthropic\n  \
+           ironclaw models set-provider ollama --model llama3  # Switch to local Ollama"
     )]
     Models(ModelsCommand),
 
     /// Probe external dependencies and validate configuration
     #[command(
-        about = "Run diagnostics",
-        long_about = "Checks dependencies and config validity.\nExample: ironclaw doctor"
+        about = "Run diagnostics (check if everything is configured correctly)",
+        long_about = "Probes LLM provider, database, channels, and external dependencies.\n\
+         Surfaces misconfiguration before it causes problems at runtime.\n\n\
+         Run this if something is not working — it will tell you what to fix.\n\n\
+         Example:\n  ironclaw doctor"
     )]
     Doctor,
 
@@ -286,8 +322,11 @@ pub enum Command {
 
     /// Authenticate with a provider (re-login)
     #[command(
-        about = "Authenticate with a provider",
-        long_about = "Re-authenticate with an LLM provider.\nExample: ironclaw login --openai-codex"
+        about = "Authenticate with a provider (re-login)",
+        long_about = "Re-authenticate with an LLM provider.\n\n\
+         For most providers, set the API key environment variable instead.\n\
+         For interactive setup: `ironclaw onboard --step provider`\n\n\
+         Example:\n  ironclaw login --openai-codex"
     )]
     Login {
         /// Authenticate with OpenAI Codex (ChatGPT subscription)

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -222,7 +222,8 @@ fn print_model_list(models: &Option<Vec<String>>, active_model: Option<&String>)
         }
         None => {
             println!(
-                "\n  Could not fetch model list (missing credentials or provider unavailable)."
+                "\n  Could not fetch model list (missing credentials or provider unavailable).\
+                 \n  Tip: Run `ironclaw doctor` to check your configuration."
             );
         }
     }
@@ -364,7 +365,9 @@ fn cmd_set_provider(
                 .chain(registry.all().iter().map(|d| d.id.as_str()))
                 .collect();
             anyhow::anyhow!(
-                "Unknown provider '{}'. Known providers: {}",
+                "Unknown provider '{}'.\n\nAvailable providers: {}\n\n\
+                 Tip: Run `ironclaw models list` to see all providers with descriptions,\n\
+                 or `ironclaw onboard --step provider` for interactive setup.",
                 provider,
                 known.join(", ")
             )
@@ -413,6 +416,21 @@ fn cmd_set_provider(
             .map(|p| p.display().to_string())
             .unwrap_or_else(|| config_toml_path().display().to_string())
     );
+
+    // Remind the user about API key requirements for the newly selected provider
+    if let Some(def) = registry.find(&canonical_id)
+        && def.api_key_required
+        && let Some(ref env_var) = def.api_key_env
+    {
+        let has_key = std::env::var(env_var).is_ok();
+        if !has_key {
+            println!();
+            println!(
+                "Note: {} requires an API key. Set {} or run `ironclaw onboard --step provider` to configure.",
+                canonical_id, env_var
+            );
+        }
+    }
 
     Ok(())
 }
@@ -551,6 +569,9 @@ async fn cmd_list_providers(
     if !verbose {
         println!();
         println!("* = active provider. Use --verbose for details.");
+        println!();
+        println!("To switch provider: ironclaw models set-provider <name>");
+        println!("For guided setup:   ironclaw onboard --step provider");
     }
 
     Ok(())
@@ -619,7 +640,8 @@ async fn cmd_show_provider(
             .chain(registry.all().iter().map(|d| d.id.as_str()))
             .collect();
         anyhow::anyhow!(
-            "Unknown provider '{}'. Known providers: {}",
+            "Unknown provider '{}'.\n\nAvailable providers: {}\n\n\
+             Tip: Run `ironclaw models list` to see all providers with descriptions.",
             id,
             known.join(", ")
         )

--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -422,7 +422,10 @@ fn cmd_set_provider(
         && def.api_key_required
         && let Some(ref env_var) = def.api_key_env
     {
-        let has_key = std::env::var(env_var).is_ok();
+        let has_key = crate::config::helpers::optional_env(env_var)
+            .ok()
+            .flatten()
+            .is_some();
         if !has_key {
             println!();
             println!(

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -8,8 +8,8 @@ Usage: ironclaw [OPTIONS] [COMMAND]
 
 Commands:
   run         Run the AI agent
-  onboard     Run interactive setup wizard
-  config      Manage app configs
+  onboard     Run interactive setup wizard (start here if new to IronClaw)
+  config      Manage app configuration settings
   tool        Manage WASM tools
   registry    Browse/install extensions
   channels    Manage channels
@@ -22,11 +22,11 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
-  doctor      Run diagnostics
+  doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
-  login       Authenticate with a provider
+  login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -2,17 +2,28 @@
 source: src/cli/mod.rs
 expression: help
 ---
-IronClaw is a secure AI assistant. Use 'ironclaw <subcommand> --help' for details.
-Examples:
-  ironclaw run  # Start the agent
-  ironclaw config list  # List configs
+IronClaw is a secure AI assistant.
+
+Getting started:
+  ironclaw onboard              # Interactive setup wizard (recommended for first run)
+  ironclaw onboard --quick      # Quick setup: just pick a provider and model
+  ironclaw models set-provider openai  # Switch to a specific provider
+  ironclaw doctor               # Check your configuration
+
+Common commands:
+  ironclaw run                  # Start the agent
+  ironclaw config list          # View all settings
+  ironclaw models status        # Show current provider and model
+  ironclaw models list          # List available providers
+
+Use 'ironclaw <subcommand> --help' for details on any command.
 
 Usage: ironclaw [OPTIONS] [COMMAND]
 
 Commands:
   run         Run the AI agent
-  onboard     Run interactive setup wizard
-  config      Manage app configs
+  onboard     Run interactive setup wizard (start here if new to IronClaw)
+  config      Manage app configuration settings
   tool        Manage WASM tools
   registry    Browse/install extensions
   channels    Manage channels
@@ -25,11 +36,11 @@ Commands:
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models
-  doctor      Run diagnostics
+  doctor      Run diagnostics (check if everything is configured correctly)
   logs        View and manage gateway logs
   status      Show system status
   completion  Generate completions
-  login       Authenticate with a provider
+  login       Authenticate with a provider (re-login)
   acp         Manage ACP agents
   help        Print this message or the help of the given subcommand(s)
 

--- a/src/llm/error.rs
+++ b/src/llm/error.rs
@@ -155,4 +155,94 @@ mod tests {
         assert!(auth_guidance("ollama").contains("Ollama is running"));
         assert!(auth_guidance("bedrock").contains("AWS"));
     }
+
+    // ------------------------------------------------------------------
+    // Snapshot-style coverage for rendered AuthFailed messages.
+    //
+    // The auth error text is policy-bearing product guidance: it tells
+    // users which env var to set and where to get an API key. Treat it
+    // as compatibility-sensitive — any change to these strings should
+    // be a deliberate, reviewed edit. These tests assert the full
+    // rendered `Display` output (the same text users see in the CLI
+    // and logs) via `insta::assert_snapshot!` with inline snapshots.
+    //
+    // We render through `LlmError::AuthFailed { .. }.to_string()`
+    // rather than calling `auth_guidance()` directly so that a change
+    // to the outer `#[error(..)]` format string is also caught
+    // (test-through-the-caller discipline, per CLAUDE.md).
+    // ------------------------------------------------------------------
+
+    fn render_auth_failed(provider: &str) -> String {
+        LlmError::AuthFailed {
+            provider: provider.to_string(),
+        }
+        .to_string()
+    }
+
+    #[test]
+    fn snapshot_auth_failed_nearai() {
+        insta::assert_snapshot!(
+            render_auth_failed("nearai"),
+            @"Authentication failed for provider 'nearai'. Set NEARAI_API_KEY (from https://cloud.near.ai) or run `ironclaw onboard` to log in. Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_openai() {
+        insta::assert_snapshot!(
+            render_auth_failed("openai"),
+            @"Authentication failed for provider 'openai'. Set OPENAI_API_KEY (from https://platform.openai.com/api-keys). Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_anthropic() {
+        insta::assert_snapshot!(
+            render_auth_failed("anthropic"),
+            @"Authentication failed for provider 'anthropic'. Set ANTHROPIC_API_KEY (from https://console.anthropic.com/settings/keys). Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_ollama() {
+        insta::assert_snapshot!(
+            render_auth_failed("ollama"),
+            @"Authentication failed for provider 'ollama'. Ensure Ollama is running locally (no API key needed). Set OLLAMA_BASE_URL if not at default http://localhost:11434. Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_openai_compatible() {
+        insta::assert_snapshot!(
+            render_auth_failed("openai_compatible"),
+            @"Authentication failed for provider 'openai_compatible'. Set LLM_API_KEY and LLM_BASE_URL for your OpenAI-compatible endpoint. Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_tinfoil() {
+        insta::assert_snapshot!(
+            render_auth_failed("tinfoil"),
+            @"Authentication failed for provider 'tinfoil'. Set TINFOIL_API_KEY. Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_bedrock() {
+        insta::assert_snapshot!(
+            render_auth_failed("bedrock"),
+            @"Authentication failed for provider 'bedrock'. Configure AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE). Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
+
+    #[test]
+    fn snapshot_auth_failed_unknown_provider() {
+        // The generic fallback — exercised when a new provider is added
+        // but not yet wired into `auth_guidance()`. Snapshotted so that
+        // any change to the generic fallback is also deliberate.
+        insta::assert_snapshot!(
+            render_auth_failed("some_future_provider"),
+            @"Authentication failed for provider 'some_future_provider'. Check that the required API key environment variable is set for this provider. Or run `ironclaw onboard --step provider` to configure interactively."
+        );
+    }
 }

--- a/src/llm/error.rs
+++ b/src/llm/error.rs
@@ -26,7 +26,10 @@ pub enum LlmError {
     #[error("Model {model} not available on provider {provider}")]
     ModelNotAvailable { provider: String, model: String },
 
-    #[error("Authentication failed for provider {provider}")]
+    #[error(
+        "Authentication failed for provider '{provider}'. {}",
+        auth_guidance(provider)
+    )]
     AuthFailed { provider: String },
 
     #[error("Session expired for provider {provider}")]
@@ -43,4 +46,113 @@ pub enum LlmError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+}
+
+/// Return actionable setup guidance for a provider's authentication failure.
+///
+/// This helps users who see an `AuthFailed` error know exactly what to do
+/// without digging through documentation.
+fn auth_guidance(provider: &str) -> String {
+    let normalized = provider.to_lowercase();
+    let (env_hint, extra) = match normalized.as_str() {
+        "nearai" | "near_ai" | "near" => (
+            "Set NEARAI_API_KEY (from https://cloud.near.ai) or run `ironclaw onboard` to log in",
+            "",
+        ),
+        "openai" => (
+            "Set OPENAI_API_KEY (from https://platform.openai.com/api-keys)",
+            "",
+        ),
+        "anthropic" | "claude" => (
+            "Set ANTHROPIC_API_KEY (from https://console.anthropic.com/settings/keys)",
+            "",
+        ),
+        "groq" => ("Set GROQ_API_KEY (from https://console.groq.com/keys)", ""),
+        "ollama" => (
+            "Ensure Ollama is running locally (no API key needed). Set OLLAMA_BASE_URL if not at default http://localhost:11434",
+            "",
+        ),
+        "openai_compatible" => (
+            "Set LLM_API_KEY and LLM_BASE_URL for your OpenAI-compatible endpoint",
+            "",
+        ),
+        "tinfoil" => ("Set TINFOIL_API_KEY", ""),
+        "bedrock" | "aws_bedrock" | "aws" => (
+            "Configure AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY or AWS_PROFILE)",
+            "",
+        ),
+        "openai_codex" | "codex" => ("Run `ironclaw login --openai-codex` to authenticate", ""),
+        "github_copilot" => (
+            "Set GITHUB_COPILOT_TOKEN or run `ironclaw onboard --step provider` to log in via device code",
+            "",
+        ),
+        _ => (
+            "Check that the required API key environment variable is set for this provider",
+            "",
+        ),
+    };
+    if extra.is_empty() {
+        format!("{env_hint}. Or run `ironclaw onboard --step provider` to configure interactively.")
+    } else {
+        format!(
+            "{env_hint}. {extra} Or run `ironclaw onboard --step provider` to configure interactively."
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn auth_failed_error_includes_guidance() {
+        let err = LlmError::AuthFailed {
+            provider: "openai".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("OPENAI_API_KEY"),
+            "should mention the env var: {msg}"
+        );
+        assert!(
+            msg.contains("ironclaw onboard"),
+            "should mention onboard command: {msg}"
+        );
+    }
+
+    #[test]
+    fn auth_failed_error_for_anthropic() {
+        let err = LlmError::AuthFailed {
+            provider: "anthropic".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("ANTHROPIC_API_KEY"),
+            "should mention ANTHROPIC_API_KEY: {msg}"
+        );
+    }
+
+    #[test]
+    fn auth_failed_error_for_unknown_provider() {
+        let err = LlmError::AuthFailed {
+            provider: "my_custom_provider".to_string(),
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("API key environment variable"),
+            "should give generic guidance: {msg}"
+        );
+        assert!(
+            msg.contains("ironclaw onboard"),
+            "should still mention onboard: {msg}"
+        );
+    }
+
+    #[test]
+    fn auth_guidance_is_provider_specific() {
+        assert!(auth_guidance("nearai").contains("NEARAI_API_KEY"));
+        assert!(auth_guidance("groq").contains("GROQ_API_KEY"));
+        assert!(auth_guidance("ollama").contains("Ollama is running"));
+        assert!(auth_guidance("bedrock").contains("AWS"));
+    }
 }


### PR DESCRIPTION
## Summary
Addresses #1852 with targeted UX improvements for non-technical users:

- **`src/llm/error.rs`**: `AuthFailed` now includes provider-specific guidance with env var name, signup URL, and `ironclaw onboard --step provider` hint. Covers all providers (4 new tests)
- **`src/cli/mod.rs`**: Top-level `--help` now has "Getting started" and "Common commands" sections; `onboard`/`config`/`models`/`doctor`/`login` long_about improved
- **`src/cli/models.rs`**: Unknown provider errors list available providers; warns when API key env var not set after switching; model list footer shows how to switch

## Test plan
- [x] `cargo fmt`, `cargo clippy --all-features` zero warnings
- [x] All 4037 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)