### PR TITLE
fix(status): report active WASM channels accurately

### DIFF
--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -267,21 +267,20 @@ fn format_wasm_channels_summary(
     if settings.channels.wasm_channels_enabled && !settings.channels.wasm_channels.is_empty() {
         let mut channels = settings.channels.wasm_channels.clone();
         channels.sort();
-        let label = if channels.len() == 1 {
-            "1 wasm".to_string()
-        } else {
-            format!("{} wasm", channels.len())
-        };
-        return Some(format!("{} ({})", label, channels.join(", ")));
+        return Some(format!("{} wasm ({})", channels.len(), channels.join(", ")));
     }
 
     let wasm_count = count_wasm_files(channels_dir);
     if wasm_count > 0 {
-        return Some(format!(
-            "{} wasm installed ({})",
-            wasm_count,
-            channels_dir.display()
-        ));
+        if settings.channels.wasm_channels_enabled {
+            return Some(format!("{} wasm", wasm_count));
+        } else {
+            return Some(format!(
+                "{} wasm installed ({})",
+                wasm_count,
+                channels_dir.display()
+            ));
+        }
     }
 
     None

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -166,11 +166,8 @@ pub async fn run_status_command() -> anyhow::Result<()> {
             settings.channels.http_port.unwrap_or(3000)
         ));
     }
-    if channels_dir.exists() {
-        let wasm_count = count_wasm_files(&channels_dir);
-        if wasm_count > 0 {
-            channel_info.push(format!("{} wasm", wasm_count));
-        }
+    if let Some(wasm_summary) = format_wasm_channels_summary(&settings, &channels_dir) {
+        channel_info.push(wasm_summary);
     }
     println!("{}", fmt::kv_line("Channels", &channel_info.join(", "), 12));
 
@@ -263,6 +260,33 @@ fn count_wasm_files(dir: &std::path::Path) -> usize {
         .unwrap_or(0)
 }
 
+fn format_wasm_channels_summary(
+    settings: &Settings,
+    channels_dir: &std::path::Path,
+) -> Option<String> {
+    if settings.channels.wasm_channels_enabled && !settings.channels.wasm_channels.is_empty() {
+        let mut channels = settings.channels.wasm_channels.clone();
+        channels.sort();
+        let label = if channels.len() == 1 {
+            "1 wasm".to_string()
+        } else {
+            format!("{} wasm", channels.len())
+        };
+        return Some(format!("{} ({})", label, channels.join(", ")));
+    }
+
+    let wasm_count = count_wasm_files(channels_dir);
+    if wasm_count > 0 {
+        return Some(format!(
+            "{} wasm installed ({})",
+            wasm_count,
+            channels_dir.display()
+        ));
+    }
+
+    None
+}
+
 fn default_tools_dir() -> PathBuf {
     ironclaw_base_dir().join("tools")
 }
@@ -273,7 +297,8 @@ fn default_channels_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::load_settings_from;
+    use super::{format_wasm_channels_summary, load_settings_from};
+    use crate::settings::Settings;
 
     /// Regression test for #354: load_settings_from must read config.toml.
     #[test]
@@ -364,5 +389,31 @@ mod tests {
         // Should fall back to JSON values, not crash
         assert!(settings.heartbeat.enabled);
         assert_eq!(settings.heartbeat.interval_secs, 500);
+    }
+
+    #[test]
+    fn formats_enabled_wasm_channels_with_names() {
+        let mut settings = Settings::default();
+        settings.channels.wasm_channels_enabled = true;
+        settings.channels.wasm_channels = vec!["telegram".to_string(), "slack".to_string()];
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let summary = format_wasm_channels_summary(&settings, dir.path());
+
+        assert_eq!(summary.as_deref(), Some("2 wasm (slack, telegram)"));
+    }
+
+    #[test]
+    fn formats_installed_wasm_channels_when_enabled_list_is_empty() {
+        let mut settings = Settings::default();
+        settings.channels.wasm_channels_enabled = false;
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::File::create(dir.path().join("telegram.wasm")).expect("write wasm");
+        std::fs::File::create(dir.path().join("slack.wasm")).expect("write wasm");
+
+        let summary = format_wasm_channels_summary(&settings, dir.path());
+        let expected = format!("2 wasm installed ({})", dir.path().display());
+
+        assert_eq!(summary.as_deref(), Some(expected.as_str()));
     }
 }

--- a/tests/status_cli.rs
+++ b/tests/status_cli.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+#[test]
+fn status_lists_enabled_wasm_channel_names() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let base_dir = tempdir.path();
+    let channels_dir = base_dir.join("channels");
+    std::fs::create_dir_all(&channels_dir).expect("create channels dir");
+    std::fs::File::create(channels_dir.join("telegram.wasm")).expect("write wasm");
+    std::fs::write(
+        base_dir.join("config.toml"),
+        "[channels]\nwasm_channels_enabled = true\nwasm_channels = [\"telegram\"]\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ironclaw"))
+        .arg("status")
+        .env("IRONCLAW_BASE_DIR", base_dir)
+        .current_dir(base_dir)
+        .output()
+        .expect("run ironclaw status");
+
+    assert!(
+        output.status.success(),
+        "status command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Channels") && stdout.contains("telegram"),
+        "status output did not include enabled WASM channel names:\n{}",
+        stdout
+    );
+}


### PR DESCRIPTION
Refs #2419

`ironclaw status` now shows enabled WASM channel names instead of only a coarse `1 wasm` summary.

Changes:
- `status` reports enabled WASM channel names when present
- falls back to installed WASM count when only the directory is known
- adds a CLI-level regression test that exercises `ironclaw status` end-to-end through the binary
