### PR TITLE
fix(web): prevent browser crash from timer leaks, DOM growth, SSE buffer

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -90,6 +90,7 @@ let pairingPollInterval = null;
 let unreadThreads = new Map(); // thread_id -> unread count
 let _loadThreadsTimer = null;
 const JOB_EVENTS_CAP = 500;
+const JOB_EVENTS_MAX_JOBS = 50;
 const MEMORY_SEARCH_QUERY_MAX_LENGTH = 100;
 let stagedImages = [];
 let authFlowPending = false;
@@ -235,6 +236,18 @@ const DONE_WITHOUT_RESPONSE_TIMEOUT_MS = 1500;
 // matters here. Per-thread state is unnecessary.
 let _turnResponseReceived = false;
 let _doneWithoutResponseTimer = null;
+
+// Clean up connection-level timers and buffers.
+// Called before creating a new connection, on tab hide, and on page unload
+// to prevent leaked intervals/timeouts from accumulating across reconnects.
+// Note: _doneWithoutResponseTimer is intentionally NOT cleared here — it is a
+// turn-level concern managed by the onopen and response handlers (#2079).
+function cleanupConnectionState() {
+  if (_streamDebounceTimer) { clearInterval(_streamDebounceTimer); _streamDebounceTimer = null; }
+  _streamBuffer = '';
+  if (_connectionLostTimer) { clearTimeout(_connectionLostTimer); _connectionLostTimer = null; }
+  if (jobListRefreshTimer) { clearTimeout(jobListRefreshTimer); jobListRefreshTimer = null; }
+}
 
 // --- Send Cooldown State ---
 let _sendCooldown = false;
