### PR TITLE
fix: Feishu webhook auth refresh and extension card overflow

### DIFF
--- a/channels-src/feishu/src/lib.rs
+++ b/channels-src/feishu/src/lib.rs
@@ -539,11 +539,18 @@ fn handle_message_event(event_data: &serde_json::Value) {
                         "chat_id": msg_event.message.chat_id,
                         "chat_type": chat_type,
                     });
-                    match channel_host::pairing_upsert_request("feishu", sender_id, &meta.to_string()) {
+                    match channel_host::pairing_upsert_request(
+                        "feishu",
+                        sender_id,
+                        &meta.to_string(),
+                    ) {
                         Ok(result) => {
                             channel_host::log(
                                 channel_host::LogLevel::Info,
-                                &format!("Pairing request created for {}: {}", sender_id, result.code),
+                                &format!(
+                                    "Pairing request created for {}: {}",
+                                    sender_id, result.code
+                                ),
                             );
                             let _ = send_message(
                                 sender_id,

--- a/crates/ironclaw_gateway/static/style.css
+++ b/crates/ironclaw_gateway/static/style.css
@@ -3383,6 +3383,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  min-width: 0;
   transition: border-color var(--transition-base), box-shadow var(--transition-base), transform 0.2s;
 }
 
@@ -3411,13 +3412,17 @@ body {
 .ext-header {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-2);
+  min-width: 0;
 }
 
 .ext-name {
   font-weight: 600;
   font-size: var(--text-base);
   color: var(--text);
+  flex: 1 1 180px;
+  min-width: 0;
 }
 
 .ext-kind {
@@ -3453,6 +3458,7 @@ body {
   font-size: var(--text-xs);
   color: var(--text-muted);
   font-family: var(--font-mono);
+  margin-left: auto;
 }
 
 .ext-auth-dot {
@@ -3492,15 +3498,23 @@ body {
 
 .ext-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 6px;
   align-items: center;
   margin-top: 4px;
+  min-width: 0;
 }
 
 .ext-active-label {
   font-size: 12px;
   color: var(--success);
   font-weight: 500;
+}
+
+.ext-actions .ext-active-label,
+.ext-actions .ext-pairing-label {
+  flex: 1 1 140px;
+  min-width: 0;
 }
 
 /* WASM channel setup stepper */
@@ -3696,6 +3710,7 @@ body {
   margin-top: 8px;
   border-top: 1px solid var(--border);
   padding-top: 8px;
+  min-width: 0;
 }
 
 .ext-onboarding {
@@ -3729,13 +3744,19 @@ body {
 
 .pairing-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--space-2);
   margin-bottom: 4px;
+  min-width: 0;
 }
 
 .pairing-manual {
   margin-bottom: 8px;
+}
+
+.pairing-row > * {
+  min-width: 0;
 }
 
 .pairing-help {
@@ -3750,7 +3771,7 @@ body {
 }
 
 .pairing-manual-input {
-  flex: 1;
+  flex: 1 1 14rem;
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
@@ -3767,7 +3788,7 @@ body {
 }
 
 .pairing-input {
-  flex: 1;
+  flex: 1 1 14rem;
   padding: 8px 12px;
   background: var(--bg-secondary);
   border: 1px solid var(--border);
@@ -3791,12 +3812,20 @@ body {
   background: var(--bg-tertiary);
   padding: 2px 6px;
   border-radius: 3px;
+  flex-shrink: 0;
 }
 
 .pairing-sender {
   font-size: 12px;
   color: var(--text-secondary);
-  flex: 1;
+  flex: 1 1 14rem;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.pairing-row > .btn-ext {
+  flex-shrink: 0;
+  margin-left: auto;
 }
 
 /* Configure modal */

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -305,6 +305,31 @@ fn build_wasm_channel_runtime_config_updates(
     config_updates
 }
 
+async fn inject_wasm_channel_secret_config_updates(
+    secrets: &(dyn crate::secrets::SecretsStore + Send + Sync),
+    owner_id: &str,
+    channel_name: &str,
+    config_updates: &mut HashMap<String, serde_json::Value>,
+) {
+    let secret_config_mappings: &[(&str, &str)] = match channel_name {
+        "feishu" => &[
+            ("app_id", "feishu_app_id"),
+            ("app_secret", "feishu_app_secret"),
+            ("verification_token", "feishu_verification_token"),
+        ],
+        _ => return,
+    };
+
+    for &(config_key, secret_name) in secret_config_mappings {
+        if let Ok(decrypted) = secrets.get_decrypted(owner_id, secret_name).await {
+            config_updates.insert(
+                config_key.to_string(),
+                serde_json::Value::String(decrypted.expose().to_string()),
+            );
+        }
+    }
+}
+
 fn channel_auth_instructions(
     channel_name: &str,
     secret: &crate::channels::wasm::SecretSetupSchema,
@@ -5528,6 +5553,7 @@ impl ExtensionManager {
         let owner_actor_id = owner_id.map(|id| id.to_string());
         let webhook_secret_name = loaded.webhook_secret_name();
         let secret_header = loaded.webhook_secret_header().map(|s| s.to_string());
+        let webhook_secret_managed_by_host = loaded.webhook_secret_managed_by_host();
         let sig_key_secret_name = loaded.signature_key_secret_name();
         let hmac_secret_name = loaded.hmac_secret_name();
 
@@ -5553,6 +5579,13 @@ impl ExtensionManager {
                 self.load_channel_runtime_config_overrides(&channel_name)
                     .await,
             );
+            inject_wasm_channel_secret_config_updates(
+                self.secrets.as_ref(),
+                &self.user_id,
+                &channel_name,
+                &mut config_updates,
+            )
+            .await;
 
             if !config_updates.is_empty() {
                 channel_arc.update_config(config_updates).await;
@@ -5567,19 +5600,24 @@ impl ExtensionManager {
 
         // Register with webhook router
         {
+            let host_webhook_secret = if webhook_secret_managed_by_host {
+                webhook_secret.clone()
+            } else {
+                None
+            };
             let webhook_path = format!("/webhook/{}", channel_name);
             let endpoints = vec![RegisteredEndpoint {
                 channel_name: channel_name.clone(),
                 path: webhook_path,
                 methods: vec!["POST".to_string()],
-                require_secret: webhook_secret.is_some(),
+                require_secret: host_webhook_secret.is_some(),
             }];
 
             wasm_channel_router
                 .register(
                     Arc::clone(&channel_arc),
                     endpoints,
-                    webhook_secret,
+                    host_webhook_secret,
                     secret_header,
                 )
                 .await;
@@ -5741,6 +5779,10 @@ impl ExtensionManager {
             .as_ref()
             .map(|f| f.webhook_secret_name())
             .unwrap_or_else(|| format!("{}_webhook_secret", name));
+        let webhook_secret_managed_by_host = capabilities_file
+            .as_ref()
+            .map(|f| f.webhook_secret_managed_by_host())
+            .unwrap_or(true);
 
         let sig_key_secret_name = capabilities_file
             .as_ref()
@@ -5756,13 +5798,21 @@ impl ExtensionManager {
             self.current_channel_owner_id(name).await,
         );
         config_updates.extend(self.load_channel_runtime_config_overrides(name).await);
+        inject_wasm_channel_secret_config_updates(
+            self.secrets.as_ref(),
+            &self.user_id,
+            name,
+            &mut config_updates,
+        )
+        .await;
         let mut should_rerun_on_start = false;
 
         // Refresh webhook secret
-        if let Ok(secret) = self
-            .secrets
-            .get_decrypted(user_id, &webhook_secret_name)
-            .await
+        if webhook_secret_managed_by_host
+            && let Ok(secret) = self
+                .secrets
+                .get_decrypted(user_id, &webhook_secret_name)
+                .await
         {
             router
                 .update_secret(name, secret.expose().to_string())


### PR DESCRIPTION
## Summary

- Fixed WASM channel webhook-secret refresh/registration logic so host-managed webhook auth is only applied when `managed_by_host=true`; this unblocks Feishu (`managed_by_host=false`) webhook auth from incorrectly failing at the host layer.
- Added Feishu secret-to-runtime injection during hot activation and refresh (`app_id`, `app_secret`, `verification_token`) so runtime config stays consistent after secret updates.
- Resolved Clippy `collapsible_if` in `src/extensions/manager.rs` with a let-chain condition.
- Fixed extension card/pairing UI overflow by improving flex wrapping and long-text handling in `crates/ironclaw_gateway/static/style.css` (prevents pairing `Approve` button from being pushed outside card bounds).

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

#1673 

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: 
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: restarted service, validated Feishu webhook endpoint behavior moved from host-level `Webhook secret required` failure to channel-level verification flow (`Webhook authentication failed` for invalid payload), confirmed channel loads as `feishu`, and verified extension card layout no longer overflows with long pairing sender IDs.
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

Additional checks run:
- `cargo clippy -p ironclaw --lib -- -D warnings` (pass)

## Security Impact

Touches webhook authentication path for WASM channels.  
Change narrows host-layer webhook secret enforcement to channels that explicitly opt into host-managed secrets, and preserves Feishu’s channel-level verification-token auth path. No new permissions, network allowlists, or secret scopes were added.

## Database Impact

None.

## Blast Radius

- `src/extensions/manager.rs` hot activation / credential refresh path for WASM channels.
- Feishu runtime secret injection behavior.
- Gateway extensions UI card layout in `crates/ironclaw_gateway/static/style.css`.

Potential regressions:
- Other WASM channels with unusual webhook capability metadata could be affected by secret-handling assumptions during refresh.
- Minor visual regressions in extension cards on narrow widths (layout behavior intentionally changed to wrap).

## Rollback Plan

- Revert commit `f1fc8a8d`.
- Restart the IronClaw service.
- Re-verify webhook behavior and extension UI after rollback.

## Review Follow-Through

- Reviewer focus requested on `managed_by_host` handling in `src/extensions/manager.rs` for non-Feishu channels.
- Pairing/authorization parity issues in Feishu channel logic (owner gating/allowlist behavior) remain separate follow-up work and are not fully addressed in this PR.

---

**Review track**: C
