### PR TITLE
[codex] Support web file uploads

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -1305,18 +1305,29 @@ function formatFileSize(bytes) {
 }
 
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB per file
+const MAX_TOTAL_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB per message
 const MAX_STAGED_FILES = 5;
 
 function handleAttachmentFiles(files) {
+  let stagedBytes = stagedFiles.reduce((sum, file) => sum + (file.size || 0), 0);
+  let stagedCount = stagedFiles.length;
+
   Array.from(files).forEach(file => {
+    if (stagedCount >= MAX_STAGED_FILES) {
+      alert(I18n.t('chat.maxFiles', { n: MAX_STAGED_FILES }));
+      return;
+    }
     if (file.size > MAX_FILE_SIZE_BYTES) {
       alert(I18n.t('chat.fileTooBig', { name: file.name, size: (file.size / 1024 / 1024).toFixed(1) }));
       return;
     }
-    if (stagedFiles.length >= MAX_STAGED_FILES) {
-      alert(I18n.t('chat.maxFiles', { n: MAX_STAGED_FILES }));
+    if (stagedBytes + file.size > MAX_TOTAL_FILE_SIZE_BYTES) {
+      alert(I18n.t('chat.filesTooBig', { size: (MAX_TOTAL_FILE_SIZE_BYTES / 1024 / 1024).toFixed(0) }));
       return;
     }
+    stagedBytes += file.size;
+    stagedCount += 1;
+
     const reader = new FileReader();
     reader.onload = function(e) {
       const dataUrl = e.target.result;

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -91,7 +91,7 @@ let unreadThreads = new Map(); // thread_id -> unread count
 let _loadThreadsTimer = null;
 const JOB_EVENTS_CAP = 500;
 const MEMORY_SEARCH_QUERY_MAX_LENGTH = 100;
-let stagedImages = [];
+let stagedFiles = [];
 let authFlowPending = false;
 let _ghostSuggestion = '';
 let currentSettingsSubtab = 'inference';
@@ -1149,7 +1149,7 @@ function sendMessage() {
   }
   if (_sendCooldown) return;
   const content = input.value.trim();
-  if (!content && stagedImages.length === 0) return;
+  if (!content && stagedFiles.length === 0) return;
 
   // Intercept approval keywords when an unresolved approval card is pending.
   // Find the most recent unresolved card for the current thread (resolved cards
@@ -1183,15 +1183,20 @@ function sendMessage() {
     }
   }
 
-  const userMsg = addMessage('user', content || '(images attached)');
+  const filesForSend = stagedFiles.slice();
+  const userMsg = addMessage('user', content || formatAttachedFilesMessage(filesForSend));
   input.value = '';
   autoResizeTextarea(input);
   input.focus();
 
   const body = { content, thread_id: currentThreadId || undefined, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
-  if (stagedImages.length > 0) {
-    body.images = stagedImages.map(img => ({ media_type: img.media_type, data: img.data }));
-    stagedImages = [];
+  if (filesForSend.length > 0) {
+    body.attachments = filesForSend.map(file => ({
+      media_type: file.media_type,
+      data: file.data,
+      filename: file.filename,
+    }));
+    stagedFiles = [];
     renderImagePreviews();
   }
 
@@ -1222,6 +1227,8 @@ function sendMessage() {
         e.preventDefault();
         if (userMsg.parentNode) userMsg.parentNode.removeChild(userMsg);
         input.value = content;
+        stagedFiles = filesForSend.slice();
+        renderImagePreviews();
         sendMessage();
       });
       userMsg.appendChild(retryLink);
@@ -1239,46 +1246,75 @@ function enableChatInput() {
   if (btn) btn.disabled = false;
 }
 
-// --- Image Upload ---
+// --- File Upload ---
 
 function renderImagePreviews() {
   const strip = document.getElementById('image-preview-strip');
   strip.innerHTML = '';
-  stagedImages.forEach((img, idx) => {
+  stagedFiles.forEach((file, idx) => {
     const container = document.createElement('div');
-    container.className = 'image-preview-container';
+    container.className = file.media_type.startsWith('image/')
+      ? 'image-preview-container'
+      : 'file-preview-container';
 
-    const preview = document.createElement('img');
-    preview.className = 'image-preview';
-    preview.src = img.dataUrl;
-    preview.alt = 'Attached image';
+    if (file.media_type.startsWith('image/')) {
+      const preview = document.createElement('img');
+      preview.className = 'image-preview';
+      preview.src = file.dataUrl;
+      preview.alt = file.filename || 'Attached image';
+      container.appendChild(preview);
+    } else {
+      const icon = document.createElement('span');
+      icon.className = 'file-preview-icon';
+      icon.textContent = '\uD83D\uDCCE';
+      const name = document.createElement('span');
+      name.className = 'file-preview-name';
+      name.textContent = file.filename || 'attached file';
+      const meta = document.createElement('span');
+      meta.className = 'file-preview-meta';
+      meta.textContent = formatFileSize(file.size);
+      container.appendChild(icon);
+      container.appendChild(name);
+      container.appendChild(meta);
+    }
 
     const removeBtn = document.createElement('button');
     removeBtn.className = 'image-preview-remove';
     removeBtn.textContent = '\u00d7';
     removeBtn.addEventListener('click', () => {
-      stagedImages.splice(idx, 1);
+      stagedFiles.splice(idx, 1);
       renderImagePreviews();
     });
 
-    container.appendChild(preview);
     container.appendChild(removeBtn);
     strip.appendChild(container);
   });
 }
 
-const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB per image
-const MAX_STAGED_IMAGES = 5;
+function formatAttachedFilesMessage(files) {
+  if (!files || files.length === 0) return '(files attached)';
+  if (files.length === 1) return 'Attached: ' + (files[0].filename || 'file');
+  return 'Attached ' + files.length + ' files';
+}
 
-function handleImageFiles(files) {
+function formatFileSize(bytes) {
+  if (!bytes && bytes !== 0) return '';
+  if (bytes < 1024) return bytes + ' B';
+  if (bytes < 1024 * 1024) return Math.ceil(bytes / 1024) + ' KB';
+  return (bytes / 1024 / 1024).toFixed(1) + ' MB';
+}
+
+const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB per file
+const MAX_STAGED_FILES = 5;
+
+function handleAttachmentFiles(files) {
   Array.from(files).forEach(file => {
-    if (!file.type.startsWith('image/')) return;
-    if (file.size > MAX_IMAGE_SIZE_BYTES) {
-      alert(I18n.t('chat.imageTooBig', { name: file.name, size: (file.size / 1024 / 1024).toFixed(1) }));
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      alert(I18n.t('chat.fileTooBig', { name: file.name, size: (file.size / 1024 / 1024).toFixed(1) }));
       return;
     }
-    if (stagedImages.length >= MAX_STAGED_IMAGES) {
-      alert(I18n.t('chat.maxImages', { n: MAX_STAGED_IMAGES }));
+    if (stagedFiles.length >= MAX_STAGED_FILES) {
+      alert(I18n.t('chat.maxFiles', { n: MAX_STAGED_FILES }));
       return;
     }
     const reader = new FileReader();
@@ -1287,8 +1323,14 @@ function handleImageFiles(files) {
       const commaIdx = dataUrl.indexOf(',');
       const meta = dataUrl.substring(0, commaIdx); // e.g. "data:image/png;base64"
       const base64 = dataUrl.substring(commaIdx + 1);
-      const mediaType = meta.replace('data:', '').replace(';base64', '');
-      stagedImages.push({ media_type: mediaType, data: base64, dataUrl: dataUrl });
+      const mediaType = file.type || meta.replace('data:', '').replace(';base64', '') || 'application/octet-stream';
+      stagedFiles.push({
+        media_type: mediaType,
+        data: base64,
+        dataUrl: dataUrl,
+        filename: file.name || 'attachment',
+        size: file.size,
+      });
       renderImagePreviews();
     };
     reader.readAsDataURL(file);
@@ -1300,16 +1342,16 @@ document.getElementById('attach-btn').addEventListener('click', () => {
 });
 
 document.getElementById('image-file-input').addEventListener('change', (e) => {
-  handleImageFiles(e.target.files);
+  handleAttachmentFiles(e.target.files);
   e.target.value = '';
 });
 
 document.getElementById('chat-input').addEventListener('paste', (e) => {
   const items = (e.clipboardData || e.originalEvent.clipboardData).items;
   for (let i = 0; i < items.length; i++) {
-    if (items[i].kind === 'file' && items[i].type.startsWith('image/')) {
+    if (items[i].kind === 'file') {
       const file = items[i].getAsFile();
-      if (file) handleImageFiles([file]);
+      if (file) handleAttachmentFiles([file]);
     }
   }
 });

--- a/crates/ironclaw_gateway/static/i18n/en.js
+++ b/crates/ironclaw_gateway/static/i18n/en.js
@@ -679,6 +679,7 @@ I18n.register('en', {
   'chat.authRequiredBeforeSend': 'Complete the auth step before sending chat messages.',
   'chat.rateLimited': 'Rate limited. Please wait.',
   'chat.fileTooBig': 'File "{name}" exceeds 10 MB limit ({size} MB)',
+  'chat.filesTooBig': 'Files exceed the {size} MB per-message limit',
   'chat.maxFiles': 'Maximum {n} files allowed per message',
   'chat.readOnlyThread': 'Read-only thread (external channel)',
   'chat.threadCreateFailed': 'Failed to create thread: {message}',

--- a/crates/ironclaw_gateway/static/i18n/en.js
+++ b/crates/ironclaw_gateway/static/i18n/en.js
@@ -118,7 +118,7 @@ I18n.register('en', {
   'chat.assistant': 'Assistant',
   'chat.conversations': 'Conversations',
   'chat.send': 'Send',
-  'chat.attachImages': 'Attach Images',
+  'chat.attachImages': 'Attach files',
   'chat.scrollToBottom': 'Scroll to bottom',
   'chat.empty': 'Select a file to view content',
   'chat.loading': 'Loading...',
@@ -678,8 +678,8 @@ I18n.register('en', {
   // Chat (dynamic)
   'chat.authRequiredBeforeSend': 'Complete the auth step before sending chat messages.',
   'chat.rateLimited': 'Rate limited. Please wait.',
-  'chat.imageTooBig': 'Image "{name}" exceeds 5 MB limit ({size} MB)',
-  'chat.maxImages': 'Maximum {n} images allowed per message',
+  'chat.fileTooBig': 'File "{name}" exceeds 10 MB limit ({size} MB)',
+  'chat.maxFiles': 'Maximum {n} files allowed per message',
   'chat.readOnlyThread': 'Read-only thread (external channel)',
   'chat.threadCreateFailed': 'Failed to create thread: {message}',
 

--- a/crates/ironclaw_gateway/static/i18n/ko.js
+++ b/crates/ironclaw_gateway/static/i18n/ko.js
@@ -678,6 +678,7 @@ I18n.register('ko', {
   'chat.authRequiredBeforeSend': '채팅 메시지를 보내기 전에 인증 단계를 완료하세요.',
   'chat.rateLimited': '속도가 제한됩니다. 잠시 기다려 주세요.',
   'chat.fileTooBig': '파일 "{name}"이(가) 10 MB 한도를 초과했습니다 ({size} MB)',
+  'chat.filesTooBig': '파일이 메시지당 {size} MB 한도를 초과했습니다',
   'chat.maxFiles': '메시지당 최대 {n}개의 파일이 허용됩니다',
   'chat.readOnlyThread': '읽기 전용 스레드 (외부 채널)',
   'chat.threadCreateFailed': '스레드 생성 실패: {message}',

--- a/crates/ironclaw_gateway/static/i18n/ko.js
+++ b/crates/ironclaw_gateway/static/i18n/ko.js
@@ -118,7 +118,7 @@ I18n.register('ko', {
   'chat.assistant': '어시스턴트',
   'chat.conversations': '대화',
   'chat.send': '보내기',
-  'chat.attachImages': '이미지 첨부',
+  'chat.attachImages': '파일 첨부',
   'chat.scrollToBottom': '맨 아래로 스크롤',
   'chat.empty': '내용을 보려면 파일을 선택하세요',
   'chat.loading': '로딩 중...',
@@ -677,8 +677,8 @@ I18n.register('ko', {
   // 채팅 (동적)
   'chat.authRequiredBeforeSend': '채팅 메시지를 보내기 전에 인증 단계를 완료하세요.',
   'chat.rateLimited': '속도가 제한됩니다. 잠시 기다려 주세요.',
-  'chat.imageTooBig': '이미지 "{name}"이(가) 5 MB 한도를 초과했습니다 ({size} MB)',
-  'chat.maxImages': '메시지당 최대 {n}개의 이미지가 허용됩니다',
+  'chat.fileTooBig': '파일 "{name}"이(가) 10 MB 한도를 초과했습니다 ({size} MB)',
+  'chat.maxFiles': '메시지당 최대 {n}개의 파일이 허용됩니다',
   'chat.readOnlyThread': '읽기 전용 스레드 (외부 채널)',
   'chat.threadCreateFailed': '스레드 생성 실패: {message}',
 

--- a/crates/ironclaw_gateway/static/i18n/zh-CN.js
+++ b/crates/ironclaw_gateway/static/i18n/zh-CN.js
@@ -118,7 +118,7 @@ I18n.register('zh-CN', {
   'chat.assistant': '助手',
   'chat.conversations': '对话列表',
   'chat.send': '发送',
-  'chat.attachImages': '附加图片',
+  'chat.attachImages': '附加文件',
   'chat.scrollToBottom': '滚动到底部',
   'chat.empty': '选择文件查看内容',
   'chat.loading': '加载中...',
@@ -677,8 +677,8 @@ I18n.register('zh-CN', {
   // 聊天（动态）
   'chat.authRequiredBeforeSend': '请先完成认证步骤再发送聊天消息。',
   'chat.rateLimited': '速率受限，请稍候。',
-  'chat.imageTooBig': '图片 "{name}" 超过 5 MB 限制（{size} MB）',
-  'chat.maxImages': '每条消息最多允许 {n} 张图片',
+  'chat.fileTooBig': '文件 "{name}" 超过 10 MB 限制（{size} MB）',
+  'chat.maxFiles': '每条消息最多允许 {n} 个文件',
   'chat.readOnlyThread': '只读线程（外部渠道）',
   'chat.threadCreateFailed': '创建线程失败：{message}',
 

--- a/crates/ironclaw_gateway/static/i18n/zh-CN.js
+++ b/crates/ironclaw_gateway/static/i18n/zh-CN.js
@@ -678,6 +678,7 @@ I18n.register('zh-CN', {
   'chat.authRequiredBeforeSend': '请先完成认证步骤再发送聊天消息。',
   'chat.rateLimited': '速率受限，请稍候。',
   'chat.fileTooBig': '文件 "{name}" 超过 10 MB 限制（{size} MB）',
+  'chat.filesTooBig': '文件超过每条消息 {size} MB 的限制',
   'chat.maxFiles': '每条消息最多允许 {n} 个文件',
   'chat.readOnlyThread': '只读线程（外部渠道）',
   'chat.threadCreateFailed': '创建线程失败：{message}',

--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -253,9 +253,9 @@
             <textarea id="chat-input" data-i18n="chat.inputPlaceholder" data-i18n-attr="placeholder" placeholder="Message or / for commands..." rows="1"></textarea>
             <div id="ghost-text" class="ghost-text"></div>
           </div>
-          <input type="file" id="image-file-input" accept="image/*" multiple style="display:none">
-          <button id="attach-btn" class="attach-btn" data-i18n="chat.attachImages" data-i18n-attr="title" title="Attach images"
-            aria-label="Attach images">&#x1F4CE;</button>
+          <input type="file" id="image-file-input" multiple style="display:none">
+          <button id="attach-btn" class="attach-btn" data-i18n="chat.attachImages" data-i18n-attr="title" title="Attach files"
+            aria-label="Attach files">&#x1F4CE;</button>
           <button id="send-btn" data-i18n="chat.send">Send</button>
         </div>
       </div>

--- a/crates/ironclaw_gateway/static/style.css
+++ b/crates/ironclaw_gateway/static/style.css
@@ -5336,7 +5336,7 @@ input[type="checkbox"]:focus-visible {
   white-space: nowrap;
 }
 
-/* Image Upload */
+/* File Upload */
 .chat-input .attach-btn {
   background: none;
   border: none;
@@ -5377,6 +5377,41 @@ input[type="checkbox"]:focus-visible {
   position: relative;
   display: inline-block;
   flex-shrink: 0;
+}
+
+.file-preview-container {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  max-width: 220px;
+  min-height: 40px;
+  padding: 6px 28px 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text);
+  flex-shrink: 0;
+}
+
+.file-preview-icon {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+}
+
+.file-preview-name {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.file-preview-meta {
+  flex: 0 0 auto;
+  color: var(--text-secondary);
+  font-size: 11px;
 }
 
 .image-preview {

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -888,7 +888,8 @@ pub async fn start_server(
         .merge(statics)
         .merge(projects)
         .merge(protected)
-        .layer(DefaultBodyLimit::max(10 * 1024 * 1024)) // 10 MB max request body (image uploads)
+        // 10 MB decoded upload limit plus base64/JSON overhead.
+        .layer(DefaultBodyLimit::max(16 * 1024 * 1024))
         .layer(tower_http::catch_panic::CatchPanicLayer::custom(
             |panic_info: Box<dyn std::any::Any + Send + 'static>| {
                 let detail = if let Some(s) = panic_info.downcast_ref::<String>() {
@@ -2145,34 +2146,33 @@ async fn slack_relay_oauth_callback_handler(
 
 // --- Chat handlers ---
 
-/// Convert web gateway `ImageData` to `IncomingAttachment` objects.
-pub(crate) fn images_to_attachments(
-    images: &[ImageData],
+/// Convert web gateway upload data to `IncomingAttachment` objects.
+pub(crate) fn uploads_to_attachments(
+    uploads: &[ImageData],
 ) -> Vec<crate::channels::IncomingAttachment> {
     use base64::Engine;
-    images
+    uploads
         .iter()
         .enumerate()
-        .filter_map(|(i, img)| {
-            if !img.media_type.starts_with("image/") {
-                tracing::warn!(
-                    "Skipping image {i}: invalid media type '{}' (must start with 'image/')",
-                    img.media_type
-                );
-                return None;
-            }
-            let data = match base64::engine::general_purpose::STANDARD.decode(&img.data) {
+        .filter_map(|(i, upload)| {
+            let data = match base64::engine::general_purpose::STANDARD.decode(&upload.data) {
                 Ok(d) => d,
                 Err(e) => {
-                    tracing::warn!("Skipping image {i}: invalid base64 data: {e}");
+                    tracing::warn!("Skipping upload {i}: invalid base64 data: {e}");
                     return None;
                 }
             };
+            let kind = crate::channels::AttachmentKind::from_mime_type(&upload.media_type);
+            let filename = upload
+                .filename
+                .clone()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| default_upload_filename(i, &kind, &upload.media_type));
             Some(crate::channels::IncomingAttachment {
-                id: format!("web-image-{i}"),
-                kind: crate::channels::AttachmentKind::Image,
-                mime_type: img.media_type.clone(),
-                filename: Some(format!("image-{i}.{}", mime_to_ext(&img.media_type))),
+                id: format!("web-upload-{i}"),
+                kind,
+                mime_type: upload.media_type.clone(),
+                filename: Some(filename),
                 size_bytes: Some(data.len() as u64),
                 source_url: None,
                 storage_key: None,
@@ -2184,6 +2184,19 @@ pub(crate) fn images_to_attachments(
         .collect()
 }
 
+fn default_upload_filename(
+    index: usize,
+    kind: &crate::channels::AttachmentKind,
+    mime: &str,
+) -> String {
+    let prefix = match kind {
+        crate::channels::AttachmentKind::Audio => "audio",
+        crate::channels::AttachmentKind::Image => "image",
+        crate::channels::AttachmentKind::Document => "file",
+    };
+    format!("{prefix}-{index}.{}", mime_to_ext(mime))
+}
+
 /// Map MIME type to file extension.
 fn mime_to_ext(mime: &str) -> &str {
     match mime {
@@ -2191,7 +2204,22 @@ fn mime_to_ext(mime: &str) -> &str {
         "image/gif" => "gif",
         "image/webp" => "webp",
         "image/svg+xml" => "svg",
-        _ => "jpg",
+        "image/jpeg" => "jpg",
+        "application/pdf" => "pdf",
+        "text/plain" => "txt",
+        "text/csv" => "csv",
+        "application/json" => "json",
+        "text/markdown" => "md",
+        "application/xml" | "text/xml" => "xml",
+        "application/rtf" | "text/rtf" => "rtf",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document" => "docx",
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation" => "pptx",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" => "xlsx",
+        "application/msword" => "doc",
+        "application/vnd.ms-powerpoint" => "ppt",
+        "application/vnd.ms-excel" => "xls",
+        m if m.starts_with("image/") => "jpg",
+        _ => "bin",
     }
 }
 
@@ -2232,18 +2260,21 @@ async fn chat_send_handler(
     }
     msg = msg.with_metadata(meta);
 
-    // Convert uploaded images to IncomingAttachments
-    if !req.images.is_empty() {
-        let attachments = images_to_attachments(&req.images);
+    // Convert uploaded files to IncomingAttachments. `images` is kept for
+    // older clients; the web UI now sends generic files in `attachments`.
+    let mut uploads = req.attachments;
+    uploads.extend(req.images);
+    if !uploads.is_empty() {
+        let attachments = uploads_to_attachments(&uploads);
         msg = msg.with_attachments(attachments);
     }
 
     let msg_id = msg.id;
     tracing::trace!(
-        "[chat_send_handler] Created message id={}, content_len={}, images={}",
+        "[chat_send_handler] Created message id={}, content_len={}, attachments={}",
         msg_id,
         req.content.len(),
-        req.images.len()
+        msg.attachments.len()
     );
 
     // Clone sender to avoid holding RwLock read guard across send().await
@@ -3930,6 +3961,29 @@ mod tests {
 
         assert!(!readme.content.trim().is_empty());
         assert!(!identity.content.trim().is_empty());
+    }
+
+    #[test]
+    fn web_upload_accepts_document_attachment_data() {
+        use base64::Engine;
+
+        let uploads = vec![ImageData {
+            media_type: "application/pdf".to_string(),
+            data: base64::engine::general_purpose::STANDARD.encode(b"%PDF-1.4\ninvoice"),
+            filename: Some("invoice.pdf".to_string()),
+        }];
+
+        let attachments = uploads_to_attachments(&uploads);
+
+        assert_eq!(attachments.len(), 1);
+        assert_eq!(
+            attachments[0].kind,
+            crate::channels::AttachmentKind::Document
+        );
+        assert_eq!(attachments[0].mime_type, "application/pdf");
+        assert_eq!(attachments[0].filename.as_deref(), Some("invoice.pdf"));
+        assert_eq!(attachments[0].data, b"%PDF-1.4\ninvoice");
+        assert_eq!(attachments[0].size_bytes, Some(16));
     }
 
     #[test]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2149,26 +2149,22 @@ async fn slack_relay_oauth_callback_handler(
 /// Convert web gateway upload data to `IncomingAttachment` objects.
 pub(crate) fn uploads_to_attachments(
     uploads: &[ImageData],
-) -> Vec<crate::channels::IncomingAttachment> {
+) -> Result<Vec<crate::channels::IncomingAttachment>, String> {
     use base64::Engine;
     uploads
         .iter()
         .enumerate()
-        .filter_map(|(i, upload)| {
-            let data = match base64::engine::general_purpose::STANDARD.decode(&upload.data) {
-                Ok(d) => d,
-                Err(e) => {
-                    tracing::warn!("Skipping upload {i}: invalid base64 data: {e}");
-                    return None;
-                }
-            };
+        .map(|(i, upload)| {
+            let data = base64::engine::general_purpose::STANDARD
+                .decode(&upload.data)
+                .map_err(|e| format!("Invalid base64 data for upload {i}: {e}"))?;
             let kind = crate::channels::AttachmentKind::from_mime_type(&upload.media_type);
             let filename = upload
                 .filename
                 .clone()
                 .filter(|name| !name.trim().is_empty())
                 .unwrap_or_else(|| default_upload_filename(i, &kind, &upload.media_type));
-            Some(crate::channels::IncomingAttachment {
+            Ok(crate::channels::IncomingAttachment {
                 id: format!("web-upload-{i}"),
                 kind,
                 mime_type: upload.media_type.clone(),
@@ -2265,7 +2261,8 @@ async fn chat_send_handler(
     let mut uploads = req.attachments;
     uploads.extend(req.images);
     if !uploads.is_empty() {
-        let attachments = uploads_to_attachments(&uploads);
+        let attachments =
+            uploads_to_attachments(&uploads).map_err(|e| (StatusCode::BAD_REQUEST, e))?;
         msg = msg.with_attachments(attachments);
     }
 
@@ -3973,7 +3970,7 @@ mod tests {
             filename: Some("invoice.pdf".to_string()),
         }];
 
-        let attachments = uploads_to_attachments(&uploads);
+        let attachments = uploads_to_attachments(&uploads).unwrap();
 
         assert_eq!(attachments.len(), 1);
         assert_eq!(

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2146,38 +2146,46 @@ async fn slack_relay_oauth_callback_handler(
 
 // --- Chat handlers ---
 
+const MAX_UPLOAD_BYTES: usize = 10 * 1024 * 1024;
+
 /// Convert web gateway upload data to `IncomingAttachment` objects.
 pub(crate) fn uploads_to_attachments(
     uploads: &[ImageData],
 ) -> Result<Vec<crate::channels::IncomingAttachment>, String> {
     use base64::Engine;
-    uploads
-        .iter()
-        .enumerate()
-        .map(|(i, upload)| {
-            let data = base64::engine::general_purpose::STANDARD
-                .decode(&upload.data)
-                .map_err(|e| format!("Invalid base64 data for upload {i}: {e}"))?;
-            let kind = crate::channels::AttachmentKind::from_mime_type(&upload.media_type);
-            let filename = upload
-                .filename
-                .clone()
-                .filter(|name| !name.trim().is_empty())
-                .unwrap_or_else(|| default_upload_filename(i, &kind, &upload.media_type));
-            Ok(crate::channels::IncomingAttachment {
-                id: format!("web-upload-{i}"),
-                kind,
-                mime_type: upload.media_type.clone(),
-                filename: Some(filename),
-                size_bytes: Some(data.len() as u64),
-                source_url: None,
-                storage_key: None,
-                extracted_text: None,
-                data,
-                duration_secs: None,
-            })
-        })
-        .collect()
+    let mut attachments = Vec::with_capacity(uploads.len());
+    let mut total_bytes = 0usize;
+    for (i, upload) in uploads.iter().enumerate() {
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(&upload.data)
+            .map_err(|e| format!("Invalid base64 data for upload {i}: {e}"))?;
+        total_bytes = total_bytes
+            .checked_add(data.len())
+            .ok_or_else(|| "Attachments exceed the 10 MB per-message limit".to_string())?;
+        if total_bytes > MAX_UPLOAD_BYTES {
+            return Err("Attachments exceed the 10 MB per-message limit".to_string());
+        }
+
+        let kind = crate::channels::AttachmentKind::from_mime_type(&upload.media_type);
+        let filename = upload
+            .filename
+            .clone()
+            .filter(|name| !name.trim().is_empty())
+            .unwrap_or_else(|| default_upload_filename(i, &kind, &upload.media_type));
+        attachments.push(crate::channels::IncomingAttachment {
+            id: format!("web-upload-{i}"),
+            kind,
+            mime_type: upload.media_type.clone(),
+            filename: Some(filename),
+            size_bytes: Some(data.len() as u64),
+            source_url: None,
+            storage_key: None,
+            extracted_text: None,
+            data,
+            duration_secs: None,
+        });
+    }
+    Ok(attachments)
 }
 
 fn default_upload_filename(
@@ -3981,6 +3989,21 @@ mod tests {
         assert_eq!(attachments[0].filename.as_deref(), Some("invoice.pdf"));
         assert_eq!(attachments[0].data, b"%PDF-1.4\ninvoice");
         assert_eq!(attachments[0].size_bytes, Some(16));
+    }
+
+    #[test]
+    fn web_upload_rejects_decoded_payload_over_limit() {
+        use base64::Engine;
+
+        let uploads = vec![ImageData {
+            media_type: "application/pdf".to_string(),
+            data: base64::engine::general_purpose::STANDARD
+                .encode(vec![0_u8; MAX_UPLOAD_BYTES + 1]),
+            filename: Some("large.pdf".to_string()),
+        }];
+
+        let err = uploads_to_attachments(&uploads).unwrap_err();
+        assert!(err.contains("10 MB per-message limit"));
     }
 
     #[test]

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -5,13 +5,16 @@ use uuid::Uuid;
 
 // --- Chat ---
 
-/// Base64-encoded image data sent from the web frontend.
+/// Base64-encoded upload data sent from the web frontend.
 #[derive(Debug, Clone, Deserialize)]
 pub struct ImageData {
-    /// MIME type (e.g., "image/png", "image/jpeg").
+    /// MIME type (e.g., "image/png", "application/pdf").
     pub media_type: String,
-    /// Base64-encoded image data (without data: URL prefix).
+    /// Base64-encoded file data (without data: URL prefix).
     pub data: String,
+    /// Original client-side filename, if available.
+    #[serde(default)]
+    pub filename: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -22,6 +25,9 @@ pub struct SendMessageRequest {
     /// Optional images attached to the message.
     #[serde(default)]
     pub images: Vec<ImageData>,
+    /// Optional generic files attached to the message.
+    #[serde(default)]
+    pub attachments: Vec<ImageData>,
 }
 
 #[derive(Debug, Serialize)]
@@ -689,6 +695,9 @@ pub enum WsClientMessage {
         /// Optional images attached to the message.
         #[serde(default)]
         images: Vec<ImageData>,
+        /// Optional generic files attached to the message.
+        #[serde(default)]
+        attachments: Vec<ImageData>,
     },
     /// Approve or deny a pending tool execution.
     #[serde(rename = "approval")]

--- a/src/channels/web/ws.rs
+++ b/src/channels/web/ws.rs
@@ -180,8 +180,15 @@ async fn handle_client_message(
             let mut uploads = attachments;
             uploads.extend(images);
             if !uploads.is_empty() {
-                let attachments = crate::channels::web::server::uploads_to_attachments(&uploads);
-                incoming = incoming.with_attachments(attachments);
+                match crate::channels::web::server::uploads_to_attachments(&uploads) {
+                    Ok(attachments) => {
+                        incoming = incoming.with_attachments(attachments);
+                    }
+                    Err(message) => {
+                        let _ = direct_tx.send(WsServerMessage::Error { message }).await;
+                        return;
+                    }
+                }
             }
 
             // Clone sender to avoid holding RwLock read guard across send().await

--- a/src/channels/web/ws.rs
+++ b/src/channels/web/ws.rs
@@ -165,6 +165,7 @@ async fn handle_client_message(
             thread_id,
             timezone,
             images,
+            attachments,
         } => {
             let mut incoming = IncomingMessage::new("gateway", user_id, &content);
             if let Some(ref tz) = timezone {
@@ -174,9 +175,12 @@ async fn handle_client_message(
                 incoming = incoming.with_thread(tid);
             }
 
-            // Convert uploaded images to IncomingAttachments
-            if !images.is_empty() {
-                let attachments = crate::channels::web::server::images_to_attachments(&images);
+            // Convert uploaded files to IncomingAttachments. `images` is kept
+            // for older clients; `attachments` carries generic file uploads.
+            let mut uploads = attachments;
+            uploads.extend(images);
+            if !uploads.is_empty() {
+                let attachments = crate::channels::web::server::uploads_to_attachments(&uploads);
                 incoming = incoming.with_attachments(attachments);
             }
 
@@ -385,6 +389,7 @@ mod tests {
                 thread_id: Some("t1".to_string()),
                 timezone: None,
                 images: Vec::new(),
+                attachments: Vec::new(),
             },
             &state,
             "user1",
@@ -411,6 +416,7 @@ mod tests {
                 thread_id: None,
                 timezone: None,
                 images: Vec::new(),
+                attachments: Vec::new(),
             },
             &state,
             "user1",

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -823,6 +823,41 @@ async fn full_server_chat_send_accepts_document_attachment_for_alice() {
 }
 
 #[tokio::test]
+async fn full_server_chat_send_rejects_malformed_attachment_for_alice() {
+    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(64);
+    let auth = two_user_auth();
+    let (addr, _state) = TestGatewayBuilder::new()
+        .msg_tx(agent_tx)
+        .start_multi(auth)
+        .await
+        .expect("Failed to start server");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/api/chat/send", addr))
+        .header("Authorization", format!("Bearer {}", ALICE_TOKEN))
+        .json(&serde_json::json!({
+            "content": "parse this invoice",
+            "attachments": [{
+                "media_type": "application/pdf",
+                "filename": "invoice.pdf",
+                "data": "not valid base64"
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), agent_rx.recv())
+            .await
+            .is_err(),
+        "Malformed uploads must not queue a text-only agent message"
+    );
+}
+
+#[tokio::test]
 async fn full_server_chat_send_rewrites_sender_only_for_owner_scope_rebind() {
     let (addr, _state, mut agent_rx) = start_owner_scoped_sender_server().await;
 

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -779,6 +779,50 @@ async fn full_server_chat_send_accepted_for_alice() {
 }
 
 #[tokio::test]
+async fn full_server_chat_send_accepts_document_attachment_for_alice() {
+    let (agent_tx, mut agent_rx) = tokio::sync::mpsc::channel(64);
+    let auth = two_user_auth();
+    let (addr, _state) = TestGatewayBuilder::new()
+        .msg_tx(agent_tx)
+        .start_multi(auth)
+        .await
+        .expect("Failed to start server");
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("http://{}/api/chat/send", addr))
+        .header("Authorization", format!("Bearer {}", ALICE_TOKEN))
+        .json(&serde_json::json!({
+            "content": "parse this invoice",
+            "attachments": [{
+                "media_type": "application/pdf",
+                "filename": "invoice.pdf",
+                "data": "JVBERi0xLjQKaW52b2ljZQ=="
+            }]
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), 202);
+
+    let msg = tokio::time::timeout(Duration::from_secs(2), agent_rx.recv())
+        .await
+        .expect("Timed out waiting for agent message")
+        .expect("Agent channel closed");
+
+    assert_eq!(msg.content, "parse this invoice");
+    assert_eq!(msg.attachments.len(), 1);
+    assert_eq!(
+        msg.attachments[0].kind,
+        ironclaw::channels::AttachmentKind::Document
+    );
+    assert_eq!(msg.attachments[0].mime_type, "application/pdf");
+    assert_eq!(msg.attachments[0].filename.as_deref(), Some("invoice.pdf"));
+    assert_eq!(msg.attachments[0].data, b"%PDF-1.4\ninvoice");
+}
+
+#[tokio::test]
 async fn full_server_chat_send_rewrites_sender_only_for_owner_scope_rebind() {
     let (addr, _state, mut agent_rx) = start_owner_scoped_sender_server().await;
 


### PR DESCRIPTION
## Summary
- Generalize web chat upload payloads from image-only to file attachments with filenames.
- Let the gateway convert uploaded bytes by MIME type into image, audio, or document `IncomingAttachment`s.
- Update the web composer to attach PDFs/documents as well as images and add file preview UI/copy.

## Root Cause
Issue #2283 was caused by an image-only path through the web UI and gateway: the picker used `accept="image/*"`, the frontend ignored non-image files, and the backend conversion rejected non-`image/*` MIME types before the existing document extraction middleware could process PDFs or other documents.

## Validation
- `cargo test web_upload_accepts_document_attachment_data --lib`
- `cargo test channels::web::ws::tests --lib`
- `cargo test channels::web::types::tests --lib`
- `cargo test full_server_chat_send_accepts_document_attachment_for_alice --test multi_tenant_integration`
- `node --check crates/ironclaw_gateway/static/app.js`
- `git diff --check`

Fixes #2283