### PR TITLE
feat(config): default CLI_MODE to TUI

### DIFF
--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -369,7 +369,8 @@ impl ChannelsConfig {
         };
 
         let cli_enabled = db_first_bool(cs.cli_enabled, defaults.cli_enabled, "CLI_ENABLED")?;
-        let cli_mode = db_first_optional_string(&cs.cli_mode, "CLI_MODE")?.unwrap_or_default();
+        let cli_mode = db_first_optional_string(&cs.cli_mode, "CLI_MODE")?
+            .unwrap_or_else(|| "tui".to_string());
         let tui = if cli_mode.eq_ignore_ascii_case("tui") {
             Some(TuiChannelConfig {
                 theme: optional_env("TUI_THEME")?.unwrap_or_else(|| "dark".to_string()),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -446,7 +446,7 @@ impl Default for ChannelSettings {
             wasm_channels: Vec::new(),
             wasm_channels_enabled: true,
             wasm_channels_dir: None,
-            cli_mode: None,
+            cli_mode: Some("tui".to_string()),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Changes the default `CLI_MODE` from empty (REPL) to `"tui"` so new installations get the full Ratatui terminal UI out of the box
- The `tui` cargo feature was already compiled in by default — this makes the runtime default match
- Users can opt out via `CLI_MODE=repl` in env or DB settings

## Test plan
- [x] All 12 `config::channels` tests pass
- [x] All 10 `config::profile` tests pass  
- [x] All 114 `settings` tests pass
- [x] `cargo clippy --all --all-features` clean
- [ ] Manual: verify `cargo run` launches TUI without any env vars set
- [ ] Manual: verify `CLI_MODE=repl cargo run` falls back to REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)