### PR TITLE
Fix ACP sandbox job mode persistence

### DIFF
--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -1,0 +1,735 @@
+//! Matrix channel via external matrix-bridge HTTP/SSE API.
+//!
+//! Connects to a running matrix-bridge daemon.
+//! Listens for messages via SSE at `/api/v1/events` and sends via
+//! JSON-RPC at `/api/v1/rpc`.
+
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use chrono::{TimeZone, Utc};
+use futures::StreamExt;
+use lru::LruCache;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::sync::RwLock;
+use tokio::task::JoinHandle;
+use uuid::Uuid;
+
+use crate::channels::{
+    Channel, ChatApprovalPrompt, IncomingMessage, MessageStream, OutgoingResponse, StatusUpdate,
+};
+use crate::config::MatrixConfig;
+use crate::error::ChannelError;
+
+const MATRIX_HEALTH_ENDPOINT: &str = "/api/v1/check";
+const MATRIX_EVENTS_ENDPOINT: &str = "/api/v1/events";
+const MATRIX_RPC_ENDPOINT: &str = "/api/v1/rpc";
+const MAX_REPLY_TARGETS: usize = 10_000;
+const REPLY_TARGETS_CAP: NonZeroUsize = NonZeroUsize::new(MAX_REPLY_TARGETS).unwrap();
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MatrixRoute {
+    account: String,
+    room_id: String,
+    thread_root: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct MatrixEvent {
+    account: String,
+    #[allow(dead_code)]
+    event_id: String,
+    room_id: String,
+    sender: String,
+    sender_name: Option<String>,
+    body: String,
+    thread_root: Option<String>,
+    timestamp: u64,
+    #[allow(dead_code)]
+    is_encrypted: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct HealthResponse {
+    status: String,
+    #[serde(default)]
+    accounts: Vec<HealthAccount>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HealthAccount {
+    #[allow(dead_code)]
+    name: Option<String>,
+    #[allow(dead_code)]
+    user_id: Option<String>,
+    connected: bool,
+    #[allow(dead_code)]
+    last_sync_ms: Option<u64>,
+}
+
+pub struct MatrixChannel {
+    config: MatrixConfig,
+    client: Client,
+    reply_targets: Arc<RwLock<LruCache<Uuid, MatrixRoute>>>,
+    listener_task: std::sync::Mutex<Option<JoinHandle<()>>>,
+}
+
+impl MatrixChannel {
+    pub fn new(config: MatrixConfig) -> Result<Self, ChannelError> {
+        let mut config = config;
+        config.daemon_url = config.daemon_url.trim_end_matches('/').to_string();
+
+        let client = Client::builder()
+            .connect_timeout(Duration::from_secs(10))
+            .build()
+            .map_err(|e| ChannelError::Http(e.to_string()))?;
+
+        Ok(Self::from_parts(
+            config,
+            client,
+            Arc::new(RwLock::new(LruCache::new(REPLY_TARGETS_CAP))),
+        ))
+    }
+
+    fn from_parts(
+        config: MatrixConfig,
+        client: Client,
+        reply_targets: Arc<RwLock<LruCache<Uuid, MatrixRoute>>>,
+    ) -> Self {
+        Self {
+            config,
+            client,
+            reply_targets,
+            listener_task: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn route_from_metadata(metadata: &Value) -> Option<MatrixRoute> {
+        let room_id = metadata
+            .get("matrix_room")
+            .and_then(|v| v.as_str())
+            .or_else(|| metadata.get("target").and_then(|v| v.as_str()))?;
+
+        Some(MatrixRoute {
+            account: metadata
+                .get("matrix_account")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default()
+                .to_string(),
+            room_id: room_id.to_string(),
+            thread_root: metadata
+                .get("matrix_thread_root")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        })
+    }
+
+    fn is_sender_allowed(&self, sender: &str) -> bool {
+        self.config
+            .allow_from
+            .iter()
+            .any(|entry| entry == "*" || entry == sender)
+    }
+
+    fn is_room_allowed(&self, room_id: &str) -> bool {
+        self.config
+            .allow_from_rooms
+            .iter()
+            .any(|entry| entry == "*" || entry == room_id)
+    }
+
+    fn should_accept_event(&self, event: &MatrixEvent) -> bool {
+        // `dm_policy` and `room_policy` are config placeholders for the
+        // follow-on routing audit. Current POC behavior only applies flat
+        // sender and room allowlists, with Signal-style semantics:
+        // empty allowlists deny all, `*` opens access explicitly.
+        let _ = (
+            &self.config.dm_policy,
+            &self.config.room_policy,
+            &self.config.room_allow_from,
+        );
+        self.is_sender_allowed(&event.sender) && self.is_room_allowed(&event.room_id)
+    }
+
+    fn event_metadata(event: &MatrixEvent) -> Value {
+        json!({
+            "matrix_account": event.account,
+            "matrix_room": event.room_id,
+            "matrix_sender": event.sender,
+            "matrix_thread_root": event.thread_root,
+            "target": event.room_id,
+        })
+    }
+
+    fn conversation_scope(event: &MatrixEvent) -> String {
+        match event.thread_root.as_deref() {
+            Some(thread_root) => format!("{}:{}", event.room_id, thread_root),
+            None => event.room_id.clone(),
+        }
+    }
+
+    fn incoming_message_from_event(
+        &self,
+        event: MatrixEvent,
+    ) -> Option<(IncomingMessage, MatrixRoute)> {
+        if event.body.trim().is_empty() || !self.should_accept_event(&event) {
+            return None;
+        }
+
+        let conversation_scope = Self::conversation_scope(&event);
+        let thread_root = event.thread_root.clone();
+        let route = MatrixRoute {
+            account: event.account.clone(),
+            room_id: event.room_id.clone(),
+            thread_root: thread_root.clone(),
+        };
+
+        let metadata = Self::event_metadata(&event);
+        let mut msg = IncomingMessage::new("matrix", event.sender.clone(), event.body)
+            .with_sender_id(event.sender)
+            .with_metadata(metadata)
+            .with_conversation_scope(conversation_scope.clone());
+
+        if let Some(name) = event.sender_name {
+            msg = msg.with_user_name(name);
+        }
+        if let Some(thread_root) = thread_root {
+            msg = msg.with_thread(thread_root);
+            msg = msg.with_conversation_scope(conversation_scope);
+        }
+
+        if let Some(dt) = Utc.timestamp_millis_opt(event.timestamp as i64).single() {
+            msg.received_at = dt;
+        }
+
+        Some((msg, route))
+    }
+
+    async fn rpc_request(&self, method: &str, params: Value) -> Result<Value, ChannelError> {
+        let url = format!("{}{}", self.config.daemon_url, MATRIX_RPC_ENDPOINT);
+        let resp = self
+            .client
+            .post(&url)
+            .timeout(Duration::from_secs(30))
+            .json(&json!({
+                "jsonrpc": "2.0",
+                "method": method,
+                "params": params,
+                "id": Uuid::new_v4().to_string(),
+            }))
+            .send()
+            .await
+            .map_err(|e| ChannelError::Http(format!("matrix rpc request failed: {e}")))?;
+
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::Http(format!("matrix rpc response decode failed: {e}")))?;
+
+        if !status.is_success() {
+            return Err(ChannelError::Http(format!(
+                "matrix rpc returned HTTP {}",
+                status
+            )));
+        }
+
+        if let Some(err) = body.get("error") {
+            return Err(ChannelError::SendFailed {
+                name: "matrix".to_string(),
+                reason: err
+                    .get("message")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown matrix rpc error")
+                    .to_string(),
+            });
+        }
+
+        Ok(body.get("result").cloned().unwrap_or(Value::Null))
+    }
+
+    async fn send_message(&self, route: &MatrixRoute, body: &str) -> Result<(), ChannelError> {
+        if let Some(thread_root) = route.thread_root.as_deref() {
+            tracing::debug!(
+                room = %route.room_id,
+                thread_root = %thread_root,
+                "Matrix thread_root present; threaded outbound replies are deferred to the routing audit",
+            );
+        }
+        tracing::debug!(
+            room = %route.room_id,
+            account = %route.account,
+            "Sending Matrix message"
+        );
+
+        let _ = self
+            .rpc_request(
+                "send",
+                json!({
+                    "room_id": route.room_id,
+                    "body": body,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn send_typing(&self, route: &MatrixRoute, active: bool) -> Result<(), ChannelError> {
+        let _ = self
+            .rpc_request(
+                "sendTyping",
+                json!({
+                    "room_id": route.room_id,
+                    "active": active,
+                }),
+            )
+            .await?;
+        Ok(())
+    }
+
+    fn parse_broadcast_target(target: &str) -> Option<MatrixRoute> {
+        if !target.starts_with('!') {
+            return None;
+        }
+        Some(MatrixRoute {
+            account: String::new(),
+            room_id: target.to_string(),
+            thread_root: None,
+        })
+    }
+
+    fn parse_health(body: &Value) -> Result<(), String> {
+        let health: HealthResponse = serde_json::from_value(body.clone())
+            .map_err(|e| format!("invalid health payload: {e}"))?;
+
+        if health.status != "ok" {
+            return Err(format!("bridge status is {}", health.status));
+        }
+
+        if !health.accounts.iter().any(|account| account.connected) {
+            return Err("bridge reports no connected accounts".to_string());
+        }
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Channel for MatrixChannel {
+    fn name(&self) -> &str {
+        "matrix"
+    }
+
+    async fn start(&self) -> Result<MessageStream, ChannelError> {
+        let (tx, rx) = tokio::sync::mpsc::channel(256);
+
+        let config = self.config.clone();
+        let client = self.client.clone();
+        let reply_targets = Arc::clone(&self.reply_targets);
+
+        let task = tokio::spawn(async move {
+            if let Err(e) = sse_listener(config, client, tx, reply_targets).await {
+                tracing::error!("Matrix SSE listener exited with error: {e}");
+            }
+        });
+        let mut listener_task = self
+            .listener_task
+            .lock()
+            .expect("listener task mutex poisoned");
+        if let Some(previous) = listener_task.replace(task) {
+            previous.abort();
+        }
+
+        tracing::info!(url = %self.config.daemon_url, "Matrix channel started");
+        Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+    }
+
+    async fn respond(
+        &self,
+        msg: &IncomingMessage,
+        response: OutgoingResponse,
+    ) -> Result<(), ChannelError> {
+        if !response.attachments.is_empty() {
+            return Err(ChannelError::SendFailed {
+                name: "matrix".to_string(),
+                reason: "attachments are not yet supported for Matrix".to_string(),
+            });
+        }
+
+        let route = {
+            let targets = self.reply_targets.read().await;
+            targets.peek(&msg.id).cloned()
+        }
+        .or_else(|| Self::route_from_metadata(&msg.metadata))
+        .ok_or(ChannelError::MissingRoutingTarget {
+            name: "matrix".to_string(),
+            reason: "no Matrix room target found in reply cache or message metadata".to_string(),
+        })?;
+
+        let result = self.send_message(&route, &response.content).await;
+        self.reply_targets.write().await.pop(&msg.id);
+        result
+    }
+
+    async fn send_status(
+        &self,
+        status: StatusUpdate,
+        metadata: &Value,
+    ) -> Result<(), ChannelError> {
+        let route = match Self::route_from_metadata(metadata) {
+            Some(route) => route,
+            None => return Ok(()),
+        };
+
+        if matches!(status, StatusUpdate::Thinking(_)) {
+            let _ = self.send_typing(&route, true).await;
+        }
+
+        if let Some(prompt) = ChatApprovalPrompt::from_status(&status) {
+            let _ = self.send_message(&route, &prompt.markdown_message()).await;
+        }
+
+        if let StatusUpdate::Status(message) = &status {
+            let normalized = message.trim();
+            if !normalized.eq_ignore_ascii_case("done")
+                && !normalized.eq_ignore_ascii_case("awaiting approval")
+                && !normalized.eq_ignore_ascii_case("rejected")
+            {
+                let _ = self.send_message(&route, normalized).await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn broadcast(
+        &self,
+        user_id: &str,
+        response: OutgoingResponse,
+    ) -> Result<(), ChannelError> {
+        if !response.attachments.is_empty() {
+            return Err(ChannelError::SendFailed {
+                name: "matrix".to_string(),
+                reason: "attachments are not yet supported for Matrix".to_string(),
+            });
+        }
+
+        let route =
+            Self::parse_broadcast_target(user_id).ok_or(ChannelError::MissingRoutingTarget {
+                name: "matrix".to_string(),
+                reason: "Matrix broadcast target must be a room ID like !room:homeserver"
+                    .to_string(),
+            })?;
+
+        self.send_message(&route, &response.content).await
+    }
+
+    async fn health_check(&self) -> Result<(), ChannelError> {
+        let url = format!("{}{}", self.config.daemon_url, MATRIX_HEALTH_ENDPOINT);
+        let resp = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+            .map_err(|e| ChannelError::HealthCheckFailed {
+                name: format!("matrix ({}): {e}", self.config.daemon_url),
+            })?;
+
+        let status = resp.status();
+        let body: Value = resp
+            .json()
+            .await
+            .map_err(|e| ChannelError::HealthCheckFailed {
+                name: format!("matrix: invalid health payload ({e})"),
+            })?;
+
+        if !status.is_success() {
+            return Err(ChannelError::HealthCheckFailed {
+                name: format!("matrix: HTTP {status}"),
+            });
+        }
+
+        Self::parse_health(&body).map_err(|reason| ChannelError::HealthCheckFailed {
+            name: format!("matrix: {reason}"),
+        })
+    }
+
+    fn conversation_context(&self, metadata: &Value) -> HashMap<String, String> {
+        let mut ctx = HashMap::new();
+
+        if let Some(sender) = metadata.get("matrix_sender").and_then(|v| v.as_str()) {
+            ctx.insert("sender".to_string(), sender.to_string());
+        }
+        if let Some(account) = metadata.get("matrix_account").and_then(|v| v.as_str()) {
+            ctx.insert("account".to_string(), account.to_string());
+        }
+        if let Some(room) = metadata.get("matrix_room").and_then(|v| v.as_str()) {
+            ctx.insert("room".to_string(), room.to_string());
+        }
+        if let Some(thread) = metadata.get("matrix_thread_root").and_then(|v| v.as_str()) {
+            ctx.insert("thread".to_string(), thread.to_string());
+        }
+
+        ctx
+    }
+}
+
+impl Drop for MatrixChannel {
+    fn drop(&mut self) {
+        if let Some(handle) = self
+            .listener_task
+            .lock()
+            .expect("listener task mutex poisoned")
+            .take()
+        {
+            handle.abort();
+        }
+    }
+}
+
+async fn sse_listener(
+    config: MatrixConfig,
+    client: Client,
+    tx: tokio::sync::mpsc::Sender<IncomingMessage>,
+    reply_targets: Arc<RwLock<LruCache<Uuid, MatrixRoute>>>,
+) -> Result<(), ChannelError> {
+    let channel = MatrixChannel::from_parts(config, client, Arc::clone(&reply_targets));
+    let url = format!("{}{}", channel.config.daemon_url, MATRIX_EVENTS_ENDPOINT);
+
+    let mut retry_delay = Duration::from_secs(2);
+    let max_delay = Duration::from_secs(60);
+
+    loop {
+        let resp = channel
+            .client
+            .get(&url)
+            .header("Accept", "text/event-stream")
+            .send()
+            .await;
+
+        let resp = match resp {
+            Ok(r) if r.status().is_success() => r,
+            Ok(r) => {
+                tracing::warn!("Matrix SSE returned HTTP {}", r.status());
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(max_delay);
+                continue;
+            }
+            Err(e) => {
+                tracing::warn!("Matrix SSE connect error to {}: {}", url, e);
+                tokio::time::sleep(retry_delay).await;
+                retry_delay = (retry_delay * 2).min(max_delay);
+                continue;
+            }
+        };
+
+        retry_delay = Duration::from_secs(2);
+        tracing::info!("Matrix SSE connected");
+
+        let mut bytes_stream = resp.bytes_stream();
+        let mut buffer = String::new();
+        let mut current_data = String::new();
+
+        while let Some(chunk) = bytes_stream.next().await {
+            let chunk = match chunk {
+                Ok(chunk) => chunk,
+                Err(e) => {
+                    tracing::debug!("Matrix SSE chunk error, reconnecting: {e}");
+                    break;
+                }
+            };
+
+            buffer.push_str(&String::from_utf8_lossy(&chunk));
+
+            while let Some(idx) = buffer.find('\n') {
+                let mut line = buffer[..idx].to_string();
+                buffer = buffer[idx + 1..].to_string();
+                line = line.trim_end_matches('\r').to_string();
+
+                if line.is_empty() {
+                    if current_data.is_empty() {
+                        continue;
+                    }
+
+                    let event = match serde_json::from_str::<MatrixEvent>(current_data.trim_end()) {
+                        Ok(event) => event,
+                        Err(e) => {
+                            tracing::warn!("Failed to decode Matrix SSE event: {}", e);
+                            current_data.clear();
+                            continue;
+                        }
+                    };
+                    current_data.clear();
+
+                    if let Some((msg, route)) = channel.incoming_message_from_event(event) {
+                        reply_targets.write().await.put(msg.id, route);
+                        if tx.send(msg).await.is_err() {
+                            return Ok(());
+                        }
+                    }
+                    continue;
+                }
+
+                if let Some(data) = line.strip_prefix("data:") {
+                    current_data.push_str(data.trim_start());
+                    current_data.push('\n');
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_config() -> MatrixConfig {
+        MatrixConfig {
+            daemon_url: "http://127.0.0.1:8090".to_string(),
+            accounts: vec!["@bot:example.com".to_string()],
+            allow_from: vec!["*".to_string()],
+            allow_from_rooms: vec!["*".to_string()],
+            dm_policy: "open".to_string(),
+            room_policy: "allowlist".to_string(),
+            room_allow_from: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn incoming_message_from_event_sets_metadata_and_scope() {
+        let channel = MatrixChannel::new(make_config()).unwrap();
+        let event = MatrixEvent {
+            account: "@bot:example.com".to_string(),
+            event_id: "$event".to_string(),
+            room_id: "!room:example.com".to_string(),
+            sender: "@alice:example.com".to_string(),
+            sender_name: Some("Alice".to_string()),
+            body: "hello".to_string(),
+            thread_root: Some("$thread".to_string()),
+            timestamp: 1_700_000_000_000,
+            is_encrypted: true,
+        };
+
+        let (msg, route) = channel.incoming_message_from_event(event).expect("message");
+        assert_eq!(msg.channel, "matrix");
+        assert_eq!(msg.user_id, "@alice:example.com");
+        assert_eq!(msg.sender_id, "@alice:example.com");
+        assert_eq!(msg.thread_id.as_deref(), Some("$thread"));
+        assert_eq!(msg.conversation_scope(), Some("!room:example.com:$thread"));
+        assert_eq!(
+            msg.metadata.get("target").and_then(|v| v.as_str()),
+            Some("!room:example.com")
+        );
+        assert_eq!(route.room_id, "!room:example.com");
+    }
+
+    #[test]
+    fn incoming_message_respects_basic_filters() {
+        let mut config = make_config();
+        config.allow_from = vec!["@alice:example.com".to_string()];
+        config.allow_from_rooms = vec!["!room:example.com".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = MatrixEvent {
+            account: "@bot:example.com".to_string(),
+            event_id: "$event".to_string(),
+            room_id: "!room:example.com".to_string(),
+            sender: "@mallory:example.com".to_string(),
+            sender_name: None,
+            body: "hello".to_string(),
+            thread_root: None,
+            timestamp: 1,
+            is_encrypted: false,
+        };
+
+        assert!(channel.incoming_message_from_event(event).is_none());
+    }
+
+    #[test]
+    fn incoming_message_denies_when_allowlists_are_empty() {
+        let mut config = make_config();
+        config.allow_from.clear();
+        config.allow_from_rooms.clear();
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = MatrixEvent {
+            account: "@bot:example.com".to_string(),
+            event_id: "$event".to_string(),
+            room_id: "!room:example.com".to_string(),
+            sender: "@alice:example.com".to_string(),
+            sender_name: None,
+            body: "hello".to_string(),
+            thread_root: None,
+            timestamp: 1,
+            is_encrypted: false,
+        };
+
+        assert!(channel.incoming_message_from_event(event).is_none());
+    }
+
+    #[test]
+    fn incoming_message_accepts_wildcard_allowlists() {
+        let channel = MatrixChannel::new(make_config()).unwrap();
+        let event = MatrixEvent {
+            account: "@bot:example.com".to_string(),
+            event_id: "$event".to_string(),
+            room_id: "!room:example.com".to_string(),
+            sender: "@alice:example.com".to_string(),
+            sender_name: None,
+            body: "hello".to_string(),
+            thread_root: None,
+            timestamp: 1,
+            is_encrypted: false,
+        };
+
+        assert!(channel.incoming_message_from_event(event).is_some());
+    }
+
+    #[test]
+    fn conversation_context_extracts_matrix_fields() {
+        let channel = MatrixChannel::new(make_config()).unwrap();
+        let metadata = json!({
+            "matrix_sender": "@alice:example.com",
+            "matrix_account": "@bot:example.com",
+            "matrix_room": "!room:example.com",
+            "matrix_thread_root": "$thread",
+        });
+
+        let ctx = channel.conversation_context(&metadata);
+        assert_eq!(ctx.get("sender"), Some(&"@alice:example.com".to_string()));
+        assert_eq!(ctx.get("account"), Some(&"@bot:example.com".to_string()));
+        assert_eq!(ctx.get("room"), Some(&"!room:example.com".to_string()));
+        assert_eq!(ctx.get("thread"), Some(&"$thread".to_string()));
+    }
+
+    #[test]
+    fn parse_health_requires_connected_account() {
+        let healthy = json!({
+            "status": "ok",
+            "accounts": [{"connected": true}]
+        });
+        assert!(MatrixChannel::parse_health(&healthy).is_ok());
+
+        let unhealthy = json!({
+            "status": "starting",
+            "accounts": [{"connected": false}]
+        });
+        assert!(MatrixChannel::parse_health(&unhealthy).is_err());
+    }
+
+    #[test]
+    fn route_from_metadata_uses_generic_target_fallback() {
+        let route = MatrixChannel::route_from_metadata(&json!({
+            "matrix_account": "@bot:example.com",
+            "target": "!room:example.com"
+        }))
+        .expect("route");
+
+        assert_eq!(route.account, "@bot:example.com");
+        assert_eq!(route.room_id, "!room:example.com");
+    }
+}

--- a/src/channels/matrix.rs
+++ b/src/channels/matrix.rs
@@ -39,6 +39,20 @@ struct MatrixRoute {
     thread_root: Option<String>,
 }
 
+/// Parsed broadcast target. Separated from `broadcast()` so the synchronous
+/// parsing logic can be unit-tested without an RPC client.
+#[derive(Debug, PartialEq, Eq)]
+enum BroadcastTarget {
+    /// Explicit account + room routing: `account|room_id`.
+    AccountRoom { account: String, room_id: String },
+    /// Direct room send: `!room:homeserver`.
+    Room(String),
+    /// DM by user ID: `@user:homeserver` (needs async createDm).
+    DmUser(String),
+    /// Unparseable target.
+    Invalid(String),
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct MatrixEvent {
     account: String,
@@ -52,6 +66,8 @@ struct MatrixEvent {
     timestamp: u64,
     #[allow(dead_code)]
     is_encrypted: bool,
+    #[serde(default)]
+    is_direct: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -129,31 +145,58 @@ impl MatrixChannel {
         })
     }
 
-    fn is_sender_allowed(&self, sender: &str) -> bool {
-        self.config
-            .allow_from
-            .iter()
-            .any(|entry| entry == "*" || entry == sender)
+    fn sender_matches(list: &[String], sender: &str) -> bool {
+        list.iter().any(|entry| entry == "*" || entry == sender)
     }
 
-    fn is_room_allowed(&self, room_id: &str) -> bool {
-        self.config
-            .allow_from_rooms
-            .iter()
-            .any(|entry| entry == "*" || entry == room_id)
+    fn room_matches(list: &[String], room_id: &str) -> bool {
+        list.iter().any(|entry| entry == "*" || entry == room_id)
     }
 
     fn should_accept_event(&self, event: &MatrixEvent) -> bool {
-        // `dm_policy` and `room_policy` are config placeholders for the
-        // follow-on routing audit. Current POC behavior only applies flat
-        // sender and room allowlists, with Signal-style semantics:
-        // empty allowlists deny all, `*` opens access explicitly.
-        let _ = (
-            &self.config.dm_policy,
-            &self.config.room_policy,
-            &self.config.room_allow_from,
-        );
-        self.is_sender_allowed(&event.sender) && self.is_room_allowed(&event.room_id)
+        if event.is_direct {
+            match self.config.dm_policy.as_str() {
+                "open" => true,
+                "allowlist" => Self::sender_matches(&self.config.allow_from, &event.sender),
+                other => {
+                    tracing::warn!(
+                        policy = %other,
+                        "unknown matrix dm_policy, treating as allowlist"
+                    );
+                    Self::sender_matches(&self.config.allow_from, &event.sender)
+                }
+            }
+        } else {
+            match self.config.room_policy.as_str() {
+                "disabled" => false,
+                "open" => {
+                    // open = accept any room, but still enforce sender restrictions.
+                    let effective_sender_list = if self.config.room_allow_from.is_empty() {
+                        &self.config.allow_from
+                    } else {
+                        &self.config.room_allow_from
+                    };
+                    Self::sender_matches(effective_sender_list, &event.sender)
+                }
+                "allowlist" => {
+                    let room_ok = Self::room_matches(&self.config.allow_from_rooms, &event.room_id);
+                    let effective_sender_list = if self.config.room_allow_from.is_empty() {
+                        &self.config.allow_from
+                    } else {
+                        &self.config.room_allow_from
+                    };
+                    let sender_ok = Self::sender_matches(effective_sender_list, &event.sender);
+                    room_ok && sender_ok
+                }
+                other => {
+                    tracing::warn!(
+                        policy = %other,
+                        "unknown matrix room_policy, failing closed"
+                    );
+                    false
+                }
+            }
+        }
     }
 
     fn event_metadata(event: &MatrixEvent) -> Value {
@@ -162,6 +205,7 @@ impl MatrixChannel {
             "matrix_room": event.room_id,
             "matrix_sender": event.sender,
             "matrix_thread_root": event.thread_root,
+            "is_direct": event.is_direct,
             "target": event.room_id,
         })
     }
@@ -254,53 +298,60 @@ impl MatrixChannel {
     }
 
     async fn send_message(&self, route: &MatrixRoute, body: &str) -> Result<(), ChannelError> {
-        if let Some(thread_root) = route.thread_root.as_deref() {
-            tracing::debug!(
-                room = %route.room_id,
-                thread_root = %thread_root,
-                "Matrix thread_root present; threaded outbound replies are deferred to the routing audit",
-            );
-        }
         tracing::debug!(
             room = %route.room_id,
             account = %route.account,
+            thread_root = ?route.thread_root,
             "Sending Matrix message"
         );
 
-        let _ = self
-            .rpc_request(
-                "send",
-                json!({
-                    "room_id": route.room_id,
-                    "body": body,
-                }),
-            )
-            .await?;
+        let mut rpc_params = json!({
+            "room_id": route.room_id,
+            "body": body,
+        });
+        if let Some(ref thread_root) = route.thread_root {
+            rpc_params["thread_root"] = json!(thread_root);
+        }
+        if !route.account.is_empty() {
+            rpc_params["account"] = json!(route.account);
+        }
+
+        let _ = self.rpc_request("send", rpc_params).await?;
         Ok(())
+    }
+
+    /// Parse a broadcast target string into a typed target. Checked in this order:
+    /// 1. `account|room_id` (split_once BEFORE starts_with('@') — Matrix accounts start with @)
+    /// 2. `!room:homeserver`
+    /// 3. `@user:homeserver` (DM)
+    /// 4. anything else → Invalid
+    fn parse_broadcast_target(target: &str) -> BroadcastTarget {
+        if let Some((account, room)) = target.split_once('|') {
+            BroadcastTarget::AccountRoom {
+                account: account.to_string(),
+                room_id: room.to_string(),
+            }
+        } else if target.starts_with('!') {
+            BroadcastTarget::Room(target.to_string())
+        } else if target.starts_with('@') {
+            BroadcastTarget::DmUser(target.to_string())
+        } else {
+            BroadcastTarget::Invalid(format!(
+                "cannot parse broadcast target: {target} (expected !room, @user, or account|room)"
+            ))
+        }
     }
 
     async fn send_typing(&self, route: &MatrixRoute, active: bool) -> Result<(), ChannelError> {
-        let _ = self
-            .rpc_request(
-                "sendTyping",
-                json!({
-                    "room_id": route.room_id,
-                    "active": active,
-                }),
-            )
-            .await?;
-        Ok(())
-    }
-
-    fn parse_broadcast_target(target: &str) -> Option<MatrixRoute> {
-        if !target.starts_with('!') {
-            return None;
+        let mut rpc_params = json!({
+            "room_id": route.room_id,
+            "active": active,
+        });
+        if !route.account.is_empty() {
+            rpc_params["account"] = json!(route.account);
         }
-        Some(MatrixRoute {
-            account: String::new(),
-            room_id: target.to_string(),
-            thread_root: None,
-        })
+        let _ = self.rpc_request("sendTyping", rpc_params).await?;
+        Ok(())
     }
 
     fn parse_health(body: &Value) -> Result<(), String> {
@@ -361,15 +412,49 @@ impl Channel for MatrixChannel {
             });
         }
 
-        let route = {
+        let cached_route = {
             let targets = self.reply_targets.read().await;
             targets.peek(&msg.id).cloned()
         }
-        .or_else(|| Self::route_from_metadata(&msg.metadata))
-        .ok_or(ChannelError::MissingRoutingTarget {
-            name: "matrix".to_string(),
-            reason: "no Matrix room target found in reply cache or message metadata".to_string(),
-        })?;
+        .or_else(|| Self::route_from_metadata(&msg.metadata));
+
+        let route = match cached_route {
+            Some(r) => r,
+            None => {
+                // Sender fallback: resolve DM from the sender's user ID.
+                // This handles cache eviction + metadata loss gracefully.
+                if msg.sender_id.starts_with('@') {
+                    let result = self
+                        .rpc_request("createDm", json!({"target_user": &msg.sender_id}))
+                        .await
+                        .map_err(|_| ChannelError::MissingRoutingTarget {
+                            name: "matrix".into(),
+                            reason: "no reply target in cache or metadata, and DM fallback failed"
+                                .into(),
+                        })?;
+                    let room_id =
+                        result
+                            .get("room_id")
+                            .and_then(|v| v.as_str())
+                            .ok_or_else(|| ChannelError::MissingRoutingTarget {
+                                name: "matrix".into(),
+                                reason: "createDm fallback did not return room_id".into(),
+                            })?;
+                    MatrixRoute {
+                        account: String::new(),
+                        room_id: room_id.to_string(),
+                        thread_root: None,
+                    }
+                } else {
+                    return Err(ChannelError::MissingRoutingTarget {
+                        name: "matrix".into(),
+                        reason:
+                            "no Matrix room target found in reply cache, metadata, or sender fallback"
+                                .into(),
+                    });
+                }
+            }
+        };
 
         let result = self.send_message(&route, &response.content).await;
         self.reply_targets.write().await.pop(&msg.id);
@@ -419,12 +504,41 @@ impl Channel for MatrixChannel {
             });
         }
 
-        let route =
-            Self::parse_broadcast_target(user_id).ok_or(ChannelError::MissingRoutingTarget {
-                name: "matrix".to_string(),
-                reason: "Matrix broadcast target must be a room ID like !room:homeserver"
-                    .to_string(),
-            })?;
+        let route = match Self::parse_broadcast_target(user_id) {
+            BroadcastTarget::AccountRoom { account, room_id } => MatrixRoute {
+                account,
+                room_id,
+                thread_root: None,
+            },
+            BroadcastTarget::Room(room_id) => MatrixRoute {
+                account: String::new(),
+                room_id,
+                thread_root: None,
+            },
+            BroadcastTarget::DmUser(target_user) => {
+                let result = self
+                    .rpc_request("createDm", json!({"target_user": target_user}))
+                    .await?;
+                let room_id = result
+                    .get("room_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ChannelError::SendFailed {
+                        name: "matrix".into(),
+                        reason: "createDm did not return room_id".into(),
+                    })?;
+                MatrixRoute {
+                    account: String::new(),
+                    room_id: room_id.to_string(),
+                    thread_root: None,
+                }
+            }
+            BroadcastTarget::Invalid(reason) => {
+                return Err(ChannelError::MissingRoutingTarget {
+                    name: "matrix".into(),
+                    reason,
+                });
+            }
+        };
 
         self.send_message(&route, &response.content).await
     }
@@ -601,6 +715,21 @@ mod tests {
         }
     }
 
+    fn make_event(sender: &str, room_id: &str, is_direct: bool) -> MatrixEvent {
+        MatrixEvent {
+            account: "@bot:example.com".to_string(),
+            event_id: "$event".to_string(),
+            room_id: room_id.to_string(),
+            sender: sender.to_string(),
+            sender_name: None,
+            body: "hello".to_string(),
+            thread_root: None,
+            timestamp: 1,
+            is_encrypted: false,
+            is_direct,
+        }
+    }
+
     #[test]
     fn incoming_message_from_event_sets_metadata_and_scope() {
         let channel = MatrixChannel::new(make_config()).unwrap();
@@ -614,6 +743,7 @@ mod tests {
             thread_root: Some("$thread".to_string()),
             timestamp: 1_700_000_000_000,
             is_encrypted: true,
+            is_direct: false,
         };
 
         let (msg, route) = channel.incoming_message_from_event(event).expect("message");
@@ -645,6 +775,7 @@ mod tests {
             thread_root: None,
             timestamp: 1,
             is_encrypted: false,
+            is_direct: false,
         };
 
         assert!(channel.incoming_message_from_event(event).is_none());
@@ -656,37 +787,181 @@ mod tests {
         config.allow_from.clear();
         config.allow_from_rooms.clear();
         let channel = MatrixChannel::new(config).unwrap();
-        let event = MatrixEvent {
-            account: "@bot:example.com".to_string(),
-            event_id: "$event".to_string(),
-            room_id: "!room:example.com".to_string(),
-            sender: "@alice:example.com".to_string(),
-            sender_name: None,
-            body: "hello".to_string(),
-            thread_root: None,
-            timestamp: 1,
-            is_encrypted: false,
-        };
-
+        let event = make_event("@alice:example.com", "!room:example.com", false);
         assert!(channel.incoming_message_from_event(event).is_none());
     }
 
     #[test]
     fn incoming_message_accepts_wildcard_allowlists() {
         let channel = MatrixChannel::new(make_config()).unwrap();
-        let event = MatrixEvent {
-            account: "@bot:example.com".to_string(),
-            event_id: "$event".to_string(),
-            room_id: "!room:example.com".to_string(),
-            sender: "@alice:example.com".to_string(),
-            sender_name: None,
-            body: "hello".to_string(),
-            thread_root: None,
-            timestamp: 1,
-            is_encrypted: false,
-        };
-
+        let event = make_event("@alice:example.com", "!room:example.com", false);
         assert!(channel.incoming_message_from_event(event).is_some());
+    }
+
+    // ── Policy enforcement tests ──
+
+    #[test]
+    fn policy_dm_open_accepts_unlisted_sender() {
+        let mut config = make_config();
+        config.dm_policy = "open".to_string();
+        config.allow_from = Vec::new(); // empty = deny all for rooms, but open DM ignores it
+        config.allow_from_rooms = vec!["*".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@stranger:example.com", "!dm:example.com", true);
+        assert!(channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_dm_allowlist_rejects_unlisted_sender() {
+        let mut config = make_config();
+        config.dm_policy = "allowlist".to_string();
+        config.allow_from = vec!["@alice:example.com".to_string()];
+        config.allow_from_rooms = vec!["*".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@bob:example.com", "!dm:example.com", true);
+        assert!(!channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_dm_allowlist_accepts_listed_sender() {
+        let mut config = make_config();
+        config.dm_policy = "allowlist".to_string();
+        config.allow_from = vec!["@alice:example.com".to_string()];
+        config.allow_from_rooms = vec!["*".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@alice:example.com", "!dm:example.com", true);
+        assert!(channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_dm_allowlist_wildcard_accepts_all() {
+        let mut config = make_config();
+        config.dm_policy = "allowlist".to_string();
+        config.allow_from = vec!["*".to_string()];
+        config.allow_from_rooms = vec!["*".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@anyone:example.com", "!dm:example.com", true);
+        assert!(channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_room_disabled_rejects_all() {
+        let mut config = make_config();
+        config.room_policy = "disabled".to_string();
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@alice:example.com", "!room:example.com", false);
+        assert!(!channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_room_allowlist_with_room_allow_from() {
+        let mut config = make_config();
+        config.room_policy = "allowlist".to_string();
+        config.allow_from_rooms = vec!["!room:example.com".to_string()];
+        config.room_allow_from = vec!["@alice:example.com".to_string()];
+        let channel = MatrixChannel::new(config).unwrap();
+
+        let allowed = make_event("@alice:example.com", "!room:example.com", false);
+        assert!(channel.should_accept_event(&allowed));
+
+        let denied = make_event("@bob:example.com", "!room:example.com", false);
+        assert!(!channel.should_accept_event(&denied));
+    }
+
+    #[test]
+    fn policy_room_allow_from_inherits_from_allow_from_when_empty() {
+        let mut config = make_config();
+        config.room_policy = "allowlist".to_string();
+        config.allow_from = vec!["@alice:example.com".to_string()];
+        config.allow_from_rooms = vec!["!room:example.com".to_string()];
+        config.room_allow_from = Vec::new(); // should inherit from allow_from
+        let channel = MatrixChannel::new(config).unwrap();
+
+        let allowed = make_event("@alice:example.com", "!room:example.com", false);
+        assert!(channel.should_accept_event(&allowed));
+
+        let denied = make_event("@bob:example.com", "!room:example.com", false);
+        assert!(!channel.should_accept_event(&denied));
+    }
+
+    #[test]
+    fn policy_unknown_dm_policy_fails_as_allowlist() {
+        let mut config = make_config();
+        config.dm_policy = "invalid".to_string();
+        config.allow_from = Vec::new(); // empty = deny
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@alice:example.com", "!dm:example.com", true);
+        assert!(!channel.should_accept_event(&event));
+    }
+
+    #[test]
+    fn policy_unknown_room_policy_fails_closed() {
+        let mut config = make_config();
+        config.room_policy = "invalid".to_string();
+        let channel = MatrixChannel::new(config).unwrap();
+        let event = make_event("@alice:example.com", "!room:example.com", false);
+        assert!(!channel.should_accept_event(&event));
+    }
+
+    // ── Broadcast target parsing tests ──
+
+    // ── Broadcast target parsing tests (exercises production parse_broadcast_target) ──
+
+    #[test]
+    fn broadcast_pipe_parsed_before_at() {
+        // @account|!room must parse as AccountRoom, NOT DmUser.
+        let result =
+            MatrixChannel::parse_broadcast_target("@work-bot:example.com|!alerts:example.com");
+        assert_eq!(
+            result,
+            BroadcastTarget::AccountRoom {
+                account: "@work-bot:example.com".to_string(),
+                room_id: "!alerts:example.com".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn broadcast_room_target() {
+        let result = MatrixChannel::parse_broadcast_target("!room:example.com");
+        assert_eq!(
+            result,
+            BroadcastTarget::Room("!room:example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn broadcast_dm_target() {
+        let result = MatrixChannel::parse_broadcast_target("@user:example.com");
+        assert_eq!(
+            result,
+            BroadcastTarget::DmUser("@user:example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn broadcast_invalid_target() {
+        let result = MatrixChannel::parse_broadcast_target("not-a-valid-target");
+        assert!(matches!(result, BroadcastTarget::Invalid(_)));
+    }
+
+    // ── room_policy=open test ──
+
+    #[test]
+    fn policy_room_open_accepts_any_room_but_enforces_sender() {
+        let mut config = make_config();
+        config.room_policy = "open".to_string();
+        config.allow_from_rooms = Vec::new(); // empty — open means any room
+        config.allow_from = vec!["@alice:example.com".to_string()]; // sender still restricted
+        let channel = MatrixChannel::new(config).unwrap();
+
+        // Alice in an unlisted room: accepted (open room + sender matches)
+        let allowed = make_event("@alice:example.com", "!unlisted:example.com", false);
+        assert!(channel.should_accept_event(&allowed));
+
+        // Bob in an unlisted room: rejected (open room but sender doesn't match)
+        let denied = make_event("@bob:example.com", "!unlisted:example.com", false);
+        assert!(!channel.should_accept_event(&denied));
     }
 
     #[test]

--- a/src/channels/mod.rs
+++ b/src/channels/mod.rs
@@ -30,6 +30,7 @@
 mod channel;
 mod http;
 mod manager;
+mod matrix;
 pub mod relay;
 mod repl;
 mod signal;
@@ -48,6 +49,7 @@ pub use channel::{
 };
 pub use http::{HttpChannel, HttpChannelState};
 pub use manager::ChannelManager;
+pub use matrix::MatrixChannel;
 pub use repl::ReplChannel;
 pub use signal::SignalChannel;
 pub use web::GatewayChannel;

--- a/src/cli/channels.rs
+++ b/src/cli/channels.rs
@@ -128,6 +128,28 @@ async fn cmd_list(
         });
     }
 
+    // Built-in: Matrix
+    if let Some(ref matrix) = config.matrix {
+        channels.push(ChannelInfo {
+            name: "matrix".to_string(),
+            kind: "built-in",
+            enabled: true,
+            details: vec![
+                ("daemon_url", matrix.daemon_url.clone()),
+                ("accounts", matrix.accounts.join(",")),
+                ("dm_policy", matrix.dm_policy.clone()),
+                ("room_policy", matrix.room_policy.clone()),
+            ],
+        });
+    } else {
+        channels.push(ChannelInfo {
+            name: "matrix".to_string(),
+            kind: "built-in",
+            enabled: false,
+            details: vec![],
+        });
+    }
+
     // WASM channels: scan directory
     if config.wasm_channels_enabled {
         let wasm_channels = discover_wasm_channels(&config.wasm_channels_dir).await;

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use crate::bootstrap::ironclaw_base_dir;
 use crate::cli::fmt;
+use crate::config::ChannelsConfig;
 use crate::settings::Settings;
 
 /// Load settings from JSON and TOML config files, matching the runtime
@@ -50,9 +51,48 @@ async fn load_acp_agents_for_status()
     }
 }
 
+fn resolve_channels_for_status(settings: &Settings) -> Result<ChannelsConfig, String> {
+    let owner_id =
+        crate::config::resolve_owner_id(settings).unwrap_or_else(|_| "default".to_string());
+    ChannelsConfig::resolve(settings, &owner_id).map_err(|e| e.to_string())
+}
+
+async fn matrix_status_summary(channels: Result<&ChannelsConfig, &String>) -> Option<String> {
+    let channels = match channels {
+        Ok(channels) => channels,
+        Err(err) => return Some(format!("matrix:error (config resolution failed: {err})")),
+    };
+
+    let Some(matrix) = channels.matrix.as_ref() else {
+        return None;
+    };
+
+    let daemon_url = matrix.daemon_url.trim_end_matches('/').to_string();
+
+    let health_url = format!("{}/api/v1/check", daemon_url.trim_end_matches('/'));
+    match reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+    {
+        Ok(client) => match client.get(&health_url).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                Some(format!("matrix:healthy ({})", daemon_url))
+            }
+            Ok(resp) => Some(format!(
+                "matrix:unhealthy (HTTP {} @ {})",
+                resp.status(),
+                daemon_url
+            )),
+            Err(e) => Some(format!("matrix:unhealthy ({} @ {})", e, daemon_url)),
+        },
+        Err(e) => Some(format!("matrix:error ({} @ {})", e, daemon_url)),
+    }
+}
+
 /// Run the status command, printing system health info.
 pub async fn run_status_command() -> anyhow::Result<()> {
     let settings = load_settings();
+    let channels = resolve_channels_for_status(&settings);
 
     println!();
     println!("  {}IronClaw Status{}", fmt::bold(), fmt::reset());
@@ -165,6 +205,9 @@ pub async fn run_status_command() -> anyhow::Result<()> {
             "http:{}",
             settings.channels.http_port.unwrap_or(3000)
         ));
+    }
+    if let Some(matrix_status) = matrix_status_summary(channels.as_ref()).await {
+        channel_info.push(matrix_status);
     }
     if channels_dir.exists() {
         let wasm_count = count_wasm_files(&channels_dir);

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -17,6 +17,7 @@ pub struct ChannelsConfig {
     pub cli: CliConfig,
     pub http: Option<HttpConfig>,
     pub gateway: Option<GatewayConfig>,
+    pub matrix: Option<MatrixConfig>,
     pub signal: Option<SignalConfig>,
     pub tui: Option<TuiChannelConfig>,
     /// Directory containing WASM channel modules (default: ~/.ironclaw/channels/).
@@ -85,6 +86,25 @@ pub struct GatewayOidcConfig {
     pub issuer: Option<String>,
     /// Expected `aud` claim. Validated if set.
     pub audience: Option<String>,
+}
+
+/// Matrix channel configuration (external matrix-bridge daemon HTTP/SSE API).
+#[derive(Debug, Clone)]
+pub struct MatrixConfig {
+    /// Base URL of the Matrix bridge daemon (e.g. `http://127.0.0.1:8090`).
+    pub daemon_url: String,
+    /// Matrix user IDs associated with this channel configuration.
+    pub accounts: Vec<String>,
+    /// Users allowed to interact with the bot.
+    pub allow_from: Vec<String>,
+    /// Rooms allowed to interact with the bot.
+    pub allow_from_rooms: Vec<String>,
+    /// DM policy placeholder for future routing semantics work.
+    pub dm_policy: String,
+    /// Room policy placeholder for future routing semantics work.
+    pub room_policy: String,
+    /// Room-specific sender allowlist.
+    pub room_allow_from: Vec<String>,
 }
 
 /// Signal channel configuration (signal-cli daemon HTTP/JSON-RPC).
@@ -299,6 +319,81 @@ impl ChannelsConfig {
             None
         };
 
+        let matrix_enabled =
+            db_first_bool(cs.matrix_enabled, defaults.matrix_enabled, "MATRIX_ENABLED")?;
+        let matrix_url = db_first_optional_string(&cs.matrix_daemon_url, "MATRIX_DAEMON_URL")?;
+        let matrix = if matrix_enabled || matrix_url.is_some() {
+            let daemon_url = matrix_url.ok_or(ConfigError::InvalidValue {
+                key: "MATRIX_DAEMON_URL".to_string(),
+                message: "MATRIX_DAEMON_URL is required when matrix is enabled".to_string(),
+            })?;
+            match reqwest::Url::parse(&daemon_url) {
+                Ok(url) if url.scheme() == "http" || url.scheme() == "https" => {}
+                Ok(_) => {
+                    return Err(ConfigError::InvalidValue {
+                        key: "MATRIX_DAEMON_URL".to_string(),
+                        message: "must use http or https scheme".to_string(),
+                    });
+                }
+                Err(e) => {
+                    return Err(ConfigError::InvalidValue {
+                        key: "MATRIX_DAEMON_URL".to_string(),
+                        message: format!("must be a valid URL: {e}"),
+                    });
+                }
+            }
+            Some(MatrixConfig {
+                daemon_url,
+                accounts: db_first_optional_string(&cs.matrix_accounts, "MATRIX_ACCOUNTS")?
+                    .map(|s| {
+                        s.split(',')
+                            .map(|e| e.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                allow_from: db_first_optional_string(&cs.matrix_allow_from, "MATRIX_ALLOW_FROM")?
+                    .map(|s| {
+                        s.split(',')
+                            .map(|e| e.trim().to_string())
+                            .filter(|s| !s.is_empty())
+                            .collect()
+                    })
+                    .unwrap_or_default(),
+                allow_from_rooms: db_first_optional_string(
+                    &cs.matrix_allow_from_rooms,
+                    "MATRIX_ALLOW_FROM_ROOMS",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+                dm_policy: db_first_optional_string(&cs.matrix_dm_policy, "MATRIX_DM_POLICY")?
+                    .unwrap_or_else(|| "open".to_string()),
+                room_policy: db_first_optional_string(
+                    &cs.matrix_room_policy,
+                    "MATRIX_ROOM_POLICY",
+                )?
+                .unwrap_or_else(|| "allowlist".to_string()),
+                room_allow_from: db_first_optional_string(
+                    &cs.matrix_room_allow_from,
+                    "MATRIX_ROOM_ALLOW_FROM",
+                )?
+                .map(|s| {
+                    s.split(',')
+                        .map(|e| e.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            })
+        } else {
+            None
+        };
+
         let signal_enabled =
             db_first_bool(cs.signal_enabled, defaults.signal_enabled, "SIGNAL_ENABLED")?;
         let signal_url = db_first_optional_string(&cs.signal_http_url, "SIGNAL_HTTP_URL")?;
@@ -386,6 +481,7 @@ impl ChannelsConfig {
             },
             http,
             gateway,
+            matrix,
             signal,
             tui,
             wasm_channels_dir: {
@@ -548,11 +644,28 @@ mod tests {
     }
 
     #[test]
+    fn matrix_config_fields() {
+        let cfg = MatrixConfig {
+            daemon_url: "http://127.0.0.1:8090".to_string(),
+            accounts: vec!["@bot:example.com".to_string()],
+            allow_from: vec!["@alice:example.com".to_string()],
+            allow_from_rooms: vec!["!room:example.com".to_string()],
+            dm_policy: "open".to_string(),
+            room_policy: "allowlist".to_string(),
+            room_allow_from: vec!["@bob:example.com".to_string()],
+        };
+        assert_eq!(cfg.daemon_url, "http://127.0.0.1:8090");
+        assert_eq!(cfg.accounts, vec!["@bot:example.com"]);
+        assert_eq!(cfg.allow_from_rooms, vec!["!room:example.com"]);
+    }
+
+    #[test]
     fn channels_config_fields() {
         let cfg = ChannelsConfig {
             cli: CliConfig { enabled: true },
             http: None,
             gateway: None,
+            matrix: None,
             signal: None,
             tui: None,
             wasm_channels_dir: PathBuf::from("/tmp/channels"),
@@ -562,6 +675,7 @@ mod tests {
         assert!(cfg.cli.enabled);
         assert!(cfg.http.is_none());
         assert!(cfg.gateway.is_none());
+        assert!(cfg.matrix.is_none());
         assert!(cfg.signal.is_none());
         assert_eq!(cfg.wasm_channels_dir, PathBuf::from("/tmp/channels"));
         assert!(cfg.wasm_channels_enabled);
@@ -578,6 +692,7 @@ mod tests {
             cli: CliConfig { enabled: false },
             http: None,
             gateway: None,
+            matrix: None,
             signal: None,
             tui: None,
             wasm_channels_dir: PathBuf::from("/opt/channels"),
@@ -614,6 +729,12 @@ mod tests {
         settings.channels.signal_http_url = Some("http://127.0.0.1:8080".to_string());
         settings.channels.signal_account = Some("+15551234567".to_string());
         settings.channels.signal_allow_from = Some("+15551234567,+15557654321".to_string());
+        settings.channels.matrix_enabled = true;
+        settings.channels.matrix_daemon_url = Some("http://127.0.0.1:8090".to_string());
+        settings.channels.matrix_accounts = Some("@bot:example.com".to_string());
+        settings.channels.matrix_allow_from =
+            Some("@alice:example.com,@bob:example.com".to_string());
+        settings.channels.matrix_allow_from_rooms = Some("!room:example.com".to_string());
         settings.channels.wasm_channels_dir = Some(PathBuf::from("/tmp/settings-channels"));
         settings.channels.wasm_channels_enabled = false;
 
@@ -633,6 +754,15 @@ mod tests {
         assert_eq!(signal.account, "+15551234567");
         assert_eq!(signal.allow_from, vec!["+15551234567", "+15557654321"]);
 
+        let matrix = cfg.matrix.expect("matrix config");
+        assert_eq!(matrix.daemon_url, "http://127.0.0.1:8090");
+        assert_eq!(matrix.accounts, vec!["@bot:example.com"]);
+        assert_eq!(
+            matrix.allow_from,
+            vec!["@alice:example.com", "@bob:example.com"]
+        );
+        assert_eq!(matrix.allow_from_rooms, vec!["!room:example.com"]);
+
         assert_eq!(
             cfg.wasm_channels_dir,
             PathBuf::from("/tmp/settings-channels")
@@ -641,6 +771,20 @@ mod tests {
 
         // SAFETY: under ENV_MUTEX
         unsafe { std::env::remove_var("GATEWAY_AUTH_TOKEN") };
+    }
+
+    #[test]
+    fn resolve_rejects_invalid_matrix_url() {
+        let _guard = lock_env();
+        let mut settings = Settings::default();
+        settings.channels.matrix_enabled = true;
+        settings.channels.matrix_daemon_url = Some("not-a-url".to_string());
+
+        let err = ChannelsConfig::resolve(&settings, "owner-scope").unwrap_err();
+        assert!(matches!(
+            err,
+            crate::error::ConfigError::InvalidValue { .. }
+        ));
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,7 +53,7 @@ pub use self::agent::AgentConfig;
 pub use self::builder::BuilderModeConfig;
 pub use self::channels::{
     ChannelsConfig, CliConfig, DEFAULT_GATEWAY_PORT, GatewayConfig, GatewayOidcConfig, HttpConfig,
-    SignalConfig, TuiChannelConfig,
+    MatrixConfig, SignalConfig, TuiChannelConfig,
 };
 pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsql_path};
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
@@ -182,6 +182,7 @@ impl Config {
                 cli: CliConfig { enabled: false },
                 http: None,
                 gateway: None,
+                matrix: None,
                 signal: None,
                 tui: None,
                 wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,8 @@ use ironclaw::{
     agent::{Agent, AgentDeps},
     app::{AppBuilder, AppBuilderFlags},
     channels::{
-        ChannelManager, GatewayChannel, HttpChannel, ReplChannel, SignalChannel, WebhookServer,
-        WebhookServerConfig,
+        ChannelManager, GatewayChannel, HttpChannel, MatrixChannel, ReplChannel, SignalChannel,
+        WebhookServer, WebhookServerConfig,
         wasm::{WasmChannelRouter, WasmChannelRuntime},
         web::log_layer::LogBroadcaster,
     },
@@ -604,6 +604,19 @@ async fn async_main() -> anyhow::Result<()> {
                 webhook_routes.push(routes);
             }
         }
+    }
+
+    // Add Matrix channel if configured and not CLI-only mode.
+    if !cli.cli_only
+        && let Some(ref matrix_config) = config.channels.matrix
+    {
+        let matrix_channel = MatrixChannel::new(matrix_config.clone())?;
+        channel_names.push("matrix".to_string());
+        channels.add(Box::new(matrix_channel)).await;
+        tracing::debug!(
+            url = %matrix_config.daemon_url,
+            "Matrix channel enabled"
+        );
     }
 
     // Add Signal channel if configured and not CLI-only mode.

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -374,6 +374,38 @@ pub struct ChannelSettings {
     #[serde(default)]
     pub signal_enabled: bool,
 
+    /// Whether Matrix channel is enabled.
+    #[serde(default)]
+    pub matrix_enabled: bool,
+
+    /// Matrix bridge daemon URL.
+    #[serde(default)]
+    pub matrix_daemon_url: Option<String>,
+
+    /// Matrix account IDs (comma-separated user IDs).
+    #[serde(default)]
+    pub matrix_accounts: Option<String>,
+
+    /// Matrix allow from list (comma-separated user IDs).
+    #[serde(default)]
+    pub matrix_allow_from: Option<String>,
+
+    /// Matrix allow from rooms list (comma-separated room IDs).
+    #[serde(default)]
+    pub matrix_allow_from_rooms: Option<String>,
+
+    /// Matrix DM policy placeholder for future routing work.
+    #[serde(default)]
+    pub matrix_dm_policy: Option<String>,
+
+    /// Matrix room policy placeholder for future routing work.
+    #[serde(default)]
+    pub matrix_room_policy: Option<String>,
+
+    /// Matrix room allow from list (comma-separated user IDs).
+    #[serde(default)]
+    pub matrix_room_allow_from: Option<String>,
+
     /// Signal HTTP URL (signal-cli daemon endpoint).
     #[serde(default)]
     pub signal_http_url: Option<String>,
@@ -441,6 +473,14 @@ impl Default for ChannelSettings {
             gateway_auth_token: None,
             cli_enabled: true,
             signal_enabled: false,
+            matrix_enabled: false,
+            matrix_daemon_url: None,
+            matrix_accounts: None,
+            matrix_allow_from: None,
+            matrix_allow_from_rooms: None,
+            matrix_dm_policy: None,
+            matrix_room_policy: None,
+            matrix_room_allow_from: None,
             signal_http_url: None,
             signal_account: None,
             signal_allow_from: None,
@@ -2732,6 +2772,45 @@ mod tests {
             base.selected_model.as_deref(),
             Some("toml-model"),
             "TOML selected_model should be preserved when DB has no value"
+        );
+    }
+
+    #[test]
+    fn matrix_channel_settings_round_trip_via_db_map() {
+        let settings = Settings {
+            channels: ChannelSettings {
+                matrix_enabled: true,
+                matrix_daemon_url: Some("http://127.0.0.1:8090".to_string()),
+                matrix_accounts: Some("@bot:example.com".to_string()),
+                matrix_allow_from: Some("@alice:example.com,@bob:example.com".to_string()),
+                matrix_allow_from_rooms: Some("!room:example.com".to_string()),
+                matrix_dm_policy: Some("open".to_string()),
+                matrix_room_policy: Some("allowlist".to_string()),
+                matrix_room_allow_from: Some("@carol:example.com".to_string()),
+                ..ChannelSettings::default()
+            },
+            ..Settings::default()
+        };
+
+        let map = settings.to_db_map();
+        let restored = Settings::from_db_map(&map);
+
+        assert!(restored.channels.matrix_enabled);
+        assert_eq!(
+            restored.channels.matrix_daemon_url.as_deref(),
+            Some("http://127.0.0.1:8090")
+        );
+        assert_eq!(
+            restored.channels.matrix_accounts.as_deref(),
+            Some("@bot:example.com")
+        );
+        assert_eq!(
+            restored.channels.matrix_allow_from.as_deref(),
+            Some("@alice:example.com,@bob:example.com")
+        );
+        assert_eq!(
+            restored.channels.matrix_allow_from_rooms.as_deref(),
+            Some("!room:example.com")
         );
     }
 }

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -10,6 +10,7 @@ use std::sync::Arc;
 
 use base64::Engine;
 use secrecy::{ExposeSecret, SecretString};
+use serde::Deserialize;
 use url::Url;
 use uuid::Uuid;
 
@@ -490,6 +491,31 @@ pub struct SignalSetupResult {
     pub group_allow_from: String,
 }
 
+/// Result of Matrix channel setup.
+#[derive(Debug, Clone)]
+pub struct MatrixSetupResult {
+    pub enabled: bool,
+    pub daemon_url: String,
+    pub accounts: Option<String>,
+    pub allow_from: Option<String>,
+    pub allow_from_rooms: Option<String>,
+    pub dm_policy: Option<String>,
+    pub room_policy: Option<String>,
+    pub room_allow_from: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MatrixHealthResponse {
+    #[serde(default)]
+    accounts: Vec<MatrixHealthAccount>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MatrixHealthAccount {
+    #[serde(default)]
+    user_id: Option<String>,
+}
+
 /// Set up HTTP webhook channel.
 pub async fn setup_http(secrets: &SecretsContext) -> Result<HttpSetupResult, ChannelSetupError> {
     println!("HTTP Webhook Setup:");
@@ -718,6 +744,102 @@ pub async fn setup_signal(_settings: &Settings) -> Result<SignalSetupResult, Cha
         dm_policy,
         group_policy,
         group_allow_from,
+    })
+}
+
+/// Set up Matrix channel.
+pub async fn setup_matrix(_settings: &Settings) -> Result<MatrixSetupResult, ChannelSetupError> {
+    println!("Matrix Channel Setup:");
+    println!();
+    print_info("Matrix uses an external matrix-bridge daemon over HTTP/SSE.");
+    println!();
+
+    let daemon_url = input("Matrix bridge daemon URL")?;
+    match Url::parse(&daemon_url) {
+        Ok(url) if url.scheme() == "http" || url.scheme() == "https" => {}
+        Ok(_) => {
+            print_error("URL must use http or https scheme");
+            return Err(ChannelSetupError::Validation(
+                "Invalid Matrix bridge URL: must use http or https scheme".to_string(),
+            ));
+        }
+        Err(e) => {
+            print_error(&format!("Invalid URL: {}", e));
+            return Err(ChannelSetupError::Validation(format!(
+                "Invalid Matrix bridge URL: {}",
+                e
+            )));
+        }
+    }
+
+    let health_url = format!("{}/api/v1/check", daemon_url.trim_end_matches('/'));
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .map_err(|e| ChannelSetupError::Network(format!("Failed to build HTTP client: {}", e)))?;
+    let mut accounts = Vec::new();
+    match client.get(&health_url).send().await {
+        Ok(response) if response.status().is_success() => {
+            let health: MatrixHealthResponse = response.json().await.map_err(|e| {
+                ChannelSetupError::Network(format!("Invalid matrix bridge health response: {}", e))
+            })?;
+            accounts = health
+                .accounts
+                .iter()
+                .filter_map(|account| account.user_id.clone())
+                .collect::<Vec<_>>();
+
+            if let Some(first_account) = accounts.first() {
+                print_success(&format!("Connected to Matrix account: {}", first_account));
+            } else {
+                print_success("Matrix bridge reachable");
+            }
+        }
+        Ok(response) => {
+            print_info(&format!(
+                "Matrix bridge health check returned HTTP {}. Continuing with saved URL.",
+                response.status()
+            ));
+        }
+        Err(e) => {
+            print_info(&format!(
+                "Matrix bridge is not reachable right now ({}). Continuing with saved URL.",
+                e
+            ));
+        }
+    }
+
+    let allow_from = optional_input(
+        "Allow from (comma-separated Matrix user IDs, '*' for anyone; empty denies all)",
+        Some("default: deny all"),
+    )?;
+    let allow_from_rooms = optional_input(
+        "Allow from rooms (comma-separated Matrix room IDs, '*' for any room; empty denies all)",
+        Some("default: deny all"),
+    )?;
+    let dm_policy = optional_input("DM policy (open or allowlist)", Some("default: open"))?;
+    let room_policy = optional_input(
+        "Room policy (allowlist, open, disabled)",
+        Some("default: allowlist"),
+    )?;
+    let room_allow_from = optional_input(
+        "Room allow from (comma-separated Matrix user IDs; empty for none)",
+        Some("default: (none)"),
+    )?;
+
+    Ok(MatrixSetupResult {
+        enabled: true,
+        daemon_url: daemon_url.trim_end_matches('/').to_string(),
+        accounts: if accounts.is_empty() {
+            None
+        } else {
+            Some(accounts.join(","))
+        },
+        allow_from,
+        allow_from_rooms,
+        dm_policy,
+        room_policy,
+        room_allow_from,
     })
 }
 

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -33,17 +33,17 @@ use crate::llm::{SessionConfig, SessionManager};
 use crate::secrets::{SecretsCrypto, SecretsStore};
 use crate::settings::{KeySource, Settings};
 use crate::setup::channels::{
-    SecretsContext, setup_http, setup_signal, setup_tunnel, setup_wasm_channel,
+    SecretsContext, setup_http, setup_matrix, setup_signal, setup_tunnel, setup_wasm_channel,
 };
 use crate::setup::prompts::{
     confirm, input, optional_input, print_banner, print_error, print_header, print_info,
     print_step, print_success, secret_input, select_many, select_one,
 };
 
-// unused const, keep commented for clarity / future use
-// const CHANNEL_INDEX_CLI: usize = 0;
-const CHANNEL_INDEX_HTTP: usize = 1;
-const CHANNEL_INDEX_SIGNAL: usize = 2;
+const BUILTIN_CHANNEL_LABEL_CLI: &str = "CLI/TUI (always enabled)";
+const BUILTIN_CHANNEL_LABEL_HTTP: &str = "HTTP webhook";
+const BUILTIN_CHANNEL_LABEL_SIGNAL: &str = "Signal";
+const BUILTIN_CHANNEL_LABEL_MATRIX: &str = "Matrix";
 
 /// Setup wizard error.
 #[derive(Debug, thiserror::Error)]
@@ -110,6 +110,13 @@ pub struct SetupWizard {
 }
 
 impl SetupWizard {
+    fn option_selected(selected: &[usize], options: &[String], target: &str) -> bool {
+        options
+            .iter()
+            .position(|option| option == target)
+            .is_some_and(|index| selected.contains(&index))
+    }
+
     fn owner_id(&self) -> &str {
         &self.owner_id
     }
@@ -2557,15 +2564,27 @@ impl SetupWizard {
 
         // Build options list dynamically
         let mut options: Vec<(String, bool)> = vec![
-            ("CLI/TUI (always enabled)".to_string(), true),
+            (BUILTIN_CHANNEL_LABEL_CLI.to_string(), true),
             (
-                "HTTP webhook".to_string(),
+                BUILTIN_CHANNEL_LABEL_HTTP.to_string(),
                 self.settings.channels.http_enabled,
             ),
-            ("Signal".to_string(), self.settings.channels.signal_enabled),
+            (
+                BUILTIN_CHANNEL_LABEL_SIGNAL.to_string(),
+                self.settings.channels.signal_enabled,
+            ),
+            (
+                BUILTIN_CHANNEL_LABEL_MATRIX.to_string(),
+                self.settings.channels.matrix_enabled,
+            ),
         ];
 
         let non_wasm_count = options.len();
+        let builtin_options: Vec<String> = options
+            .iter()
+            .take(non_wasm_count)
+            .map(|(label, _)| label.clone())
+            .collect();
 
         // Add available WASM channels (installed + bundled + registry)
         for name in &wasm_channel_names {
@@ -2637,7 +2656,8 @@ impl SetupWizard {
 
         // Determine if we need secrets context
         let needs_secrets =
-            selected.contains(&CHANNEL_INDEX_HTTP) || !selected_wasm_channels.is_empty();
+            Self::option_selected(&selected, &builtin_options, BUILTIN_CHANNEL_LABEL_HTTP)
+                || !selected_wasm_channels.is_empty();
         let secrets = if needs_secrets {
             match self.init_secrets_context().await {
                 Ok(ctx) => Some(ctx),
@@ -2652,7 +2672,7 @@ impl SetupWizard {
         };
 
         // HTTP channel
-        if selected.contains(&CHANNEL_INDEX_HTTP) {
+        if Self::option_selected(&selected, &builtin_options, BUILTIN_CHANNEL_LABEL_HTTP) {
             println!();
             if let Some(ref ctx) = secrets {
                 let result = setup_http(ctx).await?;
@@ -2668,7 +2688,7 @@ impl SetupWizard {
         }
 
         // Signal channel
-        if selected.contains(&CHANNEL_INDEX_SIGNAL) {
+        if Self::option_selected(&selected, &builtin_options, BUILTIN_CHANNEL_LABEL_SIGNAL) {
             println!();
             let result = setup_signal(&self.settings).await?;
             self.settings.channels.signal_enabled = result.enabled;
@@ -2688,6 +2708,29 @@ impl SetupWizard {
             self.settings.channels.signal_dm_policy = None;
             self.settings.channels.signal_group_policy = None;
             self.settings.channels.signal_group_allow_from = None;
+        }
+
+        // Matrix channel
+        if Self::option_selected(&selected, &builtin_options, BUILTIN_CHANNEL_LABEL_MATRIX) {
+            println!();
+            let result = setup_matrix(&self.settings).await?;
+            self.settings.channels.matrix_enabled = result.enabled;
+            self.settings.channels.matrix_daemon_url = Some(result.daemon_url);
+            self.settings.channels.matrix_accounts = result.accounts;
+            self.settings.channels.matrix_allow_from = result.allow_from;
+            self.settings.channels.matrix_allow_from_rooms = result.allow_from_rooms;
+            self.settings.channels.matrix_dm_policy = result.dm_policy;
+            self.settings.channels.matrix_room_policy = result.room_policy;
+            self.settings.channels.matrix_room_allow_from = result.room_allow_from;
+        } else {
+            self.settings.channels.matrix_enabled = false;
+            self.settings.channels.matrix_daemon_url = None;
+            self.settings.channels.matrix_accounts = None;
+            self.settings.channels.matrix_allow_from = None;
+            self.settings.channels.matrix_allow_from_rooms = None;
+            self.settings.channels.matrix_dm_policy = None;
+            self.settings.channels.matrix_room_policy = None;
+            self.settings.channels.matrix_room_allow_from = None;
         }
 
         let discovered_by_name: HashMap<String, ChannelCapabilitiesFile> =

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -267,14 +267,16 @@ impl CreateJobTool {
         crate::tools::mcp::config::load_master_mcp_config_value(store.as_ref(), user_id).await
     }
 
-    /// Persist a sandbox job record (fire-and-forget).
-    fn persist_job(&self, record: SandboxJobRecord) {
-        if let Some(store) = self.store.clone() {
-            tokio::spawn(async move {
-                if let Err(e) = store.save_sandbox_job(&record).await {
-                    tracing::warn!(job_id = %record.id, "Failed to persist sandbox job: {}", e);
-                }
-            });
+    /// Persist a sandbox job record before container creation.
+    ///
+    /// This write must complete before we update `job_mode`, otherwise mode
+    /// persistence can race the insert and silently fall back to the DB
+    /// default (`worker`).
+    async fn persist_job(&self, record: SandboxJobRecord) {
+        if let Some(store) = self.store.clone()
+            && let Err(e) = store.save_sandbox_job(&record).await
+        {
+            tracing::warn!(job_id = %record.id, "Failed to persist sandbox job: {}", e);
         }
     }
 
@@ -472,7 +474,8 @@ impl CreateJobTool {
             credential_grants_json,
             mcp_servers: params.mcp_servers.clone(),
             max_iterations: params.max_iterations,
-        });
+        })
+        .await;
 
         // Persist the job mode to DB (for non-default modes).
         // For ACP, store "acp:<agent_name>" so restarts know which agent to use.

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -2520,6 +2520,64 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_acp_mode_persists_job_mode_before_container_creation() {
+        use std::collections::HashMap;
+
+        use crate::config::acp::{AcpAgentConfig, AcpAgentsFile, save_acp_agents_for_user};
+        use crate::testing::TestHarnessBuilder;
+
+        let harness = TestHarnessBuilder::new().build().await;
+        let store = Arc::clone(&harness.db);
+        let manager = Arc::new(ContextManager::new(5));
+
+        let mut agents = AcpAgentsFile::default();
+        agents.upsert(AcpAgentConfig::new(
+            "test-agent",
+            "/bin/false",
+            vec![],
+            HashMap::new(),
+        ));
+        save_acp_agents_for_user(Some(store.as_ref()), "default", &agents)
+            .await
+            .expect("save ACP agent");
+
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig {
+                image: "this-image-should-not-exist:never".to_string(),
+                acp_enabled: true,
+                ..Default::default()
+            },
+            crate::orchestrator::TokenStore::new(),
+        ));
+
+        let tool = CreateJobTool::new(Arc::clone(&manager)).with_sandbox(jm, Some(store.clone()));
+        let params = serde_json::json!({
+            "title": "ACP persistence regression",
+            "description": "Force container creation to fail after persistence",
+            "mode": "acp",
+            "agent_name": "test-agent",
+            "wait": false
+        });
+
+        let result = tool.execute(params, &JobContext::default()).await;
+        assert!(
+            result.is_err(),
+            "test requires container creation to fail after persistence"
+        );
+
+        let job_ids = manager.all_jobs().await;
+        assert_eq!(job_ids.len(), 1, "expected one sandbox job to be registered");
+
+        let mode = store
+            .get_sandbox_job_mode(job_ids[0])
+            .await
+            .expect("read sandbox job mode")
+            .expect("sandbox job mode should be persisted");
+        assert_eq!(mode, "acp:test-agent");
+    }
+
     #[test]
     fn test_job_mode_acp_as_str() {
         assert_eq!(JobMode::Acp.as_str(), "acp");

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -409,6 +409,7 @@ mod tests {
             cli: crate::config::CliConfig { enabled: false },
             http: None,
             gateway: None,
+            matrix: None,
             signal: None,
             tui: None,
             wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),


### PR DESCRIPTION
## Summary

This fixes a race when creating sandbox jobs in ACP mode.

`CreateJobTool` persisted the sandbox job row in a spawned task, then immediately tried to update `job_mode`. If the row had not been inserted yet, the mode update was lost and the job kept the DB default of `worker`.

That broke follow-up prompts for ACP sandbox jobs because the gateway only queues prompts for jobs whose stored mode is `claude_code` or starts with `acp`.

## What changed

- make sandbox job persistence synchronous in the create path
- ensure the row exists before `update_sandbox_job_mode()` runs
- keep the ACP mode encoding unchanged: `acp:<agent_name>`

## Why this fixes it

The mode update no longer races the initial insert. Fresh ACP sandbox jobs now persist the correct `job_mode`, so the web/API follow-up prompt path classifies them correctly.

## Validation

Verified locally against a native `ironclaw` service with ACP sandboxing enabled:

- created a fresh ACP sandbox job through the gateway
- confirmed the new row persisted `job_mode = acp:claude-shim-container`
- sent a follow-up prompt through `POST /api/jobs/{id}/prompt`
- confirmed the same job resumed and emitted a second completed turn

Observed job events on the fixed build:

- `message`: `GAMMA`
- `turn_result`: completed
- `message`: `DELTA`
- `turn_result`: completed

Added automated regression coverage:

- `test_acp_mode_persists_job_mode_before_container_creation`
  - creates an ACP sandbox job through `CreateJobTool`
  - forces container creation to fail after persistence
  - asserts the sandbox row still stores `job_mode = acp:<agent_name>`

## Notes

This was discovered while validating a Claude-over-ACP shim experiment, but the bug and fix are generic to ACP sandbox jobs and do not depend on that shim.

## Related work / non-duplicates

- Not a duplicate of `#1915` (`ACP bridge follow-up prompt failures should mark sandbox job failed`).
  That issue is about how follow-up prompt failures are reported once the ACP bridge is already running.
  This PR fixes an earlier create-time persistence bug where ACP sandbox jobs could be misclassified as `worker`.

- Adjacent to `#2119` / `#1981` follow-up prompt handling work, but distinct.
  Those changes focus on ACP completion/error propagation and terminal state handling.
  This PR fixes the sandbox job record write ordering that determines whether follow-up prompts are routed to ACP at all.

- Broader ACP architecture work such as `#2277` is also distinct.
  This PR is a narrow v1 sandbox bugfix, not a v2 ACP/thread-backend design change.

## Test command

Targeted test command:

- `cargo test -p ironclaw test_acp_mode_persists_job_mode_before_container_creation -- --nocapture`
- result: passed