### PR TITLE
fix(web): show active wasm channels correctly in settings

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -4239,7 +4239,7 @@ function renderExtensionCard(ext) {
     } else {
       var reconfigureBtn = document.createElement('button');
       reconfigureBtn.className = 'btn-ext configure';
-      reconfigureBtn.textContent = I18n.t('extensions.reconfigure');
+      reconfigureBtn.textContent = ext.authenticated ? I18n.t('ext.reconfigure') : I18n.t('ext.setup');
       reconfigureBtn.addEventListener('click', function() { showConfigureModal(ext.name); });
       actions.appendChild(reconfigureBtn);
     }
@@ -4294,6 +4294,15 @@ function renderExtensionCard(ext) {
       pairingSection.className = 'ext-pairing';
       pairingSection.setAttribute('data-channel', ext.name);
       pairingSection.__onboarding = ext.onboarding || null;
+      card.appendChild(pairingSection);
+      if (currentUserIsAdmin()) {
+        loadPairingRequests(ext.name, pairingSection, ext.onboarding || null);
+      } else {
+        renderMemberPairingClaim(ext, pairingSection, ext.onboarding || null);
+      }
+    } else if (!ext.owner_bound && ext.active) {
+      const pairingSection = document.createElement('div');
+      pairingSection.className = 'ext-pairing';
       card.appendChild(pairingSection);
       if (currentUserIsAdmin()) {
         loadPairingRequests(ext.name, pairingSection, ext.onboarding || null);

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -14,21 +14,13 @@ use crate::channels::web::types::*;
 
 /// Derive the activation status for an installed extension.
 ///
-/// `has_paired` reflects whether any sender has been paired against
-/// `channel_identities` for this WASM channel (queried from the DB-backed
-/// pairing store). `has_owner_binding` reflects whether the channel has an
-/// explicit owner_id in settings. Either is sufficient to upgrade an active
-/// channel from `Pairing` to `Active`.
-///
-/// See nearai/ironclaw#1921 for the regression that motivated plumbing
-/// `has_paired` through here instead of hardcoding it to `false`.
+/// For WASM channels, prefer runtime state over owner-binding metadata so the
+/// settings UI reflects what is actually active now.
 pub(crate) fn derive_activation_status(
     ext: &crate::extensions::InstalledExtension,
-    has_paired: bool,
-    has_owner_binding: bool,
 ) -> Option<ExtensionActivationStatus> {
     if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
-        classify_wasm_channel_activation(ext, has_paired, has_owner_binding)
+        classify_wasm_channel_activation(ext, false, false)
     } else if ext.kind == crate::extensions::ExtensionKind::ChannelRelay {
         Some(if ext.active {
             ExtensionActivationStatus::Active
@@ -57,25 +49,18 @@ pub async fn extensions_list_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let mut owner_bound_channels = std::collections::HashSet::new();
-    let mut paired_channels = std::collections::HashSet::new();
     for ext in &installed {
         if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
             if ext_mgr.has_wasm_channel_owner_binding(&ext.name).await {
                 owner_bound_channels.insert(ext.name.clone());
-            }
-            if ext_mgr.has_wasm_channel_pairing(&ext.name).await {
-                paired_channels.insert(ext.name.clone());
             }
         }
     }
     let extensions = installed
         .into_iter()
         .map(|ext| {
-            let activation_status = derive_activation_status(
-                &ext,
-                paired_channels.contains(&ext.name),
-                owner_bound_channels.contains(&ext.name),
-            );
+            let owner_bound = owner_bound_channels.contains(&ext.name);
+            let activation_status = derive_activation_status(&ext);
             ExtensionInfo {
                 name: ext.name,
                 display_name: ext.display_name,
@@ -84,6 +69,7 @@ pub async fn extensions_list_handler(
                 url: ext.url,
                 authenticated: ext.authenticated,
                 active: ext.active,
+                owner_bound,
                 tools: ext.tools,
                 needs_setup: ext.needs_setup,
                 has_auth: ext.has_auth,
@@ -188,48 +174,12 @@ mod tests {
         }
     }
 
-    /// Full truth table for an active+authenticated WASM channel.
-    ///
-    /// Either `has_paired` or `has_owner_binding` is sufficient to upgrade
-    /// from `Pairing` to `Active`. Pinning the four-cell matrix here means a
-    /// regression that drops one axis (the bug shape behind nearai/ironclaw#1921)
-    /// trips at least two cells, not zero.
     #[test]
-    fn derive_activation_status_truth_table_for_active_wasm_channel() {
-        let ext = active_authenticated_wasm_channel("discord");
-        let cases = [
-            (false, false, ExtensionActivationStatus::Pairing),
-            (false, true, ExtensionActivationStatus::Active),
-            (true, false, ExtensionActivationStatus::Active),
-            (true, true, ExtensionActivationStatus::Active),
-        ];
-        for (has_paired, has_owner_binding, expected) in cases {
-            let actual = derive_activation_status(&ext, has_paired, has_owner_binding);
-            assert_eq!(
-                actual,
-                Some(expected),
-                "derive_activation_status(has_paired={has_paired}, \
-                 has_owner_binding={has_owner_binding}) should be {:?}",
-                expected
-            );
-        }
-    }
-
-    /// Regression for nearai/ironclaw#1921 — caller-level coverage.
-    ///
-    /// Before this fix the wrapper hardcoded the underlying classifier's
-    /// `has_paired` axis to `false`, so a paired-but-not-owner-bound
-    /// channel was misreported as `Pairing`. This test pins the case
-    /// that would silently regress if a future refactor drops the
-    /// `has_paired` argument.
-    #[test]
-    fn paired_wasm_channel_without_owner_binding_is_active() {
+    fn active_authenticated_wasm_channel_without_owner_binding_is_active() {
         let ext = active_authenticated_wasm_channel("discord");
         assert_eq!(
-            derive_activation_status(&ext, true, false),
-            Some(ExtensionActivationStatus::Active),
-            "a WASM channel with paired senders must report Active even when \
-             no owner binding is set (nearai/ironclaw#1921)"
+            derive_activation_status(&ext),
+            Some(ExtensionActivationStatus::Active)
         );
     }
 }

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -50,10 +50,10 @@ pub async fn extensions_list_handler(
 
     let mut owner_bound_channels = std::collections::HashSet::new();
     for ext in &installed {
-        if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
-            if ext_mgr.has_wasm_channel_owner_binding(&ext.name).await {
-                owner_bound_channels.insert(ext.name.clone());
-            }
+        if ext.kind == crate::extensions::ExtensionKind::WasmChannel
+            && ext_mgr.has_wasm_channel_owner_binding(&ext.name).await
+        {
+            owner_bound_channels.insert(ext.name.clone());
         }
     }
     let extensions = installed

--- a/src/channels/web/handlers/extensions.rs
+++ b/src/channels/web/handlers/extensions.rs
@@ -12,28 +12,6 @@ use crate::channels::web::auth::AuthenticatedUser;
 use crate::channels::web::server::GatewayState;
 use crate::channels::web::types::*;
 
-/// Derive the activation status for an installed extension.
-///
-/// For WASM channels, prefer runtime state over owner-binding metadata so the
-/// settings UI reflects what is actually active now.
-pub(crate) fn derive_activation_status(
-    ext: &crate::extensions::InstalledExtension,
-) -> Option<ExtensionActivationStatus> {
-    if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
-        classify_wasm_channel_activation(ext, false, false)
-    } else if ext.kind == crate::extensions::ExtensionKind::ChannelRelay {
-        Some(if ext.active {
-            ExtensionActivationStatus::Active
-        } else if ext.authenticated {
-            ExtensionActivationStatus::Configured
-        } else {
-            ExtensionActivationStatus::Installed
-        })
-    } else {
-        None
-    }
-}
-
 pub async fn extensions_list_handler(
     State(state): State<Arc<GatewayState>>,
     AuthenticatedUser(user): AuthenticatedUser,
@@ -60,25 +38,7 @@ pub async fn extensions_list_handler(
         .into_iter()
         .map(|ext| {
             let owner_bound = owner_bound_channels.contains(&ext.name);
-            let activation_status = derive_activation_status(&ext);
-            ExtensionInfo {
-                name: ext.name,
-                display_name: ext.display_name,
-                kind: ext.kind.to_string(),
-                description: ext.description,
-                url: ext.url,
-                authenticated: ext.authenticated,
-                active: ext.active,
-                owner_bound,
-                tools: ext.tools,
-                needs_setup: ext.needs_setup,
-                has_auth: ext.has_auth,
-                activation_status,
-                activation_error: ext.activation_error,
-                version: ext.version,
-                onboarding_state: None,
-                onboarding: None,
-            }
+            crate::channels::web::types::extension_info_from_installed(ext, owner_bound)
         })
         .collect();
 
@@ -152,8 +112,7 @@ pub async fn extensions_remove_handler(
 
 #[cfg(test)]
 mod tests {
-    use super::derive_activation_status;
-    use crate::channels::web::types::ExtensionActivationStatus;
+    use crate::channels::web::types::{ExtensionActivationStatus, extension_activation_status};
     use crate::extensions::{ExtensionKind, InstalledExtension};
 
     fn active_authenticated_wasm_channel(name: &str) -> InstalledExtension {
@@ -178,7 +137,7 @@ mod tests {
     fn active_authenticated_wasm_channel_without_owner_binding_is_active() {
         let ext = active_authenticated_wasm_channel("discord");
         assert_eq!(
-            derive_activation_status(&ext),
+            extension_activation_status(&ext),
             Some(ExtensionActivationStatus::Active)
         );
     }

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3089,10 +3089,10 @@ async fn extensions_list_handler(
 
     let mut owner_bound_channels = std::collections::HashSet::new();
     for ext in &installed {
-        if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
-            if ext_mgr.has_wasm_channel_owner_binding(&ext.name).await {
-                owner_bound_channels.insert(ext.name.clone());
-            }
+        if ext.kind == crate::extensions::ExtensionKind::WasmChannel
+            && ext_mgr.has_wasm_channel_owner_binding(&ext.name).await
+        {
+            owner_bound_channels.insert(ext.name.clone());
         }
     }
     let extensions = installed

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3099,26 +3099,7 @@ async fn extensions_list_handler(
         .into_iter()
         .map(|ext| {
             let owner_bound = owner_bound_channels.contains(&ext.name);
-            let activation_status =
-                crate::channels::web::handlers::extensions::derive_activation_status(&ext);
-            ExtensionInfo {
-                name: ext.name,
-                display_name: ext.display_name,
-                kind: ext.kind.to_string(),
-                description: ext.description,
-                url: ext.url,
-                authenticated: ext.authenticated,
-                active: ext.active,
-                owner_bound,
-                tools: ext.tools,
-                needs_setup: ext.needs_setup,
-                has_auth: ext.has_auth,
-                activation_status,
-                activation_error: ext.activation_error,
-                version: ext.version,
-                onboarding_state: None,
-                onboarding: None,
-            }
+            crate::channels::web::types::extension_info_from_installed(ext, owner_bound)
         })
         .collect();
 
@@ -3944,7 +3925,7 @@ mod tests {
             version: None,
         };
 
-        let owner_bound = classify_wasm_channel_activation(&ext, false, true);
+        let owner_bound = classify_wasm_channel_activation(&ext);
         if owner_bound != Some(ExtensionActivationStatus::Active) {
             return Err(format!(
                 "owner-bound channel should be active, got {:?}",
@@ -3952,7 +3933,7 @@ mod tests {
             ));
         }
 
-        let unbound = classify_wasm_channel_activation(&ext, false, false);
+        let unbound = classify_wasm_channel_activation(&ext);
         if unbound != Some(ExtensionActivationStatus::Active) {
             return Err(format!(
                 "active authenticated channel should still be active, got {:?}",
@@ -3982,7 +3963,7 @@ mod tests {
         };
 
         let status = if relay.kind == crate::extensions::ExtensionKind::WasmChannel {
-            classify_wasm_channel_activation(&relay, false, false)
+            classify_wasm_channel_activation(&relay)
         } else if relay.kind == crate::extensions::ExtensionKind::ChannelRelay {
             Some(if relay.active {
                 ExtensionActivationStatus::Active

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3088,26 +3088,19 @@ async fn extensions_list_handler(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let mut owner_bound_channels = std::collections::HashSet::new();
-    let mut paired_channels = std::collections::HashSet::new();
     for ext in &installed {
         if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
             if ext_mgr.has_wasm_channel_owner_binding(&ext.name).await {
                 owner_bound_channels.insert(ext.name.clone());
-            }
-            if ext_mgr.has_wasm_channel_pairing(&ext.name).await {
-                paired_channels.insert(ext.name.clone());
             }
         }
     }
     let extensions = installed
         .into_iter()
         .map(|ext| {
+            let owner_bound = owner_bound_channels.contains(&ext.name);
             let activation_status =
-                crate::channels::web::handlers::extensions::derive_activation_status(
-                    &ext,
-                    paired_channels.contains(&ext.name),
-                    owner_bound_channels.contains(&ext.name),
-                );
+                crate::channels::web::handlers::extensions::derive_activation_status(&ext);
             ExtensionInfo {
                 name: ext.name,
                 display_name: ext.display_name,
@@ -3116,6 +3109,7 @@ async fn extensions_list_handler(
                 url: ext.url,
                 authenticated: ext.authenticated,
                 active: ext.active,
+                owner_bound,
                 tools: ext.tools,
                 needs_setup: ext.needs_setup,
                 has_auth: ext.has_auth,
@@ -3959,9 +3953,9 @@ mod tests {
         }
 
         let unbound = classify_wasm_channel_activation(&ext, false, false);
-        if unbound != Some(ExtensionActivationStatus::Pairing) {
+        if unbound != Some(ExtensionActivationStatus::Active) {
             return Err(format!(
-                "unbound channel should be pairing, got {:?}",
+                "active authenticated channel should still be active, got {:?}",
                 unbound
             ));
         }

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -371,8 +371,6 @@ pub struct ChannelOnboardingInfo {
 
 pub fn classify_wasm_channel_activation(
     ext: &crate::extensions::InstalledExtension,
-    _has_paired: bool,
-    _has_owner_binding: bool,
 ) -> Option<ExtensionActivationStatus> {
     if ext.kind != crate::extensions::ExtensionKind::WasmChannel {
         return None;
@@ -387,6 +385,47 @@ pub fn classify_wasm_channel_activation(
     } else {
         ExtensionActivationStatus::Configured
     })
+}
+
+pub fn extension_activation_status(
+    ext: &crate::extensions::InstalledExtension,
+) -> Option<ExtensionActivationStatus> {
+    match ext.kind {
+        crate::extensions::ExtensionKind::WasmChannel => classify_wasm_channel_activation(ext),
+        crate::extensions::ExtensionKind::ChannelRelay => Some(if ext.active {
+            ExtensionActivationStatus::Active
+        } else if ext.authenticated {
+            ExtensionActivationStatus::Configured
+        } else {
+            ExtensionActivationStatus::Installed
+        }),
+        _ => None,
+    }
+}
+
+pub fn extension_info_from_installed(
+    ext: crate::extensions::InstalledExtension,
+    owner_bound: bool,
+) -> ExtensionInfo {
+    let activation_status = extension_activation_status(&ext);
+    ExtensionInfo {
+        name: ext.name,
+        display_name: ext.display_name,
+        kind: ext.kind.to_string(),
+        description: ext.description,
+        url: ext.url,
+        authenticated: ext.authenticated,
+        active: ext.active,
+        owner_bound,
+        tools: ext.tools,
+        needs_setup: ext.needs_setup,
+        has_auth: ext.has_auth,
+        activation_status,
+        activation_error: ext.activation_error,
+        version: ext.version,
+        onboarding_state: None,
+        onboarding: None,
+    }
 }
 
 #[derive(Debug, Serialize)]

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -371,8 +371,8 @@ pub struct ChannelOnboardingInfo {
 
 pub fn classify_wasm_channel_activation(
     ext: &crate::extensions::InstalledExtension,
-    has_paired: bool,
-    has_owner_binding: bool,
+    _has_paired: bool,
+    _has_owner_binding: bool,
 ) -> Option<ExtensionActivationStatus> {
     if ext.kind != crate::extensions::ExtensionKind::WasmChannel {
         return None;
@@ -383,11 +383,7 @@ pub fn classify_wasm_channel_activation(
     } else if !ext.authenticated {
         ExtensionActivationStatus::Installed
     } else if ext.active {
-        if has_paired || has_owner_binding {
-            ExtensionActivationStatus::Active
-        } else {
-            ExtensionActivationStatus::Pairing
-        }
+        ExtensionActivationStatus::Active
     } else {
         ExtensionActivationStatus::Configured
     })
@@ -404,6 +400,9 @@ pub struct ExtensionInfo {
     pub url: Option<String>,
     pub authenticated: bool,
     pub active: bool,
+    /// Whether the channel has an explicit owner binding for the current user.
+    #[serde(default)]
+    pub owner_bound: bool,
     pub tools: Vec<String>,
     /// Whether this extension has configurable secrets (setup schema).
     #[serde(default)]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -9811,11 +9811,10 @@ mod tests {
 
     /// Regression for nearai/ironclaw#1921 — caller-level coverage.
     ///
-    /// The web extensions list handler used to derive
-    /// `activation_status` from `derive_activation_status(ext, has_owner_binding)`,
-    /// silently dropping the underlying classifier's `has_paired` axis. A
-    /// helper-level unit test on `derive_activation_status` could not catch
-    /// the bug because the wrapper hardcoded the dropped argument to `false`.
+    /// The web extensions list handler used to derive `activation_status`
+    /// from runtime state plus owner-binding metadata. A helper-level unit test
+    /// on `derive_activation_status` could not catch the bug because the wrapper
+    /// previously hardcoded the dropped pairing axis to `false`.
     ///
     /// This test goes through the real caller path:
     ///   ExtensionManager::has_wasm_channel_pairing

--- a/tools-src/TOOLS.md
+++ b/tools-src/TOOLS.md
@@ -9,7 +9,7 @@ All Google tools share `google_oauth_token` for authentication.
 - [x] Google Sheets - create spreadsheets, read/write/append values, manage sheets, format cells
 - [x] Google Docs - create, read, edit documents; text formatting, paragraphs, tables, lists
 - [x] Google Slides - create, read, edit presentations; shapes, images, text formatting, thumbnails, templates
-- [ ] GWS Bridge - opt-in stdio MCP fallback around a local `gws` binary for users blocked on IC-native Google OAuth
+- [x] GWS Bridge - opt-in stdio MCP fallback around a local `gws` binary for users blocked on IC-native Google OAuth
 - [ ] Google Cloud - work with cloud instances, storage, allow to spin up and configure new instances, shut them down
 
 # Instant messengers

--- a/tools-src/TOOLS.md
+++ b/tools-src/TOOLS.md
@@ -9,6 +9,7 @@ All Google tools share `google_oauth_token` for authentication.
 - [x] Google Sheets - create spreadsheets, read/write/append values, manage sheets, format cells
 - [x] Google Docs - create, read, edit documents; text formatting, paragraphs, tables, lists
 - [x] Google Slides - create, read, edit presentations; shapes, images, text formatting, thumbnails, templates
+- [ ] GWS Bridge - opt-in stdio MCP fallback around a local `gws` binary for users blocked on IC-native Google OAuth
 - [ ] Google Cloud - work with cloud instances, storage, allow to spin up and configure new instances, shut them down
 
 # Instant messengers

--- a/tools-src/gws-bridge/Cargo.toml
+++ b/tools-src/gws-bridge/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "gws-bridge"
+version = "0.1.0"
+edition = "2021"
+description = "Standalone MCP stdio bridge around a local gws binary"
+license = "MIT OR Apache-2.0"
+publish = false
+
+[dependencies]
+anyhow = "1"
+regex = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "process", "rt-multi-thread", "io-std", "io-util", "time"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+predicates = "3"
+
+[workspace]

--- a/tools-src/gws-bridge/README.md
+++ b/tools-src/gws-bridge/README.md
@@ -1,0 +1,52 @@
+# GWS MCP Bridge
+
+This is a standalone MCP stdio server that wraps a local `gws` binary.
+It is meant as an opt-in fallback for users who cannot complete the IC-native
+Google OAuth flow.
+
+## What it does
+
+- Exposes a single MCP tool: `gws_bridge`
+- Allows only a strict read-only allowlist of commands in phase 1
+- Redacts common secret/token patterns from output
+- Requires an explicit opt-in environment variable
+
+## Build
+
+```bash
+cargo build --release
+```
+
+## Run
+
+```bash
+GWS_BRIDGE_ENABLED=true \
+GWS_BINARY_PATH=/path/to/gws \
+cargo run --release
+```
+
+If `GWS_BINARY_PATH` is omitted, the server looks for `gws` in `PATH`.
+
+## Register in IronClaw
+
+Use the MCP stdio transport:
+
+```bash
+ironclaw mcp add gws-bridge \
+  --transport stdio \
+  --command /absolute/path/to/gws-bridge \
+  --env GWS_BRIDGE_ENABLED=true \
+  --env GWS_BINARY_PATH=/absolute/path/to/gws
+```
+
+## Allowed phase-1 commands
+
+- `auth status`
+- `gmail list`
+- `gmail users messages list`
+- `calendar events list`
+- `calendar users events list`
+- `drive files`
+- `drive files list`
+
+Anything else is rejected.

--- a/tools-src/gws-bridge/README.md
+++ b/tools-src/gws-bridge/README.md
@@ -10,6 +10,7 @@ Google OAuth flow.
 - Allows only a strict read-only allowlist of commands in phase 1
 - Redacts common secret/token patterns from output
 - Requires an explicit opt-in environment variable
+- Inherits only `PATH` and `HOME` for the wrapped `gws` process
 
 ## Build
 
@@ -26,6 +27,7 @@ cargo run --release
 ```
 
 If `GWS_BINARY_PATH` is omitted, the server looks for `gws` in `PATH`.
+The bridge does not forward arbitrary `GWS_*` variables to the child process.
 
 ## Register in IronClaw
 
@@ -46,7 +48,6 @@ ironclaw mcp add gws-bridge \
 - `gmail users messages list`
 - `calendar events list`
 - `calendar users events list`
-- `drive files`
 - `drive files list`
 
 Anything else is rejected.

--- a/tools-src/gws-bridge/src/lib.rs
+++ b/tools-src/gws-bridge/src/lib.rs
@@ -1,0 +1,547 @@
+use std::process::Stdio;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::Command;
+
+const PROTOCOL_VERSION: &str = "2024-11-05";
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_OUTPUT_SIZE: usize = 64 * 1024;
+
+const AUTH_STATUS_COMMAND: [&str; 2] = ["auth", "status"];
+const GMAIL_READ_COMMANDS: [&[&str]; 2] =
+    [&["gmail", "list"], &["gmail", "users", "messages", "list"]];
+const CALENDAR_READ_COMMANDS: [&[&str]; 2] = [
+    &["calendar", "events", "list"],
+    &["calendar", "users", "events", "list"],
+];
+const DRIVE_READ_COMMANDS: [&[&str]; 2] = [&["drive", "files"], &["drive", "files", "list"]];
+
+static BEARER_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| compile_regex(r"(?i)(bearer\s+)([a-zA-Z0-9_\-\.]{20,})"));
+static OAUTH_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| compile_regex(r#"(?i)(token[=\'":\s]+)([a-zA-Z0-9_\-\.]{20,})"#));
+static YA29_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| compile_regex(r"(ya29\.[a-zA-Z0-9_\-\.]+)"));
+static AKIA_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| compile_regex(r"(?i)(AKIA[0-9A-Z]{16})"));
+static SK_RE: LazyLock<Option<Regex>> =
+    LazyLock::new(|| compile_regex(r"(?i)(sk-[a-zA-Z0-9]{32,})"));
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    jsonrpc: String,
+    #[serde(default)]
+    id: Option<serde_json::Value>,
+    method: String,
+    #[serde(default)]
+    params: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcResponse {
+    jsonrpc: &'static str,
+    id: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<JsonRpcError>,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolDefinition {
+    name: &'static str,
+    description: &'static str,
+    #[serde(rename = "inputSchema")]
+    input_schema: serde_json::Value,
+    annotations: ToolAnnotations,
+}
+
+#[derive(Debug, Default, Serialize)]
+struct ToolAnnotations {
+    #[serde(rename = "readOnlyHint")]
+    read_only_hint: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct InitializeResult {
+    #[serde(rename = "protocolVersion")]
+    protocol_version: &'static str,
+    capabilities: ServerCapabilities,
+    #[serde(rename = "serverInfo")]
+    server_info: ServerInfo,
+    instructions: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerCapabilities {
+    tools: ToolsCapability,
+}
+
+#[derive(Debug, Serialize)]
+struct ToolsCapability {
+    #[serde(rename = "listChanged")]
+    list_changed: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ServerInfo {
+    name: &'static str,
+    version: &'static str,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallArguments {
+    args: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ToolCallRequest {
+    name: String,
+    #[serde(default)]
+    arguments: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+struct CallToolResult {
+    content: Vec<ContentBlock>,
+    #[serde(rename = "isError")]
+    is_error: bool,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type")]
+enum ContentBlock {
+    #[serde(rename = "text")]
+    Text { text: String },
+}
+
+pub async fn run() -> anyhow::Result<()> {
+    let stdin = tokio::io::stdin();
+    let stdout = tokio::io::stdout();
+    let mut reader = BufReader::new(stdin).lines();
+    let mut writer = stdout;
+
+    while let Some(line) = reader.next_line().await? {
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let response = handle_line(&line).await;
+        if let Some(response) = response {
+            let text = serde_json::to_string(&response)?;
+            writer.write_all(text.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_line(line: &str) -> Option<JsonRpcResponse> {
+    let parsed: serde_json::Value = match serde_json::from_str(line) {
+        Ok(v) => v,
+        Err(_) => {
+            return Some(jsonrpc_error(
+                serde_json::Value::Null,
+                -32700,
+                "Parse error".to_string(),
+            ));
+        }
+    };
+
+    let request: JsonRpcRequest = match serde_json::from_value(parsed.clone()) {
+        Ok(req) => req,
+        Err(_) => {
+            return Some(jsonrpc_error(
+                parsed.get("id").cloned().unwrap_or(serde_json::Value::Null),
+                -32600,
+                "Invalid Request".to_string(),
+            ));
+        }
+    };
+
+    handle_request(request).await
+}
+
+async fn handle_request(request: JsonRpcRequest) -> Option<JsonRpcResponse> {
+    if request.jsonrpc != "2.0" {
+        return Some(jsonrpc_error(
+            request.id.unwrap_or(serde_json::Value::Null),
+            -32600,
+            "Invalid Request".to_string(),
+        ));
+    }
+
+    let id = request.id.unwrap_or(serde_json::Value::Null);
+
+    match request.method.as_str() {
+        "initialize" => Some(jsonrpc_ok(
+            id,
+            serde_json::to_value(InitializeResult {
+                protocol_version: PROTOCOL_VERSION,
+                capabilities: ServerCapabilities {
+                    tools: ToolsCapability {
+                        list_changed: false,
+                    },
+                },
+                server_info: ServerInfo {
+                    name: "gws-bridge",
+                    version: env!("CARGO_PKG_VERSION"),
+                },
+                instructions: "Standalone fallback bridge around a local gws binary. Enable with GWS_BRIDGE_ENABLED=true and configure GWS_BINARY_PATH if needed.",
+            })
+            .expect("initialize result serializes"),
+        )),
+        "notifications/initialized" => None,
+        "tools/list" => Some(jsonrpc_ok(
+            id,
+            serde_json::json!({
+                "tools": [tool_definition()]
+            }),
+        )),
+        "tools/call" => {
+            let params = request.params.unwrap_or(serde_json::Value::Null);
+            match serde_json::from_value::<ToolCallRequest>(params) {
+                Ok(tool_call) => Some(call_tool_response(id, tool_call).await),
+                Err(e) => Some(tool_error(
+                    id,
+                    format!("Invalid tool arguments: {}", e),
+                )),
+            }
+        }
+        _ => Some(jsonrpc_error(
+            id,
+            -32601,
+            format!("Method not found: {}", request.method),
+        )),
+    }
+}
+
+async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> JsonRpcResponse {
+    if request.name != "gws_bridge" {
+        return tool_error(id, format!("Unknown tool: {}", request.name));
+    }
+
+    let args: ToolCallArguments = match serde_json::from_value(request.arguments) {
+        Ok(args) => args,
+        Err(e) => {
+            return tool_error(id, format!("Invalid tool arguments: {}", e));
+        }
+    };
+
+    if !bridge_enabled_from_env(std::env::var("GWS_BRIDGE_ENABLED").ok().as_deref()) {
+        return tool_error(
+            id,
+            "gws_bridge is disabled. Set GWS_BRIDGE_ENABLED=true to enable it.".to_string(),
+        );
+    }
+
+    if let Err(reason) = check_allowlist(&args.args) {
+        return tool_error(id, format!("Command blocked by allowlist: {}", reason));
+    }
+
+    let bin_path = std::env::var("GWS_BINARY_PATH").unwrap_or_else(|_| "gws".to_string());
+    if bin_path.is_empty() {
+        return tool_error(
+            id,
+            "GWS_BINARY_PATH is empty. Set it to a valid path or leave it unset to use gws from PATH.".to_string(),
+        );
+    }
+
+    let mut command = Command::new(&bin_path);
+    command
+        .args(&args.args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = match command.spawn() {
+        Ok(child) => child,
+        Err(e) => {
+            return tool_error(id, format!("Failed to spawn {}: {}", bin_path, e));
+        }
+    };
+
+    let stdout_handle = child.stdout.take();
+    let stderr_handle = child.stderr.take();
+
+    let result = tokio::time::timeout(DEFAULT_TIMEOUT, async {
+        let stdout_fut = async {
+            if let Some(mut out) = stdout_handle {
+                let mut buf = Vec::new();
+                let _ = (&mut out)
+                    .take(MAX_OUTPUT_SIZE as u64)
+                    .read_to_end(&mut buf)
+                    .await;
+                String::from_utf8_lossy(&buf).to_string()
+            } else {
+                String::new()
+            }
+        };
+
+        let stderr_fut = async {
+            if let Some(mut err) = stderr_handle {
+                let mut buf = Vec::new();
+                let _ = (&mut err)
+                    .take(MAX_OUTPUT_SIZE as u64)
+                    .read_to_end(&mut buf)
+                    .await;
+                String::from_utf8_lossy(&buf).to_string()
+            } else {
+                String::new()
+            }
+        };
+
+        let (stdout, stderr, wait_result) = tokio::join!(stdout_fut, stderr_fut, child.wait());
+        let status = wait_result.map_err(|e| format!("Wait error: {}", e))?;
+        Ok::<_, String>((stdout, stderr, status.code().unwrap_or(-1)))
+    })
+    .await;
+
+    match result {
+        Ok(Ok((stdout, stderr, code))) => {
+            let mut combined = if stderr.is_empty() {
+                stdout
+            } else if stdout.is_empty() {
+                stderr
+            } else {
+                format!("{}\n\n--- stderr ---\n{}", stdout, stderr)
+            };
+
+            if combined.len() > MAX_OUTPUT_SIZE {
+                let half = MAX_OUTPUT_SIZE / 2;
+                let head_end = floor_char_boundary(&combined, half);
+                let tail_start =
+                    floor_char_boundary(&combined, combined.len().saturating_sub(half));
+                combined = format!(
+                    "{}\n\n... [truncated {} bytes] ...\n\n{}",
+                    &combined[..head_end],
+                    combined.len() - MAX_OUTPUT_SIZE,
+                    &combined[tail_start..]
+                );
+            }
+
+            let redacted = redact_secrets(&combined);
+            jsonrpc_ok(
+                id,
+                serde_json::json!({
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": redacted
+                        }
+                    ],
+                    "isError": code != 0,
+                    "exit_code": code,
+                    "success": code == 0
+                }),
+            )
+        }
+        Ok(Err(e)) => tool_error(id, format!("Execution error: {}", e)),
+        Err(_) => {
+            let _ = child.kill().await;
+            tool_error(id, format!("Timed out after {:?}", DEFAULT_TIMEOUT))
+        }
+    }
+}
+
+fn tool_definition() -> ToolDefinition {
+    ToolDefinition {
+        name: "gws_bridge",
+        description: "Optional fallback pathway wrapping a local gws binary to interact with Google Workspace. Only read-only operations are permitted.",
+        input_schema: serde_json::json!({
+            "type": "object",
+            "properties": {
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Arguments to pass to the gws binary (for example [\"gmail\", \"users\", \"messages\", \"list\"])."
+                }
+            },
+            "required": ["args"]
+        }),
+        annotations: ToolAnnotations {
+            read_only_hint: true,
+        },
+    }
+}
+
+fn jsonrpc_ok(id: serde_json::Value, result: serde_json::Value) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(result),
+        error: None,
+    }
+}
+
+fn jsonrpc_error(id: serde_json::Value, code: i32, message: String) -> JsonRpcResponse {
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: None,
+        error: Some(JsonRpcError { code, message }),
+    }
+}
+
+fn tool_error(id: serde_json::Value, message: String) -> JsonRpcResponse {
+    jsonrpc_ok(
+        id,
+        serde_json::to_value(CallToolResult {
+            content: vec![ContentBlock::Text { text: message }],
+            is_error: true,
+        })
+        .expect("tool error result serializes"),
+    )
+}
+
+fn compile_regex(pattern: &str) -> Option<Regex> {
+    Regex::new(pattern).ok()
+}
+
+fn bridge_enabled_from_env(value: Option<&str>) -> bool {
+    matches!(
+        value.unwrap_or_default().to_lowercase().as_str(),
+        "true" | "1" | "yes" | "on"
+    )
+}
+
+fn check_allowlist(args: &[String]) -> Result<(), &'static str> {
+    if args.is_empty() {
+        return Err("No command provided");
+    }
+
+    match args[0].as_str() {
+        "auth" => {
+            if matches_exact_command(args, &AUTH_STATUS_COMMAND) {
+                Ok(())
+            } else {
+                Err("Only 'auth status' is permitted for auth commands")
+            }
+        }
+        "gmail" => {
+            if matches_exact_any_command(args, &GMAIL_READ_COMMANDS) {
+                Ok(())
+            } else {
+                Err("Only explicit read-only Gmail tuples are permitted in phase 1")
+            }
+        }
+        "calendar" => {
+            if matches_exact_any_command(args, &CALENDAR_READ_COMMANDS) {
+                Ok(())
+            } else {
+                Err("Only explicit read-only Calendar tuples are permitted in phase 1")
+            }
+        }
+        "drive" => {
+            if matches_exact_any_command(args, &DRIVE_READ_COMMANDS) {
+                Ok(())
+            } else {
+                Err("Only explicit read-only Drive tuples are permitted in phase 1")
+            }
+        }
+        _ => Err(
+            "Command not in the strict phase 1 allowlist (only auth status, gmail read, calendar read, drive read allowed)",
+        ),
+    }
+}
+
+fn matches_exact_command(args: &[String], allowed: &[&str]) -> bool {
+    args.len() == allowed.len()
+        && args
+            .iter()
+            .zip(allowed.iter())
+            .all(|(arg, allowed)| arg == allowed)
+}
+
+fn matches_exact_any_command(args: &[String], allowed: &[&[&str]]) -> bool {
+    allowed
+        .iter()
+        .any(|allowed| matches_exact_command(args, allowed))
+}
+
+fn redact_secrets(input: &str) -> String {
+    let mut result = input.to_string();
+    if let Some(re) = BEARER_RE.as_ref() {
+        result = re.replace_all(&result, "${1}[REDACTED]").to_string();
+    }
+    if let Some(re) = OAUTH_RE.as_ref() {
+        result = re.replace_all(&result, "${1}[REDACTED]").to_string();
+    }
+    if let Some(re) = YA29_RE.as_ref() {
+        result = re
+            .replace_all(&result, "[REDACTED_OAUTH_TOKEN]")
+            .to_string();
+    }
+    if let Some(re) = AKIA_RE.as_ref() {
+        result = re.replace_all(&result, "[REDACTED_AWS_KEY]").to_string();
+    }
+    if let Some(re) = SK_RE.as_ref() {
+        result = re.replace_all(&result, "[REDACTED_SECRET_KEY]").to_string();
+    }
+    result
+}
+
+fn floor_char_boundary(s: &str, idx: usize) -> usize {
+    let mut idx = idx.min(s.len());
+    while idx > 0 && !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    idx
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn allowlist_accepts_read_only_tuples() {
+        assert!(check_allowlist(&["auth".into(), "status".into()]).is_ok());
+        assert!(check_allowlist(&["gmail".into(), "list".into()]).is_ok());
+        assert!(check_allowlist(&[
+            "gmail".into(),
+            "users".into(),
+            "messages".into(),
+            "list".into()
+        ])
+        .is_ok());
+        assert!(check_allowlist(&["calendar".into(), "events".into(), "list".into()]).is_ok());
+        assert!(check_allowlist(&["drive".into(), "files".into(), "list".into()]).is_ok());
+    }
+
+    #[test]
+    fn allowlist_blocks_mutating_commands() {
+        assert!(check_allowlist(&["gmail".into(), "send".into()]).is_err());
+        assert!(check_allowlist(&["calendar".into(), "delete".into()]).is_err());
+        assert!(check_allowlist(&["drive".into(), "upload".into()]).is_err());
+    }
+
+    #[test]
+    fn redact_secrets_masks_known_formats() {
+        let redacted = redact_secrets(
+            "Bearer abcdefghijklmnopqrstuvwxyz123456\nya29.abcd1234\nAKIA1234567890ABCDEF\nsk-abcdefghijklmnopqrstuvwxyz1234567890",
+        );
+        assert!(!redacted.contains("abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!redacted.contains("ya29.abcd1234"));
+        assert!(!redacted.contains("AKIA1234567890ABCDEF"));
+        assert!(!redacted.contains("sk-abcdefghijklmnopqrstuvwxyz1234567890"));
+    }
+
+    #[test]
+    fn floor_char_boundary_handles_mid_codepoint_indices() {
+        let s = "héllo";
+        let idx = floor_char_boundary(s, 2);
+        assert!(s.is_char_boundary(idx));
+    }
+}

--- a/tools-src/gws-bridge/src/lib.rs
+++ b/tools-src/gws-bridge/src/lib.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::ffi::OsString;
 use std::process::Stdio;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -11,6 +12,8 @@ use tokio::process::Command;
 const PROTOCOL_VERSION: &str = "2024-11-05";
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_OUTPUT_SIZE: usize = 64 * 1024;
+const MAX_JSON_RPC_LINE_SIZE: usize = 1024 * 1024;
+const MAX_STREAM_OUTPUT_SIZE: usize = MAX_OUTPUT_SIZE / 2;
 
 const AUTH_STATUS_COMMAND: [&str; 2] = ["auth", "status"];
 const GMAIL_READ_COMMANDS: [&[&str]; 2] =
@@ -19,18 +22,19 @@ const CALENDAR_READ_COMMANDS: [&[&str]; 2] = [
     &["calendar", "events", "list"],
     &["calendar", "users", "events", "list"],
 ];
-const DRIVE_READ_COMMANDS: [&[&str]; 2] = [&["drive", "files"], &["drive", "files", "list"]];
+const DRIVE_READ_COMMANDS: [&[&str]; 1] = [&["drive", "files", "list"]];
 
-static BEARER_RE: LazyLock<Option<Regex>> =
+static BEARER_RE: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(r"(?i)(bearer\s+)([a-zA-Z0-9_\-\.]{20,})"));
-static OAUTH_RE: LazyLock<Option<Regex>> =
+static OAUTH_RE: LazyLock<Regex> =
     LazyLock::new(|| compile_regex(r#"(?i)(token[=\'":\s]+)([a-zA-Z0-9_\-\.]{20,})"#));
-static YA29_RE: LazyLock<Option<Regex>> =
-    LazyLock::new(|| compile_regex(r"(ya29\.[a-zA-Z0-9_\-\.]+)"));
-static AKIA_RE: LazyLock<Option<Regex>> =
-    LazyLock::new(|| compile_regex(r"(?i)(AKIA[0-9A-Z]{16})"));
-static SK_RE: LazyLock<Option<Regex>> =
-    LazyLock::new(|| compile_regex(r"(?i)(sk-[a-zA-Z0-9]{32,})"));
+static YA29_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(ya29\.[a-zA-Z0-9_\-\.]+)"));
+static AKIA_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?i)(AKIA[0-9A-Z]{16})"));
+static SK_RE: LazyLock<Regex> = LazyLock::new(|| compile_regex(r"(?i)(sk-[a-zA-Z0-9]{32,})"));
+static GOOGLE_REFRESH_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"(1//[0-9A-Za-z_\-]{20,})"));
+static GOOGLE_API_KEY_RE: LazyLock<Regex> =
+    LazyLock::new(|| compile_regex(r"(AIza[0-9A-Za-z_\-]{20,})"));
 
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
@@ -129,10 +133,32 @@ enum ContentBlock {
 pub async fn run() -> anyhow::Result<()> {
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-    let mut reader = BufReader::new(stdin).lines();
+    let mut reader = BufReader::new(stdin);
     let mut writer = stdout;
+    let mut line = String::new();
 
-    while let Some(line) = reader.next_line().await? {
+    loop {
+        line.clear();
+        let bytes_read = reader.read_line(&mut line).await?;
+        if bytes_read == 0 {
+            break;
+        }
+        if line.len() > MAX_JSON_RPC_LINE_SIZE {
+            let response = jsonrpc_error(
+                serde_json::Value::Null,
+                -32600,
+                format!(
+                    "Request too large: {} bytes exceeds limit of {} bytes",
+                    line.len(),
+                    MAX_JSON_RPC_LINE_SIZE
+                ),
+            );
+            let text = serde_json::to_string(&response)?;
+            writer.write_all(text.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+            continue;
+        }
         if line.trim().is_empty() {
             continue;
         }
@@ -235,6 +261,14 @@ async fn handle_request(request: JsonRpcRequest) -> Option<JsonRpcResponse> {
 }
 
 async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> JsonRpcResponse {
+    call_tool_response_with_env(id, request, &BridgeEnv::capture()).await
+}
+
+async fn call_tool_response_with_env(
+    id: serde_json::Value,
+    request: ToolCallRequest,
+    env: &BridgeEnv,
+) -> JsonRpcResponse {
     if request.name != "gws_bridge" {
         return tool_error(id, format!("Unknown tool: {}", request.name));
     }
@@ -246,7 +280,7 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
         }
     };
 
-    if !bridge_enabled_from_env(std::env::var("GWS_BRIDGE_ENABLED").ok().as_deref()) {
+    if !env.bridge_enabled {
         return tool_error(
             id,
             "gws_bridge is disabled. Set GWS_BRIDGE_ENABLED=true to enable it.".to_string(),
@@ -257,7 +291,7 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
         return tool_error(id, format!("Command blocked by allowlist: {}", reason));
     }
 
-    let bin_path = std::env::var("GWS_BINARY_PATH").unwrap_or_else(|_| "gws".to_string());
+    let bin_path = env.binary_path.clone();
     if bin_path.is_empty() {
         return tool_error(
             id,
@@ -267,19 +301,14 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
 
     let mut command = Command::new(&bin_path);
     command.env_clear();
-    if let Some(path) = std::env::var_os("PATH") {
+    if let Some(path) = env.path.clone() {
         command.env("PATH", path);
     }
-    if let Some(home) = std::env::var_os("HOME") {
+    if let Some(home) = env.home.clone() {
         command.env("HOME", home);
     }
-    for (key, value) in std::env::vars_os() {
-        if key.to_string_lossy().starts_with("GWS_")
-            && key != "GWS_BRIDGE_ENABLED"
-            && key != "GWS_BINARY_PATH"
-        {
-            command.env(key, value);
-        }
+    for (key, value) in &env.forwarded_gws_env {
+        command.env(key, value);
     }
     command
         .args(&args.args)
@@ -302,7 +331,7 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
             if let Some(mut out) = stdout_handle {
                 let mut buf = Vec::new();
                 if let Err(e) = (&mut out)
-                    .take(MAX_OUTPUT_SIZE as u64)
+                    .take(MAX_STREAM_OUTPUT_SIZE as u64)
                     .read_to_end(&mut buf)
                     .await
                 {
@@ -318,7 +347,7 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
             if let Some(mut err) = stderr_handle {
                 let mut buf = Vec::new();
                 if let Err(e) = (&mut err)
-                    .take(MAX_OUTPUT_SIZE as u64)
+                    .take(MAX_STREAM_OUTPUT_SIZE as u64)
                     .read_to_end(&mut buf)
                     .await
                 {
@@ -366,18 +395,17 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
                     "content": [
                         {
                             "type": "text",
-                            "text": redacted
+                            "text": format!("exit_code: {}\nsuccess: {}\n\n{}", code, code == 0, redacted)
                         }
                     ],
-                    "isError": code != 0,
-                    "exit_code": code,
-                    "success": code == 0
+                    "isError": code != 0
                 }),
             )
         }
         Ok(Err(e)) => tool_error(id, format!("Execution error: {}", e)),
         Err(_) => {
             let _ = child.kill().await;
+            let _ = child.wait().await;
             tool_error(id, format!("Timed out after {:?}", DEFAULT_TIMEOUT))
         }
     }
@@ -436,8 +464,8 @@ fn tool_error(id: serde_json::Value, message: String) -> JsonRpcResponse {
     }
 }
 
-fn compile_regex(pattern: &str) -> Option<Regex> {
-    Regex::new(pattern).ok()
+fn compile_regex(pattern: &str) -> Regex {
+    Regex::new(pattern).expect("static redaction regex must compile")
 }
 
 fn bridge_enabled_from_env(value: Option<&str>) -> bool {
@@ -482,7 +510,7 @@ fn check_allowlist(args: &[String]) -> Result<(), &'static str> {
             }
         }
         _ => Err(
-            "Command not in the strict phase 1 allowlist (only auth status, gmail read, calendar read, drive read allowed)",
+            "Command not in the strict phase 1 allowlist (only auth status, gmail read, calendar read, drive files list allowed)",
         ),
     }
 }
@@ -503,24 +531,25 @@ fn matches_exact_any_command(args: &[String], allowed: &[&[&str]]) -> bool {
 
 fn redact_secrets(input: &str) -> String {
     let mut result: Cow<'_, str> = Cow::Borrowed(input);
-    result = redact_secret_pattern(result, BEARER_RE.as_ref(), "${1}[REDACTED]");
-    result = redact_secret_pattern(result, OAUTH_RE.as_ref(), "${1}[REDACTED]");
-    result = redact_secret_pattern(result, YA29_RE.as_ref(), "[REDACTED_OAUTH_TOKEN]");
-    result = redact_secret_pattern(result, AKIA_RE.as_ref(), "[REDACTED_AWS_KEY]");
-    result = redact_secret_pattern(result, SK_RE.as_ref(), "[REDACTED_SECRET_KEY]");
+    result = redact_secret_pattern(result, &BEARER_RE, "${1}[REDACTED]");
+    result = redact_secret_pattern(result, &OAUTH_RE, "${1}[REDACTED]");
+    result = redact_secret_pattern(result, &YA29_RE, "[REDACTED_OAUTH_TOKEN]");
+    result = redact_secret_pattern(result, &AKIA_RE, "[REDACTED_AWS_KEY]");
+    result = redact_secret_pattern(result, &SK_RE, "[REDACTED_SECRET_KEY]");
+    result = redact_secret_pattern(
+        result,
+        &GOOGLE_REFRESH_RE,
+        "[REDACTED_GOOGLE_REFRESH_TOKEN]",
+    );
+    result = redact_secret_pattern(result, &GOOGLE_API_KEY_RE, "[REDACTED_GOOGLE_API_KEY]");
     result.into_owned()
 }
 
-fn redact_secret_pattern<'a>(
-    input: Cow<'a, str>,
-    re: Option<&Regex>,
-    replacement: &str,
-) -> Cow<'a, str> {
-    match re {
-        Some(re) if re.is_match(input.as_ref()) => {
-            Cow::Owned(re.replace_all(input.as_ref(), replacement).into_owned())
-        }
-        _ => input,
+fn redact_secret_pattern<'a>(input: Cow<'a, str>, re: &Regex, replacement: &str) -> Cow<'a, str> {
+    if re.is_match(input.as_ref()) {
+        Cow::Owned(re.replace_all(input.as_ref(), replacement).into_owned())
+    } else {
+        input
     }
 }
 
@@ -530,6 +559,29 @@ fn floor_char_boundary(s: &str, idx: usize) -> usize {
         idx -= 1;
     }
     idx
+}
+
+#[derive(Debug, Clone)]
+struct BridgeEnv {
+    bridge_enabled: bool,
+    binary_path: String,
+    path: Option<OsString>,
+    home: Option<OsString>,
+    forwarded_gws_env: Vec<(OsString, OsString)>,
+}
+
+impl BridgeEnv {
+    fn capture() -> Self {
+        Self {
+            bridge_enabled: bridge_enabled_from_env(
+                std::env::var("GWS_BRIDGE_ENABLED").ok().as_deref(),
+            ),
+            binary_path: std::env::var("GWS_BINARY_PATH").unwrap_or_else(|_| "gws".to_string()),
+            path: std::env::var_os("PATH"),
+            home: std::env::var_os("HOME"),
+            forwarded_gws_env: Vec::new(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -571,17 +623,20 @@ mod tests {
         assert!(check_allowlist(&["gmail".into(), "send".into()]).is_err());
         assert!(check_allowlist(&["calendar".into(), "delete".into()]).is_err());
         assert!(check_allowlist(&["drive".into(), "upload".into()]).is_err());
+        assert!(check_allowlist(&["drive".into(), "files".into()]).is_err());
     }
 
     #[test]
     fn redact_secrets_masks_known_formats() {
         let redacted = redact_secrets(
-            "Bearer abcdefghijklmnopqrstuvwxyz123456\nya29.abcd1234\nAKIA1234567890ABCDEF\nsk-abcdefghijklmnopqrstuvwxyz1234567890",
+            "Bearer abcdefghijklmnopqrstuvwxyz123456\nya29.abcd1234\nAKIA1234567890ABCDEF\nsk-abcdefghijklmnopqrstuvwxyz1234567890\n1//abcdefghijklmnopqrstuvwxyz123456\nAIzaabcdefghijklmnopqrstuvwxyz123456",
         );
         assert!(!redacted.contains("abcdefghijklmnopqrstuvwxyz123456"));
         assert!(!redacted.contains("ya29.abcd1234"));
         assert!(!redacted.contains("AKIA1234567890ABCDEF"));
         assert!(!redacted.contains("sk-abcdefghijklmnopqrstuvwxyz1234567890"));
+        assert!(!redacted.contains("1//abcdefghijklmnopqrstuvwxyz123456"));
+        assert!(!redacted.contains("AIzaabcdefghijklmnopqrstuvwxyz123456"));
     }
 
     #[test]
@@ -617,12 +672,7 @@ mod tests {
         perms.set_mode(0o755);
         fs::set_permissions(&script_path, perms).expect("chmod script");
 
-        std::env::set_var("GWS_BRIDGE_ENABLED", "true");
-        std::env::set_var("GWS_BINARY_PATH", &script_path);
-        std::env::set_var("GWS_CUSTOM_TEST_VAR", "kept");
-        std::env::set_var("SECRET_TOKEN_TEST_VAR", "should_not_leak");
-
-        let response = call_tool_response(
+        let response = call_tool_response_with_env(
             serde_json::Value::Null,
             ToolCallRequest {
                 name: "gws_bridge".to_string(),
@@ -630,18 +680,26 @@ mod tests {
                     "args": ["auth", "status"]
                 }),
             },
+            &BridgeEnv {
+                bridge_enabled: true,
+                binary_path: script_path.to_string_lossy().to_string(),
+                path: std::env::var_os("PATH"),
+                home: std::env::var_os("HOME"),
+                forwarded_gws_env: Vec::new(),
+            },
         )
         .await;
 
         let response_text = serde_json::to_string(&response).expect("serialize response");
-        assert!(response_text.contains("\"success\":true"));
+        assert!(response_text.contains("success: true"));
+        assert!(response_text.contains("exit_code: 0"));
 
         let env_dump = fs::read_to_string(&env_dump_path).expect("read env dump");
         assert!(env_dump.contains("HOME="));
         assert!(env_dump.contains("PATH="));
-        assert!(env_dump.contains("GWS_CUSTOM_TEST_VAR=kept"));
         assert!(!env_dump.contains("GWS_BRIDGE_ENABLED="));
         assert!(!env_dump.contains("GWS_BINARY_PATH="));
+        assert!(!env_dump.contains("GWS_CUSTOM_TEST_VAR="));
         assert!(!env_dump.contains("SECRET_TOKEN_TEST_VAR=should_not_leak"));
     }
 }

--- a/tools-src/gws-bridge/src/lib.rs
+++ b/tools-src/gws-bridge/src/lib.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::process::Stdio;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -183,26 +184,30 @@ async fn handle_request(request: JsonRpcRequest) -> Option<JsonRpcResponse> {
         ));
     }
 
+    let is_notification = request.id.is_none();
     let id = request.id.unwrap_or(serde_json::Value::Null);
 
     match request.method.as_str() {
-        "initialize" => Some(jsonrpc_ok(
-            id,
-            serde_json::to_value(InitializeResult {
-                protocol_version: PROTOCOL_VERSION,
-                capabilities: ServerCapabilities {
-                    tools: ToolsCapability {
-                        list_changed: false,
-                    },
+        "initialize" => match serde_json::to_value(InitializeResult {
+            protocol_version: PROTOCOL_VERSION,
+            capabilities: ServerCapabilities {
+                tools: ToolsCapability {
+                    list_changed: false,
                 },
-                server_info: ServerInfo {
-                    name: "gws-bridge",
-                    version: env!("CARGO_PKG_VERSION"),
-                },
-                instructions: "Standalone fallback bridge around a local gws binary. Enable with GWS_BRIDGE_ENABLED=true and configure GWS_BINARY_PATH if needed.",
-            })
-            .expect("initialize result serializes"),
-        )),
+            },
+            server_info: ServerInfo {
+                name: "gws-bridge",
+                version: env!("CARGO_PKG_VERSION"),
+            },
+            instructions: "Standalone fallback bridge around a local gws binary. Enable with GWS_BRIDGE_ENABLED=true and configure GWS_BINARY_PATH if needed.",
+        }) {
+            Ok(result) => Some(jsonrpc_ok(id, result)),
+            Err(e) => Some(jsonrpc_error(
+                id,
+                -32603,
+                format!("Failed to serialize initialize result: {}", e),
+            )),
+        },
         "notifications/initialized" => None,
         "tools/list" => Some(jsonrpc_ok(
             id,
@@ -220,6 +225,7 @@ async fn handle_request(request: JsonRpcRequest) -> Option<JsonRpcResponse> {
                 )),
             }
         }
+        _ if is_notification => None,
         _ => Some(jsonrpc_error(
             id,
             -32601,
@@ -260,6 +266,21 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
     }
 
     let mut command = Command::new(&bin_path);
+    command.env_clear();
+    if let Some(path) = std::env::var_os("PATH") {
+        command.env("PATH", path);
+    }
+    if let Some(home) = std::env::var_os("HOME") {
+        command.env("HOME", home);
+    }
+    for (key, value) in std::env::vars_os() {
+        if key.to_string_lossy().starts_with("GWS_")
+            && key != "GWS_BRIDGE_ENABLED"
+            && key != "GWS_BINARY_PATH"
+        {
+            command.env(key, value);
+        }
+    }
     command
         .args(&args.args)
         .stdin(Stdio::null())
@@ -280,10 +301,13 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
         let stdout_fut = async {
             if let Some(mut out) = stdout_handle {
                 let mut buf = Vec::new();
-                let _ = (&mut out)
+                if let Err(e) = (&mut out)
                     .take(MAX_OUTPUT_SIZE as u64)
                     .read_to_end(&mut buf)
-                    .await;
+                    .await
+                {
+                    eprintln!("Failed to read stdout from gws bridge child: {}", e);
+                }
                 String::from_utf8_lossy(&buf).to_string()
             } else {
                 String::new()
@@ -293,10 +317,13 @@ async fn call_tool_response(id: serde_json::Value, request: ToolCallRequest) -> 
         let stderr_fut = async {
             if let Some(mut err) = stderr_handle {
                 let mut buf = Vec::new();
-                let _ = (&mut err)
+                if let Err(e) = (&mut err)
                     .take(MAX_OUTPUT_SIZE as u64)
                     .read_to_end(&mut buf)
-                    .await;
+                    .await
+                {
+                    eprintln!("Failed to read stderr from gws bridge child: {}", e);
+                }
                 String::from_utf8_lossy(&buf).to_string()
             } else {
                 String::new()
@@ -396,14 +423,17 @@ fn jsonrpc_error(id: serde_json::Value, code: i32, message: String) -> JsonRpcRe
 }
 
 fn tool_error(id: serde_json::Value, message: String) -> JsonRpcResponse {
-    jsonrpc_ok(
-        id,
-        serde_json::to_value(CallToolResult {
-            content: vec![ContentBlock::Text { text: message }],
-            is_error: true,
-        })
-        .expect("tool error result serializes"),
-    )
+    match serde_json::to_value(CallToolResult {
+        content: vec![ContentBlock::Text { text: message }],
+        is_error: true,
+    }) {
+        Ok(result) => jsonrpc_ok(id, result),
+        Err(e) => jsonrpc_error(
+            id,
+            -32603,
+            format!("Failed to serialize tool error response: {}", e),
+        ),
+    }
 }
 
 fn compile_regex(pattern: &str) -> Option<Regex> {
@@ -472,25 +502,26 @@ fn matches_exact_any_command(args: &[String], allowed: &[&[&str]]) -> bool {
 }
 
 fn redact_secrets(input: &str) -> String {
-    let mut result = input.to_string();
-    if let Some(re) = BEARER_RE.as_ref() {
-        result = re.replace_all(&result, "${1}[REDACTED]").to_string();
+    let mut result: Cow<'_, str> = Cow::Borrowed(input);
+    result = redact_secret_pattern(result, BEARER_RE.as_ref(), "${1}[REDACTED]");
+    result = redact_secret_pattern(result, OAUTH_RE.as_ref(), "${1}[REDACTED]");
+    result = redact_secret_pattern(result, YA29_RE.as_ref(), "[REDACTED_OAUTH_TOKEN]");
+    result = redact_secret_pattern(result, AKIA_RE.as_ref(), "[REDACTED_AWS_KEY]");
+    result = redact_secret_pattern(result, SK_RE.as_ref(), "[REDACTED_SECRET_KEY]");
+    result.into_owned()
+}
+
+fn redact_secret_pattern<'a>(
+    input: Cow<'a, str>,
+    re: Option<&Regex>,
+    replacement: &str,
+) -> Cow<'a, str> {
+    match re {
+        Some(re) if re.is_match(input.as_ref()) => {
+            Cow::Owned(re.replace_all(input.as_ref(), replacement).into_owned())
+        }
+        _ => input,
     }
-    if let Some(re) = OAUTH_RE.as_ref() {
-        result = re.replace_all(&result, "${1}[REDACTED]").to_string();
-    }
-    if let Some(re) = YA29_RE.as_ref() {
-        result = re
-            .replace_all(&result, "[REDACTED_OAUTH_TOKEN]")
-            .to_string();
-    }
-    if let Some(re) = AKIA_RE.as_ref() {
-        result = re.replace_all(&result, "[REDACTED_AWS_KEY]").to_string();
-    }
-    if let Some(re) = SK_RE.as_ref() {
-        result = re.replace_all(&result, "[REDACTED_SECRET_KEY]").to_string();
-    }
-    result
 }
 
 fn floor_char_boundary(s: &str, idx: usize) -> usize {
@@ -504,6 +535,21 @@ fn floor_char_boundary(s: &str, idx: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::io::Write;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir() -> PathBuf {
+        let mut path = std::env::temp_dir();
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or_default();
+        path.push(format!("gws-bridge-test-{}-{}", std::process::id(), stamp));
+        path
+    }
 
     #[test]
     fn allowlist_accepts_read_only_tuples() {
@@ -543,5 +589,59 @@ mod tests {
         let s = "héllo";
         let idx = floor_char_boundary(s, 2);
         assert!(s.is_char_boundary(idx));
+    }
+
+    #[tokio::test]
+    async fn unknown_notification_is_ignored() {
+        let response = handle_line(r#"{"jsonrpc":"2.0","method":"something/unknown"}"#).await;
+        assert!(response.is_none());
+    }
+
+    #[tokio::test]
+    async fn child_process_environment_is_explicitly_scoped() {
+        let temp_dir = unique_temp_dir();
+        fs::create_dir_all(&temp_dir).expect("create temp dir");
+        let script_path = temp_dir.join("dump_env.sh");
+        let env_dump_path = temp_dir.join("env.txt");
+
+        let mut script = fs::File::create(&script_path).expect("create script");
+        writeln!(
+            script,
+            "#!/bin/sh\nprintenv | sort > \"{}\"\n",
+            env_dump_path.display()
+        )
+        .expect("write script");
+        let mut perms = fs::metadata(&script_path)
+            .expect("stat script")
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod script");
+
+        std::env::set_var("GWS_BRIDGE_ENABLED", "true");
+        std::env::set_var("GWS_BINARY_PATH", &script_path);
+        std::env::set_var("GWS_CUSTOM_TEST_VAR", "kept");
+        std::env::set_var("SECRET_TOKEN_TEST_VAR", "should_not_leak");
+
+        let response = call_tool_response(
+            serde_json::Value::Null,
+            ToolCallRequest {
+                name: "gws_bridge".to_string(),
+                arguments: serde_json::json!({
+                    "args": ["auth", "status"]
+                }),
+            },
+        )
+        .await;
+
+        let response_text = serde_json::to_string(&response).expect("serialize response");
+        assert!(response_text.contains("\"success\":true"));
+
+        let env_dump = fs::read_to_string(&env_dump_path).expect("read env dump");
+        assert!(env_dump.contains("HOME="));
+        assert!(env_dump.contains("PATH="));
+        assert!(env_dump.contains("GWS_CUSTOM_TEST_VAR=kept"));
+        assert!(!env_dump.contains("GWS_BRIDGE_ENABLED="));
+        assert!(!env_dump.contains("GWS_BINARY_PATH="));
+        assert!(!env_dump.contains("SECRET_TOKEN_TEST_VAR=should_not_leak"));
     }
 }

--- a/tools-src/gws-bridge/src/lib.rs
+++ b/tools-src/gws-bridge/src/lib.rs
@@ -135,44 +135,95 @@ pub async fn run() -> anyhow::Result<()> {
     let stdout = tokio::io::stdout();
     let mut reader = BufReader::new(stdin);
     let mut writer = stdout;
-    let mut line = String::new();
 
     loop {
-        line.clear();
-        let bytes_read = reader.read_line(&mut line).await?;
-        if bytes_read == 0 {
-            break;
-        }
-        if line.len() > MAX_JSON_RPC_LINE_SIZE {
-            let response = jsonrpc_error(
-                serde_json::Value::Null,
-                -32600,
-                format!(
-                    "Request too large: {} bytes exceeds limit of {} bytes",
-                    line.len(),
-                    MAX_JSON_RPC_LINE_SIZE
-                ),
-            );
-            let text = serde_json::to_string(&response)?;
-            writer.write_all(text.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
-            continue;
-        }
-        if line.trim().is_empty() {
-            continue;
-        }
+        match read_json_rpc_line(&mut reader).await? {
+            ReadJsonRpcLine::Eof => break,
+            ReadJsonRpcLine::Oversized(bytes_read) => {
+                let response = jsonrpc_error(
+                    serde_json::Value::Null,
+                    -32600,
+                    format!(
+                        "Request too large: {} bytes exceeds limit of {} bytes",
+                        bytes_read, MAX_JSON_RPC_LINE_SIZE
+                    ),
+                );
+                let text = serde_json::to_string(&response)?;
+                writer.write_all(text.as_bytes()).await?;
+                writer.write_all(b"\n").await?;
+                writer.flush().await?;
+            }
+            ReadJsonRpcLine::Line(line) => {
+                if line.trim().is_empty() {
+                    continue;
+                }
 
-        let response = handle_line(&line).await;
-        if let Some(response) = response {
-            let text = serde_json::to_string(&response)?;
-            writer.write_all(text.as_bytes()).await?;
-            writer.write_all(b"\n").await?;
-            writer.flush().await?;
+                let response = handle_line(&line).await;
+                if let Some(response) = response {
+                    let text = serde_json::to_string(&response)?;
+                    writer.write_all(text.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
+                    writer.flush().await?;
+                }
+            }
         }
     }
 
     Ok(())
+}
+
+#[derive(Debug)]
+enum ReadJsonRpcLine {
+    Line(String),
+    Oversized(usize),
+    Eof,
+}
+
+async fn read_json_rpc_line<R>(reader: &mut R) -> anyhow::Result<ReadJsonRpcLine>
+where
+    R: tokio::io::AsyncBufRead + Unpin,
+{
+    let mut line = Vec::new();
+    let mut total_len = 0usize;
+    let mut oversized = false;
+
+    loop {
+        let available = reader.fill_buf().await?;
+        if available.is_empty() {
+            if total_len == 0 {
+                return Ok(ReadJsonRpcLine::Eof);
+            }
+            break;
+        }
+
+        let newline_pos = available.iter().position(|b| *b == b'\n');
+        let chunk_len = newline_pos.map_or(available.len(), |pos| pos + 1);
+        let chunk = &available[..chunk_len];
+        total_len += chunk_len;
+
+        if !oversized {
+            let remaining = MAX_JSON_RPC_LINE_SIZE.saturating_sub(line.len());
+            if chunk.len() <= remaining {
+                line.extend_from_slice(chunk);
+            } else {
+                line.extend_from_slice(&chunk[..remaining]);
+                oversized = true;
+            }
+        }
+
+        reader.consume(chunk_len);
+
+        if newline_pos.is_some() {
+            break;
+        }
+    }
+
+    if oversized {
+        return Ok(ReadJsonRpcLine::Oversized(total_len));
+    }
+
+    let line = String::from_utf8(line)?;
+    Ok(ReadJsonRpcLine::Line(line))
 }
 
 async fn handle_line(line: &str) -> Option<JsonRpcResponse> {
@@ -650,6 +701,35 @@ mod tests {
     async fn unknown_notification_is_ignored() {
         let response = handle_line(r#"{"jsonrpc":"2.0","method":"something/unknown"}"#).await;
         assert!(response.is_none());
+    }
+
+    #[tokio::test]
+    async fn oversized_json_rpc_line_is_rejected_without_unbounded_buffering() {
+        let (mut writer, reader) = tokio::io::duplex(4096);
+        let oversized_line = format!(
+            "{{\"jsonrpc\":\"2.0\",\"method\":\"tools/list\",\"padding\":\"{}\"}}\n",
+            "x".repeat(MAX_JSON_RPC_LINE_SIZE + 1)
+        );
+
+        let writer_task = tokio::spawn(async move {
+            writer
+                .write_all(oversized_line.as_bytes())
+                .await
+                .expect("write oversized line");
+        });
+
+        let mut reader = BufReader::new(reader);
+        match read_json_rpc_line(&mut reader)
+            .await
+            .expect("read oversized line")
+        {
+            ReadJsonRpcLine::Oversized(bytes_read) => {
+                assert!(bytes_read > MAX_JSON_RPC_LINE_SIZE);
+            }
+            other => panic!("expected oversized line, got {:?}", other),
+        }
+
+        writer_task.await.expect("join writer task");
     }
 
     #[tokio::test]

--- a/tools-src/gws-bridge/src/main.rs
+++ b/tools-src/gws-bridge/src/main.rs
@@ -1,0 +1,4 @@
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    gws_bridge::run().await
+}


### PR DESCRIPTION
Fixes #2235.\n\nCurrent runtime behavior for authenticated WASM channels is now reflected in the settings UI:\n- active + authenticated channels are shown as Active even if owner-bound metadata is not yet resolved\n- already-authenticated cards now show Reconfigure instead of Setup\n- pairing claim UI only appears when the channel is active but not owner-bound\n\nValidated with focused Rust tests and  for the settings UI script.