### PR TITLE
style: fix cargo fmt in thread_ops.rs

### DIFF
--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -405,7 +405,9 @@ impl Agent {
                                 .iter()
                                 .any(|rule| rule.action == ironclaw_safety::PolicyAction::Block)
                             {
-                                return Ok(SubmissionResult::error("Input rejected by safety policy."));
+                                return Ok(SubmissionResult::error(
+                                    "Input rejected by safety policy.",
+                                ));
                             }
                             if let Some(warning) = self.safety().scan_inbound_for_secrets(content) {
                                 tracing::warn!(
@@ -426,7 +428,8 @@ impl Agent {
                             // acknowledgment, not a completed LLM turn.
                             return Ok(SubmissionResult::Ok {
                                 message: Some(
-                                    "Message queued — will be processed after the current turn.".into(),
+                                    "Message queued — will be processed after the current turn."
+                                        .into(),
                                 ),
                             });
                         }


### PR DESCRIPTION
## Summary
- Fixes `cargo fmt` line wrapping issues introduced by #2366

## Test plan
- [x] `cargo fmt --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)