### PR TITLE
fix(gateway): resolve assistant thread for threadless broadcasts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,7 +6635,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -6707,9 +6707,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,9 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rustls-webpki URI name constraint bypass — 0.102.8 pinned by libsql transitive dep;
+    # patched in >=0.103.12 but libsql 0.6.0 requires rustls 0.22 which pins 0.102.x
+    "RUSTSEC-2026-0098",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -61,3 +61,7 @@ pub use router::{
 
 #[cfg(feature = "libsql")]
 pub use router::reset_engine_state;
+
+// Exposed for caller-level testing of the cross-user thread_id guard
+#[cfg(test)]
+pub(crate) use router::handle_mission_notification;

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2926,13 +2926,16 @@ async fn handle_mission_notification(
 
     for channel_name in &notif.notify_channels {
         // Send via channel broadcast (proactive, no incoming message required)
+        let mut response = OutgoingResponse::text(&full_text);
+        // Only attach the mission owner's thread_id when the recipient IS the
+        // owner. When notify_user routes to a different user, omit the thread
+        // so the gateway's broadcast() fallback resolves the recipient's own
+        // assistant thread — avoids leaking the owner's thread_id cross-user.
+        if broadcast_user == notif.user_id {
+            response = response.in_thread(notif.thread_id.to_string());
+        }
         if let Err(e) = channels
-            .broadcast(
-                channel_name,
-                broadcast_user,
-                OutgoingResponse::text(&full_text)
-                    .in_thread(notif.thread_id.to_string()),
-            )
+            .broadcast(channel_name, broadcast_user, response)
             .await
         {
             debug!(

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2930,7 +2930,8 @@ async fn handle_mission_notification(
             .broadcast(
                 channel_name,
                 broadcast_user,
-                OutgoingResponse::text(&full_text),
+                OutgoingResponse::text(&full_text)
+                    .in_thread(notif.thread_id.to_string()),
             )
             .await
         {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2906,7 +2906,9 @@ fn interpret_message_event(role: &str, content_preview: &str) -> Option<&'static
 ///    its empty context) say "I haven't sent you a digest". Recording an
 ///    `Agent` entry tagged with the mission's thread id keeps the v2 history
 ///    consistent with what the user actually saw.
-async fn handle_mission_notification(
+// pub(crate) for #[cfg(test)] re-export in mod.rs; the module itself
+// is private so this has no production visibility beyond router.rs.
+pub(crate) async fn handle_mission_notification(
     notif: &ironclaw_engine::MissionNotification,
     channels: &std::sync::Arc<crate::channels::ChannelManager>,
     sse: Option<&Arc<SseManager>>,

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -756,10 +756,28 @@ impl Channel for GatewayChannel {
         let thread_id = match response.thread_id {
             Some(tid) => tid,
             None => {
-                return Err(ChannelError::MissingRoutingTarget {
-                    name: "gateway".to_string(),
-                    reason: "broadcast() requires a thread_id on the response".to_string(),
-                });
+                // Proactive broadcasts (mission notifications, self-repair,
+                // extension activation) don't always have a thread context.
+                // Route to the user's assistant conversation so the message
+                // appears in a known location instead of being rejected.
+                match self.state.store.as_ref() {
+                    Some(store) => store
+                        .get_or_create_assistant_conversation(user_id, "gateway")
+                        .await
+                        .map(|id| id.to_string())
+                        .map_err(|e| ChannelError::SendFailed {
+                            name: "gateway".to_string(),
+                            reason: format!(
+                                "broadcast() has no thread_id and assistant thread lookup failed: {e}"
+                            ),
+                        })?,
+                    None => {
+                        return Err(ChannelError::MissingRoutingTarget {
+                            name: "gateway".to_string(),
+                            reason: "broadcast() has no thread_id and no DB to resolve assistant thread".to_string(),
+                        });
+                    }
+                }
             }
         };
         self.state.sse.broadcast_for_user(

--- a/src/channels/web/tests/no_silent_drop.rs
+++ b/src/channels/web/tests/no_silent_drop.rs
@@ -211,14 +211,8 @@ async fn mission_notification_cross_user_does_not_leak_owner_thread_id() {
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(
-        &notif,
-        &channels,
-        Some(&sse),
-        Some(&store),
-        None,
-    )
-    .await;
+    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
+        .await;
 
     // The recipient should get an event with a thread_id that is NOT the
     // owner's mission thread — it should be their own assistant thread.
@@ -292,14 +286,8 @@ async fn mission_notification_same_user_attaches_owner_thread_id() {
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(
-        &notif,
-        &channels,
-        Some(&sse),
-        Some(&store),
-        None,
-    )
-    .await;
+    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
+        .await;
 
     // The owner should receive two events:
     // 1. From GatewayChannel::broadcast() (channel path)
@@ -366,14 +354,8 @@ async fn mission_notification_explicit_same_user_attaches_owner_thread_id() {
 
     let owner_thread_id = notif.thread_id.to_string();
 
-    crate::bridge::handle_mission_notification(
-        &notif,
-        &channels,
-        Some(&sse),
-        Some(&store),
-        None,
-    )
-    .await;
+    crate::bridge::handle_mission_notification(&notif, &channels, Some(&sse), Some(&store), None)
+        .await;
 
     let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
         .await

--- a/src/channels/web/tests/no_silent_drop.rs
+++ b/src/channels/web/tests/no_silent_drop.rs
@@ -82,9 +82,14 @@ async fn gateway_broadcast_without_thread_id_and_no_store_returns_error() {
 
 /// When a store IS available, broadcast() without thread_id falls back to
 /// the user's assistant conversation instead of erroring.
+/// Verifies the SSE event carries the correct resolved thread_id and that the
+/// DB conversation row exists.
 #[cfg(feature = "libsql")]
 #[tokio::test]
 async fn gateway_broadcast_without_thread_id_falls_back_to_assistant_thread() {
+    use crate::db::Database;
+    use futures::StreamExt;
+    use ironclaw_common::AppEvent;
     use std::sync::Arc;
 
     let dir = tempfile::tempdir().unwrap();
@@ -92,18 +97,49 @@ async fn gateway_broadcast_without_thread_id_falls_back_to_assistant_thread() {
     let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
         .await
         .unwrap();
-    crate::db::Database::run_migrations(&backend).await.unwrap();
-    let store: Arc<dyn crate::db::Database> = Arc::new(backend);
+    Database::run_migrations(&backend).await.unwrap();
+    let store: Arc<dyn Database> = Arc::new(backend);
 
-    let gw = test_gateway().with_store(store);
+    let gw = test_gateway().with_store(store.clone());
+
+    // Subscribe to SSE before broadcasting so we capture the event
+    let mut stream = gw
+        .state
+        .sse
+        .subscribe_raw(Some("test-user".to_string()))
+        .expect("subscribe should succeed");
+
     let response = OutgoingResponse::text("mission notification");
-
     let result = gw.broadcast("test-user", response).await;
 
     assert!(
         result.is_ok(),
-        "broadcast() without thread_id should fall back to assistant thread when store is available: {:?}",
+        "broadcast() without thread_id should fall back to assistant thread: {:?}",
         result
+    );
+
+    // Verify SSE event has the correct thread_id
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+        .await
+        .expect("should receive SSE event within 1s")
+        .expect("stream should not be empty");
+
+    let AppEvent::Response { thread_id, .. } = event else {
+        panic!("expected AppEvent::Response, got: {event:?}");
+    };
+
+    // The thread_id should be a valid UUID from get_or_create_assistant_conversation
+    let resolved_uuid =
+        uuid::Uuid::parse_str(&thread_id).expect("thread_id should be a valid UUID");
+
+    // Verify the DB conversation row exists
+    let db_conv_id = store
+        .get_or_create_assistant_conversation("test-user", "gateway")
+        .await
+        .expect("assistant conversation should exist");
+    assert_eq!(
+        resolved_uuid, db_conv_id,
+        "SSE thread_id should match the DB assistant conversation UUID"
     );
 }
 
@@ -118,5 +154,238 @@ async fn gateway_broadcast_with_thread_id_succeeds() {
         result.is_ok(),
         "broadcast() should succeed with thread_id: {:?}",
         result
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Cross-user thread_id guard tests
+//
+// Regression coverage for the security guard in handle_mission_notification
+// that prevents leaking the mission owner's thread_id to a different
+// recipient (notify_user). Tests exercise the caller, not just broadcast().
+// ---------------------------------------------------------------------------
+
+/// When notify_user routes to a different user, the owner's mission
+/// thread_id must NOT be attached to the channel broadcast.
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn mission_notification_cross_user_does_not_leak_owner_thread_id() {
+    use crate::channels::ChannelManager;
+    use crate::db::Database;
+    use futures::StreamExt;
+    use ironclaw_common::AppEvent;
+    use std::sync::Arc;
+
+    // Set up DB for broadcast fallback
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test_cross_user.db");
+    let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+        .await
+        .unwrap();
+    Database::run_migrations(&backend).await.unwrap();
+    let store: Arc<dyn Database> = Arc::new(backend);
+
+    let gw = test_gateway().with_store(store.clone());
+    let sse = Arc::clone(&gw.state.sse);
+
+    // Subscribe as the recipient ("other-user") to capture what they receive
+    let mut stream = sse
+        .subscribe_raw(Some("other-user".to_string()))
+        .expect("subscribe should succeed");
+
+    // Register the gateway channel with the channel manager
+    let mgr = ChannelManager::new();
+    mgr.add(Box::new(gw)).await;
+    let channels = Arc::new(mgr);
+
+    let notif = ironclaw_engine::MissionNotification {
+        mission_id: ironclaw_engine::MissionId(uuid::Uuid::new_v4()),
+        mission_name: "test-mission".to_string(),
+        thread_id: ironclaw_engine::ThreadId(uuid::Uuid::new_v4()),
+        user_id: "owner-user".to_string(),
+        notify_channels: vec!["gateway".to_string()],
+        notify_user: Some("other-user".to_string()),
+        response: Some("mission result".to_string()),
+        is_error: false,
+    };
+
+    let owner_thread_id = notif.thread_id.to_string();
+
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+    )
+    .await;
+
+    // The recipient should get an event with a thread_id that is NOT the
+    // owner's mission thread — it should be their own assistant thread.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+        .await
+        .expect("should receive SSE event within 1s")
+        .expect("stream should not be empty");
+
+    let AppEvent::Response { thread_id, .. } = event else {
+        panic!("expected AppEvent::Response, got: {event:?}");
+    };
+
+    assert_ne!(
+        thread_id, owner_thread_id,
+        "cross-user broadcast must NOT carry the owner's thread_id"
+    );
+
+    // The thread_id should be the recipient's own assistant conversation
+    let recipient_conv = store
+        .get_or_create_assistant_conversation("other-user", "gateway")
+        .await
+        .expect("recipient assistant conversation should exist");
+    assert_eq!(
+        thread_id,
+        recipient_conv.to_string(),
+        "cross-user broadcast should resolve to recipient's assistant thread"
+    );
+}
+
+/// When notify_user is None (owner IS the recipient), the mission
+/// thread_id SHOULD be attached to the broadcast.
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn mission_notification_same_user_attaches_owner_thread_id() {
+    use crate::channels::ChannelManager;
+    use crate::db::Database;
+    use futures::StreamExt;
+    use ironclaw_common::AppEvent;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test_same_user.db");
+    let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+        .await
+        .unwrap();
+    Database::run_migrations(&backend).await.unwrap();
+    let store: Arc<dyn Database> = Arc::new(backend);
+
+    let gw = test_gateway().with_store(store.clone());
+    let sse = Arc::clone(&gw.state.sse);
+
+    // Subscribe as the owner to capture channel broadcast events
+    let mut stream = sse
+        .subscribe_raw(Some("test-user".to_string()))
+        .expect("subscribe should succeed");
+
+    let mgr = ChannelManager::new();
+    mgr.add(Box::new(gw)).await;
+    let channels = Arc::new(mgr);
+
+    let notif = ironclaw_engine::MissionNotification {
+        mission_id: ironclaw_engine::MissionId(uuid::Uuid::new_v4()),
+        mission_name: "test-mission".to_string(),
+        thread_id: ironclaw_engine::ThreadId(uuid::Uuid::new_v4()),
+        user_id: "test-user".to_string(),
+        notify_channels: vec!["gateway".to_string()],
+        notify_user: None, // owner IS the recipient
+        response: Some("mission result".to_string()),
+        is_error: false,
+    };
+
+    let owner_thread_id = notif.thread_id.to_string();
+
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+    )
+    .await;
+
+    // The owner should receive two events:
+    // 1. From GatewayChannel::broadcast() (channel path)
+    // 2. From direct SSE broadcast_for_user (SSE path)
+    // Both should carry the owner's thread_id.
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+        .await
+        .expect("should receive SSE event within 1s")
+        .expect("stream should not be empty");
+
+    let AppEvent::Response { thread_id, .. } = event else {
+        panic!("expected AppEvent::Response, got: {event:?}");
+    };
+
+    assert_eq!(
+        thread_id, owner_thread_id,
+        "same-user broadcast should carry the owner's mission thread_id"
+    );
+}
+
+/// Edge case: notify_user is explicitly set but equals user_id.
+/// The guard compares broadcast_user == notif.user_id, which should still
+/// match. If someone refactors to check notify_user.is_none() instead,
+/// this test catches the regression.
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn mission_notification_explicit_same_user_attaches_owner_thread_id() {
+    use crate::channels::ChannelManager;
+    use crate::db::Database;
+    use futures::StreamExt;
+    use ironclaw_common::AppEvent;
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test_explicit_same_user.db");
+    let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+        .await
+        .unwrap();
+    Database::run_migrations(&backend).await.unwrap();
+    let store: Arc<dyn Database> = Arc::new(backend);
+
+    let gw = test_gateway().with_store(store.clone());
+    let sse = Arc::clone(&gw.state.sse);
+
+    let mut stream = sse
+        .subscribe_raw(Some("test-user".to_string()))
+        .expect("subscribe should succeed");
+
+    let mgr = ChannelManager::new();
+    mgr.add(Box::new(gw)).await;
+    let channels = Arc::new(mgr);
+
+    let notif = ironclaw_engine::MissionNotification {
+        mission_id: ironclaw_engine::MissionId(uuid::Uuid::new_v4()),
+        mission_name: "test-mission".to_string(),
+        thread_id: ironclaw_engine::ThreadId(uuid::Uuid::new_v4()),
+        user_id: "test-user".to_string(),
+        notify_channels: vec!["gateway".to_string()],
+        // Explicitly set to same user — guard must still attach thread_id
+        notify_user: Some("test-user".to_string()),
+        response: Some("mission result".to_string()),
+        is_error: false,
+    };
+
+    let owner_thread_id = notif.thread_id.to_string();
+
+    crate::bridge::handle_mission_notification(
+        &notif,
+        &channels,
+        Some(&sse),
+        Some(&store),
+        None,
+    )
+    .await;
+
+    let event = tokio::time::timeout(std::time::Duration::from_secs(1), stream.next())
+        .await
+        .expect("should receive SSE event within 1s")
+        .expect("stream should not be empty");
+
+    let AppEvent::Response { thread_id, .. } = event else {
+        panic!("expected AppEvent::Response, got: {event:?}");
+    };
+
+    assert_eq!(
+        thread_id, owner_thread_id,
+        "explicit notify_user == user_id should still attach the owner's thread_id"
     );
 }

--- a/src/channels/web/tests/no_silent_drop.rs
+++ b/src/channels/web/tests/no_silent_drop.rs
@@ -62,20 +62,47 @@ async fn gateway_respond_with_thread_id_succeeds() {
 }
 
 #[tokio::test]
-async fn gateway_broadcast_without_thread_id_returns_error() {
+async fn gateway_broadcast_without_thread_id_and_no_store_returns_error() {
     let gw = test_gateway();
     let response = OutgoingResponse::text("notification");
-    // response has no thread_id by default
+    // response has no thread_id by default, gateway has no store
 
     let result = gw.broadcast("test-user", response).await;
 
     assert!(
         result.is_err(),
-        "broadcast() must not silently succeed without thread_id"
+        "broadcast() without thread_id and no store should error"
     );
     assert!(
         matches!(result, Err(ChannelError::MissingRoutingTarget { .. })),
         "Expected MissingRoutingTarget, got: {:?}",
+        result
+    );
+}
+
+/// When a store IS available, broadcast() without thread_id falls back to
+/// the user's assistant conversation instead of erroring.
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn gateway_broadcast_without_thread_id_falls_back_to_assistant_thread() {
+    use std::sync::Arc;
+
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("test_broadcast_fallback.db");
+    let backend = crate::db::libsql::LibSqlBackend::new_local(&db_path)
+        .await
+        .unwrap();
+    crate::db::Database::run_migrations(&backend).await.unwrap();
+    let store: Arc<dyn crate::db::Database> = Arc::new(backend);
+
+    let gw = test_gateway().with_store(store);
+    let response = OutgoingResponse::text("mission notification");
+
+    let result = gw.broadcast("test-user", response).await;
+
+    assert!(
+        result.is_ok(),
+        "broadcast() without thread_id should fall back to assistant thread when store is available: {:?}",
         result
     );
 }


### PR DESCRIPTION
## Problem

Mission notifications, self-repair alerts, and extension activation messages broadcast via channels without a `thread_id`. The gateway's `broadcast()` rejects these with `MissingRoutingTarget`, silently dropping the messages.

## Root cause

The gateway requires `thread_id` for SSE routing (added in the no-silent-drop hardening). Three callers send without one:

- `src/bridge/router.rs:2933` — mission notifications (thread_id available but not passed)
- `src/extensions/manager.rs:6849` — Telegram owner verification (no thread context)
- `src/agent/agent_loop.rs:752,765` — self-repair notifications (no thread context)

Note: the heartbeat path (`src/agent/heartbeat.rs:416`) already resolves a thread_id via `get_or_create_heartbeat_conversation` before sending, so it is NOT affected.

## Fix

1. **Mission notification** now chains `.in_thread(notif.thread_id.to_string())`. The thread_id was already on `MissionNotification` — the SSE broadcast 3 lines below was using it.

2. **Gateway `broadcast()`** falls back to the user's assistant conversation (via `get_or_create_assistant_conversation`) when `thread_id` is None. This routes threadless messages to the assistant thread instead of rejecting them. When no DB store is available, the original `MissingRoutingTarget` error is preserved.

## Test plan

- [x] `cargo clippy --all` — zero warnings
- [x] `cargo test -- no_silent_drop` — 5 tests pass:
  - `gateway_broadcast_without_thread_id_and_no_store_returns_error` — no store = error (renamed)
  - `gateway_broadcast_with_thread_id_succeeds` — unchanged
  - `gateway_broadcast_without_thread_id_falls_back_to_assistant_thread` — **new** (libsql): creates a gateway with a real DB store, broadcasts without thread_id, verifies success via assistant thread fallback
  - `gateway_respond_without_thread_id_returns_error` — unchanged
  - `gateway_respond_with_thread_id_succeeds` — unchanged

**Local verification attempted:** Started IronClaw locally with Qwen on MLX, but the three affected callers (missions, self-repair, extension activation) are difficult to trigger in a minimal setup. The heartbeat fires successfully but uses its own thread_id resolution and doesn't exercise the broken path. The unit test exercises the exact `broadcast()` method with a real libsql-backed gateway, which is the code path all three callers share.

- [ ] Staging: fire a mission with `notify_channels: ["gateway"]` and verify the notification appears in the assistant thread

Fixes #2405