### PR TITLE
Fix ACP sandbox job mode persistence

### DIFF
--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -267,14 +267,16 @@ impl CreateJobTool {
         crate::tools::mcp::config::load_master_mcp_config_value(store.as_ref(), user_id).await
     }
 
-    /// Persist a sandbox job record (fire-and-forget).
-    fn persist_job(&self, record: SandboxJobRecord) {
-        if let Some(store) = self.store.clone() {
-            tokio::spawn(async move {
-                if let Err(e) = store.save_sandbox_job(&record).await {
-                    tracing::warn!(job_id = %record.id, "Failed to persist sandbox job: {}", e);
-                }
-            });
+    /// Persist a sandbox job record before container creation.
+    ///
+    /// This write must complete before we update `job_mode`, otherwise mode
+    /// persistence can race the insert and silently fall back to the DB
+    /// default (`worker`).
+    async fn persist_job(&self, record: SandboxJobRecord) {
+        if let Some(store) = self.store.clone()
+            && let Err(e) = store.save_sandbox_job(&record).await
+        {
+            tracing::warn!(job_id = %record.id, "Failed to persist sandbox job: {}", e);
         }
     }
 
@@ -472,7 +474,8 @@ impl CreateJobTool {
             credential_grants_json,
             mcp_servers: params.mcp_servers.clone(),
             max_iterations: params.max_iterations,
-        });
+        })
+        .await;
 
         // Persist the job mode to DB (for non-default modes).
         // For ACP, store "acp:<agent_name>" so restarts know which agent to use.

--- a/src/tools/builtin/job.rs
+++ b/src/tools/builtin/job.rs
@@ -2520,6 +2520,64 @@ mod tests {
         );
     }
 
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_acp_mode_persists_job_mode_before_container_creation() {
+        use std::collections::HashMap;
+
+        use crate::config::acp::{AcpAgentConfig, AcpAgentsFile, save_acp_agents_for_user};
+        use crate::testing::TestHarnessBuilder;
+
+        let harness = TestHarnessBuilder::new().build().await;
+        let store = Arc::clone(&harness.db);
+        let manager = Arc::new(ContextManager::new(5));
+
+        let mut agents = AcpAgentsFile::default();
+        agents.upsert(AcpAgentConfig::new(
+            "test-agent",
+            "/bin/false",
+            vec![],
+            HashMap::new(),
+        ));
+        save_acp_agents_for_user(Some(store.as_ref()), "default", &agents)
+            .await
+            .expect("save ACP agent");
+
+        let jm = Arc::new(ContainerJobManager::new(
+            crate::orchestrator::job_manager::ContainerJobConfig {
+                image: "this-image-should-not-exist:never".to_string(),
+                acp_enabled: true,
+                ..Default::default()
+            },
+            crate::orchestrator::TokenStore::new(),
+        ));
+
+        let tool = CreateJobTool::new(Arc::clone(&manager)).with_sandbox(jm, Some(store.clone()));
+        let params = serde_json::json!({
+            "title": "ACP persistence regression",
+            "description": "Force container creation to fail after persistence",
+            "mode": "acp",
+            "agent_name": "test-agent",
+            "wait": false
+        });
+
+        let result = tool.execute(params, &JobContext::default()).await;
+        assert!(
+            result.is_err(),
+            "test requires container creation to fail after persistence"
+        );
+
+        let job_ids = manager.all_jobs().await;
+        assert_eq!(job_ids.len(), 1, "expected one sandbox job to be registered");
+
+        let mode = store
+            .get_sandbox_job_mode(job_ids[0])
+            .await
+            .expect("read sandbox job mode")
+            .expect("sandbox job mode should be persisted");
+        assert_eq!(mode, "acp:test-agent");
+    }
+
     #[test]
     fn test_job_mode_acp_as_str() {
         assert_eq!(JobMode::Acp.as_str(), "acp");


### PR DESCRIPTION
## Summary

This fixes a race when creating sandbox jobs in ACP mode.

`CreateJobTool` persisted the sandbox job row in a spawned task, then immediately tried to update `job_mode`. If the row had not been inserted yet, the mode update was lost and the job kept the DB default of `worker`.

That broke follow-up prompts for ACP sandbox jobs because the gateway only queues prompts for jobs whose stored mode is `claude_code` or starts with `acp`.

## What changed

- make sandbox job persistence synchronous in the create path
- ensure the row exists before `update_sandbox_job_mode()` runs
- keep the ACP mode encoding unchanged: `acp:<agent_name>`

## Why this fixes it

The mode update no longer races the initial insert. Fresh ACP sandbox jobs now persist the correct `job_mode`, so the web/API follow-up prompt path classifies them correctly.

## Validation

Verified locally against a native `ironclaw` service with ACP sandboxing enabled:

- created a fresh ACP sandbox job through the gateway
- confirmed the new row persisted `job_mode = acp:claude-shim-container`
- sent a follow-up prompt through `POST /api/jobs/{id}/prompt`
- confirmed the same job resumed and emitted a second completed turn

Observed job events on the fixed build:

- `message`: `GAMMA`
- `turn_result`: completed
- `message`: `DELTA`
- `turn_result`: completed

Added automated regression coverage:

- `test_acp_mode_persists_job_mode_before_container_creation`
  - creates an ACP sandbox job through `CreateJobTool`
  - forces container creation to fail after persistence
  - asserts the sandbox row still stores `job_mode = acp:<agent_name>`

## Notes

This was discovered while validating a Claude-over-ACP shim experiment, but the bug and fix are generic to ACP sandbox jobs and do not depend on that shim.

## Related work / non-duplicates

- Not a duplicate of `#1915` (`ACP bridge follow-up prompt failures should mark sandbox job failed`).
  That issue is about how follow-up prompt failures are reported once the ACP bridge is already running.
  This PR fixes an earlier create-time persistence bug where ACP sandbox jobs could be misclassified as `worker`.

- Adjacent to `#2119` / `#1981` follow-up prompt handling work, but distinct.
  Those changes focus on ACP completion/error propagation and terminal state handling.
  This PR fixes the sandbox job record write ordering that determines whether follow-up prompts are routed to ACP at all.

- Broader ACP architecture work such as `#2277` is also distinct.
  This PR is a narrow v1 sandbox bugfix, not a v2 ACP/thread-backend design change.

## Test command

Targeted test command:

- `cargo test -p ironclaw test_acp_mode_persists_job_mode_before_container_creation -- --nocapture`
- result: passed
