### PR TITLE
ci: add live canary regression lanes

### DIFF
--- a/.github/workflows/live-canary.yml
+++ b/.github/workflows/live-canary.yml
@@ -1,0 +1,424 @@
+name: Live LLM Canary
+
+on:
+  schedule:
+    - cron: "0 3 * * *"   # Daily public smoke + rotating persona
+    - cron: "0 5 * * 0"   # Weekly provider matrix
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: "Lane to run"
+        type: choice
+        required: true
+        default: public-smoke
+        options:
+          - all
+          - deterministic-replay
+          - public-smoke
+          - persona-rotating
+          - private-oauth
+          - provider-matrix
+          - release-public-full
+          - upgrade-canary
+      scenario:
+        description: "Optional scenario/test filter. Use auto for rotating persona."
+        type: string
+        required: false
+        default: ""
+      previous_ref:
+        description: "Previous release/tag for upgrade-canary"
+        type: string
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: live-canary-${{ github.event_name }}-${{ inputs.lane || github.event.schedule }}
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+  DATABASE_BACKEND: libsql
+  ALLOW_LOCAL_TOOLS: "true"
+  AGENT_AUTO_APPROVE_TOOLS: "true"
+  RUST_LOG: ironclaw=info
+
+jobs:
+  deterministic-replay:
+    name: Deterministic Replay
+    if: >
+      github.event_name == 'workflow_dispatch' &&
+      (inputs.lane == 'all' || inputs.lane == 'deterministic-replay')
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-deterministic-replay
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Run deterministic replay lane
+        env:
+          LANE: deterministic-replay
+          SCENARIO: ${{ inputs.scenario }}
+          PROVIDER: replay
+          COMMAND_TIMEOUT: 90m
+          LIBSQL_PATH: ${{ runner.temp }}/ironclaw-live-replay.db
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-deterministic-replay
+          path: artifacts/live-canary/
+          retention-days: 14
+
+  public-smoke:
+    name: Public Live Smoke
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'public-smoke'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      LLM_BACKEND: anthropic
+      ANTHROPIC_API_KEY: ${{ secrets.LIVE_ANTHROPIC_API_KEY }}
+      ANTHROPIC_MODEL: ${{ vars.LIVE_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-public-smoke
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Run public smoke lane
+        env:
+          LANE: public-smoke
+          SCENARIO: ${{ inputs.scenario }}
+          PROVIDER: anthropic
+          COMMAND_TIMEOUT: 90m
+          LIBSQL_PATH: ${{ runner.temp }}/ironclaw-live-public-smoke.db
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-public-smoke
+          path: artifacts/live-canary/
+          retention-days: 14
+      - name: Open failure issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "Live canary lane \`public-smoke\` failed."
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- Lane: public-smoke"
+            echo "- Provider: anthropic"
+          } > /tmp/live-canary-issue.md
+          gh issue create --repo "${REPO}" --title "Live canary failed: public-smoke" --body-file /tmp/live-canary-issue.md
+
+  persona-rotating:
+    name: Rotating Persona Live
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 3 * * *') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'persona-rotating'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      LLM_BACKEND: anthropic
+      ANTHROPIC_API_KEY: ${{ secrets.LIVE_ANTHROPIC_API_KEY }}
+      ANTHROPIC_MODEL: ${{ vars.LIVE_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-persona-rotating
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Run rotating persona lane
+        env:
+          LANE: persona-rotating
+          SCENARIO: ${{ inputs.scenario || 'auto' }}
+          PROVIDER: anthropic
+          COMMAND_TIMEOUT: 150m
+          LIBSQL_PATH: ${{ runner.temp }}/ironclaw-live-persona.db
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-persona-rotating
+          path: artifacts/live-canary/
+          retention-days: 14
+      - name: Open failure issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "Live canary lane \`persona-rotating\` failed."
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- Lane: persona-rotating"
+            echo "- Provider: anthropic"
+          } > /tmp/live-canary-issue.md
+          gh issue create --repo "${REPO}" --title "Live canary failed: persona-rotating" --body-file /tmp/live-canary-issue.md
+
+  private-oauth:
+    name: Private OAuth Live
+    if: >
+      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'private-oauth')) ||
+      (github.event_name == 'schedule' && github.event.schedule == '0 3 * * *' && vars.LIVE_CANARY_PRIVATE_OAUTH_ENABLED == 'true')
+    runs-on: [self-hosted, ironclaw-live]
+    timeout-minutes: 120
+    env:
+      LANE: private-oauth
+      PROVIDER: dedicated-runner
+      COMMAND_TIMEOUT: 60m
+      STRICT_ARTIFACT_SCRUB: "true"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Run private OAuth lane
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload summaries only
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-private-oauth-summary
+          path: |
+            artifacts/live-canary/**/summary.md
+            artifacts/live-canary/**/env-summary.txt
+            artifacts/live-canary/**/trace-fixture-status.txt
+            artifacts/live-canary/**/scrub-matches.txt
+          retention-days: 7
+      - name: Open failure issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          {
+            echo "Live canary lane \`private-oauth\` failed on the dedicated runner."
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- Lane: private-oauth"
+          } > /tmp/live-canary-issue.md
+          gh issue create --repo "${REPO}" --title "Live canary failed: private-oauth" --body-file /tmp/live-canary-issue.md
+
+  provider-matrix:
+    name: Provider Matrix (${{ matrix.provider }})
+    if: >
+      (github.event_name == 'schedule' && github.event.schedule == '0 5 * * 0') ||
+      (github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'provider-matrix'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - provider: anthropic
+            test_target: e2e_live
+            scenario: zizmor_scan
+          - provider: openai-compatible
+            test_target: e2e_live_mission
+            scenario: mission_daily_news_digest_with_followup
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-provider-${{ matrix.provider }}
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Configure Anthropic provider
+        if: matrix.provider == 'anthropic'
+        env:
+          LIVE_ANTHROPIC_API_KEY: ${{ secrets.LIVE_ANTHROPIC_API_KEY }}
+          LIVE_ANTHROPIC_MODEL: ${{ vars.LIVE_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+        run: |
+          echo "LLM_BACKEND=anthropic" >> "${GITHUB_ENV}"
+          echo "ANTHROPIC_MODEL=${LIVE_ANTHROPIC_MODEL}" >> "${GITHUB_ENV}"
+          echo "ANTHROPIC_API_KEY=${LIVE_ANTHROPIC_API_KEY}" >> "${GITHUB_ENV}"
+      - name: Configure OpenAI-compatible provider
+        if: matrix.provider == 'openai-compatible'
+        env:
+          LIVE_OPENAI_COMPATIBLE_API_KEY: ${{ secrets.LIVE_OPENAI_COMPATIBLE_API_KEY }}
+          LIVE_OPENAI_COMPATIBLE_BASE_URL: ${{ secrets.LIVE_OPENAI_COMPATIBLE_BASE_URL }}
+          LIVE_OPENAI_COMPATIBLE_MODEL: ${{ vars.LIVE_OPENAI_COMPATIBLE_MODEL }}
+        run: |
+          echo "LLM_BACKEND=openai_compatible" >> "${GITHUB_ENV}"
+          echo "LLM_API_KEY=${LIVE_OPENAI_COMPATIBLE_API_KEY}" >> "${GITHUB_ENV}"
+          echo "LLM_BASE_URL=${LIVE_OPENAI_COMPATIBLE_BASE_URL}" >> "${GITHUB_ENV}"
+          echo "LLM_MODEL=${LIVE_OPENAI_COMPATIBLE_MODEL}" >> "${GITHUB_ENV}"
+      - name: Run provider matrix lane
+        env:
+          LANE: provider-matrix
+          PROVIDER: ${{ matrix.provider }}
+          PROVIDER_TEST_TARGET: ${{ matrix.test_target }}
+          SCENARIO: ${{ inputs.scenario || matrix.scenario }}
+          COMMAND_TIMEOUT: 90m
+          LIBSQL_PATH: ${{ runner.temp }}/ironclaw-live-provider-${{ matrix.provider }}.db
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-provider-${{ matrix.provider }}
+          path: artifacts/live-canary/
+          retention-days: 14
+      - name: Open failure issue
+        if: failure() && github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PROVIDER: ${{ matrix.provider }}
+        run: |
+          {
+            echo "Live canary provider lane failed."
+            echo
+            echo "- Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            echo "- Commit: ${GITHUB_SHA}"
+            echo "- Lane: provider-matrix"
+            echo "- Provider: ${PROVIDER}"
+          } > /tmp/live-canary-issue.md
+          gh issue create --repo "${REPO}" --title "Live canary failed: provider-matrix ${PROVIDER}" --body-file /tmp/live-canary-issue.md
+
+  release-public-full:
+    name: Release Public Full Live
+    if: github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'release-public-full')
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    env:
+      LLM_BACKEND: anthropic
+      ANTHROPIC_API_KEY: ${{ secrets.LIVE_ANTHROPIC_API_KEY }}
+      ANTHROPIC_MODEL: ${{ vars.LIVE_ANTHROPIC_MODEL || 'claude-sonnet-4-6' }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-release-public-full
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Run release public full lane
+        env:
+          LANE: release-public-full
+          PROVIDER: anthropic
+          COMMAND_TIMEOUT: 300m
+          LIBSQL_PATH: ${{ runner.temp }}/ironclaw-live-release.db
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-release-public-full
+          path: artifacts/live-canary/
+          retention-days: 30
+
+  upgrade-canary:
+    name: Upgrade Canary
+    if: github.event_name == 'workflow_dispatch' && (inputs.lane == 'all' || inputs.lane == 'upgrade-canary')
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: live-canary-upgrade
+      - name: Run upgrade canary lane
+        env:
+          LANE: upgrade-canary
+          PROVIDER: upgrade
+          PREVIOUS_REF: ${{ inputs.previous_ref }}
+          CURRENT_REF: ${{ github.sha }}
+          COMMAND_TIMEOUT: 150m
+        run: scripts/live-canary/run.sh
+      - name: Scrub artifacts
+        if: always()
+        run: scripts/live-canary/scrub-artifacts.sh artifacts/live-canary
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: live-canary-upgrade
+          path: artifacts/live-canary/
+          retention-days: 30

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,36 @@ jobs:
           timeout --signal=INT --kill-after=30s 10m \
             cargo test --features integration --test telegram_auth_integration test_private_messages_use_chat_id_as_thread_scope -- --exact
 
+  llm-live-replay:
+    name: LLM Live Replay Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 70
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+          persist-credentials: false
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-wasip2
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          key: llm-live-replay
+      - name: Install cargo-component
+        run: cargo install cargo-component --locked || true
+      - name: Build WASM extensions
+        run: ./scripts/build-wasm-extensions.sh
+      - name: Replay live E2E traces
+        run: |
+          timeout --signal=INT --kill-after=30s 15m \
+            cargo test --features libsql --test e2e_live -- --ignored --nocapture --test-threads=1
+          timeout --signal=INT --kill-after=30s 15m \
+            cargo test --features libsql --test e2e_live_mission -- --ignored --nocapture --test-threads=1
+          timeout --signal=INT --kill-after=30s 20m \
+            cargo test --features libsql --test e2e_live_personas -- --ignored --nocapture --test-threads=1
+
   telegram-tests:
     name: Telegram Channel Tests
     if: >
@@ -217,7 +247,7 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     if: always()
-    needs: [tests, heavy-integration-tests, telegram-tests, wasm-wit-compat, docker-build, windows-build, version-check, bench-compile]
+    needs: [tests, heavy-integration-tests, llm-live-replay, telegram-tests, wasm-wit-compat, docker-build, windows-build, version-check, bench-compile]
     steps:
       - run: |
           # Unit tests must always pass
@@ -227,6 +257,10 @@ jobs:
           fi
           if [[ "${{ needs.heavy-integration-tests.result }}" != "success" ]]; then
             echo "Heavy integration tests failed"
+            exit 1
+          fi
+          if [[ "${{ needs.llm-live-replay.result }}" != "success" ]]; then
+            echo "LLM live replay tests failed"
             exit 1
           fi
           # Gated jobs: must pass on promotion PRs / push, skipped on developer PRs

--- a/docs/internal/live-canary.md
+++ b/docs/internal/live-canary.md
@@ -1,0 +1,172 @@
+# Live Canary Regression Lanes
+
+IronClaw has two complementary regression systems:
+
+- deterministic CI, which replays committed LLM traces without network calls;
+- live canaries, which use real LLM providers and selected real tools to catch
+  provider drift, prompt/tool orchestration drift, OAuth expiry, and release
+  upgrade problems.
+
+The implementation lives in:
+
+- `.github/workflows/test.yml` for the blocking replay lane;
+- `.github/workflows/live-canary.yml` for scheduled and manual live lanes;
+- `scripts/live-canary/run.sh` for lane dispatch;
+- `scripts/live-canary/scrub-artifacts.sh` for artifact scanning;
+- `scripts/live-canary/upgrade-canary.sh` for previous-release upgrade checks.
+
+For local commands and GitHub secret setup, see
+`scripts/live-canary/README.md`.
+
+## Lane Summary
+
+| Lane | Scope | Runner | Trigger | Blocking |
+| --- | --- | --- | --- | --- |
+| `deterministic-replay` | Replays `tests/e2e_live*.rs` fixtures without live LLM calls | GitHub-hosted | PR/staging via `test.yml`; manual via `live-canary.yml` | Yes in `test.yml` |
+| `public-smoke` | Real LLM plus public tools: `zizmor_scan` and mission digest | GitHub-hosted | Daily and manual | Opens issue on scheduled failure |
+| `persona-rotating` | Real LLM multi-turn persona workflow, one persona per day | GitHub-hosted | Daily and manual | Opens issue on scheduled failure |
+| `private-oauth` | Google Drive auth gate and transparent refresh against a dedicated test account | Self-hosted `ironclaw-live` runner | Manual; scheduled only when enabled | Opens issue on scheduled failure |
+| `provider-matrix` | Same live behavior against multiple provider adapters | GitHub-hosted | Weekly and manual | Opens issue on scheduled failure |
+| `release-public-full` | Full public live suite for release candidates | GitHub-hosted | Manual | Release checklist gate |
+| `upgrade-canary` | Previous release DB opened by current checkout | GitHub-hosted | Manual | Release checklist gate |
+
+## Required Repository Configuration
+
+Secrets:
+
+- `LIVE_ANTHROPIC_API_KEY`: API key for the default public live lanes.
+- `LIVE_OPENAI_COMPATIBLE_API_KEY`: provider-matrix key for the OpenAI-compatible lane.
+- `LIVE_OPENAI_COMPATIBLE_BASE_URL`: provider-matrix base URL, for example an OpenRouter, LiteLLM, or internal gateway URL.
+
+Variables:
+
+- `LIVE_ANTHROPIC_MODEL`: optional; defaults to `claude-sonnet-4-6`.
+- `LIVE_OPENAI_COMPATIBLE_MODEL`: required when the OpenAI-compatible provider lane is enabled.
+- `LIVE_CANARY_PRIVATE_OAUTH_ENABLED`: set to `true` only after the self-hosted runner is ready.
+
+Keep the public live keys scoped to a budget-limited account. These lanes are
+scheduled and intentionally exercise multi-turn agent behavior.
+
+## Runner Setup
+
+### GitHub-hosted public lanes
+
+No persistent state is required. The workflow sets:
+
+```bash
+DATABASE_BACKEND=libsql
+LIBSQL_PATH=${RUNNER_TEMP}/ironclaw-live-*.db
+ALLOW_LOCAL_TOOLS=true
+AGENT_AUTO_APPROVE_TOOLS=true
+IRONCLAW_LIVE_TEST=1
+```
+
+The live harness starts from a clean libSQL database. Tests that need state must
+seed it in the test body.
+
+### Self-hosted private OAuth lane
+
+Use a dedicated runner with labels:
+
+```text
+self-hosted
+ironclaw-live
+```
+
+Provision a dedicated test Google account, not a maintainer account. On that
+runner, run IronClaw once manually and complete Google Drive auth so the local
+profile has these secrets:
+
+- `google_oauth_token`
+- `google_oauth_token_refresh_token`
+- `google_oauth_token_scopes`
+
+The `private-oauth` lane calls `with_no_trace_recording()` in the underlying
+tests. Do not upload raw logs from this lane. The workflow uploads only summary
+files and runs the strict artifact scrubber before upload.
+
+## Commands
+
+Replay locally without LLM calls:
+
+```bash
+LANE=deterministic-replay scripts/live-canary/run.sh
+```
+
+Run public live smoke locally:
+
+```bash
+IRONCLAW_LIVE_TEST=1 \
+LLM_BACKEND=anthropic \
+ANTHROPIC_API_KEY=... \
+LANE=public-smoke \
+scripts/live-canary/run.sh
+```
+
+Run a specific persona:
+
+```bash
+IRONCLAW_LIVE_TEST=1 \
+LLM_BACKEND=anthropic \
+ANTHROPIC_API_KEY=... \
+LANE=persona-rotating \
+SCENARIO=developer_full_workflow \
+scripts/live-canary/run.sh
+```
+
+Run private OAuth on the dedicated runner:
+
+```bash
+LANE=private-oauth scripts/live-canary/run.sh
+```
+
+Run an upgrade canary:
+
+```bash
+LANE=upgrade-canary \
+PREVIOUS_REF=v0.1.2 \
+CURRENT_REF=HEAD \
+scripts/live-canary/run.sh
+```
+
+## Persona Rotation
+
+The rotating persona lane uses UTC day of week:
+
+| Day | Scenario |
+| --- | --- |
+| Monday | `ceo_full_workflow` |
+| Tuesday | `content_creator_full_workflow` |
+| Wednesday | `trader_full_workflow` |
+| Thursday | `developer_full_workflow` |
+| Friday | `developer_full_workflow` |
+| Saturday | `ceo_full_workflow` |
+| Sunday | `content_creator_full_workflow` |
+
+Override with `SCENARIO=<test-name>` or workflow dispatch input `scenario`.
+
+## Failure Handling
+
+Scheduled live failures create GitHub issues with the run URL and commit SHA.
+Treat these as canary findings, not automatic release blockers, until the lane
+has passed consistently for two weeks.
+
+Release candidates should manually run:
+
+1. `release-public-full`
+2. `private-oauth` on the dedicated runner
+3. `provider-matrix`
+4. `upgrade-canary`
+
+Do not override a release live gate without writing the failure mode and rollback
+risk in the release issue or PR.
+
+## Trace and Artifact Policy
+
+Live mode can update files under `tests/fixtures/llm_traces/live/`. CI does not
+commit those files. If a developer intentionally re-records traces, follow the
+PII scrub checklist in `tests/support/LIVE_TESTING.md` before committing them.
+
+Artifact uploads must come from `artifacts/live-canary/`, not from
+`tests/fixtures/llm_traces/live/`. Private OAuth lanes must not upload raw logs
+or trace files.

--- a/scripts/live-canary/README.md
+++ b/scripts/live-canary/README.md
@@ -1,0 +1,222 @@
+# Live Canary Local and GitHub Setup
+
+This directory contains the runner scripts for the live regression lanes:
+
+- `run.sh` dispatches named lanes and writes artifacts.
+- `scrub-artifacts.sh` scans artifacts before upload.
+- `upgrade-canary.sh` checks previous-release DB compatibility.
+
+Run commands from the repository root:
+
+```bash
+cd /tmp/ironclaw-live-canary
+```
+
+## Local Secrets
+
+For local live runs, put provider secrets in either your shell environment or
+`~/.ironclaw/.env`. The live harness loads `~/.ironclaw/.env`, so that is the
+cleanest option.
+
+Example `~/.ironclaw/.env` for Anthropic:
+
+```bash
+DATABASE_BACKEND=libsql
+LIBSQL_PATH=/Users/firatsertgoz/.ironclaw/ironclaw.db
+
+LLM_BACKEND=anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+ANTHROPIC_MODEL=claude-sonnet-4-6
+
+ALLOW_LOCAL_TOOLS=true
+AGENT_AUTO_APPROVE_TOOLS=true
+```
+
+You can also pass secrets inline for a one-off run:
+
+```bash
+LLM_BACKEND=anthropic \
+ANTHROPIC_API_KEY=sk-ant-... \
+ANTHROPIC_MODEL=claude-sonnet-4-6 \
+LANE=public-smoke \
+scripts/live-canary/run.sh
+```
+
+## Local Commands
+
+Replay committed live traces without LLM calls:
+
+```bash
+LANE=deterministic-replay scripts/live-canary/run.sh
+```
+
+Run the public live smoke lane:
+
+```bash
+LANE=public-smoke scripts/live-canary/run.sh
+```
+
+Run a specific persona:
+
+```bash
+LANE=persona-rotating SCENARIO=developer_full_workflow scripts/live-canary/run.sh
+```
+
+Use the UTC day-of-week persona rotation:
+
+```bash
+LANE=persona-rotating SCENARIO=auto scripts/live-canary/run.sh
+```
+
+Run the private OAuth lane:
+
+```bash
+LANE=private-oauth scripts/live-canary/run.sh
+```
+
+For private OAuth, the local `~/.ironclaw/ironclaw.db` must already contain:
+
+```text
+google_oauth_token
+google_oauth_token_refresh_token
+google_oauth_token_scopes
+```
+
+The usual setup is to run IronClaw normally once, complete Google Drive auth
+with a dedicated test Google account, and then run the canary.
+
+Run the provider matrix with Anthropic:
+
+```bash
+LLM_BACKEND=anthropic \
+ANTHROPIC_API_KEY=sk-ant-... \
+ANTHROPIC_MODEL=claude-sonnet-4-6 \
+LANE=provider-matrix \
+PROVIDER=anthropic \
+PROVIDER_TEST_TARGET=e2e_live \
+SCENARIO=zizmor_scan \
+scripts/live-canary/run.sh
+```
+
+Run the provider matrix with an OpenAI-compatible endpoint:
+
+```bash
+LLM_BACKEND=openai_compatible \
+LLM_BASE_URL=https://your-provider.example/v1 \
+LLM_API_KEY=... \
+LLM_MODEL=your-model \
+LANE=provider-matrix \
+PROVIDER=openai-compatible \
+PROVIDER_TEST_TARGET=e2e_live_mission \
+SCENARIO=mission_daily_news_digest_with_followup \
+scripts/live-canary/run.sh
+```
+
+Run with the OpenAI Codex ChatGPT-subscription backend:
+
+```bash
+# One-time interactive login. Follow the printed device-code URL.
+cargo run --features libsql -- login --openai-codex
+
+# Then run a live lane with the persisted Codex session.
+LLM_BACKEND=openai_codex \
+OPENAI_CODEX_MODEL=gpt-5.3-codex \
+LANE=public-smoke \
+PROVIDER=openai-codex \
+scripts/live-canary/run.sh
+```
+
+By default, IronClaw writes the Codex session to:
+
+```text
+~/.ironclaw/openai_codex_session.json
+```
+
+Use `OPENAI_CODEX_SESSION_PATH` when you want an isolated canary session:
+
+```bash
+LLM_BACKEND=openai_codex \
+OPENAI_CODEX_SESSION_PATH=/path/to/openai_codex_session.json \
+LANE=public-smoke \
+PROVIDER=openai-codex \
+scripts/live-canary/run.sh
+```
+
+Run an upgrade canary:
+
+```bash
+LANE=upgrade-canary \
+PREVIOUS_REF=v0.1.2 \
+CURRENT_REF=HEAD \
+scripts/live-canary/run.sh
+```
+
+Artifacts are written under:
+
+```text
+artifacts/live-canary/<lane>/<provider>/<timestamp>/
+```
+
+## GitHub Secrets and Variables
+
+Add repository secrets under:
+
+```text
+Settings -> Secrets and variables -> Actions -> Secrets
+```
+
+Required secrets:
+
+```text
+LIVE_ANTHROPIC_API_KEY
+LIVE_OPENAI_COMPATIBLE_API_KEY
+LIVE_OPENAI_COMPATIBLE_BASE_URL
+```
+
+Optional secret for an OpenAI Codex GitHub-hosted lane:
+
+```text
+LIVE_OPENAI_CODEX_SESSION_JSON
+```
+
+This should contain the full contents of `~/.ironclaw/openai_codex_session.json`
+from a dedicated test account. Prefer a self-hosted runner for this when
+possible, because the session is refreshable credential material.
+
+Use a secret for `LIVE_OPENAI_COMPATIBLE_BASE_URL` because internal provider
+URLs can expose infrastructure details.
+
+Add repository variables under:
+
+```text
+Settings -> Secrets and variables -> Actions -> Variables
+```
+
+Variables:
+
+```text
+LIVE_ANTHROPIC_MODEL=claude-sonnet-4-6
+LIVE_OPENAI_COMPATIBLE_MODEL=<your model>
+LIVE_OPENAI_CODEX_MODEL=gpt-5.3-codex
+LIVE_CANARY_PRIVATE_OAUTH_ENABLED=false
+```
+
+Set `LIVE_CANARY_PRIVATE_OAUTH_ENABLED=true` only after the self-hosted runner
+is ready.
+
+## Self-Hosted OAuth Runner
+
+The private OAuth lane requires a self-hosted runner with these labels:
+
+```text
+self-hosted
+ironclaw-live
+```
+
+That runner needs a dedicated `~/.ironclaw/.env` and `~/.ironclaw/ironclaw.db`
+with a test Google account authenticated. Do not use a maintainer's personal
+Google account.
+
+The workflow uploads only summary artifacts for this lane and runs the strict
+artifact scrubber before upload. Raw OAuth logs and trace files should not be
+uploaded.

--- a/scripts/live-canary/run.sh
+++ b/scripts/live-canary/run.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run named live-canary lanes with consistent logging and artifact layout.
+#
+# Required environment is lane-specific. Public live lanes require an LLM
+# provider configured in the environment. Private OAuth lanes must run on an
+# isolated runner with a dedicated ~/.ironclaw profile.
+
+LANE="${LANE:-${1:-public-smoke}}"
+SCENARIO="${SCENARIO:-${2:-}}"
+PROVIDER="${PROVIDER:-default}"
+COMMAND_TIMEOUT="${COMMAND_TIMEOUT:-90m}"
+ARTIFACT_ROOT="${ARTIFACT_ROOT:-artifacts/live-canary}"
+TIMESTAMP="${TIMESTAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+RUN_DIR="${RUN_DIR:-${ARTIFACT_ROOT}/${LANE}/${PROVIDER}/${TIMESTAMP}}"
+
+mkdir -p "${RUN_DIR}"
+
+LOG_FILE="${RUN_DIR}/test-output.log"
+SUMMARY_FILE="${RUN_DIR}/summary.md"
+ENV_FILE="${RUN_DIR}/env-summary.txt"
+TRACE_STATUS_FILE="${RUN_DIR}/trace-fixture-status.txt"
+
+: > "${LOG_FILE}"
+
+started_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+status=0
+
+finish() {
+  status=$?
+  record_trace_status || true
+  write_summary || true
+  log "[live-canary] summary=${SUMMARY_FILE}"
+  log "[live-canary] log=${LOG_FILE}"
+  exit "${status}"
+}
+
+log() {
+  echo "$@" | tee -a "${LOG_FILE}"
+}
+
+write_env_summary() {
+  {
+    echo "lane=${LANE}"
+    echo "scenario=${SCENARIO:-<default>}"
+    echo "provider=${PROVIDER}"
+    echo "started_at=${started_at}"
+    echo "sha=$(git rev-parse HEAD)"
+    echo "branch=$(git rev-parse --abbrev-ref HEAD)"
+    echo "rustc=$(rustc --version 2>/dev/null || true)"
+    echo "cargo=$(cargo --version 2>/dev/null || true)"
+    echo "IRONCLAW_LIVE_TEST=${IRONCLAW_LIVE_TEST:-<unset>}"
+    echo "LLM_BACKEND=${LLM_BACKEND:-<unset>}"
+    echo "LLM_MODEL=${LLM_MODEL:-<unset>}"
+    echo "ANTHROPIC_MODEL=${ANTHROPIC_MODEL:-<unset>}"
+    echo "OPENAI_MODEL=${OPENAI_MODEL:-<unset>}"
+    echo "GEMINI_MODEL=${GEMINI_MODEL:-<unset>}"
+    echo "DATABASE_BACKEND=${DATABASE_BACKEND:-<unset>}"
+    echo "LIBSQL_PATH=${LIBSQL_PATH:-<unset>}"
+  } > "${ENV_FILE}"
+}
+
+run_with_timeout() {
+  log "[live-canary] running: $*"
+  if command -v timeout >/dev/null 2>&1; then
+    timeout --signal=INT --kill-after=30s "${COMMAND_TIMEOUT}" "$@" 2>&1 | tee -a "${LOG_FILE}"
+  else
+    "$@" 2>&1 | tee -a "${LOG_FILE}"
+  fi
+  return "${PIPESTATUS[0]}"
+}
+
+run_cargo_test() {
+  local test_target="$1"
+  local filter="${2:-}"
+
+  if [[ -n "${filter}" ]]; then
+    run_with_timeout cargo test --features libsql --test "${test_target}" "${filter}" -- --ignored --nocapture --test-threads=1
+  else
+    run_with_timeout cargo test --features libsql --test "${test_target}" -- --ignored --nocapture --test-threads=1
+  fi
+}
+
+select_rotating_persona() {
+  if [[ -n "${SCENARIO}" && "${SCENARIO}" != "auto" ]]; then
+    echo "${SCENARIO}"
+    return
+  fi
+
+  case "$(date -u +%u)" in
+    1) echo "ceo_full_workflow" ;;
+    2) echo "content_creator_full_workflow" ;;
+    3) echo "trader_full_workflow" ;;
+    4) echo "developer_full_workflow" ;;
+    5) echo "developer_full_workflow" ;;
+    6) echo "ceo_full_workflow" ;;
+    *) echo "content_creator_full_workflow" ;;
+  esac
+}
+
+record_trace_status() {
+  git status --short tests/fixtures/llm_traces/live > "${TRACE_STATUS_FILE}" || true
+  if [[ -s "${TRACE_STATUS_FILE}" ]]; then
+    log "Live trace fixture changes detected:"
+    tee -a "${LOG_FILE}" < "${TRACE_STATUS_FILE}"
+  else
+    echo "No live trace fixture changes detected." > "${TRACE_STATUS_FILE}"
+  fi
+}
+
+write_summary() {
+  local finished_at
+  finished_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  {
+    echo "## Live Canary Summary"
+    echo
+    echo "| Field | Value |"
+    echo "| --- | --- |"
+    echo "| Lane | \`${LANE}\` |"
+    echo "| Scenario | \`${SCENARIO:-<default>}\` |"
+    echo "| Provider | \`${PROVIDER}\` |"
+    echo "| Status | \`${status}\` |"
+    echo "| Started | \`${started_at}\` |"
+    echo "| Finished | \`${finished_at}\` |"
+    echo "| Commit | \`$(git rev-parse HEAD)\` |"
+    echo
+    echo "Artifacts:"
+    echo "- \`${LOG_FILE}\`"
+    echo "- \`${ENV_FILE}\`"
+    echo "- \`${TRACE_STATUS_FILE}\`"
+  } > "${SUMMARY_FILE}"
+}
+
+main() {
+  write_env_summary
+
+  log "[live-canary] lane=${LANE} scenario=${SCENARIO:-<default>} provider=${PROVIDER}"
+  log "[live-canary] artifacts=${RUN_DIR}"
+
+  case "${LANE}" in
+    deterministic-replay)
+      IRONCLAW_LIVE_TEST=0 run_cargo_test e2e_live "${SCENARIO}"
+      IRONCLAW_LIVE_TEST=0 run_cargo_test e2e_live_mission ""
+      IRONCLAW_LIVE_TEST=0 run_cargo_test e2e_live_personas ""
+      ;;
+    public-smoke)
+      export IRONCLAW_LIVE_TEST=1
+      run_cargo_test e2e_live "${SCENARIO:-zizmor_scan}"
+      run_cargo_test e2e_live_mission "mission_daily_news_digest_with_followup"
+      ;;
+    persona-rotating)
+      export IRONCLAW_LIVE_TEST=1
+      selected="$(select_rotating_persona)"
+      SCENARIO="${selected}"
+      run_cargo_test e2e_live_personas "${selected}"
+      ;;
+    private-oauth)
+      export IRONCLAW_LIVE_TEST=1
+      run_cargo_test e2e_live "drive_auth_gate_roundtrip"
+      run_cargo_test e2e_live "drive_transparent_oauth_refresh"
+      ;;
+    provider-matrix)
+      export IRONCLAW_LIVE_TEST=1
+      run_cargo_test "${PROVIDER_TEST_TARGET:-e2e_live}" "${SCENARIO:-zizmor_scan}"
+      ;;
+    release-public-full)
+      export IRONCLAW_LIVE_TEST=1
+      run_cargo_test e2e_live "zizmor_scan"
+      run_cargo_test e2e_live "zizmor_scan_v2"
+      run_cargo_test e2e_live_mission ""
+      run_cargo_test e2e_live_personas ""
+      ;;
+    upgrade-canary)
+      scripts/live-canary/upgrade-canary.sh
+      ;;
+    *)
+      log "Unknown live canary lane: ${LANE}"
+      log "Known lanes: deterministic-replay, public-smoke, persona-rotating, private-oauth, provider-matrix, release-public-full, upgrade-canary"
+      return 2
+      ;;
+  esac
+}
+
+trap finish EXIT
+main

