### PR TITLE
fix(gateway): persist user messages at send time (#2409)

### DIFF
--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1745,7 +1745,7 @@ impl Agent {
                     // gets its own DB persist — the flag only applies to the
                     // original message, not drain-loop follow-ups.
                     if let Some(obj) = queued_msg.metadata.as_object_mut() {
-                        obj.remove("user_message_persisted");
+                        obj.remove(crate::channels::web::util::GATEWAY_PERSISTED_FLAG);
                     }
                     result = self
                         .process_user_input(

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1929,6 +1929,12 @@ impl Agent {
 
                         let mut queued_msg = message.clone();
                         queued_msg.attachments.clear();
+                        // Clear the gateway early-persist flag so queued content
+                        // gets its own DB persist — the flag only applies to the
+                        // original message, not drain-loop follow-ups.
+                        if let Some(obj) = queued_msg.metadata.as_object_mut() {
+                            obj.remove(crate::channels::web::util::GATEWAY_PERSISTED_FLAG);
+                        }
                         result = self
                             .process_user_input(
                                 &queued_msg,

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -1741,6 +1741,12 @@ impl Agent {
                     // message's attachments to unrelated queued text.
                     let mut queued_msg = message.clone();
                     queued_msg.attachments.clear();
+                    // Clear the gateway early-persist flag so queued content
+                    // gets its own DB persist — the flag only applies to the
+                    // original message, not drain-loop follow-ups.
+                    if let Some(obj) = queued_msg.metadata.as_object_mut() {
+                        obj.remove("user_message_persisted");
+                    }
                     result = self
                         .process_user_input(
                             &queued_msg,

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -633,19 +633,36 @@ impl Agent {
             thread.messages()
         };
 
-        // Persist user message to DB immediately so it survives crashes
-        tracing::debug!(
-            message_id = %message.id,
-            thread_id = %thread_id,
-            "Persisting user message to DB"
-        );
-        self.persist_user_message(
-            thread_id,
-            &message.channel,
-            &message.user_id,
-            effective_content,
-        )
-        .await;
+        // Persist user message to DB immediately so it survives crashes.
+        // Skip if the gateway already persisted it (indicated by metadata flag).
+        // Only trust this flag from the gateway channel to prevent non-gateway
+        // channels from skipping persistence by setting the flag themselves.
+        let already_persisted = message.channel == "gateway"
+            && message
+                .metadata
+                .get("user_message_persisted")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        if already_persisted {
+            tracing::debug!(
+                message_id = %message.id,
+                thread_id = %thread_id,
+                "User message already persisted by gateway, skipping"
+            );
+        } else {
+            tracing::debug!(
+                message_id = %message.id,
+                thread_id = %thread_id,
+                "Persisting user message to DB"
+            );
+            self.persist_user_message(
+                thread_id,
+                &message.channel,
+                &message.user_id,
+                effective_content,
+            )
+            .await;
+        }
 
         tracing::debug!(
             message_id = %message.id,

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -640,7 +640,7 @@ impl Agent {
         let already_persisted = message.channel == "gateway"
             && message
                 .metadata
-                .get("user_message_persisted")
+                .get(crate::channels::web::util::GATEWAY_PERSISTED_FLAG)
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
         if already_persisted {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2411,6 +2411,16 @@ async fn handle_with_engine_inner(
     // Dual-write to v1 database so the gateway history API shows messages.
     // Use the thread-scoped conversation (from thread_id) when available,
     // falling back to the default assistant conversation.
+    //
+    // Skip if the gateway already persisted it (indicated by metadata flag).
+    // Only trust this flag from the gateway channel to prevent non-gateway
+    // channels from skipping persistence by setting the flag themselves.
+    let already_persisted = message.channel == "gateway"
+        && message
+            .metadata
+            .get(crate::channels::web::util::GATEWAY_PERSISTED_FLAG)
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
     if let Some(ref db) = state.db {
         let v1_conv_id = if let Some(tid) = scope
             && let Ok(uuid) = uuid::Uuid::parse_str(tid)
@@ -2431,7 +2441,9 @@ async fn handle_with_engine_inner(
                 .await
                 .ok()
         };
-        if let Some(cid) = v1_conv_id {
+        if let Some(cid) = v1_conv_id
+            && !already_persisted
+        {
             let _ = db.add_conversation_message(cid, "user", content).await;
         }
     }
@@ -5196,5 +5208,58 @@ mod tests {
     fn parse_credential_name_none_for_missing_field() {
         assert_eq!(parse_credential_name("nothing to see here"), None);
         assert_eq!(parse_credential_name(r#"{"foo":"bar"}"#), None);
+    }
+
+    /// Verifies the `GATEWAY_PERSISTED_FLAG` check in `handle_with_engine_inner`
+    /// uses the same key as the gateway and v1 agent loop. A key-name mismatch
+    /// would silently re-introduce the duplicate-persist bug (#2409).
+    #[test]
+    fn v2_dual_write_respects_gateway_persisted_flag() {
+        use crate::channels::web::util::GATEWAY_PERSISTED_FLAG;
+
+        // Gateway channel with flag set → should be detected as already persisted
+        let mut msg = IncomingMessage::new("gateway", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        if let Some(obj) = msg.metadata.as_object_mut() {
+            obj.insert(GATEWAY_PERSISTED_FLAG.to_string(), serde_json::json!(true));
+        }
+        let already_persisted = msg.channel == "gateway"
+            && msg
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(
+            already_persisted,
+            "Flag must be detected for gateway channel"
+        );
+
+        // Gateway channel without flag → should NOT be detected
+        let msg_no_flag = IncomingMessage::new("gateway", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        let not_persisted = msg_no_flag.channel == "gateway"
+            && msg_no_flag
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(!not_persisted, "Flag must not be detected when not set");
+
+        // Non-gateway channel with flag set → must NOT be trusted
+        let mut msg_other = IncomingMessage::new("telegram", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        if let Some(obj) = msg_other.metadata.as_object_mut() {
+            obj.insert(GATEWAY_PERSISTED_FLAG.to_string(), serde_json::json!(true));
+        }
+        let untrusted = msg_other.channel == "gateway"
+            && msg_other
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(
+            !untrusted,
+            "Flag from non-gateway channel must not skip persistence"
+        );
     }
 }

--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -341,7 +341,7 @@ mod tests {
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[1].user_input, "Lost message");
         assert!(turns[1].response.is_none());
-        assert_eq!(turns[1].state, "Failed");
+        assert_eq!(turns[1].state, "Processing");
     }
 
     #[test]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2330,8 +2330,23 @@ async fn chat_send_handler(
     // (scan_inbound_for_secrets, check_policy). This is acceptable because
     // the DB is an audit log ("LLM data is never deleted") and blocked
     // content is still valuable for security review.
-    // dispatch-exempt: pre-job write, no JobContext exists yet to dispatch through
-    if let Some(ref thread_id_str) = req.thread_id
+    // Skip when the thread is already Processing to maintain correct DB
+    // message ordering — the agent loop drain path persists in turn order.
+    // dispatch-exempt: no JobContext at gateway send boundary; dispatcher requires JobContext for audit trail
+    let thread_is_processing = if let Some(ref sm) = state.session_manager
+        && let Some(ref tid_str) = req.thread_id
+        && let Ok(tid) = uuid::Uuid::parse_str(tid_str)
+    {
+        let session = sm.get_or_create_session(&user.user_id).await;
+        let sess = session.lock().await;
+        sess.threads
+            .get(&tid)
+            .is_some_and(|t| t.state == crate::agent::session::ThreadState::Processing)
+    } else {
+        false
+    };
+    if !thread_is_processing
+        && let Some(ref thread_id_str) = req.thread_id
         && let Ok(tid) = uuid::Uuid::parse_str(thread_id_str)
         && let Some(ref store) = state.store
     {
@@ -2339,16 +2354,23 @@ async fn chat_send_handler(
             .ensure_conversation(tid, "gateway", &user.user_id, None, Some("gateway"))
             .await
         {
-            Ok(true) => store
-                .add_conversation_message(tid, "user", &req.content)
-                .await
-                .map(|_| true)
-                .unwrap_or_else(|e| {
-                    tracing::debug!("Early user message persist failed: {e}");
-                    false
-                }),
+            // ensure_conversation uses a WHERE clause that rejects cross-tenant
+            // writes (returns Ok(false) above). The add_conversation_message
+            // call below goes through TenantScope for defense-in-depth ownership
+            // enforcement, matching the handler-layer pattern.
+            Ok(true) => {
+                let tenant = crate::tenant::TenantScope::new(&user.user_id, store.clone());
+                tenant
+                    .add_conversation_message(tid, "user", &req.content)
+                    .await
+                    .map(|_| true)
+                    .unwrap_or_else(|e| {
+                        tracing::debug!("Early user message persist failed: {e}");
+                        false
+                    })
+            }
             Ok(false) => {
-                tracing::debug!("Early persist skipped: conversation not writable");
+                tracing::debug!("Early persist skipped: thread belongs to a different user/channel");
                 false
             }
             Err(e) => {
@@ -2358,7 +2380,7 @@ async fn chat_send_handler(
         };
         if persisted && let Some(obj) = msg.metadata.as_object_mut() {
             obj.insert(
-                "user_message_persisted".to_string(),
+                crate::channels::web::util::GATEWAY_PERSISTED_FLAG.to_string(),
                 serde_json::json!(true),
             );
         }
@@ -4124,6 +4146,171 @@ mod tests {
 
         // DB allows duplicate rows — the metadata flag is what prevents this
         // in production (process_user_input checks already_persisted and skips).
+        assert_eq!(
+            messages.len(),
+            2,
+            "DB allows duplicate rows; the metadata flag is what prevents this"
+        );
+    }
+
+    /// Caller-level test: verifies the `GATEWAY_PERSISTED_FLAG` metadata key
+    /// is consistent between the gateway (server.rs) and the agent loop
+    /// (thread_ops.rs). A key-name mismatch would silently break dedup.
+    #[test]
+    fn test_gateway_persisted_flag_metadata_roundtrip() {
+        use crate::channels::web::util::GATEWAY_PERSISTED_FLAG;
+        use crate::channels::IncomingMessage;
+
+        // Simulate what the gateway does: create message with metadata object
+        // (chat_send_handler calls with_metadata(json!({...})) before setting flag)
+        let mut msg = IncomingMessage::new("gateway", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        if let Some(obj) = msg.metadata.as_object_mut() {
+            obj.insert(GATEWAY_PERSISTED_FLAG.to_string(), serde_json::json!(true));
+        }
+
+        // Simulate what thread_ops.rs checks: channel == "gateway" && flag is true
+        let already_persisted = msg.channel == "gateway"
+            && msg
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(
+            already_persisted,
+            "Flag must be detected when set by gateway"
+        );
+
+        // Without the flag, should be false
+        let msg_no_flag = IncomingMessage::new("gateway", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        let not_persisted = msg_no_flag.channel == "gateway"
+            && msg_no_flag
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(
+            !not_persisted,
+            "Flag must not be detected when not set"
+        );
+
+        // Non-gateway channel with flag set — must not trust it
+        let mut msg_other = IncomingMessage::new("telegram", "user-1", "Hello")
+            .with_metadata(serde_json::json!({"user_id": "user-1"}));
+        if let Some(obj) = msg_other.metadata.as_object_mut() {
+            obj.insert(GATEWAY_PERSISTED_FLAG.to_string(), serde_json::json!(true));
+        }
+        let untrusted = msg_other.channel == "gateway"
+            && msg_other
+                .metadata
+                .get(GATEWAY_PERSISTED_FLAG)
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+        assert!(
+            !untrusted,
+            "Flag from non-gateway channel must not be trusted"
+        );
+    }
+
+    /// Helper: connect to a PostgreSQL test database via DATABASE_URL.
+    /// Returns `None` (gracefully skips) when the env var is missing or
+    /// the connection cannot be established.
+    #[cfg(all(feature = "integration", feature = "postgres"))]
+    async fn pg_test_db() -> Option<std::sync::Arc<dyn crate::db::Database>> {
+        use crate::config::{DatabaseBackend, DatabaseConfig, SslMode};
+        use crate::db::Database as _;
+        use secrecy::SecretString;
+        use std::sync::Arc;
+
+        let url = match std::env::var("DATABASE_URL") {
+            Ok(u) => u,
+            Err(_) => {
+                eprintln!("skipping: DATABASE_URL not set");
+                return None;
+            }
+        };
+        let config = DatabaseConfig {
+            backend: DatabaseBackend::Postgres,
+            url: SecretString::from(url),
+            pool_size: 2,
+            ssl_mode: SslMode::Disable,
+            libsql_path: None,
+            libsql_url: None,
+            libsql_auth_token: None,
+        };
+        let backend = match crate::db::postgres::PgBackend::new(&config).await {
+            Ok(b) => b,
+            Err(e) => {
+                eprintln!("skipping: PostgreSQL unavailable ({e})");
+                return None;
+            }
+        };
+        if let Err(e) = backend.run_migrations().await {
+            eprintln!("skipping: migration failed ({e})");
+            return None;
+        }
+        Some(Arc::new(backend) as Arc<dyn crate::db::Database>)
+    }
+
+    /// PostgreSQL counterpart of `test_early_persist_writes_user_message_to_db`.
+    #[cfg(all(feature = "integration", feature = "postgres"))]
+    #[tokio::test]
+    async fn test_early_persist_writes_user_message_to_db_pg() {
+        let Some(db) = pg_test_db().await else {
+            return;
+        };
+        let thread_id = uuid::Uuid::new_v4();
+
+        let ok = db
+            .ensure_conversation(thread_id, "gateway", "user-pg-1", None, Some("gateway"))
+            .await
+            .expect("ensure_conversation");
+        assert!(ok);
+
+        db.add_conversation_message(thread_id, "user", "Hello from gateway (pg)")
+            .await
+            .expect("add_conversation_message");
+
+        let (messages, _) = db
+            .list_conversation_messages_paginated(thread_id, None, 50)
+            .await
+            .expect("list messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "Hello from gateway (pg)");
+
+        let turns = build_turns_from_db_messages(&messages);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].state, "Processing");
+    }
+
+    /// PostgreSQL counterpart of `test_db_allows_duplicate_user_messages_without_flag`.
+    #[cfg(all(feature = "integration", feature = "postgres"))]
+    #[tokio::test]
+    async fn test_db_allows_duplicate_user_messages_without_flag_pg() {
+        let Some(db) = pg_test_db().await else {
+            return;
+        };
+        let thread_id = uuid::Uuid::new_v4();
+
+        db.ensure_conversation(thread_id, "gateway", "user-pg-1", None, Some("gateway"))
+            .await
+            .expect("ensure_conversation");
+
+        db.add_conversation_message(thread_id, "user", "Hello pg")
+            .await
+            .expect("first add");
+
+        db.add_conversation_message(thread_id, "user", "Hello pg")
+            .await
+            .expect("second add (duplicate)");
+
+        let (messages, _) = db
+            .list_conversation_messages_paginated(thread_id, None, 50)
+            .await
+            .expect("list messages");
+
         assert_eq!(
             messages.len(),
             2,

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2323,6 +2323,47 @@ async fn chat_send_handler(
         req.images.len()
     );
 
+    // Persist user message to DB immediately so it is visible in history
+    // even before the agent loop picks it up (#2409). Best-effort: if DB
+    // write fails the agent loop will persist later as a fallback.
+    // Note: this writes raw content before the agent loop's safety pipeline
+    // (scan_inbound_for_secrets, check_policy). This is acceptable because
+    // the DB is an audit log ("LLM data is never deleted") and blocked
+    // content is still valuable for security review.
+    // dispatch-exempt: pre-job write, no JobContext exists yet to dispatch through
+    if let Some(ref thread_id_str) = req.thread_id
+        && let Ok(tid) = uuid::Uuid::parse_str(thread_id_str)
+        && let Some(ref store) = state.store
+    {
+        let persisted = match store
+            .ensure_conversation(tid, "gateway", &user.user_id, None, Some("gateway"))
+            .await
+        {
+            Ok(true) => store
+                .add_conversation_message(tid, "user", &req.content)
+                .await
+                .map(|_| true)
+                .unwrap_or_else(|e| {
+                    tracing::debug!("Early user message persist failed: {e}");
+                    false
+                }),
+            Ok(false) => {
+                tracing::debug!("Early persist skipped: conversation not writable");
+                false
+            }
+            Err(e) => {
+                tracing::debug!("Early persist ensure_conversation failed: {e}");
+                false
+            }
+        };
+        if persisted && let Some(obj) = msg.metadata.as_object_mut() {
+            obj.insert(
+                "user_message_persisted".to_string(),
+                serde_json::json!(true),
+            );
+        }
+    }
+
     // Clone sender to avoid holding RwLock read guard across send().await
     let tx = {
         let tx_guard = state.msg_tx.read().await;
@@ -3986,7 +4027,7 @@ mod tests {
         assert_eq!(turns.len(), 2);
         assert_eq!(turns[1].user_input, "Lost message");
         assert!(turns[1].response.is_none());
-        assert_eq!(turns[1].state, "Failed");
+        assert_eq!(turns[1].state, "Processing");
     }
 
     #[test]
@@ -4013,6 +4054,80 @@ mod tests {
         assert_eq!(
             info.tool_calls[0].error.as_deref(),
             Some("Tool 'http' failed: timeout")
+        );
+    }
+
+    /// Regression test for #2409: user message must be in DB before the agent
+    /// loop picks it up, so thread-switch + loadHistory() finds it.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_early_persist_writes_user_message_to_db() {
+        let (db, _dir) = crate::testing::test_db().await;
+        let thread_id = uuid::Uuid::new_v4();
+
+        // Simulate the gateway's early persist path:
+        // 1. ensure_conversation creates the conversation row
+        let ok = db
+            .ensure_conversation(thread_id, "gateway", "user-1", None, Some("gateway"))
+            .await
+            .expect("ensure_conversation");
+        assert!(ok);
+
+        // 2. add_conversation_message writes the user message
+        db.add_conversation_message(thread_id, "user", "Hello from gateway")
+            .await
+            .expect("add_conversation_message");
+
+        // Before the agent loop runs, the message must be queryable
+        let (messages, _) = db
+            .list_conversation_messages_paginated(thread_id, None, 50)
+            .await
+            .expect("list messages");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0].role, "user");
+        assert_eq!(messages[0].content, "Hello from gateway");
+
+        // build_turns_from_db_messages should show it as "Processing"
+        let turns = build_turns_from_db_messages(&messages);
+        assert_eq!(turns.len(), 1);
+        assert_eq!(turns[0].state, "Processing");
+    }
+
+    /// Proves the DB has no built-in dedup for duplicate user messages —
+    /// the `user_message_persisted` metadata flag in process_user_input is
+    /// the only thing preventing double rows. If the flag logic is removed,
+    /// this test documents what would happen.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn test_db_allows_duplicate_user_messages_without_flag() {
+        let (db, _dir) = crate::testing::test_db().await;
+        let thread_id = uuid::Uuid::new_v4();
+
+        db.ensure_conversation(thread_id, "gateway", "user-1", None, Some("gateway"))
+            .await
+            .expect("ensure_conversation");
+
+        // Gateway persists the message (early path)
+        db.add_conversation_message(thread_id, "user", "Hello")
+            .await
+            .expect("first add");
+
+        // Without the metadata flag, the agent loop would persist again
+        db.add_conversation_message(thread_id, "user", "Hello")
+            .await
+            .expect("second add (duplicate)");
+
+        let (messages, _) = db
+            .list_conversation_messages_paginated(thread_id, None, 50)
+            .await
+            .expect("list messages");
+
+        // DB allows duplicate rows — the metadata flag is what prevents this
+        // in production (process_user_input checks already_persisted and skips).
+        assert_eq!(
+            messages.len(),
+            2,
+            "DB allows duplicate rows; the metadata flag is what prevents this"
         );
     }
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2370,7 +2370,9 @@ async fn chat_send_handler(
                     })
             }
             Ok(false) => {
-                tracing::debug!("Early persist skipped: thread belongs to a different user/channel");
+                tracing::debug!(
+                    "Early persist skipped: thread belongs to a different user/channel"
+                );
                 false
             }
             Err(e) => {
@@ -4158,8 +4160,8 @@ mod tests {
     /// (thread_ops.rs). A key-name mismatch would silently break dedup.
     #[test]
     fn test_gateway_persisted_flag_metadata_roundtrip() {
-        use crate::channels::web::util::GATEWAY_PERSISTED_FLAG;
         use crate::channels::IncomingMessage;
+        use crate::channels::web::util::GATEWAY_PERSISTED_FLAG;
 
         // Simulate what the gateway does: create message with metadata object
         // (chat_send_handler calls with_metadata(json!({...})) before setting flag)
@@ -4190,10 +4192,7 @@ mod tests {
                 .get(GATEWAY_PERSISTED_FLAG)
                 .and_then(|v| v.as_bool())
                 .unwrap_or(false);
-        assert!(
-            !not_persisted,
-            "Flag must not be detected when not set"
-        );
+        assert!(!not_persisted, "Flag must not be detected when not set");
 
         // Non-gateway channel with flag set — must not trust it
         let mut msg_other = IncomingMessage::new("telegram", "user-1", "Hello")

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -8,6 +8,16 @@ pub use ironclaw_common::truncate_preview;
 const MAX_HISTORY_IMAGE_DATA_URL_BYTES_PER_IMAGE: usize = 512 * 1024;
 const MAX_HISTORY_IMAGE_DATA_URL_BYTES_PER_RESPONSE: usize = 1024 * 1024;
 
+/// Metadata key the gateway sets on an `IncomingMessage` after early-persisting
+/// the user message to the DB. The agent loop checks this flag to avoid
+/// writing a duplicate row. Defined once here so a typo cannot silently
+/// break dedup across `server.rs`, `thread_ops.rs`, and `agent_loop.rs`.
+pub const GATEWAY_PERSISTED_FLAG: &str = "user_message_persisted";
+
+/// Unanswered user messages older than this are shown as "Failed" in the UI;
+/// younger ones are shown as "Processing". Used by `build_turns_from_db_messages`.
+pub const INCOMPLETE_TURN_THRESHOLD: chrono::TimeDelta = chrono::TimeDelta::minutes(5);
+
 /// Convert stored tool errors into plain text suitable for UI display.
 pub fn tool_error_for_display(error: &str) -> String {
     ironclaw_safety::SafetyLayer::unwrap_tool_output(error).unwrap_or_else(|| error.to_string())
@@ -184,7 +194,7 @@ pub fn build_turns_from_db_messages(
             // older ones are likely stuck/crashed.
             if turn.response.is_none() {
                 let age = chrono::Utc::now() - msg.created_at;
-                if age < chrono::TimeDelta::minutes(5) {
+                if age < INCOMPLETE_TURN_THRESHOLD {
                     turn.state = "Processing".to_string();
                 } else {
                     turn.state = "Failed".to_string();
@@ -286,6 +296,21 @@ mod tests {
             created_at: chrono::Utc::now() - chrono::TimeDelta::minutes(10),
         };
         let turns = build_turns_from_db_messages(&[stale_msg]);
+        assert_eq!(turns.len(), 1);
+        assert!(turns[0].response.is_none());
+        assert_eq!(turns[0].state, "Failed");
+    }
+
+    #[test]
+    fn test_build_turns_incomplete_at_exact_threshold() {
+        // Exactly at the threshold boundary (5 min) — strict `<` means this is "Failed"
+        let boundary_msg = crate::history::ConversationMessage {
+            id: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+            created_at: chrono::Utc::now() - super::INCOMPLETE_TURN_THRESHOLD,
+        };
+        let turns = build_turns_from_db_messages(&[boundary_msg]);
         assert_eq!(turns.len(), 1);
         assert!(turns[0].response.is_none());
         assert_eq!(turns[0].state, "Failed");

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -179,9 +179,16 @@ pub fn build_turns_from_db_messages(
                 turn.completed_at = Some(assistant_msg.created_at.to_rfc3339());
             }
 
-            // Incomplete turn (user message without response)
+            // Incomplete turn: no assistant response yet.
+            // Recent messages (< 5 min) are likely still processing;
+            // older ones are likely stuck/crashed.
             if turn.response.is_none() {
-                turn.state = "Failed".to_string();
+                let age = chrono::Utc::now() - msg.created_at;
+                if age < chrono::TimeDelta::minutes(5) {
+                    turn.state = "Processing".to_string();
+                } else {
+                    turn.state = "Failed".to_string();
+                }
             }
 
             turns.push(turn);
@@ -260,9 +267,25 @@ mod tests {
     }
 
     #[test]
-    fn test_build_turns_incomplete() {
+    fn test_build_turns_incomplete_recent() {
+        // A recent unanswered message is still processing
         let messages = vec![make_msg("user", "Hello", 0)];
         let turns = build_turns_from_db_messages(&messages);
+        assert_eq!(turns.len(), 1);
+        assert!(turns[0].response.is_none());
+        assert_eq!(turns[0].state, "Processing");
+    }
+
+    #[test]
+    fn test_build_turns_incomplete_stale() {
+        // An old unanswered message (>5 min) is marked as failed
+        let stale_msg = crate::history::ConversationMessage {
+            id: Uuid::new_v4(),
+            role: "user".to_string(),
+            content: "Hello".to_string(),
+            created_at: chrono::Utc::now() - chrono::TimeDelta::minutes(10),
+        };
+        let turns = build_turns_from_db_messages(&[stale_msg]);
         assert_eq!(turns.len(), 1);
         assert!(turns[0].response.is_none());
         assert_eq!(turns[0].state, "Failed");

--- a/tests/e2e/scenarios/test_message_persistence.py
+++ b/tests/e2e/scenarios/test_message_persistence.py
@@ -1,0 +1,345 @@
+"""E2E tests for user message persistence (#2409).
+
+Verifies that user messages are persisted to the DB immediately at send
+time (before the agent loop processes them), so they survive thread
+switches and are never duplicated.
+"""
+
+import asyncio
+import os
+import signal
+import socket
+import tempfile
+from pathlib import Path
+
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from helpers import (
+    AUTH_TOKEN,
+    SEL,
+    api_get,
+    api_post,
+    send_chat_and_wait_for_terminal_message,
+    wait_for_ready,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _wait_for_turn_in_history(
+    base_url: str,
+    thread_id: str,
+    *,
+    predicate=None,
+    timeout: float = 20.0,
+) -> list:
+    """Poll chat history until a turn matching `predicate` appears.
+
+    Returns the full turns list on success.
+    """
+    deadline = asyncio.get_running_loop().time() + timeout
+    while asyncio.get_running_loop().time() < deadline:
+        resp = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}")
+        assert resp.status_code == 200, resp.text
+        turns = resp.json()["turns"]
+        if predicate is None and len(turns) > 0:
+            return turns
+        if predicate is not None and any(predicate(t) for t in turns):
+            return turns
+        await asyncio.sleep(0.5)
+    raise AssertionError(
+        f"Timed out waiting for matching turn in history for thread {thread_id}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# v1 engine tests (use the default session-scoped ironclaw_server)
+# ---------------------------------------------------------------------------
+
+
+async def test_user_message_appears_in_history_immediately(page, ironclaw_server):
+    """After POST /api/chat/send, the user message is in the DB before the
+    agent loop responds — the core early-persist guarantee."""
+    # Create an isolated thread
+    resp = await api_post(ironclaw_server, "/api/chat/thread/new")
+    assert resp.status_code == 200, resp.text
+    thread_id = resp.json()["id"]
+
+    # Send a message via API (not UI) to avoid waiting for the response
+    resp = await api_post(
+        ironclaw_server,
+        "/api/chat/send",
+        json={"content": "early persist check", "thread_id": thread_id},
+    )
+    assert resp.status_code == 202, resp.text
+
+    # Immediately query history — the DB write is synchronous before 202
+    resp = await api_get(
+        ironclaw_server,
+        f"/api/chat/history?thread_id={thread_id}",
+    )
+    assert resp.status_code == 200, resp.text
+    turns = resp.json()["turns"]
+    assert len(turns) >= 1, f"Expected at least 1 turn, got {turns}"
+    assert turns[0]["user_input"] == "early persist check", turns[0]
+    # The agent hasn't responded yet, so the turn should be in-progress
+    assert turns[0]["state"] in ("Processing", "Failed"), turns[0]["state"]
+
+
+async def test_message_survives_thread_switch(page, ironclaw_server):
+    """Send on thread A, switch to B, switch back to A — message is retained."""
+    # Create thread A via the UI new-thread button
+    prev_thread = await page.evaluate("() => currentThreadId")
+    await page.locator("#thread-new-btn").click()
+    await page.wait_for_function(
+        "(prev) => !!currentThreadId && currentThreadId !== prev",
+        arg=prev_thread,
+        timeout=10000,
+    )
+    thread_a = await page.evaluate("() => currentThreadId")
+
+    # Send a message on thread A and wait for the assistant response
+    result = await send_chat_and_wait_for_terminal_message(page, "hello")
+    assert result["role"] == "assistant"
+
+    # Wait for DB settlement
+    await page.wait_for_timeout(2000)
+
+    # Create thread B (switch away from A)
+    await page.locator("#thread-new-btn").click()
+    await page.wait_for_function(
+        "(a) => !!currentThreadId && currentThreadId !== a",
+        arg=thread_a,
+        timeout=10000,
+    )
+
+    # Switch back to thread A
+    await page.evaluate("(id) => switchThread(id)", thread_a)
+    await page.wait_for_function(
+        "(id) => currentThreadId === id",
+        arg=thread_a,
+        timeout=10000,
+    )
+
+    # Wait for the user message to reappear from the DB-backed history load
+    await page.locator(SEL["message_user"]).filter(
+        has_text="hello"
+    ).wait_for(state="visible", timeout=15000)
+
+    # Also verify via API
+    resp = await api_get(
+        ironclaw_server,
+        f"/api/chat/history?thread_id={thread_a}",
+    )
+    assert resp.status_code == 200, resp.text
+    turns = resp.json()["turns"]
+    assert any("hello" in t["user_input"].lower() for t in turns), turns
+
+
+async def test_no_duplicate_user_messages_after_processing(page, ironclaw_server):
+    """After full agent processing, there is exactly one user message in the DB
+    — the GATEWAY_PERSISTED_FLAG prevents double-write."""
+    # Create an isolated thread
+    resp = await api_post(ironclaw_server, "/api/chat/thread/new")
+    assert resp.status_code == 200, resp.text
+    thread_id = resp.json()["id"]
+
+    # Switch the UI to this thread
+    await page.evaluate("(id) => switchThread(id)", thread_id)
+    await page.wait_for_function(
+        "(id) => currentThreadId === id",
+        arg=thread_id,
+        timeout=10000,
+    )
+
+    # Send a message and wait for the full response
+    result = await send_chat_and_wait_for_terminal_message(page, "What is 2+2?")
+    assert result["role"] == "assistant"
+    assert "4" in result["text"], result
+
+    # Wait for DB settlement
+    await page.wait_for_timeout(3000)
+
+    # Switch away from the thread to force DB fallback on history query
+    await page.locator("#thread-new-btn").click()
+    await page.wait_for_function(
+        "(tid) => !!currentThreadId && currentThreadId !== tid",
+        arg=thread_id,
+        timeout=10000,
+    )
+
+    # Query history via API — since thread is no longer active in-memory,
+    # this reads from the database
+    resp = await api_get(
+        ironclaw_server,
+        f"/api/chat/history?thread_id={thread_id}",
+    )
+    assert resp.status_code == 200, resp.text
+    turns = resp.json()["turns"]
+
+    # There must be exactly one user turn (not two from double-persist)
+    user_turns = [t for t in turns if t.get("user_input")]
+    assert len(user_turns) == 1, (
+        f"Expected exactly 1 user turn, got {len(user_turns)}: {user_turns}"
+    )
+    assert "2+2" in user_turns[0]["user_input"] or "2 + 2" in user_turns[0]["user_input"]
+    assert user_turns[0].get("response") and "4" in user_turns[0]["response"]
+    assert user_turns[0]["state"] == "Completed", user_turns[0]["state"]
+
+
+# ---------------------------------------------------------------------------
+# v2 engine test (dedicated server with ENGINE_V2=true)
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_V2_PERSIST_DB_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-v2-persist-e2e-")
+_V2_PERSIST_HOME_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-v2-persist-e2e-home-")
+
+
+def _forward_coverage_env(env: dict):
+    """Forward LLVM coverage env vars from outer environment."""
+    for key in os.environ:
+        if key.startswith(("CARGO_LLVM_COV", "LLVM_", "CARGO_ENCODED_RUSTFLAGS",
+                           "CARGO_INCREMENTAL")):
+            env[key] = os.environ[key]
+
+
+async def _stop_process(proc, sig=signal.SIGINT, timeout=5):
+    """Send signal and wait for process to exit."""
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+
+
+@pytest.fixture(scope="module")
+async def v2_persistence_server(ironclaw_binary, mock_llm_server):
+    """Start ironclaw with ENGINE_V2=true for message persistence tests."""
+    home_dir = _V2_PERSIST_HOME_TMPDIR.name
+    os.makedirs(os.path.join(home_dir, ".ironclaw"), exist_ok=True)
+
+    socks = []
+    for _ in range(2):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        socks.append(s)
+    gateway_port = socks[0].getsockname()[1]
+    http_port = socks[1].getsockname()[1]
+    for s in socks:
+        s.close()
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+        "RUST_LOG": "ironclaw=debug",
+        "RUST_BACKTRACE": "1",
+        "ENGINE_V2": "true",
+        "GATEWAY_ENABLED": "true",
+        "GATEWAY_HOST": "127.0.0.1",
+        "GATEWAY_PORT": str(gateway_port),
+        "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+        "GATEWAY_USER_ID": "e2e-v2-persist-tester",
+        "HTTP_HOST": "127.0.0.1",
+        "HTTP_PORT": str(http_port),
+        "CLI_ENABLED": "false",
+        "LLM_BACKEND": "openai_compatible",
+        "LLM_BASE_URL": mock_llm_server,
+        "LLM_MODEL": "mock-model",
+        "DATABASE_BACKEND": "libsql",
+        "LIBSQL_PATH": os.path.join(_V2_PERSIST_DB_TMPDIR.name, "v2-persist-e2e.db"),
+        "SANDBOX_ENABLED": "false",
+        "SKILLS_ENABLED": "false",
+        "ROUTINES_ENABLED": "false",
+        "HEARTBEAT_ENABLED": "false",
+        "EMBEDDING_ENABLED": "false",
+        "WASM_ENABLED": "false",
+        "ONBOARD_COMPLETED": "true",
+    }
+    _forward_coverage_env(env)
+
+    proc = await asyncio.create_subprocess_exec(
+        ironclaw_binary, "--no-onboard",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+
+    base_url = f"http://127.0.0.1:{gateway_port}"
+    try:
+        await wait_for_ready(f"{base_url}/api/health", timeout=60)
+        yield base_url
+    except TimeoutError:
+        if proc.returncode is None:
+            await _stop_process(proc, timeout=2)
+        stderr_bytes = b""
+        if proc.stderr:
+            try:
+                stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+            except asyncio.TimeoutError:
+                pass
+        pytest.fail(
+            f"v2 persistence server failed to start on port {gateway_port}.\n"
+            f"stderr: {stderr_bytes.decode('utf-8', errors='replace')}"
+        )
+    finally:
+        if proc.returncode is None:
+            await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+            if proc.returncode is None:
+                await _stop_process(proc, sig=signal.SIGTERM, timeout=5)
+
+
+async def test_v2_no_duplicate_user_messages(v2_persistence_server):
+    """v2 engine: the GATEWAY_PERSISTED_FLAG prevents double-write to v1 DB."""
+    base_url = v2_persistence_server
+
+    # Create a thread
+    resp = await api_post(base_url, "/api/chat/thread/new")
+    assert resp.status_code == 200, resp.text
+    thread_id = resp.json()["id"]
+
+    # Send a message and wait for the agent to complete
+    resp = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={"content": "hello", "thread_id": thread_id},
+    )
+    assert resp.status_code == 202, resp.text
+
+    # Wait for the turn to complete (assistant responds)
+    turns = await _wait_for_turn_in_history(
+        base_url,
+        thread_id,
+        predicate=lambda t: t.get("response") and len(t["response"]) > 0,
+        timeout=30,
+    )
+
+    # Create a second thread to force the original out of in-memory cache
+    resp2 = await api_post(base_url, "/api/chat/thread/new")
+    assert resp2.status_code == 200, resp2.text
+
+    # Small delay to let any async DB writes settle
+    await asyncio.sleep(2)
+
+    # Re-query history for the original thread (now DB-backed)
+    resp = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}")
+    assert resp.status_code == 200, resp.text
+    turns = resp.json()["turns"]
+
+    # Exactly one user turn — not two from double-persist
+    user_turns = [t for t in turns if t.get("user_input")]
+    assert len(user_turns) == 1, (
+        f"Expected exactly 1 user turn, got {len(user_turns)}: {user_turns}"
+    )
+    assert "hello" in user_turns[0]["user_input"].lower()


### PR DESCRIPTION
## Summary
- User messages disappear when switching threads in the web gateway because the DB persist happens asynchronously in the agent loop — there's a timing gap where `loadHistory()` finds nothing
- `chat_send_handler` now writes the user message to DB immediately before returning 202, so history queries always find it
- Agent loop skips duplicate persist via a `user_message_persisted` metadata flag, scoped to the gateway channel only (non-gateway channels can't abuse it)
- Drain loop clears the flag on cloned messages so queued follow-up turns always get their own DB persist
- Incomplete turns now use time-based state: recent (<5 min) = "Processing", stale = "Failed"

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] 19 `build_turns` unit tests pass (including new stale/recent split)
- [x] 2 new libsql regression tests: `test_early_persist_writes_user_message_to_db`, `test_db_allows_duplicate_user_messages_without_flag`
- [ ] Manual: send message in thread A, switch to B, switch back to A — message visible with "Processing..." indicator
- [ ] Manual: wait for response, switch away and back — full turn visible
- [ ] Manual: refresh page — same behavior

Closes #2409

🤖 Generated with [Claude Code](https://claude.com/claude-code)