### PR TITLE
fix(engine): guard consecutive-error checks against None limit

### DIFF
--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -467,6 +467,7 @@ def run_loop(context, goal, actions, state, config):
     max_iterations = config.get("max_iterations", 30)
     max_nudges = config.get("max_tool_intent_nudges", 2)
     nudge_enabled = config.get("enable_tool_intent_nudge", True)
+    # None means "no limit" — callers can disable the guard explicitly.
     max_consecutive_errors = config.get("max_consecutive_errors", 5)
     consecutive_nudges = 0
     consecutive_errors = 0
@@ -657,7 +658,7 @@ def run_loop(context, goal, actions, state, config):
             # Track consecutive errors
             if result.get("had_error"):
                 consecutive_errors += 1
-                if consecutive_errors >= max_consecutive_errors:
+                if max_consecutive_errors is not None and consecutive_errors >= max_consecutive_errors:
                     __transition_to__("failed", "too many consecutive errors")
                     return complete_result(
                         state,
@@ -866,14 +867,14 @@ def run_loop(context, goal, actions, state, config):
             elif batch_error_count > 0:
                 consecutive_action_errors += 1
 
-            if consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors + 2:
+            if max_consecutive_errors is not None and consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors + 2:
                 __transition_to__("failed", "too many consecutive action errors")
                 return complete_result(
                     state,
                     "failed",
                     error=str(consecutive_action_errors) + " consecutive action errors — all recent tool calls failed",
                 )
-            elif consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors:
+            elif max_consecutive_errors is not None and consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors:
                 append_message(
                     working_messages,
                     "User",

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -3655,6 +3655,56 @@ else:
     }
 
     #[test]
+    fn action_errors_none_limit_skips_check_without_typeerror() {
+        // Regression: when max_consecutive_errors is None (meaning "no limit"),
+        // the arithmetic `max_consecutive_errors + 2` used to crash with
+        // TypeError on the first action error. The guard must short-circuit
+        // on None and leave both the nudge and failure branches untaken.
+        let result = eval_python_int(
+            r#"
+max_consecutive_errors = None
+consecutive_action_errors = 1
+nudge = False
+failed = False
+if max_consecutive_errors is not None and consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors + 2:
+    failed = True
+elif max_consecutive_errors is not None and consecutive_action_errors > 0 and consecutive_action_errors >= max_consecutive_errors:
+    nudge = True
+# Return 0=nothing, 1=nudge, 2=failed
+if failed:
+    FINAL(2)
+elif nudge:
+    FINAL(1)
+else:
+    FINAL(0)
+"#,
+        );
+        assert_eq!(result, 0, "None limit should disable the guard entirely");
+    }
+
+    #[test]
+    fn code_errors_none_limit_skips_failure_check() {
+        // Regression: same None-guard for the code-error branch at line 660.
+        let result = eval_python_int(
+            r#"
+max_consecutive_errors = None
+consecutive_errors = 99
+failed = False
+if max_consecutive_errors is not None and consecutive_errors >= max_consecutive_errors:
+    failed = True
+if failed:
+    FINAL(1)
+else:
+    FINAL(0)
+"#,
+        );
+        assert_eq!(
+            result, 0,
+            "None limit should not trigger failure regardless of consecutive_errors"
+        );
+    }
+
+    #[test]
     fn action_error_prefix_added_to_error_output() {
         // Verify that [ACTION FAILED] prefix is prepended to error outputs.
         // Returns 1 if prefix present, 0 if not.

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -156,7 +156,7 @@ impl Default for ThreadConfig {
             enable_tool_intent_nudge: true,
             max_tool_intent_nudges: 2,
             max_tokens_total: None,
-            max_consecutive_errors: None,
+            max_consecutive_errors: Some(5),
             max_budget_usd: None,
             model_context_limit: 128_000,
             enable_compaction: false,
@@ -368,6 +368,17 @@ mod tests {
     }
 
     // ── State machine tests ─────────────────────────────────
+
+    #[test]
+    fn default_config_has_concrete_consecutive_error_limit() {
+        // Regression: a None default serializes to null and makes the Python
+        // orchestrator's `consecutive_action_errors >= max_consecutive_errors + 2`
+        // guard crash with TypeError on the first action error, since
+        // dict.get("key", 5) returns None (not 5) when the key is present
+        // with a null value.
+        let config = ThreadConfig::default();
+        assert_eq!(config.max_consecutive_errors, Some(5));
+    }
 
     #[test]
     fn created_can_transition_to_running() {


### PR DESCRIPTION
## Summary
- `ThreadConfig::default()` had `max_consecutive_errors: None`, which serializes to `null`. In the Python orchestrator, `config.get("max_consecutive_errors", 5)` returns `None` (not `5`) when the key is present with a null value, so `consecutive_action_errors >= max_consecutive_errors + 2` crashed with TypeError on the first action error (e.g. a missing `commitments/README.md` on `memory_read`).
- Fixed on both sides: Rust default is now `Some(5)` so callers using `ThreadConfig::default()` send a real int; Python guards (`default.py:661`, `:870`, `:877`) now short-circuit on `None` and treat it as "no limit", matching the `Option<u32>` semantics used elsewhere (`max_tokens_total`, `max_budget_usd`).

## Test plan
- [x] `cargo test -p ironclaw_engine --lib -- default_config_has_concrete none_limit` — new regression tests cover the Rust default and both Python guards (action errors + code errors) with `max_consecutive_errors = None`
- [x] `cargo check -p ironclaw_engine` clean
- [x] `cargo fmt`