### PR TITLE
fix(security): gate test URL rewriters behind #[cfg(test)] (fixes #2056)

### DIFF
--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -62,12 +62,13 @@ use crate::tools::wasm::{
 };
 use ironclaw_safety::LeakDetector;
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(test)]
 const TEST_HTTP_REWRITE_MAP_ENV: &str = "IRONCLAW_TEST_HTTP_REWRITE_MAP";
 
 const WEBSOCKET_EVENT_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue";
 const WEBSOCKET_EVENT_PROCESSING_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue_processing";
 const WEBSOCKET_EVENT_QUEUE_MAX_ITEMS: usize = 100;
+#[cfg(test)]
 const TELEGRAM_TEST_API_BASE_ENV: &str = "IRONCLAW_TEST_TELEGRAM_API_BASE_URL";
 
 // Generate component model bindings from the WIT file
@@ -384,17 +385,27 @@ impl near::agent::channel_host::Host for ChannelStoreData {
             self.inject_host_credentials(&host, &mut headers, &mut logical_url);
         }
 
-        let rewritten_transport_url = rewrite_http_url_for_testing(&logical_url)
-            .or_else(|| rewrite_telegram_api_url_for_testing(&logical_url));
-        let allow_private_test_target = rewritten_transport_url.is_some();
-        let transport_url = rewritten_transport_url.unwrap_or_else(|| logical_url.clone());
-        if transport_url != logical_url {
-            tracing::info!(
-                logical_url = %logical_url,
-                transport_url = %transport_url,
-                "Rewriting outbound HTTP request to test base URL"
-            );
-        }
+        let (transport_url, allow_private_test_target) = {
+            #[cfg(test)]
+            {
+                let rewritten = rewrite_http_url_for_testing(&logical_url)
+                    .or_else(|| rewrite_telegram_api_url_for_testing(&logical_url));
+                let is_rewritten = rewritten.is_some();
+                let url = rewritten.unwrap_or_else(|| logical_url.clone());
+                if url != logical_url {
+                    tracing::info!(
+                        logical_url = %logical_url,
+                        transport_url = %url,
+                        "Rewriting outbound HTTP request to test base URL"
+                    );
+                }
+                (url, is_rewritten)
+            }
+            #[cfg(not(test))]
+            {
+                (logical_url.clone(), false)
+            }
+        };
 
         // Get the max response size from capabilities (default 10MB).
         let max_response_bytes = self
@@ -4107,7 +4118,7 @@ fn extract_host_from_url(url: &str) -> Option<String> {
 ///
 /// The replacement preserves the original path and query string so tests can
 /// point production hosts at local fakes without adding channel-specific code.
-#[cfg(any(test, debug_assertions))]
+#[cfg(test)]
 fn rewrite_http_url_for_testing(url: &str) -> Option<String> {
     let parsed = url::Url::parse(url).ok()?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -4128,12 +4139,7 @@ fn rewrite_http_url_for_testing(url: &str) -> Option<String> {
     Some(rewritten)
 }
 
-#[cfg(not(any(test, debug_assertions)))]
-fn rewrite_http_url_for_testing(_url: &str) -> Option<String> {
-    None
-}
-
-#[cfg(any(test, debug_assertions))]
+#[cfg(test)]
 fn parse_test_http_rewrite_map(raw: &str) -> HashMap<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -4163,7 +4169,7 @@ fn parse_test_http_rewrite_map(raw: &str) -> HashMap<String, String> {
     }
 }
 
-#[cfg(any(test, debug_assertions))]
+#[cfg(test)]
 fn rewrite_telegram_api_url_for_testing(url: &str) -> Option<String> {
     let override_base = std::env::var(TELEGRAM_TEST_API_BASE_ENV)
         .ok()
@@ -4187,11 +4193,6 @@ fn rewrite_telegram_api_url_for_testing(url: &str) -> Option<String> {
         rewritten.push_str(query);
     }
     Some(rewritten)
-}
-
-#[cfg(not(any(test, debug_assertions)))]
-fn rewrite_telegram_api_url_for_testing(_url: &str) -> Option<String> {
-    None
 }
 fn should_skip_response_leak_scan(url: &str) -> bool {
     url::Url::parse(url).is_ok_and(|parsed| {


### PR DESCRIPTION
## Summary

- **Security fix**: `rewrite_telegram_api_url_for_testing()`, `rewrite_http_url_for_testing()`, and supporting constants/helpers were gated behind `#[cfg(any(test, debug_assertions))]`, meaning they shipped in all debug builds including development/staging deployments. An attacker who could set `IRONCLAW_TEST_TELEGRAM_API_BASE_URL` or `IRONCLAW_TEST_HTTP_REWRITE_MAP` environment variables could redirect Telegram API traffic and other outbound HTTP traffic to an arbitrary host.
- Narrowed all test URL rewrite infrastructure from `#[cfg(any(test, debug_assertions))]` to `#[cfg(test)]` so these functions are completely excluded from production and debug release binaries.
- Added missing `#[cfg(test)]` to `TELEGRAM_TEST_API_BASE_ENV` constant which had no gate at all.
- Wrapped the call site in `http_request()` with `#[cfg(test)]`/`#[cfg(not(test))]` blocks so production builds use `logical_url` directly without any rewrite logic.
- Removed now-unnecessary `#[cfg(not(...))]` stub functions that returned `None`.

## Test plan

- [x] `cargo check` passes (zero errors)
- [x] `cargo test --lib -- channels::wasm::wrapper` passes (78 tests, including `test_rewrite_telegram_api_url_for_testing_uses_test_override`, `test_rewrite_http_url_for_testing_uses_host_map`, and `test_http_request_allows_private_target_for_telegram_test_rewrite`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)