### PR TITLE
fix(gateway): show descriptive chat titles instead of hex hash IDs

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -4213,8 +4213,8 @@ function threadTitle(thread) {
   if (thread.thread_type === 'heartbeat') return I18n.t('thread.heartbeatAlerts');
   if (thread.thread_type === 'routine') return I18n.t('thread.routine');
   if (ch !== 'gateway') return ch.charAt(0).toUpperCase() + ch.slice(1);
-  if (thread.turn_count === 0) return 'New chat';
-  return thread.id.substring(0, 8);
+  if (thread.turn_count === 0) return I18n.t('thread.newChat');
+  return I18n.t('thread.untitled');
 }
 
 function relativeTime(isoStr) {

--- a/crates/ironclaw_gateway/static/i18n/en.js
+++ b/crates/ironclaw_gateway/static/i18n/en.js
@@ -723,6 +723,8 @@ I18n.register('en', {
   // Thread types
   'thread.heartbeatAlerts': 'Heartbeat Alerts',
   'thread.routine': 'Routine',
+  'thread.newChat': 'New chat',
+  'thread.untitled': 'Untitled chat',
 
   // Extensions (dynamic)
   'extensions.openingAuth': 'Opening authentication for {name}',

--- a/crates/ironclaw_gateway/static/i18n/ko.js
+++ b/crates/ironclaw_gateway/static/i18n/ko.js
@@ -722,6 +722,8 @@ I18n.register('ko', {
   // 스레드 유형
   'thread.heartbeatAlerts': '하트비트 알림',
   'thread.routine': '루틴',
+  'thread.newChat': '새 대화',
+  'thread.untitled': '제목 없는 대화',
 
   // 확장 (동적)
   'extensions.openingAuth': '{name}에 대한 인증을 여는 중',

--- a/crates/ironclaw_gateway/static/i18n/zh-CN.js
+++ b/crates/ironclaw_gateway/static/i18n/zh-CN.js
@@ -722,6 +722,8 @@ I18n.register('zh-CN', {
   // 线程类型
   'thread.heartbeatAlerts': '心跳提醒',
   'thread.routine': '定时任务',
+  'thread.newChat': '新对话',
+  'thread.untitled': '未命名对话',
 
   // 扩展（动态）
   'extensions.openingAuth': '正在为 {name} 打开认证',

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,11 @@ ignore = [
     "RUSTSEC-2025-0111",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rustls-webpki URI name constraint bypass — 0.102.8 pinned by libsql transitive dep;
+    # patched in >=0.103.12 but libsql 0.6.0 requires rustls 0.22 which pins 0.102.x
+    "RUSTSEC-2026-0098",
+    # rustls-webpki wildcard name constraint bypass — same 0.102.8 pin from libsql
+    "RUSTSEC-2026-0099",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",

--- a/deny.toml
+++ b/deny.toml
@@ -9,11 +9,6 @@ ignore = [
     "RUSTSEC-2025-0111",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
-    # rustls-webpki URI name constraint bypass — 0.102.8 pinned by libsql transitive dep;
-    # patched in >=0.103.12 but libsql 0.6.0 requires rustls 0.22 which pins 0.102.x
-    "RUSTSEC-2026-0098",
-    # rustls-webpki wildcard name constraint bypass — same 0.102.8 pin from libsql
-    "RUSTSEC-2026-0099",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1041,7 +1041,7 @@ impl Agent {
             return None;
         }
 
-        match store
+        let result = match store
             .add_conversation_message(thread_id, "user", user_input)
             .await
         {
@@ -1076,9 +1076,11 @@ impl Agent {
                 .await;
                 None
             }
-        }
+        };
 
         crate::db::set_title_if_missing(store.as_ref(), thread_id, user_input).await;
+
+        result
     }
 
     /// Persist the assistant response to the DB after the agentic loop completes.

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1078,19 +1078,7 @@ impl Agent {
             }
         }
 
-        // Set a conversation title from the first user message so the
-        // thread list shows a descriptive name in the sidebar.
-        if let Ok(None) = store
-            .get_conversation_metadata(thread_id)
-            .await
-            .map(|m| m.and_then(|v| v.get("title").and_then(|t| t.as_str()).map(String::from)))
-        {
-            let title_text: String = user_input.chars().take(100).collect();
-            let title_val = serde_json::json!(title_text);
-            let _ = store
-                .update_conversation_metadata_field(thread_id, "title", &title_val)
-                .await;
-        }
+        crate::db::set_title_if_missing(store.as_ref(), thread_id, user_input).await;
     }
 
     /// Persist the assistant response to the DB after the agentic loop completes.

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1077,6 +1077,20 @@ impl Agent {
                 None
             }
         }
+
+        // Set a conversation title from the first user message so the
+        // thread list shows a descriptive name in the sidebar.
+        if let Ok(None) = store
+            .get_conversation_metadata(thread_id)
+            .await
+            .map(|m| m.and_then(|v| v.get("title").and_then(|t| t.as_str()).map(String::from)))
+        {
+            let title_text: String = user_input.chars().take(100).collect();
+            let title_val = serde_json::json!(title_text);
+            let _ = store
+                .update_conversation_metadata_field(thread_id, "title", &title_val)
+                .await;
+        }
     }
 
     /// Persist the assistant response to the DB after the agentic loop completes.

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2969,6 +2969,20 @@ async fn handle_with_engine_inner(
         };
         if let Some(cid) = v1_conv_id {
             let _ = db.add_conversation_message(cid, "user", content).await;
+            // Set a conversation title from the first user message so the
+            // thread list shows a descriptive name even if the subquery-based
+            // title derivation has timing issues.
+            if let Ok(None) = db
+                .get_conversation_metadata(cid)
+                .await
+                .map(|m| m.and_then(|v| v.get("title").and_then(|t| t.as_str()).map(String::from)))
+            {
+                let title_text: String = content.chars().take(100).collect();
+                let title_val = serde_json::json!(title_text);
+                let _ = db
+                    .update_conversation_metadata_field(cid, "title", &title_val)
+                    .await;
+            }
         }
     }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2969,20 +2969,7 @@ async fn handle_with_engine_inner(
         };
         if let Some(cid) = v1_conv_id {
             let _ = db.add_conversation_message(cid, "user", content).await;
-            // Set a conversation title from the first user message so the
-            // thread list shows a descriptive name even if the subquery-based
-            // title derivation has timing issues.
-            if let Ok(None) = db
-                .get_conversation_metadata(cid)
-                .await
-                .map(|m| m.and_then(|v| v.get("title").and_then(|t| t.as_str()).map(String::from)))
-            {
-                let title_text: String = content.chars().take(100).collect();
-                let title_val = serde_json::json!(title_text);
-                let _ = db
-                    .update_conversation_metadata_field(cid, "title", &title_val)
-                    .await;
-            }
+            crate::db::set_title_if_missing(db.as_ref(), cid, content).await;
         }
     }
 

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -174,7 +174,7 @@ pub async fn chat_threads_handler(
             let title = t
                 .turns
                 .first()
-                .map(|turn| turn.user_input.chars().take(100).collect::<String>())
+                .map(|turn| turn.user_input.trim().chars().take(100).collect::<String>())
                 .filter(|s| !s.is_empty());
             ThreadInfo {
                 id: t.id,

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -170,15 +170,22 @@ pub async fn chat_threads_handler(
     sorted_threads.sort_by_key(|t| std::cmp::Reverse(t.updated_at));
     let threads: Vec<ThreadInfo> = sorted_threads
         .into_iter()
-        .map(|t| ThreadInfo {
-            id: t.id,
-            state: format!("{:?}", t.state),
-            turn_count: t.turns.len(),
-            created_at: t.created_at.to_rfc3339(),
-            updated_at: t.updated_at.to_rfc3339(),
-            title: None,
-            thread_type: None,
-            channel: Some("gateway".to_string()),
+        .map(|t| {
+            let title = t
+                .turns
+                .first()
+                .map(|turn| turn.user_input.chars().take(100).collect::<String>())
+                .filter(|s| !s.is_empty());
+            ThreadInfo {
+                id: t.id,
+                state: format!("{:?}", t.state),
+                turn_count: t.turns.len(),
+                created_at: t.created_at.to_rfc3339(),
+                updated_at: t.updated_at.to_rfc3339(),
+                title,
+                thread_type: None,
+                channel: Some("gateway".to_string()),
+            }
         })
         .collect();
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -1256,15 +1256,23 @@ pub(crate) async fn chat_threads_handler(
     sorted_threads.sort_by_key(|t| std::cmp::Reverse(t.updated_at));
     let threads: Vec<ThreadInfo> = sorted_threads
         .into_iter()
-        .map(|t| ThreadInfo {
-            id: t.id,
-            state: thread_state_label(t.state).to_string(),
-            turn_count: t.turns.len(),
-            created_at: t.created_at.to_rfc3339(),
-            updated_at: t.updated_at.to_rfc3339(),
-            title: None,
-            thread_type: None,
-            channel: Some("gateway".to_string()),
+        .map(|t| {
+            // Derive title from first turn's user input when no DB is available
+            let title = t
+                .turns
+                .first()
+                .map(|turn| turn.user_input.chars().take(100).collect::<String>())
+                .filter(|s| !s.is_empty());
+            ThreadInfo {
+                id: t.id,
+                state: thread_state_label(t.state).to_string(),
+                turn_count: t.turns.len(),
+                created_at: t.created_at.to_rfc3339(),
+                updated_at: t.updated_at.to_rfc3339(),
+                title,
+                thread_type: None,
+                channel: Some("gateway".to_string()),
+            }
         })
         .collect();
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -1261,7 +1261,7 @@ pub(crate) async fn chat_threads_handler(
             let title = t
                 .turns
                 .first()
-                .map(|turn| turn.user_input.chars().take(100).collect::<String>())
+                .map(|turn| turn.user_input.trim().chars().take(100).collect::<String>())
                 .filter(|s| !s.is_empty());
             ThreadInfo {
                 id: t.id,

--- a/src/db/libsql/conversations.rs
+++ b/src/db/libsql/conversations.rs
@@ -171,12 +171,20 @@ impl ConversationStore for LibSqlBackend {
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let sql_title = get_opt_text(&row, 6);
-            let title = sql_title.or_else(|| {
-                metadata
-                    .get("routine_name")
-                    .and_then(|v| v.as_str())
-                    .map(String::from)
-            });
+            let title = sql_title
+                .or_else(|| {
+                    metadata
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(String::from)
+                })
+                .or_else(|| {
+                    metadata
+                        .get("routine_name")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                });
             results.push(ConversationSummary {
                 id: row
                     .get::<String>(0)
@@ -250,12 +258,20 @@ impl ConversationStore for LibSqlBackend {
                 .and_then(|v| v.as_str())
                 .map(String::from);
             let sql_title = get_opt_text(&row, 6);
-            let title = sql_title.or_else(|| {
-                metadata
-                    .get("routine_name")
-                    .and_then(|v| v.as_str())
-                    .map(String::from)
-            });
+            let title = sql_title
+                .or_else(|| {
+                    metadata
+                        .get("title")
+                        .and_then(|v| v.as_str())
+                        .filter(|s| !s.is_empty())
+                        .map(String::from)
+                })
+                .or_else(|| {
+                    metadata
+                        .get("routine_name")
+                        .and_then(|v| v.as_str())
+                        .map(String::from)
+                });
             results.push(ConversationSummary {
                 id: row
                     .get::<String>(0)
@@ -1007,6 +1023,87 @@ mod tests {
             source.as_deref(),
             Some("gateway"),
             "assistant thread lookup should backfill a legacy NULL source_channel"
+        );
+    }
+
+    /// Regression test for #2237: conversations with a metadata title should
+    /// use it as a fallback when the message-derived title is NULL.
+    #[tokio::test]
+    async fn test_metadata_title_used_as_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_metadata_title.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-title-test";
+
+        // Create a conversation with no messages
+        backend
+            .ensure_conversation(conv_id, "gateway", user_id, None, Some("gateway"))
+            .await
+            .unwrap();
+
+        // Set a metadata title (simulating what persist_user_message does)
+        let title_val = serde_json::json!("What is the weather today?");
+        backend
+            .update_conversation_metadata_field(conv_id, "title", &title_val)
+            .await
+            .unwrap();
+
+        // List conversations -- title should come from metadata even without messages
+        let convs = backend
+            .list_conversations_all_channels(user_id, 50)
+            .await
+            .unwrap();
+
+        let conv = convs.iter().find(|c| c.id == conv_id).unwrap();
+        assert_eq!(
+            conv.title.as_deref(),
+            Some("What is the weather today?"),
+            "Conversation title should fall back to metadata title when no user messages exist"
+        );
+    }
+
+    /// Regression test for #2237: message-derived title takes precedence over metadata.
+    #[tokio::test]
+    async fn test_message_title_takes_precedence_over_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test_message_title_precedence.db");
+        let backend = LibSqlBackend::new_local(&db_path).await.unwrap();
+        backend.run_migrations().await.unwrap();
+
+        let conv_id = Uuid::new_v4();
+        let user_id = "user-title-precedence";
+
+        backend
+            .ensure_conversation(conv_id, "gateway", user_id, None, Some("gateway"))
+            .await
+            .unwrap();
+
+        // Set metadata title
+        let title_val = serde_json::json!("metadata title");
+        backend
+            .update_conversation_metadata_field(conv_id, "title", &title_val)
+            .await
+            .unwrap();
+
+        // Add a user message
+        backend
+            .add_conversation_message(conv_id, "user", "actual user message")
+            .await
+            .unwrap();
+
+        let convs = backend
+            .list_conversations_all_channels(user_id, 50)
+            .await
+            .unwrap();
+
+        let conv = convs.iter().find(|c| c.id == conv_id).unwrap();
+        assert_eq!(
+            conv.title.as_deref(),
+            Some("actual user message"),
+            "Message-derived title should take precedence over metadata title"
         );
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -494,6 +494,39 @@ pub trait ConversationStore: Send + Sync {
     ) -> Result<Option<String>, DatabaseError>;
 }
 
+/// Set a conversation title from user input if one hasn't been set yet.
+///
+/// Skips empty/whitespace-only input so that image-only or attachment-only
+/// messages don't permanently block title-setting with an empty string.
+/// Truncates to the first 100 characters for sidebar display.
+pub async fn set_title_if_missing(
+    store: &(dyn ConversationStore + Send + Sync),
+    conversation_id: Uuid,
+    user_input: &str,
+) {
+    let trimmed = user_input.trim();
+    if trimmed.is_empty() {
+        return;
+    }
+
+    let has_title = match store.get_conversation_metadata(conversation_id).await {
+        Ok(Some(meta)) => meta
+            .get("title")
+            .and_then(|t| t.as_str())
+            .is_some_and(|s| !s.is_empty()),
+        Ok(None) => false,
+        Err(_) => return,
+    };
+
+    if !has_title {
+        let title_text: String = trimmed.chars().take(100).collect();
+        let title_val = serde_json::json!(title_text);
+        let _ = store
+            .update_conversation_metadata_field(conversation_id, "title", &title_val)
+            .await;
+    }
+}
+
 #[async_trait]
 pub trait JobStore: Send + Sync {
     async fn save_job(&self, ctx: &JobContext) -> Result<(), DatabaseError>;

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -1839,12 +1839,20 @@ impl Store {
                     .and_then(|v| v.as_str())
                     .map(String::from);
                 let sql_title: Option<String> = r.get("title");
-                let title = sql_title.or_else(|| {
-                    metadata
-                        .get("routine_name")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                });
+                let title = sql_title
+                    .or_else(|| {
+                        metadata
+                            .get("title")
+                            .and_then(|v| v.as_str())
+                            .filter(|s| !s.is_empty())
+                            .map(String::from)
+                    })
+                    .or_else(|| {
+                        metadata
+                            .get("routine_name")
+                            .and_then(|v| v.as_str())
+                            .map(String::from)
+                    });
                 ConversationSummary {
                     id: r.get("id"),
                     title,
@@ -1913,12 +1921,20 @@ impl Store {
                 // For routine/heartbeat threads, derive title from metadata
                 // since they may have no user messages.
                 let sql_title: Option<String> = r.get("title");
-                let title = sql_title.or_else(|| {
-                    metadata
-                        .get("routine_name")
-                        .and_then(|v| v.as_str())
-                        .map(String::from)
-                });
+                let title = sql_title
+                    .or_else(|| {
+                        metadata
+                            .get("title")
+                            .and_then(|v| v.as_str())
+                            .filter(|s| !s.is_empty())
+                            .map(String::from)
+                    })
+                    .or_else(|| {
+                        metadata
+                            .get("routine_name")
+                            .and_then(|v| v.as_str())
+                            .map(String::from)
+                    });
                 ConversationSummary {
                     id: r.get("id"),
                     title,


### PR DESCRIPTION
## Summary

Fixes #2237 -- New conversations in the web sidebar were displaying truncated UUIDs (e.g., "5638f52c") instead of descriptive titles based on conversation topic.

**Root cause:** The `threadTitle()` frontend function fell through to `thread.id.substring(0, 8)` when the backend-provided title was null. The title comes from a SQL subquery that reads the first user message from `conversation_messages`, but this can be null due to timing issues in the dual-write path (v2 engine) or when the in-memory fallback path is used (no DB / DB error).

**Three-layer fix:**
- **Backend (v1 + v2):** Store conversation title in the conversation metadata (`metadata.title`) on the first user message. This provides a reliable title source independent of the SQL subquery timing.
- **SQL queries:** Both PostgreSQL and libSQL `list_conversations_*` now check `metadata.title` as a fallback between the message-subquery title and `routine_name`.
- **Frontend:** `threadTitle()` shows "Untitled chat" (i18n: `thread.untitled`) instead of hex hash. In-memory fallback now derives title from the first turn's user input. Added i18n keys for en, zh-CN, ko.

## Test plan

- [x] `cargo fmt` -- clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` -- zero warnings
- [x] `cargo check` (postgres) -- clean
- [x] `cargo check --no-default-features --features libsql` -- clean
- [x] New regression test: `test_metadata_title_used_as_fallback` -- metadata title used when no user messages exist
- [x] New regression test: `test_message_title_takes_precedence_over_metadata` -- message-derived title wins over metadata

Generated with [Claude Code](https://claude.com/claude-code)