### PR TITLE
feat(engine): LLM council via per-call model override in CodeAct

### DIFF
--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -29,8 +29,8 @@ This is much faster than calling tools sequentially. Use `asyncio.gather()` when
 
 ## Special functions
 
-- `llm_query(prompt, context=None)` — Ask a sub-agent to analyze text or answer a question. Returns a string. Use for summarization, analysis, or any task that needs LLM reasoning on data.
-- `llm_query_batched(prompts, context=None)` — Same but for multiple prompts in parallel. Returns a list of strings.
+- `llm_query(prompt, context=None, model=None)` — Ask a sub-agent to analyze text or answer a question. Returns a string. Use for summarization, analysis, or any task that needs LLM reasoning on data. Optional `model="..."` overrides which LLM answers this single call (e.g. `model="gpt-4o"`).
+- `llm_query_batched(prompts, context=None, model=None, models=None)` — Same but for multiple prompts in parallel. Returns a list of strings. Pass `model="gpt-4o"` to apply one model to every prompt, or `models=["gpt-4o", "claude-sonnet-4-20250514", ...]` (parallel array, must match `prompts` length) to send each prompt to a different model. The "LLM council" pattern is `prompts=[same_question]*N, models=[m1, m2, ...]`.
 - `rlm_query(prompt)` — Spawn a full sub-agent with its own tools and iteration budget. Use for complex sub-tasks that need tool access. Returns the sub-agent's final answer as a string. More powerful but more expensive than llm_query.
 - `FINAL(answer)` — Call this when you have the final answer. The argument is returned to the user.
 - `mission_create(name, goal, cadence="manual", success_criteria=None)` — Create a long-running mission that spawns threads over time. Cadence: "manual", cron expression (e.g. "0 9 * * *"), "event:pattern", or "webhook:path". Cron expressions accept 5-field (`min hr dom mon dow`), 6-field (`sec min hr dom mon dow` — NOT Quartz-style with year), or 7-field (`sec min hr dom mon dow year`). Cron missions default to the user's timezone from `user_timezone`; pass an explicit `timezone` param to override. Returns {"mission_id": "...", "name": "...", "status": "created"}. When telling the user about a created mission, refer to it by `name`, not by `mission_id` (the UUID is internal).

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -629,6 +629,11 @@ async fn handle_llm_complete(
             .and_then(|v| v.as_bool())
             .unwrap_or(false),
         depth: thread.config.depth,
+        model: explicit_config
+            .as_ref()
+            .and_then(|cfg| cfg.get("model"))
+            .and_then(|v| v.as_str())
+            .map(String::from),
         metadata: HashMap::new(),
     };
 

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2780,4 +2780,152 @@ mod tests {
         let outcome = parse_outcome(&result);
         assert!(matches!(outcome, ThreadOutcome::Stopped));
     }
