### PR TITLE
Suppress LLM_BACKEND warning when config.toml and .env values match

### DIFF
--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -92,9 +92,13 @@ impl LlmConfig {
             );
         });
         // Warn operators when a DB-persisted value silently overrides LLM_BACKEND.
+        // Skip the warning when both values are identical — this is the normal
+        // state after `ironclaw models set-provider`, which intentionally writes
+        // to both config.toml and .env for immediate effect.
         if backend_source == "db:llm_backend"
             && let Ok(env_val) = std::env::var("LLM_BACKEND")
             && !env_val.is_empty()
+            && env_val != backend
         {
             tracing::warn!(
                 db_value = %backend,


### PR DESCRIPTION
## Summary

`ironclaw models set-provider` intentionally writes to both `config.toml` and `.env` for immediate effect. This causes the config resolver in `LlmConfig::resolve()` to always emit:

```
WARN: LLM_BACKEND env var is set but DB setting takes priority.
Unset llm_backend in the DB (via settings UI) to use the env var.
```

…even though both values are identical and there is no silent override happening. The warning is unresolvable — clearing one source just breaks config loading, and both sources exist by design.

## Fix

Add `env_val != backend` to the warn condition so the warning is only emitted when the values actually differ (i.e. a real override is happening).

## Test plan

- [x] `cargo check` passes
- [x] Existing test `db_llm_backend_takes_priority_over_env_var` passes (tests the case where values differ)
- [x] Verified locally: warning no longer appears after `ironclaw models set-provider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)