### PR TITLE
fix(llm): map HTTP 413 to ContextLengthExceeded for auto-compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,8 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rand 0.8.x unsoundness with custom logger — pinned by transitive deps, upgrade tracked separately
+    "RUSTSEC-2026-0097",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -7,18 +7,10 @@ ignore = [
     "RUSTSEC-2025-0068",
     # tokio-tar PAX header parsing — sandbox containers only
     "RUSTSEC-2025-0111",
-    # wasmtime fd_renumber host panic — WASIp1, mitigated by fuel limits
-    "RUSTSEC-2025-0046",
-    # wasmtime shared linear memory unsoundness — no shared memory in our guests
-    "RUSTSEC-2025-0118",
-    # wasmtime guest-controlled resource exhaustion — mitigated by fuel/memory limits
-    "RUSTSEC-2026-0020",
-    # wasmtime wasi:http/types.fields panic — mitigated by fuel limits
-    "RUSTSEC-2026-0021",
-    # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
-    "RUSTSEC-2026-0049",
     # rand 0.8.x unsoundness with custom logger — pinned by transitive deps, upgrade tracked separately
     "RUSTSEC-2026-0097",
+    # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
+    "RUSTSEC-2026-0049",
 ]
 
 [licenses]

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -303,19 +303,26 @@ impl NearAiChatProvider {
             // request size limit. Map to ContextLengthExceeded so the dispatcher
             // can trigger automatic compaction instead of crashing.
             if status_code == 413 {
-                return Err(LlmError::ContextLengthExceeded { used: 0, limit: 0 });
+                let lower = response_text.to_ascii_lowercase();
+                let (used, limit) =
+                    crate::llm::rig_adapter::parse_token_counts(&lower);
+                return Err(LlmError::ContextLengthExceeded { used, limit });
             }
 
             // Some providers return 400 with "context_length_exceeded" in the body
             // (e.g., OpenAI-compatible endpoints behind NEAR AI).
             if status_code == 400 {
-                let lower = response_text.to_lowercase();
-                if lower.contains("context_length_exceeded")
-                    || lower.contains("maximum context length")
-                    || lower.contains("too many tokens")
-                    || lower.contains("payload too large")
-                {
-                    return Err(LlmError::ContextLengthExceeded { used: 0, limit: 0 });
+                let lower = response_text.to_ascii_lowercase();
+                const CONTEXT_PATTERNS: &[&str] = &[
+                    "context_length_exceeded",
+                    "maximum context length",
+                    "too many tokens",
+                    "payload too large",
+                ];
+                if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
+                    let (used, limit) =
+                        crate::llm::rig_adapter::parse_token_counts(&lower);
+                    return Err(LlmError::ContextLengthExceeded { used, limit });
                 }
             }
 

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -304,8 +304,7 @@ impl NearAiChatProvider {
             // can trigger automatic compaction instead of crashing.
             if status_code == 413 {
                 let lower = response_text.to_ascii_lowercase();
-                let (used, limit) =
-                    crate::llm::rig_adapter::parse_token_counts(&lower);
+                let (used, limit) = crate::llm::rig_adapter::parse_token_counts(&lower);
                 return Err(LlmError::ContextLengthExceeded { used, limit });
             }
 
@@ -320,8 +319,7 @@ impl NearAiChatProvider {
                     "payload too large",
                 ];
                 if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
-                    let (used, limit) =
-                        crate::llm::rig_adapter::parse_token_counts(&lower);
+                    let (used, limit) = crate::llm::rig_adapter::parse_token_counts(&lower);
                     return Err(LlmError::ContextLengthExceeded { used, limit });
                 }
             }

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -299,6 +299,26 @@ impl NearAiChatProvider {
                 });
             }
 
+            // Payload too large — the accumulated context exceeds the provider's
+            // request size limit. Map to ContextLengthExceeded so the dispatcher
+            // can trigger automatic compaction instead of crashing.
+            if status_code == 413 {
+                return Err(LlmError::ContextLengthExceeded { used: 0, limit: 0 });
+            }
+
+            // Some providers return 400 with "context_length_exceeded" in the body
+            // (e.g., OpenAI-compatible endpoints behind NEAR AI).
+            if status_code == 400 {
+                let lower = response_text.to_lowercase();
+                if lower.contains("context_length_exceeded")
+                    || lower.contains("maximum context length")
+                    || lower.contains("too many tokens")
+                    || lower.contains("payload too large")
+                {
+                    return Err(LlmError::ContextLengthExceeded { used: 0, limit: 0 });
+                }
+            }
+
             let truncated = crate::agent::truncate_for_preview(&response_text, 512);
             return Err(LlmError::RequestFailed {
                 provider: "nearai_chat".to_string(),

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -1044,10 +1044,7 @@ where
             self.model
                 .completion(rig_req)
                 .await
-                .map_err(|e| LlmError::RequestFailed {
-                    provider: self.model_name.clone(),
-                    reason: e.to_string(),
-                })?;
+                .map_err(|e| map_rig_error(&self.model_name, e))?;
 
         let (text, _tool_calls, finish) = extract_response(&response.choice, &response.usage);
 
@@ -1106,10 +1103,7 @@ where
             self.model
                 .completion(rig_req)
                 .await
-                .map_err(|e| LlmError::RequestFailed {
-                    provider: self.model_name.clone(),
-                    reason: e.to_string(),
-                })?;
+                .map_err(|e| map_rig_error(&self.model_name, e))?;
 
         let (text, mut tool_calls, finish) = extract_response(&response.choice, &response.usage);
 
@@ -1166,6 +1160,28 @@ where
                      Restart with a different model configured."
                 .to_string(),
         })
