### PR TITLE
fix(oidc): make audience claim optional for OIDC-proxying load balancers

### DIFF
--- a/src/channels/web/platform/auth.rs
+++ b/src/channels/web/platform/auth.rs
@@ -865,17 +865,19 @@ async fn validate_oidc_jwt(oidc: &OidcState, jwt: &str) -> Result<String, OidcEr
     validation.insecure_disable_signature_validation();
 
     // Build the set of required claims. `exp` is required by default.
-    // When issuer/audience are configured, require their presence in the
-    // JWT — not just mismatch rejection — to prevent tokens that omit
-    // these claims entirely from passing validation.
+    // When issuer is configured, require its presence in the JWT.
     let mut required = vec!["exp".to_string()];
     if let Some(ref iss) = oidc.config.issuer {
         validation.set_issuer(&[iss]);
         required.push("iss".to_string());
     }
     if let Some(ref aud) = oidc.config.audience {
+        // Validate `aud` when present in the JWT, but do not require it.
+        // AWS ALB re-signs OIDC user-info into its own JWT (`x-amzn-oidc-data`)
+        // which omits the `aud` claim. Making `aud` required would reject
+        // all ALB-forwarded tokens even though the upstream IdP did validate
+        // the audience during the original OIDC flow.
         validation.set_audience(&[aud]);
-        required.push("aud".to_string());
     } else {
         validation.validate_aud = false;
     }
