### PR TITLE
fix: restore issue-2402 v2 gate resume and action alias consistency

### DIFF
--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -700,6 +700,56 @@ mod tests {
         assert_eq!(result.results[1].call_id, "id_bbbb");
     }
 
+    #[tokio::test]
+    async fn alias_normalization_stays_consistent_between_preflight_and_consume() {
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+        let effects: Arc<dyn EffectExecutor> = Arc::new(MockEffects::new(
+            vec![test_action("create-issue")],
+            vec![Ok(ActionResult {
+                call_id: String::new(),
+                action_name: "create-issue".into(),
+                output: serde_json::json!({"ok": true}),
+                is_error: false,
+                duration: Duration::from_millis(1),
+            })],
+        ));
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(
+                thread.id,
+                "github",
+                GrantedActions::Specific(vec!["create_issue".into()]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let calls = vec![ActionCall {
+            id: "call_alias_consume".into(),
+            action_name: "create-issue".into(),
+            parameters: serde_json::json!({"title": "test"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].call_id, "call_alias_consume");
+        assert_eq!(result.results[0].action_name, "create-issue");
+        assert!(!result.results[0].is_error);
+    }
+
     // ── GatePaused(Authentication) tests ─────────────────────
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -106,7 +106,7 @@ pub async fn execute_action_calls(
             .available_actions(std::slice::from_ref(&lease))
             .await?
             .into_iter()
-            .find(|a| a.name == call.action_name);
+            .find(|a| action_name_matches(&a.name, &call.action_name));
 
         if let Some(ref action_def) = action_def {
             let decision = policy.evaluate(action_def, &lease, capability_policies);
@@ -411,6 +411,17 @@ fn classify_exec_result(
 
 fn interrupted_call_needs_refund(result: &Result<ActionResult, EngineError>) -> bool {
     matches!(result, Err(EngineError::GatePaused { .. }))
+}
+
+fn action_name_matches(candidate: &str, requested: &str) -> bool {
+    if candidate == requested {
+        return true;
+    }
+
+    let candidate_hyphenated = candidate.replace('_', "-");
+    let candidate_underscored = candidate.replace('-', "_");
+
+    requested == candidate_hyphenated || requested == candidate_underscored
 }
 
 #[cfg(test)]
@@ -748,6 +759,84 @@ mod tests {
         assert_eq!(result.results[0].call_id, "call_alias_consume");
         assert_eq!(result.results[0].action_name, "create-issue");
         assert!(!result.results[0].is_error);
+    }
+
+    #[tokio::test]
+    async fn aliased_action_name_still_triggers_policy_approval() {
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+        let effects: Arc<dyn EffectExecutor> = Arc::new(MockEffects::new(
+            vec![ActionDef {
+                name: "create_issue".into(),
+                description: "Create issue".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![EffectType::WriteExternal],
+                requires_approval: true,
+            }],
+            vec![Ok(ActionResult {
+                call_id: String::new(),
+                action_name: "create_issue".into(),
+                output: serde_json::json!({"ok": true}),
+                is_error: false,
+                duration: Duration::from_millis(1),
+            })],
+        ));
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(
+                thread.id,
+                "github",
+                GrantedActions::Specific(vec!["create_issue".into()]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let calls = vec![ActionCall {
+            id: "call_alias_policy".into(),
+            action_name: "create-issue".into(),
+            parameters: serde_json::json!({"title": "policy should still apply"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        match result.need_approval {
+            Some(ThreadOutcome::GatePaused {
+                gate_name,
+                action_name,
+                call_id,
+                ..
+            }) => {
+                assert_eq!(gate_name, "approval");
+                assert_eq!(action_name, "create-issue");
+                assert_eq!(call_id, "call_alias_policy");
+            }
+            other => panic!("expected approval gate for aliased action, got {other:?}"),
+        }
+
+        assert!(
+            result.results.is_empty(),
+            "policy preflight should pause before executing the aliased action"
+        );
+        assert!(
+            result.events.iter().any(|event| matches!(
+                event,
+                EventKind::ApprovalRequested { action_name, call_id, .. }
+                    if action_name == "create-issue" && call_id == "call_alias_policy"
+            )),
+            "approval event should use the aliased action name and original call id"
+        );
     }
 
     // ── GatePaused(Authentication) tests ─────────────────────

--- a/crates/ironclaw_engine/src/types/capability.rs
+++ b/crates/ironclaw_engine/src/types/capability.rs
@@ -30,9 +30,13 @@ pub enum GrantedActions {
 impl GrantedActions {
     /// Check whether a specific action is covered.
     pub fn covers(&self, action_name: &str) -> bool {
+        let hyphenated = action_name.replace('_', "-");
+        let underscored = action_name.replace('-', "_");
         match self {
             GrantedActions::All => true,
-            GrantedActions::Specific(actions) => actions.iter().any(|a| a == action_name),
+            GrantedActions::Specific(actions) => actions.iter().any(|action| {
+                action == action_name || action == &hyphenated || action == &underscored
+            }),
         }
     }
 
@@ -344,5 +348,15 @@ mod tests {
         assert!(lease.covers_action("create_issue"));
         assert!(lease.covers_action("list_prs"));
         assert!(!lease.covers_action("delete_repo"));
+    }
+
+    #[test]
+    fn covers_action_matches_hyphen_underscore_aliases() {
+        let mut lease = make_lease();
+        lease.granted_actions = GrantedActions::Specific(vec!["create_issue".into()]);
+        assert!(lease.covers_action("create-issue"));
+
+        lease.granted_actions = GrantedActions::Specific(vec!["list-prs".into()]);
+        assert!(lease.covers_action("list_prs"));
     }
 }

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -405,7 +405,9 @@ impl Agent {
                                 .iter()
                                 .any(|rule| rule.action == ironclaw_safety::PolicyAction::Block)
                             {
-                                return Ok(SubmissionResult::error("Input rejected by safety policy."));
+                                return Ok(SubmissionResult::error(
+                                    "Input rejected by safety policy.",
+                                ));
                             }
                             if let Some(warning) = self.safety().scan_inbound_for_secrets(content) {
                                 tracing::warn!(
@@ -426,7 +428,8 @@ impl Agent {
                             // acknowledgment, not a completed LLM turn.
                             return Ok(SubmissionResult::Ok {
                                 message: Some(
-                                    "Message queued — will be processed after the current turn.".into(),
+                                    "Message queued — will be processed after the current turn."
+                                        .into(),
                                 ),
                             });
                         }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -191,7 +191,10 @@ fn resolved_call_id_for_pending_action(
     // writes ActionResult messages to `internal_messages` via
     // `sync_runtime_state`, so scanning only `messages` would leave the
     // resolved-ids set empty and the fallback would never match.
-    let all_messages = thread.messages.iter().chain(thread.internal_messages.iter());
+    let all_messages = thread
+        .messages
+        .iter()
+        .chain(thread.internal_messages.iter());
 
     let resolved_ids: HashSet<&str> = all_messages
         .clone()

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -218,6 +218,28 @@ pub(super) fn synthetic_action_call_id(action_name: &str) -> String {
     format!("synthetic-{}-{}", action_name, uuid::Uuid::new_v4())
 }
 
+async fn resolved_or_synthetic_call_id_for_pending_action(
+    state: &EngineState,
+    pending: &PendingGate,
+) -> Result<String, Error> {
+    let thread = state
+        .store
+        .load_thread(pending.thread_id)
+        .await
+        .map_err(|e| engine_err("load thread", e))?
+        .ok_or_else(|| engine_err("load thread", "thread not found"))?;
+
+    Ok(resolved_call_id_for_pending_action(&thread, pending).unwrap_or_else(|| {
+        tracing::warn!(
+            action = %pending.action_name,
+            thread_id = %pending.thread_id,
+            "no historical call_id for pending gate; synthesizing one to keep \
+             ActionResult correlator non-empty"
+        );
+        synthetic_action_call_id(&pending.action_name)
+    }))
+}
+
 /// Validate a credential identifier shape: non-empty, ≤64 chars, ASCII
 /// alphanumeric or underscore only. Used by the auth-fallback parser to
 /// reject anything that isn't structurally a credential name before it's
@@ -365,16 +387,7 @@ async fn execute_pending_gate_action(
         .await
         .map_err(|e| engine_err("load thread", e))?
         .ok_or_else(|| engine_err("load thread", "thread not found"))?;
-    let resolved_call_id =
-        resolved_call_id_for_pending_action(&thread, pending).unwrap_or_else(|| {
-            tracing::warn!(
-                action = %pending.action_name,
-                thread_id = %pending.thread_id,
-                "no historical call_id for pending gate; synthesizing one to keep \
-                 ActionResult correlator non-empty"
-            );
-            synthetic_action_call_id(&pending.action_name)
-        });
+    let resolved_call_id = resolved_or_synthetic_call_id_for_pending_action(state, pending).await?;
 
     let lease = state
         .thread_manager
@@ -1759,18 +1772,20 @@ pub async fn resolve_gate(
                 }
 
                 if let Some(resume_output) = pending.resume_output.clone() {
+                    let resolved_call_id =
+                        resolved_or_synthetic_call_id_for_pending_action(state, &pending).await?;
                     state
                         .thread_manager
                         .resume_thread(
                             pending.thread_id,
                             message.user_id.clone(),
                             Some(resumed_action_result_message(
-                                &pending.call_id,
+                                &resolved_call_id,
                                 &pending.action_name,
                                 &resume_output,
                             )),
                             None,
-                            Some(pending.call_id.clone()),
+                            Some(resolved_call_id),
                         )
                         .await
                         .map_err(|e| engine_err("resume error", e))?;
@@ -1811,18 +1826,20 @@ pub async fn resolve_gate(
                 );
             }
             if let Some(resume_output) = pending.resume_output.clone() {
+                let resolved_call_id =
+                    resolved_or_synthetic_call_id_for_pending_action(state, &pending).await?;
                 state
                     .thread_manager
                     .resume_thread(
                         pending.thread_id,
                         message.user_id.clone(),
                         Some(resumed_action_result_message(
-                            &pending.call_id,
+                            &resolved_call_id,
                             &pending.action_name,
                             &resume_output,
                         )),
                         None,
-                        Some(pending.call_id.clone()),
+                        Some(resolved_call_id),
                     )
                     .await
                     .map_err(|e| engine_err("resume error", e))?;
@@ -4991,6 +5008,71 @@ mod tests {
         (agent, statuses)
     }
 
+    fn make_expected_test_state_with_llm(
+        store: Arc<TestStore>,
+        llm: Arc<dyn ironclaw_engine::LlmBackend>,
+    ) -> EngineState {
+        use ironclaw_engine::{
+            CapabilityRegistry, ConversationManager, LeaseManager, PolicyEngine, ThreadManager,
+        };
+
+        struct NoopEffects;
+        #[async_trait::async_trait]
+        impl ironclaw_engine::EffectExecutor for NoopEffects {
+            async fn execute_action(
+                &self,
+                _: &str,
+                _: serde_json::Value,
+                _: &ironclaw_engine::CapabilityLease,
+                _: &ironclaw_engine::ThreadExecutionContext,
+            ) -> Result<ironclaw_engine::ActionResult, ironclaw_engine::EngineError> {
+                unreachable!()
+            }
+            async fn available_actions(
+                &self,
+                _: &[ironclaw_engine::CapabilityLease],
+            ) -> Result<Vec<ironclaw_engine::ActionDef>, ironclaw_engine::EngineError> {
+                Ok(vec![])
+            }
+        }
+
+        let store_dyn: Arc<dyn Store> = store;
+        let effect_adapter = Arc::new(EffectBridgeAdapter::new(
+            Arc::new(crate::tools::ToolRegistry::new()),
+            Arc::new(ironclaw_safety::SafetyLayer::new(
+                &ironclaw_safety::SafetyConfig {
+                    max_output_length: 10_000,
+                    injection_check_enabled: false,
+                },
+            )),
+            Arc::new(crate::hooks::HookRegistry::default()),
+        ));
+
+        let tm = Arc::new(ThreadManager::new(
+            llm,
+            Arc::new(NoopEffects),
+            store_dyn.clone(),
+            Arc::new(CapabilityRegistry::new()),
+            Arc::new(LeaseManager::new()),
+            Arc::new(PolicyEngine::new()),
+        ));
+
+        let cm = Arc::new(ConversationManager::new(Arc::clone(&tm), store_dyn.clone()));
+
+        EngineState {
+            thread_manager: tm,
+            conversation_manager: cm,
+            effect_adapter,
+            store: store_dyn,
+            default_project_id: ironclaw_engine::ProjectId::new(),
+            pending_gates: Arc::new(crate::gate::store::PendingGateStore::in_memory()),
+            sse: None,
+            db: None,
+            secrets_store: None,
+            auth_manager: None,
+        }
+    }
+
     #[tokio::test]
     async fn handle_with_engine_reemits_approval_status_for_pending_gate() {
         let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
@@ -5053,6 +5135,152 @@ mod tests {
 
         *lock.write().await = None;
         outcome.expect("router approval re-emit test");
+    }
+
+    #[tokio::test]
+    async fn resolve_gate_repairs_call_id_for_resume_output_auth_resume() {
+        struct InspectingLlm {
+            expected_call_id: String,
+        }
+
+        #[async_trait::async_trait]
+        impl ironclaw_engine::LlmBackend for InspectingLlm {
+            async fn complete(
+                &self,
+                messages: &[ironclaw_engine::ThreadMessage],
+                _: &[ironclaw_engine::ActionDef],
+                _: &ironclaw_engine::LlmCallConfig,
+            ) -> Result<ironclaw_engine::LlmOutput, ironclaw_engine::EngineError> {
+                let matched = messages.iter().any(|message| {
+                    message.role == ironclaw_engine::MessageRole::ActionResult
+                        && message.action_name.as_deref() == Some("shell")
+                        && message.action_call_id.as_deref()
+                            == Some(self.expected_call_id.as_str())
+                });
+
+                Ok(ironclaw_engine::LlmOutput {
+                    response: ironclaw_engine::LlmResponse::Text(if matched {
+                        "paired".into()
+                    } else {
+                        "missing-pairing".into()
+                    }),
+                    usage: ironclaw_engine::TokenUsage::default(),
+                })
+            }
+
+            fn model_name(&self) -> &str {
+                "inspect-call-id"
+            }
+        }
+
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(InspectingLlm {
+                expected_call_id: "call-2".to_string(),
+            });
+
+            let mut thread = ironclaw_engine::Thread::new(
+                "goal",
+                ironclaw_engine::ThreadType::Foreground,
+                ironclaw_engine::ProjectId::new(),
+                "alice",
+                ironclaw_engine::ThreadConfig::default(),
+            );
+            thread.add_message(ironclaw_engine::ThreadMessage::assistant_with_actions(
+                Some("parallel shell calls".to_string()),
+                vec![
+                    ironclaw_engine::ActionCall {
+                        id: "call-1".to_string(),
+                        action_name: "shell".to_string(),
+                        parameters: serde_json::json!({"cmd": "pwd"}),
+                    },
+                    ironclaw_engine::ActionCall {
+                        id: "call-2".to_string(),
+                        action_name: "shell".to_string(),
+                        parameters: serde_json::json!({"cmd": "ls"}),
+                    },
+                ],
+            ));
+            thread.add_message(ironclaw_engine::ThreadMessage::action_result(
+                "call-1",
+                "shell",
+                "{\"ok\":true}",
+            ));
+            thread.state = ironclaw_engine::ThreadState::Waiting;
+            store.save_thread(&thread).await.expect("save waiting thread");
+
+            let mut conversation = ironclaw_engine::ConversationSurface::new("web", "alice");
+            conversation.track_thread(thread.id);
+            let conversation_id = conversation.id;
+            store
+                .save_conversation(&conversation)
+                .await
+                .expect("save conversation");
+
+            let state = make_expected_test_state_with_llm(store.clone(), llm);
+            state
+                .conversation_manager
+                .bootstrap_user("alice")
+                .await
+                .expect("bootstrap conversations");
+
+            let pending = PendingGate {
+                call_id: String::new(),
+                conversation_id,
+                action_name: "shell".into(),
+                parameters: serde_json::json!({"cmd": "ls"}),
+                resume_kind: ironclaw_engine::ResumeKind::Authentication {
+                    credential_name: "github_token".into(),
+                    instructions: "paste token".into(),
+                    auth_url: None,
+                },
+                resume_output: Some(serde_json::json!({"ok": true})),
+                ..sample_pending_gate(
+                    "alice",
+                    thread.id,
+                    ironclaw_engine::ResumeKind::Authentication {
+                        credential_name: "github_token".into(),
+                        instructions: "paste token".into(),
+                        auth_url: None,
+                    },
+                )
+            };
+            state
+                .pending_gates
+                .insert(pending.clone())
+                .await
+                .expect("insert pending gate");
+
+            *lock.write().await = Some(state);
+
+            let (agent, _statuses) = make_test_agent_with_status_channel("web").await;
+            let message = IncomingMessage::new("web", "alice", "token")
+                .with_thread(thread.id.to_string());
+
+            let result = resolve_gate(
+                &agent,
+                &message,
+                thread.id,
+                pending.request_id,
+                ironclaw_engine::GateResolution::CredentialProvided {
+                    token: "secret-token".into(),
+                },
+            )
+            .await
+            .expect("resolve gate");
+
+            assert_eq!(result.as_deref(), Some("paired"));
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("router auth resume_output call-id repair test");
     }
 
     /// find_most_recent_thread returns the active thread when one exists.

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -229,15 +229,17 @@ async fn resolved_or_synthetic_call_id_for_pending_action(
         .map_err(|e| engine_err("load thread", e))?
         .ok_or_else(|| engine_err("load thread", "thread not found"))?;
 
-    Ok(resolved_call_id_for_pending_action(&thread, pending).unwrap_or_else(|| {
-        tracing::warn!(
-            action = %pending.action_name,
-            thread_id = %pending.thread_id,
-            "no historical call_id for pending gate; synthesizing one to keep \
-             ActionResult correlator non-empty"
-        );
-        synthetic_action_call_id(&pending.action_name)
-    }))
+    Ok(
+        resolved_call_id_for_pending_action(&thread, pending).unwrap_or_else(|| {
+            tracing::warn!(
+                action = %pending.action_name,
+                thread_id = %pending.thread_id,
+                "no historical call_id for pending gate; synthesizing one to keep \
+                 ActionResult correlator non-empty"
+            );
+            synthetic_action_call_id(&pending.action_name)
+        }),
+    )
 }
 
 /// Validate a credential identifier shape: non-empty, ≤64 chars, ASCII
@@ -5154,8 +5156,7 @@ mod tests {
                 let matched = messages.iter().any(|message| {
                     message.role == ironclaw_engine::MessageRole::ActionResult
                         && message.action_name.as_deref() == Some("shell")
-                        && message.action_call_id.as_deref()
-                            == Some(self.expected_call_id.as_str())
+                        && message.action_call_id.as_deref() == Some(self.expected_call_id.as_str())
                 });
 
                 Ok(ironclaw_engine::LlmOutput {
@@ -5211,7 +5212,10 @@ mod tests {
                 "{\"ok\":true}",
             ));
             thread.state = ironclaw_engine::ThreadState::Waiting;
-            store.save_thread(&thread).await.expect("save waiting thread");
+            store
+                .save_thread(&thread)
+                .await
+                .expect("save waiting thread");
 
             let mut conversation = ironclaw_engine::ConversationSurface::new("web", "alice");
             conversation.track_thread(thread.id);
@@ -5258,8 +5262,8 @@ mod tests {
             *lock.write().await = Some(state);
 
             let (agent, _statuses) = make_test_agent_with_status_channel("web").await;
-            let message = IncomingMessage::new("web", "alice", "token")
-                .with_thread(thread.id.to_string());
+            let message =
+                IncomingMessage::new("web", "alice", "token").with_thread(thread.id.to_string());
 
             let result = resolve_gate(
                 &agent,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -186,9 +186,15 @@ fn resolved_call_id_for_pending_action(
         return Some(pending.call_id.clone());
     }
 
-    let resolved_ids: HashSet<&str> = thread
-        .messages
-        .iter()
+    // Scan both user-visible `messages` AND `internal_messages` (the
+    // orchestrator's working transcript).  In production the orchestrator
+    // writes ActionResult messages to `internal_messages` via
+    // `sync_runtime_state`, so scanning only `messages` would leave the
+    // resolved-ids set empty and the fallback would never match.
+    let all_messages = thread.messages.iter().chain(thread.internal_messages.iter());
+
+    let resolved_ids: HashSet<&str> = all_messages
+        .clone()
         .filter_map(|message| {
             (message.role == ironclaw_engine::types::message::MessageRole::ActionResult)
                 .then_some(message.action_call_id.as_deref())
@@ -196,7 +202,7 @@ fn resolved_call_id_for_pending_action(
         })
         .collect();
 
-    thread.messages.iter().rev().find_map(|message| {
+    all_messages.rev().find_map(|message| {
         if message.role != ironclaw_engine::types::message::MessageRole::Assistant {
             return None;
         }
@@ -4728,6 +4734,58 @@ mod tests {
             )
         };
 
+        assert_eq!(
+            resolved_call_id_for_pending_action(&thread, &pending),
+            Some("call-2".to_string())
+        );
+    }
+
+    /// Regression: in production the orchestrator writes ActionResult and
+    /// assistant-with-actions messages to `internal_messages` via
+    /// `sync_runtime_state`, not `messages`.  The legacy fallback must scan
+    /// `internal_messages` to find unresolved call ids.
+    #[test]
+    fn resolved_call_id_legacy_fallback_scans_internal_messages() {
+        let mut thread = ironclaw_engine::Thread::new(
+            "goal",
+            ironclaw_engine::ThreadType::Foreground,
+            ironclaw_engine::ProjectId::new(),
+            "alice",
+            ironclaw_engine::ThreadConfig::default(),
+        );
+
+        // Simulate production: assistant + action results in internal_messages
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::assistant_with_actions(
+            Some("parallel shell calls".to_string()),
+            vec![
+                ironclaw_engine::ActionCall {
+                    id: "call-1".to_string(),
+                    action_name: "shell".to_string(),
+                    parameters: serde_json::json!({"cmd": "pwd"}),
+                },
+                ironclaw_engine::ActionCall {
+                    id: "call-2".to_string(),
+                    action_name: "shell".to_string(),
+                    parameters: serde_json::json!({"cmd": "ls"}),
+                },
+            ],
+        ));
+        thread.add_internal_message(ironclaw_engine::ThreadMessage::action_result(
+            "call-1",
+            "shell",
+            "{\"ok\":true}",
+        ));
+
+        let pending = PendingGate {
+            call_id: String::new(),
+            ..sample_pending_gate(
+                "alice",
+                thread.id,
+                ironclaw_engine::ResumeKind::Approval { allow_always: true },
+            )
+        };
+
+        // Before the fix this returned None because only `messages` was scanned.
         assert_eq!(
             resolved_call_id_for_pending_action(&thread, &pending),
             Some("call-2".to_string())

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -167,6 +167,94 @@ impl GateMockEffects {
     }
 }
 
+struct InstallThenAliasEffects {
+    calls: RwLock<Vec<(String, serde_json::Value)>>,
+    authenticated: RwLock<std::collections::HashSet<String>>,
+}
+
+impl InstallThenAliasEffects {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            calls: RwLock::new(Vec::new()),
+            authenticated: RwLock::new(std::collections::HashSet::new()),
+        })
+    }
+
+    async fn mark_authenticated(&self, action_name: &str) {
+        self.authenticated
+            .write()
+            .await
+            .insert(action_name.to_string());
+    }
+
+    async fn recorded_calls(&self) -> Vec<(String, serde_json::Value)> {
+        self.calls.read().await.clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl EffectExecutor for InstallThenAliasEffects {
+    async fn execute_action(
+        &self,
+        action_name: &str,
+        parameters: serde_json::Value,
+        _lease: &CapabilityLease,
+        _context: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<ActionResult, EngineError> {
+        self.calls
+            .write()
+            .await
+            .push((action_name.to_string(), parameters.clone()));
+
+        if action_name == "tool_install"
+            && !self.authenticated.read().await.contains("tool_install")
+        {
+            return Err(EngineError::GatePaused {
+                gate_name: "authentication".into(),
+                action_name: action_name.to_string(),
+                call_id: "call_install_1".into(),
+                parameters: Box::new(parameters),
+                resume_kind: Box::new(ResumeKind::Authentication {
+                    credential_name: "github".into(),
+                    instructions: "Authenticate GitHub".into(),
+                    auth_url: None,
+                }),
+                resume_output: None,
+            });
+        }
+
+        Ok(ActionResult {
+            call_id: String::new(),
+            action_name: action_name.to_string(),
+            output: serde_json::json!({"status": "ok", "action": action_name}),
+            is_error: false,
+            duration: Duration::from_millis(1),
+        })
+    }
+
+    async fn available_actions(
+        &self,
+        _leases: &[CapabilityLease],
+    ) -> Result<Vec<ActionDef>, EngineError> {
+        Ok(vec![
+            ActionDef {
+                name: "tool_install".into(),
+                description: "Install a tool".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![EffectType::WriteExternal],
+                requires_approval: false,
+            },
+            ActionDef {
+                name: "create-issue".into(),
+                description: "Create an issue after install".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![EffectType::WriteExternal],
+                requires_approval: false,
+            },
+        ])
+    }
+}
+
 #[async_trait::async_trait]
 impl EffectExecutor for GateMockEffects {
     async fn execute_action(
@@ -503,6 +591,33 @@ fn make_caps_with_approval_tool() -> CapabilityRegistry {
             effects: vec![EffectType::WriteExternal],
             requires_approval: false,
         }],
+        knowledge: vec![],
+        policies: vec![],
+    });
+    caps
+}
+
+fn make_caps_with_install_and_alias_followup() -> CapabilityRegistry {
+    let mut caps = CapabilityRegistry::new();
+    caps.register(Capability {
+        name: "tools".into(),
+        description: "test tools".into(),
+        actions: vec![
+            ActionDef {
+                name: "tool_install".into(),
+                description: "Install a tool".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![EffectType::WriteExternal],
+                requires_approval: false,
+            },
+            ActionDef {
+                name: "create_issue".into(),
+                description: "Create a follow-up issue".into(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![EffectType::WriteExternal],
+                requires_approval: false,
+            },
+        ],
         knowledge: vec![],
         policies: vec![],
     });
@@ -1157,6 +1272,134 @@ async fn approval_chains_directly_into_auth_for_install_flow() {
         install_calls, 3,
         "install flow should retry once for approval and once for auth"
     );
+}
+
+#[tokio::test]
+async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_hanging() {
+    let project_id = ProjectId::new();
+    let effects = InstallThenAliasEffects::new();
+
+    let llm = ScriptedLlm::new(vec![
+        LlmOutput {
+            response: LlmResponse::ActionCalls {
+                calls: vec![ironclaw_engine::ActionCall {
+                    id: "call_install_1".into(),
+                    action_name: "tool_install".into(),
+                    parameters: serde_json::json!({"kind": "mcp_server", "name": "github"}),
+                }],
+                content: None,
+            },
+            usage: TokenUsage::default(),
+        },
+        LlmOutput {
+            response: LlmResponse::ActionCalls {
+                calls: vec![ironclaw_engine::ActionCall {
+                    id: "call_followup_1".into(),
+                    action_name: "create-issue".into(),
+                    parameters: serde_json::json!({"title": "Issue after install"}),
+                }],
+                content: None,
+            },
+            usage: TokenUsage::default(),
+        },
+        LlmOutput {
+            response: LlmResponse::Text("done".into()),
+            usage: TokenUsage::default(),
+        },
+    ]);
+
+    let store = TestStore::new();
+    let mgr = ThreadManager::new(
+        llm,
+        effects.clone(),
+        store.clone() as Arc<dyn Store>,
+        Arc::new(make_caps_with_install_and_alias_followup()),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    );
+
+    let tid = mgr
+        .spawn_thread(
+            "install github and then create an issue",
+            ThreadType::Foreground,
+            project_id,
+            ThreadConfig::default(),
+            None,
+            "test-user",
+        )
+        .await
+        .expect("spawn_thread");
+
+    let first = mgr.join_thread(tid).await.expect("first join");
+    assert!(matches!(first, ThreadOutcome::GatePaused { .. }));
+    assert_eq!(
+        store.load_thread(tid).await.unwrap().unwrap().state,
+        ThreadState::Waiting
+    );
+
+    let thread = store.load_thread(tid).await.unwrap().unwrap();
+    let lease = mgr
+        .leases
+        .find_lease_for_action(tid, "tool_install")
+        .await
+        .expect("lease for tool_install");
+    let exec_ctx = ironclaw_engine::ThreadExecutionContext {
+        thread_id: tid,
+        thread_type: thread.thread_type,
+        project_id: thread.project_id,
+        user_id: "test-user".into(),
+        step_id: ironclaw_engine::StepId::new(),
+        current_call_id: Some("call_install_1".into()),
+        source_channel: None,
+        user_timezone: None,
+    };
+
+    effects.mark_authenticated("tool_install").await;
+    let install_result = effects
+        .execute_action(
+            "tool_install",
+            serde_json::json!({"kind": "mcp_server", "name": "github"}),
+            &lease,
+            &exec_ctx,
+        )
+        .await
+        .expect("authenticated install should complete directly");
+    mgr.resume_thread(
+        tid,
+        "test-user",
+        Some(resumed_action_result_message(
+            "call_install_1",
+            "tool_install",
+            &install_result.output,
+        )),
+        None,
+        Some("call_install_1".into()),
+    )
+    .await
+    .expect("resume after auth");
+
+    let outcome = mgr.join_thread(tid).await.expect("second join");
+    match outcome {
+        ThreadOutcome::Completed { response } => {
+            assert_eq!(response.as_deref(), Some("done"));
+        }
+        other => panic!("expected completion after auth + aliased follow-up call, got {other:?}"),
+    }
+
+    let saved = store.load_thread(tid).await.unwrap().unwrap();
+    assert_eq!(saved.state, ThreadState::Done);
+
+    let calls = effects.recorded_calls().await;
+    let install_calls = calls
+        .iter()
+        .filter(|(name, _)| name == "tool_install")
+        .count();
+    let followup_calls = calls
+        .iter()
+        .filter(|(name, _)| name == "create-issue")
+        .count();
+    assert_eq!(install_calls, 2, "install should be retried once after auth");
+    assert_eq!(followup_calls, 1, "aliased follow-up tool should execute once");
 }
 
 // ── Tests: PendingGateStore full lifecycle ────────────────────

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -1398,8 +1398,14 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
         .iter()
         .filter(|(name, _)| name == "create-issue")
         .count();
-    assert_eq!(install_calls, 2, "install should be retried once after auth");
-    assert_eq!(followup_calls, 1, "aliased follow-up tool should execute once");
+    assert_eq!(
+        install_calls, 2,
+        "install should be retried once after auth"
+    );
+    assert_eq!(
+        followup_calls, 1,
+        "aliased follow-up tool should execute once"
+    );
 }
 
 // ── Tests: PendingGateStore full lifecycle ────────────────────


### PR DESCRIPTION
## Summary
- add a staging regression for auth/external gate resumes that proved v2 could lose `ActionResult` call pairing when `pending.call_id` was empty or stale, then fix the resume branches to resolve or synthesize the correct correlator before resuming the thread
- add a staging regression for hyphen/underscore action aliases in the real structured executor path, then make granted-action matching consistent so lease preflight, policy, and consumption agree on aliased action names
- validate the fixes with targeted staging regressions, adjacent router/capability tests, and `cargo check -p ironclaw_engine -p ironclaw`

## Validation
- cargo test -p ironclaw_engine alias_normalization_stays_consistent_between_preflight_and_consume
- cargo test -p ironclaw covers_action
- cargo test -p ironclaw resolve_gate_repairs_call_id_for_resume_output_auth_resume
- cargo test -p ironclaw resolved_call_id_
- cargo test -p ironclaw handle_with_engine_reemits_approval_status_for_pending_gate
- cargo check -p ironclaw_engine -p ironclaw