### PR TITLE
fix(engine): prefer direct tool calls before CodeAct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -431,6 +431,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "atomic-polyfill"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1049,12 +1058,27 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec 0.6.3",
+]
+
+[[package]]
+name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bit-vec"
@@ -1407,12 +1431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1631,20 +1649,6 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
-dependencies = [
- "castaway",
- "cfg-if",
- "itoa",
- "rustversion",
- "ryu",
- "static_assertions",
-]
-
-[[package]]
-name = "compact_str"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
@@ -1734,7 +1738,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "980c2afde4af43d6a05c5be738f9eae595cff86dce1f38f88b95058a98c027f3"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
 ]
 
 [[package]]
@@ -1996,7 +2000,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04a63daf06a168535c74ab97cdba3ed4fa5d4f32cb36e437dcceb83d66854b7c"
 dependencies = [
  "crokey-proc_macros",
- "crossterm 0.29.0",
+ "crossterm",
  "once_cell",
  "serde",
  "strict",
@@ -2008,7 +2012,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "847f11a14855fc490bd5d059821895c53e77eeb3c2b73ee3dded7ce77c93b231"
 dependencies = [
- "crossterm 0.29.0",
+ "crossterm",
  "proc-macro2",
  "quote",
  "strict",
@@ -2084,22 +2088,6 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
-dependencies = [
- "bitflags 2.11.0",
- "crossterm_winapi",
- "mio",
- "parking_lot",
- "rustix 0.38.44",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
@@ -2140,6 +2128,16 @@ dependencies = [
  "generic-array",
  "rand_core 0.6.4",
  "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -2284,6 +2282,12 @@ checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
 ]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der"
@@ -2644,6 +2648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2695,11 +2708,21 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set 0.5.3",
+ "regex",
+]
+
+[[package]]
+name = "fancy-regex"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
- "bit-set",
+ "bit-set 0.8.0",
  "regex-automata",
  "regex-syntax",
 ]
@@ -2757,6 +2780,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2772,6 +2806,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
 
 [[package]]
 name = "fixedbitset"
@@ -3034,7 +3074,7 @@ version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a"
 dependencies = [
- "compact_str 0.9.0",
+ "compact_str",
  "get-size-derive2",
  "hashbrown 0.16.1",
  "ordermap",
@@ -3211,8 +3251,6 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
  "foldhash 0.1.5",
 ]
 
@@ -3317,7 +3355,7 @@ dependencies = [
  "base64 0.22.1",
  "html-escape",
  "html5ever 0.39.0",
- "lru 0.16.3",
+ "lru",
  "once_cell",
  "regex",
  "serde",
@@ -3888,7 +3926,7 @@ dependencies = [
  "clap_complete",
  "cookie",
  "cron",
- "crossterm 0.29.0",
+ "crossterm",
  "deadpool-postgres",
  "dirs",
  "dotenvy",
@@ -3917,7 +3955,7 @@ dependencies = [
  "jsonschema",
  "jsonwebtoken",
  "libsql",
- "lru 0.16.3",
+ "lru",
  "mime_guess",
  "open",
  "pdf-extract",
@@ -4055,13 +4093,14 @@ dependencies = [
  "chrono",
  "image",
  "pulldown-cmark",
+ "rat-scrolled",
  "ratatui",
+ "ratatui-textarea",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
- "tui-textarea",
  "unicode-width 0.2.0",
 ]
 
@@ -4127,15 +4166,6 @@ name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
 dependencies = [
  "either",
 ]
@@ -4233,7 +4263,7 @@ dependencies = [
  "bytecount",
  "data-encoding",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "fraction",
  "getrandom 0.3.4",
  "idna",
@@ -4266,6 +4296,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "kuchikikiki"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4279,6 +4320,12 @@ dependencies = [
  "precomputed-hash",
  "selectors 0.35.0",
 ]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
 
 [[package]]
 name = "lazy-regex"
@@ -4529,6 +4576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "line-clipping"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.11.0",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4587,15 +4643,6 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
-dependencies = [
- "hashbrown 0.15.5",
-]
-
-[[package]]
-name = "lru"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
@@ -4614,6 +4661,16 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix 0.29.0",
+ "winapi",
+]
 
 [[package]]
 name = "mach2"
@@ -4733,6 +4790,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
 name = "memoffset"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4802,7 +4865,7 @@ dependencies = [
  "ahash 0.8.12",
  "bytemuck",
  "chrono",
- "fancy-regex",
+ "fancy-regex 0.17.0",
  "hashbrown 0.16.1",
  "indexmap 2.13.0",
  "itertools 0.14.0",
@@ -4947,6 +5010,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4993,6 +5067,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
  "libc",
 ]
 
@@ -5145,6 +5228,15 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
@@ -5232,12 +5324,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5251,7 +5337,7 @@ checksum = "cbb3a5387b94b9053c1e69d8abfd4dd6dae7afda65a5c5279bc1f42ab39df575"
 dependencies = [
  "adobe-cmap-parser",
  "encoding_rs",
- "euclid",
+ "euclid 0.20.14",
  "lopdf",
  "postscript",
  "type1-encoding-parser",
@@ -5349,6 +5435,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
+ "phf_macros 0.11.3",
  "phf_shared 0.11.3",
 ]
 
@@ -5367,7 +5454,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
  "serde",
 ]
@@ -5410,6 +5497,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -6076,23 +6176,134 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "973443cf09a9c8656b574a866ab68dfa19f0867d0340648c7d2f6a71b8a8ea68"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rat-event"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "b8791fc15b399e958369ce532e9bf2bc3588f364d1e508d0ae122d0fb76a3065"
+dependencies = [
+ "log",
+ "ratatui-core",
+ "ratatui-crossterm",
+]
+
+[[package]]
+name = "rat-reloc"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb74cb1c265b3a5160001211ed8becbc56ccd8b66855a6b094e097525d98b735"
+dependencies = [
+ "ratatui-core",
+]
+
+[[package]]
+name = "rat-scrolled"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704022f132ae450adce30adcba41c43503ca3d832611905e6c1e90fe8b94c0c3"
+dependencies = [
+ "log",
+ "rat-event",
+ "rat-reloc",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
 dependencies = [
  "bitflags 2.11.0",
- "cassowary",
- "compact_str 0.8.1",
- "crossterm 0.28.1",
+ "compact_str",
+ "hashbrown 0.16.1",
  "indoc",
- "instability",
- "itertools 0.13.0",
- "lru 0.12.5",
- "paste",
- "strum 0.26.3",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru",
+ "strum 0.27.2",
+ "thiserror 2.0.18",
  "unicode-segmentation",
  "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
+ "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-textarea"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f109a42d924f1fe4f4d521a1f473161f6c08eb53a2d9b862ca6efd14f6e51c"
+dependencies = [
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-widgets",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.2",
+ "time",
+ "unicode-segmentation",
  "unicode-width 0.2.0",
 ]
 
@@ -6386,7 +6597,7 @@ dependencies = [
  "mime",
  "mime_guess",
  "nanoid",
- "ordered-float",
+ "ordered-float 5.3.0",
  "pin-project-lite",
  "reqwest",
  "schemars 1.2.1",
@@ -6449,7 +6660,7 @@ source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cd
 dependencies = [
  "aho-corasick",
  "bitflags 2.11.0",
- "compact_str 0.9.0",
+ "compact_str",
  "get-size2",
  "is-macro",
  "memchr",
@@ -6467,7 +6678,7 @@ source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cd
 dependencies = [
  "bitflags 2.11.0",
  "bstr",
- "compact_str 0.9.0",
+ "compact_str",
  "get-size2",
  "memchr",
  "ruff_python_ast",
@@ -7420,15 +7631,6 @@ dependencies = [
 
 [[package]]
 name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros 0.26.4",
-]
-
-[[package]]
-name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
@@ -7443,19 +7645,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -7656,6 +7845,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf 0.11.3",
+ "phf_codegen 0.11.3",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bitflags 2.11.0",
+ "fancy-regex 0.11.0",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.29.0",
+ "num-derive",
+ "num-traits",
+ "ordered-float 4.6.0",
+ "pest",
+ "pest_derive",
+ "phf 0.11.3",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
 name = "testcontainers"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7764,7 +8016,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -8394,17 +8648,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
-name = "tui-textarea"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
-dependencies = [
- "crossterm 0.28.1",
- "ratatui",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "tungstenite"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8528,13 +8771,13 @@ checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -8648,6 +8891,7 @@ version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "atomic",
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
@@ -8688,6 +8932,15 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "walkdir"
@@ -9294,6 +9547,78 @@ name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float 4.6.0",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid 0.22.14",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
+]
 
 [[package]]
 name = "which"

--- a/crates/ironclaw_engine/prompts/codeact_postamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_postamble.md
@@ -7,7 +7,7 @@
 4. Use llm_query() to analyze or summarize large text
 5. Call FINAL() with the answer when done
 
-Think step by step. Execute code immediately — don't just describe what you would do.
+Think step by step. Prefer the lightest path that can complete the task: direct tool calls first for simple/tool-covered work, CodeAct only when you truly need multi-step orchestration.
 
 ## Error recovery
 

--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -1,8 +1,14 @@
-You are an AI assistant with a Python REPL environment. You solve tasks by writing and executing Python code.
+You are an AI assistant that can solve tasks either by calling tools directly or, when needed, by writing and executing Python code.
 
 ## How to respond
 
-Write Python code inside ```repl fenced blocks. The code will be executed, and you'll see the output. All tool calls are async — use `await` to get results.
+Choose the simplest execution path that solves the task.
+
+- If the task can be solved with one or a few direct tool calls, use the `tool_calls` mechanism directly.
+- Use Python inside ```repl fenced blocks only when you genuinely need CodeAct orchestration: multi-step workflows, loops, branching, stateful transformations, combining multiple tool results, or recovery after a direct tool path is insufficient.
+- Do not wrap a single straightforward tool lookup in Python just because CodeAct is available.
+
+When you do use Python code, put it inside ```repl fenced blocks. The code will be executed, and you'll see the output. All tool calls are async — use `await` to get results.
 
 ```repl
 result = await web_search(query="latest AI news", count=5)
@@ -49,15 +55,18 @@ This is much faster than calling tools sequentially. Use `asyncio.gather()` when
 
 ## Important rules
 
-1. ALWAYS respond with a ```repl code block. NEVER answer with plain text only. Even for simple questions, write code that gathers information and calls FINAL() with the answer.
-2. NEVER answer from memory or training data alone. Always use tools (web_search, llm_context, shell, read_file, etc.) to get real, current information before answering.
-3. When you have the final answer, call `FINAL(answer)` inside a code block. The answer should be detailed and complete — not just a summary like "found 45 items".
-4. All tool calls are async — always use `await` (e.g. `result = await web_search(...)`). For parallel calls, use `asyncio.gather()`.
-5. Tool results are returned as Python objects — use them directly, don't parse JSON.
-6. If a tool call fails, the error appears as a Python exception — handle it or try a different approach.
-7. For large data, process it in chunks using llm_query() on subsets rather than loading everything into context.
-8. Outputs are truncated to 8000 chars — use variables to store large intermediate results.
-9. Include the actual content in your FINAL() answer, not just a count or summary. Users want to see the details.
+1. Prefer direct structured tool calls for simple retrieval, lookup, or inspection tasks whenever a dedicated tool or capability already covers the job. Before using CodeAct, ask whether the task is already solvable by one or a few obvious tool calls from the available actions.
+2. Use ```repl code blocks only when the task actually benefits from CodeAct orchestration. Do not write Python that merely wraps one obvious tool call.
+3. NEVER answer from memory or training data alone. Use tools to get real, current information before answering.
+4. When you use CodeAct and have the final answer, call `FINAL(answer)` inside a code block. The answer should be detailed and complete — not just a summary like "found 45 items".
+5. All tool calls are async — always use `await` (e.g. `result = await web_search(...)`). For parallel calls, use `asyncio.gather()`.
+6. Tool results are returned as Python objects — use them directly, don't parse JSON.
+7. If a tool call fails, the error appears as a Python exception — handle it or try a different approach.
+8. For large data, process it in chunks using llm_query() on subsets rather than loading everything into context.
+9. Outputs are truncated to 8000 chars — use variables to store large intermediate results.
+10. Include the actual content in your FINAL() answer, not just a count or summary. Users want to see the details.
+
+Examples of tasks that usually should stay out of CodeAct unless they become multi-step: reading a known memory path, listing recent items, opening an issue or PR via a dedicated GitHub action, a single fetch/read/list/search call, or any other request already covered by a first-class tool.
 
 ## Runtime environment
 

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -200,9 +200,37 @@ mod tests {
     async fn prompt_without_store_uses_compiled_preamble() {
         let prompt =
             build_codeact_system_prompt(&[], None, ProjectId(uuid::Uuid::nil()), None).await;
-        assert!(prompt.contains("Python REPL environment"));
+        assert!(prompt.contains("calling tools directly or, when needed, by writing and executing Python code"));
+        assert!(prompt.contains("Choose the simplest execution path"));
         assert!(prompt.contains("Strategy"));
         assert!(!prompt.contains("Learned Rules"));
+    }
+
+    #[tokio::test]
+    async fn prompt_includes_tool_first_guidance_for_simple_tasks() {
+        let prompt = build_codeact_system_prompt(
+            &[ActionDef {
+                name: "memory_read".into(),
+                description: "Read a workspace memory file".into(),
+                parameters_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "path": { "type": "string" }
+                    }
+                }),
+                effects: vec![],
+                requires_approval: false,
+            }],
+            None,
+            ProjectId(uuid::Uuid::nil()),
+            None,
+        )
+        .await;
+
+        assert!(prompt.contains("whenever a dedicated tool or capability already covers the job"));
+        assert!(prompt.contains("already solvable by one or a few obvious tool calls from the available actions"));
+        assert!(prompt.contains("Do not write Python that merely wraps one obvious tool call"));
+        assert!(prompt.contains("already covered by a first-class tool"));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_tui/Cargo.toml
+++ b/crates/ironclaw_tui/Cargo.toml
@@ -14,8 +14,9 @@ default = ["clipboard"]
 clipboard = ["dep:arboard", "dep:image"]
 
 [dependencies]
-ratatui = { version = "0.29", features = ["crossterm"] }
-tui-textarea = { version = "0.7", features = ["crossterm"] }
+rat-scrolled = "2.0"
+ratatui = { version = "0.30", features = ["crossterm"] }
+ratatui-textarea = { version = "0.9", features = ["crossterm"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["sync", "macros", "rt", "time"] }

--- a/crates/ironclaw_tui/src/app.rs
+++ b/crates/ironclaw_tui/src/app.rs
@@ -31,8 +31,9 @@ use crate::input::{InputAction, map_key};
 use crate::layout::TuiLayout;
 use crate::widgets::approval::{ApprovalAction, ApprovalWidget};
 use crate::widgets::command_palette::CommandPaletteWidget;
-use crate::widgets::help_overlay::HelpOverlayWidget;
+use crate::widgets::conversation::ConversationWidget;
 use crate::widgets::logs::LogsWidget;
+use crate::widgets::help_overlay::HelpOverlayWidget;
 use crate::widgets::model_picker::{ModelPickerState, ModelPickerWidget};
 use crate::widgets::registry::{BuiltinWidgets, create_default_widgets};
 use crate::widgets::thread_list::engine_thread_index_at;
@@ -183,7 +184,7 @@ async fn run_tui(
                     kind: MouseEventKind::ScrollUp,
                     ..
                 }))) => {
-                    if poll_tx.send(TuiEvent::MouseScroll(-1)).await.is_err() {
+                    if poll_tx.send(TuiEvent::MouseScroll(-3)).await.is_err() {
                         break;
                     }
                 }
@@ -191,7 +192,7 @@ async fn run_tui(
                     kind: MouseEventKind::ScrollDown,
                     ..
                 }))) => {
-                    if poll_tx.send(TuiEvent::MouseScroll(1)).await.is_err() {
+                    if poll_tx.send(TuiEvent::MouseScroll(3)).await.is_err() {
                         break;
                     }
                 }
@@ -266,7 +267,31 @@ async fn run_tui(
                 let Some(event) = event else {
                     break; // Channel closed
                 };
-                handle_event(event, &mut state, &mut widgets, &msg_tx, &layout).await;
+
+                // Drain all pending events from the channel, coalescing consecutive
+                // MouseScroll events into a single net delta so that reversing scroll
+                // direction takes effect immediately instead of unwinding a backlog.
+                let mut pending = vec![event];
+                while let Ok(e) = event_rx.try_recv() {
+                    pending.push(e);
+                }
+                let mut coalesced: Vec<TuiEvent> = Vec::with_capacity(pending.len());
+                for ev in pending {
+                    if let TuiEvent::MouseScroll(delta) = &ev
+                        && let Some(TuiEvent::MouseScroll(prev)) = coalesced.last_mut()
+                    {
+                        *prev += delta;
+                        continue;
+                    }
+                    coalesced.push(ev);
+                }
+                // Drop scroll events that netted to zero
+                for ev in coalesced {
+                    if let TuiEvent::MouseScroll(0) = ev {
+                        continue;
+                    }
+                    handle_event(ev, &mut state, &mut widgets, &msg_tx, &layout).await;
+                }
             }
         }
 
@@ -433,7 +458,6 @@ async fn handle_event(
                             timestamp: chrono::Utc::now(),
                             cost_summary: None,
                         });
-                        state.scroll_offset = 0;
                         state.pinned_to_bottom = true;
                         if let Some(model) = selected_model {
                             state.model = model;
@@ -468,7 +492,7 @@ async fn handle_event(
                 InputAction::ScrollUp => match state.active_tab {
                     ActiveTab::Conversation => {
                         let page = state.conversation_height.max(2).saturating_sub(2) as i16;
-                        widgets.conversation.scroll(state, -page);
+                        ConversationWidget::scroll(state, -page);
                     }
                     ActiveTab::Logs => {
                         LogsWidget::scroll(state, -5);
@@ -477,14 +501,13 @@ async fn handle_event(
                 InputAction::ScrollDown => match state.active_tab {
                     ActiveTab::Conversation => {
                         let page = state.conversation_height.max(2).saturating_sub(2) as i16;
-                        widgets.conversation.scroll(state, page);
+                        ConversationWidget::scroll(state, page);
                     }
                     ActiveTab::Logs => {
                         LogsWidget::scroll(state, 5);
                     }
                 },
                 InputAction::ScrollToBottom => {
-                    state.scroll_offset = 0;
                     state.pinned_to_bottom = true;
                 }
                 InputAction::Interrupt => {
@@ -631,7 +654,6 @@ async fn handle_event(
                                 timestamp: chrono::Utc::now(),
                                 cost_summary: None,
                             });
-                            state.scroll_offset = 0;
                             state.pinned_to_bottom = true;
 
                             if let Some(model) = command.strip_prefix("/model ") {
@@ -685,7 +707,6 @@ async fn handle_event(
                                         timestamp: chrono::Utc::now(),
                                         cost_summary: None,
                                     });
-                                    state.scroll_offset = 0;
                                     state.pinned_to_bottom = true;
 
                                     update_local_thread_scope_after_submit(state, &command);
@@ -898,9 +919,11 @@ async fn handle_event(
         TuiEvent::MouseScroll(delta) => {
             if let Some(ref mut modal) = state.tool_detail_modal {
                 if delta < 0 {
-                    modal.scroll = modal.scroll.saturating_add(delta.unsigned_abs());
+                    // Scroll up — show earlier content (decrease Paragraph offset)
+                    modal.scroll = modal.scroll.saturating_sub(delta.unsigned_abs());
                 } else {
-                    modal.scroll = modal.scroll.saturating_sub(delta as u16);
+                    // Scroll down — show later content (increase Paragraph offset)
+                    modal.scroll = modal.scroll.saturating_add(delta as u16);
                 }
             } else if let Some(ref mut picker) = state.pending_thread_picker {
                 if delta < 0 {
@@ -922,7 +945,7 @@ async fn handle_event(
             } else if !state.help_visible {
                 match state.active_tab {
                     ActiveTab::Conversation => {
-                        widgets.conversation.scroll(state, delta);
+                        ConversationWidget::scroll(state, delta);
                     }
                     ActiveTab::Logs => {
                         LogsWidget::scroll(state, delta);
@@ -1041,8 +1064,7 @@ async fn handle_event(
                     cost_summary: None,
                 });
             }
-            state.scroll_offset = 0;
-            state.pinned_to_bottom = true;
+            // pinned_to_bottom is checked during render — no offset update needed
         }
 
         TuiEvent::Status(msg) => {
@@ -1083,8 +1105,7 @@ async fn handle_event(
                     cost_summary: None,
                 });
             }
-            state.scroll_offset = 0;
-            state.pinned_to_bottom = true;
+            // pinned_to_bottom is checked during render — no offset update needed
             state.active_tools.clear();
 
             if let Some((active_model, models)) = parsed_model_response {
@@ -1421,7 +1442,6 @@ async fn handle_event(
                 });
             }
 
-            state.scroll_offset = 0;
             state.pinned_to_bottom = true;
             state.toasts.push(Toast {
                 message: format!("Resumed conversation ({} messages)", state.messages.len()),
@@ -2144,6 +2164,8 @@ fn render_frame(
                     .conversation
                     .render(main_area, frame.buffer_mut(), state);
             }
+            // Sync max_scroll_offset from the last render for scroll clamping
+            state.max_scroll_offset = widgets.conversation.last_max_offset();
         }
     }
 
@@ -2324,9 +2346,25 @@ fn render_tool_detail_modal(
     block.render(area, frame.buffer_mut());
 
     let lines = crate::render::render_markdown(&modal.content, inner.width as usize, &theme);
+    let total_lines = lines.len();
+    let visible = inner.height as usize;
 
     let paragraph = Paragraph::new(lines).scroll((modal.scroll, 0));
     paragraph.render(inner, frame.buffer_mut());
+
+    // Render scrollbar when content exceeds viewport
+    if total_lines > visible {
+        use rat_scrolled::{Scroll, ScrollState};
+        use ratatui::widgets::StatefulWidget;
+        let mut ss = ScrollState::default();
+        ss.set_offset(modal.scroll as usize);
+        ss.set_page_len(visible);
+        ss.set_max_offset(total_lines.saturating_sub(visible));
+        Scroll::vertical()
+            .begin_symbol(None)
+            .end_symbol(None)
+            .render(inner, frame.buffer_mut(), &mut ss);
+    }
 }
 
 /// Render notification toasts in the bottom-right corner.

--- a/crates/ironclaw_tui/src/widgets/conversation.rs
+++ b/crates/ironclaw_tui/src/widgets/conversation.rs
@@ -1,12 +1,14 @@
 //! Conversation widget: renders chat messages with basic markdown.
 
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::RwLock;
 
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
-use ratatui::widgets::{Scrollbar, ScrollbarOrientation, ScrollbarState, StatefulWidget, Widget};
+use ratatui::widgets::{StatefulWidget, Widget};
+use rat_scrolled::{Scroll, ScrollState};
 
 use crate::layout::TuiSlot;
 use unicode_width::UnicodeWidthStr;
@@ -34,10 +36,6 @@ const BANNER_TAGLINE: &str = "Secure AI Assistant";
 struct ConversationRenderCache {
     usable_width: usize,
     messages: Vec<CachedRenderedMessage>,
-    /// Total content lines computed during last render (used for scroll clamping).
-    total_lines: usize,
-    /// Visible height during last render (used for scroll clamping).
-    visible_height: usize,
 }
 
 struct CachedRenderedMessage {
@@ -55,6 +53,8 @@ impl CachedRenderedMessage {
 pub struct ConversationWidget {
     theme: Theme,
     render_cache: RwLock<ConversationRenderCache>,
+    /// Last computed max scroll offset — written during render, read by scroll logic.
+    last_max_offset: AtomicUsize,
 }
 
 impl ConversationWidget {
@@ -62,7 +62,13 @@ impl ConversationWidget {
         Self {
             theme,
             render_cache: RwLock::new(ConversationRenderCache::default()),
+            last_max_offset: AtomicUsize::new(0),
         }
+    }
+
+    /// Return the last computed max scroll offset (set during render).
+    pub fn last_max_offset(&self) -> usize {
+        self.last_max_offset.load(Ordering::Relaxed)
     }
 }
 
@@ -231,22 +237,24 @@ impl TuiWidget for ConversationWidget {
                 .collect();
         }
 
-        // Compute visible window (scroll from bottom)
+        // Compute visible window
         let visible_height = area.height as usize;
         let total_lines = all_lines.len();
+        let max_offset = total_lines.saturating_sub(visible_height);
 
-        // Store for scroll clamping in scroll()
-        if let Ok(mut cache) = self.render_cache.write() {
-            cache.total_lines = total_lines;
-            cache.visible_height = visible_height;
-        }
+        // Store max_offset for scroll clamping outside render
+        self.last_max_offset.store(max_offset, Ordering::Relaxed);
 
-        // Clamp scroll offset to valid range
-        let max_scroll = total_lines.saturating_sub(visible_height);
-        let scroll = (state.scroll_offset as usize).min(max_scroll);
+        // Determine effective scroll offset from AppState
+        let offset = if state.pinned_to_bottom {
+            max_offset
+        } else {
+            state.scroll_offset.min(max_offset)
+        };
 
-        let start = total_lines.saturating_sub(visible_height + scroll);
-        let end = total_lines.saturating_sub(scroll).min(total_lines);
+        let start = offset;
+        let end = (start + visible_height).min(total_lines);
+        let lines_below = max_offset.saturating_sub(offset);
 
         let mut visible: Vec<Line<'static>> = all_lines
             .into_iter()
@@ -274,8 +282,8 @@ impl TuiWidget for ConversationWidget {
             if visible.len() > visible_height {
                 visible.pop();
             }
-        } else if scroll > 0 && start > 0 {
-            // Scroll position indicator when not at bottom
+        } else if start > 0 {
+            // Scroll position indicator when not at top
             let indicator = format!("\u{2191} {start} more ");
             let indicator_line = Line::from(vec![
                 Span::styled(
@@ -290,9 +298,9 @@ impl TuiWidget for ConversationWidget {
             }
         }
 
-        // "↓ N more" indicator at bottom when scrolled up
-        if scroll > 0 {
-            let indicator = format!("\u{2193} {scroll} more \u{2193} End to return ");
+        // "↓ N more" indicator at bottom when not at the end
+        if lines_below > 0 {
+            let indicator = format!("\u{2193} {lines_below} more \u{2193} End to return ");
             if let Some(last) = visible.last_mut() {
                 let pad_len = (area.width as usize).saturating_sub(indicator.len() + 1);
                 *last = Line::from(vec![
@@ -307,15 +315,14 @@ impl TuiWidget for ConversationWidget {
 
         // Render scrollbar when content exceeds viewport
         if total_lines > visible_height {
-            let position = total_lines.saturating_sub(visible_height + scroll);
-            let mut scrollbar_state =
-                ScrollbarState::new(total_lines.saturating_sub(visible_height)).position(position);
-            let scrollbar = Scrollbar::new(ScrollbarOrientation::VerticalRight)
+            let mut ss = ScrollState::default();
+            ss.set_offset(offset);
+            ss.set_page_len(visible_height);
+            ss.set_max_offset(max_offset);
+            Scroll::vertical()
                 .begin_symbol(None)
                 .end_symbol(None)
-                .track_symbol(Some("\u{2502}"))
-                .thumb_symbol("\u{2503}");
-            scrollbar.render(area, buf, &mut scrollbar_state);
+                .render(area, buf, &mut ss);
         }
     }
 }
@@ -870,26 +877,18 @@ impl ConversationWidget {
     }
 
     /// Handle scroll up/down with clamping and auto-follow management.
-    pub fn scroll(&self, state: &mut AppState, delta: i16) {
-        let max_scroll = {
-            let cache = match self.render_cache.read() {
-                Ok(c) => c,
-                Err(p) => p.into_inner(),
-            };
-            cache.total_lines.saturating_sub(cache.visible_height) as u16
-        };
-
+    pub fn scroll(state: &mut AppState, delta: i16) {
         if delta < 0 {
-            // Scrolling up
-            state.scroll_offset = state
-                .scroll_offset
-                .saturating_add(delta.unsigned_abs())
-                .min(max_scroll);
+            // Scrolling up (show earlier content)
+            state.scroll_offset = state.scroll_offset.saturating_sub(delta.unsigned_abs() as usize);
             state.pinned_to_bottom = false;
         } else {
-            // Scrolling down
-            state.scroll_offset = state.scroll_offset.saturating_sub(delta as u16);
-            if state.scroll_offset == 0 {
+            // Scrolling down (show later content)
+            state.scroll_offset = state
+                .scroll_offset
+                .saturating_add(delta as usize)
+                .min(state.max_scroll_offset);
+            if state.scroll_offset >= state.max_scroll_offset {
                 state.pinned_to_bottom = true;
             }
         }

--- a/crates/ironclaw_tui/src/widgets/input_box.rs
+++ b/crates/ironclaw_tui/src/widgets/input_box.rs
@@ -1,4 +1,6 @@
-//! User input area widget using tui-textarea.
+//! User input area widget using ratatui-textarea.
+
+use std::sync::Mutex;
 
 use ratatui::buffer::Buffer;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
@@ -6,7 +8,7 @@ use ratatui::layout::Rect;
 use ratatui::style::Modifier;
 use ratatui::text::{Line, Span};
 use ratatui::widgets::Widget;
-use tui_textarea::TextArea;
+use ratatui_textarea::TextArea;
 
 use crate::layout::TuiSlot;
 use crate::theme::Theme;
@@ -15,7 +17,7 @@ use super::{AppState, TuiWidget};
 
 pub struct InputBoxWidget {
     theme: Theme,
-    textarea: TextArea<'static>,
+    textarea: Mutex<TextArea<'static>>,
 }
 
 impl InputBoxWidget {
@@ -26,37 +28,39 @@ impl InputBoxWidget {
             .set_block(ratatui::widgets::Block::default().borders(ratatui::widgets::Borders::NONE));
         textarea.set_placeholder_text("Ask anything... (/ for commands, F1 for help)");
         textarea.set_placeholder_style(theme.dim_style());
-        Self { theme, textarea }
+        Self {
+            theme,
+            textarea: Mutex::new(textarea),
+        }
     }
 
     /// Get the current input text and clear the textarea.
     pub fn take_input(&mut self) -> String {
-        let lines: Vec<String> = self
-            .textarea
-            .lines()
-            .iter()
-            .map(|l| l.to_string())
-            .collect();
+        let textarea = self.textarea.get_mut().expect("textarea lock poisoned");
+        let lines: Vec<String> = textarea.lines().iter().map(|l| l.to_string()).collect();
         let text = lines.join("\n");
-        // Clear by selecting all and deleting
-        self.textarea.select_all();
-        self.textarea.cut();
+        textarea.select_all();
+        textarea.cut();
         text
     }
 
     /// Returns true if the textarea is empty.
     pub fn is_empty(&self) -> bool {
-        self.textarea.lines().iter().all(|l| l.is_empty())
+        let textarea = self.textarea.lock().expect("textarea lock poisoned");
+        textarea.lines().iter().all(|l| l.is_empty())
     }
 
     /// Peek at the current text content without consuming it.
     pub fn current_text(&self) -> String {
-        self.textarea.lines().join("\n")
+        let textarea = self.textarea.lock().expect("textarea lock poisoned");
+        textarea.lines().join("\n")
     }
 
     /// Return the current cursor position as (row, column).
     pub fn cursor(&self) -> (usize, usize) {
-        self.textarea.cursor()
+        let textarea = self.textarea.lock().expect("textarea lock poisoned");
+        let c = textarea.cursor();
+        (c.0, c.1)
     }
 
     /// Returns true when the cursor is on the first input line.
@@ -67,19 +71,22 @@ impl InputBoxWidget {
     /// Returns true when the cursor is on the last input line.
     pub fn is_cursor_on_last_line(&self) -> bool {
         let (row, _) = self.cursor();
-        row + 1 >= self.textarea.lines().len().max(1)
+        let textarea = self.textarea.lock().expect("textarea lock poisoned");
+        row + 1 >= textarea.lines().len().max(1)
     }
 
     /// Replace the current text content with `text`.
     pub fn set_text(&mut self, text: &str) {
-        self.textarea.select_all();
-        self.textarea.cut();
-        self.textarea.insert_str(text);
+        let textarea = self.textarea.get_mut().expect("textarea lock poisoned");
+        textarea.select_all();
+        textarea.cut();
+        textarea.insert_str(text);
     }
 
     /// Insert text at the current cursor position.
     pub fn insert_text(&mut self, text: &str) {
-        self.textarea.insert_str(text);
+        let textarea = self.textarea.get_mut().expect("textarea lock poisoned");
+        textarea.insert_str(text);
     }
 }
 
@@ -163,7 +170,8 @@ impl TuiWidget for InputBoxWidget {
             };
 
             prompt_widget.render(prompt_area, buf);
-            (&self.textarea).render(input_area, buf);
+            let textarea = self.textarea.lock().expect("textarea lock poisoned");
+            (&*textarea).render(input_area, buf);
         } else {
             prompt_widget.render(remaining_area, buf);
         }
@@ -177,8 +185,9 @@ impl TuiWidget for InputBoxWidget {
         if key.code == KeyCode::Esc {
             return false;
         }
-        // Let tui-textarea handle everything else
-        self.textarea.input(key);
+        // Let ratatui-textarea handle everything else
+        let textarea = self.textarea.get_mut().expect("textarea lock poisoned");
+        textarea.input(key);
         true
     }
 }

--- a/crates/ironclaw_tui/src/widgets/logs.rs
+++ b/crates/ironclaw_tui/src/widgets/logs.rs
@@ -4,7 +4,8 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::text::{Line, Span};
-use ratatui::widgets::Widget;
+use ratatui::widgets::{StatefulWidget, Widget};
+use rat_scrolled::{Scroll, ScrollState};
 
 use crate::layout::TuiSlot;
 use crate::theme::Theme;
@@ -46,9 +47,11 @@ impl LogsWidget {
     /// Handle scroll in logs view.
     pub fn scroll(state: &mut AppState, delta: i16) {
         if delta < 0 {
-            state.log_scroll = state.log_scroll.saturating_add(delta.unsigned_abs());
+            state.log_scroll = state
+                .log_scroll
+                .saturating_sub(delta.unsigned_abs() as usize);
         } else {
-            state.log_scroll = state.log_scroll.saturating_sub(delta as u16);
+            state.log_scroll = state.log_scroll.saturating_add(delta as usize);
         }
     }
 }
@@ -108,12 +111,14 @@ impl TuiWidget for LogsWidget {
             all_lines.push(line);
         }
 
-        // Compute visible window (scroll from bottom)
+        // Compute visible window
         let visible_height = area.height as usize;
         let total_lines = all_lines.len();
-        let scroll = state.log_scroll as usize;
-        let start = total_lines.saturating_sub(visible_height + scroll);
-        let end = total_lines.saturating_sub(scroll).min(total_lines);
+        let max_offset = total_lines.saturating_sub(visible_height);
+        let offset = state.log_scroll.min(max_offset);
+
+        let start = offset;
+        let end = (start + visible_height).min(total_lines);
 
         let visible: Vec<Line<'_>> = all_lines
             .into_iter()
@@ -123,6 +128,18 @@ impl TuiWidget for LogsWidget {
 
         let paragraph = ratatui::widgets::Paragraph::new(visible);
         paragraph.render(area, buf);
+
+        // Render scrollbar when content exceeds viewport
+        if total_lines > visible_height {
+            let mut ss = ScrollState::default();
+            ss.set_offset(offset);
+            ss.set_page_len(visible_height);
+            ss.set_max_offset(max_offset);
+            Scroll::vertical()
+                .begin_symbol(None)
+                .end_symbol(None)
+                .render(area, buf, &mut ss);
+        }
     }
 }
 

--- a/crates/ironclaw_tui/src/widgets/mod.rs
+++ b/crates/ironclaw_tui/src/widgets/mod.rs
@@ -61,14 +61,17 @@ pub struct AppState {
     /// Conversation messages.
     pub messages: Vec<ChatMessage>,
 
-    /// Scroll offset in the conversation (0 = bottom / most recent).
-    pub scroll_offset: u16,
-
     /// Whether the conversation auto-scrolls to follow new content.
     pub pinned_to_bottom: bool,
 
-    /// Maximum valid scroll offset (set during render).
-    pub max_scroll_offset: u16,
+    /// Conversation scroll offset (top-anchored: 0 = top of content).
+    pub scroll_offset: usize,
+
+    /// Maximum scroll offset for conversation (total_lines - visible_height).
+    pub max_scroll_offset: usize,
+
+    /// Logs scroll offset (top-anchored: 0 = top of content).
+    pub log_scroll: usize,
 
     /// Last known conversation area height in rows (set during render).
     pub conversation_height: u16,
@@ -114,9 +117,6 @@ pub struct AppState {
 
     /// Ring buffer of captured log entries.
     pub log_entries: LogRingBuffer,
-
-    /// Scroll offset in the logs view (0 = bottom / most recent).
-    pub log_scroll: u16,
 
     /// Maximum context window size in tokens for the active model.
     pub context_window: u64,
@@ -223,9 +223,10 @@ impl Default for AppState {
             total_output_tokens: 0,
             total_cost_usd: "$0.00".to_string(),
             messages: Vec::new(),
-            scroll_offset: 0,
             pinned_to_bottom: true,
+            scroll_offset: 0,
             max_scroll_offset: 0,
+            log_scroll: 0,
             conversation_height: 0,
             active_tools: Vec::new(),
             recent_tools: Vec::new(),
@@ -241,7 +242,6 @@ impl Default for AppState {
             should_quit: false,
             active_tab: ActiveTab::default(),
             log_entries: LogRingBuffer::new(500),
-            log_scroll: 0,
             context_window: 128_000,
             command_palette: CommandPaletteState::default(),
             model_picker: ModelPickerState::default(),


### PR DESCRIPTION
## Summary
- update the engine v2 CodeAct prompt to prefer the lightest execution path first, using direct structured tool calls when a dedicated action/capability already covers the task
- stop instructing the model to always answer with Python code for simple requests, while preserving CodeAct for genuinely multi-step orchestration
- add regression coverage in `crates/ironclaw_engine/src/executor/prompt.rs` so the tool-first guidance stays pinned

## Why
Engine v2 was over-triggering Tier 1 / CodeAct for simple or tool-covered asks because fresh threads were still being framed too strongly as Python-first. This PR applies the lowest-risk first step: fix the prompt contract, measure the behavior change, and only add a harder step-0 selector later if traces still show unnecessary escalation.

## Validation
- `cargo check -p ironclaw_engine`
- `cargo test -p ironclaw_engine prompt_`

## Follow-up
- if prompt-only guidance is not sufficient, implement the explicit step-0 selector proposed in #2350