@@ -2395,7 +2397,10 @@ mod tests {
     /// We add `aud` to `required_spec_claims` when configured, so a JWT
     /// missing the claim entirely is now rejected (not just mismatches).
     #[tokio::test]
-    async fn test_oidc_audience_configured_but_missing_in_jwt_rejected() {
+    async fn test_oidc_audience_configured_but_missing_in_jwt_accepted() {
+        // AWS ALB re-signs OIDC tokens and omits `aud`. When the audience is
+        // configured but the JWT lacks the claim entirely, validation should
+        // still succeed — the audience check only fires when `aud` is present.
         let mut config = test_oidc_config();
         config.audience = Some("my-client-id".to_string());
         let oidc = test_oidc_state_with_config(config).await;
@@ -2405,8 +2410,8 @@ mod tests {
         );
         let result = validate_oidc_jwt(&oidc, &jwt).await;
         assert!(
-            result.is_err(),
-            "missing aud should be rejected when audience is configured"
+            result.is_ok(),
+            "missing aud should be accepted — ALB strips the claim"
         );
     }
 


### PR DESCRIPTION
## Summary

`set_required_spec_claims()` was introduced in #1798 to harden OIDC JWT validation. When `GATEWAY_OIDC_AUDIENCE` is configured, the `aud` claim is now **mandatory** — a JWT without it is rejected outright. This breaks all deployments that sit behind an OIDC-proxying load balancer.

This PR makes the `aud` claim **validated but not required**: if the JWT contains `aud`, it must match the configured audience; if the JWT omits `aud` entirely, validation succeeds.

## Problem

OIDC-proxying load balancers authenticate users via the standard OIDC authorization code flow (where the IdP validates `client_id`/audience), then re-sign the authenticated user's identity claims into a **new JWT** that is forwarded to the backend in a custom header. This re-signed JWT typically includes `sub`, `email`, `exp`, and `iss`, but **strips the `aud` claim** since it's an IdP-specific artifact that the downstream service doesn't need.

**Affected load balancers:**

| Load Balancer | Header | Strips `aud`? |
|---|---|---|
| **AWS Application Load Balancer** | `x-amzn-oidc-data` | Yes — ALB signs its own ES256 JWT with user claims, `aud` is omitted |
| **Google Cloud IAP** | `x-goog-iap-jwt-assertion` | Yes — IAP issues its own JWT; `aud` is `/projects/N/apps/A`, not the IdP client ID |
| **Azure Front Door** | `x-ms-token-*` | Varies — the forwarded token may or may not preserve `aud` depending on configuration |

### Concrete failure

With `GATEWAY_OIDC_ENABLED=true` and `GATEWAY_OIDC_AUDIENCE=<okta_client_id>`:

```
WARN OIDC auth failed error=claim validation failed: Missing required claim: aud
```

Every request is rejected. The `aud` claim simply does not exist in the ALB-signed JWT.

### Regression introduced by

PR #1798 (`feat(auth): direct OAuth/social login`) added this block at `src/channels/web/auth.rs:854-866`:

```rust
let mut required = vec!["exp".to_string()];
// ...
if let Some(ref aud) = oidc.config.audience {
    validation.set_audience(&[aud]);
    required.push("aud".to_string());  // <-- NEW: makes aud mandatory
}
validation.set_required_spec_claims(&required);
```

Prior to #1798, `set_audience()` was called but `aud` was not added to the required claims list. The `jsonwebtoken` crate's `set_audience()` only validates `aud` **if the claim is present** — it does not reject tokens that omit it. Adding `aud` to `set_required_spec_claims()` changed the behavior to reject tokens without the claim entirely.

## Fix

Remove `aud` from the `required` claims vector. Keep the `set_audience()` call so that:

- **JWT has `aud` matching config** → accepted (unchanged)
- **JWT has `aud` not matching config** → rejected (unchanged)
- **JWT omits `aud` entirely** → accepted (was rejected, now fixed)

```rust
if let Some(ref aud) = oidc.config.audience {
    // Validate aud when present, but don't require the claim.
    // OIDC-proxying LBs (AWS ALB, GCP IAP, Azure Front Door) strip
    // aud when re-signing tokens. The IdP already validated the
    // audience during the original OIDC authorization flow.
    validation.set_audience(&[aud]);
} else {
    validation.validate_aud = false;
}
```

## Security analysis

**Why this is safe:**

1. **The IdP already validated the audience.** In the OIDC authorization code flow, the IdP checks that the `client_id` in the authorization request matches a registered application. The load balancer only forwards authenticated users — it would not have completed the flow if the audience was wrong.

2. **The LB's own signature is the trust boundary.** The backend trusts the LB's JWT signature (verified via JWKS), not the `aud` claim. A valid signature from the LB means "I (the LB) authenticated this user via OIDC." The `aud` claim, if present, is supplementary.

3. **Mismatched `aud` is still rejected.** If a JWT *does* contain `aud` (e.g., from a direct IdP token that wasn't re-signed), `set_audience()` ensures it must match the configured value. This PR only relaxes the "claim must exist" requirement, not the "claim must match" requirement.

4. **`iss` validation is unaffected.** The issuer claim remains required when configured, providing provenance validation.

**What this does NOT do:**

- Does not disable audience validation — `set_audience()` is still called
- Does not affect issuer (`iss`) validation — still required when configured
- Does not affect expiry (`exp`) validation — still required
- Does not affect signature verification — still performed before claim validation

## Edge cases

| Scenario | Before this PR | After this PR |
|---|---|---|
| JWT has `aud` matching `GATEWAY_OIDC_AUDIENCE` | Accepted | Accepted |
| JWT has `aud` not matching `GATEWAY_OIDC_AUDIENCE` | Rejected | Rejected |
| JWT omits `aud`, `GATEWAY_OIDC_AUDIENCE` configured | **Rejected** | **Accepted** |
| JWT omits `aud`, `GATEWAY_OIDC_AUDIENCE` not configured | Accepted | Accepted |
| `GATEWAY_OIDC_ENABLED=false` | N/A (OIDC disabled) | N/A |

## Test plan

- [x] `test_oidc_audience_match_accepted` — JWT with matching `aud` passes
- [x] `test_oidc_audience_mismatch_rejected` — JWT with wrong `aud` fails
- [x] `test_oidc_audience_configured_but_missing_in_jwt_accepted` — JWT without `aud` passes (updated from `_rejected`)
- [x] `cargo clippy --all --all-features` — zero warnings
- [x] Tested with live AWS ALB + Okta deployment

## Context

- Original OIDC auth PR: #1463
- Regression introduced in: #1798

🤖 Generated with [Claude Code](https://claude.com/claude-code)