### PR TITLE
docs(setup): warn that Telegram open mode splits history

### DIFF
--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -350,6 +350,10 @@ key first, then falls back to the standard env var.
 **Telegram special case** (`setup_telegram`):
 - Validates bot token via Telegram `getMe` API
 - Owner binding: polls `getUpdates` for 120s to capture sender's user ID
+- Pairing mode is the right choice if you want a Telegram conversation to
+  continue in the browser history sidebar. Open mode keeps the bot usable in
+  Telegram, but it creates a split identity that does not automatically merge
+  into the web UI thread list.
 - Optional webhook secret auto-generation for webhook mode
 
 **SecretsContext creation** (`init_secrets_context`):

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -841,7 +841,7 @@ pub async fn setup_wasm_channel(
 }
 
 fn setup_mode_note(channel_name: &str) -> Option<&'static str> {
-    if channel_name.eq_ignore_ascii_case("telegram") {
+    if channel_name.to_ascii_lowercase() == "telegram" {
         Some(
             "Telegram pairing is recommended if you want browser history continuity. \
              Open mode keeps chats working in Telegram, but it can leave the web UI \

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -739,6 +739,10 @@ pub async fn setup_wasm_channel(
 ) -> Result<WasmChannelSetupResult, ChannelSetupError> {
     println!("{} Setup:", channel_name);
     println!();
+    if let Some(note) = setup_mode_note(channel_name) {
+        print_info(note);
+        println!();
+    }
 
     for secret_config in &setup.required_secrets {
         // Check if this secret already exists
@@ -834,6 +838,19 @@ pub async fn setup_wasm_channel(
         enabled: true,
         channel_name: channel_name.to_string(),
     })
+}
+
+fn setup_mode_note(channel_name: &str) -> Option<&'static str> {
+    if channel_name.eq_ignore_ascii_case("telegram") {
+        Some(
+            "Telegram pairing is recommended if you want browser history continuity. \
+             Open mode keeps chats working in Telegram, but it can leave the web UI \
+             thread list looking empty because the exchange is not bound to the same \
+             IronClaw identity.",
+        )
+    } else {
+        None
+    }
 }
 
 async fn validate_channel_credentials(
@@ -1183,6 +1200,13 @@ mod tests {
 
         let s2 = generate_secret_with_length(1);
         assert_eq!(s2.len(), 2);
+    }
+
+    #[test]
+    fn test_setup_mode_note_only_mentions_telegram() {
+        assert!(super::setup_mode_note("telegram").is_some());
+        assert!(super::setup_mode_note("Telegram").is_some());
+        assert!(super::setup_mode_note("signal").is_none());
     }
 
     #[test]

--- a/src/setup/channels.rs
+++ b/src/setup/channels.rs
@@ -841,7 +841,7 @@ pub async fn setup_wasm_channel(
 }
 
 fn setup_mode_note(channel_name: &str) -> Option<&'static str> {
-    if channel_name.to_ascii_lowercase() == "telegram" {
+    if channel_name.eq_ignore_ascii_case("telegram") {
         Some(
             "Telegram pairing is recommended if you want browser history continuity. \
              Open mode keeps chats working in Telegram, but it can leave the web UI \


### PR DESCRIPTION
Refs #2426

Telegram setup now prints a warning that pairing is the right choice if the user wants browser history continuity. Open mode keeps the bot usable in Telegram, but it can leave the web UI thread list empty because the exchange is not bound to the same IronClaw identity.

This is a discoverability fix only; it does not change Telegram runtime behavior.