### PR TITLE
fix(engine): always append ActionResult for every tool call

### DIFF
--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -720,22 +720,29 @@ def run_loop(context, goal, actions, state, config):
             # Rust handles preflight (lease/policy), parallel execution via
             # JoinSet, and event emission in call order.
             results = __execute_actions_parallel__(executable_calls)
-            for idx in range(len(results)):
-                r = results[idx]
-                if r is None:
-                    continue
-                call = executable_calls[idx] if idx < len(executable_calls) else {}
+            # Every tool call in the assistant message MUST have a matching
+            # ActionResult, otherwise the LLM API rejects the sequence with
+            # "No tool output found for function call <id>". Iterate over
+            # executable_calls (not results) so we cover calls that the Rust
+            # batch handler skipped (e.g. RequireApproval early return).
+            for idx in range(len(executable_calls)):
+                call = executable_calls[idx]
                 call_id = call.get("call_id", "")
-                action_name = r.get("action_name", call.get("name", ""))
-                output = r.get("output")
-                if output is not None:
-                    append_message(
-                        working_messages,
-                        "ActionResult",
-                        str(output),
-                        action_name=action_name,
-                        action_call_id=call_id,
-                    )
+                r = results[idx] if idx < len(results) else None
+                if r is not None:
+                    action_name = r.get("action_name", call.get("name", ""))
+                    output = r.get("output")
+                    output_str = str(output) if output is not None else "[no output]"
+                else:
+                    action_name = call.get("name", "unknown")
+                    output_str = "[execution skipped]"
+                append_message(
+                    working_messages,
+                    "ActionResult",
+                    output_str,
+                    action_name=action_name,
+                    action_call_id=call_id,
+                )
 
             # Check results for auth/approval interrupts
             for r_idx, r in enumerate(results):

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -1317,6 +1317,12 @@ async fn handle_execute_actions_parallel(
                         })
                         .unwrap_or_default(),
                     }));
+                    // Pad with nulls for calls that weren't reached so the
+                    // Python-side loop can emit ActionResult placeholders for
+                    // every tool call in the assistant message.
+                    while results_json.len() < parsed.len() {
+                        results_json.push(serde_json::json!(null));
+                    }
                     return ExtFunctionResult::Return(json_to_monty(&serde_json::json!(
                         results_json
                     )));
@@ -3327,5 +3333,75 @@ mod tests {
             .as_ref()
             .expect("empty array should produce Some(vec![])");
         assert!(calls.is_empty());
+    }
+
+    /// Regression test: every assistant tool_call must have a matching
+    /// ActionResult after parsing. If an ActionResult is missing, the LLM
+    /// API rejects with "No tool output found for function call <id>".
+    ///
+    /// This was the root cause of the HTTP 400 from the OpenAI Codex
+    /// provider: a tool returning null output caused the Python
+    /// orchestrator to skip appending the ActionResult.
+    #[test]
+    fn json_to_thread_messages_every_tool_call_has_action_result() {
+        // Simulate working_messages after the Python fix: every call gets
+        // an ActionResult, even when the original output was null.
+        let messages = serde_json::json!([
+            {"role": "System", "content": "You are a helpful assistant."},
+            {"role": "User", "content": "Update all tools."},
+            {
+                "role": "Assistant",
+                "content": "",
+                "action_calls": [
+                    {"call_id": "call_AAA", "name": "tool_a", "params": {}},
+                    {"call_id": "call_BBB", "name": "tool_b", "params": {}},
+                    {"call_id": "call_CCC", "name": "tool_c", "params": {}}
+                ]
+            },
+            {
+                "role": "ActionResult",
+                "content": "{\"ok\": true}",
+                "action_name": "tool_a",
+                "action_call_id": "call_AAA"
+            },
+            {
+                "role": "ActionResult",
+                "content": "[no output]",
+                "action_name": "tool_b",
+                "action_call_id": "call_BBB"
+            },
+            {
+                "role": "ActionResult",
+                "content": "{\"done\": true}",
+                "action_name": "tool_c",
+                "action_call_id": "call_CCC"
+            }
+        ]);
+
+        let parsed = json_to_thread_messages(&messages).expect("must parse");
+        assert_eq!(parsed.len(), 6);
+
+        // Extract call IDs from the assistant message
+        let assistant_calls: std::collections::HashSet<String> = parsed
+            .iter()
+            .filter_map(|m| m.action_calls.as_ref())
+            .flat_map(|calls| calls.iter().map(|c| c.id.clone()))
+            .collect();
+
+        // Extract call IDs from ActionResult messages
+        let result_call_ids: std::collections::HashSet<String> = parsed
+            .iter()
+            .filter(|m| m.role == crate::types::message::MessageRole::ActionResult)
+            .filter_map(|m| m.action_call_id.clone())
+            .collect();
+
+        // Every tool_call must have a matching ActionResult
+        for call_id in &assistant_calls {
+            assert!(
+                result_call_ids.contains(call_id),
+                "tool_call {call_id} has no matching ActionResult — \
+                 this would cause 'No tool output found' from the LLM API"
+            );
+        }
     }
 }

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -708,4 +708,76 @@ And also check the token price:\n\
         let text = "```python\nprint('no closing fence')";
         assert!(extract_code_block(text).is_none());
     }