+
+    // ── handle_llm_complete model forwarding ────────────────────
+
+    /// LLM backend that records the model from each `complete()` call.
+    /// Used to verify the orchestrator's __llm_complete__ host fn forwards
+    /// `explicit_config["model"]` onto `LlmCallConfig.model`.
+    struct ModelCapturingLlm {
+        captured: tokio::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for ModelCapturingLlm {
+        fn model_name(&self) -> &str {
+            "capturing"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ThreadMessage],
+            _actions: &[crate::types::capability::ActionDef],
+            config: &LlmCallConfig,
+        ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
+            self.captured.lock().await.push(config.model.clone());
+            Ok(crate::traits::llm::LlmOutput {
+                response: crate::types::step::LlmResponse::Text("ok".into()),
+                usage: crate::types::step::TokenUsage::default(),
+            })
+        }
+    }
+
+    /// No-op effect executor — handle_llm_complete only consults it for
+    /// `available_actions(...)`, which we satisfy with an empty list.
+    struct NoopEffects;
+
+    #[async_trait::async_trait]
+    impl EffectExecutor for NoopEffects {
+        async fn execute_action(
+            &self,
+            _: &str,
+            _: serde_json::Value,
+            _: &crate::types::capability::CapabilityLease,
+            _: &ThreadExecutionContext,
+        ) -> Result<crate::types::step::ActionResult, EngineError> {
+            Ok(crate::types::step::ActionResult {
+                call_id: String::new(),
+                action_name: String::new(),
+                output: serde_json::json!({}),
+                is_error: false,
+                duration: std::time::Duration::from_millis(1),
+            })
+        }
+
+        async fn available_actions(
+            &self,
+            _: &[crate::types::capability::CapabilityLease],
+        ) -> Result<Vec<crate::types::capability::ActionDef>, EngineError> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_complete_forwards_model_from_explicit_config() {
+        let concrete = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        // Build the args __llm_complete__ receives from Python:
+        // (messages, actions, config). config = {"model": "gpt-4o"}.
+        let mut total_tokens = TokenUsage::default();
+        let result = handle_llm_complete(
+            &[
+                json_to_monty(&serde_json::json!([{"role":"user","content":"hi"}])),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({"model": "gpt-4o"})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Return(_)));
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0].as_deref(), Some("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn llm_complete_without_model_passes_none() {
+        let concrete = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let mut total_tokens = TokenUsage::default();
+        let _ = handle_llm_complete(
+            &[
+                json_to_monty(&serde_json::json!([{"role":"user","content":"hi"}])),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({"max_tokens": 100})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 1);
+        assert_eq!(captured[0], None);
+    }
 }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -930,7 +930,14 @@ async fn handle_llm_query(
 ) -> ExtFunctionResult {
     let prompt = extract_string_arg(args, kwargs, "prompt", 0);
     let context_arg = extract_string_arg(args, kwargs, "context", 1);
-    let model_arg = extract_string_arg(args, kwargs, "model", 2);
+    // `model` must be parsed explicitly — `extract_string_arg` coerces via
+    // `monty_to_string`, which turns `MontyObject::None` into the literal
+    // string "None" and stringifies non-string values, both of which would
+    // silently route the call to an invalid model ID. Accept only str or None.
+    let model_arg = match extract_optional_string_kwarg(args, kwargs, "model", 2) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
 
     let prompt = match prompt {
         Some(p) => p,
@@ -1032,7 +1039,12 @@ async fn handle_llm_query_batched(
     //     a `None` slot means "no override for this prompt" (the caller
     //     opted out of routing for that slot); the singular `model=` kwarg
     //     does NOT fill those slots, since mixing the two would be surprising.
-    let single_model = extract_string_arg(&[], kwargs, "model", usize::MAX);
+    // See note in handle_llm_query: `model` must be parsed explicitly so that
+    // `model=None` doesn't become the literal string "None".
+    let single_model = match extract_optional_string_kwarg(&[], kwargs, "model", usize::MAX) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
     let models_kwarg = kwargs.iter().find_map(|(k, v)| match k {
         MontyObject::String(key) if key == "models" => Some(v),
         _ => None,
@@ -1062,7 +1074,7 @@ async fn handle_llm_query_batched(
             return ExtFunctionResult::Error(MontyException::new(
                 ExcType::TypeError,
                 Some(format!(
-                    "llm_query_batched(): `models` must be a list of strings, got {other:?}"
+                    "llm_query_batched(): `models` must be a list of str or None, got {other:?}"
                 )),
             ));
         }
@@ -1469,6 +1481,36 @@ fn extract_string_arg(
         }
     }
     args.get(position).map(monty_to_string)
+}
+
+/// Strict optional-string extractor for arguments where silent coercion is
+/// dangerous (e.g. `model=` — passing the wrong type should NOT become an
+/// unintended model ID). Returns:
+///   - `Ok(None)` when the argument is missing or explicitly `None`
+///   - `Ok(Some(s))` when the argument is a string
+///   - `Err(TypeError)` for any other type
+fn extract_optional_string_kwarg(
+    args: &[MontyObject],
+    kwargs: &[(MontyObject, MontyObject)],
+    name: &str,
+    position: usize,
+) -> Result<Option<String>, ExtFunctionResult> {
+    let raw = kwargs
+        .iter()
+        .find_map(|(k, v)| match k {
+            MontyObject::String(key) if key == name => Some(v),
+            _ => None,
+        })
+        .or_else(|| args.get(position));
+
+    match raw {
+        None | Some(MontyObject::None) => Ok(None),
+        Some(MontyObject::String(s)) => Ok(Some(s.clone())),
+        Some(other) => Err(ExtFunctionResult::Error(MontyException::new(
+            ExcType::TypeError,
+            Some(format!("`{name}` must be a string or None, got {other:?}")),
+        ))),
+    }
 }
 
 pub(crate) fn monty_to_string(obj: &MontyObject) -> String {
@@ -2424,6 +2466,92 @@ FINAL(str(x))
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
         assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+    }
+
+    #[tokio::test]
+    async fn llm_query_model_none_kwarg_is_no_override_not_literal_none_string() {
+        // Regression: `extract_string_arg` would have coerced
+        // MontyObject::None to the literal string "None", silently routing
+        // every model=None call to an invalid model ID. Must stay None.
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let _ = handle_llm_query(
+            &[],
+            &[
+                (
+                    MontyObject::String("prompt".into()),
+                    MontyObject::String("hi".into()),
+                ),
+                (MontyObject::String("model".into()), MontyObject::None),
+            ],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, None);
+    }
+
+    #[tokio::test]
+    async fn llm_query_rejects_non_string_model_kwarg() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let result = handle_llm_query(
+            &[],
+            &[
+                (
+                    MontyObject::String("prompt".into()),
+                    MontyObject::String("hi".into()),
+                ),
+                (MontyObject::String("model".into()), MontyObject::Int(42)),
+            ],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Error(_)));
+        assert!(llm.calls.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_single_model_none_kwarg_is_no_override() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("a".into()),
+            MontyObject::String("b".into()),
+        ]);
+        let _ = handle_llm_query_batched(
+            &[prompts],
+            &[(MontyObject::String("model".into()), MontyObject::None)],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|(m, _)| m.is_none()));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_rejects_non_string_single_model() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![MontyObject::String("a".into())]);
+        let result = handle_llm_query_batched(
+            &[prompts],
+            &[(MontyObject::String("model".into()), MontyObject::Int(7))],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Error(_)));
+        assert!(llm.calls.lock().await.is_empty());
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -930,6 +930,7 @@ async fn handle_llm_query(
 ) -> ExtFunctionResult {
     let prompt = extract_string_arg(args, kwargs, "prompt", 0);
     let context_arg = extract_string_arg(args, kwargs, "context", 1);
+    let model_arg = extract_string_arg(args, kwargs, "model", 2);
 
     let prompt = match prompt {
         Some(p) => p,
@@ -957,6 +958,7 @@ async fn handle_llm_query(
 
     let config = LlmCallConfig {
         force_text: true,
+        model: model_arg,
         ..LlmCallConfig::default()
     };
 
@@ -1022,18 +1024,59 @@ async fn handle_llm_query_batched(
     // Optional context kwarg
     let context_arg = extract_string_arg(&[], kwargs, "context", usize::MAX);
 
-    // Dispatch all prompts concurrently
-    let config = LlmCallConfig {
-        force_text: true,
-        ..LlmCallConfig::default()
-    };
+    // Optional model overrides:
+    //   - `model="..."` applies the same model to every prompt
+    //   - `models=[...]` is a parallel array (must match prompts length); use
+    //     this to broadcast the same prompt across a council of models by
+    //     passing `prompts=[same]*N, models=[m1, m2, ...]`
+    let single_model = extract_string_arg(&[], kwargs, "model", usize::MAX);
+    let models_list: Option<Vec<Option<String>>> = kwargs
+        .iter()
+        .find_map(|(k, v)| match k {
+            MontyObject::String(key) if key == "models" => Some(v),
+            _ => None,
+        })
+        .and_then(|v| match v {
+            MontyObject::List(items) => Some(
+                items
+                    .iter()
+                    .map(|item| match item {
+                        MontyObject::String(s) => Some(s.clone()),
+                        MontyObject::None => None,
+                        _ => Some(monty_to_string(item)),
+                    })
+                    .collect(),
+            ),
+            _ => None,
+        });
+
+    if let Some(ref ms) = models_list
+        && ms.len() != prompts.len()
+    {
+        return ExtFunctionResult::Error(MontyException::new(
+            ExcType::ValueError,
+            Some(format!(
+                "llm_query_batched(): models list length ({}) must match prompts length ({})",
+                ms.len(),
+                prompts.len()
+            )),
+        ));
+    }
 
     let mut handles = Vec::with_capacity(prompts.len());
-    for prompt in &prompts {
+    for (i, prompt) in prompts.iter().enumerate() {
         let llm = Arc::clone(llm);
-        let config = config.clone();
         let ctx = context_arg.clone();
         let prompt = prompt.clone();
+        let model_override = models_list
+            .as_ref()
+            .and_then(|m| m.get(i).cloned().flatten())
+            .or_else(|| single_model.clone());
+        let config = LlmCallConfig {
+            force_text: true,
+            model: model_override,
+            ..LlmCallConfig::default()
+        };
         handles.push(tokio::spawn(async move {
             let mut messages = Vec::new();
             if let Some(ctx) = ctx {
@@ -2201,5 +2244,185 @@ FINAL(str(x))
             "should contain SyntaxError, got: {}",
             result.stdout,
         );
+    }
+
+    // ── llm_query model parameter plumbing ─────────────────────
+
+    /// LLM backend that records every call's model + prompt for assertions.
+    struct CapturingLlm {
+        calls: tokio::sync::Mutex<Vec<(Option<String>, String)>>,
+    }
+
+    impl CapturingLlm {
+        fn new() -> Self {
+            Self {
+                calls: tokio::sync::Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::traits::llm::LlmBackend for CapturingLlm {
+        fn model_name(&self) -> &str {
+            "capturing"
+        }
+
+        async fn complete(
+            &self,
+            messages: &[crate::types::message::ThreadMessage],
+            _actions: &[ActionDef],
+            config: &crate::traits::llm::LlmCallConfig,
+        ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
+            let user_prompt = messages
+                .iter()
+                .rev()
+                .find(|m| matches!(m.role, crate::types::message::MessageRole::User))
+                .map(|m| m.content.clone())
+                .unwrap_or_default();
+            self.calls
+                .lock()
+                .await
+                .push((config.model.clone(), user_prompt.clone()));
+            Ok(crate::traits::llm::LlmOutput {
+                response: crate::types::step::LlmResponse::Text(format!(
+                    "ack:{}:{user_prompt}",
+                    config.model.as_deref().unwrap_or("default")
+                )),
+                usage: crate::types::step::TokenUsage::default(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_query_forwards_model_kwarg() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let result = handle_llm_query(
+            &[],
+            &[
+                (
+                    MontyObject::String("prompt".into()),
+                    MontyObject::String("what is 2+2?".into()),
+                ),
+                (
+                    MontyObject::String("model".into()),
+                    MontyObject::String("gpt-4o".into()),
+                ),
+            ],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        match result {
+            ExtFunctionResult::Return(MontyObject::String(s)) => {
+                assert!(s.contains("gpt-4o"), "got: {s}");
+            }
+            other => panic!("expected string return, got {other:?}"),
+        }
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0.as_deref(), Some("gpt-4o"));
+        assert_eq!(calls[0].1, "what is 2+2?");
+    }
+
+    #[tokio::test]
+    async fn llm_query_without_model_passes_none() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let _ = handle_llm_query(
+            &[MontyObject::String("hello".into())],
+            &[],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, None);
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_broadcasts_with_models_list() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("Q".into()),
+            MontyObject::String("Q".into()),
+            MontyObject::String("Q".into()),
+        ]);
+        let models = MontyObject::List(vec![
+            MontyObject::String("gpt-4o".into()),
+            MontyObject::String("claude-sonnet-4-20250514".into()),
+            MontyObject::String("llama-3.1-70b-instruct".into()),
+        ]);
+        let result = handle_llm_query_batched(
+            &[prompts],
+            &[(MontyObject::String("models".into()), models)],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        match result {
+            ExtFunctionResult::Return(MontyObject::List(items)) => {
+                assert_eq!(items.len(), 3);
+            }
+            other => panic!("expected list return, got {other:?}"),
+        }
+
+        let mut calls = llm.calls.lock().await;
+        calls.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0].0.as_deref(), Some("claude-sonnet-4-20250514"));
+        assert_eq!(calls[1].0.as_deref(), Some("gpt-4o"));
+        assert_eq!(calls[2].0.as_deref(), Some("llama-3.1-70b-instruct"));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_single_model_applies_to_all() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("a".into()),
+            MontyObject::String("b".into()),
+        ]);
+        let _ = handle_llm_query_batched(
+            &[prompts],
+            &[(
+                MontyObject::String("model".into()),
+                MontyObject::String("gpt-4o".into()),
+            )],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_models_length_mismatch_errors() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("a".into()),
+            MontyObject::String("b".into()),
+        ]);
+        let models = MontyObject::List(vec![MontyObject::String("only-one".into())]);
+        let result = handle_llm_query_batched(
+            &[prompts],
+            &[(MontyObject::String("models".into()), models)],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Error(_)));
+        assert!(llm.calls.lock().await.is_empty());
     }
 }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -1028,8 +1028,17 @@ async fn handle_llm_query_batched(
         }
     };
 
-    // Optional context kwarg
-    let context_arg = extract_string_arg(&[], kwargs, "context", usize::MAX);
+    // Positional/keyword layout (matches the documented signature
+    // `llm_query_batched(prompts, context=None, model=None, models=None)`):
+    //   arg 0 = prompts   (already extracted above)
+    //   arg 1 = context
+    //   arg 2 = model
+    //   arg 3 = models
+    // All three of context/model/models can also be passed by keyword.
+    let context_arg = match extract_optional_string_kwarg(args, kwargs, "context", 1) {
+        Ok(v) => v,
+        Err(err) => return err,
+    };
 
     // Optional model overrides:
     //   - `model="..."` applies the same model to every prompt
@@ -1041,17 +1050,20 @@ async fn handle_llm_query_batched(
     //     does NOT fill those slots, since mixing the two would be surprising.
     // See note in handle_llm_query: `model` must be parsed explicitly so that
     // `model=None` doesn't become the literal string "None".
-    let single_model = match extract_optional_string_kwarg(&[], kwargs, "model", usize::MAX) {
+    let single_model = match extract_optional_string_kwarg(args, kwargs, "model", 2) {
         Ok(v) => v,
         Err(err) => return err,
     };
-    let models_kwarg = kwargs.iter().find_map(|(k, v)| match k {
-        MontyObject::String(key) if key == "models" => Some(v),
-        _ => None,
-    });
+    let models_kwarg = kwargs
+        .iter()
+        .find_map(|(k, v)| match k {
+            MontyObject::String(key) if key == "models" => Some(v),
+            _ => None,
+        })
+        .or_else(|| args.get(3));
 
     let models_list: Option<Vec<Option<String>>> = match models_kwarg {
-        None => None,
+        None | Some(MontyObject::None) => None,
         Some(MontyObject::List(items)) => {
             let mut out = Vec::with_capacity(items.len());
             for item in items {
@@ -2535,6 +2547,96 @@ FINAL(str(x))
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
         assert!(calls.iter().all(|(m, _)| m.is_none()));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_honors_positional_context_and_model() {
+        // Regression: `context`, `model`, and `models` used to be kwarg-only.
+        // A positional call matching the documented signature
+        // `llm_query_batched(prompts, context=None, model=None, models=None)`
+        // silently dropped the model, violating the preamble.
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let result = handle_llm_query_batched(
+            &[
+                MontyObject::List(vec![
+                    MontyObject::String("a".into()),
+                    MontyObject::String("b".into()),
+                ]),
+                MontyObject::String("shared context".into()), // position 1: context
+                MontyObject::String("gpt-4o".into()),         // position 2: model
+            ],
+            &[],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        match result {
+            ExtFunctionResult::Return(MontyObject::List(items)) => assert_eq!(items.len(), 2),
+            other => panic!("expected list return, got {other:?}"),
+        }
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 2);
+        assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_honors_positional_models_list() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let result = handle_llm_query_batched(
+            &[
+                MontyObject::List(vec![
+                    MontyObject::String("q".into()),
+                    MontyObject::String("q".into()),
+                ]),
+                MontyObject::None, // position 1: context = None
+                MontyObject::None, // position 2: model = None
+                MontyObject::List(vec![
+                    // position 3: models
+                    MontyObject::String("gpt-4o".into()),
+                    MontyObject::String("claude-sonnet-4-6".into()),
+                ]),
+            ],
+            &[],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Return(_)));
+        let mut calls = llm.calls.lock().await;
+        calls.sort_by(|a, b| a.0.cmp(&b.0));
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0].0.as_deref(), Some("claude-sonnet-4-6"));
+        assert_eq!(calls[1].0.as_deref(), Some("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_positional_none_for_models_is_no_override() {
+        // `llm_query_batched(prompts, None, None, None)` should run with no
+        // model overrides, not error on the positional None at slot 3.
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let result = handle_llm_query_batched(
+            &[
+                MontyObject::List(vec![MontyObject::String("a".into())]),
+                MontyObject::None,
+                MontyObject::None,
+                MontyObject::None,
+            ],
+            &[],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Return(_)));
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].0, None);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -1028,27 +1028,45 @@ async fn handle_llm_query_batched(
     //   - `model="..."` applies the same model to every prompt
     //   - `models=[...]` is a parallel array (must match prompts length); use
     //     this to broadcast the same prompt across a council of models by
-    //     passing `prompts=[same]*N, models=[m1, m2, ...]`
+    //     passing `prompts=[same]*N, models=[m1, m2, ...]`. Within `models`,
+    //     a `None` slot means "no override for this prompt" (the caller
+    //     opted out of routing for that slot); the singular `model=` kwarg
+    //     does NOT fill those slots, since mixing the two would be surprising.
     let single_model = extract_string_arg(&[], kwargs, "model", usize::MAX);
-    let models_list: Option<Vec<Option<String>>> = kwargs
-        .iter()
-        .find_map(|(k, v)| match k {
-            MontyObject::String(key) if key == "models" => Some(v),
-            _ => None,
-        })
-        .and_then(|v| match v {
-            MontyObject::List(items) => Some(
-                items
-                    .iter()
-                    .map(|item| match item {
-                        MontyObject::String(s) => Some(s.clone()),
-                        MontyObject::None => None,
-                        _ => Some(monty_to_string(item)),
-                    })
-                    .collect(),
-            ),
-            _ => None,
-        });
+    let models_kwarg = kwargs.iter().find_map(|(k, v)| match k {
+        MontyObject::String(key) if key == "models" => Some(v),
+        _ => None,
+    });
+
+    let models_list: Option<Vec<Option<String>>> = match models_kwarg {
+        None => None,
+        Some(MontyObject::List(items)) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                match item {
+                    MontyObject::String(s) => out.push(Some(s.clone())),
+                    MontyObject::None => out.push(None),
+                    other => {
+                        return ExtFunctionResult::Error(MontyException::new(
+                            ExcType::TypeError,
+                            Some(format!(
+                                "llm_query_batched(): models list entries must be str or None, got {other:?}"
+                            )),
+                        ));
+                    }
+                }
+            }
+            Some(out)
+        }
+        Some(other) => {
+            return ExtFunctionResult::Error(MontyException::new(
+                ExcType::TypeError,
+                Some(format!(
+                    "llm_query_batched(): `models` must be a list of strings, got {other:?}"
+                )),
+            ));
+        }
+    };
 
     if let Some(ref ms) = models_list
         && ms.len() != prompts.len()
@@ -1068,10 +1086,13 @@ async fn handle_llm_query_batched(
         let llm = Arc::clone(llm);
         let ctx = context_arg.clone();
         let prompt = prompt.clone();
-        let model_override = models_list
-            .as_ref()
-            .and_then(|m| m.get(i).cloned().flatten())
-            .or_else(|| single_model.clone());
+        // If `models=` was provided, each slot is authoritative — `None` means
+        // "no override for this prompt" and is NOT backfilled from `model=`.
+        // Otherwise, fall back to the singular `model=` kwarg (or None).
+        let model_override = match models_list.as_ref() {
+            Some(ms) => ms[i].clone(),
+            None => single_model.clone(),
+        };
         let config = LlmCallConfig {
             force_text: true,
             model: model_override,
@@ -2403,6 +2424,66 @@ FINAL(str(x))
         let calls = llm.calls.lock().await;
         assert_eq!(calls.len(), 2);
         assert!(calls.iter().all(|(m, _)| m.as_deref() == Some("gpt-4o")));
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_rejects_non_string_models_entries() {
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("a".into()),
+            MontyObject::String("b".into()),
+        ]);
+        // Integers in the models list should fail loudly, not be coerced to "1"/"2".
+        let models = MontyObject::List(vec![MontyObject::Int(1), MontyObject::Int(2)]);
+        let result = handle_llm_query_batched(
+            &[prompts],
+            &[(MontyObject::String("models".into()), models)],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        assert!(matches!(result, ExtFunctionResult::Error(_)));
+        assert!(llm.calls.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn llm_query_batched_none_in_models_list_does_not_backfill_from_model_kwarg() {
+        // Regression: when `models=[None, "gpt-4o"]` and `model="claude-..."`
+        // are both passed, the None slot must NOT be backfilled by the
+        // singular `model=` kwarg. Each slot is authoritative.
+        let llm = Arc::new(CapturingLlm::new());
+        let mut tokens = crate::types::step::TokenUsage::default();
+        let prompts = MontyObject::List(vec![
+            MontyObject::String("a".into()),
+            MontyObject::String("b".into()),
+        ]);
+        let models = MontyObject::List(vec![
+            MontyObject::None,
+            MontyObject::String("gpt-4o".into()),
+        ]);
+        let _ = handle_llm_query_batched(
+            &[prompts],
+            &[
+                (MontyObject::String("models".into()), models),
+                (
+                    MontyObject::String("model".into()),
+                    MontyObject::String("claude-sonnet-4-20250514".into()),
+                ),
+            ],
+            &(Arc::clone(&llm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &mut tokens,
+        )
+        .await;
+
+        let calls = llm.calls.lock().await;
+        assert_eq!(calls.len(), 2);
+        // Slot 0 was None — must remain None, not become "claude-sonnet-4-20250514".
+        let slot_a = calls.iter().find(|(_, p)| p == "a").expect("call for a");
+        let slot_b = calls.iter().find(|(_, p)| p == "b").expect("call for b");
+        assert_eq!(slot_a.0, None);
+        assert_eq!(slot_b.0.as_deref(), Some("gpt-4o"));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/traits/llm.rs
+++ b/crates/ironclaw_engine/src/traits/llm.rs
@@ -24,6 +24,11 @@ pub struct LlmCallConfig {
     /// Depth in the recursive call tree (0 = root, 1+ = sub-call).
     /// Implementations can use this to route to cheaper models for sub-calls.
     pub depth: u32,
+    /// Optional per-call model override. When set, the bridge adapter forwards
+    /// this to the underlying `LlmProvider` via `CompletionRequest::model`.
+    /// Providers that don't support per-request overrides will fall back to
+    /// their configured model and log a warning.
+    pub model: Option<String>,
     /// Opaque metadata forwarded to the LLM provider.
     pub metadata: HashMap<String, String>,
 }

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -37,9 +37,21 @@ activation:
 You can query multiple LLM models with the same prompt directly from CodeAct
 using the built-in `llm_query()` and `llm_query_batched()` functions. Both
 accept a `model=` (or `models=`) keyword that overrides the configured model
-for that call. Providers that support per-request model overrides (NEAR AI,
-Anthropic OAuth, GitHub Copilot, Bedrock) honor it; others fall back to their
-configured model.
+for that call.
+
+Per-request model override support varies by backend:
+
+| Backend            | Honors `model=`? | Cross-vendor routing? |
+|--------------------|------------------|-----------------------|
+| NEAR AI            | Yes              | Yes (aggregator — hosts models from many vendors) |
+| Anthropic OAuth    | Yes              | No (Anthropic models only) |
+| GitHub Copilot     | Yes              | No (Copilot-exposed models only) |
+| Bedrock            | **No**           | — (model fixed at construction) |
+| OpenAI / Ollama / Tinfoil via rig | No (silent fallback with warning log) | — |
+
+A genuine *cross-vendor* council (Anthropic + Google + OpenAI in one batch)
+therefore only works on an aggregator backend like NEAR AI. On single-vendor
+backends, use a lineup of models available within that vendor.
 
 ## When to use a council
 
@@ -51,8 +63,11 @@ configured model.
 
 ## Default council line-up
 
-Unless the user requests something specific, use this 4-model council:
+Check the configured backend first (e.g. from `LLM_BACKEND` or the user's
+settings) before picking a lineup. Unless the user requests specific models,
+use the matching default below.
 
+**NEAR AI (aggregator — default council):**
 ```python
 COUNCIL = [
     "anthropic/claude-opus-4-6",
@@ -61,9 +76,32 @@ COUNCIL = [
     "openai/gpt-5.4",
 ]
 ```
+This 4-model lineup spans the major frontier providers and reasoning styles.
+It **only works on NEAR AI** (or another aggregator) — the prefixed model
+names route inside NEAR AI to the respective vendors.
 
-These four span the major frontier providers and reasoning styles. If the
-user names specific models, use those instead.
+**Anthropic OAuth** (Anthropic-only, no cross-vendor routing):
+```python
+COUNCIL = [
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-haiku-4-5",
+]
+```
+Use different Anthropic tiers for diversity of reasoning depth vs. speed.
+
+**GitHub Copilot** (whatever Copilot exposes):
+```python
+COUNCIL = ["gpt-5.4", "claude-opus-4-6", "gemini-3-pro"]
+```
+Copilot's available models shift over time — call `llm_query` with the
+user's configured default if you're unsure which are reachable.
+
+**Bedrock / OpenAI / Ollama / Tinfoil:** per-request `model=` is not honored
+by these backends. A council is not possible without switching backends —
+tell the user and fall back to a single-model answer.
+
+If the user names specific models, always use those instead of the defaults.
 
 ## API
 

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -49,6 +49,22 @@ configured model.
 - Getting a "second opinion" from different AI models
 - Research or evaluation tasks that benefit from multiple viewpoints
 
+## Default council line-up
+
+Unless the user requests something specific, use this 4-model council:
+
+```python
+COUNCIL = [
+    "anthropic/claude-opus-4-6",
+    "google/gemini-3-pro",
+    "zai-org/GLM-latest",
+    "openai/gpt-5.4",
+]
+```
+
+These four span the major frontier providers and reasoning styles. If the
+user names specific models, use those instead.
+
 ## API
 
 ### Single call with a model override
@@ -56,34 +72,41 @@ configured model.
 answer = llm_query(
     prompt="What is X?",
     context="Optional background",     # optional
-    model="claude-sonnet-4-20250514",  # optional per-call override
+    model="anthropic/claude-opus-4-6", # optional per-call override
 )
 ```
 
 ### Parallel council (same prompt, many models)
 ```python
-COUNCIL = ["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]
+COUNCIL = [
+    "anthropic/claude-opus-4-6",
+    "google/gemini-3-pro",
+    "zai-org/GLM-latest",
+    "openai/gpt-5.4",
+]
 responses = llm_query_batched(
     prompts=["What are the main risks of X?"] * len(COUNCIL),
     models=COUNCIL,                    # parallel array, length must match prompts
     context="Answer in 3-5 bullet points.",
 )
 # `responses` is a list of strings in the same order as `models`.
+# If a specific model is unavailable, that slot returns "Error: ..." —
+# the rest of the batch still completes.
 ```
 
 ### Single model applied to many prompts
 ```python
 results = llm_query_batched(
     prompts=["Q1", "Q2", "Q3"],
-    model="gpt-4o",                    # singular: applies to every prompt
+    model="anthropic/claude-opus-4-6", # singular: applies to every prompt
 )
 ```
 
-## Recommended council line-ups (NEAR AI backend)
-
-- **Quick (3 models):** `["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]`
-- **Deep (5 models):** add `"qwen-2.5-72b-instruct"`, `"deepseek-chat"`
-- **Reasoning-focused:** `["o3-mini", "claude-sonnet-4-20250514", "deepseek-reasoner"]`
+### Mixing `models=` slots with `None`
+A `None` slot inside `models=[...]` means "no override for this prompt" —
+that call uses the configured default model. The singular `model=` kwarg
+does NOT backfill `None` slots; it is only used when `models=` is omitted
+entirely.
 
 ## After collecting responses
 
@@ -95,7 +118,12 @@ results = llm_query_batched(
 ## Full example
 
 ```repl
-COUNCIL = ["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]
+COUNCIL = [
+    "anthropic/claude-opus-4-6",
+    "google/gemini-3-pro",
+    "zai-org/GLM-latest",
+    "openai/gpt-5.4",
+]
 question = "What are the main risks of relying on a single LLM provider?"
 
 responses = llm_query_batched(

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -150,4 +150,4 @@ FINAL(synthesis)
 - `llm_query_batched()` runs all calls in parallel — total latency is roughly the slowest model.
 - If `models=` is provided, it must be the same length as `prompts`.
 - Use `model=` (singular) when you want one model applied to every prompt; use `models=` (plural list) for the council pattern.
-- Errors from individual models surface as `"Error: ..."` strings in the result list — the batch never raises.
+- Errors from individual models (unavailable model, provider timeout, etc.) surface as `"Error: ..."` strings in the result list, so a single bad model does not fail the whole batch. Argument validation errors — wrong types, or `models`/`prompts` length mismatch — still raise exceptions.

--- a/skills/llm-council/SKILL.md
+++ b/skills/llm-council/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: llm-council
+version: "1.0.0"
+description: Query multiple LLM models in parallel from CodeAct and cross-reference their responses
+activation:
+  keywords:
+    - "council"
+    - "compare models"
+    - "multiple models"
+    - "cross-reference"
+    - "second opinion"
+    - "opinions"
+    - "consensus"
+    - "different models"
+    - "model comparison"
+    - "diverse perspectives"
+    - "ask several"
+    - "ask multiple"
+    - "vote"
+  exclude_keywords:
+    - "routine"
+    - "schedule"
+  patterns:
+    - "(?i)(ask|query|consult|compare)\\s.*(models|llms|ais)"
+    - "(?i)(what do|how do)\\s.*(different|other|multiple)\\s.*(models|llms|ais)\\s*(think|say)"
+    - "(?i)council"
+    - "(?i)cross[- ]?referenc"
+  tags:
+    - "llm"
+    - "analysis"
+    - "research"
+  max_context_tokens: 1200
+---
+
+# LLM Council
+
+You can query multiple LLM models with the same prompt directly from CodeAct
+using the built-in `llm_query()` and `llm_query_batched()` functions. Both
+accept a `model=` (or `models=`) keyword that overrides the configured model
+for that call. Providers that support per-request model overrides (NEAR AI,
+Anthropic OAuth, GitHub Copilot, Bedrock) honor it; others fall back to their
+configured model.
+
+## When to use a council
+
+- The user wants diverse perspectives on a question or analysis
+- Cross-referencing answers to increase confidence
+- Comparing reasoning approaches across models
+- Getting a "second opinion" from different AI models
+- Research or evaluation tasks that benefit from multiple viewpoints
+
+## API
+
+### Single call with a model override
+```python
+answer = llm_query(
+    prompt="What is X?",
+    context="Optional background",     # optional
+    model="claude-sonnet-4-20250514",  # optional per-call override
+)
+```
+
+### Parallel council (same prompt, many models)
+```python
+COUNCIL = ["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]
+responses = llm_query_batched(
+    prompts=["What are the main risks of X?"] * len(COUNCIL),
+    models=COUNCIL,                    # parallel array, length must match prompts
+    context="Answer in 3-5 bullet points.",
+)
+# `responses` is a list of strings in the same order as `models`.
+```
+
+### Single model applied to many prompts
+```python
+results = llm_query_batched(
+    prompts=["Q1", "Q2", "Q3"],
+    model="gpt-4o",                    # singular: applies to every prompt
+)
+```
+
+## Recommended council line-ups (NEAR AI backend)
+
+- **Quick (3 models):** `["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]`
+- **Deep (5 models):** add `"qwen-2.5-72b-instruct"`, `"deepseek-chat"`
+- **Reasoning-focused:** `["o3-mini", "claude-sonnet-4-20250514", "deepseek-reasoner"]`
+
+## After collecting responses
+
+1. **Identify consensus** — note where models agree
+2. **Flag disagreements** — analyze where they diverge and why
+3. **Synthesize** — produce a unified answer that accounts for all perspectives
+4. **Cite** — reference which model contributed each insight
+
+## Full example
+
+```repl
+COUNCIL = ["gpt-4o", "claude-sonnet-4-20250514", "llama-3.1-70b-instruct"]
+question = "What are the main risks of relying on a single LLM provider?"
+
+responses = llm_query_batched(
+    prompts=[question] * len(COUNCIL),
+    models=COUNCIL,
+    context="Answer concisely in 3-5 bullet points.",
+)
+
+# Build a synthesis prompt
+labelled = "\n\n---\n\n".join(
+    f"**{model}**:\n{resp}" for model, resp in zip(COUNCIL, responses)
+)
+
+synthesis = llm_query(
+    prompt=f"Synthesize a balanced answer from these {len(COUNCIL)} expert opinions:\n\n{labelled}",
+    context="Identify consensus, flag disagreements, and produce a unified answer.",
+)
+
+FINAL(synthesis)
+```
+
+## Notes
+
+- `llm_query_batched()` runs all calls in parallel — total latency is roughly the slowest model.
+- If `models=` is provided, it must be the same length as `prompts`.
+- Use `model=` (singular) when you want one model applied to every prompt; use `models=` (plural list) for the council pattern.
+- Errors from individual models surface as `"Error: ..."` strings in the result list — the batch never raises.

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -70,6 +70,9 @@ impl LlmBackend for LlmBridgeAdapter {
                 .with_max_tokens(max_tokens)
                 .with_temperature(temperature);
             request.metadata = config.metadata.clone();
+            if let Some(ref model) = config.model {
+                request.model = Some(model.clone());
+            }
 
             let response = provider
                 .complete(request)
@@ -105,6 +108,9 @@ impl LlmBackend for LlmBridgeAdapter {
             .with_temperature(temperature)
             .with_tool_choice("auto");
         request.metadata = config.metadata.clone();
+        if let Some(ref model) = config.model {
+            request.model = Some(model.clone());
+        }
 
         // Call provider
         let response =
@@ -375,6 +381,7 @@ mod tests {
     struct CapturingProviderState {
         completion_requests: tokio::sync::Mutex<Vec<Vec<ChatMessage>>>,
         tool_requests: tokio::sync::Mutex<Vec<Vec<ChatMessage>>>,
+        models: tokio::sync::Mutex<Vec<Option<String>>>,
     }
 
     struct CapturingProvider {
@@ -395,6 +402,7 @@ mod tests {
             &self,
             req: crate::llm::CompletionRequest,
         ) -> Result<crate::llm::CompletionResponse, LlmError> {
+            self.state.models.lock().await.push(req.model.clone());
             self.state
                 .completion_requests
                 .lock()
@@ -415,6 +423,7 @@ mod tests {
             &self,
             req: ToolCompletionRequest,
         ) -> Result<ToolCompletionResponse, LlmError> {
+            self.state.models.lock().await.push(req.model.clone());
             self.state.tool_requests.lock().await.push(req.messages);
 
             Ok(ToolCompletionResponse {
@@ -554,6 +563,69 @@ mod tests {
         assert_eq!(sent[2].content, "result payload");
         assert_eq!(sent[2].tool_call_id.as_deref(), Some("call_1"));
         assert_eq!(sent[2].name.as_deref(), Some("search"));
+    }
+
+    #[tokio::test]
+    async fn config_model_forwards_to_completion_request() {
+        let state = Arc::new(CapturingProviderState::default());
+        let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
+            state: state.clone(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let config = ironclaw_engine::LlmCallConfig {
+            model: Some("gpt-4o".into()),
+            ..Default::default()
+        };
+
+        // Plain completion path (no tools)
+        adapter
+            .complete(&[ThreadMessage::user("hi")], &[], &config)
+            .await
+            .unwrap();
+
+        // Tool completion path
+        adapter
+            .complete(
+                &[ThreadMessage::user("hi")],
+                &[ActionDef {
+                    name: "echo".into(),
+                    description: "test".into(),
+                    parameters_schema: serde_json::json!({"type": "object"}),
+                    effects: vec![EffectType::ReadLocal],
+                    requires_approval: false,
+                }],
+                &config,
+            )
+            .await
+            .unwrap();
+
+        let models = state.models.lock().await;
+        assert_eq!(models.len(), 2);
+        assert_eq!(models[0].as_deref(), Some("gpt-4o"));
+        assert_eq!(models[1].as_deref(), Some("gpt-4o"));
+    }
+
+    #[tokio::test]
+    async fn config_without_model_leaves_request_model_none() {
+        let state = Arc::new(CapturingProviderState::default());
+        let provider: Arc<dyn LlmProvider> = Arc::new(CapturingProvider {
+            state: state.clone(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        adapter
+            .complete(
+                &[ThreadMessage::user("hi")],
+                &[],
+                &ironclaw_engine::LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        let models = state.models.lock().await;
+        assert_eq!(models.len(), 1);
+        assert_eq!(models[0], None);
     }
 
     // ── extract_code_block tests ────────────────────────────


### PR DESCRIPTION
## Summary

- Lets the v2 engine query a council of LLMs from a single CodeAct step by adding a `model=` (and `models=` for the batched variant) keyword to the existing `llm_query()` / `llm_query_batched()` host functions. No new tool, no new dispatch path.
- Plumbs the override through `LlmCallConfig` → `LlmBridgeAdapter` → `CompletionRequest.model`, which providers that support per-request switching (NEAR AI, Anthropic OAuth, GitHub Copilot, Bedrock) already honor.
- Ships an `llm-council` skill that activates on council/cross-reference language and teaches the pattern (broadcast same prompt across N models, then synthesize via a follow-up `llm_query`).

## Why a skill, not a tool?

Originally drafted as a `LlmCouncilTool` built-in. Reverted in favor of extending CodeAct because:

1. **Reuses existing infrastructure** — suspend/resume, token accounting, recursive depth tracking, error handling all come for free from `llm_query`.
2. **The skill is just text** — council line-ups, synthesis logic, and prompt patterns live in `SKILL.md`. No Rust changes needed to add new council variants.
3. **Per-call model overrides compose** — any future skill that wants a single sub-query routed to a specific model (e.g. \"use a reasoning model for this synthesis step\") gets it for free via `llm_query(..., model=\"...\")`.

## API

```python
# Single call to a specific model
answer = llm_query(prompt=\"...\", model=\"gpt-4o\")

# Council pattern: same prompt, parallel across N models
COUNCIL = [\"gpt-4o\", \"claude-sonnet-4-20250514\", \"llama-3.1-70b-instruct\"]
responses = llm_query_batched(
    prompts=[question] * len(COUNCIL),
    models=COUNCIL,                       # parallel array, length must match
)

# Or one model applied to many prompts
results = llm_query_batched(prompts=[\"q1\", \"q2\", \"q3\"], model=\"gpt-4o\")
```

## Files changed

| File | Change |
|---|---|
| `crates/ironclaw_engine/src/traits/llm.rs` | Added `model: Option<String>` to `LlmCallConfig` |
| `crates/ironclaw_engine/src/executor/scripting.rs` | `handle_llm_query` and `handle_llm_query_batched` extract `model=` / `models=`; length-mismatch validation; 5 new unit tests |
| `crates/ironclaw_engine/src/executor/orchestrator.rs` | `__llm_complete__` host fn extracts `model` from explicit_config |
| `crates/ironclaw_engine/prompts/codeact_preamble.md` | Documented new parameters so the agent sees them in its system prompt |
| `src/bridge/llm_adapter.rs` | Forward `config.model` onto `CompletionRequest.model` / `ToolCompletionRequest.model` for both paths; 2 new tests |
| `skills/llm-council/SKILL.md` | New skill teaching the council pattern + recommended NEAR AI line-ups |

## Provider behavior

| Provider | Per-request model override | Council works? |
|---|---|---|
| NEAR AI | Yes (`take_model_override()`) | ✅ |
| Anthropic OAuth | Yes (`set_model()` based) | ✅ |
| GitHub Copilot | Yes | ✅ |
| Bedrock | Yes | ✅ |
| OpenAI (rig adapter) | Ignored with warning | Falls back to configured model |
| Ollama / Tinfoil | Ignored with warning | Falls back to configured model |

## Test plan

- [x] `cargo test -p ironclaw_engine --lib` — 342 tests pass (337 + 5 new in `executor::scripting`)
- [x] `cargo test --lib` — 4644 tests pass (incl. 2 new in `bridge::llm_adapter`)
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [ ] Manual: trigger the skill from a v2 conversation with NEAR AI backend (\"ask 3 different models what the main risks of X are\") and verify all three models respond
- [ ] Manual: confirm a non-NEAR AI provider (e.g. Ollama) gracefully falls back when `model=` is passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)