### PR TITLE
fix(safety): quiet warn-only leak scan noise

### DIFF
--- a/crates/ironclaw_safety/src/leak_detector.rs
+++ b/crates/ironclaw_safety/src/leak_detector.rs
@@ -273,12 +273,12 @@ impl LeakDetector {
             });
         }
 
-        // Log warn-action matches at debug level (not warn!) to avoid
-        // corrupting REPL/TUI output. These are informational — real leaks
-        // use LeakAction::Redact which modifies the content silently.
+        // Warn-action matches are informational only. Keep them at trace so
+        // ordinary debug/server logging does not get flooded by common
+        // high-entropy values that are not actually secrets.
         for m in &result.matches {
             if m.action == LeakAction::Warn {
-                tracing::debug!(
+                tracing::trace!(
                     pattern = %m.pattern_name,
                     severity = %m.severity,
                     preview = %m.masked_preview,

--- a/src/channels/web/log_layer.rs
+++ b/src/channels/web/log_layer.rs
@@ -68,10 +68,18 @@ impl LogBroadcaster {
         // Scrub secrets from the message before it reaches any subscriber.
         // This is defense-in-depth: even if code elsewhere accidentally logs
         // a secret, it won't be broadcast to SSE clients.
-        entry.message = self
-            .leak_detector
-            .scan_and_clean(&entry.message)
-            .unwrap_or_else(|_| "[log message redacted: contained blocked secret]".to_string());
+        //
+        // Use the raw scan result here instead of scan_and_clean() so we avoid
+        // emitting the detector's warn-only debug logs for ordinary high-entropy
+        // values that appear frequently in operational logs.
+        let scan = self.leak_detector.scan(&entry.message);
+        entry.message = if scan.should_block {
+            "[log message redacted: contained blocked secret]".to_string()
+        } else if let Some(redacted) = scan.redacted_content {
+            redacted
+        } else {
+            entry.message
+        };
 
         // Stash in ring buffer (for late joiners)
         if let Ok(mut buf) = self.recent.lock() {
@@ -481,5 +489,24 @@ mod tests {
         let result = detector.scan_and_clean(msg);
         assert!(result.is_ok());
         assert_eq!(result.unwrap(), msg);
+    }
+
+    #[test]
+    fn test_log_broadcaster_redacts_blocked_secret() {
+        let broadcaster = LogBroadcaster::new();
+        let mut rx = broadcaster.subscribe();
+
+        broadcaster.send(LogEntry {
+            level: "INFO".to_string(),
+            target: "ironclaw::test".to_string(),
+            message: "token sk-proj-test1234567890abcdefghij".to_string(),
+            timestamp: "2024-01-01T00:00:00.000Z".to_string(),
+        });
+
+        let entry = rx.try_recv().expect("should receive entry");
+        assert_eq!(
+            entry.message,
+            "[log message redacted: contained blocked secret]"
+        );
     }
 }


### PR DESCRIPTION
Refs #2412

Reduce false-positive log noise from warn-only leak detection by:
- lowering warn-only leak matches from debug to trace
- avoiding detector debug spam in the web log broadcaster while preserving redaction/blocking

This keeps actual secret blocking and redaction intact, but stops ordinary high-entropy values from flooding server logs during normal operations.