--- a/scripts/live-canary/scrub-artifacts.sh
+++ b/scripts/live-canary/scrub-artifacts.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Scan live canary artifacts before upload. This is intentionally conservative:
+# public live lanes may upload sanitized logs, while private OAuth lanes should
+# upload only summaries and should normally set STRICT_ARTIFACT_SCRUB=true.
+
+ARTIFACT_DIR="${1:-${RUN_DIR:-artifacts/live-canary}}"
+STRICT_ARTIFACT_SCRUB="${STRICT_ARTIFACT_SCRUB:-false}"
+
+if [[ ! -d "${ARTIFACT_DIR}" ]]; then
+  echo "Artifact directory does not exist: ${ARTIFACT_DIR}" >&2
+  exit 2
+fi
+
+patterns=(
+  'bearer[[:space:]]+[A-Za-z0-9._~+/=-]+'
+  'api[_-]?key[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
+  'access[_-]?token[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
+  'refresh[_-]?token[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
+  'secret[[:space:]]*[:=][[:space:]]*[^[:space:]]+'
+  'sk-[A-Za-z0-9_-]{20,}'
+  '[A-Za-z0-9_-]{48,}'
+)
+
+matches_file="${ARTIFACT_DIR}/scrub-matches.txt"
+: > "${matches_file}"
+
+while IFS= read -r -d '' file; do
+  if [[ "${file}" == "${matches_file}" ]]; then
+    continue
+  fi
+  case "${file}" in
+    *.png|*.jpg|*.jpeg|*.gif|*.webp|*.sqlite|*.db) continue ;;
+  esac
+  for pattern in "${patterns[@]}"; do
+    if grep -nIEi "${pattern}" "${file}" >> "${matches_file}" 2>/dev/null; then
+      true
+    fi
+  done
+done < <(find "${ARTIFACT_DIR}" -type f -print0)
+
+if [[ -s "${matches_file}" ]]; then
+  echo "Potential secret material found in live canary artifacts:"
+  sed -E 's/(bearer[[:space:]]+)[^[:space:]]+/\1<REDACTED>/Ig; s/(token[[:space:]]*[:=][[:space:]]*)[^[:space:]]+/\1<REDACTED>/Ig; s/(key[[:space:]]*[:=][[:space:]]*)[^[:space:]]+/\1<REDACTED>/Ig; s/(secret[[:space:]]*[:=][[:space:]]*)[^[:space:]]+/\1<REDACTED>/Ig' "${matches_file}" | head -200
+  if [[ "${STRICT_ARTIFACT_SCRUB}" == "true" ]]; then
+    exit 1
+  fi
+  echo "Continuing because STRICT_ARTIFACT_SCRUB is not true."
+else
+  echo "No obvious secret material found in ${ARTIFACT_DIR}."
+fi

