### PR TITLE
fix(llm): normalize NEAR AI tool schemas

### DIFF
--- a/src/llm/CLAUDE.md
+++ b/src/llm/CLAUDE.md
@@ -92,6 +92,8 @@ ID, migrate to it immediately. Advanced users can override headers via
 
 **Tool message flattening:** NEAR AI's API doesn't support `role: "tool"` messages in the standard format. `nearai_chat.rs` defaults `flatten_tool_messages = true`, converting tool results to user messages with `[Tool result from <name>]: <content>` format. Use `NearAiChatProvider::new_with_flatten(..., false)` to disable for compliant endpoints.
 
+**Tool schema normalization:** `nearai_chat.rs` applies the same `normalize_schema_strict()` boundary normalization as `RigAdapter::convert_tools` and `openai_codex_provider.rs` before sending tool definitions. Top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` schemas are flattened into a permissive object envelope so providers that reject those shapes do not fail with HTTP 400.
+
 **Pricing auto-fetch:** On startup, `NearAiChatProvider` fires a background task to fetch per-model pricing from `/v1/model/list`. If the fetch fails, it silently falls back to `costs::model_cost()` / `costs::default_cost()`. Pricing is stored in-memory only.
 
 **HTTP request timeout:** The NEAR AI HTTP client has a 120-second timeout per request. Rate limit `Retry-After` headers are parsed (both delay-seconds and HTTP-date formats) and forwarded as `LlmError::RateLimited { retry_after }` for the `RetryProvider` to honor.

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -22,7 +22,7 @@ use crate::llm::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, Role, ToolCall,
     ToolCompletionRequest, ToolCompletionResponse,
 };
-use crate::llm::{costs, session::SessionManager};
+use crate::llm::{costs, rig_adapter::normalize_schema_strict, session::SessionManager};
 
 /// Information about an available model from NEAR AI API.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -543,28 +543,15 @@ impl LlmProvider for NearAiChatProvider {
             messages
         };
 
-        let tools: Vec<ChatCompletionTool> = req
-            .tools
-            .into_iter()
-            .map(|t| ChatCompletionTool {
-                tool_type: "function".to_string(),
-                function: ChatCompletionFunction {
-                    name: t.name,
-                    description: Some(t.description),
-                    parameters: Some(t.parameters),
-                },
-            })
-            .collect();
-
-        let request = ChatCompletionRequest {
+        let request = build_chat_completion_request(
             model,
             messages,
-            temperature: req.temperature,
-            max_tokens: req.max_tokens,
-            stop: req.stop_sequences,
-            tools: if tools.is_empty() { None } else { Some(tools) },
-            tool_choice: req.tool_choice,
-        };
+            req.tools,
+            req.temperature,
+            req.max_tokens,
+            req.stop_sequences,
+            req.tool_choice,
+        );
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
 
@@ -1023,6 +1010,47 @@ struct ChatCompletionFunction {
     parameters: Option<serde_json::Value>,
 }
 
+/// Convert a `ToolDefinition` to NEAR AI Chat Completions tool format.
+///
+/// Applies the same strict schema normalization used by the other OpenAI-compatible
+/// provider adapters so that top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` schemas
+/// are flattened before request serialization.
+fn convert_tool_definition(tool: crate::llm::provider::ToolDefinition) -> ChatCompletionTool {
+    let mut description = tool.description.clone();
+    let parameters = normalize_schema_strict(&tool.parameters, &mut description);
+
+    ChatCompletionTool {
+        tool_type: "function".to_string(),
+        function: ChatCompletionFunction {
+            name: tool.name,
+            description: Some(description),
+            parameters: Some(parameters),
+        },
+    }
+}
+
+fn build_chat_completion_request(
+    model: String,
+    messages: Vec<ChatCompletionMessage>,
+    tools: Vec<crate::llm::provider::ToolDefinition>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    stop: Option<Vec<String>>,
+    tool_choice: Option<String>,
+) -> ChatCompletionRequest {
+    let tools: Vec<ChatCompletionTool> = tools.into_iter().map(convert_tool_definition).collect();
+
+    ChatCompletionRequest {
+        model,
+        messages,
+        temperature,
+        max_tokens,
+        stop,
+        tools: if tools.is_empty() { None } else { Some(tools) },
+        tool_choice,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ChatCompletionResponse {
     #[allow(dead_code)]
@@ -1213,6 +1241,44 @@ mod tests {
         let msg = ChatMessage::assistant("Hello");
         let chat_msg: ChatCompletionMessage = msg.into();
         assert!(chat_msg.tool_calls.is_none());
+    }
+
+    #[test]
+    fn test_convert_tool_definition_normalizes_top_level_oneof() {
+        use crate::llm::provider::ToolDefinition;
+
+        let tool = ToolDefinition {
+            name: "github".to_string(),
+            description: "Search GitHub".to_string(),
+            parameters: serde_json::json!({
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "repo": { "type": "string" }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "owner": { "type": "string" }
+                        }
+                    }
+                ]
+            }),
+        };
+
+        let converted = convert_tool_definition(tool);
+        let params = converted.function.parameters.expect("parameters");
+
+        assert_eq!(params["type"], "object");
+        assert!(params.get("oneOf").is_none());
+        let description = converted
+            .function
+            .description
+            .expect("description")
+            .to_lowercase();
+        assert!(description.contains("oneof"));
     }
 
     #[test]
@@ -1713,6 +1779,47 @@ mod tests {
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
         }
+    }
+
+    #[test]
+    fn test_build_chat_completion_request_normalizes_top_level_oneof() {
+        use crate::llm::provider::ToolDefinition;
+
+        let request = build_chat_completion_request(
+            "test-model".to_string(),
+            vec![ChatMessage::user("Use the github tool").into()],
+            vec![ToolDefinition {
+                name: "github".to_string(),
+                description: "Search GitHub".to_string(),
+                parameters: serde_json::json!({
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "repo": { "type": "string" }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "owner": { "type": "string" }
+                            }
+                        }
+                    ]
+                }),
+            }],
+            Some(0.2),
+            Some(16),
+            None,
+            Some("auto".to_string()),
+        );
+
+        let tools = request.tools.expect("tools present");
+        assert_eq!(tools.len(), 1);
+        let parameters = tools[0].function.parameters.as_ref().expect("parameters");
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("properties").is_some());
     }
 
     // -- ModelInfo serde alias tests ------------------------------------------


### PR DESCRIPTION
`nearai_chat` now applies the same `normalize_schema_strict()` boundary normalization as `RigAdapter::convert_tools` and `openai_codex_provider.rs` before sending tool definitions. This prevents top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` tool schemas from reaching the provider unchanged and failing with HTTP 400.

Validation:
- `cargo fmt --all --check`
- `cargo test -p ironclaw --lib llm::nearai_chat::tests::test_build_chat_completion_request_normalizes_top_level_oneof -- --nocapture`
- `cargo test -p ironclaw --lib llm::nearai_chat::tests::test_convert_tool_definition_normalizes_top_level_oneof -- --nocapture`

The repo-wide preflight script still reports the existing baseline violations in unrelated files, but nothing branch-specific showed up for this change.
