### PR TITLE
fix(ci): exclude test files from PR size classification

### DIFF
--- a/.github/scripts/pr-labeler.sh
+++ b/.github/scripts/pr-labeler.sh
@@ -43,7 +43,10 @@ classify_size() {
   local total
   total=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" \
     --paginate --jq '
-      [.[] | select(.filename | test("\\.(md|txt|rst|adoc)$") | not) | .changes]
+      [.[]
+        | select(.filename | test("\\.(md|txt|rst|adoc)$") | not)
+        | select(.filename | test("^tests/|_test\\.rs$|_tests\\.rs$|/tests/|\\.test\\.[jt]sx?$|\\.spec\\.[jt]sx?$") | not)
+        | .changes]
       | add // 0
     ')
 


### PR DESCRIPTION
## Summary
- PR size labels now only count production code changes, excluding test files
- Previously a 1-line production fix with 500 lines of tests would be classified as XL
- Excluded patterns: `tests/`, `*_test.rs`, `*_tests.rs`, `*.test.{js,ts,jsx,tsx}`, `*.spec.{js,ts,jsx,tsx}`

## Test plan
- [ ] Open a PR with mostly test changes and verify the size label reflects only non-test lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)