### PR TITLE
feat(testing): Claude Code trace import + worktree-based replay

### DIFF
--- a/scripts/convert_claude_trace.py
+++ b/scripts/convert_claude_trace.py
@@ -1,0 +1,912 @@
+#!/usr/bin/env python3
+"""Convert Claude Code JSONL conversation history to IronClaw trace fixtures.
+
+Takes a Claude Code session JSONL file and produces one or more IronClaw
+trace fixture JSON files suitable for deterministic E2E replay via TraceLlm.
+
+Usage:
+    python3 scripts/convert_claude_trace.py <session.jsonl> [--output-dir <dir>]
+    python3 scripts/convert_claude_trace.py <session.jsonl> --turn 2  # single turn
+    python3 scripts/convert_claude_trace.py <session.jsonl> --list    # list turns
+    python3 scripts/convert_claude_trace.py <session.jsonl> --all     # one file per turn
+
+Tool mapping (Claude Code -> IronClaw):
+    Bash   -> shell       (command -> command)
+    Read   -> read_file   (file_path -> path, offset, limit)
+    Write  -> write_file  (file_path -> path, content)
+    Edit   -> apply_patch (file_path -> path, old_string, new_string, replace_all)
+    Grep   -> grep        (pattern, path, glob, output_mode, context, ...)
+    Glob   -> glob        (pattern, path)
+
+Unmappable tools (Agent, ToolSearch, Skill, Task*, etc.) are skipped.
+Turns that contain only unmappable tools are excluded.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+# ── Tool mapping ──────────────────────────────────────────────────────
+
+TOOL_MAP: dict[str, str] = {
+    "Bash": "shell",
+    "Read": "read_file",
+    "Write": "write_file",
+    "Edit": "apply_patch",
+    "Grep": "grep",
+    "Glob": "glob",
+}
+
+# Tools we silently skip (no IronClaw equivalent or not useful in replay)
+SKIP_TOOLS: set[str] = {
+    "Agent",
+    "ToolSearch",
+    "Skill",
+    "TaskCreate",
+    "TaskUpdate",
+    "TaskGet",
+    "TaskList",
+    "TaskOutput",
+    "TaskStop",
+    "ScheduleWakeup",
+    "AskUserQuestion",
+    "EnterPlanMode",
+    "ExitPlanMode",
+    "EnterWorktree",
+    "ExitWorktree",
+    "CronCreate",
+    "CronDelete",
+    "CronList",
+    "NotebookEdit",
+    "LSP",
+    "Monitor",
+    "RemoteTrigger",
+    "WebSearch",
+    "SendMessage",
+}
+
+
+def map_tool_args(claude_name: str, claude_input: dict[str, Any]) -> dict[str, Any] | None:
+    """Map Claude Code tool arguments to IronClaw tool arguments.
+
+    Returns None if the tool is unmappable.
+    """
+    ic_name = TOOL_MAP.get(claude_name)
+    if ic_name is None:
+        return None
+
+    if ic_name == "shell":
+        args: dict[str, Any] = {"command": claude_input.get("command", "")}
+        if "timeout" in claude_input:
+            # Claude Code uses milliseconds, IronClaw uses seconds
+            timeout_ms = claude_input["timeout"]
+            if isinstance(timeout_ms, (int, float)) and timeout_ms > 0:
+                args["timeout"] = max(1, int(timeout_ms / 1000))
+        return args
+
+    if ic_name == "read_file":
+        args = {"path": claude_input.get("file_path", "")}
+        if "offset" in claude_input:
+            args["offset"] = claude_input["offset"]
+        if "limit" in claude_input:
+            args["limit"] = claude_input["limit"]
+        return args
+
+    if ic_name == "write_file":
+        return {
+            "path": claude_input.get("file_path", ""),
+            "content": claude_input.get("content", ""),
+        }
+
+    if ic_name == "apply_patch":
+        args = {
+            "path": claude_input.get("file_path", ""),
+            "old_string": claude_input.get("old_string", ""),
+            "new_string": claude_input.get("new_string", ""),
+        }
+        if claude_input.get("replace_all"):
+            args["replace_all"] = True
+        return args
+
+    if ic_name == "grep":
+        args = {"pattern": claude_input.get("pattern", "")}
+        if "path" in claude_input:
+            args["path"] = claude_input["path"]
+        if "glob" in claude_input:
+            args["glob"] = claude_input["glob"]
+        if "output_mode" in claude_input:
+            args["output_mode"] = claude_input["output_mode"]
+        # Map context flags
+        for flag in ("context", "-C", "-A", "-B"):
+            if flag in claude_input:
+                ic_flag = {
+                    "context": "context",
+                    "-C": "context",
+                    "-A": "after_context",
+                    "-B": "before_context",
+                }.get(flag, flag)
+                args[ic_flag] = claude_input[flag]
+        if claude_input.get("-i"):
+            args["case_insensitive"] = True
+        if claude_input.get("-n") is False:
+            args["line_numbers"] = False
+        if "type" in claude_input:
+            args["file_type"] = claude_input["type"]
+        if "head_limit" in claude_input:
+            args["max_results"] = claude_input["head_limit"]
+        return args
+
+    if ic_name == "glob":
+        args = {"pattern": claude_input.get("pattern", "")}
+        if "path" in claude_input:
+            args["path"] = claude_input["path"]
+        return args
+
+    return None
+
+
+def map_tool_call(
+    claude_name: str, claude_input: dict[str, Any], call_id: str
+) -> dict[str, Any] | None:
+    """Map a single Claude Code tool_use to an IronClaw TraceToolCall.
+
+    Returns None if the tool is unmappable.
+    """
+    ic_name = TOOL_MAP.get(claude_name)
+    if ic_name is None:
+        return None
+
+    args = map_tool_args(claude_name, claude_input)
+    if args is None:
+        return None
+
+    return {"id": call_id, "name": ic_name, "arguments": args}
+
+
+# ── JSONL parsing ─────────────────────────────────────────────────────
+
+
+def parse_jsonl(path: str) -> list[dict]:
+    """Parse a Claude Code JSONL file into a list of message objects."""
+    messages = []
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                messages.append(json.loads(line))
+    return messages
+
+
+def build_uuid_index(messages: list[dict]) -> dict[str, dict]:
+    """Build a UUID -> message index."""
+    idx = {}
+    for msg in messages:
+        uuid = msg.get("uuid")
+        if uuid:
+            idx[uuid] = msg
+    return idx
+
+
+def group_by_api_msg_id(messages: list[dict]) -> dict[str, list[dict]]:
+    """Group assistant messages by their API message ID (streaming chunks)."""
+    groups: dict[str, list[dict]] = defaultdict(list)
+    for msg in messages:
+        if msg.get("type") == "assistant":
+            api_id = msg.get("message", {}).get("id", "")
+            if api_id:
+                groups[api_id].append(msg)
+    return groups
+
+
+# ── Conversation linearization ────────────────────────────────────────
+
+
+def linearize_conversation(messages: list[dict]) -> list[dict]:
+    """Extract the linear conversation from the JSONL stream.
+
+    The JSONL file is already in temporal order. We just filter to
+    user/assistant messages on the main chain (not sidechains) and
+    skip metadata entries.
+    """
+    return [
+        m
+        for m in messages
+        if m.get("type") in ("user", "assistant")
+        and not m.get("isSidechain", False)
+    ]
+
+
+# ── LLM response grouping ────────────────────────────────────────────
+
+
+class LlmResponse:
+    """A single logical LLM response (may span multiple streaming chunks)."""
+
+    def __init__(self):
+        self.api_msg_id: str = ""
+        self.thinking: list[str] = []
+        self.text_blocks: list[str] = []
+        self.tool_calls: list[dict] = []  # {name, input, id, uuid}
+        self.stop_reason: str | None = None
+        self.input_tokens: int = 0
+        self.output_tokens: int = 0
+
+    def add_chunk(self, msg: dict):
+        api_msg = msg.get("message", {})
+        self.api_msg_id = api_msg.get("id", self.api_msg_id)
+
+        if api_msg.get("stop_reason"):
+            self.stop_reason = api_msg["stop_reason"]
+
+        usage = api_msg.get("usage", {})
+        # Take the max token counts (they accumulate in streaming)
+        self.input_tokens = max(
+            self.input_tokens, usage.get("input_tokens", 0)
+        )
+        self.output_tokens = max(
+            self.output_tokens, usage.get("output_tokens", 0)
+        )
+
+        for block in api_msg.get("content", []):
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "thinking":
+                text = block.get("thinking", "")
+                if text:
+                    self.thinking.append(text)
+            elif btype == "text":
+                text = block.get("text", "")
+                if text:
+                    self.text_blocks.append(text)
+            elif btype == "tool_use":
+                self.tool_calls.append(
+                    {
+                        "name": block.get("name", ""),
+                        "input": block.get("input", {}),
+                        "id": block.get("id", ""),
+                        "uuid": msg.get("uuid", ""),
+                    }
+                )
+
+
+def group_llm_responses(linear: list[dict]) -> list[dict]:
+    """Process the linear message list into grouped LLM responses.
+
+    Returns a new list where each assistant entry is a fully merged
+    LlmResponse, and user messages are preserved as-is. This makes
+    it easy to iterate and build trace steps.
+
+    Streaming chunks of the same API response (same message.id) are
+    merged even when tool_result messages are interleaved between them.
+    This happens because Claude Code executes tool calls mid-stream and
+    inserts tool results into the tree between streaming chunks.
+    """
+    result: list[dict] = []
+    current_response: LlmResponse | None = None
+    current_api_id: str | None = None
+    # Buffer tool_results that arrive between streaming chunks of the
+    # same API response.
+    buffered_tool_results: list[dict] = []
+
+    def flush_response():
+        nonlocal current_response, current_api_id
+        if current_response is not None:
+            result.append({"_type": "llm_response", "_data": current_response})
+            current_response = None
+            current_api_id = None
+
+    def flush_tool_results():
+        nonlocal buffered_tool_results
+        for tr in buffered_tool_results:
+            result.append(tr)
+        buffered_tool_results = []
+
+    for msg in linear:
+        if msg.get("type") == "assistant":
+            api_id = msg.get("message", {}).get("id", "")
+            if api_id == current_api_id and current_response is not None:
+                # Continue the same streaming response — flush any
+                # buffered tool results first (they belong between the
+                # previous tool_calls step and this continuation).
+                flush_tool_results()
+                current_response.add_chunk(msg)
+            else:
+                # New API response — flush everything
+                flush_response()
+                flush_tool_results()
+                current_response = LlmResponse()
+                current_response.add_chunk(msg)
+                current_api_id = api_id
+        else:
+            # User message — could be a tool_result between streaming
+            # chunks or a genuine new user message.
+            content = msg.get("message", {}).get("content", "")
+            is_tool_result = isinstance(content, list) and any(
+                isinstance(c, dict) and c.get("type") == "tool_result"
+                for c in content
+            )
+            if is_tool_result and current_response is not None:
+                # Buffer tool_result — might be mid-stream
+                buffered_tool_results.append(msg)
+            else:
+                # Genuine user text message — flush everything
+                flush_response()
+                flush_tool_results()
+                result.append(msg)
+
+    flush_response()
+    flush_tool_results()
+    return result
+
+
+# ── Turn extraction ──────────────────────────────────────────────────
+
+
+def extract_tool_result(msg: dict) -> dict | None:
+    """Extract tool result info from a user message containing tool_result."""
+    content = msg.get("message", {}).get("content", [])
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if isinstance(block, dict) and block.get("type") == "tool_result":
+            tool_use_result = msg.get("toolUseResult", {})
+            if isinstance(tool_use_result, str):
+                tool_use_result = {"stdout": tool_use_result}
+            elif not isinstance(tool_use_result, dict):
+                tool_use_result = {}
+            return {
+                "tool_use_id": block.get("tool_use_id", ""),
+                "content": block.get("content", ""),
+                "is_error": block.get("is_error", False),
+                "stdout": tool_use_result.get("stdout", ""),
+                "stderr": tool_use_result.get("stderr", ""),
+            }
+    return None
+
+
+def extract_turns(messages: list[dict]) -> list[dict]:
+    """Extract conversation turns from the linearized, grouped message list.
+
+    Each turn starts with a user text message and contains the LLM response
+    steps that follow until the next user text message.
+
+    Returns: list of {user_input: str, steps: list[step]}
+    """
+    grouped = group_llm_responses(messages)
+
+    turns: list[dict] = []
+    current_turn: dict | None = None
+    pending_tool_results: dict[str, dict] = {}  # tool_use_id -> result info
+
+    for entry in grouped:
+        if entry.get("_type") == "llm_response":
+            if current_turn is None:
+                continue  # Skip LLM responses before first user message
+
+            resp: LlmResponse = entry["_data"]
+
+            # Build expected_tool_results from any pending results
+            expected_results = []
+            for tool_use_id, result in pending_tool_results.items():
+                expected_results.append(
+                    {
+                        "tool_call_id": tool_use_id,
+                        "name": "",  # Will be filled below
+                        "content": result.get("content", result.get("stdout", "")),
+                    }
+                )
+            pending_tool_results.clear()
+
+            # If response has tool calls, create a tool_calls step
+            if resp.tool_calls:
+                mapped_calls = []
+                skipped_tool_ids: set[str] = set()
+                for tc in resp.tool_calls:
+                    mapped = map_tool_call(tc["name"], tc["input"], tc["id"])
+                    if mapped is not None:
+                        mapped_calls.append(mapped)
+                    elif tc["name"] in SKIP_TOOLS or tc["name"] not in TOOL_MAP:
+                        skipped_tool_ids.add(tc["id"])
+
+                if mapped_calls:
+                    step: dict[str, Any] = {
+                        "response": {
+                            "type": "tool_calls",
+                            "tool_calls": mapped_calls,
+                            "input_tokens": resp.input_tokens or 60,
+                            "output_tokens": resp.output_tokens or 20,
+                        }
+                    }
+
+                    # Add expected_tool_results if we have them
+                    if expected_results:
+                        # Try to fill in tool names from the mapped calls
+                        call_id_to_name = {c["id"]: c["name"] for c in mapped_calls}
+                        for er in expected_results:
+                            if er["tool_call_id"] in call_id_to_name:
+                                er["name"] = call_id_to_name[er["tool_call_id"]]
+                        # Only include results for mapped tools
+                        expected_results = [
+                            er for er in expected_results if er["name"]
+                        ]
+                        if expected_results:
+                            step["expected_tool_results"] = expected_results
+
+                    current_turn["steps"].append(step)
+
+            # If response has text, create a text step
+            if resp.text_blocks:
+                text = "\n".join(resp.text_blocks)
+                step = {
+                    "response": {
+                        "type": "text",
+                        "content": text,
+                        "input_tokens": resp.input_tokens or 80,
+                        "output_tokens": resp.output_tokens or 15,
+                    }
+                }
+                if expected_results and not resp.tool_calls:
+                    # Attach expected_tool_results to text step if no tool_calls step
+                    step["expected_tool_results"] = [
+                        er for er in expected_results if er["content"]
+                    ]
+                current_turn["steps"].append(step)
+
+        elif entry.get("type") == "user":
+            content = entry.get("message", {}).get("content", "")
+
+            # Check if this is a tool_result message
+            tool_result = extract_tool_result(entry)
+            if tool_result is not None:
+                pending_tool_results[tool_result["tool_use_id"]] = tool_result
+                continue
+
+            # This is a text user message — starts a new turn
+            if isinstance(content, str) and content.strip():
+                if current_turn is not None:
+                    turns.append(current_turn)
+                current_turn = {
+                    "user_input": content.strip(),
+                    "steps": [],
+                    "timestamp": entry.get("timestamp", ""),
+                    "git_branch": entry.get("gitBranch", ""),
+                }
+
+    # Flush last turn
+    if current_turn is not None:
+        turns.append(current_turn)
+
+    return turns
+
+
+# ── Trace generation ──────────────────────────────────────────────────
+
+
+# ── Git commit resolution ─────────────────────────────────────────────
+
+
+def detect_repo_root(messages: list[dict]) -> str | None:
+    """Detect the original repo root from user message cwd or file paths.
+
+    Looks at cwd fields and tool call arguments to find the common repo path.
+    """
+    candidates: list[str] = []
+    for msg in messages:
+        cwd = msg.get("cwd", "")
+        if cwd:
+            candidates.append(cwd)
+
+    if not candidates:
+        return None
+
+    # The most common cwd is likely the repo root
+    from collections import Counter
+    most_common = Counter(candidates).most_common(1)[0][0]
+    return most_common
+
+
+def resolve_commit(
+    repo_path: str, branch: str, timestamp: str
+) -> str | None:
+    """Resolve the git commit active on `branch` at `timestamp`.
+
+    Tries local branch first, then origin/<branch>.
+    """
+    import subprocess
+
+    for ref in [branch, f"origin/{branch}"]:
+        result = subprocess.run(
+            [
+                "git",
+                "-C",
+                repo_path,
+                "log",
+                f"--before={timestamp}",
+                "--format=%H",
+                "-1",
+                ref,
+            ],
+            capture_output=True,
+            text=True,
+        )
+        commit = result.stdout.strip()
+        if commit:
+            return commit
+    return None
+
+
+def resolve_turn_commits(
+    turns: list[dict], repo_path: str
+) -> dict[str, str]:
+    """Resolve git commits for each unique (branch, timestamp) pair.
+
+    Returns a map of branch -> commit hash.
+    """
+    resolved: dict[str, str] = {}
+    for turn in turns:
+        branch = turn.get("git_branch", "")
+        ts = turn.get("timestamp", "")
+        if not branch or not ts or branch in resolved:
+            continue
+        commit = resolve_commit(repo_path, branch, ts)
+        if commit:
+            resolved[branch] = commit
+    return resolved
+
+
+# ── Path rewriting ────────────────────────────────────────────────────
+
+# Placeholder used in trace fixtures for the repo root.
+# At replay time, the test harness replaces this with the worktree path.
+REPO_ROOT_PLACEHOLDER = "{{repo_root}}"
+
+
+def rewrite_paths_in_value(value: Any, old_prefix: str) -> Any:
+    """Recursively rewrite absolute paths in a JSON value.
+
+    Replaces `old_prefix` with the placeholder `{{repo_root}}` so that
+    the test harness can substitute the actual worktree path at runtime.
+    """
+    if isinstance(value, str):
+        if old_prefix and old_prefix in value:
+            return value.replace(old_prefix, REPO_ROOT_PLACEHOLDER)
+        return value
+    if isinstance(value, dict):
+        return {k: rewrite_paths_in_value(v, old_prefix) for k, v in value.items()}
+    if isinstance(value, list):
+        return [rewrite_paths_in_value(v, old_prefix) for v in value]
+    return value
+
+
+def rewrite_paths_in_trace(trace: dict, repo_root: str):
+    """Rewrite all absolute paths in a trace to use {{repo_root}} placeholder."""
+    # Normalize: ensure no trailing slash
+    repo_root = repo_root.rstrip("/")
+
+    for turn in trace.get("turns", []):
+        for step in turn.get("steps", []):
+            resp = step.get("response", {})
+            if resp.get("type") == "tool_calls":
+                resp["tool_calls"] = [
+                    {
+                        **tc,
+                        "arguments": rewrite_paths_in_value(
+                            tc["arguments"], repo_root
+                        ),
+                    }
+                    for tc in resp.get("tool_calls", [])
+                ]
+            if "expected_tool_results" in step:
+                step["expected_tool_results"] = [
+                    {**er, "content": er["content"].replace(repo_root, REPO_ROOT_PLACEHOLDER)}
+                    if isinstance(er.get("content"), str)
+                    else er
+                    for er in step["expected_tool_results"]
+                ]
+
+
+def add_request_hints(turns: list[dict]):
+    """Add request_hint to the first step of each turn."""
+    for turn in turns:
+        if not turn.get("steps"):
+            continue
+        user_input = turn.get("user_input", "")
+        # Pick a distinctive substring from the user message
+        hint_text = user_input[:80].strip()
+        if hint_text:
+            turn["steps"][0]["request_hint"] = {
+                "last_user_message_contains": hint_text
+            }
+
+
+def build_expects(turn: dict) -> dict:
+    """Build an expects block for a turn based on its steps."""
+    expects: dict[str, Any] = {}
+    tools_used: set[str] = set()
+
+    for step in turn.get("steps", []):
+        resp = step.get("response", {})
+        if resp.get("type") == "tool_calls":
+            for tc in resp.get("tool_calls", []):
+                tools_used.add(tc["name"])
+
+    if tools_used:
+        expects["tools_used"] = sorted(tools_used)
+        expects["all_tools_succeeded"] = True
+
+    if turn.get("steps"):
+        expects["min_responses"] = 1
+
+    return expects
+
+
+def generate_trace(
+    turns: list[dict],
+    model_name: str,
+    session_id: str = "",
+    commits: dict[str, str] | None = None,
+    repo_root: str | None = None,
+    rewrite_paths: bool = True,
+) -> dict:
+    """Generate an IronClaw trace fixture from extracted turns."""
+    add_request_hints(turns)
+
+    trace_turns = []
+    for turn in turns:
+        if not turn.get("steps"):
+            continue  # Skip empty turns
+
+        trace_turn: dict[str, Any] = {
+            "user_input": turn["user_input"],
+            "steps": turn["steps"],
+        }
+
+        expects = build_expects(turn)
+        if expects:
+            trace_turn["expects"] = expects
+
+        trace_turns.append(trace_turn)
+
+    if not trace_turns:
+        return {}
+
+    # Build top-level expects
+    all_tools: set[str] = set()
+    for turn in trace_turns:
+        for step in turn.get("steps", []):
+            resp = step.get("response", {})
+            if resp.get("type") == "tool_calls":
+                for tc in resp.get("tool_calls", []):
+                    all_tools.add(tc["name"])
+
+    trace: dict[str, Any] = {
+        "model_name": model_name,
+        "turns": trace_turns,
+    }
+
+    if all_tools:
+        trace["expects"] = {
+            "tools_used": sorted(all_tools),
+            "all_tools_succeeded": True,
+            "min_responses": 1,
+        }
+
+    # Embed repo metadata for worktree-based replay.
+    # The test harness reads these to set up a git worktree at the right commit.
+    if commits or repo_root:
+        repo_meta: dict[str, Any] = {}
+        if repo_root:
+            repo_meta["repo_root"] = repo_root
+        if commits:
+            # Use the first turn's branch as primary commit
+            first_branch = turns[0].get("git_branch", "")
+            if first_branch and first_branch in commits:
+                repo_meta["commit"] = commits[first_branch]
+                repo_meta["branch"] = first_branch
+            # Include all branch->commit mappings if multi-branch
+            if len(commits) > 1:
+                repo_meta["branch_commits"] = commits
+        trace["repo"] = repo_meta
+
+    # Rewrite absolute paths to {{repo_root}} placeholders
+    if rewrite_paths and repo_root:
+        rewrite_paths_in_trace(trace, repo_root)
+
+    return trace
+
+
+# ── CLI ───────────────────────────────────────────────────────────────
+
+
+def list_turns(turns: list[dict]):
+    """Print a summary of each turn."""
+    for i, turn in enumerate(turns):
+        user_msg = turn["user_input"][:80]
+        n_steps = len(turn.get("steps", []))
+        tools = set()
+        for step in turn.get("steps", []):
+            resp = step.get("response", {})
+            if resp.get("type") == "tool_calls":
+                for tc in resp.get("tool_calls", []):
+                    tools.add(tc["name"])
+        tool_str = ", ".join(sorted(tools)) if tools else "(text only)"
+        branch = turn.get("git_branch", "")
+        print(f"  Turn {i}: [{n_steps} steps] [{tool_str}] {user_msg}")
+        if branch:
+            print(f"          branch: {branch}")
+
+
+def write_trace(trace: dict, output_path: str):
+    """Write a trace fixture to a JSON file."""
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    with open(output_path, "w") as f:
+        json.dump(trace, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print(f"  Wrote {output_path} ({os.path.getsize(output_path) / 1024:.1f} KB)")
+
+
+def sanitize_name(s: str) -> str:
+    """Make a string safe for use in a filename."""
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in s)[:60]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert Claude Code JSONL history to IronClaw trace fixtures"
+    )
+    parser.add_argument("input", help="Path to Claude Code .jsonl session file")
+    parser.add_argument(
+        "--output-dir",
+        "-o",
+        default="tests/fixtures/llm_traces/imported",
+        help="Output directory for trace files (default: tests/fixtures/llm_traces/imported)",
+    )
+    parser.add_argument(
+        "--list", "-l", action="store_true", help="List turns without converting"
+    )
+    parser.add_argument(
+        "--turn", "-t", type=int, help="Convert only this turn number"
+    )
+    parser.add_argument(
+        "--all", "-a", action="store_true", help="Generate one trace file per turn"
+    )
+    parser.add_argument(
+        "--model-name",
+        "-m",
+        help="Model name prefix for traces (default: imported-<session_id>)",
+    )
+    parser.add_argument(
+        "--include-expected-results",
+        action="store_true",
+        help="Include expected_tool_results for regression checking",
+    )
+    parser.add_argument(
+        "--deterministic-only",
+        "-d",
+        action="store_true",
+        help="Skip turns with non-deterministic tools (shell commands that depend on external state)",
+    )
+    parser.add_argument(
+        "--repo",
+        help="Path to the original git repo for commit resolution and path rewriting "
+        "(default: auto-detect from cwd in JSONL)",
+    )
+    parser.add_argument(
+        "--no-rewrite-paths",
+        action="store_true",
+        help="Keep absolute paths as-is (don't rewrite to {{repo_root}} placeholders)",
+    )
+
+    args = parser.parse_args()
+
+    if not os.path.exists(args.input):
+        print(f"Error: {args.input} not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Parse session ID from filename
+    session_id = Path(args.input).stem
+
+    print(f"Parsing {args.input}...")
+    messages = parse_jsonl(args.input)
+    print(f"  {len(messages)} raw messages")
+
+    # Linearize the conversation tree
+    linear = linearize_conversation(messages)
+    print(f"  {len(linear)} linearized messages (excluding sidechains)")
+
+    # Extract turns
+    turns = extract_turns(linear)
+    print(f"  {len(turns)} turns extracted")
+
+    # Filter out turns with no mappable steps
+    nonempty_turns = [t for t in turns if t.get("steps")]
+    skipped = len(turns) - len(nonempty_turns)
+    if skipped:
+        print(f"  {skipped} turns skipped (no mappable tool calls)")
+    turns = nonempty_turns
+
+    if not turns:
+        print("No convertible turns found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Detect repo root and resolve commits
+    repo_root = args.repo or detect_repo_root(messages)
+    commits: dict[str, str] = {}
+    if repo_root and os.path.isdir(os.path.join(repo_root, ".git")):
+        commits = resolve_turn_commits(turns, repo_root)
+        if commits:
+            print(f"  Resolved commits:")
+            for branch, commit_hash in commits.items():
+                print(f"    {branch} -> {commit_hash[:12]}")
+    elif repo_root:
+        print(f"  Warning: {repo_root} is not a git repo, skipping commit resolution")
+
+    # Remove internal metadata from turns before output
+    if not args.include_expected_results:
+        for turn in turns:
+            for step in turn.get("steps", []):
+                step.pop("expected_tool_results", None)
+
+    if args.list:
+        list_turns(turns)
+        return
+
+    model_prefix = args.model_name or f"imported-{session_id[:8]}"
+
+    if args.turn is not None:
+        if args.turn < 0 or args.turn >= len(turns):
+            print(
+                f"Error: turn {args.turn} out of range (0-{len(turns) - 1})",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+
+        turn = turns[args.turn]
+        model_name = f"{model_prefix}-turn{args.turn}"
+        trace = generate_trace(
+            [turn], model_name, session_id,
+            commits=commits, repo_root=repo_root,
+            rewrite_paths=not args.no_rewrite_paths,
+        )
+        if trace:
+            fname = f"{sanitize_name(model_name)}.json"
+            write_trace(trace, os.path.join(args.output_dir, fname))
+        return
+
+    if args.all:
+        for i, turn in enumerate(turns):
+            model_name = f"{model_prefix}-turn{i}"
+            trace = generate_trace(
+                [turn], model_name, session_id,
+                commits=commits, repo_root=repo_root,
+                rewrite_paths=not args.no_rewrite_paths,
+            )
+            if trace:
+                fname = f"{sanitize_name(model_name)}.json"
+                write_trace(trace, os.path.join(args.output_dir, fname))
+        return
+
+    # Default: all turns in one file
+    model_name = model_prefix
+    trace = generate_trace(
+        turns, model_name, session_id,
+        commits=commits, repo_root=repo_root,
+        rewrite_paths=not args.no_rewrite_paths,
+    )
+    if trace:
+        # Clean up internal metadata from turns
+        for turn in trace.get("turns", []):
+            turn.pop("timestamp", None)
+            turn.pop("git_branch", None)
+
+        fname = f"{sanitize_name(model_name)}.json"
+        write_trace(trace, os.path.join(args.output_dir, fname))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1,6 +1,7 @@
 //! Tool registry for managing available tools.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use tokio::sync::RwLock;
@@ -572,6 +573,42 @@ impl ToolRegistry {
         self.register_sync(Arc::new(FileUndoTool::new(file_history)));
 
         tracing::debug!("Registered 8 development tools");
+    }
+
+    /// Register development tools sandboxed to a specific directory.
+    ///
+    /// All file operations (`read_file`, `write_file`, `apply_patch`, `glob`,
+    /// `grep`) are restricted to `dir` via `base_dir`, and `shell` commands
+    /// default to `dir` as their working directory. Useful for trace replay
+    /// against a git worktree at a specific historical commit.
+    pub fn register_dev_tools_in_dir(&self, dir: PathBuf) {
+        let file_history = shared_file_history();
+        let read_state = shared_read_file_state();
+
+        self.register_sync(Arc::new(ShellTool::new().with_working_dir(dir.clone())));
+        self.register_sync(Arc::new(
+            ReadFileTool::new()
+                .with_base_dir(dir.clone())
+                .with_read_state(Arc::clone(&read_state)),
+        ));
+        self.register_sync(Arc::new(
+            WriteFileTool::new()
+                .with_base_dir(dir.clone())
+                .with_file_history(Arc::clone(&file_history))
+                .with_read_state(Arc::clone(&read_state)),
+        ));
+        self.register_sync(Arc::new(ListDirTool::new().with_base_dir(dir.clone())));
+        self.register_sync(Arc::new(
+            ApplyPatchTool::new()
+                .with_base_dir(dir.clone())
+                .with_file_history(Arc::clone(&file_history))
+                .with_read_state(Arc::clone(&read_state)),
+        ));
+        self.register_sync(Arc::new(GlobTool::new().with_base_dir(dir.clone())));
+        self.register_sync(Arc::new(GrepTool::new().with_base_dir(dir.clone())));
+        self.register_sync(Arc::new(FileUndoTool::new(file_history)));
+
+        tracing::debug!("Registered 8 development tools in {}", dir.display());
     }
 
     /// Register memory tools with a workspace resolver.

--- a/tests/e2e_tool_param_coercion.rs
+++ b/tests/e2e_tool_param_coercion.rs
@@ -238,6 +238,7 @@ mod tests {
                 tool_results_contain: std::collections::HashMap::new(),
                 tools_order: vec!["google_sheets_write_fixture".to_string()],
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -316,6 +317,7 @@ mod tests {
                 tool_results_contain: std::collections::HashMap::new(),
                 tools_order: vec!["google_docs_batch_update_fixture".to_string()],
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -574,6 +576,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -649,6 +652,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -726,6 +730,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 

--- a/tests/e2e_wasm_github_coercion.rs
+++ b/tests/e2e_wasm_github_coercion.rs
@@ -138,6 +138,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -203,6 +204,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -269,6 +271,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -333,6 +336,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -408,6 +412,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -485,6 +490,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -564,6 +570,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -635,6 +642,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 
@@ -712,6 +720,7 @@ mod tests {
                 min_responses: Some(1),
                 ..Default::default()
             },
+            repo: Default::default(),
             steps: Vec::new(),
         };
 

--- a/tests/e2e_worktree_replay.rs
+++ b/tests/e2e_worktree_replay.rs
@@ -1,0 +1,149 @@
+//! E2E trace test: replays imported Claude Code traces against a git worktree
+//! checked out at the historical commit, verifying that IronClaw's tools
+//! produce correct results against the same repo state.
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod tests {
+    use std::path::{Path, PathBuf};
+    use std::process::Command;
+    use std::time::Duration;
+
+    use crate::support::test_rig::TestRigBuilder;
+    use crate::support::trace_llm::LlmTrace;
+
+    /// The source repo that the Claude Code sessions were recorded against.
+    const SOURCE_REPO: &str = "/Users/coder/ironclaw";
+
+    /// Create a git worktree at the given commit in a temp directory.
+    /// Returns the worktree path. The worktree must be cleaned up by the caller.
+    fn create_worktree(repo: &str, commit: &str) -> PathBuf {
+        let worktree_dir = std::env::temp_dir().join(format!("ironclaw_trace_wt_{}", &commit[..8]));
+
+        // Clean up any stale worktree from a previous failed run.
+        if worktree_dir.exists() {
+            let _ = Command::new("git")
+                .args(["-C", repo, "worktree", "remove", "--force"])
+                .arg(&worktree_dir)
+                .output();
+            let _ = std::fs::remove_dir_all(&worktree_dir);
+        }
+
+        let output = Command::new("git")
+            .args(["-C", repo, "worktree", "add", "--detach"])
+            .arg(&worktree_dir)
+            .arg(commit)
+            .output()
+            .expect("failed to run git worktree add");
+
+        assert!(
+            output.status.success(),
+            "git worktree add failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert!(
+            worktree_dir.exists(),
+            "worktree was not created at {}",
+            worktree_dir.display()
+        );
+
+        worktree_dir
+    }
+
+    /// Remove a git worktree.
+    fn remove_worktree(repo: &str, worktree_path: &Path) {
+        let _ = Command::new("git")
+            .args(["-C", repo, "worktree", "remove", "--force"])
+            .arg(worktree_path)
+            .output();
+    }
+
+    /// RAII guard that cleans up the worktree on drop.
+    struct WorktreeGuard {
+        repo: String,
+        path: PathBuf,
+    }
+
+    impl Drop for WorktreeGuard {
+        fn drop(&mut self) {
+            remove_worktree(&self.repo, &self.path);
+        }
+    }
+
+    /// Load a trace, resolve its repo metadata, create a worktree, and run it.
+    async fn run_worktree_trace(fixture_name: &str) {
+        let fixture_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/llm_traces/imported")
+            .join(fixture_name);
+
+        let mut trace = LlmTrace::from_file(&fixture_path)
+            .unwrap_or_else(|e| panic!("Failed to load {}: {}", fixture_name, e));
+
+        // Extract commit from trace metadata.
+        let commit = trace
+            .repo
+            .commit
+            .as_deref()
+            .expect("trace must have repo.commit for worktree replay");
+
+        // Skip if the source repo isn't present (e.g. CI without this checkout).
+        if !Path::new(SOURCE_REPO).join(".git").exists() {
+            eprintln!("[skip] source repo {SOURCE_REPO} not found — worktree replay skipped");
+            return;
+        }
+
+        // Skip if the commit isn't reachable in this repo.
+        let commit_check = Command::new("git")
+            .args(["-C", SOURCE_REPO, "cat-file", "-e"])
+            .arg(commit)
+            .output()
+            .expect("failed to run git cat-file");
+        if !commit_check.status.success() {
+            eprintln!(
+                "[skip] commit {commit} not found in {SOURCE_REPO} — worktree replay skipped"
+            );
+            return;
+        }
+
+        // Create worktree at the commit.
+        let worktree_path = create_worktree(SOURCE_REPO, commit);
+        let _guard = WorktreeGuard {
+            repo: SOURCE_REPO.to_string(),
+            path: worktree_path.clone(),
+        };
+
+        // Resolve {{repo_root}} placeholders to the worktree path.
+        trace.resolve_repo_root(&worktree_path);
+
+        // Build a test rig with tools sandboxed to the worktree.
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_working_dir(worktree_path)
+            .build()
+            .await;
+
+        // Run all turns and verify expects.
+        let all_responses = rig
+            .run_and_verify_trace(&trace, Duration::from_secs(30))
+            .await;
+
+        for (i, responses) in all_responses.iter().enumerate() {
+            assert!(
+                !responses.is_empty(),
+                "Turn {i}: expected at least one response"
+            );
+        }
+
+        rig.shutdown();
+    }
+
+    /// Replay a trace that reads files and greps the transcription module.
+    /// The worktree is checked out at the commit where these files existed.
+    #[tokio::test]
+    async fn worktree_read_and_grep() {
+        run_worktree_trace("worktree_read_test.json").await;
+    }
+}

--- a/tests/fixtures/llm_traces/imported/imported-2abe252f.json
+++ b/tests/fixtures/llm_traces/imported/imported-2abe252f.json
@@ -1,0 +1,1117 @@
+{
+  "model_name": "imported-2abe252f",
+  "turns": [
+    {
+      "user_input": "are there Anthropic related PRs?",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01DLY4HbNT6sLDa3FanXKHVj",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr list --search \"anthropic\" --state open --limit 20"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 152
+          },
+          "request_hint": {
+            "last_user_message_contains": "are there Anthropic related PRs?"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01CibHFpU8dpCsTqF5KYSvEm",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr list --search \"anthropic in:title,body\" --state open --limit 20 2>/dev/null; echo \"---\"; gh pr list --search \"anthropic\" --state all --limit 10 2>/dev/null"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 164
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The search in PR titles didn't surface Anthropic-specific results. Let me also search in PR bodies and branches.",
+            "input_tokens": 1,
+            "output_tokens": 164
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01WDWJXD6xjUhW9iJDdFwVND",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr list --search \"claude OR anthropic\" --state all --limit 20 | grep -iv \"promote\\|staging\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 106
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Here are the Anthropic-related PRs I found:\n\n**Open:**\n- **#1259** — `fix: ensure LLM calls always end with user message (closes #763)` — branch references Claude 4x assistant prefill issue\n- **#1498** — `Import claude convo history` — importing Claude conversation history\n- **#113** — `feat: native Anthropic provider with Claude Max OAuth support` (closed, not merged)\n\n**Merged:**\n- **#1213** — `fix(llm): persist refreshed Anthropic OAuth token after Keychain re-read` — fixed OAuth token expiry for Anthropic\n- **#384** — `feat(setup): Anthropic OAuth onboarding with setup-token support` — added Anthropic OAuth to the onboarding flow\n\n**Closed (not merged):**\n- **#113** — `feat: native Anthropic provider with Claude Max OAuth support`\n\nThe most directly relevant open one is **#1259** (fixing LLM message ordering for Claude models) and **#1498** (importing Claude conversation history). Want me to dig into any of these?",
+            "input_tokens": 1,
+            "output_tokens": 262
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "my problem is that I choose Anthropic OAuth Token and I'm getting error running any inference:\n\n2026-03-25T07:24:41.215795Z  WARN Retrying after transient error (tools) provider=claude-sonnet-4-6 attempt=3 max_retries=3 delay_ms=3705 error=Provider anthropic_oauth request failed: HTTP 400 Bad Request: {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Error\"},\"request_id\":\"req_011CZPQ6wNChWFTS9bkqtYiK\"}",
+      "steps": [
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me investigate the Anthropic OAuth provider implementation to understand what could cause this 400 error.",
+            "input_tokens": 3,
+            "output_tokens": 378
+          },
+          "request_hint": {
+            "last_user_message_contains": "my problem is that I choose Anthropic OAuth Token and I'm getting error running"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01CK96KUMgejjYVymjvgZcQJ",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr view 1259 --json title,body,state,files 2>/dev/null | head -200"
+                }
+              },
+              {
+                "id": "toolu_011pokG5KW7RHE7iMZHeRMo4",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "limit": 50
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 347
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me check PR #1259 and the current message conversion code to see if it's related.",
+            "input_tokens": 3,
+            "output_tokens": 347
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_018buF7WmBXkP97SbWdDGyFN",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 100,
+                  "limit": 150
+                }
+              },
+              {
+                "id": "toolu_01HLLmQyFM766qPeJ7keMxqP",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 370,
+                  "limit": 200
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 286
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me look at the message conversion and the `complete_with_tools` implementation to see if the assistant-ending-message issue exists there too.",
+            "input_tokens": 1,
+            "output_tokens": 286
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01GQSWibLQboonyE6Hpy4KPW",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 270,
+                  "limit": 100
+                }
+              },
+              {
+                "id": "toolu_015iHfHiUmDS7AswRpzpZaYr",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/util.rs",
+                  "limit": 80
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 201
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me check `complete_with_tools` to see if it handles the ending-with-user-message requirement.",
+            "input_tokens": 1,
+            "output_tokens": 201
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01MAeztVvrziKakuBUgCf7zX",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "ensure_ends_with_user_message",
+                  "output_mode": "content"
+                }
+              },
+              {
+                "id": "toolu_016chGV9hkjwR5JU74WRhaDp",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "before_llm_call|complete_with_tools",
+                  "path": "/Users/coder/ironclaw/src/agent",
+                  "output_mode": "content"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 1123
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me check if the main agent loop applies the same guard that PR #1259 adds to the worker paths.",
+            "input_tokens": 1,
+            "output_tokens": 1123
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01C2rt1PpMcAKabc8E2o7VGP",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "offset": 255,
+                  "limit": 40
+                }
+              },
+              {
+                "id": "toolu_01BuPWZxzEfE4gtbFPCduGja",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/agentic_loop.rs",
+                  "offset": 130,
+                  "limit": 40
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 193
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01H5j92RosyroqBAQkDGjN1E",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "complete_with_tools",
+                  "path": "/Users/coder/ironclaw/src/llm/reasoning.rs",
+                  "output_mode": "content",
+                  "after_context": 10,
+                  "before_context": 5
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 1486
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me check the Reasoning engine to see what messages flow into `complete_with_tools`.",
+            "input_tokens": 1,
+            "output_tokens": 1486
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01TajJWJR6hTgQLgonjvsNkF",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "messages.*push|push.*ChatMessage\"",
+                  "path": "/Users/coder/ironclaw/src/agent/agentic_loop.rs",
+                  "output_mode": "content",
+                  "after_context": 5,
+                  "before_context": 2
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 152
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01TE7NbpVAasrT6m82p4fVkm",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/agentic_loop.rs",
+                  "offset": 155,
+                  "limit": 80
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 129
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me look at the complete tool execution flow to see what messages get appended after tool calls.",
+            "input_tokens": 1,
+            "output_tokens": 129
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01UzqRx6jU6bm6Fo8cqVegoR",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "fn execute_tool_calls",
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "output_mode": "content",
+                  "after_context": 80
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 127
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01NcnBCFXritX3eA3GLbHiJT",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "offset": 580,
+                  "limit": 80
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 103
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01HEW2S1z1Xwy3mMnWKsHV68",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "offset": 700,
+                  "limit": 100
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 103
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01TDUr5ChQV1TRG34h1Qoo1H",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "offset": 800,
+                  "limit": 80
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 103
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01BQzBGWohkTUMaLmx5G5Unn",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "fn handle_text_response",
+                  "path": "/Users/coder/ironclaw/src/agent/dispatcher.rs",
+                  "output_mode": "content",
+                  "after_context": 30
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 430
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_0191jv59Qgtc9MiPuRYnK47M",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 479,
+                  "limit": 85
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 1535
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Based on my analysis, **PR #1259 is probably not your issue**, but the root cause is related. Here's why:\n\n**PR #1259** fixes the specific error `\"This model does not support assistant message prefill\"` on the **worker/job/routine paths** only. Your error is a generic `\"message\":\"Error\"` on the main **chat path**, which #1259 doesn't touch.\n\nThe more likely cause is in the `AnthropicOAuthProvider` itself. Let me check for a message ordering issue in `convert_messages()`:",
+            "input_tokens": 1,
+            "output_tokens": 1535
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01WMyEPFygettZmLbKNLSZwi",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "fn system|fn tool_result|fn assistant_with_tool_calls|fn user",
+                  "path": "/Users/coder/ironclaw/src/llm/provider.rs",
+                  "output_mode": "content",
+                  "after_context": 8
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 171
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me check what `ChatMessage::system` does and whether system messages injected mid-conversation could cause consecutive same-role issues.",
+            "input_tokens": 1,
+            "output_tokens": 171
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_013SuK8Q9o1o1dUcqkLrkGh7",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 25,
+                  "limit": 8
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 2262
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "I found the likely root cause. It's **not PR #1259** — it's a missing beta flag in the OAuth provider.\n\nThe OAuth provider is forced to use API version `2023-06-01` (line 27), but tool use was NOT GA in that version — it requires a separate beta flag. The code only sends `oauth-2025-04-20`:\n\n```rust:src/llm/anthropic_oauth.rs:130-131\n.header(\"anthropic-version\", ANTHROPIC_API_VERSION)    // 2023-06-01\n.header(\"anthropic-beta\", ANTHROPIC_OAUTH_BETA)         // oauth-2025-04-20\n```\n\nOn API version `2023-06-01`, tool use requires the `tools-2024-05-16` beta flag. Without it, sending `tools` in the request body produces a 400. The generic `\"message\":\"Error\"` is because the older API version doesn't know how to produce a descriptive error for an unknown field.\n\nHere's the fix:",
+            "input_tokens": 1,
+            "output_tokens": 2262
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01JZq6doNEhtLK4Lkab9Dhcr",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "/// Required beta flag to enable OAuth Bearer auth on api.anthropic.com.\n/// Without this header, the API returns 401 \"OAuth authentication is currently not supported.\"\nconst ANTHROPIC_OAUTH_BETA: &str = \"oauth-2025-04-20\";",
+                  "new_string": "/// Required beta flags for OAuth Bearer auth on api.anthropic.com.\n/// - `oauth-2025-04-20`: enables Bearer token auth (without it, 401 \"OAuth authentication is currently not supported.\")\n/// - `tools-2024-05-16`: enables tool use on the 2023-06-01 API version (without it, tool requests return 400)\nconst ANTHROPIC_OAUTH_BETA: &str = \"oauth-2025-04-20,tools-2024-05-16\";"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 291
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_011wVN4gQCsGoX9vVhgYeKrj",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 165,
+                  "limit": 15
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 129
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me also fix the retry path (line 171) which hardcodes the same header:",
+            "input_tokens": 1,
+            "output_tokens": 129
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01NJ8mUX19MgkkxSDk9E93Cw",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 580
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 130
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Good — the retry path already uses the `ANTHROPIC_OAUTH_BETA` constant, so it'll pick up the fix automatically.\n\nNow let me add a regression test:",
+            "input_tokens": 1,
+            "output_tokens": 130
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_012FZB9kehWnvmXmuUYraeAg",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "    /// Regression test for #1136: token field must be mutable via RwLock\n    /// so that a refreshed token persists across subsequent requests.\n    #[test]\n    fn test_token_update_persists() {",
+                  "new_string": "    /// Verify the beta header includes both OAuth and tools flags.\n    /// Without `tools-2024-05-16`, tool-use requests on the 2023-06-01\n    /// API version return HTTP 400.\n    #[test]\n    fn test_oauth_beta_includes_tools_flag() {\n        assert!(\n            ANTHROPIC_OAUTH_BETA.contains(\"oauth-2025-04-20\"),\n            \"OAuth beta flag must be present\"\n        );\n        assert!(\n            ANTHROPIC_OAUTH_BETA.contains(\"tools-2024-05-16\"),\n            \"Tools beta flag must be present for 2023-06-01 API version\"\n        );\n    }\n\n    /// Regression test for #1136: token field must be mutable via RwLock\n    /// so that a refreshed token persists across subsequent requests.\n    #[test]\n    fn test_token_update_persists() {"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 387
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_019j1UTCN46aX1YhsBHexEYK",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo clippy --all --benches --tests --examples --all-features 2>&1 | tail -20",
+                  "timeout": 300
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 137
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me run the quality gate:",
+            "input_tokens": 1,
+            "output_tokens": 137
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01PpdUsQRqacWjsdfvqyGcJ4",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo test --lib anthropic_oauth 2>&1 | tail -20",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 108
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch",
+          "grep",
+          "read_file",
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "let's print the exact request that is being sent to anthropic so we can debug it here",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_019KjYoSmyix3a1Wc3s34j6a",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 118,
+                  "limit": 22
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 129
+          },
+          "request_hint": {
+            "last_user_message_contains": "let's print the exact request that is being sent to anthropic so we can debug it"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "\n\nGood idea. Let me add debug logging for the serialized request body right before it's sent.",
+            "input_tokens": 3,
+            "output_tokens": 129
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_013U8bhN6bsWQ1QiZkGwC85p",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "        tracing::debug!(\"Sending request to Anthropic OAuth: {}\", url);\n\n        let response = self",
+                  "new_string": "        tracing::debug!(\"Sending request to Anthropic OAuth: {}\", url);\n\n        if tracing::enabled!(tracing::Level::TRACE) {\n            match serde_json::to_string_pretty(body) {\n                Ok(json) => tracing::trace!(\"Anthropic OAuth request body:\\n{}\", json),\n                Err(e) => tracing::warn!(\"Failed to serialize request for logging: {}\", e),\n            }\n        }\n\n        let response = self"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 251
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now run with `RUST_LOG=ironclaw::llm::anthropic_oauth=trace` to see the exact JSON being sent:\n\n```bash\nRUST_LOG=ironclaw::llm::anthropic_oauth=trace cargo run\n```\n\nThis will print the full request body at TRACE level so we can see exactly what's hitting the API. The token itself won't be logged (it goes through `bearer_auth`), just the JSON payload.",
+            "input_tokens": 1,
+            "output_tokens": 105
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch",
+          "read_file"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "2026-03-25T07:40:14.254481Z DEBUG Sending request to Anthropic OAuth: https://api.anthropic.com/v1/messages\n2026-03-25T07:40:14.257167Z TRACE Anthropic OAuth request body:\n{\n  \"model\": \"claude-sonnet-4-6\",\n  \"messages\": [\n    {\n      \"role\": \"user\",\n      \"content\": \"test\"\n    }\n  ],\n  \"system\": \"You are IronClaw Agent, a secure autonomous assistant.\\n\\n## Response Format — CRITICAL\\n\\nALL internal reasoning MUST be inside <think>...</think> tags.\\nDo not output any analysis, planning, or self-\n────────────────────────────────────────────────────────────────────────────────\nError: LLM error: Provider anthropic_oauth request failed: HTTP 400 Bad Request:\n{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Error\"},\"request_id\":\"req_011CZPRHkQKQw2\nxZUBabPyhL\"}\n\nit's truncated so unclear",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_011LvzKdRhG5ouRB8FQzu3dC",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "        if tracing::enabled!(tracing::Level::TRACE) {\n            match serde_json::to_string_pretty(body) {\n                Ok(json) => tracing::trace!(\"Anthropic OAuth request body:\\n{}\", json),\n                Err(e) => tracing::warn!(\"Failed to serialize request for logging: {}\", e),\n            }\n        }",
+                  "new_string": "        if let Ok(json) = serde_json::to_string_pretty(body) {\n            let _ = std::fs::write(\"/tmp/ironclaw_anthropic_request.json\", &json);\n            tracing::debug!(\"Anthropic OAuth request dumped to /tmp/ironclaw_anthropic_request.json ({} bytes)\", json.len());\n        }"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 414
+          },
+          "request_hint": {
+            "last_user_message_contains": "2026-03-25T07:40:14.254481Z DEBUG Sending request to Anthropic OAuth: https://ap"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me dump the full request to a file instead so nothing gets truncated.",
+            "input_tokens": 3,
+            "output_tokens": 414
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now run it again and we can inspect the full request:\n\n```bash\ncargo run 2>&1 | head -20\n# then after the error:\ncat /tmp/ironclaw_anthropic_request.json\n```",
+            "input_tokens": 1,
+            "output_tokens": 54
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "see the  /tmp/ironclaw_anthropic_request.json",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01G91AsejHwTnBk3Y5TUBTMK",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/tmp/ironclaw_anthropic_request.json"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 66
+          },
+          "request_hint": {
+            "last_user_message_contains": "see the  /tmp/ironclaw_anthropic_request.json"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01P8G4YW5Eog4FrnQaKKF37V",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/tmp/ironclaw_anthropic_request.json",
+                  "limit": 100
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 82
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01AQ55SyScgrBvcbvEWjXSsE",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/tmp/ironclaw_anthropic_request.json",
+                  "offset": 100,
+                  "limit": 200
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 99
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_015fqXqhaosaecDDpV8xj7Jr",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 28,
+                  "limit": 5
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 1799
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The request body looks structurally fine — valid messages, valid tool schemas. This confirms my earlier theory: the issue is the **missing tools beta flag**.\n\nWith API version `2023-06-01`, the `\"tools\"` field is not part of the base spec. It was added via the `tools-2024-05-16` beta. Without that beta flag, the API rejects the unknown `\"tools\"` field with a generic 400.\n\nThe fix I already applied should work — the beta header now sends both flags:\n\n```\nanthropic-beta: oauth-2025-04-20,tools-2024-05-16\n```\n\nLet me verify the change is correct and run the tests:",
+            "input_tokens": 1,
+            "output_tokens": 1799
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Want to rebuild and try it? `cargo run` should now send the combined beta header, which tells the API to accept the `tools` field.",
+            "input_tokens": 1,
+            "output_tokens": 34
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "read_file"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "I was running the fresh binary already",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01FvqH2hPW9yJHmeEp2BNqGv",
+                "name": "shell",
+                "arguments": {
+                  "command": "cat /tmp/ironclaw_anthropic_request.json | python3 -c \"\nimport json, sys\nreq = json.load(sys.stdin)\n# Minimal request: just model, messages, max_tokens — no tools\nminimal = {\n    'model': req['model'],\n    'messages': req['messages'],\n    'max_tokens': req['max_tokens']\n}\njson.dump(minimal, sys.stdout)\n\" > /tmp/ironclaw_minimal_request.json && cat /tmp/ironclaw_minimal_request.json"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 1811
+          },
+          "request_hint": {
+            "last_user_message_contains": "I was running the fresh binary already"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "So the fix didn't help — still 400? Let me test the API directly with a minimal curl to isolate the issue. We can use the same token:",
+            "input_tokens": 3,
+            "output_tokens": 1811
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Try these two curl commands to narrow it down — you'll need to substitute your OAuth token:\n\n```bash\n# Test 1: minimal request (no tools)\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20,tools-2024-05-16\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @/tmp/ironclaw_minimal_request.json\n\n# Test 2: full request (with tools)\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20,tools-2024-05-16\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @/tmp/ironclaw_anthropic_request.json\n```\n\nThis will tell us if it's the tools, the model name, the API version, or the token itself.",
+            "input_tokens": 1,
+            "output_tokens": 298
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "let's print out the token from the binary for now - just so I can debug",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01XF8vXUPccvBbupggnyeFM4",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "offset": 122,
+                  "limit": 20
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 108
+          },
+          "request_hint": {
+            "last_user_message_contains": "let's print out the token from the binary for now - just so I can debug"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_019noi8pr7RrQPTUmVh3JBaW",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "        if let Ok(json) = serde_json::to_string_pretty(body) {\n            let _ = std::fs::write(\"/tmp/ironclaw_anthropic_request.json\", &json);\n            tracing::debug!(\"Anthropic OAuth request dumped to /tmp/ironclaw_anthropic_request.json ({} bytes)\", json.len());\n        }",
+                  "new_string": "        if let Ok(json) = serde_json::to_string_pretty(body) {\n            let _ = std::fs::write(\"/tmp/ironclaw_anthropic_request.json\", &json);\n            tracing::debug!(\"Anthropic OAuth request dumped to /tmp/ironclaw_anthropic_request.json ({} bytes)\", json.len());\n        }\n\n        // DEBUG: print token prefix for debugging auth issues\n        {\n            let tok = self.current_token();\n            let preview = if tok.len() > 20 { &tok[..20] } else { &tok };\n            tracing::warn!(\"Anthropic OAuth token preview: {}...\", preview);\n        }"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 382
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Rebuild and run — the token prefix will appear in the logs at WARN level so it's always visible. Look for:\n\n```\nAnthropic OAuth token preview: sk-ant-oat01-XXXXXX...\n```\n\nIf the prefix doesn't start with `sk-ant-oat`, the token extraction is broken.",
+            "input_tokens": 1,
+            "output_tokens": 76
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch",
+          "read_file"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "show me full token with println!",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_016AtH4bTVzGvQqq74Kw7WHz",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/anthropic_oauth.rs",
+                  "old_string": "        // DEBUG: print token prefix for debugging auth issues\n        {\n            let tok = self.current_token();\n            let preview = if tok.len() > 20 { &tok[..20] } else { &tok };\n            tracing::warn!(\"Anthropic OAuth token preview: {}...\", preview);\n        }",
+                  "new_string": "        // DEBUG: print full token for local debugging — REMOVE BEFORE COMMIT\n        println!(\"DEBUG ANTHROPIC TOKEN: {}\", self.current_token());"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 240
+          },
+          "request_hint": {
+            "last_user_message_contains": "show me full token with println!"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Rebuild and run. The full token will print to stdout.",
+            "input_tokens": 1,
+            "output_tokens": 16
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "curl -s https://api.anthropic.com/v1/messages \\\n    -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n    -H \"anthropic-version: 2023-06-01\" \\\n    -H \"anthropic-beta: oauth-2025-04-20,tools-2024-05-16\" \\\n    -H \"Content-Type: application/json\" \\\n    -d @/tmp/ironclaw_anthropic_request.json\n\nfails with the same error.\n\nand /tmp/ironclaw_minimal_request.json doesn't exist anymore",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01M2YvaRorFpuAYjBKhXBupH",
+                "name": "shell",
+                "arguments": {
+                  "command": "python3 -c \"\nimport json\nwith open('/tmp/ironclaw_anthropic_request.json') as f:\n    req = json.load(f)\nminimal = {\n    'model': req['model'],\n    'messages': req['messages'],\n    'max_tokens': req['max_tokens']\n}\nwith open('/tmp/ironclaw_minimal_request.json', 'w') as f:\n    json.dump(minimal, f)\nprint(json.dumps(minimal))\n\""
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 195
+          },
+          "request_hint": {
+            "last_user_message_contains": "curl -s https://api.anthropic.com/v1/messages \\\n    -H \"Authorization: Bearer $Y"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Try these two separately to isolate tools vs model vs token:\n\n```bash\n# Test 1: minimal (no tools) — is it the token or model?\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @/tmp/ironclaw_minimal_request.json\n\n# Test 2: if test 1 works, try with tools\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20,tools-2024-05-16\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @/tmp/ironclaw_anthropic_request.json\n```",
+            "input_tokens": 1,
+            "output_tokens": 270
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "test 1 fails",
+      "steps": [
+        {
+          "response": {
+            "type": "text",
+            "content": "\n\nSo it's not about tools at all — the basic request fails. Let me revert my tools beta fix since that's not the issue, and let's test with the newer API version instead.\n\n```bash\n# Test: try with 2024-10-22 API version instead of 2023-06-01\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2024-10-22\" \\\n  -H \"anthropic-beta: oauth-2025-04-20\" \\\n  -H \"Content-Type: application/json\" \\\n  -d @/tmp/ironclaw_minimal_request.json\n```\n\nThe comment in the code says `2024-10-22` doesn't work with the OAuth beta flag, but that might be outdated. Let's see what happens.",
+            "input_tokens": 3,
+            "output_tokens": 213
+          },
+          "request_hint": {
+            "last_user_message_contains": "test 1 fails"
+          }
+        }
+      ],
+      "expects": {
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"anthropic-version: \\\"2024-10-22\\\" is not a valid version\"},\"request_id\":\"req_011CZQYTafXgfnxMAmiqRWEa\"}⏎",
+      "steps": [
+        {
+          "response": {
+            "type": "text",
+            "content": "OK so the API version is correct. Let's test if it's the model name:\n\n```bash\n# Test with full model name\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"claude-sonnet-4-6-20250514\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":4096}'\n\n# Test with an older model name\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"claude-sonnet-4-20250514\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":4096}'\n```\n\nThis will tell us if `claude-sonnet-4-6` is an invalid model name for the OAuth endpoint.",
+            "input_tokens": 3,
+            "output_tokens": 471
+          },
+          "request_hint": {
+            "last_user_message_contains": "{\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"anthropic-ver"
+          }
+        }
+      ],
+      "expects": {
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "full model name - {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"model: claude-sonnet-4-6-20250514\"},\"request_id\":\"req_011CZQYWKgDKkjX9Jn9zqXTB\"}⏎\n\nolder model name - {\"type\":\"error\",\"error\":{\"type\":\"invalid_request_error\",\"message\":\"Error\"},\"request_id\":\"req_011CZQYbpwVJPuF8RPPwV54Y\"}⏎",
+      "steps": [
+        {
+          "response": {
+            "type": "text",
+            "content": "Interesting — `claude-sonnet-4-6-20250514` gives a proper \"not found\" error (that date suffix is probably wrong), but the others give the generic \"Error\". Let's try a known-good model to isolate if it's a token/auth issue vs model issue:\n\n```bash\n# Try a model that definitely exists\ncurl -s https://api.anthropic.com/v1/messages \\\n  -H \"Authorization: Bearer $YOUR_TOKEN\" \\\n  -H \"anthropic-version: 2023-06-01\" \\\n  -H \"anthropic-beta: oauth-2025-04-20\" \\\n  -H \"Content-Type: application/json\" \\\n  -d '{\"model\":\"claude-3-5-sonnet-20241022\",\"messages\":[{\"role\":\"user\",\"content\":\"test\"}],\"max_tokens\":256}'\n```\n\nIf this also fails, it's the token. If it works, the OAuth endpoint doesn't support the Claude 4.x model names yet.",
+            "input_tokens": 3,
+            "output_tokens": 712
+          },
+          "request_hint": {
+            "last_user_message_contains": "full model name - {\"type\":\"error\",\"error\":{\"type\":\"not_found_error\",\"message\":\"m"
+          }
+        }
+      ],
+      "expects": {
+        "min_responses": 1
+      }
+    }
+  ],
+  "expects": {
+    "tools_used": [
+      "apply_patch",
+      "grep",
+      "read_file",
+      "shell"
+    ],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  }
+}

--- a/tests/fixtures/llm_traces/imported/imported-7f91faf5.json
+++ b/tests/fixtures/llm_traces/imported/imported-7f91faf5.json
@@ -1,0 +1,153 @@
+{
+  "model_name": "imported-7f91faf5",
+  "turns": [
+    {
+      "user_input": "are there open issues or pull requests related to settings / resetting of settings after restart/rebuild?",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01B8FGvorGYK9ntobYgYd1m9",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue list --search \"settings reset restart rebuild\" --limit 20 2>&1"
+                }
+              },
+              {
+                "id": "toolu_013iKoSf9qm4ys8H2QWk6cw2",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr list --search \"settings reset restart rebuild\" --limit 20 2>&1"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 240
+          },
+          "request_hint": {
+            "last_user_message_contains": "are there open issues or pull requests related to settings / resetting of settin"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01RpYQzeANM5Fv32DLt11Fob",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue list --search \"settings\" --limit 30 2>&1"
+                }
+              },
+              {
+                "id": "toolu_01Vk5gaPwyMXGX1ndzGTNqMs",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr list --search \"settings\" --limit 30 2>&1"
+                }
+              },
+              {
+                "id": "toolu_01PHvo2W3sp6Zja3xds2cgC7",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue list --search \"config persist\" --limit 20 2>&1"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 232
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01SjH6bpQxCjnZnoZ7p2Pwqd",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue view 846 2>&1 | head -60"
+                }
+              },
+              {
+                "id": "toolu_01SWdTu2jMBu2fA4cZjBBPwi",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue view 1119 2>&1 | head -60"
+                }
+              },
+              {
+                "id": "toolu_01GUc3g3fxnu91M4bDm7hRrF",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue view 1350 2>&1 | head -60"
+                }
+              },
+              {
+                "id": "toolu_01RBXjW5yMy13LFy8sdz3oqd",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh issue list --search \"settings lost OR settings reset OR settings overwritten OR config lost\" --limit 20 2>&1"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 328
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01G9yGy1iGHG2PXp8FoFqvqQ",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr view 1191 --json state,title 2>&1"
+                }
+              },
+              {
+                "id": "toolu_015gU3iTghybyo33svzG1smf",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr view 1401 --json state,title,body 2>&1 | head -40"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 175
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Here's what I found related to settings persistence / reset across restarts:\n\n### Most Directly Relevant Issues\n\n1. **#1119** — **Unify configuration sources before hot-reload** (OPEN)\n   - This is the core issue. IronClaw has **5 config sources** (env vars, TOML, DB settings, JSON legacy, runtime overlays) with inconsistent resolution. Some `config set` changes don't survive restarts because the resolver reads env vars directly and ignores DB-persisted values. Auto-generated values also don't persist across restarts.\n\n2. **#846** — **`onboard` fails with \"Failed to save settings to database\"** (OPEN)\n   - Onboarding wizard can't persist settings to DB, yet `ironclaw` starts fine afterward — suggests settings from onboarding may be silently lost.\n\n3. **#1350** — **Support hot-reload of LLM provider without restart** (OPEN, assigned to `serrrfirat`)\n   - LLM provider changes via web UI are saved to DB but **don't take effect until restart**. Blocked by #1119.\n\n4. **#86** — **Configuration system enhancements (hot-reload, JSON5/YAML)** (OPEN)\n   - Umbrella issue for the config system overhaul. Depends on #1119 being resolved first.\n\n### Related Open PRs\n\n- **PR #1401** — **Config conflict detection warnings** (OPEN) — Phase 3 of #1119; adds `tracing::warn()` when env vars silently override user-configured settings (the \"why did my setting disappear\" problem).\n- **PR #1491** — **Expose cheap_model and smart_routing_cascade in settings UI** (OPEN) — extends web settings.\n\n### Closed/Merged\n\n- **PR #1191** — **Unified settings page with subtabs** — already merged.\n\n### Summary\n\nThe root cause for \"settings reset after restart\" is tracked in **#1119**: the 5 config sources have no unified resolution order, so DB-persisted settings can be silently overridden by env vars or lost when the resolver skips the DB path. PR #1401 is an incremental fix (warns about conflicts), but the full fix requires completing the env > settings > default unification from #1119.",
+            "input_tokens": 1,
+            "output_tokens": 542
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    }
+  ],
+  "expects": {
+    "tools_used": [
+      "shell"
+    ],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  },
+  "repo": {
+    "repo_root": "/Users/coder/ironclaw",
+    "commit": "b3533e2b68abb8d9294e84a3286539ea044ba9ba",
+    "branch": "staging"
+  }
+}

--- a/tests/fixtures/llm_traces/imported/imported-9f613cdd-turn0.json
+++ b/tests/fixtures/llm_traces/imported/imported-9f613cdd-turn0.json
@@ -1,0 +1,367 @@
+{
+  "model_name": "imported-9f613cdd-turn0-turn0",
+  "turns": [
+    {
+      "user_input": "let's @src/transcription into @src/llm as it's part of LLM capabilities",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01P1KVEmqpH3GVcCbhHAcR7b",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/transcription/mod.rs"
+                }
+              },
+              {
+                "id": "toolu_01K6B27XzfmWdpJugawPhTNc",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/transcription/chat_completions.rs"
+                }
+              },
+              {
+                "id": "toolu_01X4NsZEXDmwFVQBsQLNKHcj",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/transcription/openai.rs"
+                }
+              },
+              {
+                "id": "toolu_01XaWbY5XkZYCiBBd4SgsrUX",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/llm/mod.rs"
+                }
+              },
+              {
+                "id": "toolu_01Ta4heJWX5kd9pzZmE3wJvH",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/lib.rs"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 435
+          },
+          "request_hint": {
+            "last_user_message_contains": "let's @src/transcription into @src/llm as it's part of LLM capabilities"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me read the transcription module files and understand how they're wired up.",
+            "input_tokens": 3,
+            "output_tokens": 435
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01AMFr8DTeiFr2BcMa6N25ju",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "crate::transcription|use.*transcription",
+                  "output_mode": "content"
+                }
+              }
+            ],
+            "input_tokens": 1502,
+            "output_tokens": 142
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me find all references to the transcription module across the codebase.",
+            "input_tokens": 1502,
+            "output_tokens": 142
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01G6QzHSH4LTjv6sC9EM15d6",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/config/transcription.rs"
+                }
+              },
+              {
+                "id": "toolu_01PNABpfPDRXhcB4tQXyHkZJ",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/agent/agent_loop.rs",
+                  "offset": 160,
+                  "limit": 10
+                }
+              },
+              {
+                "id": "toolu_013dWBKDf7DtZoAuS45BTWn7",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/config/mod.rs",
+                  "offset": 50,
+                  "limit": 10
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 244
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01BvjLdpdrqAwpn29CoDP8g8",
+                "name": "shell",
+                "arguments": {
+                  "command": "mkdir -p {{repo_root}}/src/llm/transcription && mv {{repo_root}}/src/transcription/mod.rs {{repo_root}}/src/llm/transcription/mod.rs && mv {{repo_root}}/src/transcription/chat_completions.rs {{repo_root}}/src/llm/transcription/chat_completions.rs && mv {{repo_root}}/src/transcription/openai.rs {{repo_root}}/src/llm/transcription/openai.rs && rmdir {{repo_root}}/src/transcription"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 758
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "I have a clear picture of the move. Here's what needs to happen:\n\n1. Move the 3 files from `src/transcription/` to `src/llm/transcription/`\n2. Declare the submodule in `src/llm/mod.rs`\n3. Remove the top-level module from `src/lib.rs`\n4. Update 3 files that reference `crate::transcription`\n\nLet me do it.",
+            "input_tokens": 1,
+            "output_tokens": 758
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01R9Ao2DCdovV3qrB93y3q3s",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/lib.rs",
+                  "old_string": "pub mod transcription;\npub mod tunnel;",
+                  "new_string": "pub mod tunnel;"
+                }
+              },
+              {
+                "id": "toolu_018qLrpx6xe2YQi84jbQ3JW6",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/llm/mod.rs",
+                  "old_string": "mod token_refreshing;\n\n#[cfg(test)]\nmod codex_test_helpers;",
+                  "new_string": "mod token_refreshing;\npub mod transcription;\n\n#[cfg(test)]\nmod codex_test_helpers;"
+                }
+              },
+              {
+                "id": "toolu_01AbX4Gixwenj7wBWCruV1W9",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/config/transcription.rs",
+                  "old_string": "    pub fn create_provider(&self) -> Option<Box<dyn crate::transcription::TranscriptionProvider>> {",
+                  "new_string": "    pub fn create_provider(&self) -> Option<Box<dyn crate::llm::transcription::TranscriptionProvider>> {"
+                }
+              },
+              {
+                "id": "toolu_01MfdvgYrNeaBQyhUrcNRNgM",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/config/transcription.rs",
+                  "old_string": "                let mut provider = crate::transcription::ChatCompletionsTranscriptionProvider::new(",
+                  "new_string": "                let mut provider = crate::llm::transcription::ChatCompletionsTranscriptionProvider::new("
+                }
+              },
+              {
+                "id": "toolu_01Bib9UjdCPNNDz3jDDGhjcZ",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/config/transcription.rs",
+                  "old_string": "                    crate::transcription::OpenAiWhisperProvider::new(api_key.clone())",
+                  "new_string": "                    crate::llm::transcription::OpenAiWhisperProvider::new(api_key.clone())"
+                }
+              },
+              {
+                "id": "toolu_01JUw4TuJv47kT4FVnLnaVzt",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/agent/agent_loop.rs",
+                  "old_string": "    pub transcription: Option<Arc<crate::transcription::TranscriptionMiddleware>>,",
+                  "new_string": "    pub transcription: Option<Arc<crate::llm::transcription::TranscriptionMiddleware>>,"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 820
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now update all the references:",
+            "input_tokens": 1,
+            "output_tokens": 820
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01HPmWjBJahkJkdgnxktqGmZ",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "crate::transcription[^_]",
+                  "output_mode": "content"
+                }
+              },
+              {
+                "id": "toolu_01J1djUFjVUw8hb1LCWXNWpL",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo check 2>&1 | tail -30",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 215
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me also check if there are any references to `crate::transcription` in `app.rs` or anywhere else I might have missed, and verify it compiles.",
+            "input_tokens": 1,
+            "output_tokens": 215
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_013U5PyHhVM4dwjm7JXsv5W1",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/main.rs",
+                  "offset": 848,
+                  "limit": 8
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 111
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "One more reference in `main.rs`:",
+            "input_tokens": 1,
+            "output_tokens": 111
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_017vwuUSFEy2YPN3ysuCctwv",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "{{repo_root}}/src/main.rs",
+                  "old_string": "            .map(|p| Arc::new(ironclaw::transcription::TranscriptionMiddleware::new(p))),",
+                  "new_string": "            .map(|p| Arc::new(ironclaw::llm::transcription::TranscriptionMiddleware::new(p))),"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 164
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_016e2pnPb5pmBBDCy3rseZpn",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo check 2>&1 | tail -20",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 104
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01D4gmU9MJeYY3vX7sH6Bs4j",
+                "name": "shell",
+                "arguments": {
+                  "command": "cat /private/tmp/claude-505/-Users-coder-ironclaw/9f613cdd-7dab-4033-8f23-bbd0cd4aa8b9/tasks/byooinjz3.output",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 144
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Compiles cleanly. Done. Here's what I did:\n\n- **Moved** `src/transcription/{mod,chat_completions,openai}.rs` → `src/llm/transcription/`\n- **Removed** `pub mod transcription;` from `src/lib.rs`\n- **Added** `pub mod transcription;` to `src/llm/mod.rs`\n- **Updated references** in `src/config/transcription.rs`, `src/agent/agent_loop.rs`, and `src/main.rs` from `crate::transcription` → `crate::llm::transcription`",
+            "input_tokens": 1,
+            "output_tokens": 151
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch",
+          "grep",
+          "read_file",
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    }
+  ],
+  "expects": {
+    "tools_used": [
+      "apply_patch",
+      "grep",
+      "read_file",
+      "shell"
+    ],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  },
+  "repo": {
+    "repo_root": "/Users/coder/ironclaw",
+    "commit": "a09c0236421e02a70d76e7244b4fb5625c753fd6",
+    "branch": "staging",
+    "branch_commits": {
+      "staging": "a09c0236421e02a70d76e7244b4fb5625c753fd6",
+      "refactor/move-transcription-into-llm": "99c6eaf2bf9d1d9cab60db3a24c4555fc0b88b06"
+    }
+  }
+}

--- a/tests/fixtures/llm_traces/imported/imported-9f613cdd.json
+++ b/tests/fixtures/llm_traces/imported/imported-9f613cdd.json
@@ -1,0 +1,783 @@
+{
+  "model_name": "imported-9f613cdd",
+  "turns": [
+    {
+      "user_input": "let's @src/transcription into @src/llm as it's part of LLM capabilities",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01P1KVEmqpH3GVcCbhHAcR7b",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/transcription/mod.rs"
+                }
+              },
+              {
+                "id": "toolu_01K6B27XzfmWdpJugawPhTNc",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/transcription/chat_completions.rs"
+                }
+              },
+              {
+                "id": "toolu_01X4NsZEXDmwFVQBsQLNKHcj",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/transcription/openai.rs"
+                }
+              },
+              {
+                "id": "toolu_01XaWbY5XkZYCiBBd4SgsrUX",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/mod.rs"
+                }
+              },
+              {
+                "id": "toolu_01Ta4heJWX5kd9pzZmE3wJvH",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/lib.rs"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 435
+          },
+          "request_hint": {
+            "last_user_message_contains": "let's @src/transcription into @src/llm as it's part of LLM capabilities"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Let me read the transcription module files and understand how they're wired up.",
+            "input_tokens": 3,
+            "output_tokens": 435
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01AMFr8DTeiFr2BcMa6N25ju",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "crate::transcription|use.*transcription",
+                  "output_mode": "content"
+                }
+              }
+            ],
+            "input_tokens": 1502,
+            "output_tokens": 142
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me find all references to the transcription module across the codebase.",
+            "input_tokens": 1502,
+            "output_tokens": 142
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01G6QzHSH4LTjv6sC9EM15d6",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/config/transcription.rs"
+                }
+              },
+              {
+                "id": "toolu_01PNABpfPDRXhcB4tQXyHkZJ",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/agent_loop.rs",
+                  "offset": 160,
+                  "limit": 10
+                }
+              },
+              {
+                "id": "toolu_013dWBKDf7DtZoAuS45BTWn7",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/config/mod.rs",
+                  "offset": 50,
+                  "limit": 10
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 244
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01BvjLdpdrqAwpn29CoDP8g8",
+                "name": "shell",
+                "arguments": {
+                  "command": "mkdir -p /Users/coder/ironclaw/src/llm/transcription && mv /Users/coder/ironclaw/src/transcription/mod.rs /Users/coder/ironclaw/src/llm/transcription/mod.rs && mv /Users/coder/ironclaw/src/transcription/chat_completions.rs /Users/coder/ironclaw/src/llm/transcription/chat_completions.rs && mv /Users/coder/ironclaw/src/transcription/openai.rs /Users/coder/ironclaw/src/llm/transcription/openai.rs && rmdir /Users/coder/ironclaw/src/transcription"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 758
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "I have a clear picture of the move. Here's what needs to happen:\n\n1. Move the 3 files from `src/transcription/` to `src/llm/transcription/`\n2. Declare the submodule in `src/llm/mod.rs`\n3. Remove the top-level module from `src/lib.rs`\n4. Update 3 files that reference `crate::transcription`\n\nLet me do it.",
+            "input_tokens": 1,
+            "output_tokens": 758
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01R9Ao2DCdovV3qrB93y3q3s",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/lib.rs",
+                  "old_string": "pub mod transcription;\npub mod tunnel;",
+                  "new_string": "pub mod tunnel;"
+                }
+              },
+              {
+                "id": "toolu_018qLrpx6xe2YQi84jbQ3JW6",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/llm/mod.rs",
+                  "old_string": "mod token_refreshing;\n\n#[cfg(test)]\nmod codex_test_helpers;",
+                  "new_string": "mod token_refreshing;\npub mod transcription;\n\n#[cfg(test)]\nmod codex_test_helpers;"
+                }
+              },
+              {
+                "id": "toolu_01AbX4Gixwenj7wBWCruV1W9",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/config/transcription.rs",
+                  "old_string": "    pub fn create_provider(&self) -> Option<Box<dyn crate::transcription::TranscriptionProvider>> {",
+                  "new_string": "    pub fn create_provider(&self) -> Option<Box<dyn crate::llm::transcription::TranscriptionProvider>> {"
+                }
+              },
+              {
+                "id": "toolu_01MfdvgYrNeaBQyhUrcNRNgM",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/config/transcription.rs",
+                  "old_string": "                let mut provider = crate::transcription::ChatCompletionsTranscriptionProvider::new(",
+                  "new_string": "                let mut provider = crate::llm::transcription::ChatCompletionsTranscriptionProvider::new("
+                }
+              },
+              {
+                "id": "toolu_01Bib9UjdCPNNDz3jDDGhjcZ",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/config/transcription.rs",
+                  "old_string": "                    crate::transcription::OpenAiWhisperProvider::new(api_key.clone())",
+                  "new_string": "                    crate::llm::transcription::OpenAiWhisperProvider::new(api_key.clone())"
+                }
+              },
+              {
+                "id": "toolu_01JUw4TuJv47kT4FVnLnaVzt",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/agent/agent_loop.rs",
+                  "old_string": "    pub transcription: Option<Arc<crate::transcription::TranscriptionMiddleware>>,",
+                  "new_string": "    pub transcription: Option<Arc<crate::llm::transcription::TranscriptionMiddleware>>,"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 820
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now update all the references:",
+            "input_tokens": 1,
+            "output_tokens": 820
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01HPmWjBJahkJkdgnxktqGmZ",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "crate::transcription[^_]",
+                  "output_mode": "content"
+                }
+              },
+              {
+                "id": "toolu_01J1djUFjVUw8hb1LCWXNWpL",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo check 2>&1 | tail -30",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 215
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now let me also check if there are any references to `crate::transcription` in `app.rs` or anywhere else I might have missed, and verify it compiles.",
+            "input_tokens": 1,
+            "output_tokens": 215
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_013U5PyHhVM4dwjm7JXsv5W1",
+                "name": "read_file",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/main.rs",
+                  "offset": 848,
+                  "limit": 8
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 111
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "One more reference in `main.rs`:",
+            "input_tokens": 1,
+            "output_tokens": 111
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_017vwuUSFEy2YPN3ysuCctwv",
+                "name": "apply_patch",
+                "arguments": {
+                  "path": "/Users/coder/ironclaw/src/main.rs",
+                  "old_string": "            .map(|p| Arc::new(ironclaw::transcription::TranscriptionMiddleware::new(p))),",
+                  "new_string": "            .map(|p| Arc::new(ironclaw::llm::transcription::TranscriptionMiddleware::new(p))),"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 164
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_016e2pnPb5pmBBDCy3rseZpn",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo check 2>&1 | tail -20",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 104
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01D4gmU9MJeYY3vX7sH6Bs4j",
+                "name": "shell",
+                "arguments": {
+                  "command": "cat /private/tmp/claude-505/-Users-coder-ironclaw/9f613cdd-7dab-4033-8f23-bbd0cd4aa8b9/tasks/byooinjz3.output",
+                  "timeout": 120
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 144
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Compiles cleanly. Done. Here's what I did:\n\n- **Moved** `src/transcription/{mod,chat_completions,openai}.rs` → `src/llm/transcription/`\n- **Removed** `pub mod transcription;` from `src/lib.rs`\n- **Added** `pub mod transcription;` to `src/llm/mod.rs`\n- **Updated references** in `src/config/transcription.rs`, `src/agent/agent_loop.rs`, and `src/main.rs` from `crate::transcription` → `crate::llm::transcription`",
+            "input_tokens": 1,
+            "output_tokens": 151
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "apply_patch",
+          "grep",
+          "read_file",
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "<task-notification>\n<task-id>byooinjz3</task-id>\n<tool-use-id>toolu_016e2pnPb5pmBBDCy3rseZpn</tool-use-id>\n<output-file>/private/tmp/claude-505/-Users-coder-ironclaw/9f613cdd-7dab-4033-8f23-bbd0cd4aa8b9/tasks/byooinjz3.output</output-file>\n<status>completed</status>\n<summary>Background command \"Verify compilation after fixing main.rs\" completed (exit code 0)</summary>\n</task-notification>\nRead the output file to retrieve the result: /private/tmp/claude-505/-Users-coder-ironclaw/9f613cdd-7dab-4033-8f23-bbd0cd4aa8b9/tasks/byooinjz3.output",
+      "steps": [
+        {
+          "response": {
+            "type": "text",
+            "content": "Already retrieved that output — compilation succeeded. The move is complete.",
+            "input_tokens": 3,
+            "output_tokens": 16
+          },
+          "request_hint": {
+            "last_user_message_contains": "<task-notification>\n<task-id>byooinjz3</task-id>\n<tool-use-id>toolu_016e2pnPb5pm"
+          }
+        }
+      ],
+      "expects": {
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "let's create a new pr with this",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01Cppq2oTpwazEu3pjYeVsSr",
+                "name": "shell",
+                "arguments": {
+                  "command": "git status"
+                }
+              },
+              {
+                "id": "toolu_01REmwxT6JphqdfvNnCCTVyG",
+                "name": "shell",
+                "arguments": {
+                  "command": "git diff"
+                }
+              },
+              {
+                "id": "toolu_014PPmQrba3LurE66utanNd8",
+                "name": "shell",
+                "arguments": {
+                  "command": "git log --oneline -5"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 225
+          },
+          "request_hint": {
+            "last_user_message_contains": "let's create a new pr with this"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_015E85G5MTUM9o4SAuEugCV4",
+                "name": "shell",
+                "arguments": {
+                  "command": "git checkout -b refactor/move-transcription-into-llm"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 89
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01TreA8u2Z2ZEBJVZR1t625e",
+                "name": "shell",
+                "arguments": {
+                  "command": "git add src/agent/agent_loop.rs src/config/transcription.rs src/lib.rs src/llm/mod.rs src/llm/transcription/ src/main.rs src/transcription/"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 121
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01MLnsmnnDmidptGk3pMrkSH",
+                "name": "shell",
+                "arguments": {
+                  "command": "git commit -m \"$(cat <<'EOF'\nrefactor(llm): move transcription module into src/llm/\n\nTranscription is an LLM capability (Whisper, Chat Completions audio).\nMove it from a top-level module into src/llm/transcription/ to reflect\nthis, and update all references across the codebase.\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\nEOF\n)\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 191
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_012xLCiFYqeTZV2vCZ5tJrWL",
+                "name": "shell",
+                "arguments": {
+                  "command": "git push -u origin refactor/move-transcription-into-llm"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 88
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01LwyDvwkbSJNCYok6qNmLEe",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr create --base main --title \"refactor(llm): move transcription module into src/llm/\" --body \"$(cat <<'EOF'\n## Summary\n- Moved `src/transcription/` into `src/llm/transcription/` — transcription is an LLM capability (Whisper, Chat Completions audio input) and belongs under the LLM module\n- Updated all references in `src/lib.rs`, `src/llm/mod.rs`, `src/main.rs`, `src/agent/agent_loop.rs`, and `src/config/transcription.rs`\n\n## Test plan\n- [x] `cargo check` passes\n- [ ] `cargo test` passes (transcription unit tests unchanged, just relocated)\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\nEOF\n)\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 269
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "PR created: https://github.com/nearai/ironclaw/pull/1559",
+            "input_tokens": 1,
+            "output_tokens": 23
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "change base branch to staging",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_0126MiU36HG5vTPA2WYutvtt",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr edit 1559 --base staging"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 84
+          },
+          "request_hint": {
+            "last_user_message_contains": "change base branch to staging"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Done — PR #1559 base branch changed to `staging`.",
+            "input_tokens": 1,
+            "output_tokens": 17
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "now question if TranscriptionMiddleware should be just under the hood for LLM provider somehow?",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_014kZ5W7eS8PRqaTFBnkpznF",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "transcription",
+                  "path": "/Users/coder/ironclaw/src/agent",
+                  "output_mode": "content",
+                  "context": 3
+                }
+              },
+              {
+                "id": "toolu_01Tsu25kx1mMotitoEKbWtMg",
+                "name": "grep",
+                "arguments": {
+                  "pattern": "transcription",
+                  "path": "/Users/coder/ironclaw/src/app.rs",
+                  "output_mode": "content",
+                  "context": 3
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 439
+          },
+          "request_hint": {
+            "last_user_message_contains": "now question if TranscriptionMiddleware should be just under the hood for LLM pr"
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Good question. Let me check how the middleware is actually used in the agent flow to reason about this properly.",
+            "input_tokens": 3,
+            "output_tokens": 439
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Here's the current flow:\n\n```\nIncoming message (with audio) \n  → agent_loop.rs:770  transcription.process(&mut message)  // audio → text\n  → message.content now has transcribed text\n  → LLM sees plain text\n```\n\nI'd argue **no** — it should stay as a separate middleware, not be hidden inside `LlmProvider`. Reasons:\n\n1. **Different concern.** `LlmProvider` takes text in, produces text out. Transcription is an *input preprocessing* step — it transforms the message *before* anything touches the LLM. Folding it into the provider would violate single responsibility.\n\n2. **Provider-agnostic.** The transcription provider (Whisper, OpenRouter) is often a *different* API/model than the main LLM. Hiding it inside `LlmProvider` would couple two independent service calls — the Whisper API key/endpoint has nothing to do with the chat completion provider.\n\n3. **Symmetry with `DocumentExtractionMiddleware`.** It sits right next to transcription at line 774 doing the same pattern — preprocess attachments before the LLM sees them. If you absorbed transcription into the provider, you'd need to do the same for document extraction, image description, etc. That turns `LlmProvider` into a kitchen sink.\n\n4. **Visibility.** Keeping it explicit in the agent loop means the transcribed text is visible in the message *before* it hits the LLM — useful for logging, safety checks, and the user seeing what was transcribed.\n\nThe current placement (middleware in the agent loop, code living under `src/llm/transcription/`) is the right split: the *code* lives with LLM capabilities where it logically belongs, but the *execution* stays in the message processing pipeline where it has access to the full `IncomingMessage`.",
+            "input_tokens": 1,
+            "output_tokens": 434
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "grep"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "ci fails",
+      "steps": [
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_016B83KmeP8kSWwotAd9p9sX",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr checks 1559 2>&1 | head -30"
+                }
+              }
+            ],
+            "input_tokens": 3,
+            "output_tokens": 91
+          },
+          "request_hint": {
+            "last_user_message_contains": "ci fails"
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_019BcE7MHQeAfHzg89mUEDEK",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo fmt -- --check 2>&1 | head -30"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 234
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Two failures: **Formatting** and **Version Bump Check**. Let me fix both.",
+            "input_tokens": 1,
+            "output_tokens": 234
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_013r5f5oZzhBnfVems4ZGYE4",
+                "name": "shell",
+                "arguments": {
+                  "command": "cargo fmt"
+                }
+              },
+              {
+                "id": "toolu_01PM1CnK8J69ZXiy6fzuboTa",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr edit 1559 --add-label \"skip-version-check\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 172
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Formatting needs fixing, and the version bump check can be skipped with a label. Let me fix both.",
+            "input_tokens": 1,
+            "output_tokens": 172
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01NtcLqXDsh52WS8GepgT5cS",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh label create \"skip-version-check\" --description \"Skip version bump check for refactors\" --color \"ededed\" 2>&1 || true"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 118
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Need to create the label first.",
+            "input_tokens": 1,
+            "output_tokens": 118
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01V9ZjgiZKmb7zaFXTqoXc66",
+                "name": "shell",
+                "arguments": {
+                  "command": "gh pr edit 1559 --add-label \"skip-version-check\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 94
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_019K9CQm8yutYnzvKxkXZ2uQ",
+                "name": "shell",
+                "arguments": {
+                  "command": "git add src/config/transcription.rs src/main.rs && git commit -m \"$(cat <<'EOF'\nstyle: fix rustfmt formatting after module move\n\nCo-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>\nEOF\n)\""
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 153
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Now commit and push the formatting fix.",
+            "input_tokens": 1,
+            "output_tokens": 153
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "toolu_01PZUZzVk7VTY5S2sYgRCJoQ",
+                "name": "shell",
+                "arguments": {
+                  "command": "git push"
+                }
+              }
+            ],
+            "input_tokens": 1,
+            "output_tokens": 72
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Pushed. Fixed the formatting issue and added `skip-version-check` label for the version bump check (this is a pure refactor with no extension changes).",
+            "input_tokens": 1,
+            "output_tokens": 37
+          }
+        }
+      ],
+      "expects": {
+        "tools_used": [
+          "shell"
+        ],
+        "all_tools_succeeded": true,
+        "min_responses": 1
+      }
+    }
+  ],
+  "expects": {
+    "tools_used": [
+      "apply_patch",
+      "grep",
+      "read_file",
+      "shell"
+    ],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  }
+}

--- a/tests/fixtures/llm_traces/imported/worktree_read_test.json
+++ b/tests/fixtures/llm_traces/imported/worktree_read_test.json
@@ -1,0 +1,50 @@
+{
+  "model_name": "imported-worktree-read-test",
+  "repo": {
+    "repo_root": "/Users/coder/ironclaw",
+    "commit": "a09c0236421e02a70d76e7244b4fb5625c753fd6",
+    "branch": "staging"
+  },
+  "expects": {
+    "tools_used": ["read_file"],
+    "all_tools_succeeded": true,
+    "tool_results_contain": {
+      "read_file": "TranscriptionProvider"
+    },
+    "min_responses": 1
+  },
+  "turns": [
+    {
+      "user_input": "Read the transcription module and confirm TranscriptionProvider exists",
+      "steps": [
+        {
+          "request_hint": {
+            "last_user_message_contains": "transcription"
+          },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_read_1",
+                "name": "read_file",
+                "arguments": {
+                  "path": "{{repo_root}}/src/transcription/mod.rs"
+                }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The transcription module defines a TranscriptionProvider trait for speech-to-text backends.",
+            "input_tokens": 200,
+            "output_tokens": 30
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -597,6 +597,7 @@ pub struct TestRigBuilder {
     engine_v2: bool,
     channel_name_override: Option<String>,
     seeded_secrets: Option<SeededSecretsConfig>,
+    working_dir: Option<std::path::PathBuf>,
 }
 
 impl TestRigBuilder {
@@ -619,6 +620,7 @@ impl TestRigBuilder {
             engine_v2: false,
             channel_name_override: None,
             seeded_secrets: None,
+            working_dir: None,
         }
     }
 
@@ -762,6 +764,17 @@ impl TestRigBuilder {
         self
     }
 
+    /// Sandbox all dev tools (shell, file, grep, glob) to a directory.
+    ///
+    /// When set, `register_dev_tools_in_dir(dir)` is used instead of
+    /// `register_dev_tools()`. File operations are restricted to `dir` via
+    /// `base_dir`, and shell commands default to `dir` as their working
+    /// directory. Useful for trace replay against a git worktree.
+    pub fn with_working_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.working_dir = Some(dir);
+        self
+    }
+
     /// Add pre-recorded HTTP exchanges for the `ReplayingHttpInterceptor`.
     ///
     /// When set, all `http` tool calls will return these responses in order
@@ -811,6 +824,7 @@ impl TestRigBuilder {
             engine_v2,
             channel_name_override,
             seeded_secrets,
+            working_dir,
         } = self;
 
         // 1. Create temp dir + fresh libSQL database + run migrations.
@@ -1004,7 +1018,11 @@ impl TestRigBuilder {
             // (real-binary parity mode), respect the allow_local_tools flag.
             // Otherwise always register them for test convenience.
             if !has_config_override || components.config.agent.allow_local_tools {
-                components.tools.register_dev_tools();
+                if let Some(ref dir) = working_dir {
+                    components.tools.register_dev_tools_in_dir(dir.clone());
+                } else {
+                    components.tools.register_dev_tools();
+                }
             }
 
             components.tools.register_job_tools(

--- a/tests/support/trace_llm.rs
+++ b/tests/support/trace_llm.rs
@@ -62,6 +62,9 @@ pub struct LlmTrace {
     /// Declarative expectations for the whole trace (optional).
     #[serde(default, skip_serializing_if = "TraceExpects::is_empty")]
     pub expects: TraceExpects,
+    /// Source repository metadata for worktree-based replay.
+    #[serde(default)]
+    pub repo: TraceRepoMeta,
     /// Raw steps before turn conversion (populated only for recorded traces).
     /// Used by `playable_steps()` for recorded-format inspection.
     #[serde(skip)]
@@ -123,6 +126,23 @@ impl TraceExpects {
     }
 }
 
+/// Metadata about the source repository for worktree-based replay.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TraceRepoMeta {
+    /// Original repo root path (informational).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub repo_root: Option<String>,
+    /// Primary git commit hash for the trace.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub commit: Option<String>,
+    /// Primary branch name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    /// All branch -> commit mappings (for multi-branch sessions).
+    #[serde(default, skip_serializing_if = "std::collections::HashMap::is_empty")]
+    pub branch_commits: std::collections::HashMap<String, String>,
+}
+
 /// Raw deserialization helper -- accepts either `turns` or flat `steps`.
 #[derive(Deserialize)]
 struct RawLlmTrace {
@@ -137,6 +157,8 @@ struct RawLlmTrace {
     http_exchanges: Vec<HttpExchange>,
     #[serde(default)]
     expects: TraceExpects,
+    #[serde(default)]
+    repo: TraceRepoMeta,
 }
 
 impl<'de> Deserialize<'de> for LlmTrace {
@@ -190,6 +212,7 @@ impl<'de> Deserialize<'de> for LlmTrace {
             memory_snapshot: raw.memory_snapshot,
             http_exchanges: raw.http_exchanges,
             expects: raw.expects,
+            repo: raw.repo,
             steps: raw_steps,
         })
     }
@@ -205,6 +228,7 @@ impl LlmTrace {
             memory_snapshot: Vec::new(),
             http_exchanges: Vec::new(),
             expects: TraceExpects::default(),
+            repo: TraceRepoMeta::default(),
             steps: Vec::new(),
         }
     }
@@ -225,7 +249,48 @@ impl LlmTrace {
             memory_snapshot: Vec::new(),
             http_exchanges: Vec::new(),
             expects: TraceExpects::default(),
+            repo: TraceRepoMeta::default(),
             steps: Vec::new(),
+        }
+    }
+
+    /// Replace `{{repo_root}}` placeholders in all tool call arguments
+    /// with the given worktree path. Call this before passing to TraceLlm.
+    pub fn resolve_repo_root(&mut self, worktree_path: &std::path::Path) {
+        let replacement = worktree_path.to_string_lossy();
+        for turn in &mut self.turns {
+            for step in &mut turn.steps {
+                if let TraceResponse::ToolCalls {
+                    ref mut tool_calls, ..
+                } = step.response
+                {
+                    for tc in tool_calls.iter_mut() {
+                        Self::replace_placeholder(&mut tc.arguments, &replacement);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Recursively replace `{{repo_root}}` in all string values.
+    fn replace_placeholder(value: &mut serde_json::Value, replacement: &str) {
+        match value {
+            serde_json::Value::String(s) => {
+                if s.contains("{{repo_root}}") {
+                    *s = s.replace("{{repo_root}}", replacement);
+                }
+            }
+            serde_json::Value::Object(map) => {
+                for v in map.values_mut() {
+                    Self::replace_placeholder(v, replacement);
+                }
+            }
+            serde_json::Value::Array(arr) => {
+                for v in arr.iter_mut() {
+                    Self::replace_placeholder(v, replacement);
+                }
+            }
+            _ => {}
         }
     }
 

--- a/tests/trace_format.rs
+++ b/tests/trace_format.rs
@@ -174,6 +174,34 @@ mod trace_format_tests {
         assert_eq!(trace.turns[1].steps.len(), 1);
     }
 
+    /// Imported Claude Code traces can be deserialized by TraceLlm.
+    #[test]
+    fn imported_claude_code_trace_loads() {
+        let dir = std::path::Path::new("tests/fixtures/llm_traces/imported");
+        if !dir.exists() {
+            // Skip if no imported traces present.
+            return;
+        }
+        for entry in std::fs::read_dir(dir).unwrap() {
+            let entry = entry.unwrap();
+            let path = entry.path();
+            if path.extension().is_none_or(|e| e != "json") {
+                continue;
+            }
+            let trace = LlmTrace::from_file(&path)
+                .unwrap_or_else(|e| panic!("Failed to load {}: {}", path.display(), e));
+            assert!(!trace.turns.is_empty(), "{}: no turns", path.display());
+            for (i, turn) in trace.turns.iter().enumerate() {
+                assert!(
+                    !turn.steps.is_empty(),
+                    "{}: turn {} has no steps",
+                    path.display(),
+                    i
+                );
+            }
+        }
+    }
+
     /// Steps before the first UserInput get placeholder input.
     #[test]
     fn steps_before_first_user_input_get_placeholder() {


### PR DESCRIPTION
## Summary

Adds tooling to convert Claude Code JSONL history into IronClaw trace fixtures, then replay them deterministically against a git worktree checked out at the historical commit. Tests real tool execution (read_file, apply_patch, shell, grep, glob) against the exact repo state that existed when the LLM made its original decisions — the LLM is mocked, everything else is real.

## What's in the box

**Converter** — `scripts/convert_claude_trace.py`
- Parses the Claude Code JSONL tree: temporal order, streaming chunks merged by API message ID, parallel tool calls grouped per-response
- Tool mapping: \`Bash→shell\`, \`Read→read_file\`, \`Write→write_file\`, \`Edit→apply_patch\`, \`Grep→grep\`, \`Glob→glob\` (unmappable tools like \`Agent\`, \`TaskCreate\`, etc. are silently skipped)
- Resolves git commits from \`gitBranch\` + \`timestamp\` metadata on each message
- Rewrites absolute paths to \`{{repo_root}}\` placeholders
- Embeds \`repo\` metadata block (commit, branch, branch_commits) in the output trace

**Tool sandboxing** — \`ToolRegistry::register_dev_tools_in_dir(dir)\`
- Binds all dev tools to a directory: \`base_dir\` for file/grep/glob tools, \`working_dir\` for shell
- File operations cannot escape the sandbox (existing path_utils enforcement)

**TestRig integration** — \`TestRigBuilder::with_working_dir(path)\`
- Routes through \`register_dev_tools_in_dir\` when set

**Trace format extensions** — \`LlmTrace\`
- New \`repo\` field (TraceRepoMeta) carrying commit/branch
- New \`resolve_repo_root(worktree_path)\` method for placeholder substitution at load time

**Worktree replay test** — \`tests/e2e_worktree_replay.rs\`
- Creates a \`git worktree add --detach <commit>\` in a temp dir, resolves placeholders against it, runs the trace, verifies tool outputs via \`expects\`, and cleans up via a Drop guard
- Skips gracefully when the source repo isn't present (CI-safe)

## What this actually tests

| Layer | Real or Mocked? |
|---|---|
| LLM responses | Mocked (TraceLlm replay) |
| Tool dispatch, safety pipeline | **Real** |
| File I/O, shell, grep, glob, apply_patch | **Real** — executed against the worktree |
| Repo state | **Real** — git worktree at the recorded commit |

Proven working: the included \`worktree_read_test.json\` reads \`src/transcription/mod.rs\` from commit \`a09c0236\` (the state where that file still existed before being moved) and asserts the content contains \`TranscriptionProvider\`.

## Why this is a draft

- Imported trace fixtures (~100KB) contain content from my local Claude Code sessions — may want to trim or gitignore them depending on reviewer preference
- The worktree replay is hardcoded to \`/Users/coder/ironclaw\` as the source repo — needs to be configurable or resolved via a workspace-relative path before merging
- Only one smoke test wired up so far; the larger imported traces reference historical commits that exist in our repo history but haven't been wired to tests yet

## Test plan
- [x] \`cargo test --test trace_format\` — 9/9 pass (includes imported trace deserialization)
- [x] \`cargo test --test e2e_worktree_replay\` — passes locally (reads real file from worktree, asserts content)
- [x] \`cargo clippy --tests -- -D warnings\` — zero warnings
- [x] \`cargo fmt\` applied
- [ ] Decide fate of \`tests/fixtures/llm_traces/imported/*.json\` (keep / trim / gitignore)
- [ ] Make \`SOURCE_REPO\` configurable (env var or workspace discovery)