### PR TITLE
fix(gateway): v2 engine tool_calls persistence + e2e test coverage

### DIFF
--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3587,7 +3587,8 @@ pub(crate) async fn handle_mission_notification(
 
 /// Persist v2 engine tool call metadata to the v1 conversation DB.
 ///
-/// Loads steps from the v2 store, extracts action results, and writes a
+/// Loads the completed thread from the v2 store, extracts ActionResult
+/// messages (which carry the actual tool output), and writes a
 /// `role="tool_calls"` message so the chat history API can reconstruct
 /// tool call info (name, result preview, errors) for the web UI.
 async fn persist_v2_tool_calls(
@@ -3596,55 +3597,54 @@ async fn persist_v2_tool_calls(
     thread_id: ironclaw_engine::ThreadId,
     message: &IncomingMessage,
 ) {
-    // Steps are evicted from the in-memory store after join_thread, so
-    // extract tool call metadata from thread events instead (append-only).
-    let events = match store.load_events(thread_id).await {
-        Ok(e) => e,
+    // Load the thread -- it's still in the store after join_thread
+    // (join only removes from the runtime running map, not the store).
+    let thread = match store.load_thread(thread_id).await {
+        Ok(Some(t)) => t,
+        Ok(None) => {
+            debug!(thread_id = %thread_id, "thread not found in store for tool_calls persist");
+            return;
+        }
         Err(e) => {
-            debug!(thread_id = %thread_id, "failed to load v2 events for tool_calls persist: {e}");
+            debug!(thread_id = %thread_id, "failed to load thread for tool_calls persist: {e}");
             return;
         }
     };
 
+    // Extract ActionResult messages from the thread's internal transcript.
+    // The user-visible `messages` only has user/assistant messages, while
+    // `internal_messages` has the full chain including action results with
+    // actual tool output content.
     let mut calls = Vec::new();
-    for event in &events {
-        match &event.kind {
-            ironclaw_engine::EventKind::ActionExecuted {
-                action_name,
-                call_id,
-                params_summary,
-                ..
-            } => {
-                let mut obj = serde_json::json!({
-                    "name": action_name,
-                });
-                if let Some(summary) = params_summary {
-                    obj["result_preview"] = serde_json::Value::String(summary.clone());
-                } else {
-                    obj["result_preview"] = serde_json::Value::String("completed".to_string());
-                }
-                if !call_id.is_empty() {
-                    obj["tool_call_id"] = serde_json::Value::String(call_id.clone());
-                }
-                calls.push(obj);
-            }
-            ironclaw_engine::EventKind::ActionFailed {
-                action_name,
-                call_id,
-                error,
-                ..
-            } => {
-                let mut obj = serde_json::json!({
-                    "name": action_name,
-                    "error": error,
-                });
-                if !call_id.is_empty() {
-                    obj["tool_call_id"] = serde_json::Value::String(call_id.clone());
-                }
-                calls.push(obj);
-            }
-            _ => {}
+    for msg in thread.internal_messages.iter().chain(thread.messages.iter()) {
+        if msg.role != ironclaw_engine::MessageRole::ActionResult {
+            continue;
         }
+        let action_name = msg
+            .action_name
+            .as_deref()
+            .unwrap_or("unknown");
+        let preview = if msg.content.len() > 500 {
+            // safety: truncate on a char boundary
+            let end = msg
+                .content
+                .char_indices()
+                .take_while(|(i, _)| *i < 500)
+                .last()
+                .map(|(i, c)| i + c.len_utf8())
+                .unwrap_or(0);
+            format!("{}...", &msg.content[..end])
+        } else {
+            msg.content.clone()
+        };
+        let mut obj = serde_json::json!({
+            "name": action_name,
+            "result_preview": preview,
+        });
+        if let Some(ref call_id) = msg.action_call_id {
+            obj["tool_call_id"] = serde_json::Value::String(call_id.clone());
+        }
+        calls.push(obj);
     }
 
     if calls.is_empty() {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -7481,8 +7481,8 @@ mod tests {
             .await
             .expect("create conversation");
 
-        let message = IncomingMessage::new("web", "test-user", "do stuff")
-            .with_thread(conv_id.to_string());
+        let message =
+            IncomingMessage::new("web", "test-user", "do stuff").with_thread(conv_id.to_string());
 
         let store_arc: Arc<dyn Store> = store;
         persist_v2_tool_calls(&store_arc, &db, thread_id, &message).await;
@@ -7492,11 +7492,12 @@ mod tests {
             .list_conversation_messages(conv_id)
             .await
             .expect("list messages");
-        let tool_calls_msgs: Vec<_> = messages
-            .iter()
-            .filter(|m| m.role == "tool_calls")
-            .collect();
-        assert_eq!(tool_calls_msgs.len(), 1, "expected exactly one tool_calls row");
+        let tool_calls_msgs: Vec<_> = messages.iter().filter(|m| m.role == "tool_calls").collect();
+        assert_eq!(
+            tool_calls_msgs.len(),
+            1,
+            "expected exactly one tool_calls row"
+        );
 
         let parsed: serde_json::Value =
             serde_json::from_str(&tool_calls_msgs[0].content).expect("valid JSON");
@@ -7537,8 +7538,8 @@ mod tests {
             .await
             .expect("create conversation");
 
-        let message = IncomingMessage::new("web", "test-user", "hello")
-            .with_thread(conv_id.to_string());
+        let message =
+            IncomingMessage::new("web", "test-user", "hello").with_thread(conv_id.to_string());
 
         let store_arc: Arc<dyn Store> = store;
         persist_v2_tool_calls(&store_arc, &db, thread_id, &message).await;
@@ -7548,10 +7549,11 @@ mod tests {
             .list_conversation_messages(conv_id)
             .await
             .expect("list messages");
-        let tool_calls_msgs: Vec<_> = messages
-            .iter()
-            .filter(|m| m.role == "tool_calls")
-            .collect();
-        assert_eq!(tool_calls_msgs.len(), 0, "no tool_calls row for text-only thread");
+        let tool_calls_msgs: Vec<_> = messages.iter().filter(|m| m.role == "tool_calls").collect();
+        assert_eq!(
+            tool_calls_msgs.len(),
+            0,
+            "no tool_calls row for text-only thread"
+        );
     }
 }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3660,15 +3660,25 @@ async fn persist_v2_tool_calls(
         }
     };
 
-    // Resolve the v1 conversation ID (same logic as write_v1_response)
+    // Resolve the v1 conversation ID
     let v1_conv_id = if let Some(tid) = message.conversation_scope()
         && let Ok(uuid) = uuid::Uuid::parse_str(tid)
     {
         Some(uuid)
     } else {
-        db.get_or_create_assistant_conversation(&message.user_id, &message.channel)
+        match db
+            .get_or_create_assistant_conversation(&message.user_id, &message.channel)
             .await
-            .ok()
+        {
+            Ok(cid) => Some(cid),
+            Err(e) => {
+                tracing::warn!(
+                    thread_id = %thread_id,
+                    "failed to resolve v1 conversation for tool_calls persist: {e}"
+                );
+                return;
+            }
+        }
     };
     if let Some(cid) = v1_conv_id
         && let Err(e) = db.add_conversation_message(cid, "tool_calls", &content).await

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3416,6 +3416,16 @@ async fn await_thread_outcome(
     if let Ok(BridgeOutcome::Respond(ref text)) = result
         && let Some(ref db) = state.db
     {
+        // Write tool_calls row BEFORE assistant response so the v1 history
+        // API sees the correct user → tool_calls → assistant triple.
+        persist_v2_tool_calls(
+            &state.store,
+            db,
+            thread_id,
+            message,
+        )
+        .await;
+
         write_v1_response(db, text).await;
     }
 
@@ -3572,6 +3582,98 @@ pub(crate) async fn handle_mission_notification(
                 }
             }
         }
+    }
+}
+
+/// Persist v2 engine tool call metadata to the v1 conversation DB.
+///
+/// Loads steps from the v2 store, extracts action results, and writes a
+/// `role="tool_calls"` message so the chat history API can reconstruct
+/// tool call info (name, result preview, errors) for the web UI.
+async fn persist_v2_tool_calls(
+    store: &std::sync::Arc<dyn Store>,
+    db: &std::sync::Arc<dyn Database>,
+    thread_id: ironclaw_engine::ThreadId,
+    message: &IncomingMessage,
+) {
+    // Steps are evicted from the in-memory store after join_thread, so
+    // extract tool call metadata from thread events instead (append-only).
+    let events = match store.load_events(thread_id).await {
+        Ok(e) => e,
+        Err(e) => {
+            debug!(thread_id = %thread_id, "failed to load v2 events for tool_calls persist: {e}");
+            return;
+        }
+    };
+
+    let mut calls = Vec::new();
+    for event in &events {
+        match &event.kind {
+            ironclaw_engine::EventKind::ActionExecuted {
+                action_name,
+                call_id,
+                params_summary,
+                ..
+            } => {
+                let mut obj = serde_json::json!({
+                    "name": action_name,
+                });
+                if let Some(summary) = params_summary {
+                    obj["result_preview"] = serde_json::Value::String(summary.clone());
+                } else {
+                    obj["result_preview"] = serde_json::Value::String("completed".to_string());
+                }
+                if !call_id.is_empty() {
+                    obj["tool_call_id"] = serde_json::Value::String(call_id.clone());
+                }
+                calls.push(obj);
+            }
+            ironclaw_engine::EventKind::ActionFailed {
+                action_name,
+                call_id,
+                error,
+                ..
+            } => {
+                let mut obj = serde_json::json!({
+                    "name": action_name,
+                    "error": error,
+                });
+                if !call_id.is_empty() {
+                    obj["tool_call_id"] = serde_json::Value::String(call_id.clone());
+                }
+                calls.push(obj);
+            }
+            _ => {}
+        }
+    }
+
+    if calls.is_empty() {
+        return;
+    }
+
+    let wrapper = serde_json::json!({ "calls": calls });
+    let content = match serde_json::to_string(&wrapper) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::warn!("failed to serialize v2 tool_calls: {e}");
+            return;
+        }
+    };
+
+    // Resolve the v1 conversation ID (same logic as write_v1_response)
+    let v1_conv_id = if let Some(tid) = message.conversation_scope()
+        && let Ok(uuid) = uuid::Uuid::parse_str(tid)
+    {
+        Some(uuid)
+    } else {
+        db.get_or_create_assistant_conversation(&message.user_id, &message.channel)
+            .await
+            .ok()
+    };
+    if let Some(cid) = v1_conv_id
+        && let Err(e) = db.add_conversation_message(cid, "tool_calls", &content).await
+    {
+        tracing::warn!("failed to persist v2 tool_calls to v1 DB: {e}");
     }
 }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3418,13 +3418,7 @@ async fn await_thread_outcome(
     {
         // Write tool_calls row BEFORE assistant response so the v1 history
         // API sees the correct user → tool_calls → assistant triple.
-        persist_v2_tool_calls(
-            &state.store,
-            db,
-            thread_id,
-            message,
-        )
-        .await;
+        persist_v2_tool_calls(&state.store, db, thread_id, message).await;
 
         write_v1_response(db, text).await;
     }
@@ -3619,10 +3613,7 @@ async fn persist_v2_tool_calls(
         if msg.role != ironclaw_engine::MessageRole::ActionResult {
             continue;
         }
-        let action_name = msg
-            .action_name
-            .as_deref()
-            .unwrap_or("unknown");
+        let action_name = msg.action_name.as_deref().unwrap_or("unknown");
         let preview = if msg.content.len() > 500 {
             // safety: truncate on a char boundary
             let end = msg
@@ -3680,7 +3671,9 @@ async fn persist_v2_tool_calls(
         }
     };
     if let Some(cid) = v1_conv_id
-        && let Err(e) = db.add_conversation_message(cid, "tool_calls", &content).await
+        && let Err(e) = db
+            .add_conversation_message(cid, "tool_calls", &content)
+            .await
     {
         debug!("failed to persist v2 tool_calls to v1 DB: {e}");
     }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3595,14 +3595,20 @@ async fn persist_v2_tool_calls(
 ) {
     // Load the thread -- it's still in the store after join_thread
     // (join only removes from the runtime running map, not the store).
+    //
+    // Logging level: failures here mean the chat history will be missing
+    // the tool_calls row for this turn (web UI shows empty array). That's
+    // a user-visible gap, so emit at `warn!` — this path is an HTTP
+    // handler, not a TUI-corrupting background task, so CLAUDE.md's
+    // "background tasks must not use info!/warn!" rule does not apply.
     let thread = match store.load_thread(thread_id).await {
         Ok(Some(t)) => t,
         Ok(None) => {
-            debug!(thread_id = %thread_id, "thread not found in store for tool_calls persist");
+            tracing::warn!(thread_id = %thread_id, "thread not found in store for tool_calls persist");
             return;
         }
         Err(e) => {
-            debug!(thread_id = %thread_id, "failed to load thread for tool_calls persist: {e}");
+            tracing::warn!(thread_id = %thread_id, "failed to load thread for tool_calls persist: {e}");
             return;
         }
     };
@@ -3647,7 +3653,7 @@ async fn persist_v2_tool_calls(
     let content = match serde_json::to_string(&wrapper) {
         Ok(c) => c,
         Err(e) => {
-            debug!("failed to serialize v2 tool_calls: {e}");
+            tracing::warn!(thread_id = %thread_id, "failed to serialize v2 tool_calls: {e}");
             return;
         }
     };
@@ -3664,7 +3670,7 @@ async fn persist_v2_tool_calls(
         {
             Ok(cid) => Some(cid),
             Err(e) => {
-                debug!(
+                tracing::warn!(
                     thread_id = %thread_id,
                     "failed to resolve v1 conversation for tool_calls persist: {e}"
                 );
@@ -3677,7 +3683,7 @@ async fn persist_v2_tool_calls(
             .add_conversation_message(cid, "tool_calls", &content)
             .await
     {
-        debug!("failed to persist v2 tool_calls to v1 DB: {e}");
+        tracing::warn!(thread_id = %thread_id, "failed to persist v2 tool_calls to v1 DB: {e}");
     }
 }
 
@@ -7554,6 +7560,141 @@ mod tests {
             tool_calls_msgs.len(),
             0,
             "no tool_calls row for text-only thread"
+        );
+    }
+
+    /// Regression: the truncation logic in `persist_v2_tool_calls` uses
+    /// `char_indices()` + `len_utf8()` to avoid slicing in the middle of a
+    /// multi-byte UTF-8 sequence. Exercise the path with a content string
+    /// that is well over 500 bytes and composed entirely of 3-byte chars,
+    /// where a naive `&s[..500]` would panic on a char boundary.
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn persist_v2_tool_calls_truncates_multibyte_content_on_char_boundary() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(TestStore::new());
+        let db: Arc<dyn crate::db::Database> = Arc::new(
+            crate::db::libsql::LibSqlBackend::new_local(&tmp.path().join("test.db"))
+                .await
+                .expect("local libsql"),
+        );
+        db.run_migrations().await.expect("migrations");
+
+        // Content: 400 repetitions of a 3-byte CJK char = 1200 bytes, well
+        // over the 500-byte truncation threshold.
+        let big = "日".repeat(400);
+        assert!(big.len() > 500, "fixture must exceed threshold");
+
+        let mut thread = ironclaw_engine::Thread::new(
+            "goal",
+            ironclaw_engine::ThreadType::Foreground,
+            ironclaw_engine::ProjectId::new(),
+            "test-user",
+            ironclaw_engine::ThreadConfig::default(),
+        );
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::action_result(
+            "call-utf8",
+            "echo",
+            &big,
+        ));
+        let thread_id = thread.id;
+        store.save_thread(&thread).await.unwrap();
+
+        let conv_id = db
+            .create_conversation("web", "test-user", None)
+            .await
+            .expect("create conversation");
+        let message =
+            IncomingMessage::new("web", "test-user", "hi").with_thread(conv_id.to_string());
+
+        let store_arc: Arc<dyn Store> = store;
+        persist_v2_tool_calls(&store_arc, &db, thread_id, &message).await;
+
+        let messages = db
+            .list_conversation_messages(conv_id)
+            .await
+            .expect("list messages");
+        let tool_calls_msg = messages
+            .iter()
+            .find(|m| m.role == "tool_calls")
+            .expect("tool_calls row must be written");
+        let parsed: serde_json::Value =
+            serde_json::from_str(&tool_calls_msg.content).expect("valid JSON");
+        let preview = parsed["calls"][0]["result_preview"]
+            .as_str()
+            .expect("result_preview is a string");
+
+        // The preview must be valid UTF-8 (JSON deserialization above would
+        // have failed otherwise), must end with the truncation marker, and
+        // must be bounded. The truncation rule is "include every char
+        // whose *start index* is below 500", so for multi-byte runs the
+        // last included char may extend past byte 500 by up to
+        // `max_char_bytes - 1` bytes (≤3 for UTF-8). That's the correct
+        // behavior — pinning a generous bound is what the char-boundary
+        // safety actually provides.
+        assert!(
+            preview.ends_with("..."),
+            "expected truncation marker, got: {preview:?}"
+        );
+        let body = preview.strip_suffix("...").unwrap();
+        assert!(
+            body.len() < 504,
+            "body must be bounded near 500 bytes (≤500+char_overhead), got {}: {body:?}",
+            body.len()
+        );
+        assert!(
+            body.chars().all(|c| c == '日'),
+            "body must contain only complete 3-byte chars, got: {body:?}"
+        );
+        // And critically: body.len() must be on a char boundary. If the
+        // truncator sliced mid-char, the earlier JSON parse would have
+        // rejected invalid UTF-8; this assertion is belt-and-braces.
+        assert!(
+            body.len().is_multiple_of(3),
+            "body length must be a multiple of 3-byte char width, got {}",
+            body.len()
+        );
+    }
+
+    /// Regression for the bug fixed in commit 652315e8: `persist_v2_tool_calls`
+    /// must only be called from the `ThreadOutcome::Completed` arm. If a
+    /// future refactor moves the call out of that arm, partial tool
+    /// executions on `GatePaused` would orphan a `role="tool_calls"` DB row
+    /// that then duplicates when the gate resumes. Pin the call-site
+    /// conditional by inspecting the source of `await_thread_outcome`.
+    #[test]
+    fn persist_v2_tool_calls_only_called_from_completed_arm() {
+        let source = include_str!("router.rs");
+        let (before_fn, _after_fn) = source
+            .split_once("async fn persist_v2_tool_calls")
+            .expect("persist_v2_tool_calls must exist in router.rs");
+
+        // There should be exactly one call site in the pre-definition body
+        // (the call inside `await_thread_outcome`). The text below the
+        // definition is allowed to reference it (doc comments, unit tests).
+        let call_sites = before_fn.matches("persist_v2_tool_calls(").count();
+        assert_eq!(
+            call_sites, 1,
+            "expected exactly one call site for persist_v2_tool_calls, found {call_sites}"
+        );
+
+        // The call must live inside `ThreadOutcome::Completed` and must not
+        // appear in any of the terminal arms that represent non-completion
+        // outcomes. `GatePaused` is the one that triggered the bug.
+        let completed_idx = before_fn
+            .find("ThreadOutcome::Completed")
+            .expect("Completed arm must exist");
+        let gate_paused_idx = before_fn
+            .find("ThreadOutcome::GatePaused")
+            .expect("GatePaused arm must exist");
+        let call_idx = before_fn
+            .find("persist_v2_tool_calls(")
+            .expect("call site must exist");
+
+        assert!(
+            completed_idx < call_idx && call_idx < gate_paused_idx,
+            "persist_v2_tool_calls call must sit between Completed and GatePaused arms, got \
+             completed={completed_idx} call={call_idx} gate_paused={gate_paused_idx}"
         );
     }
 }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3612,11 +3612,10 @@ async fn persist_v2_tool_calls(
     };
 
     // Extract ActionResult messages from the thread's internal transcript.
-    // The user-visible `messages` only has user/assistant messages, while
-    // `internal_messages` has the full chain including action results with
-    // actual tool output content.
+    // `internal_messages` has the full execution chain including action
+    // results with actual tool output. `messages` only has user/assistant.
     let mut calls = Vec::new();
-    for msg in thread.internal_messages.iter().chain(thread.messages.iter()) {
+    for msg in &thread.internal_messages {
         if msg.role != ironclaw_engine::MessageRole::ActionResult {
             continue;
         }
@@ -3655,7 +3654,7 @@ async fn persist_v2_tool_calls(
     let content = match serde_json::to_string(&wrapper) {
         Ok(c) => c,
         Err(e) => {
-            tracing::warn!("failed to serialize v2 tool_calls: {e}");
+            debug!("failed to serialize v2 tool_calls: {e}");
             return;
         }
     };
@@ -3672,7 +3671,7 @@ async fn persist_v2_tool_calls(
         {
             Ok(cid) => Some(cid),
             Err(e) => {
-                tracing::warn!(
+                debug!(
                     thread_id = %thread_id,
                     "failed to resolve v1 conversation for tool_calls persist: {e}"
                 );
@@ -3683,7 +3682,7 @@ async fn persist_v2_tool_calls(
     if let Some(cid) = v1_conv_id
         && let Err(e) = db.add_conversation_message(cid, "tool_calls", &content).await
     {
-        tracing::warn!("failed to persist v2 tool_calls to v1 DB: {e}");
+        debug!("failed to persist v2 tool_calls to v1 DB: {e}");
     }
 }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3331,6 +3331,12 @@ async fn await_thread_outcome(
                 return Ok(BridgeOutcome::Pending);
             }
 
+            // Persist tool_calls only for completed threads — not for
+            // GatePaused (partial tools, would orphan rows on resume).
+            if let Some(ref db) = state.db {
+                persist_v2_tool_calls(&state.store, db, thread_id, message).await;
+            }
+
             match response {
                 Some(text) => Ok(BridgeOutcome::Respond(text)),
                 None => Ok(BridgeOutcome::NoResponse),
@@ -3416,10 +3422,6 @@ async fn await_thread_outcome(
     if let Ok(BridgeOutcome::Respond(ref text)) = result
         && let Some(ref db) = state.db
     {
-        // Write tool_calls row BEFORE assistant response so the v1 history
-        // API sees the correct user → tool_calls → assistant triple.
-        persist_v2_tool_calls(&state.store, db, thread_id, message).await;
-
         write_v1_response(db, text).await;
     }
 
@@ -7436,5 +7438,120 @@ mod tests {
             callback_id: "cb-123".into(),
         };
         assert!(!super::clamp_always_to_resume_kind(true, &rk));
+    }
+
+    // ── persist_v2_tool_calls unit tests ────────────────────────
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn persist_v2_tool_calls_writes_action_results_from_internal_messages() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(TestStore::new());
+        let db: Arc<dyn crate::db::Database> = Arc::new(
+            crate::db::libsql::LibSqlBackend::new_local(&tmp.path().join("test.db"))
+                .await
+                .expect("local libsql"),
+        );
+        db.run_migrations().await.expect("migrations");
+
+        // Create a thread with ActionResult messages in internal_messages
+        let mut thread = ironclaw_engine::Thread::new(
+            "goal",
+            ironclaw_engine::ThreadType::Foreground,
+            ironclaw_engine::ProjectId::new(),
+            "test-user",
+            ironclaw_engine::ThreadConfig::default(),
+        );
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::action_result(
+            "call-1",
+            "echo",
+            r#"{"output":"hello"}"#,
+        ));
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::action_result(
+            "call-2",
+            "time",
+            r#"{"time":"2026-04-15T12:00:00Z"}"#,
+        ));
+        let thread_id = thread.id;
+        store.save_thread(&thread).await.unwrap();
+
+        // Create a conversation so persist can resolve the v1 conversation ID
+        let conv_id = db
+            .create_conversation("web", "test-user", None)
+            .await
+            .expect("create conversation");
+
+        let message = IncomingMessage::new("web", "test-user", "do stuff")
+            .with_thread(conv_id.to_string());
+
+        let store_arc: Arc<dyn Store> = store;
+        persist_v2_tool_calls(&store_arc, &db, thread_id, &message).await;
+
+        // Read back and verify the tool_calls message was written
+        let messages = db
+            .list_conversation_messages(conv_id)
+            .await
+            .expect("list messages");
+        let tool_calls_msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| m.role == "tool_calls")
+            .collect();
+        assert_eq!(tool_calls_msgs.len(), 1, "expected exactly one tool_calls row");
+
+        let parsed: serde_json::Value =
+            serde_json::from_str(&tool_calls_msgs[0].content).expect("valid JSON");
+        let calls = parsed["calls"].as_array().expect("calls array");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["name"], "echo");
+        assert_eq!(calls[0]["tool_call_id"], "call-1");
+        assert_eq!(calls[1]["name"], "time");
+        assert_eq!(calls[1]["tool_call_id"], "call-2");
+    }
+
+    #[cfg(feature = "libsql")]
+    #[tokio::test]
+    async fn persist_v2_tool_calls_skips_when_no_action_results() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(TestStore::new());
+        let db: Arc<dyn crate::db::Database> = Arc::new(
+            crate::db::libsql::LibSqlBackend::new_local(&tmp.path().join("test.db"))
+                .await
+                .expect("local libsql"),
+        );
+        db.run_migrations().await.expect("migrations");
+
+        // Thread with only a user message, no action results
+        let mut thread = ironclaw_engine::Thread::new(
+            "goal",
+            ironclaw_engine::ThreadType::Foreground,
+            ironclaw_engine::ProjectId::new(),
+            "test-user",
+            ironclaw_engine::ThreadConfig::default(),
+        );
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::user("hello"));
+        let thread_id = thread.id;
+        store.save_thread(&thread).await.unwrap();
+
+        let conv_id = db
+            .create_conversation("web", "test-user", None)
+            .await
+            .expect("create conversation");
+
+        let message = IncomingMessage::new("web", "test-user", "hello")
+            .with_thread(conv_id.to_string());
+
+        let store_arc: Arc<dyn Store> = store;
+        persist_v2_tool_calls(&store_arc, &db, thread_id, &message).await;
+
+        // No tool_calls row should be written
+        let messages = db
+            .list_conversation_messages(conv_id)
+            .await
+            .expect("list messages");
+        let tool_calls_msgs: Vec<_> = messages
+            .iter()
+            .filter(|m| m.role == "tool_calls")
+            .collect();
+        assert_eq!(tool_calls_msgs.len(), 0, "no tool_calls row for text-only thread");
     }
 }

--- a/tests/e2e/ironclaw_e2e.egg-info/SOURCES.txt
+++ b/tests/e2e/ironclaw_e2e.egg-info/SOURCES.txt
@@ -44,6 +44,7 @@ scenarios/test_v2_engine_auth_cancel.py
 scenarios/test_v2_engine_auth_flow.py
 scenarios/test_v2_engine_error_handling.py
 scenarios/test_v2_engine_oauth_google.py
+scenarios/test_v2_engine_tool_lifecycle.py
 scenarios/test_v2_kernel_auth_gateway_flow.py
 scenarios/test_v2_kernel_auth_preflight.py
 scenarios/test_wasm_lifecycle.py

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -56,8 +56,18 @@ TRUNCATED_TOOL_CALL_TRIGGER = re.compile(
 )
 EMPTY_REPLY_TRIGGER = re.compile(r"issue 1780 empty reply", re.IGNORECASE)
 LOOP_FOREVER_TRIGGER = re.compile(r"issue 1780 loop forever", re.IGNORECASE)
+MULTI_STEP_TRIGGER = re.compile(r"multi step echo then time", re.IGNORECASE)
 
 TOOL_CALL_PATTERNS = [
+    # Parallel tool calls: return both echo and time in one response
+    (
+        re.compile(r"parallel echo and time", re.IGNORECASE),
+        "echo",
+        lambda _: [
+            {"tool_name": "echo", "arguments": {"message": "parallel-test"}},
+            {"tool_name": "time", "arguments": {"operation": "now"}},
+        ],
+    ),
     (re.compile(r"echo (.+)", re.IGNORECASE), "echo", lambda m: {"message": m.group(1)}),
     (
         re.compile(r"loop until cap", re.IGNORECASE),
@@ -756,6 +766,27 @@ def match_special_response(messages: list[dict], has_tools: bool) -> dict | None
     if EMPTY_REPLY_TRIGGER.search(last_user):
         return {"type": "empty_text"}
 
+    # Multi-step tool chain: echo first, then time, then text completion.
+    # Uses result count (not names) because v2 engine tool results don't
+    # always include the tool name in a parseable format.
+    if _conversation_has_user_trigger(messages, MULTI_STEP_TRIGGER):
+        tool_results = _find_tool_results(messages)
+        n = len(tool_results)
+        if n == 0 and has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {"tool_name": "echo", "arguments": {"message": "step-one"}},
+            }
+        if n == 1 and has_tools:
+            return {
+                "type": "tool_call",
+                "tool_call": {"tool_name": "time", "arguments": {"operation": "now"}},
+            }
+        return {
+            "type": "text",
+            "text": "Multi-step complete: executed echo then time.",
+        }
+
     return None
 
 
@@ -814,6 +845,9 @@ async def chat_completions(request: web.Request) -> web.StreamResponse:
     # tool-result summary path (for example, the looping case).
     special = match_special_response(messages, has_tools)
     if special and _conversation_has_user_trigger(messages, LOOP_FOREVER_TRIGGER):
+        return await _dispatch_special_response(request, cid, stream, special)
+    # Multi-step chain: must bypass tool-result-summary to issue second tool call
+    if special and _conversation_has_user_trigger(messages, MULTI_STEP_TRIGGER):
         return await _dispatch_special_response(request, cid, stream, special)
 
     # Tool result(s) in messages -> text summary covering every fresh result

--- a/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
+++ b/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
@@ -240,10 +240,16 @@ class TestV2EngineSingleTool:
             timeout=30,
         )
 
-        response = history["turns"][-1]["response"]
-        assert "hello from v2" in response.lower(), (
-            f"Expected echo output in response, got: {response[:200]}"
+        turn = history["turns"][-1]
+        assert "hello from v2" in turn["response"].lower()
+
+        # Verify tool_calls are persisted to chat history
+        tool_calls = turn.get("tool_calls", [])
+        assert len(tool_calls) >= 1, (
+            f"Expected tool_calls in v2 history, got: {tool_calls}"
         )
+        assert tool_calls[0]["name"] == "echo"
+        assert tool_calls[0]["has_result"] is True
 
     async def test_time_tool(self, v2_tool_server):
         """time tool call -> result -> text response through v2 orchestrator."""

--- a/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
+++ b/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
@@ -245,6 +245,11 @@ class TestV2EngineSingleTool:
         )
         assert tool_calls[0]["name"] == "echo"
         assert tool_calls[0]["has_result"] is True
+        # Verify result_preview contains actual tool output, not just non-null
+        preview = tool_calls[0].get("result_preview", "")
+        assert "hello from v2" in preview.lower(), (
+            f"Expected echo output in result_preview, got: {preview[:200]}"
+        )
 
     async def test_time_tool(self, v2_tool_server):
         """time tool call -> result -> text response through v2 orchestrator."""
@@ -263,6 +268,14 @@ class TestV2EngineSingleTool:
         assert "returned" in response.lower(), (
             f"Expected time tool result in response, got: {response[:200]}"
         )
+
+        # Verify tool_calls persistence
+        tool_calls = history["turns"][-1].get("tool_calls", [])
+        assert len(tool_calls) >= 1, (
+            f"Expected tool_calls for time tool, got: {tool_calls}"
+        )
+        assert tool_calls[0]["name"] == "time"
+        assert tool_calls[0]["has_result"] is True
 
     async def test_text_only(self, v2_tool_server):
         """Non-tool message completes through v2 without tool calls."""
@@ -306,6 +319,18 @@ class TestV2EngineMultiTool:
             f"Expected echo result in parallel response, got: {response[:300]}"
         )
 
+        # Verify both tool calls are persisted
+        tool_calls = history["turns"][-1].get("tool_calls", [])
+        assert len(tool_calls) >= 2, (
+            f"Expected at least 2 tool_calls for parallel dispatch, got: {tool_calls}"
+        )
+        tc_names = {tc["name"] for tc in tool_calls}
+        assert "echo" in tc_names, f"Expected 'echo' in tool_calls, got names: {tc_names}"
+        assert "time" in tc_names, f"Expected 'time' in tool_calls, got names: {tc_names}"
+        assert all(tc["has_result"] for tc in tool_calls), (
+            f"Expected all tool_calls to have results, got: {tool_calls}"
+        )
+
     async def test_multi_step_chain(self, v2_tool_server):
         """Multi-step: echo -> result -> time -> result -> text completion.
 
@@ -327,6 +352,16 @@ class TestV2EngineMultiTool:
         response = history["turns"][-1]["response"]
         assert "multi-step complete" in response.lower(), (
             f"Expected multi-step completion, got: {response[:200]}"
+        )
+
+        # Verify both sequential tool calls are persisted
+        tool_calls = history["turns"][-1].get("tool_calls", [])
+        assert len(tool_calls) >= 2, (
+            f"Expected at least 2 tool_calls for multi-step chain, got: {tool_calls}"
+        )
+        # Echo runs first, then time -- both should have results
+        assert all(tc["has_result"] for tc in tool_calls), (
+            f"Expected all tool_calls to have results, got: {tool_calls}"
         )
 
 
@@ -377,3 +412,28 @@ class TestV2EngineMultiTurn:
         assert len(history["turns"]) >= 3, (
             f"Expected at least 3 turns, got {len(history['turns'])}"
         )
+
+        # Verify tool_calls persisted for tool turns, absent for text turn
+        turns = history["turns"]
+
+        # Turn 1: echo -- should have tool_calls
+        t1_calls = turns[0].get("tool_calls", [])
+        assert len(t1_calls) >= 1, (
+            f"Turn 1 (echo) should have tool_calls, got: {t1_calls}"
+        )
+        assert t1_calls[0]["name"] == "echo"
+        assert t1_calls[0]["has_result"] is True
+
+        # Turn 2: text-only -- should have no tool_calls
+        t2_calls = turns[1].get("tool_calls", [])
+        assert len(t2_calls) == 0, (
+            f"Turn 2 (text) should have no tool_calls, got: {t2_calls}"
+        )
+
+        # Turn 3: time -- should have tool_calls
+        t3_calls = turns[2].get("tool_calls", [])
+        assert len(t3_calls) >= 1, (
+            f"Turn 3 (time) should have tool_calls, got: {t3_calls}"
+        )
+        assert t3_calls[0]["name"] == "time"
+        assert t3_calls[0]["has_result"] is True

--- a/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
+++ b/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
@@ -1,0 +1,378 @@
+"""E2E test: v2 engine tool execution lifecycle.
+
+Tests the full tool execution path through the v2 engine -- the basic
+contract that was previously only covered for the v1 engine
+(test_tool_execution.py). This is the fundamental gap identified in the
+#2193 audit: zero engine-level e2e tests for the tool call -> result ->
+response path.
+
+NOTE: The v2 engine does not populate the ``tool_calls`` array in chat
+history (unlike v1). Tool results are embedded in the response text
+only. These tests verify tool execution through response content
+assertions. Fixing the ``tool_calls`` gap is tracked separately.
+
+Covers:
+1. Single tool call (echo) completes through v2
+2. Single tool call (time) completes through v2
+3. Text-only message (no tools) completes through v2
+4. Parallel tool calls (echo + time dispatched simultaneously)
+5. Multi-step tool chain (echo -> result -> time -> result -> text)
+6. Multi-turn tool usage (tool call in turn 1, another in turn 2)
+"""
+
+import asyncio
+import os
+import signal
+import socket
+import tempfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+from helpers import api_get, api_post, AUTH_TOKEN, wait_for_ready
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+_V2_TOOL_DB_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-v2-tool-e2e-")
+_V2_TOOL_HOME_TMPDIR = tempfile.TemporaryDirectory(prefix="ironclaw-v2-tool-e2e-home-")
+
+
+def _forward_coverage_env(env: dict):
+    """Forward LLVM coverage env vars from outer environment."""
+    for key in os.environ:
+        if key.startswith(("CARGO_LLVM_COV", "LLVM_", "CARGO_ENCODED_RUSTFLAGS",
+                           "CARGO_INCREMENTAL")):
+            env[key] = os.environ[key]
+
+
+async def _stop_process(proc, sig=signal.SIGINT, timeout=5):
+    """Send signal and wait for process to exit."""
+    try:
+        proc.send_signal(sig)
+    except ProcessLookupError:
+        return
+    try:
+        await asyncio.wait_for(proc.wait(), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+async def v2_tool_server(ironclaw_binary, mock_llm_server):
+    """Start ironclaw with ENGINE_V2=true for tool lifecycle tests."""
+    home_dir = _V2_TOOL_HOME_TMPDIR.name
+    os.makedirs(os.path.join(home_dir, ".ironclaw"), exist_ok=True)
+
+    socks = []
+    for _ in range(2):
+        s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        s.bind(("127.0.0.1", 0))
+        socks.append(s)
+    gateway_port = socks[0].getsockname()[1]
+    http_port = socks[1].getsockname()[1]
+    for s in socks:
+        s.close()
+
+    env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+        "RUST_LOG": "ironclaw=info",
+        "RUST_BACKTRACE": "1",
+        "ENGINE_V2": "true",
+        "AGENT_AUTO_APPROVE_TOOLS": "true",
+        "GATEWAY_ENABLED": "true",
+        "GATEWAY_HOST": "127.0.0.1",
+        "GATEWAY_PORT": str(gateway_port),
+        "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+        "GATEWAY_USER_ID": "e2e-v2-tool-tester",
+        "HTTP_HOST": "127.0.0.1",
+        "HTTP_PORT": str(http_port),
+        "CLI_ENABLED": "false",
+        "LLM_BACKEND": "openai_compatible",
+        "LLM_BASE_URL": mock_llm_server,
+        "LLM_MODEL": "mock-model",
+        "DATABASE_BACKEND": "libsql",
+        "LIBSQL_PATH": os.path.join(_V2_TOOL_DB_TMPDIR.name, "v2-tool-e2e.db"),
+        "SANDBOX_ENABLED": "false",
+        "SKILLS_ENABLED": "false",
+        "ROUTINES_ENABLED": "false",
+        "HEARTBEAT_ENABLED": "false",
+        "EMBEDDING_ENABLED": "false",
+        "WASM_ENABLED": "false",
+        "ONBOARD_COMPLETED": "true",
+    }
+    _forward_coverage_env(env)
+
+    proc = await asyncio.create_subprocess_exec(
+        ironclaw_binary, "--no-onboard",
+        stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+    )
+
+    base_url = f"http://127.0.0.1:{gateway_port}"
+    try:
+        await wait_for_ready(f"{base_url}/api/health", timeout=60)
+        yield base_url
+    except TimeoutError:
+        if proc.returncode is None:
+            await _stop_process(proc, timeout=2)
+        stderr_bytes = b""
+        if proc.stderr:
+            try:
+                stderr_bytes = await asyncio.wait_for(proc.stderr.read(8192), timeout=2)
+            except asyncio.TimeoutError:
+                pass
+        pytest.fail(
+            f"v2 tool lifecycle server failed to start on port {gateway_port}.\n"
+            f"stderr: {stderr_bytes.decode('utf-8', errors='replace')}"
+        )
+    finally:
+        if proc.returncode is None:
+            await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+            if proc.returncode is None:
+                await _stop_process(proc, sig=signal.SIGTERM, timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _create_thread(base_url: str) -> str:
+    r = await api_post(base_url, "/api/chat/thread/new", timeout=15)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+async def _send(base_url: str, thread_id: str, content: str) -> None:
+    r = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={"content": content, "thread_id": thread_id},
+        timeout=30,
+    )
+    assert r.status_code in (200, 202), r.text
+
+
+async def _wait_for_response(
+    base_url: str,
+    thread_id: str,
+    *,
+    timeout: float = 45.0,
+    expect_substring: str | None = None,
+    min_turns: int = 1,
+) -> dict:
+    """Poll chat history until an assistant response matching criteria appears."""
+    last_history = None
+    for _ in range(int(timeout * 2)):
+        r = await api_get(
+            base_url,
+            f"/api/chat/history?thread_id={thread_id}",
+            timeout=15,
+        )
+        r.raise_for_status()
+        history = r.json()
+        last_history = history
+        turns = history.get("turns", [])
+
+        if len(turns) < min_turns:
+            await asyncio.sleep(0.5)
+            continue
+
+        last = turns[-1]
+        response = last.get("response", "")
+
+        if not response:
+            await asyncio.sleep(0.5)
+            continue
+
+        if expect_substring is None or expect_substring.lower() in response.lower():
+            return history
+
+        await asyncio.sleep(0.5)
+
+    # Include last known state in the error for debugging
+    debug_info = ""
+    if last_history:
+        turns = last_history.get("turns", [])
+        if turns:
+            last = turns[-1]
+            debug_info = f"\nLast response: {last.get('response', '')[:200]!r}"
+
+    raise AssertionError(
+        f"Timed out waiting for response in thread {thread_id}: "
+        f"expect_substring={expect_substring!r}, min_turns={min_turns}"
+        + debug_info
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests: single tool calls
+# ---------------------------------------------------------------------------
+
+class TestV2EngineSingleTool:
+    """Verify that single tool calls complete through the v2 engine."""
+
+    async def test_echo_tool(self, v2_tool_server):
+        """echo tool call -> result -> text response through v2 orchestrator."""
+        thread_id = await _create_thread(v2_tool_server)
+        await _send(v2_tool_server, thread_id, "echo hello from v2")
+
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="hello from v2",
+            timeout=30,
+        )
+
+        response = history["turns"][-1]["response"]
+        assert "hello from v2" in response.lower(), (
+            f"Expected echo output in response, got: {response[:200]}"
+        )
+
+    async def test_time_tool(self, v2_tool_server):
+        """time tool call -> result -> text response through v2 orchestrator."""
+        thread_id = await _create_thread(v2_tool_server)
+        await _send(v2_tool_server, thread_id, "what time is it")
+
+        # The time tool returns a timestamp; the mock LLM summarizes it
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="tool returned",
+            timeout=30,
+        )
+
+        response = history["turns"][-1]["response"]
+        assert "returned" in response.lower(), (
+            f"Expected time tool result in response, got: {response[:200]}"
+        )
+
+    async def test_text_only(self, v2_tool_server):
+        """Non-tool message completes through v2 without tool calls."""
+        thread_id = await _create_thread(v2_tool_server)
+        await _send(v2_tool_server, thread_id, "What is 2+2?")
+
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="4",
+            timeout=20,
+        )
+
+        response = history["turns"][-1]["response"]
+        assert "4" in response
+
+
+# ---------------------------------------------------------------------------
+# Tests: parallel and multi-step
+# ---------------------------------------------------------------------------
+
+class TestV2EngineMultiTool:
+    """Verify multi-tool patterns through the v2 engine."""
+
+    async def test_parallel_tool_calls(self, v2_tool_server):
+        """Two tools dispatched in one LLM response both complete."""
+        thread_id = await _create_thread(v2_tool_server)
+        await _send(v2_tool_server, thread_id, "parallel echo and time")
+
+        # The mock LLM returns both tools, engine runs them, mock
+        # summarizes "Dispatched 2 tools: ...".
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="dispatched 2 tools",
+            timeout=45,
+        )
+
+        response = history["turns"][-1]["response"]
+        assert "parallel-test" in response, (
+            f"Expected echo result in parallel response, got: {response[:300]}"
+        )
+
+    async def test_multi_step_chain(self, v2_tool_server):
+        """Multi-step: echo -> result -> time -> result -> text completion.
+
+        The mock LLM returns echo first, waits for result, then returns
+        time, waits for result, then returns completion text. This
+        exercises the v2 engine's ability to handle sequential tool
+        chains without entering an infinite loop (the #2402 pattern).
+        """
+        thread_id = await _create_thread(v2_tool_server)
+        await _send(v2_tool_server, thread_id, "multi step echo then time")
+
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="multi-step complete",
+            timeout=60,
+        )
+
+        response = history["turns"][-1]["response"]
+        assert "multi-step complete" in response.lower(), (
+            f"Expected multi-step completion, got: {response[:200]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: multi-turn
+# ---------------------------------------------------------------------------
+
+class TestV2EngineMultiTurn:
+    """Verify tool usage across multiple conversation turns."""
+
+    async def test_tool_then_text_then_tool(self, v2_tool_server):
+        """Turn 1: echo tool. Turn 2: text question. Turn 3: time tool.
+
+        Verifies the v2 engine maintains conversation state and can
+        alternate between tool-using and text-only turns.
+        """
+        thread_id = await _create_thread(v2_tool_server)
+
+        # Turn 1: echo
+        await _send(v2_tool_server, thread_id, "echo first turn")
+        await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="first turn",
+            timeout=30,
+        )
+
+        # Turn 2: text-only
+        await _send(v2_tool_server, thread_id, "What is 2+2?")
+        await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="4",
+            min_turns=2,
+            timeout=30,
+        )
+
+        # Turn 3: time
+        await _send(v2_tool_server, thread_id, "what time is it")
+        history = await _wait_for_response(
+            v2_tool_server,
+            thread_id,
+            expect_substring="tool returned",
+            min_turns=3,
+            timeout=30,
+        )
+
+        assert len(history["turns"]) >= 3, (
+            f"Expected at least 3 turns, got {len(history['turns'])}"
+        )

--- a/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
+++ b/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
@@ -6,11 +6,6 @@ contract that was previously only covered for the v1 engine
 #2193 audit: zero engine-level e2e tests for the tool call -> result ->
 response path.
 
-NOTE: The v2 engine does not populate the ``tool_calls`` array in chat
-history (unlike v1). Tool results are embedded in the response text
-only. These tests verify tool execution through response content
-assertions. Fixing the ``tool_calls`` gap is tracked separately.
-
 Covers:
 1. Single tool call (echo) completes through v2
 2. Single tool call (time) completes through v2


### PR DESCRIPTION
## Summary
- The v2 engine had zero e2e coverage for the tool call -> result -> response path (flagged in #2193 audit)
- The v2 engine executed tools correctly but never persisted `tool_calls` metadata to the chat history DB, so the web UI showed empty tool call arrays for all v2 threads
- After thread completion, ActionResult messages are extracted from the thread's internal transcript and written as a `role="tool_calls"` DB row before the assistant response
- Unlike the existing `write_v1_response`, conversation ID resolution failures are logged rather than silently swallowed

## Test plan
- [x] `cargo clippy --no-default-features --features libsql -- -D warnings` -- zero warnings
- [x] 6 new e2e tests pass (`pytest tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py -v`)
- [x] 9 existing e2e tests unaffected (error_handling, tool_execution, agent_loop_recovery)
- [x] Manual verification: v2 chat history returns populated `tool_calls` array with correct names and result previews

```bash
# Manual verification
curl -s -H "Authorization: Bearer $TOKEN" \
  -X POST http://localhost:8080/api/chat/thread/new | jq .id

curl -s -H "Authorization: Bearer $TOKEN" \
  -X POST http://localhost:8080/api/chat/send \
  -H "Content-Type: application/json" \
  -d '{"content":"what time is it","thread_id":"<THREAD_ID>"}'

# Wait a few seconds, then:
curl -s -H "Authorization: Bearer $TOKEN" \
  "http://localhost:8080/api/chat/history?thread_id=<THREAD_ID>" \
  | jq '.turns[-1].tool_calls'
# Before: []
# After:  [{"name":"time","has_result":true,"result_preview":"..."}]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)