### PR TITLE
feat(cli): add `ironclaw profile list` subcommand

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -28,6 +28,7 @@ mod mcp;
 pub mod memory;
 mod models;
 mod pairing;
+mod profile;
 mod registry;
 mod routines;
 mod service;
@@ -49,6 +50,7 @@ pub use memory::MemoryCommand;
 pub use memory::run_memory_command_with_db;
 pub use models::{ModelsCommand, run_models_command};
 pub use pairing::{PairingCommand, run_pairing_command, run_pairing_command_with_store};
+pub use profile::{ProfileCommand, run_profile_command};
 pub use registry::{RegistryCommand, run_registry_command};
 pub use routines::{RoutinesCommand, run_routines_command};
 pub use service::{ServiceCommand, run_service_command};
@@ -203,6 +205,14 @@ pub enum Command {
         long_about = "Approve or manage pairing requests.\nExamples:\n  ironclaw pairing list telegram\n  ironclaw pairing approve telegram ABC12345"
     )]
     Pairing(PairingCommand),
+
+    /// Manage deployment profiles
+    #[command(
+        subcommand,
+        about = "Manage deployment profiles",
+        long_about = "List available deployment profiles.\nExamples:\n  ironclaw profile list\n  ironclaw profile list --json"
+    )]
+    Profile(ProfileCommand),
 
     /// Manage OS service (launchd / systemd)
     #[command(

--- a/src/cli/profile.rs
+++ b/src/cli/profile.rs
@@ -1,0 +1,154 @@
+//! Deployment profile CLI commands.
+//!
+//! Lists available deployment profiles and shows which is active.
+
+use clap::Subcommand;
+
+use crate::config::profile::{ProfileInfo, list_profiles};
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ProfileCommand {
+    /// List all available deployment profiles
+    List {
+        /// Output as JSON
+        #[arg(long)]
+        json: bool,
+    },
+}
+
+/// Run the profile CLI subcommand.
+pub fn run_profile_command(cmd: ProfileCommand) -> anyhow::Result<()> {
+    match cmd {
+        ProfileCommand::List { json } => cmd_list(json),
+    }
+}
+
+/// List all available profiles, marking the active one.
+fn cmd_list(json: bool) -> anyhow::Result<()> {
+    let profiles = list_profiles();
+    let active = std::env::var("IRONCLAW_PROFILE")
+        .ok()
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_ascii_lowercase());
+
+    if json {
+        let entries: Vec<serde_json::Value> = profiles
+            .iter()
+            .map(|p| profile_to_json(p, &active))
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&entries).unwrap_or_else(|_| "[]".to_string())
+        );
+        return Ok(());
+    }
+
+    if profiles.is_empty() {
+        println!("No profiles found.");
+        return Ok(());
+    }
+
+    println!("Available profiles ({} total):\n", profiles.len());
+
+    for p in &profiles {
+        let is_active = active.as_deref() == Some(&p.name);
+        let marker = if is_active { " (active)" } else { "" };
+        let source = profile_source(p);
+        println!("  {:<24} {:<10}{}", p.name, source, marker);
+    }
+
+    println!();
+    if active.is_none() {
+        println!("No profile active. Set IRONCLAW_PROFILE=<name> to activate one.");
+    }
+    println!("User profiles directory: ~/.ironclaw/profiles/");
+
+    Ok(())
+}
+
+fn profile_source(p: &ProfileInfo) -> &'static str {
+    match (p.builtin, &p.path) {
+        (true, Some(_)) => "override",
+        (true, None) => "built-in",
+        (false, _) => "user",
+    }
+}
+
+fn profile_to_json(p: &ProfileInfo, active: &Option<String>) -> serde_json::Value {
+    serde_json::json!({
+        "name": p.name,
+        "builtin": p.builtin,
+        "source": profile_source(p),
+        "path": p.path.as_ref().map(|p| p.display().to_string()),
+        "active": active.as_deref() == Some(&p.name),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_list_includes_builtin_profiles() {
+        let profiles = list_profiles();
+        let names: Vec<&str> = profiles.iter().map(|p| p.name.as_str()).collect();
+        assert!(names.contains(&"local"), "Should include 'local' profile");
+        assert!(names.contains(&"server"), "Should include 'server' profile");
+    }
+
+    #[test]
+    fn test_profile_source_builtin() {
+        let p = ProfileInfo {
+            name: "server".to_string(),
+            builtin: true,
+            path: None,
+        };
+        assert_eq!(profile_source(&p), "built-in");
+    }
+
+    #[test]
+    fn test_profile_source_user() {
+        let p = ProfileInfo {
+            name: "custom".to_string(),
+            builtin: false,
+            path: Some("/home/user/.ironclaw/profiles/custom.toml".into()),
+        };
+        assert_eq!(profile_source(&p), "user");
+    }
+
+    #[test]
+    fn test_profile_source_override() {
+        let p = ProfileInfo {
+            name: "server".to_string(),
+            builtin: true,
+            path: Some("/home/user/.ironclaw/profiles/server.toml".into()),
+        };
+        assert_eq!(profile_source(&p), "override");
+    }
+
+    #[test]
+    fn test_profile_to_json_inactive() {
+        let p = ProfileInfo {
+            name: "local".to_string(),
+            builtin: true,
+            path: None,
+        };
+        let json = profile_to_json(&p, &None);
+        assert_eq!(json["name"], "local");
+        assert_eq!(json["builtin"], true);
+        assert_eq!(json["active"], false);
+        assert_eq!(json["source"], "built-in");
+    }
+
+    #[test]
+    fn test_profile_to_json_active() {
+        let p = ProfileInfo {
+            name: "server".to_string(),
+            builtin: true,
+            path: None,
+        };
+        let active = Some("server".to_string());
+        let json = profile_to_json(&p, &active);
+        assert_eq!(json["active"], true);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,10 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return run_pairing_command(pairing_cmd.clone()).await;
         }
+        Some(Command::Profile(profile_cmd)) => {
+            init_cli_tracing();
+            return ironclaw::cli::run_profile_command(profile_cmd.clone());
+        }
         Some(Command::Service(service_cmd)) => {
             init_cli_tracing();
             return run_service_command(service_cmd);


### PR DESCRIPTION
## Summary

- Adds `ironclaw profile list` CLI subcommand that lists all available deployment profiles (built-in + user-defined)
- Marks the active profile (from `IRONCLAW_PROFILE` env var) and shows source type (built-in / user / override)
- Supports `--json` flag for machine-readable output

Closes #2271

## Changes

- **`src/cli/profile.rs`** (new): `ProfileCommand` enum, `run_profile_command()`, display/JSON formatting helpers
- **`src/cli/mod.rs`**: Wire up `profile` module and `Profile` command variant
- **`src/main.rs`**: Dispatch `Command::Profile` to `run_profile_command()`

## Test plan

- [x] 6 unit tests covering: builtin profile listing, source detection (built-in/user/override), JSON serialization (active/inactive)
- [ ] Manual: `cargo run -- profile list` and `cargo run -- profile list --json`
- [ ] Manual: `IRONCLAW_PROFILE=server cargo run -- profile list` (verify active marker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)