+
+    /// Regression test: the full ThreadMessage -> ChatMessage -> sanitize
+    /// pipeline must preserve 1:1 correspondence between assistant
+    /// tool_calls and Tool messages. A gap causes the LLM API to reject
+    /// with "No tool output found for function call <id>".
+    #[test]
+    fn tool_call_result_correspondence_after_sanitize() {
+        // Simulate messages that include a "[no output]" placeholder
+        // (the fix for null tool output).
+        let messages: Vec<ThreadMessage> = vec![
+            ThreadMessage::system("system prompt"),
+            ThreadMessage::user("update all tools"),
+            ThreadMessage::assistant_with_actions(
+                Some(String::new()),
+                vec![
+                    ActionCall {
+                        id: "call_AAA".into(),
+                        action_name: "tool_a".into(),
+                        parameters: serde_json::json!({}),
+                    },
+                    ActionCall {
+                        id: "call_BBB".into(),
+                        action_name: "tool_b".into(),
+                        parameters: serde_json::json!({}),
+                    },
+                    ActionCall {
+                        id: "call_CCC".into(),
+                        action_name: "tool_c".into(),
+                        parameters: serde_json::json!({}),
+                    },
+                ],
+            ),
+            ThreadMessage::action_result("call_AAA", "tool_a", "{\"ok\": true}"),
+            // call_BBB had null output; Python now sends "[no output]"
+            ThreadMessage::action_result("call_BBB", "tool_b", "[no output]"),
+            ThreadMessage::action_result("call_CCC", "tool_c", "{\"done\": true}"),
+        ];
+
+        let mut chat_messages: Vec<ChatMessage> = messages.iter().map(thread_msg_to_chat).collect();
+        sanitize_tool_messages(&mut chat_messages);
+
+        // Collect tool_call IDs from assistant messages
+        let mut expected_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for msg in &chat_messages {
+            if msg.role == Role::Assistant
+                && let Some(ref calls) = msg.tool_calls
+            {
+                for tc in calls {
+                    expected_ids.insert(tc.id.clone());
+                }
+            }
+        }
+
+        // Collect tool_call_ids from Tool messages
+        let mut result_ids: std::collections::HashSet<String> = std::collections::HashSet::new();
+        for msg in &chat_messages {
+            if msg.role == Role::Tool
+                && let Some(ref id) = msg.tool_call_id
+            {
+                result_ids.insert(id.clone());
+            }
+        }
+
+        assert_eq!(expected_ids.len(), 3, "assistant should have 3 tool calls");
+        for id in &expected_ids {
+            assert!(
+                result_ids.contains(id),
+                "tool_call {id} has no matching Tool message after sanitize — \
+                 LLM API would reject with 'No tool output found'"
+            );
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes HTTP 400 `No tool output found for function call <id>` from OpenAI's Responses API when a tool call in the assistant message has no corresponding tool result.

The Python orchestrator only appended `ActionResult` messages when `output is not None`, leaving dangling `tool_calls` in `working_messages` in three scenarios:

1. **Tool returns null output** - JSON `null` -> Python `None`, skipping the append
2. **Gate-paused results** - `result_json` has no `output` field at all
3. **RequireApproval preflight early return** - Rust returned fewer results than calls, so trailing calls got no slot

OpenAI's Responses API requires 1:1 correspondence between `function_call` and `function_call_output` items, so the next LLM turn fails with the 400.

## Changes

- **`crates/ironclaw_engine/orchestrator/default.py`** - iterate over `executable_calls` (not `results`) and emit an `ActionResult` for every call, with `"[no output]"` / `"[execution skipped]"` placeholders when the real output is missing.
- **`crates/ironclaw_engine/src/executor/orchestrator.rs`** - pad the `RequireApproval` early-return `results_json` to `parsed.len()` so Python sees a null slot for every call and emits the placeholder.
- Regression tests at both layers:
  - `json_to_thread_messages_every_tool_call_has_action_result` (engine) - parse path
  - `tool_call_result_correspondence_after_sanitize` (bridge) - full `ThreadMessage` -> `ChatMessage` -> `sanitize_tool_messages` pipeline

## Test plan

- [x] `cargo test -p ironclaw_engine` (350 pass, including new regression test)
- [x] `cargo test --lib -- bridge::llm_adapter` (new regression test passes)
- [x] `cargo clippy --lib --bins -- -D warnings` clean
- [ ] Rerun the failing `update all tools` flow against the OpenAI Codex provider and confirm no more HTTP 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)