@@ -390,6 +403,7 @@ document.getElementById('token-input').addEventListener('keydown', (e) => {
 // Without this, stale SSE connections from prior page loads linger and exhaust
 // the HTTP/1.1 per-origin connection limit (6), blocking API fetch calls.
 window.addEventListener('beforeunload', () => {
+  cleanupConnectionState();
   if (eventSource) { eventSource.close(); eventSource = null; }
   if (logEventSource) { logEventSource.close(); logEventSource = null; }
 });
@@ -400,6 +414,7 @@ window.addEventListener('beforeunload', () => {
 // the 3rd tab exhausts the browser's per-origin limit.
 document.addEventListener('visibilitychange', () => {
   if (document.hidden) {
+    cleanupConnectionState();
     if (eventSource) { eventSource.close(); eventSource = null; }
     if (logEventSource) { logEventSource.close(); logEventSource = null; }
   } else if (token) {
@@ -693,6 +708,7 @@ function rememberSseEventId(event) {
 
 function connectSSE(lastEventIdOverride) {
   if (eventSource) eventSource.close();
+  cleanupConnectionState();
 
   // In OIDC mode the reverse proxy provides auth; no query token needed.
   let chatSseUrl = (token && !oidcProxyAuth)
@@ -846,6 +862,7 @@ function connectSSE(lastEventIdOverride) {
     }
     finalizeActivityGroup();
     addMessage('assistant', data.content);
+    pruneOldMessages();
     enableChatInput();
     // Refresh thread list so new titles appear after first message
     loadThreads();
@@ -1047,6 +1064,16 @@ function connectSSE(lastEventIdOverride) {
       events.push({ type: evtType, data: data, ts: Date.now() });
       // Cap per-job events to prevent memory leak
       while (events.length > JOB_EVENTS_CAP) events.shift();
+      // Cap total tracked jobs — evict the one with the oldest last event
+      if (jobEvents.size > JOB_EVENTS_MAX_JOBS) {
+        let oldestKey = null, oldestTs = Infinity;
+        for (const [k, v] of jobEvents) {
+          if (k === jobId) continue; // never evict the job we just updated
+          const lastTs = v.length > 0 ? v[v.length - 1].ts : 0;
+          if (lastTs < oldestTs) { oldestTs = lastTs; oldestKey = k; }
+        }
+        if (oldestKey) jobEvents.delete(oldestKey);
+      }
       // If the Activity tab is currently visible for this job, refresh it
       refreshActivityTab(jobId);
       // Auto-refresh job list when on jobs tab (debounced)
@@ -1824,6 +1851,26 @@ function maybeInsertTimeSeparator(container, timestamp) {
   sep.className = 'time-separator';
   sep.textContent = label;
   container.appendChild(sep);
+}
+
+const MAX_DOM_MESSAGES = 200;
+
+// Remove oldest messages/activity groups from the DOM when the chat container
+// exceeds MAX_DOM_MESSAGES elements. Users can scroll up to trigger
+// loadHistory() for older content. This prevents unbounded DOM growth during
+// long sessions. Elements with data-streaming="true" are preserved to avoid
+// breaking mid-stream responses.
+function pruneOldMessages() {
+  const container = document.getElementById('chat-messages');
+  const items = container.querySelectorAll('.message, .activity-group, .time-separator');
+  if (items.length <= MAX_DOM_MESSAGES) return;
+  let removed = 0;
+  const target = items.length - MAX_DOM_MESSAGES;
+  for (let i = 0; i < items.length && removed < target; i++) {
+    if (items[i].getAttribute('data-streaming') === 'true') continue;
+    items[i].remove();
+    removed++;
+  }
 }
 
 function addMessage(role, content) {
@@ -2991,6 +3038,7 @@ function loadHistory(before) {
 
     hasMore = data.has_more || false;
     oldestTimestamp = data.oldest_timestamp || null;
+    pruneOldMessages();
   }).catch(() => {
     // No history or no active thread
   }).finally(() => {

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -246,6 +246,7 @@ function cleanupConnectionState() {
   if (_streamDebounceTimer) { clearInterval(_streamDebounceTimer); _streamDebounceTimer = null; }
   _streamBuffer = '';
   if (_connectionLostTimer) { clearTimeout(_connectionLostTimer); _connectionLostTimer = null; }
+  _connectionLostAt = null;
   if (jobListRefreshTimer) { clearTimeout(jobListRefreshTimer); jobListRefreshTimer = null; }
 }
 
@@ -1068,7 +1069,7 @@ function connectSSE(lastEventIdOverride) {
       if (jobEvents.size > JOB_EVENTS_MAX_JOBS) {
         let oldestKey = null, oldestTs = Infinity;
         for (const [k, v] of jobEvents) {
-          if (k === jobId) continue; // never evict the job we just updated
+          if (k === jobId || k === currentJobId) continue; // never evict the active or viewed job
           const lastTs = v.length > 0 ? v[v.length - 1].ts : 0;
           if (lastTs < oldestTs) { oldestTs = lastTs; oldestKey = k; }
         }
@@ -3038,7 +3039,7 @@ function loadHistory(before) {
 
     hasMore = data.has_more || false;
     oldestTimestamp = data.oldest_timestamp || null;
-    pruneOldMessages();
+    if (!isPaginating) pruneOldMessages();
   }).catch(() => {
     // No history or no active thread
   }).finally(() => {

--- a/src/channels/web/sse.rs
+++ b/src/channels/web/sse.rs
@@ -23,6 +23,10 @@ pub const DEFAULT_MAX_CONNECTIONS: u64 = 100;
 /// a cascade. Configurable via `SSE_BROADCAST_BUFFER` env var.
 const DEFAULT_BROADCAST_BUFFER: usize = 1024;
 
+/// Upper bound for the broadcast buffer to prevent accidental OOM from
+/// misconfigured env vars. 65 536 events * ~1 KB each ≈ 64 MB worst case.
+const MAX_BROADCAST_BUFFER: usize = 65_536;
+
 /// Envelope for broadcast events: carries an optional user scope.
 ///
 /// `user_id = None` means the event is global (e.g. Heartbeat) and delivered
@@ -61,7 +65,8 @@ impl SseManager {
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|&n| n > 0)
-            .unwrap_or(DEFAULT_BROADCAST_BUFFER);
+            .unwrap_or(DEFAULT_BROADCAST_BUFFER)
+            .min(MAX_BROADCAST_BUFFER);
         let (tx, _) = broadcast::channel(buffer_size);
         Self {
             tx,

--- a/src/channels/web/sse.rs
+++ b/src/channels/web/sse.rs
@@ -18,6 +18,11 @@ use crate::channels::web::types::AppEvent;
 /// Prevents resource exhaustion from connection flooding.
 pub const DEFAULT_MAX_CONNECTIONS: u64 = 100;
 
+/// Default broadcast buffer size. Under heavy tool use each tool call generates
+/// 5-10 SSE events; a small buffer causes slow clients to lag and reconnect in
+/// a cascade. Configurable via `SSE_BROADCAST_BUFFER` env var.
+const DEFAULT_BROADCAST_BUFFER: usize = 1024;
+
 /// Envelope for broadcast events: carries an optional user scope.
 ///
 /// `user_id = None` means the event is global (e.g. Heartbeat) and delivered
@@ -52,8 +57,12 @@ impl SseManager {
 
     /// Create a new SSE manager with a custom connection limit.
     pub fn with_max_connections(max_connections: u64) -> Self {
-        // Buffer 256 events; slow clients will miss events (acceptable for SSE with reconnect)
-        let (tx, _) = broadcast::channel(256);
+        let buffer_size = std::env::var("SSE_BROADCAST_BUFFER")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&n| n > 0)
+            .unwrap_or(DEFAULT_BROADCAST_BUFFER);
+        let (tx, _) = broadcast::channel(buffer_size);
         Self {
             tx,
             connection_count: Arc::new(AtomicU64::new(0)),

--- a/tests/e2e/scenarios/test_dom_resource_limits.py
+++ b/tests/e2e/scenarios/test_dom_resource_limits.py
@@ -52,8 +52,16 @@ async def test_no_timer_leak_across_reconnects(page):
 
     baseline = await page.evaluate("window.__testIntervalCount")
 
-    # Force 5 reconnect cycles
+    # Force 5 reconnect cycles, triggering _streamDebounceTimer each time
+    # by dispatching a synthetic stream_chunk event before disconnecting.
     for _ in range(5):
+        await page.evaluate("""() => {
+            // Trigger the stream_chunk handler which creates _streamDebounceTimer
+            const evt = new MessageEvent('stream_chunk', {
+                data: JSON.stringify({ content: 'test', thread_id: currentThreadId })
+            });
+            if (eventSource) eventSource.dispatchEvent(evt);
+        }""")
         await page.evaluate("if (eventSource) eventSource.close()")
         await page.evaluate("sseHasConnectedBefore = false; connectSSE()")
         await _wait_for_connected(page, timeout=10000)

--- a/tests/e2e/scenarios/test_dom_resource_limits.py
+++ b/tests/e2e/scenarios/test_dom_resource_limits.py
@@ -1,0 +1,94 @@
+"""DOM and timer resource limit tests for issue #2406.
+
+Verifies that the web UI does not exhaust browser resources during extended
+sessions: DOM node count stays bounded, timers are cleaned up on reconnect,
+and streaming messages survive pruning.
+"""
+
+from helpers import SEL
+
+
+async def _wait_for_connected(page, *, timeout: int = 10000) -> None:
+    await page.wait_for_function(
+        "() => typeof sseHasConnectedBefore !== 'undefined' && sseHasConnectedBefore === true",
+        timeout=timeout,
+    )
+
+
+async def test_dom_pruned_after_many_messages(page):
+    """DOM stays bounded at MAX_DOM_MESSAGES after many insertions (#2406)."""
+    # Inject 250 messages directly (faster than round-tripping through LLM)
+    await page.evaluate("""() => {
+        for (let i = 0; i < 250; i++) {
+            addMessage(i % 2 === 0 ? 'user' : 'assistant', 'Message ' + i);
+        }
+        pruneOldMessages();
+    }""")
+
+    count = await page.locator(f"{SEL['chat_messages']} .message").count()
+    assert count <= 200, f"Expected <= 200 DOM messages after pruning, got {count}"
+    assert count >= 100, f"Expected at least 100 DOM messages (not over-pruned), got {count}"
+
+
+async def test_no_timer_leak_across_reconnects(page):
+    """Reconnect cycles do not accumulate leaked setInterval timers (#2406)."""
+    await _wait_for_connected(page, timeout=10000)
+
+    # Instrument: track net interval count via monkeypatching
+    await page.evaluate("""() => {
+        window.__testIntervalCount = 0;
+        const origSet = window.setInterval;
+        const origClear = window.clearInterval;
+        window.setInterval = function(...args) {
+            const id = origSet.apply(this, args);
+            window.__testIntervalCount++;
+            return id;
+        };
+        window.clearInterval = function(id) {
+            if (id != null) window.__testIntervalCount--;
+            return origClear.call(this, id);
+        };
+    }""")
+
+    baseline = await page.evaluate("window.__testIntervalCount")
+
+    # Force 5 reconnect cycles
+    for _ in range(5):
+        await page.evaluate("if (eventSource) eventSource.close()")
+        await page.evaluate("sseHasConnectedBefore = false; connectSSE()")
+        await _wait_for_connected(page, timeout=10000)
+
+    after = await page.evaluate("window.__testIntervalCount")
+    # Allow at most 1 net new interval (the gateway status poller or similar)
+    assert after <= baseline + 1, (
+        f"Interval leak detected: baseline={baseline}, after 5 reconnects={after}"
+    )
+
+
+async def test_prune_preserves_streaming_message(page):
+    """pruneOldMessages must not remove a message with data-streaming=true (#2406)."""
+    # Fill the DOM to just under the cap
+    await page.evaluate("""() => {
+        for (let i = 0; i < 199; i++) {
+            addMessage('assistant', 'msg ' + i);
+        }
+    }""")
+
+    # Mark the last assistant message as actively streaming
+    await page.evaluate("""() => {
+        const msgs = document.querySelectorAll('#chat-messages .message.assistant');
+        msgs[msgs.length - 1].setAttribute('data-streaming', 'true');
+    }""")
+
+    # Push over the cap and prune
+    await page.evaluate("""() => {
+        for (let i = 0; i < 10; i++) {
+            addMessage('user', 'overflow ' + i);
+        }
+        pruneOldMessages();
+    }""")
+
+    streaming_count = await page.locator('[data-streaming="true"]').count()
+    assert streaming_count == 1, (
+        f"Streaming message was pruned: expected 1 element with data-streaming, got {streaming_count}"
+    )


### PR DESCRIPTION
## Summary

Fixes #2406 — the web UI became unresponsive and triggered Chrome's "Pages Unresponsive" dialog during extended bug bash sessions with heavy bot interactions and parallel chats.

**Root cause:** The browser accumulated resources that were never cleaned up — leaked `setInterval` timers across SSE reconnects, unbounded DOM node growth, unbounded in-memory job event storage, and a too-small SSE broadcast buffer causing reconnect cascades.

**Changes:**
- **Timer cleanup** (`cleanupConnectionState()`): Clears `_streamDebounceTimer`, `_streamBuffer`, `_connectionLostTimer`, and `jobListRefreshTimer` on SSE reconnect, tab-hide, and page unload. Intentionally excludes `_doneWithoutResponseTimer` which is a turn-level concern (#2079).
- **DOM pruning** (`pruneOldMessages()`): Caps `#chat-messages` at 200 elements. Streaming-aware — skips `data-streaming="true"` elements. Called at turn boundaries (after `response` event) and after `loadHistory()`, not per-`addMessage()` to avoid O(N²) during bulk loads.
- **Job events cap**: Limits `jobEvents` Map to 50 entries with LRU eviction by last event timestamp. Excludes the current job from the eviction scan to prevent self-eviction.
- **SSE broadcast buffer**: Increased from 256 to 1024 events (configurable via `SSE_BROADCAST_BUFFER` env var). Includes `.filter(|&n| n > 0)` guard to prevent `broadcast::channel(0)` panic from misconfigured env.

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] `cargo test --lib` — passes (pre-existing `file_history` SIGABRT unrelated)
- [x] 3 new Playwright E2E tests pass (`test_dom_resource_limits.py`):
  - `test_dom_pruned_after_many_messages` — injects 250 messages, asserts DOM <= 200
  - `test_no_timer_leak_across_reconnects` — 5 reconnect cycles, asserts no interval leak
  - `test_prune_preserves_streaming_message` — streaming element survives pruning
- [ ] Manual browser testing on staging: extended session with heavy tool use, tab switching, parallel chats

🤖 Generated with [Claude Code](https://claude.com/claude-code)