+    }
+}
+
+/// Map a rig-core completion error to an appropriate `LlmError` variant.
+///
+/// Detects context-length / payload-size errors in the error message and maps
+/// them to `ContextLengthExceeded` so the dispatcher can trigger compaction
+/// instead of retrying the same oversized payload.
+fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
+    let msg = e.to_string();
+    let lower = msg.to_lowercase();
+    if lower.contains("context_length_exceeded")
+        || lower.contains("maximum context length")
+        || lower.contains("too many tokens")
+        || lower.contains("payload too large")
+        || lower.contains("413")
+    {
+        return LlmError::ContextLengthExceeded { used: 0, limit: 0 };
+    }
+    LlmError::RequestFailed {
+        provider: model_name.to_string(),
+        reason: msg,
     }
 }
 
@@ -2663,5 +2679,55 @@ mod tests {
         let mut req = make_rig_request(None);
         inject_model_override(&mut req, None);
         assert!(req.additional_params.is_none());
+    }
+
+    // ── map_rig_error: context length detection ─────────────────────────
+
+    #[test]
+    fn test_map_rig_error_detects_context_length_exceeded() {
+        let err = map_rig_error("openai", "Error: context_length_exceeded");
+        assert!(
+            matches!(err, LlmError::ContextLengthExceeded { .. }),
+            "Should detect context_length_exceeded: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_map_rig_error_detects_maximum_context_length() {
+        let err = map_rig_error(
+            "openai",
+            "This model's maximum context length is 128000 tokens",
+        );
+        assert!(
+            matches!(err, LlmError::ContextLengthExceeded { .. }),
+            "Should detect maximum context length: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_map_rig_error_detects_too_many_tokens() {
+        let err = map_rig_error("anthropic", "Request has too many tokens (150000)");
+        assert!(
+            matches!(err, LlmError::ContextLengthExceeded { .. }),
+            "Should detect too many tokens: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_map_rig_error_detects_413() {
+        let err = map_rig_error("nearai", "HTTP 413: Payload Too Large");
+        assert!(
+            matches!(err, LlmError::ContextLengthExceeded { .. }),
+            "Should detect 413: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_map_rig_error_generic_error_is_request_failed() {
+        let err = map_rig_error("openai", "Connection refused");
+        assert!(
+            matches!(err, LlmError::RequestFailed { .. }),
+            "Generic error should be RequestFailed: {err:?}"
+        );
     }
 }

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -1170,19 +1170,47 @@ where
 /// instead of retrying the same oversized payload.
 fn map_rig_error(model_name: &str, e: impl std::fmt::Display) -> LlmError {
     let msg = e.to_string();
-    let lower = msg.to_lowercase();
-    if lower.contains("context_length_exceeded")
-        || lower.contains("maximum context length")
-        || lower.contains("too many tokens")
-        || lower.contains("payload too large")
-        || lower.contains("413")
-    {
-        return LlmError::ContextLengthExceeded { used: 0, limit: 0 };
+    let lower = msg.to_ascii_lowercase();
+
+    const CONTEXT_PATTERNS: &[&str] = &[
+        "context_length_exceeded",
+        "maximum context length",
+        "too many tokens",
+        "payload too large",
+    ];
+
+    if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
+        let (used, limit) = parse_token_counts(&lower);
+        return LlmError::ContextLengthExceeded { used, limit };
     }
     LlmError::RequestFailed {
         provider: model_name.to_string(),
         reason: msg,
     }
+}
+
+/// Try to extract token counts from a context-length error message.
+///
+/// Handles patterns like:
+/// - "maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens."
+/// - "context_length_exceeded ... 150000 tokens ... limit 128000"
+///
+/// Returns `(0, 0)` if parsing fails.
+pub(crate) fn parse_token_counts(lower: &str) -> (usize, usize) {
+    // OpenAI pattern: "maximum context length is {limit} tokens. ... resulted in {used} tokens"
+    if lower.contains("maximum context length") {
+        let numbers: Vec<usize> = lower
+            .split(|c: char| !c.is_ascii_digit())
+            .filter(|s| !s.is_empty())
+            .filter_map(|s| s.parse().ok())
+            .filter(|&n| n > 0)
+            .collect();
+        if numbers.len() >= 2 {
+            // First large number is typically the limit, second is the used count
+            return (numbers[1], numbers[0]);
+        }
+    }
+    (0, 0)
 }
 
 /// Normalize a tool call name returned by an OpenAI-compatible provider.
@@ -2714,11 +2742,29 @@ mod tests {
     }
 
     #[test]
-    fn test_map_rig_error_detects_413() {
+    fn test_map_rig_error_detects_payload_too_large() {
         let err = map_rig_error("nearai", "HTTP 413: Payload Too Large");
         assert!(
             matches!(err, LlmError::ContextLengthExceeded { .. }),
-            "Should detect 413: {err:?}"
+            "Should detect payload too large: {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_map_rig_error_bare_413_no_false_positive() {
+        // Bare "413" should NOT trigger ContextLengthExceeded — avoids false
+        // positives on timestamps ("2026-04-13"), token counts ("used 1413"),
+        // and request IDs.
+        let err = map_rig_error("nearai", "Rate limit: 413 requests per minute exceeded");
+        assert!(
+            matches!(err, LlmError::RequestFailed { .. }),
+            "Bare 413 in rate limit message should not be ContextLengthExceeded: {err:?}"
+        );
+
+        let err = map_rig_error("nearai", "Error at 2026-04-13T10:00:00Z");
+        assert!(
+            matches!(err, LlmError::RequestFailed { .. }),
+            "413 in timestamp should not be ContextLengthExceeded: {err:?}"
         );
     }
 
@@ -2729,5 +2775,36 @@ mod tests {
             matches!(err, LlmError::RequestFailed { .. }),
             "Generic error should be RequestFailed: {err:?}"
         );
+    }
+
+    #[test]
+    fn test_parse_token_counts_openai_format() {
+        let msg = "this model's maximum context length is 128000 tokens. however, your messages resulted in 150000 tokens.";
+        let (used, limit) = parse_token_counts(msg);
+        assert_eq!(limit, 128000);
+        assert_eq!(used, 150000);
+    }
+
+    #[test]
+    fn test_parse_token_counts_unparseable_returns_zero() {
+        let msg = "context_length_exceeded";
+        let (used, limit) = parse_token_counts(msg);
+        assert_eq!(used, 0);
+        assert_eq!(limit, 0);
+    }
+
+    #[test]
+    fn test_map_rig_error_extracts_token_counts() {
+        let err = map_rig_error(
+            "openai",
+            "This model's maximum context length is 128000 tokens. However, your messages resulted in 150000 tokens.",
+        );
+        match err {
+            LlmError::ContextLengthExceeded { used, limit } => {
+                assert_eq!(limit, 128000);
+                assert_eq!(used, 150000);
+            }
+            other => panic!("Expected ContextLengthExceeded, got: {other:?}"),
+        }
     }
 }

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -1040,11 +1040,11 @@ where
 
         inject_model_override(&mut rig_req, model_override.as_deref());
 
-        let response =
-            self.model
-                .completion(rig_req)
-                .await
-                .map_err(|e| map_rig_error(&self.model_name, e))?;
+        let response = self
+            .model
+            .completion(rig_req)
+            .await
+            .map_err(|e| map_rig_error(&self.model_name, e))?;
 
         let (text, _tool_calls, finish) = extract_response(&response.choice, &response.usage);
 
@@ -1099,11 +1099,11 @@ where
 
         inject_model_override(&mut rig_req, model_override.as_deref());
 
-        let response =
-            self.model
-                .completion(rig_req)
-                .await
-                .map_err(|e| map_rig_error(&self.model_name, e))?;
+        let response = self
+            .model
+            .completion(rig_req)
+            .await
+            .map_err(|e| map_rig_error(&self.model_name, e))?;
 
         let (text, mut tool_calls, finish) = extract_response(&response.choice, &response.usage);
 


### PR DESCRIPTION
## Summary

- Maps HTTP 413 (Payload Too Large) to `LlmError::ContextLengthExceeded` instead of generic `RequestFailed`
- Detects context-length errors in HTTP 400 response bodies (OpenAI-compatible endpoints)
- Adds `map_rig_error()` helper in rig_adapter to detect context overflow patterns from all providers

Closes #2276

## The Bug

When accumulated context exceeded the provider's payload limit:
1. **nearai_chat.rs** returned `RequestFailed` (a transient error)
2. **RetryProvider** retried the same oversized payload 3x with exponential backoff
3. **CircuitBreaker** counted it toward the trip threshold (5 failures = 30s blackout)
4. **FailoverProvider** tried the next provider with the same too-large payload
5. **dispatcher.rs** had recovery code for `ContextLengthExceeded` that triggers compaction, but it was never reached

## The Fix

Map 413 to `ContextLengthExceeded` so the existing recovery path kicks in:
- `ContextLengthExceeded` is non-retryable (won't waste retries)
- It doesn't trip the circuit breaker (it's a client problem, not backend degradation)
- The dispatcher auto-compacts context and retries with a smaller window

## Files changed

| File | Change |
|------|--------|
| `src/llm/nearai_chat.rs` | Explicit 413 check + context-length detection in 400 bodies |
| `src/llm/rig_adapter.rs` | `map_rig_error()` helper + 5 regression tests |

## Test plan

- [x] 5 unit tests for `map_rig_error()` (context_length_exceeded, maximum context length, too many tokens, 413, generic error)
- [x] `cargo clippy` zero warnings
- [ ] Manual: accumulate large context via repeated tool calls, verify compaction triggers instead of crash