### PR TITLE
fix: resolve cargo-deny failures (wildcard deps + rand advisory)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,11 +116,11 @@ jsonschema = { version = "0.45", default-features = false }
 ironclaw_common = { path = "crates/ironclaw_common", version = "0.2.0" }
 
 # Safety/sanitization
-ironclaw_engine = { path = "crates/ironclaw_engine" }
-ironclaw_gateway = { path = "crates/ironclaw_gateway" }
+ironclaw_engine = { path = "crates/ironclaw_engine", version = "0.1.0" }
+ironclaw_gateway = { path = "crates/ironclaw_gateway", version = "0.1.0" }
 ironclaw_safety = { path = "crates/ironclaw_safety", version = "0.2.1" }
 ironclaw_skills = { path = "crates/ironclaw_skills", version = "0.1.0" }
-ironclaw_tui = { path = "crates/ironclaw_tui", optional = true }
+ironclaw_tui = { path = "crates/ironclaw_tui", optional = true, version = "0.1.0" }
 regex = "1"
 aho-corasick = "1"
 

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,8 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern
+    "RUSTSEC-2026-0097",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -17,7 +17,8 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
-    # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern
+    # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
+    # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",
 ]
 


### PR DESCRIPTION
## Summary
- Add `version` constraints to `ironclaw_engine`, `ironclaw_gateway`, and `ironclaw_tui` path dependencies so cargo-deny's wildcard check passes for public crates
- Ignore RUSTSEC-2026-0097 (rand unsoundness with custom logger calling `rand::rng()` during reseed) — we don't use that pattern; transitive deps pin rand 0.8 so upgrading isn't viable yet

## Test plan
- [x] `cargo deny check` passes: `advisories ok, bans ok, licenses ok, sources ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)