### PR TITLE
Prompt for local profile during quick onboarding

### DIFF
--- a/profiles/local-sandbox.toml
+++ b/profiles/local-sandbox.toml
@@ -1,7 +1,8 @@
 # IronClaw Profile: local-sandbox
 #
 # Solo developer setup with Docker sandbox enabled for secure tool execution.
-# Same as 'local' but tools run inside isolated containers.
+# Same as 'local' but tools run inside isolated containers. Background tasks
+# remain enabled for the personal-assistant experience.
 #
 # Prerequisites:
 #   - Docker daemon running
@@ -19,10 +20,10 @@ enabled = true
 policy = "readonly"
 
 [heartbeat]
-enabled = false
+enabled = true
 
 [routines]
-enabled = false
+enabled = true
 
 [hygiene]
-enabled = false
+enabled = true

--- a/profiles/local.toml
+++ b/profiles/local.toml
@@ -1,8 +1,8 @@
 # IronClaw Profile: local
 #
-# Stripped-down configuration for solo developers working locally.
-# Disables server-oriented features (gateway, heartbeat, routines, sandbox)
-# and enables the rich TUI for an interactive terminal experience.
+# Configuration for solo developers working locally.
+# Disables server-oriented gateway and Docker sandbox features while keeping
+# personal-assistant background tasks enabled.
 #
 # Usage: set IRONCLAW_PROFILE=local in your environment or .env file.
 #
@@ -19,10 +19,10 @@ cli_mode = "tui"
 enabled = false
 
 [heartbeat]
-enabled = false
+enabled = true
 
 [routines]
-enabled = false
+enabled = true
 
 [hygiene]
