### PR TITLE
feat: support public Generative Language API for headless deployments

### DIFF
--- a/src/llm/gemini_oauth.rs
+++ b/src/llm/gemini_oauth.rs
@@ -1137,6 +1137,9 @@ impl GeminiOauthProvider {
     }
 
     pub fn model_uses_cloud_code_api(model: &str) -> bool {
+        if std::env::var("GEMINI_USE_LEGACY_API").is_ok() {
+            return false;
+        }
         let model = model.to_ascii_lowercase();
         // Models containing "-preview" suffix or "gemini-3" use the Cloud Code API.
         // Using "-preview" (with hyphen) to avoid false positives on unrelated model names.
@@ -1589,6 +1592,21 @@ impl GeminiOauthProvider {
         }
     }
 
+    /// Strip JSON Schema fields unsupported by the public Generative Language API.
+    fn strip_unsupported_schema_fields(val: &mut serde_json::Value) {
+        if let Some(obj) = val.as_object_mut() {
+            obj.remove("additionalProperties");
+            obj.remove("$schema");
+            for (_, v) in obj.iter_mut() {
+                Self::strip_unsupported_schema_fields(v);
+            }
+        } else if let Some(arr) = val.as_array_mut() {
+            for v in arr.iter_mut() {
+                Self::strip_unsupported_schema_fields(v);
+            }
+        }
+    }
+
     fn to_gemini_request(
         messages: &[ChatMessage],
         tools: Option<&[ToolDefinition]>,
@@ -1709,10 +1727,12 @@ impl GeminiOauthProvider {
             let declarations: Vec<serde_json::Value> = tool_defs
                 .iter()
                 .map(|t| {
+                    let mut params = t.parameters.clone();
+                    Self::strip_unsupported_schema_fields(&mut params);
                     serde_json::json!({
                         "name": t.name,
                         "description": t.description,
-                        "parameters": t.parameters
+                        "parameters": params
                     })
                 })
                 .collect();


### PR DESCRIPTION
## Summary

- Add `GEMINI_USE_LEGACY_API` env var that forces all Gemini models (including 2.0+) through `generativelanguage.googleapis.com` instead of the Cloud Code API
- Strip `additionalProperties` and `$schema` from tool parameter schemas before sending, as the public API uses a stricter JSON Schema subset

## Motivation

The `gemini_oauth` backend routes Gemini 2.0+ models to `cloudcode-pa.googleapis.com`, which works for interactive users with browser-based OAuth but fails for headless/server deployments:

- Cloud Code doesn't accept API key auth
- OAuth credentials from non-consumer accounts get HTTP 500
- No way to opt into the public Generative Language API for newer models

The public API supports the same models, accepts `GEMINI_API_KEY` via `x-goog-api-key` header, and is designed for programmatic use.

## Changes

**`src/llm/gemini_oauth.rs`**:
- `model_uses_cloud_code_api()`: return `false` early when `GEMINI_USE_LEGACY_API` is set
- `strip_unsupported_schema_fields()`: recursively remove `additionalProperties` and `$schema` from tool parameter JSON
- `to_gemini_request()`: apply schema stripping to tool declarations

## Usage

```bash
export GEMINI_USE_LEGACY_API=true
export GEMINI_API_KEY=your-key
export GEMINI_MODEL=gemini-3.1-pro-preview
```

No behavior change when `GEMINI_USE_LEGACY_API` is unset.

Fixes #2307