--- a/scripts/live-canary/upgrade-canary.sh
+++ b/scripts/live-canary/upgrade-canary.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that a database created by the previous release can be opened and used
+# by the current checkout. This is a pre-release/manual lane, not a PR gate.
+
+PREVIOUS_REF="${PREVIOUS_REF:-}"
+CURRENT_REF="${CURRENT_REF:-HEAD}"
+WORK_ROOT="${WORK_ROOT:-${TMPDIR:-/tmp}/ironclaw-upgrade-canary}"
+PREVIOUS_DIR="${WORK_ROOT}/previous"
+CURRENT_DIR="${WORK_ROOT}/current"
+DB_PATH="${DB_PATH:-${WORK_ROOT}/upgrade-canary.db}"
+
+if [[ -z "${PREVIOUS_REF}" ]]; then
+  PREVIOUS_REF="$(git describe --tags --abbrev=0 2>/dev/null || true)"
+fi
+
+if [[ -z "${PREVIOUS_REF}" ]]; then
+  echo "PREVIOUS_REF is required when no tag can be auto-detected." >&2
+  exit 2
+fi
+
+cleanup() {
+  git worktree remove --force "${PREVIOUS_DIR}" >/dev/null 2>&1 || true
+  git worktree remove --force "${CURRENT_DIR}" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+mkdir -p "${WORK_ROOT}"
+rm -f "${DB_PATH}"
+
+echo "[upgrade-canary] previous=${PREVIOUS_REF} current=${CURRENT_REF} db=${DB_PATH}"
+
+git worktree add --detach "${PREVIOUS_DIR}" "${PREVIOUS_REF}"
+git worktree add --detach "${CURRENT_DIR}" "${CURRENT_REF}"
+
+common_env=(
+  "DATABASE_BACKEND=libsql"
+  "LIBSQL_PATH=${DB_PATH}"
+  "ONBOARD_COMPLETED=true"
+  "LLM_BACKEND=openai_compatible"
+  "LLM_BASE_URL=http://127.0.0.1:9/v1"
+  "LLM_MODEL=upgrade-canary-placeholder"
+  "LLM_API_KEY=upgrade-canary-placeholder"
+  "RUST_LOG=ironclaw=info"
+)
+
+echo "[upgrade-canary] building previous release"
+(
+  cd "${PREVIOUS_DIR}"
+  cargo build --no-default-features --features libsql
+  env "${common_env[@]}" cargo test --features libsql --test config_round_trip -- --nocapture
+)
+
+echo "[upgrade-canary] building current checkout"
+(
+  cd "${CURRENT_DIR}"
+  cargo build --no-default-features --features libsql
+  env "${common_env[@]}" cargo test --features libsql --test config_round_trip -- --nocapture
+  env "${common_env[@]}" cargo test --features libsql --test workspace_integration -- --nocapture
+)
+
+echo "[upgrade-canary] completed"

--- a/tests/support/LIVE_TESTING.md
+++ b/tests/support/LIVE_TESTING.md
@@ -6,6 +6,9 @@ under `tests/fixtures/llm_traces/live/`. The fixture lets the same test
 re-run deterministically in CI in *replay* mode without ever calling out
 to a paid LLM.
 
+For scheduled live CI lanes, runner setup, and release gating policy, see
+`docs/internal/live-canary.md`.
+
 ## Modes
 
 `LiveTestHarnessBuilder::build()` picks one of two modes based on the


### PR DESCRIPTION
## Summary
- add scheduled/manual live canary workflow lanes and replay gating
- add live-canary runner scripts, artifact scrubbing, and upgrade canary helper
- document local, GitHub, and OpenAI Codex setup for live canaries

## Notes
- Draft because this is the CI/runbook infrastructure PR and may need final review of runner/secrets policy before merge.
- Generated live trace outputs from local canary runs are intentionally not included.