### PR TITLE
fix(agent): detect and escalate repeated identical failing tool calls

### DIFF
--- a/src/agent/agentic_loop.rs
+++ b/src/agent/agentic_loop.rs
@@ -7,11 +7,14 @@
 
 use async_trait::async_trait;
 use std::borrow::Cow;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
 
 use crate::agent::session::PendingApproval;
 use crate::error::Error;
 use crate::llm::{
     ChatMessage, FinishReason, Reasoning, ReasoningContext, RespondResult, ResponseMetadata,
+    ToolCall,
 };
 
 /// Signal from the delegate indicating how the loop should proceed.
@@ -115,6 +118,10 @@ pub trait LoopDelegate: Send + Sync {
 
     /// Execute tool calls and add results to context.
     /// Return `Some(outcome)` to break the loop (e.g. approval needed).
+    ///
+    /// Implementations should call `reason_ctx.set_last_tool_batch_all_failed(true/false)`
+    /// to report whether every tool in the batch failed. This enables the
+    /// duplicate tool call detector to escalate repeated identical failures.
     async fn execute_tool_calls(
         &self,
         tool_calls: Vec<crate::llm::ToolCall>,
@@ -128,6 +135,75 @@ pub trait LoopDelegate: Send + Sync {
 
     /// Called after each successful iteration (no error, no early return).
     async fn after_iteration(&self, _iteration: usize) {}
+}
+
+/// Warning injected after repeated identical failing tool calls.
+const DUPLICATE_TOOL_CALL_WARNING: &str = "\
+You have repeated the exact same failing tool call multiple times. \
+The tool is returning the same error each time. \
+Please try a DIFFERENT approach — use different parameters, a different tool, \
+or explain to the user what went wrong and what alternatives exist.";
+
+/// Threshold: after this many consecutive duplicate failures, inject a warning.
+const DUPLICATE_WARNING_THRESHOLD: u32 = 3;
+
+/// Threshold: after this many consecutive duplicate failures, force text-only mode.
+const DUPLICATE_FORCE_TEXT_THRESHOLD: u32 = 5;
+
+/// Tracks repeated identical tool calls that all fail, and escalates.
+///
+/// Fingerprints each batch of tool calls by hashing `(tool_name, canonicalized_args)`
+/// for every call in the batch. If the fingerprint matches the previous batch AND
+/// every tool in the batch produced an error result, the consecutive counter increments.
+/// Resets when the LLM calls different tools, any tool succeeds, or a text response
+/// is produced.
+struct DuplicateToolCallTracker {
+    last_fingerprint: Option<u64>,
+    consecutive_count: u32,
+}
+
+impl DuplicateToolCallTracker {
+    fn new() -> Self {
+        Self {
+            last_fingerprint: None,
+            consecutive_count: 0,
+        }
+    }
+
+    /// Compute a fingerprint for a batch of tool calls.
+    fn fingerprint(tool_calls: &[ToolCall]) -> u64 {
+        let mut hasher = DefaultHasher::new();
+        for tc in tool_calls {
+            tc.name.hash(&mut hasher);
+            let canonical = crate::util::canonicalize_json_value(tc.arguments.clone());
+            canonical.to_string().hash(&mut hasher);
+        }
+        hasher.finish()
+    }
+
+    /// Record a pre-computed fingerprint and whether all tools failed.
+    /// Returns the current consecutive duplicate failure count after this update.
+    fn record_with_fingerprint(&mut self, fp: u64, all_failed: bool) -> u32 {
+        if all_failed && self.last_fingerprint == Some(fp) {
+            self.consecutive_count += 1;
+        } else if all_failed {
+            // Different tool calls but still all failed — start a new streak
+            self.last_fingerprint = Some(fp);
+            self.consecutive_count = 1;
+        } else {
+            // At least one tool succeeded — reset
+            self.reset();
+            self.last_fingerprint = Some(fp);
+        }
+
+        self.consecutive_count
+    }
+
+    /// Reset when the LLM produces a text response or calls different tools successfully.
+    fn reset(&mut self) {
+        self.last_fingerprint = None;
+        self.consecutive_count = 0;
+    }
 }
 
 /// Run the unified agentic loop.
@@ -144,6 +220,7 @@ pub async fn run_agentic_loop(
     // Accumulates across all iterations (not reset by text responses) so
     // non-consecutive truncations still escalate to force_text.
     let mut truncation_count: u32 = 0;
+    let mut dup_tracker = DuplicateToolCallTracker::new();
 
     for iteration in 1..=config.max_iterations {
         // Check for external signals (stop, cancellation, user messages)
@@ -216,6 +293,9 @@ pub async fn run_agentic_loop(
                     consecutive_tool_intent_nudges = 0;
                 }
 
+                // Text response breaks any duplicate tool call streak.
+                dup_tracker.reset();
+
                 match delegate
                     .handle_text_response(&text, output.metadata, reason_ctx)
                     .await
@@ -258,11 +338,43 @@ pub async fn run_agentic_loop(
                 consecutive_tool_intent_nudges = 0;
                 truncation_count = 0;
 
+                // Fingerprint before execution (avoids cloning the full Vec).
+                let batch_fingerprint = DuplicateToolCallTracker::fingerprint(&tool_calls);
+
+                // Reset the flag before execution; delegates set it in execute_tool_calls.
+                reason_ctx.last_tool_batch_all_failed = false;
+
                 if let Some(outcome) = delegate
                     .execute_tool_calls(tool_calls, content, reason_ctx)
                     .await?
                 {
                     return Ok(outcome);
+                }
+
+                // Track duplicate failing tool calls and escalate.
+                let dup_count = dup_tracker.record_with_fingerprint(
+                    batch_fingerprint,
+                    reason_ctx.last_tool_batch_all_failed,
+                );
+                if dup_count >= DUPLICATE_FORCE_TEXT_THRESHOLD {
+                    tracing::debug!(
+                        iteration,
+                        dup_count,
+                        "Repeated duplicate failing tool calls — forcing text mode"
+                    );
+                    reason_ctx.force_text = true;
+                    reason_ctx
+                        .messages
+                        .push(ChatMessage::user(DUPLICATE_TOOL_CALL_WARNING));
+                } else if dup_count >= DUPLICATE_WARNING_THRESHOLD {
+                    tracing::debug!(
+                        iteration,
+                        dup_count,
+                        "Repeated duplicate failing tool calls — injecting warning"
+                    );
+                    reason_ctx
+                        .messages
+                        .push(ChatMessage::user(DUPLICATE_TOOL_CALL_WARNING));
                 }
             }
         }
@@ -338,6 +450,8 @@ mod tests {
         iterations_seen: Mutex<Vec<usize>>,
         early_exit: Mutex<Option<(usize, LoopOutcome)>>,
         nudge_count: AtomicUsize,
+        /// When true, execute_tool_calls sets last_tool_batch_all_failed = true.
+        simulate_all_failed: bool,
     }
 
     impl MockDelegate {
@@ -350,6 +464,7 @@ mod tests {
                 iterations_seen: Mutex::new(Vec::new()),
                 early_exit: Mutex::new(None),
                 nudge_count: AtomicUsize::new(0),
+                simulate_all_failed: false,
             }
         }
 
@@ -419,6 +534,7 @@ mod tests {
             reason_ctx
                 .messages
                 .push(ChatMessage::user("tool result stub"));
+            reason_ctx.last_tool_batch_all_failed = self.simulate_all_failed;
             let outcome = self.tool_exec_outcome.lock().await.take();
             Ok(outcome)
         }
@@ -833,6 +949,297 @@ mod tests {
         assert!(
             ctx.force_text,
             "Should escalate to force_text after repeated truncations"
+        );
+    }
+
+    // --- Duplicate tool call tracker unit tests ---
+
+    #[test]
+    fn test_dup_tracker_no_duplicates_when_tools_succeed() {
+        let mut tracker = DuplicateToolCallTracker::new();
+        let calls = vec![ToolCall {
+            id: "c1".into(),
+            name: "echo".into(),
+            arguments: serde_json::json!({"msg": "hi"}),
+            reasoning: None,
+        }];
+        let fp = DuplicateToolCallTracker::fingerprint(&calls);
+        // Tool succeeded — count stays at 0
+        assert_eq!(tracker.record_with_fingerprint(fp, false), 0);
+        assert_eq!(tracker.record_with_fingerprint(fp, false), 0);
+    }
+
+    #[test]
+    fn test_dup_tracker_counts_identical_failures() {
+        let mut tracker = DuplicateToolCallTracker::new();
+        let calls = vec![ToolCall {
+            id: "c1".into(),
+            name: "http_get".into(),
+            arguments: serde_json::json!({"url": "https://example.com"}),
+            reasoning: None,
+        }];
+        let fp = DuplicateToolCallTracker::fingerprint(&calls);
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 1);
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 2);
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 3);
+    }
+
+    #[test]
+    fn test_dup_tracker_resets_on_success() {
+        let mut tracker = DuplicateToolCallTracker::new();
+        let calls = vec![ToolCall {
+            id: "c1".into(),
+            name: "http_get".into(),
+            arguments: serde_json::json!({"url": "https://example.com"}),
+            reasoning: None,
+        }];
+        let fp = DuplicateToolCallTracker::fingerprint(&calls);
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 1);
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 2);
+        // Success resets the tracker
+        assert_eq!(tracker.record_with_fingerprint(fp, false), 0);
+        // Starts fresh
+        assert_eq!(tracker.record_with_fingerprint(fp, true), 1);
+    }
+
+    #[test]
+    fn test_dup_tracker_different_args_restarts_streak() {
+        let mut tracker = DuplicateToolCallTracker::new();
+        let calls_a = vec![ToolCall {
+            id: "c1".into(),
+            name: "http_get".into(),
+            arguments: serde_json::json!({"url": "https://a.com"}),
+            reasoning: None,
+        }];
+        let calls_b = vec![ToolCall {
+            id: "c1".into(),
+            name: "http_get".into(),
+            arguments: serde_json::json!({"url": "https://b.com"}),
+            reasoning: None,
+        }];
+        let fp_a = DuplicateToolCallTracker::fingerprint(&calls_a);
+        let fp_b = DuplicateToolCallTracker::fingerprint(&calls_b);
+        assert_eq!(tracker.record_with_fingerprint(fp_a, true), 1);
+        assert_eq!(tracker.record_with_fingerprint(fp_a, true), 2);
+        // Different call — streak restarts at 1
+        assert_eq!(tracker.record_with_fingerprint(fp_b, true), 1);
+    }
+
+    #[test]
+    fn test_dup_tracker_canonicalizes_arg_order() {
+        // Same keys in different insertion order should produce same fingerprint
+        let calls_a = vec![ToolCall {
+            id: "c1".into(),
+            name: "echo".into(),
+            arguments: serde_json::json!({"a": 1, "b": 2}),
+            reasoning: None,
+        }];
+        let calls_b = vec![ToolCall {
+            id: "c1".into(),
+            name: "echo".into(),
+            arguments: serde_json::json!({"b": 2, "a": 1}),
+            reasoning: None,
+        }];
+        assert_eq!(
+            DuplicateToolCallTracker::fingerprint(&calls_a),
+            DuplicateToolCallTracker::fingerprint(&calls_b),
+        );
+    }
+
+    // --- Agentic loop integration tests for duplicate detection ---
+
+    #[tokio::test]
+    async fn test_duplicate_failing_tool_calls_inject_warning() {
+        let same_call = || ToolCall {
+            id: "call_1".to_string(),
+            name: "http_get".to_string(),
+            arguments: serde_json::json!({"url": "https://broken.example.com"}),
+            reasoning: None,
+        };
+        // 3 identical failing tool calls, then text response
+        let mut delegate = MockDelegate::new(vec![
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            text_output("I give up."),
+        ]);
+        delegate.simulate_all_failed = true;
+        let reasoning = stub_reasoning();
+        let mut ctx = ReasoningContext::new();
+        let config = AgenticLoopConfig {
+            max_iterations: 10,
+            ..Default::default()
+        };
+
+        let outcome = run_agentic_loop(&delegate, &reasoning, &mut ctx, &config)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, LoopOutcome::Response(_)));
+        assert_eq!(delegate.tool_exec_count.load(Ordering::SeqCst), 3);
+        // After 3 consecutive duplicate failures, a warning should be injected
+        let warning_count = ctx
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == crate::llm::Role::User && m.content.contains("same failing tool call")
+            })
+            .count();
+        assert!(
+            warning_count >= 1,
+            "Should have at least 1 duplicate warning message in context"
+        );
+        // force_text should NOT be set yet (only at threshold 5)
+        assert!(
+            !ctx.force_text,
+            "force_text should not be set after only 3 duplicate failures"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_failing_tool_calls_force_text_at_threshold() {
+        let same_call = || ToolCall {
+            id: "call_1".to_string(),
+            name: "http_get".to_string(),
+            arguments: serde_json::json!({"url": "https://broken.example.com"}),
+            reasoning: None,
+        };
+        // 5 identical failing tool calls, then text response
+        let mut delegate = MockDelegate::new(vec![
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            tool_calls_output(vec![same_call()]),
+            text_output("Forced text response."),
+        ]);
+        delegate.simulate_all_failed = true;
+        let reasoning = stub_reasoning();
+        let mut ctx = ReasoningContext::new();
+        let config = AgenticLoopConfig {
+            max_iterations: 10,
+            ..Default::default()
+        };
+
+        let outcome = run_agentic_loop(&delegate, &reasoning, &mut ctx, &config)
+            .await
+            .unwrap();
+
+        assert!(matches!(outcome, LoopOutcome::Response(_)));
+        assert_eq!(delegate.tool_exec_count.load(Ordering::SeqCst), 5);
+        assert!(
+            ctx.force_text,
+            "force_text should be set after 5 consecutive duplicate failures"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_tracker_resets_on_text_response() {
+        let call_a = || ToolCall {
+            id: "call_1".to_string(),
+            name: "http_get".to_string(),
+            arguments: serde_json::json!({"url": "https://broken.example.com"}),
+            reasoning: None,
+        };
+        // 2 failing calls, then a text continuation, then 2 more of the same failing calls
+        // The text response in the middle should reset the streak, so we never hit 3.
+        struct DupResetDelegate {
+            llm_responses: Mutex<Vec<RespondOutput>>,
+            tool_exec_count: AtomicUsize,
+            text_response_count: AtomicUsize,
+        }
+
+        #[async_trait]
+        impl LoopDelegate for DupResetDelegate {
+            async fn check_signals(&self) -> LoopSignal {
+                LoopSignal::Continue
+            }
+            async fn before_llm_call(
+                &self,
+                _: &mut ReasoningContext,
+                _: usize,
+            ) -> Option<LoopOutcome> {
+                None
+            }
+            async fn call_llm(
+                &self,
+                _: &Reasoning,
+                _: &mut ReasoningContext,
+                _: usize,
+            ) -> Result<crate::llm::RespondOutput, crate::error::Error> {
+                let mut responses = self.llm_responses.lock().await;
+                if responses.is_empty() {
+                    panic!("No more responses");
+                }
+                Ok(responses.remove(0))
+            }
+            async fn handle_text_response(
+                &self,
+                text: &str,
+                _: ResponseMetadata,
+                ctx: &mut ReasoningContext,
+            ) -> TextAction {
+                let count = self.text_response_count.fetch_add(1, Ordering::SeqCst);
+                if count >= 1 {
+                    // Second text response — return final result
+                    TextAction::Return(LoopOutcome::Response(text.to_string()))
+                } else {
+                    ctx.messages.push(ChatMessage::assistant("thinking..."));
+                    TextAction::Continue
+                }
+            }
+            async fn execute_tool_calls(
+                &self,
+                _: Vec<ToolCall>,
+                _: Option<String>,
+                reason_ctx: &mut ReasoningContext,
+            ) -> Result<Option<LoopOutcome>, crate::error::Error> {
+                self.tool_exec_count.fetch_add(1, Ordering::SeqCst);
+                reason_ctx.messages.push(ChatMessage::user("tool error"));
+                reason_ctx.last_tool_batch_all_failed = true;
+                Ok(None)
+            }
+        }
+
+        let delegate = DupResetDelegate {
+            llm_responses: Mutex::new(vec![
+                tool_calls_output(vec![call_a()]),
+                tool_calls_output(vec![call_a()]),
+                text_output("Let me reconsider."),
+                tool_calls_output(vec![call_a()]),
+                tool_calls_output(vec![call_a()]),
+                text_output("Final answer."),
+            ]),
+            tool_exec_count: AtomicUsize::new(0),
+            text_response_count: AtomicUsize::new(0),
+        };
+        let reasoning = stub_reasoning();
+        let mut ctx = ReasoningContext::new();
+        let config = AgenticLoopConfig {
+            max_iterations: 10,
+            ..Default::default()
+        };
+
+        let _outcome = run_agentic_loop(&delegate, &reasoning, &mut ctx, &config)
+            .await
+            .unwrap();
+
+        // No warning should have been injected because the text response
+        // reset the streak before it hit 3.
+        let warning_count = ctx
+            .messages
+            .iter()
+            .filter(|m| {
+                m.role == crate::llm::Role::User && m.content.contains("same failing tool call")
+            })
+            .count();
+        assert_eq!(
+            warning_count, 0,
+            "No duplicate warning should be injected when text response resets the streak"
+        );
+        assert!(
+            !ctx.force_text,
+            "force_text should not be set when streak was reset"
         );
     }
 }

--- a/src/agent/dispatcher.rs
+++ b/src/agent/dispatcher.rs
@@ -1105,10 +1105,13 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
 
         // === Phase 3: Post-flight (sequential, in original order) ===
         let mut selected_auth_prompt: Option<(String, ParsedAuthData)> = None;
+        let mut tool_failure_count: usize = 0;
+        let total_tools = preflight.len();
 
         for (pf_idx, (tc, outcome)) in preflight.into_iter().enumerate() {
             match outcome {
                 PreflightOutcome::Rejected(error_msg) => {
+                    tool_failure_count += 1;
                     let (result_content, tool_message) = preflight_rejection_tool_message(
                         self.agent.safety(),
                         &tc.name,
@@ -1208,6 +1211,9 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                     }
 
                     let is_tool_error = tool_result.is_err();
+                    if is_tool_error {
+                        tool_failure_count += 1;
+                    }
                     let (result_content, tool_message) = crate::tools::execute::process_tool_result(
                         self.agent.safety(),
                         &tc.name,
@@ -1236,6 +1242,10 @@ impl<'a> LoopDelegate for ChatDelegate<'a> {
                 }
             }
         }
+
+        // Report whether every tool in the batch failed (for duplicate detection).
+        reason_ctx.last_tool_batch_all_failed =
+            total_tools > 0 && tool_failure_count == total_tools;
 
         // Approval pauses take precedence over surfacing auth prompts. Persist
         // the prompt so it can be replayed after approval, and also emit it now

--- a/src/agent/routine.rs
+++ b/src/agent/routine.rs
@@ -603,23 +603,7 @@ fn write_routine_verification_record(
 }
 
 fn canonicalize_json_value(value: Value) -> Value {
-    match value {
-        Value::Array(items) => {
-            Value::Array(items.into_iter().map(canonicalize_json_value).collect())
-        }
-        Value::Object(obj) => {
-            let mut keys: Vec<String> = obj.keys().cloned().collect();
-            keys.sort();
-            let mut canonical = Map::new();
-            for key in keys {
-                if let Some(value) = obj.get(&key) {
-                    canonical.insert(key, canonicalize_json_value(value.clone()));
-                }
-            }
-            Value::Object(canonical)
-        }
-        other => other,
-    }
+    crate::util::canonicalize_json_value(value)
 }
 
 pub fn routine_verification_fingerprint(routine: &Routine) -> String {

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -216,6 +216,10 @@ pub struct ReasoningContext {
     /// 0.7 default in `respond_with_tools`. Per-request temperature from API
     /// callers takes precedence over this.
     pub temperature: Option<f32>,
+    /// Set by `execute_tool_calls` to indicate whether every tool in the last
+    /// batch failed. Used by the duplicate tool call tracker in the agentic loop.
+    /// Reset to `false` at the start of each iteration.
+    pub last_tool_batch_all_failed: bool,
 }
 
 impl ReasoningContext {
@@ -231,6 +235,7 @@ impl ReasoningContext {
             system_prompt: None,
             model_override: None,
             temperature: None,
+            last_tool_batch_all_failed: false,
         }
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,6 +1,7 @@
 //! Shared utility functions used across the codebase.
 
 use crate::llm::{ChatMessage, Role};
+use serde_json::{Map, Value};
 
 /// Find the largest valid UTF-8 char boundary at or before `pos`.
 ///
@@ -83,10 +84,77 @@ pub fn llm_signals_completion(response: &str) -> bool {
     positive_phrases.iter().any(|p| lower.contains(p))
 }
 
+/// Recursively sort JSON object keys for deterministic comparison/hashing.
+///
+/// Arrays preserve order, objects get sorted keys, scalars pass through.
+pub fn canonicalize_json_value(value: Value) -> Value {
+    match value {
+        Value::Array(items) => {
+            Value::Array(items.into_iter().map(canonicalize_json_value).collect())
+        }
+        Value::Object(obj) => {
+            let mut keys: Vec<String> = obj.keys().cloned().collect();
+            keys.sort();
+            let mut canonical = Map::new();
+            for key in keys {
+                if let Some(value) = obj.get(&key) {
+                    canonical.insert(key, canonicalize_json_value(value.clone()));
+                }
+            }
+            Value::Object(canonical)
+        }
+        other => other,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::llm::ChatMessage;
-    use crate::util::{ensure_ends_with_user_message, floor_char_boundary, llm_signals_completion};
+    use crate::util::{
+        canonicalize_json_value, ensure_ends_with_user_message, floor_char_boundary,
+        llm_signals_completion,
+    };
+
+    // ── canonicalize_json_value ──
+
+    #[test]
+    fn canonicalize_sorts_object_keys() {
+        let input = serde_json::json!({"z": 1, "a": 2, "m": 3});
+        let result = canonicalize_json_value(input);
+        let keys: Vec<&String> = result.as_object().unwrap().keys().collect();
+        assert_eq!(keys, vec!["a", "m", "z"]);
+    }
+
+    #[test]
+    fn canonicalize_is_recursive() {
+        let input = serde_json::json!({"outer": {"z": 1, "a": 2}});
+        let result = canonicalize_json_value(input);
+        let inner_keys: Vec<&String> = result["outer"].as_object().unwrap().keys().collect();
+        assert_eq!(inner_keys, vec!["a", "z"]);
+    }
+
+    #[test]
+    fn canonicalize_preserves_array_order() {
+        let input = serde_json::json!([3, 1, 2]);
+        let result = canonicalize_json_value(input);
+        assert_eq!(result, serde_json::json!([3, 1, 2]));
+    }
+
+    #[test]
+    fn canonicalize_preserves_scalars() {
+        assert_eq!(
+            canonicalize_json_value(serde_json::json!("hello")),
+            serde_json::json!("hello")
+        );
+        assert_eq!(
+            canonicalize_json_value(serde_json::json!(42)),
+            serde_json::json!(42)
+        );
+        assert_eq!(
+            canonicalize_json_value(serde_json::json!(null)),
+            serde_json::json!(null)
+        );
+    }
 
     // ── floor_char_boundary ──
 

--- a/src/worker/container.rs
+++ b/src/worker/container.rs
@@ -536,6 +536,8 @@ impl LoopDelegate for ContainerDelegate {
             ));
 
         // Execute tools sequentially (container context — no parallel execution)
+        let mut tool_failure_count: usize = 0;
+        let total_tools = tool_calls.len();
         for tc in tool_calls {
             self.post_event(
                 "tool_use",
@@ -573,6 +575,10 @@ impl LoopDelegate for ContainerDelegate {
             )
             .await;
 
+            if result.is_err() {
+                tool_failure_count += 1;
+            }
+
             if let Ok(ref output) = result {
                 *self.last_output.lock().await = output.clone();
             }
@@ -581,6 +587,9 @@ impl LoopDelegate for ContainerDelegate {
             let (_, message) = process_tool_result(&self.safety, &tc.name, &tc.id, &result);
             reason_ctx.messages.push(message);
         }
+
+        reason_ctx.last_tool_batch_all_failed =
+            total_tools > 0 && tool_failure_count == total_tools;
 
         Ok(None)
     }

--- a/src/worker/job.rs
+++ b/src/worker/job.rs
@@ -1739,23 +1739,35 @@ impl<'a> LoopDelegate for JobDelegate<'a> {
             .collect();
 
         // Execute tools (parallel for multiple, direct for single)
+        let mut tool_failure_count: usize = 0;
+        let total_tools = selections.len();
+
         if selections.len() == 1 {
             let selection = &selections[0];
             let result = self
                 .worker
                 .execute_tool(&selection.tool_name, &selection.parameters)
                 .await;
+            if result.is_err() {
+                tool_failure_count += 1;
+            }
             self.worker
                 .process_tool_result_job(reason_ctx, selection, result)
                 .await?;
         } else {
             let results = self.worker.execute_tools_parallel(&selections).await;
             for (selection, result) in selections.iter().zip(results) {
+                if result.result.is_err() {
+                    tool_failure_count += 1;
+                }
                 self.worker
                     .process_tool_result_job(reason_ctx, selection, result.result)
                     .await?;
             }
         }
+
+        reason_ctx.last_tool_batch_all_failed =
+            total_tools > 0 && tool_failure_count == total_tools;
 
         Ok(None)
     }


### PR DESCRIPTION
## Summary

Closes #2240

- Adds a `DuplicateToolCallTracker` to the shared agentic loop that fingerprints each tool call batch by hashing `(tool_name, canonicalized_args)` and detects consecutive identical failing batches
- After 3 consecutive duplicate failures: injects a warning message telling the LLM to try a different approach
- After 5 consecutive duplicate failures: sets `force_text = true` to disable tool calls entirely, guaranteeing termination
- Resets when the LLM calls different tools, any tool succeeds, or produces a text response
- Extracts `canonicalize_json_value` from `agent/routine.rs` to `util.rs` for shared use
- All three delegate implementations (ChatDelegate, JobDelegate, ContainerDelegate) report tool batch failure status via `ReasoningContext.last_tool_batch_all_failed`

## Design

Follows the same counter + threshold + escalation pattern as the existing tool intent nudge (`consecutive_tool_intent_nudges` / `max_tool_intent_nudges`) and truncation detection (`truncation_count` / `force_text`) mechanisms already in the agentic loop.

## Test plan

- [x] Unit tests for `DuplicateToolCallTracker` (fingerprinting, counting, reset on success, reset on different args, canonicalization of key order)
- [x] Unit tests for extracted `canonicalize_json_value` in `util.rs`
- [x] Integration test: 3 consecutive duplicate failures inject warning message
- [x] Integration test: 5 consecutive duplicate failures set `force_text = true`
- [x] Integration test: text response between duplicate failures resets the streak
- [x] `cargo clippy --all --benches --tests --examples --all-features` passes with zero warnings
- [x] `cargo test` passes (4713 of 4714 pass; 1 pre-existing flaky SQLite test unrelated to this change)

Generated with [Claude Code](https://claude.com/claude-code)