-enabled = false
+enabled = true

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn local_profile_disables_gateway() {
+    fn local_profile_disables_gateway_and_sandbox() {
         let _guard = lock_env();
         unsafe { std::env::set_var("IRONCLAW_PROFILE", "local") };
 
@@ -242,9 +242,9 @@ mod tests {
 
         assert!(!settings.channels.gateway_enabled);
         assert!(!settings.sandbox.enabled);
-        assert!(!settings.heartbeat.enabled);
-        assert!(!settings.routines.enabled);
-        assert!(!settings.hygiene.enabled);
+        assert!(settings.heartbeat.enabled);
+        assert!(settings.routines.enabled);
+        assert!(settings.hygiene.enabled);
         assert_eq!(settings.channels.cli_mode.as_deref(), Some("tui"));
         assert_eq!(settings.database_backend.as_deref(), Some("libsql"));
     }
@@ -292,6 +292,9 @@ mod tests {
         assert!(settings.sandbox.enabled);
         assert_eq!(settings.sandbox.policy, "readonly");
         assert!(!settings.channels.gateway_enabled);
+        assert!(settings.heartbeat.enabled);
+        assert!(settings.routines.enabled);
+        assert!(settings.hygiene.enabled);
     }
 
     #[test]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1033,7 +1033,52 @@ pub struct TranscriptionSettings {
     pub enabled: bool,
 }
 
+/// Snapshot of database-related fields from [`Settings`], used to preserve
+/// user-configured DB settings across profile application.
+pub struct DatabaseConfigBackup {
+    pub database_backend: Option<String>,
+    pub database_url: Option<String>,
+    pub database_pool_size: Option<usize>,
+    pub libsql_path: Option<String>,
+    pub libsql_url: Option<String>,
+}
+
+impl DatabaseConfigBackup {
+    /// Returns `true` if any database field was explicitly set.
+    pub fn has_values(&self) -> bool {
+        self.database_backend.is_some()
+            || self.database_url.is_some()
+            || self.database_pool_size.is_some()
+            || self.libsql_path.is_some()
+            || self.libsql_url.is_some()
+    }
+}
+
 impl Settings {
+    /// Snapshot the current database-related fields so they can be restored
+    /// after a profile is applied (profiles may overwrite DB settings).
+    pub fn backup_database_config(&self) -> DatabaseConfigBackup {
+        DatabaseConfigBackup {
+            database_backend: self.database_backend.clone(),
+            database_url: self.database_url.clone(),
+            database_pool_size: self.database_pool_size,
+            libsql_path: self.libsql_path.clone(),
+            libsql_url: self.libsql_url.clone(),
+        }
+    }
+
+    /// Restore database-related fields from a prior backup, but only if the
+    /// backup contained at least one explicit value.
+    pub fn restore_database_config(&mut self, backup: DatabaseConfigBackup) {
+        if backup.has_values() {
+            self.database_backend = backup.database_backend;
+            self.database_url = backup.database_url;
+            self.database_pool_size = backup.database_pool_size;
+            self.libsql_path = backup.libsql_path;
+            self.libsql_url = backup.libsql_url;
+        }
+    }
+
     /// Reconstruct Settings from a flat key-value map (as stored in the DB).
     ///
     /// Each key is a dotted path (e.g., "agent.name"), value is a JSONB value.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1033,52 +1033,7 @@ pub struct TranscriptionSettings {
     pub enabled: bool,
 }
 
-/// Snapshot of database-related fields from [`Settings`], used to preserve
-/// user-configured DB settings across profile application.
-pub struct DatabaseConfigBackup {
-    pub database_backend: Option<String>,
-    pub database_url: Option<String>,
-    pub database_pool_size: Option<usize>,
-    pub libsql_path: Option<String>,
-    pub libsql_url: Option<String>,
-}
-
-impl DatabaseConfigBackup {
-    /// Returns `true` if any database field was explicitly set.
-    pub fn has_values(&self) -> bool {
-        self.database_backend.is_some()
-            || self.database_url.is_some()
-            || self.database_pool_size.is_some()
-            || self.libsql_path.is_some()
-            || self.libsql_url.is_some()
-    }
-}
-
 impl Settings {
-    /// Snapshot the current database-related fields so they can be restored
-    /// after a profile is applied (profiles may overwrite DB settings).
-    pub fn backup_database_config(&self) -> DatabaseConfigBackup {
-        DatabaseConfigBackup {
-            database_backend: self.database_backend.clone(),
-            database_url: self.database_url.clone(),
-            database_pool_size: self.database_pool_size,
-            libsql_path: self.libsql_path.clone(),
-            libsql_url: self.libsql_url.clone(),
-        }
-    }
-
-    /// Restore database-related fields from a prior backup, but only if the
-    /// backup contained at least one explicit value.
-    pub fn restore_database_config(&mut self, backup: DatabaseConfigBackup) {
-        if backup.has_values() {
-            self.database_backend = backup.database_backend;
-            self.database_url = backup.database_url;
-            self.database_pool_size = backup.database_pool_size;
-            self.libsql_path = backup.libsql_path;
-            self.libsql_url = backup.libsql_url;
-        }
-    }
-
     /// Reconstruct Settings from a flat key-value map (as stored in the DB).
     ///
     /// Each key is a dotted path (e.g., "agent.name"), value is a JSONB value.

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -56,16 +56,27 @@ The `--no-onboard` CLI flag suppresses auto-detection.
 
 Quick mode (`--quick` flag, or auto-triggered on first run) provides a
 near-instant onboarding experience by auto-defaulting everything except
-the LLM provider and model selection.
+the local deployment profile, LLM provider, and model selection.
 
 ```
+Local Usage Profile     ← choose local or local-sandbox when unset
 auto_setup_database()    → libsql at ~/.ironclaw/ironclaw.db (zero prompts)
 auto_setup_security()    → keychain or env var (zero prompts)
-Step 1/2: Inference Provider  ← only interactive step
-Step 2/2: Model Selection     ← only interactive step
+Step 1/2: Inference Provider  ← interactive unless provider env is detected
+Step 2/2: Model Selection     ← interactive unless defaulted by detected provider
        ↓
    save_and_summarize()      → includes tip to run `ironclaw onboard`
 ```
+
+**Local usage profile:** If `IRONCLAW_PROFILE` is already set, quick mode
+respects it and does not prompt. On a true first run with no profile and no
+existing DB settings, quick mode asks whether the user wants:
+- `local`: TUI, local libSQL, background tasks enabled, no Docker sandbox
+- `local-sandbox`: TUI, local libSQL, background tasks enabled, Docker sandbox enabled with read-only policy
+
+The selected profile is written to `~/.ironclaw/.env` as `IRONCLAW_PROFILE`
+so subsequent startups apply the same built-in profile before database-backed
+settings are loaded.
 
 **`auto_setup_database()`:** Uses existing env vars if set (`DATABASE_URL`
 for postgres, `LIBSQL_PATH` for libsql) without prompting. Otherwise
@@ -415,9 +426,10 @@ Settings are persisted in two places:
 **Layer 1: `~/.ironclaw/.env`** (bootstrap vars)
 
 Contains only the settings needed BEFORE database connection. Written by
-`save_bootstrap_env()` in `bootstrap.rs`.
+`write_bootstrap_env()` in `wizard.rs` via `upsert_bootstrap_vars()`.
 
 ```env
+IRONCLAW_PROFILE="local"
 DATABASE_BACKEND="libsql"
 LIBSQL_PATH="/Users/name/.ironclaw/ironclaw.db"
 SECRETS_MASTER_KEY="..."   # only if env key source selected
@@ -426,6 +438,7 @@ ONBOARD_COMPLETED="true"
 
 Or for PostgreSQL:
 ```env
+IRONCLAW_PROFILE="local"
 DATABASE_BACKEND="postgres"
 DATABASE_URL="postgres://user:pass@localhost/ironclaw"
 SECRETS_MASTER_KEY="..."
@@ -433,8 +446,9 @@ ONBOARD_COMPLETED="true"
 ```
 
 **Why separate?** Chicken-and-egg: you need `DATABASE_BACKEND` to know
-which database to connect to, and `SECRETS_MASTER_KEY` to decrypt the
-secrets store — neither can be stored in the database. LLM settings
+which database to connect to, `IRONCLAW_PROFILE` to apply built-in defaults
+before DB overlays, and `SECRETS_MASTER_KEY` to decrypt the
+secrets store; none of these can rely on database settings. LLM settings
 (`LLM_BACKEND`, base URLs, model names) are persisted to the DB via
 `persist_settings()` and loaded after connection. API keys are stored
 encrypted in the secrets DB.
@@ -501,6 +515,7 @@ Final step of the wizard:
 
 Bootstrap vars written to `~/.ironclaw/.env` (only true chicken-and-egg vars
 that are needed before the DB is connected):
+- `IRONCLAW_PROFILE` (when quick first-run setup selected a profile)
 - `DATABASE_BACKEND` (always)
 - `DATABASE_URL` (if postgres)
 - `LIBSQL_PATH` (if libsql)

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -1179,28 +1179,13 @@ impl SetupWizard {
             }
         }
 
-        let prior_database_backend = self.settings.database_backend.clone();
-        let prior_database_url = self.settings.database_url.clone();
-        let prior_database_pool_size = self.settings.database_pool_size;
-        let prior_libsql_path = self.settings.libsql_path.clone();
-        let prior_libsql_url = self.settings.libsql_url.clone();
+        let prior_db_settings = self.settings.backup_database_config();
 
         crate::config::set_runtime_env("IRONCLAW_PROFILE", profile);
         crate::config::profile::apply_profile(&mut self.settings)
             .map_err(|e| SetupError::Config(e.to_string()))?;
 
-        if prior_database_backend.is_some()
-            || prior_database_url.is_some()
-            || prior_database_pool_size.is_some()
-            || prior_libsql_path.is_some()
-            || prior_libsql_url.is_some()
-        {
-            self.settings.database_backend = prior_database_backend;
-            self.settings.database_url = prior_database_url;
-            self.settings.database_pool_size = prior_database_pool_size;
-            self.settings.libsql_path = prior_libsql_path;
-            self.settings.libsql_url = prior_libsql_url;
-        }
+        self.settings.restore_database_config(prior_db_settings);
 
         self.selected_deployment_profile = Some(profile.to_string());
         Ok(())

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -267,16 +267,19 @@ impl SetupWizard {
             // Quick mode: auto-default database + security, only ask for
             // the local usage profile (on true first run), LLM provider,
             // and model. Designed for first-run experience.
+
+            // Profile selection runs first so that `apply_profile()` can set
+            // `database_backend` before `auto_setup_database()` connects.
+            // The subsequent clone → try_load → merge_from cycle preserves
+            // these wizard-chosen values over any stale DB values.
+            self.step_quick_local_profile()?;
+
             self.auto_setup_database().await?;
 
             // Load existing settings from DB (if any prior partial run)
             let step1_settings = self.settings.clone();
-            let existing_settings_loaded = self.try_load_existing_settings().await;
+            self.try_load_existing_settings().await;
             self.settings.merge_from(&step1_settings);
-
-            if !existing_settings_loaded {
-                self.step_quick_local_profile()?;
-            }
 
             self.auto_setup_security().await?;
             self.persist_after_step().await;
@@ -1161,7 +1164,8 @@ impl SetupWizard {
             .map_err(SetupError::Io)?;
         let profile = match choice {
             0 => QUICK_PROFILE_LOCAL,
-            _ => QUICK_PROFILE_LOCAL_SANDBOX,
+            1 => QUICK_PROFILE_LOCAL_SANDBOX,
+            _ => unreachable!("select_one only returns 0 or 1 for a two-option menu"),
         };
 
         self.apply_quick_local_profile(profile)?;
@@ -1179,13 +1183,9 @@ impl SetupWizard {
             }
         }
 
-        let prior_db_settings = self.settings.backup_database_config();
-
         crate::config::set_runtime_env("IRONCLAW_PROFILE", profile);
         crate::config::profile::apply_profile(&mut self.settings)
             .map_err(|e| SetupError::Config(e.to_string()))?;
-
-        self.settings.restore_database_config(prior_db_settings);
 
         self.selected_deployment_profile = Some(profile.to_string());
         Ok(())
@@ -3458,6 +3458,11 @@ impl SetupWizard {
     /// prefers the `other` argument's non-default values. Without this,
     /// stale DB values would overwrite fresh user choices.
     async fn try_load_existing_settings(&mut self) -> bool {
+        // NB: `loaded` starts false and is only reassigned inside feature-gated
+        // blocks below.  When *neither* `postgres` nor `libsql` is enabled the
+        // function always returns false (no DB backend → nothing to load).
+        // Each block shadows `loaded` via `let loaded = …` so the compiler
+        // sees a use on every path; this is intentional, not accidental shadowing.
         let loaded = false;
 
         #[cfg(feature = "postgres")]
@@ -4045,6 +4050,62 @@ mod tests {
         assert!(
             !vars.iter().any(|(key, _)| key == "IRONCLAW_PROFILE"),
             "only a wizard-selected profile should be written back"
+        );
+    }
+
+    #[test]
+    fn test_apply_quick_local_profile_sets_profile_and_preserves_db_config_on_merge() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::clear("IRONCLAW_PROFILE");
+
+        let mut wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+        // Simulate a pre-existing database_url chosen earlier in the wizard
+        // (e.g. by auto_setup_database before profile selection was reordered).
+        wizard.settings.database_url = Some("postgres://my-host/db".to_string());
+        wizard.settings.database_backend = Some("postgres".to_string());
+
+        // Snapshot settings *before* profile application — mimics the
+        // `let step1_settings = self.settings.clone()` line in quick mode.
+        let step1_settings = wizard.settings.clone();
+
+        wizard
+            .apply_quick_local_profile(QUICK_PROFILE_LOCAL)
+            .expect("apply_quick_local_profile should succeed");
+
+        // Profile applies its own database_backend (libsql) which overwrites
+        // the wizard-chosen value.
+        assert_eq!(
+            wizard.settings.database_backend.as_deref(),
+            Some("libsql"),
+            "profile should overwrite database_backend"
+        );
+
+        // After merge_from, the wizard-chosen values should win back.
+        wizard.settings.merge_from(&step1_settings);
+
+        assert_eq!(
+            wizard.settings.database_backend.as_deref(),
+            Some("postgres"),
+            "merge_from should restore the wizard-chosen database_backend"
+        );
+        assert_eq!(
+            wizard.settings.database_url.as_deref(),
+            Some("postgres://my-host/db"),
+            "merge_from should restore the wizard-chosen database_url"
+        );
+        // Profile-applied non-DB settings should still be present since
+        // step1_settings had defaults for them.
+        assert!(
+            wizard.settings.heartbeat.enabled,
+            "profile-set heartbeat.enabled should survive merge"
+        );
+        assert_eq!(
+            wizard.selected_deployment_profile.as_deref(),
+            Some("local"),
+            "selected_deployment_profile should be set"
         );
     }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -44,6 +44,8 @@ use crate::setup::prompts::{
 // const CHANNEL_INDEX_CLI: usize = 0;
 const CHANNEL_INDEX_HTTP: usize = 1;
 const CHANNEL_INDEX_SIGNAL: usize = 2;
+const QUICK_PROFILE_LOCAL: &str = "local";
+const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
 /// Setup wizard error.
 #[derive(Debug, thiserror::Error)]
@@ -95,6 +97,7 @@ pub struct SetupConfig {
 pub struct SetupWizard {
     config: SetupConfig,
     settings: Settings,
+    selected_deployment_profile: Option<String>,
     owner_id: String,
     session_manager: Option<Arc<SessionManager>>,
     /// Database pool (created during setup, postgres only).
@@ -123,6 +126,7 @@ impl SetupWizard {
         Self {
             config,
             settings,
+            selected_deployment_profile: None,
             owner_id: "default".to_string(),
             session_manager: None,
             #[cfg(feature = "postgres")]
@@ -142,6 +146,7 @@ impl SetupWizard {
         Ok(Self {
             config,
             settings,
+            selected_deployment_profile: None,
             owner_id,
             session_manager: None,
             #[cfg(feature = "postgres")]
@@ -260,13 +265,18 @@ impl SetupWizard {
             self.persist_after_step().await;
         } else if self.config.quick {
             // Quick mode: auto-default database + security, only ask for
-            // LLM provider + model. Designed for first-run experience.
+            // the local usage profile (on true first run), LLM provider,
+            // and model. Designed for first-run experience.
             self.auto_setup_database().await?;
 
             // Load existing settings from DB (if any prior partial run)
             let step1_settings = self.settings.clone();
-            self.try_load_existing_settings().await;
+            let existing_settings_loaded = self.try_load_existing_settings().await;
             self.settings.merge_from(&step1_settings);
+
+            if !existing_settings_loaded {
+                self.step_quick_local_profile()?;
+            }
 
             self.auto_setup_security().await?;
             self.persist_after_step().await;
@@ -1131,6 +1141,69 @@ impl SetupWizard {
         {
             self.step_database().await
         }
+    }
+
+    /// Quick first-run local deployment profile selection.
+    ///
+    /// Existing `IRONCLAW_PROFILE` values are respected because
+    /// `load_bootstrap_settings()` has already applied them before the wizard
+    /// starts. This prompt only fills in the missing first-run local default.
+    fn step_quick_local_profile(&mut self) -> Result<(), SetupError> {
+        if crate::config::env_or_override("IRONCLAW_PROFILE").is_some() {
+            return Ok(());
+        }
+
+        let options = [
+            "Local (TUI + background tasks, no Docker sandbox)",
+            "Local sandbox (TUI + background tasks + Docker sandbox)",
+        ];
+        let choice = select_one("How should IronClaw run on this machine?", &options)
+            .map_err(SetupError::Io)?;
+        let profile = match choice {
+            0 => QUICK_PROFILE_LOCAL,
+            _ => QUICK_PROFILE_LOCAL_SANDBOX,
+        };
+
+        self.apply_quick_local_profile(profile)?;
+        print_success(&format!("Using '{profile}' deployment profile"));
+        Ok(())
+    }
+
+    fn apply_quick_local_profile(&mut self, profile: &str) -> Result<(), SetupError> {
+        match profile {
+            QUICK_PROFILE_LOCAL | QUICK_PROFILE_LOCAL_SANDBOX => {}
+            other => {
+                return Err(SetupError::Config(format!(
+                    "unsupported quick local profile: {other}"
+                )));
+            }
+        }
+
+        let prior_database_backend = self.settings.database_backend.clone();
+        let prior_database_url = self.settings.database_url.clone();
+        let prior_database_pool_size = self.settings.database_pool_size;
+        let prior_libsql_path = self.settings.libsql_path.clone();
+        let prior_libsql_url = self.settings.libsql_url.clone();
+
+        crate::config::set_runtime_env("IRONCLAW_PROFILE", profile);
+        crate::config::profile::apply_profile(&mut self.settings)
+            .map_err(|e| SetupError::Config(e.to_string()))?;
+
+        if prior_database_backend.is_some()
+            || prior_database_url.is_some()
+            || prior_database_pool_size.is_some()
+            || prior_libsql_path.is_some()
+            || prior_libsql_url.is_some()
+        {
+            self.settings.database_backend = prior_database_backend;
+            self.settings.database_url = prior_database_url;
+            self.settings.database_pool_size = prior_database_pool_size;
+            self.settings.libsql_path = prior_libsql_path;
+            self.settings.libsql_url = prior_libsql_url;
+        }
+
+        self.selected_deployment_profile = Some(profile.to_string());
+        Ok(())
     }
 
     /// Auto-setup security with zero prompts (quick mode).
@@ -3203,8 +3276,8 @@ impl SetupWizard {
     /// Write bootstrap environment variables to `~/.ironclaw/.env`.
     ///
     /// Only true chicken-and-egg settings are written here — things needed
-    /// before the database is connected: `DATABASE_BACKEND`, `DATABASE_URL`,
-    /// `LIBSQL_PATH`, `SECRETS_MASTER_KEY`, `ONBOARD_COMPLETED`, and
+    /// before the database is connected: `IRONCLAW_PROFILE`, `DATABASE_BACKEND`,
+    /// `DATABASE_URL`, `LIBSQL_PATH`, `SECRETS_MASTER_KEY`, `ONBOARD_COMPLETED`, and
     /// channel config vars (Signal, Claude Code sandbox).
     ///
     /// **LLM settings and credentials are NOT written here.** `LLM_BACKEND`,
@@ -3212,8 +3285,12 @@ impl SetupWizard {
     /// `persist_settings()` and loaded by `Config::from_db_with_toml()`.
     /// API keys live only in the encrypted secrets DB and are injected via
     /// `inject_llm_keys_from_secrets()` after DB init.
-    fn write_bootstrap_env(&self) -> Result<(), SetupError> {
+    fn bootstrap_env_vars(&self) -> Vec<(String, String)> {
         let mut env_vars: Vec<(String, String)> = Vec::new();
+
+        if let Some(ref profile) = self.selected_deployment_profile {
+            env_vars.push(("IRONCLAW_PROFILE".to_string(), profile.clone()));
+        }
 
         if let Some(ref backend) = self.settings.database_backend {
             env_vars.push(("DATABASE_BACKEND".to_string(), backend.clone()));
@@ -3277,6 +3354,12 @@ impl SetupWizard {
                 group_allow_from.clone(),
             ));
         }
+
+        env_vars
+    }
+
+    fn write_bootstrap_env(&self) -> Result<(), SetupError> {
+        let env_vars = self.bootstrap_env_vars();
 
         if !env_vars.is_empty() {
             let pairs: Vec<(&str, &str)> = env_vars
@@ -3389,7 +3472,7 @@ impl SetupWizard {
     /// via `self.settings.merge_from(&step_settings)`, since `merge_from`
     /// prefers the `other` argument's non-default values. Without this,
     /// stale DB values would overwrite fresh user choices.
-    async fn try_load_existing_settings(&mut self) {
+    async fn try_load_existing_settings(&mut self) -> bool {
         let loaded = false;
 
         #[cfg(feature = "postgres")]
@@ -3440,8 +3523,7 @@ impl SetupWizard {
             loaded
         };
 
-        // Suppress unused variable warning when only one backend is compiled.
-        let _ = loaded;
+        loaded
     }
 
     /// Save settings to the database and `~/.ironclaw/.env`, then print
@@ -3936,6 +4018,49 @@ mod tests {
         let wizard = SetupWizard::try_with_config_and_toml(Default::default(), Some(&path))
             .expect("wizard should load owner_id from TOML"); // safety: test-only assertion
         assert_eq!(wizard.owner_id(), "toml-owner"); // safety: test-only assertion
+    }
+
+    #[test]
+    fn test_bootstrap_env_vars_include_selected_deployment_profile() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::clear("IRONCLAW_PROFILE");
+        let mut wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+        wizard.selected_deployment_profile = Some(QUICK_PROFILE_LOCAL_SANDBOX.to_string());
+        wizard.settings.database_backend = Some("libsql".to_string());
+
+        let vars = wizard.bootstrap_env_vars();
+
+        assert!(
+            vars.iter().any(|(key, value)| {
+                key == "IRONCLAW_PROFILE" && value == QUICK_PROFILE_LOCAL_SANDBOX
+            }),
+            "selected deployment profile should be persisted to bootstrap env"
+        );
+        assert!(
+            vars.iter()
+                .any(|(key, value)| key == "DATABASE_BACKEND" && value == "libsql"),
+            "existing bootstrap vars should still be written"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_env_vars_do_not_persist_unselected_profile() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::set("IRONCLAW_PROFILE", QUICK_PROFILE_LOCAL);
+        let wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+
+        let vars = wizard.bootstrap_env_vars();
+
+        assert!(
+            !vars.iter().any(|(key, _)| key == "IRONCLAW_PROFILE"),
+            "only a wizard-selected profile should be written back"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add a first-run quick onboarding choice between `local` and `local-sandbox`
- persist the selected profile to bootstrap `.env` as `IRONCLAW_PROFILE`
- make local profiles proactive by default with heartbeat, routines, and hygiene enabled
- update setup docs and profile tests

## ⚠️ Breaking change for existing `local` / `local-sandbox` users

Both `profiles/local.toml` and `profiles/local-sandbox.toml` now set
`heartbeat.enabled = true`, `routines.enabled = true`, and
`hygiene.enabled = true`. Existing users with `IRONCLAW_PROFILE=local`
(or `local-sandbox`) will get background tasks on next startup without
explicit opt-in. Previously the profile comment described these as
"disabled server-oriented features".

**Migration:** Users who want the old behavior can add
`heartbeat.enabled = false`, `routines.enabled = false`, and
`hygiene.enabled = false` to `~/.ironclaw/config.toml`.

## Tests
- `RUSTFLAGS=-Cdebuginfo=0 cargo test --no-default-features --features libsql local_profile --lib`
- `RUSTFLAGS=-Cdebuginfo=0 cargo test --no-default-features --features libsql local_sandbox_enables_sandbox --lib`
- `RUSTFLAGS=-Cdebuginfo=0 cargo test --no-default-features --features libsql test_bootstrap_env_vars_ --lib`
- `RUSTFLAGS=-Cdebuginfo=0 cargo test --no-default-features --features libsql test_apply_quick_local_profile_ --lib`
- `git diff --check`