### PR TITLE
fix(web): infer gateway thread id from response metadata

### DIFF
--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -62,6 +62,18 @@ use self::server::GatewayState;
 use self::sse::SseManager;
 use self::types::AppEvent;
 
+fn response_thread_id(response: &OutgoingResponse) -> Option<String> {
+    response.thread_id.clone().or_else(|| {
+        response
+            .metadata
+            .get("notify_thread_id")
+            .and_then(|v| v.as_str())
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(ToOwned::to_owned)
+    })
+}
+
 fn build_gateway_auth_manager(
     state: &GatewayState,
 ) -> Option<Arc<crate::bridge::auth_manager::AuthManager>> {
@@ -758,12 +770,12 @@ impl Channel for GatewayChannel {
         user_id: &str,
         response: OutgoingResponse,
     ) -> Result<(), ChannelError> {
-        let thread_id = match response.thread_id {
+        let thread_id = match response_thread_id(&response) {
             Some(tid) => tid,
             None => {
                 return Err(ChannelError::MissingRoutingTarget {
                     name: "gateway".to_string(),
-                    reason: "broadcast() requires a thread_id on the response".to_string(),
+                    reason: "broadcast() requires a thread_id on the response or notify_thread_id in response.metadata".to_string(),
                 });
             }
         };

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -63,15 +63,20 @@ use self::sse::SseManager;
 use self::types::AppEvent;
 
 fn response_thread_id(response: &OutgoingResponse) -> Option<String> {
-    response.thread_id.clone().or_else(|| {
-        response
-            .metadata
-            .get("notify_thread_id")
-            .and_then(|v| v.as_str())
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(ToOwned::to_owned)
-    })
+    response
+        .thread_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            response
+                .metadata
+                .get("notify_thread_id")
+                .and_then(|v| v.as_str())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+        })
+        .map(ToOwned::to_owned)
 }
 
 fn build_gateway_auth_manager(

--- a/src/channels/web/tests/no_silent_drop.rs
+++ b/src/channels/web/tests/no_silent_drop.rs
@@ -2,7 +2,8 @@
 //!
 //! Previously, `respond()` and `broadcast()` returned `Ok(())` when thread_id
 //! was missing, making callers believe the message was delivered when it wasn't.
-//! These tests ensure that missing routing info produces an explicit error.
+//! These tests ensure that missing routing info produces an explicit error, and
+//! that broadcast can recover thread context from response metadata when present.
 
 use crate::channels::channel::{Channel, IncomingMessage, OutgoingResponse};
 use crate::channels::web::GatewayChannel;
@@ -90,6 +91,27 @@ async fn gateway_broadcast_with_thread_id_succeeds() {
     assert!(
         result.is_ok(),
         "broadcast() should succeed with thread_id: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+async fn gateway_broadcast_with_notify_thread_id_metadata_succeeds() {
+    let gw = test_gateway();
+    let response = OutgoingResponse {
+        content: "notification".to_string(),
+        thread_id: None,
+        attachments: Vec::new(),
+        metadata: serde_json::json!({
+            "notify_thread_id": "thread-789",
+        }),
+    };
+
+    let result = gw.broadcast("test-user", response).await;
+
+    assert!(
+        result.is_ok(),
+        "broadcast() should succeed when notify_thread_id metadata is present: {:?}",
         result
     );
 }

--- a/tests/e2e/mock_llm.py
+++ b/tests/e2e/mock_llm.py
@@ -95,6 +95,14 @@ TOOL_CALL_PATTERNS = [
         "mock_mcp_mock_search",
         lambda _: {"query": "refresh-check"},
     ),
+    (
+        re.compile(r"gateway broadcast smoke|gateway thread routing smoke", re.IGNORECASE),
+        "message",
+        lambda _: {
+            "channel": "gateway",
+            "content": "Gateway routing smoke test",
+        },
+    ),
     (re.compile(r"what time|current time", re.IGNORECASE), "time", lambda _: {"operation": "now"}),
     (
         re.compile(

--- a/tests/e2e/scenarios/test_tool_execution.py
+++ b/tests/e2e/scenarios/test_tool_execution.py
@@ -2,7 +2,7 @@
 
 import asyncio
 
-from helpers import api_get, api_post
+from helpers import api_get, api_post, send_chat_and_wait_for_terminal_message
 
 
 async def _create_thread(base_url: str) -> str:
@@ -108,3 +108,27 @@ async def test_non_tool_message_still_works(ironclaw_server):
     )
 
     assert "4" in (turn.get("response") or ""), turn
+
+
+async def test_gateway_message_tool_round_trip(page, ironclaw_server):
+    """A browser chat turn can route a proactive message through the gateway."""
+    result = await send_chat_and_wait_for_terminal_message(page, "gateway broadcast smoke")
+
+    assert result["role"] == "assistant"
+    assert "Sent message to gateway" in result["text"], result
+
+    thread_id = await page.evaluate("() => currentThreadId")
+    assert thread_id, "browser should retain the active thread id"
+
+    response = await api_get(
+        ironclaw_server,
+        f"/api/chat/history?thread_id={thread_id}",
+        timeout=15,
+    )
+    assert response.status_code == 200, response.text
+    history = response.json()
+    turns = history.get("turns", [])
+    assert turns, history
+    last_turn = turns[-1]
+    assert any(tc.get("name") == "message" for tc in last_turn.get("tool_calls", [])), last_turn
+    assert "Sent message to gateway" in (last_turn.get("response") or ""), last_turn


### PR DESCRIPTION
Resolves #2405 by allowing GatewayChannel::broadcast() to recover thread context from response.metadata.notify_thread_id before returning MissingRoutingTarget. This keeps explicit routing failures for truly unscoped messages while letting broadcasted responses that already carry routing metadata reach the correct thread.

Validation:
- cargo fmt --all -- --check
- cargo test -p ironclaw --lib gateway_broadcast_with_notify_thread_id_metadata_succeeds -- --nocapture
- cargo test -p ironclaw --lib gateway_broadcast_without_thread_id_returns_error -- --nocapture
- cargo clippy -p ironclaw --lib --all-features -- -D warnings