### PR TITLE
feat(engine): add code execution failure categorization instrumentation

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -774,6 +774,27 @@ async fn handle_execute_code_step(
                     let _ = tx.send(failed_event.clone());
                 }
                 thread.events.push(failed_event);
+
+                // Emit structured CodeExecutionFailed event for instrumentation.
+                // This enables aggregate analysis of WHY code execution fails
+                // (Monty limitation vs LLM logic error vs tool dispatch failure).
+                if let Some(ref category) = result.failure_category {
+                    let error_text: String = result.stdout.chars().take(500).collect();
+                    let instrumentation_event = ThreadEvent::new(
+                        thread.id,
+                        EventKind::CodeExecutionFailed {
+                            step_id: exec_ctx.step_id,
+                            category: category.clone(),
+                            error: error_text,
+                            code_hash: Some(crate::executor::scripting::code_hash(&code)),
+                            duration_ms: 0, // not timed at this layer
+                        },
+                    );
+                    if let Some(tx) = event_tx {
+                        let _ = tx.send(instrumentation_event.clone());
+                    }
+                    thread.events.push(instrumentation_event);
+                }
             }
             thread.updated_at = chrono::Utc::now();
 

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -751,15 +751,10 @@ async fn handle_execute_code_step(
             // fall back to the LLM via the result dict and never warn callers.
             if let Some(ref category) = result.failure {
                 let error_msg = if !result.stdout.is_empty() {
-                    // Take the *last* 500 chars — error tracebacks appear at the
-                    // end of stdout, after any print() output.
-                    let char_count = result.stdout.chars().count();
-                    let snippet: String = if char_count > 500 {
-                        result.stdout.chars().skip(char_count - 500).collect()
-                    } else {
-                        result.stdout.clone()
-                    };
-                    format!("CodeAct execution failed: {snippet}")
+                    format!(
+                        "CodeAct execution failed: {}",
+                        tail_chars(&result.stdout, 500)
+                    )
                 } else {
                     "CodeAct execution failed (no stdout)".to_string()
                 };
@@ -786,12 +781,7 @@ async fn handle_execute_code_step(
                 // Emit structured CodeExecutionFailed event for instrumentation.
                 // This enables aggregate analysis of WHY code execution fails
                 // (Monty limitation vs LLM logic error vs tool dispatch failure).
-                let char_count = result.stdout.chars().count();
-                let error_text: String = if char_count > 500 {
-                    result.stdout.chars().skip(char_count - 500).collect()
-                } else {
-                    result.stdout.clone()
-                };
+                let error_text = tail_chars(&result.stdout, 500);
                 let instrumentation_event = ThreadEvent::new(
                     thread.id,
                     EventKind::CodeExecutionFailed {
@@ -2226,6 +2216,19 @@ fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
             }
         })
         .collect()
+}
+
+/// Extract the last `n` characters from `s`.
+///
+/// Error tracebacks appear at the end of stdout, after any `print()` output.
+/// Using the head would capture the print statements instead of the error.
+fn tail_chars(s: &str, n: usize) -> String {
+    let char_count = s.chars().count();
+    if char_count > n {
+        s.chars().skip(char_count - n).collect()
+    } else {
+        s.to_owned()
+    }
 }
 
 /// Build a PII-safe summary of an `action_calls` JSON value for log output.

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -720,6 +720,7 @@ async fn handle_execute_code_step(
     };
 
     // Run user code in a nested Monty VM (same pattern as rlm_query)
+    let code_start = std::time::Instant::now();
     match Box::pin(execute_code(
         &code,
         thread,
@@ -748,9 +749,16 @@ async fn handle_execute_code_step(
             // error, etc.), surface it as an ActionFailed event so traces and
             // observers see the failure. Without this, parse errors silently
             // fall back to the LLM via the result dict and never warn callers.
-            if result.had_error {
+            if let Some(ref category) = result.failure {
                 let error_msg = if !result.stdout.is_empty() {
-                    let snippet: String = result.stdout.chars().take(500).collect();
+                    // Take the *last* 500 chars — error tracebacks appear at the
+                    // end of stdout, after any print() output.
+                    let char_count = result.stdout.chars().count();
+                    let snippet: String = if char_count > 500 {
+                        result.stdout.chars().skip(char_count - 500).collect()
+                    } else {
+                        result.stdout.clone()
+                    };
                     format!("CodeAct execution failed: {snippet}")
                 } else {
                     "CodeAct execution failed (no stdout)".to_string()
@@ -778,23 +786,26 @@ async fn handle_execute_code_step(
                 // Emit structured CodeExecutionFailed event for instrumentation.
                 // This enables aggregate analysis of WHY code execution fails
                 // (Monty limitation vs LLM logic error vs tool dispatch failure).
-                if let Some(ref category) = result.failure_category {
-                    let error_text: String = result.stdout.chars().take(500).collect();
-                    let instrumentation_event = ThreadEvent::new(
-                        thread.id,
-                        EventKind::CodeExecutionFailed {
-                            step_id: exec_ctx.step_id,
-                            category: category.clone(),
-                            error: error_text,
-                            code_hash: Some(crate::executor::scripting::code_hash(&code)),
-                            duration_ms: 0, // not timed at this layer
-                        },
-                    );
-                    if let Some(tx) = event_tx {
-                        let _ = tx.send(instrumentation_event.clone());
-                    }
-                    thread.events.push(instrumentation_event);
+                let char_count = result.stdout.chars().count();
+                let error_text: String = if char_count > 500 {
+                    result.stdout.chars().skip(char_count - 500).collect()
+                } else {
+                    result.stdout.clone()
+                };
+                let instrumentation_event = ThreadEvent::new(
+                    thread.id,
+                    EventKind::CodeExecutionFailed {
+                        step_id: exec_ctx.step_id,
+                        category: category.clone(),
+                        error: error_text,
+                        code_hash: Some(crate::executor::scripting::code_hash(&code)),
+                        duration_ms: code_start.elapsed().as_millis() as u64,
+                    },
+                );
+                if let Some(tx) = event_tx {
+                    let _ = tx.send(instrumentation_event.clone());
                 }
+                thread.events.push(instrumentation_event);
             }
             thread.updated_at = chrono::Utc::now();
 
@@ -816,7 +827,7 @@ async fn handle_execute_code_step(
                 "stdout": result.stdout,
                 "action_results": action_results,
                 "final_answer": result.final_answer,
-                "had_error": result.had_error,
+                "had_error": result.failure.is_some(),
                 "pending_gate": result.need_approval.as_ref().map(|na| {
                     match na {
                         ThreadOutcome::GatePaused { gate_name, action_name, call_id, parameters, resume_kind, resume_output } => serde_json::json!({
@@ -3880,5 +3891,86 @@ FINAL(batch_error_count)
                  this would cause 'No tool output found' from the LLM API"
             );
         }
+    }
+
+    // ── CodeExecutionFailed event emission (caller test) ────────
+
+    #[tokio::test]
+    async fn execute_code_step_emits_code_execution_failed_event() {
+        let llm: Arc<dyn LlmBackend> = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+
+        let mut thread = Thread::new(
+            "test code execution failure instrumentation",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        // Pass intentionally broken Python code (syntax error)
+        let args = &[
+            json_to_monty(&serde_json::json!("def ==")),
+            json_to_monty(&serde_json::json!({})),
+        ];
+
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        let _result = handle_execute_code_step(
+            args,
+            &[],
+            &mut thread,
+            &llm,
+            &effects,
+            &leases,
+            &policy,
+            Some(&tx),
+        )
+        .await;
+
+        // Verify CodeExecutionFailed event was emitted on thread.events
+        let code_failed_events: Vec<_> = thread
+            .events
+            .iter()
+            .filter(|e| matches!(&e.kind, EventKind::CodeExecutionFailed { .. }))
+            .collect();
+
+        assert_eq!(
+            code_failed_events.len(),
+            1,
+            "expected exactly one CodeExecutionFailed event, got {}",
+            code_failed_events.len()
+        );
+
+        if let EventKind::CodeExecutionFailed {
+            category,
+            duration_ms,
+            code_hash,
+            ..
+        } = &code_failed_events[0].kind
+        {
+            assert_eq!(
+                *category,
+                crate::types::step::CodeExecutionFailure::SyntaxError
+            );
+            assert!(*duration_ms > 0 || *duration_ms == 0); // timing is real now
+            assert!(code_hash.is_some());
+        } else {
+            panic!("expected CodeExecutionFailed event kind");
+        }
+
+        // Also verify ActionFailed was emitted (existing behavior)
+        let action_failed = thread
+            .events
+            .iter()
+            .any(|e| matches!(&e.kind, EventKind::ActionFailed { .. }));
+        assert!(
+            action_failed,
+            "expected ActionFailed event alongside CodeExecutionFailed"
+        );
     }
 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -3948,7 +3948,6 @@ FINAL(batch_error_count)
 
         if let EventKind::CodeExecutionFailed {
             category,
-            duration_ms,
             code_hash,
             ..
         } = &code_failed_events[0].kind
@@ -3957,7 +3956,6 @@ FINAL(batch_error_count)
                 *category,
                 crate::types::step::CodeExecutionFailure::SyntaxError
             );
-            assert!(*duration_ms > 0 || *duration_ms == 0); // timing is real now
             assert!(code_hash.is_some());
         } else {
             panic!("expected CodeExecutionFailed event kind");

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -74,6 +74,9 @@ pub struct CodeExecutionResult {
     pub final_answer: Option<String>,
     /// Whether the code execution hit an error (traceback included in stdout).
     pub had_error: bool,
+    /// Classified failure category when `had_error` is true.
+    /// `None` when execution succeeded.
+    pub failure_category: Option<crate::types::step::CodeExecutionFailure>,
 }
 
 /// Build a compact output summary for inclusion in LLM context between steps.
@@ -336,6 +339,7 @@ pub async fn execute_code_with_skills(
                 recursive_tokens,
                 final_answer: None,
                 had_error: true,
+                failure_category: Some(crate::types::step::CodeExecutionFailure::SyntaxError),
             });
         }
         Err(_) => {
@@ -356,6 +360,7 @@ pub async fn execute_code_with_skills(
         Ok(Ok(p)) => p,
         Ok(Err(e)) => {
             // Runtime error flows back to LLM
+            let category = classify_runtime_error(&e.to_string());
             return Ok(CodeExecutionResult {
                 return_value: serde_json::Value::Null,
                 stdout: format!("{stdout}\nError: {e}"),
@@ -365,6 +370,7 @@ pub async fn execute_code_with_skills(
                 recursive_tokens,
                 final_answer: None,
                 had_error: true,
+                failure_category: Some(category),
             });
         }
         Err(_) => {
@@ -393,6 +399,7 @@ pub async fn execute_code_with_skills(
                     recursive_tokens,
                     final_answer,
                     had_error,
+                    failure_category: None,
                 });
             }
 
@@ -489,6 +496,7 @@ pub async fn execute_code_with_skills(
                                 recursive_tokens,
                                 final_answer,
                                 had_error,
+                                failure_category: Some(classify_runtime_error(&e.to_string())),
                             });
                         }
                         Err(_) => {
@@ -519,6 +527,7 @@ pub async fn execute_code_with_skills(
                                 recursive_tokens,
                                 final_answer,
                                 had_error,
+                                failure_category: Some(classify_runtime_error(&e.to_string())),
                             });
                         }
                         Err(_) => {
@@ -595,6 +604,9 @@ pub async fn execute_code_with_skills(
                                     recursive_tokens,
                                     final_answer,
                                     had_error,
+                                    failure_category: Some(
+                                        crate::types::step::CodeExecutionFailure::ToolError,
+                                    ),
                                 });
                             }
                             Err(_) => {
@@ -622,6 +634,9 @@ pub async fn execute_code_with_skills(
                                     recursive_tokens,
                                     final_answer,
                                     had_error,
+                                    failure_category: Some(
+                                        crate::types::step::CodeExecutionFailure::ToolError,
+                                    ),
                                 });
                             }
                             Err(_) => {
@@ -641,6 +656,9 @@ pub async fn execute_code_with_skills(
                             recursive_tokens,
                             final_answer: None,
                             had_error,
+                            failure_category: Some(
+                                crate::types::step::CodeExecutionFailure::GatePause,
+                            ),
                         });
                     }
                 }
@@ -712,6 +730,7 @@ pub async fn execute_code_with_skills(
                             recursive_tokens,
                             final_answer,
                             had_error,
+                            failure_category: Some(classify_runtime_error(&e.to_string())),
                         });
                     }
                     Err(_) => {
@@ -757,6 +776,9 @@ pub async fn execute_code_with_skills(
                             recursive_tokens,
                             final_answer,
                             had_error,
+                            failure_category: Some(
+                                crate::types::step::CodeExecutionFailure::NameLookup,
+                            ),
                         });
                     }
                     Err(_) => {
@@ -789,6 +811,9 @@ pub async fn execute_code_with_skills(
                             recursive_tokens,
                             final_answer,
                             had_error,
+                            failure_category: Some(
+                                crate::types::step::CodeExecutionFailure::OsDenied,
+                            ),
                         });
                     }
                     Err(_) => {
@@ -800,6 +825,48 @@ pub async fn execute_code_with_skills(
             }
         }
     }
+}
+
+// ── Error classification ────────────────────────────────────
+
+/// Classify a runtime error message into a failure category.
+///
+/// Parses the error text from Monty to distinguish between LLM logic bugs
+/// (NameError, TypeError, etc.), resource limit hits, and Monty VM issues.
+fn classify_runtime_error(error_msg: &str) -> crate::types::step::CodeExecutionFailure {
+    use crate::types::step::CodeExecutionFailure;
+
+    let lower = error_msg.to_lowercase();
+
+    if lower.contains("syntax") {
+        CodeExecutionFailure::SyntaxError
+    } else if lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("memory limit")
+        || lower.contains("allocation limit")
+        || lower.contains("fuel")
+        || lower.contains("resource limit")
+    {
+        CodeExecutionFailure::ResourceLimit
+    } else if lower.contains("os operations are not permitted")
+        || lower.contains("oserror")
+        || (lower.contains("os") && lower.contains("denied"))
+    {
+        CodeExecutionFailure::OsDenied
+    } else {
+        // NameError, TypeError, ValueError, AttributeError, IndexError,
+        // KeyError, ModuleNotFoundError, NotImplementedError, etc.
+        CodeExecutionFailure::RuntimeError
+    }
+}
+
+/// Compute a short hash of Python code for dedup/correlation in events.
+pub fn code_hash(code: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    code.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
 }
 
 // ── Pending future tracking ─────────────────────────────────
@@ -2735,5 +2802,70 @@ FINAL(str(x))
 
         assert!(matches!(result, ExtFunctionResult::Error(_)));
         assert!(llm.calls.lock().await.is_empty());
+    }
+
+    // ── Error classification tests ──────────────────────────────
+
+    #[test]
+    fn classify_syntax_error() {
+        let cat = classify_runtime_error("SyntaxError: unexpected token");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::SyntaxError);
+    }
+
+    #[test]
+    fn classify_timeout() {
+        let cat = classify_runtime_error("execution timed out after 30s");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+    }
+
+    #[test]
+    fn classify_memory_limit() {
+        let cat = classify_runtime_error("memory limit exceeded");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+    }
+
+    #[test]
+    fn classify_fuel_exhaustion() {
+        let cat = classify_runtime_error("fuel exhausted during execution");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+    }
+
+    #[test]
+    fn classify_os_denied() {
+        let cat = classify_runtime_error("OS operations are not permitted in CodeAct scripts");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::OsDenied);
+    }
+
+    #[test]
+    fn classify_name_error_as_runtime() {
+        // NameError from Monty (not NameLookup) is classified as RuntimeError
+        let cat = classify_runtime_error("NameError: name 'foo' is not defined");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+    }
+
+    #[test]
+    fn classify_type_error_as_runtime() {
+        let cat = classify_runtime_error("TypeError: unsupported operand");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+    }
+
+    #[test]
+    fn classify_module_not_found_as_runtime() {
+        let cat = classify_runtime_error("ModuleNotFoundError: No module named 'csv'");
+        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+    }
+
+    #[test]
+    fn code_hash_deterministic() {
+        let h1 = code_hash("print('hello')");
+        let h2 = code_hash("print('hello')");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn code_hash_differs_for_different_code() {
+        let h1 = code_hash("print('hello')");
+        let h2 = code_hash("print('world')");
+        assert_ne!(h1, h2);
     }
 }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -1918,7 +1918,7 @@ FINAL(str(result))
             result.stdout
         );
         assert!(
-            !result.failure.is_some(),
+            result.failure.is_none(),
             "should not error, stdout: {}",
             result.stdout
         );
@@ -1970,7 +1970,7 @@ FINAL(str(a + b))
             result.stdout
         );
         assert_eq!(result.action_results.len(), 2);
-        assert!(!result.failure.is_some());
+        assert!(result.failure.is_none());
     }
 
     // ── asyncio.gather three tools ──────────────────────────
@@ -2020,7 +2020,7 @@ FINAL(str(s) + "|" + str(h) + "|" + str(m))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
+        assert!(result.failure.is_none(), "stdout: {}", result.stdout);
         assert_eq!(result.action_results.len(), 3);
         let answer = result.final_answer.unwrap();
         assert!(answer.contains("search results"), "got: {answer}");
@@ -2060,7 +2060,7 @@ FINAL(str(b))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
+        assert!(result.failure.is_none(), "stdout: {}", result.stdout);
         assert_eq!(result.action_results.len(), 2);
         assert_eq!(result.final_answer.as_deref(), Some("final"));
     }
@@ -2139,7 +2139,7 @@ FINAL("hello from sync")
 
         let result = run_code(code, effects, &thread).await.unwrap();
         assert_eq!(result.final_answer.as_deref(), Some("hello from sync"));
-        assert!(!result.failure.is_some());
+        assert!(result.failure.is_none());
     }
 
     // ── globals() still works ───────────────────────────────
@@ -2160,7 +2160,7 @@ FINAL(str(has_search) + "|" + str(has_http))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
+        assert!(result.failure.is_none(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("True|True"));
     }
 
@@ -2178,7 +2178,7 @@ FINAL(str(len(results)))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
+        assert!(result.failure.is_none(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("0"));
     }
 
@@ -2205,7 +2205,7 @@ FINAL(str(results[0]))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
+        assert!(result.failure.is_none(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("gathered"));
         assert_eq!(result.action_results.len(), 1);
     }

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -886,7 +886,8 @@ fn classify_runtime_error(error_msg: &str) -> CodeExecutionFailure {
         || lower.contains("timeout")
         || lower.contains("memory limit")
         || lower.contains("allocation limit")
-        || lower.contains("fuel")
+        || lower.contains("out of fuel")
+        || lower.contains("fuel exhausted")
         || lower.contains("resource limit")
     {
         CodeExecutionFailure::ResourceLimit
@@ -2428,10 +2429,7 @@ FINAL(str(x))
 
         let code = "def broken(\nFINAL('nope')";
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(
-            result.failure.is_some(),
-            "syntax error should set had_error"
-        );
+        assert!(result.failure.is_some(), "syntax error should set failure");
         assert!(
             result.stdout.contains("SyntaxError") || result.stdout.contains("Error"),
             "should contain SyntaxError, got: {}",

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -33,7 +33,7 @@ use crate::traits::llm::{LlmBackend, LlmCallConfig};
 use crate::types::error::EngineError;
 use crate::types::event::EventKind;
 use crate::types::message::{MessageRole, ThreadMessage};
-use crate::types::step::{ActionResult, LlmResponse, TokenUsage};
+use crate::types::step::{ActionResult, CodeExecutionFailure, LlmResponse, TokenUsage};
 use crate::types::thread::Thread;
 use ironclaw_common::ValidTimezone;
 
@@ -72,11 +72,10 @@ pub struct CodeExecutionResult {
     pub recursive_tokens: TokenUsage,
     /// If set, the code called FINAL() or FINAL_VAR() with this answer.
     pub final_answer: Option<String>,
-    /// Whether the code execution hit an error (traceback included in stdout).
-    pub had_error: bool,
-    /// Classified failure category when `had_error` is true.
-    /// `None` when execution succeeded.
-    pub failure_category: Option<crate::types::step::CodeExecutionFailure>,
+    /// Classified failure category. `None` when execution succeeded or was
+    /// paused by a gate. `Some(category)` when code execution failed —
+    /// `failure.is_some()` replaces the former `had_error: bool` field.
+    pub failure: Option<CodeExecutionFailure>,
 }
 
 /// Build a compact output summary for inclusion in LLM context between steps.
@@ -300,7 +299,6 @@ pub async fn execute_code_with_skills(
     let mut events = Vec::new();
     let mut recursive_tokens = TokenUsage::default();
     let mut final_answer: Option<String> = None;
-    let mut had_error = false;
 
     // Build context variables including persisted state from prior steps
     let (input_names, input_values) = build_context_inputs(thread, persisted_state);
@@ -338,13 +336,19 @@ pub async fn execute_code_with_skills(
                 need_approval: None,
                 recursive_tokens,
                 final_answer: None,
-                had_error: true,
-                failure_category: Some(crate::types::step::CodeExecutionFailure::SyntaxError),
+                failure: Some(CodeExecutionFailure::SyntaxError),
             });
         }
         Err(_) => {
-            return Err(EngineError::Effect {
-                reason: "Monty VM panicked during code parsing".into(),
+            return Ok(CodeExecutionResult {
+                return_value: serde_json::Value::Null,
+                stdout: format!("{stdout}\nVmPanic: Monty VM panicked during code parsing"),
+                action_results,
+                events,
+                need_approval: None,
+                recursive_tokens,
+                final_answer: None,
+                failure: Some(CodeExecutionFailure::VmPanic),
             });
         }
     };
@@ -369,13 +373,19 @@ pub async fn execute_code_with_skills(
                 need_approval: None,
                 recursive_tokens,
                 final_answer: None,
-                had_error: true,
-                failure_category: Some(category),
+                failure: Some(category),
             });
         }
         Err(_) => {
-            return Err(EngineError::Effect {
-                reason: "Monty VM panicked during execution start".into(),
+            return Ok(CodeExecutionResult {
+                return_value: serde_json::Value::Null,
+                stdout: format!("{stdout}\nVmPanic: Monty VM panicked during execution start"),
+                action_results,
+                events,
+                need_approval: None,
+                recursive_tokens,
+                final_answer: None,
+                failure: Some(CodeExecutionFailure::VmPanic),
             });
         }
     };
@@ -398,8 +408,7 @@ pub async fn execute_code_with_skills(
                     need_approval: None,
                     recursive_tokens,
                     final_answer,
-                    had_error,
-                    failure_category: None,
+                    failure: None,
                 });
             }
 
@@ -486,7 +495,6 @@ pub async fn execute_code_with_skills(
                         Ok(Ok(p)) => progress = p,
                         Ok(Err(e)) => {
                             stdout.push_str(&format!("\nError: {e}"));
-                            had_error = true;
                             return Ok(CodeExecutionResult {
                                 return_value: serde_json::Value::Null,
                                 stdout,
@@ -495,13 +503,21 @@ pub async fn execute_code_with_skills(
                                 need_approval: None,
                                 recursive_tokens,
                                 final_answer,
-                                had_error,
-                                failure_category: Some(classify_runtime_error(&e.to_string())),
+                                failure: Some(classify_runtime_error(&e.to_string())),
                             });
                         }
                         Err(_) => {
-                            return Err(EngineError::Effect {
-                                reason: "Monty VM panicked during resume".into(),
+                            return Ok(CodeExecutionResult {
+                                return_value: serde_json::Value::Null,
+                                stdout: format!(
+                                    "{stdout}\nVmPanic: Monty VM panicked during resume"
+                                ),
+                                action_results,
+                                events,
+                                need_approval: None,
+                                recursive_tokens,
+                                final_answer,
+                                failure: Some(CodeExecutionFailure::VmPanic),
                             });
                         }
                     }
@@ -517,7 +533,6 @@ pub async fn execute_code_with_skills(
                         Ok(Ok(p)) => progress = p,
                         Ok(Err(e)) => {
                             stdout.push_str(&format!("\nError: {e}"));
-                            had_error = true;
                             return Ok(CodeExecutionResult {
                                 return_value: serde_json::Value::Null,
                                 stdout,
@@ -526,13 +541,21 @@ pub async fn execute_code_with_skills(
                                 need_approval: None,
                                 recursive_tokens,
                                 final_answer,
-                                had_error,
-                                failure_category: Some(classify_runtime_error(&e.to_string())),
+                                failure: Some(classify_runtime_error(&e.to_string())),
                             });
                         }
                         Err(_) => {
-                            return Err(EngineError::Effect {
-                                reason: "Monty VM panicked during resume_pending".into(),
+                            return Ok(CodeExecutionResult {
+                                return_value: serde_json::Value::Null,
+                                stdout: format!(
+                                    "{stdout}\nVmPanic: Monty VM panicked during resume_pending"
+                                ),
+                                action_results,
+                                events,
+                                need_approval: None,
+                                recursive_tokens,
+                                final_answer,
+                                failure: Some(CodeExecutionFailure::VmPanic),
                             });
                         }
                     }
@@ -594,7 +617,6 @@ pub async fn execute_code_with_skills(
                             Ok(Ok(p)) => progress = p,
                             Ok(Err(e)) => {
                                 stdout.push_str(&format!("\nError: {e}"));
-                                had_error = true;
                                 return Ok(CodeExecutionResult {
                                     return_value: serde_json::Value::Null,
                                     stdout,
@@ -603,15 +625,21 @@ pub async fn execute_code_with_skills(
                                     need_approval: None,
                                     recursive_tokens,
                                     final_answer,
-                                    had_error,
-                                    failure_category: Some(
-                                        crate::types::step::CodeExecutionFailure::ToolError,
-                                    ),
+                                    failure: Some(CodeExecutionFailure::ToolError),
                                 });
                             }
                             Err(_) => {
-                                return Err(EngineError::Effect {
-                                    reason: "Monty VM panicked during resume_pending".into(),
+                                return Ok(CodeExecutionResult {
+                                    return_value: serde_json::Value::Null,
+                                    stdout: format!(
+                                        "{stdout}\nVmPanic: Monty VM panicked during resume_pending"
+                                    ),
+                                    action_results,
+                                    events,
+                                    need_approval: None,
+                                    recursive_tokens,
+                                    final_answer,
+                                    failure: Some(CodeExecutionFailure::VmPanic),
                                 });
                             }
                         }
@@ -624,7 +652,6 @@ pub async fn execute_code_with_skills(
                             Ok(Ok(p)) => progress = p,
                             Ok(Err(e)) => {
                                 stdout.push_str(&format!("\nError: {e}"));
-                                had_error = true;
                                 return Ok(CodeExecutionResult {
                                     return_value: serde_json::Value::Null,
                                     stdout,
@@ -633,15 +660,21 @@ pub async fn execute_code_with_skills(
                                     need_approval: None,
                                     recursive_tokens,
                                     final_answer,
-                                    had_error,
-                                    failure_category: Some(
-                                        crate::types::step::CodeExecutionFailure::ToolError,
-                                    ),
+                                    failure: Some(CodeExecutionFailure::ToolError),
                                 });
                             }
                             Err(_) => {
-                                return Err(EngineError::Effect {
-                                    reason: "Monty VM panicked during resume".into(),
+                                return Ok(CodeExecutionResult {
+                                    return_value: serde_json::Value::Null,
+                                    stdout: format!(
+                                        "{stdout}\nVmPanic: Monty VM panicked during resume"
+                                    ),
+                                    action_results,
+                                    events,
+                                    need_approval: None,
+                                    recursive_tokens,
+                                    final_answer,
+                                    failure: Some(CodeExecutionFailure::VmPanic),
                                 });
                             }
                         }
@@ -655,10 +688,7 @@ pub async fn execute_code_with_skills(
                             need_approval: Some(outcome),
                             recursive_tokens,
                             final_answer: None,
-                            had_error,
-                            failure_category: Some(
-                                crate::types::step::CodeExecutionFailure::GatePause,
-                            ),
+                            failure: None,
                         });
                     }
                 }
@@ -720,7 +750,6 @@ pub async fn execute_code_with_skills(
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
                         stdout.push_str(&format!("\nError: {e}"));
-                        had_error = true;
                         return Ok(CodeExecutionResult {
                             return_value: serde_json::Value::Null,
                             stdout,
@@ -729,13 +758,21 @@ pub async fn execute_code_with_skills(
                             need_approval: None,
                             recursive_tokens,
                             final_answer,
-                            had_error,
-                            failure_category: Some(classify_runtime_error(&e.to_string())),
+                            failure: Some(classify_runtime_error(&e.to_string())),
                         });
                     }
                     Err(_) => {
-                        return Err(EngineError::Effect {
-                            reason: "Monty VM panicked during ResolveFutures resume".into(),
+                        return Ok(CodeExecutionResult {
+                            return_value: serde_json::Value::Null,
+                            stdout: format!(
+                                "{stdout}\nVmPanic: Monty VM panicked during ResolveFutures resume"
+                            ),
+                            action_results,
+                            events,
+                            need_approval: None,
+                            recursive_tokens,
+                            final_answer,
+                            failure: Some(CodeExecutionFailure::VmPanic),
                         });
                     }
                 }
@@ -766,7 +803,6 @@ pub async fn execute_code_with_skills(
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
                         stdout.push_str(&format!("\nNameError: {e}"));
-                        had_error = true;
                         return Ok(CodeExecutionResult {
                             return_value: serde_json::Value::Null,
                             stdout,
@@ -775,15 +811,21 @@ pub async fn execute_code_with_skills(
                             need_approval: None,
                             recursive_tokens,
                             final_answer,
-                            had_error,
-                            failure_category: Some(
-                                crate::types::step::CodeExecutionFailure::NameLookup,
-                            ),
+                            failure: Some(CodeExecutionFailure::NameLookup),
                         });
                     }
                     Err(_) => {
-                        return Err(EngineError::Effect {
-                            reason: "Monty VM panicked during name lookup".into(),
+                        return Ok(CodeExecutionResult {
+                            return_value: serde_json::Value::Null,
+                            stdout: format!(
+                                "{stdout}\nVmPanic: Monty VM panicked during name lookup"
+                            ),
+                            action_results,
+                            events,
+                            need_approval: None,
+                            recursive_tokens,
+                            final_answer,
+                            failure: Some(CodeExecutionFailure::VmPanic),
                         });
                     }
                 }
@@ -801,7 +843,6 @@ pub async fn execute_code_with_skills(
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
                         stdout.push_str(&format!("\nOSError: {e}"));
-                        had_error = true;
                         return Ok(CodeExecutionResult {
                             return_value: serde_json::Value::Null,
                             stdout,
@@ -810,15 +851,19 @@ pub async fn execute_code_with_skills(
                             need_approval: None,
                             recursive_tokens,
                             final_answer,
-                            had_error,
-                            failure_category: Some(
-                                crate::types::step::CodeExecutionFailure::OsDenied,
-                            ),
+                            failure: Some(CodeExecutionFailure::OsDenied),
                         });
                     }
                     Err(_) => {
-                        return Err(EngineError::Effect {
-                            reason: "Monty VM panicked during OS call".into(),
+                        return Ok(CodeExecutionResult {
+                            return_value: serde_json::Value::Null,
+                            stdout: format!("{stdout}\nVmPanic: Monty VM panicked during OS call"),
+                            action_results,
+                            events,
+                            need_approval: None,
+                            recursive_tokens,
+                            final_answer,
+                            failure: Some(CodeExecutionFailure::VmPanic),
                         });
                     }
                 }
@@ -833,14 +878,11 @@ pub async fn execute_code_with_skills(
 ///
 /// Parses the error text from Monty to distinguish between LLM logic bugs
 /// (NameError, TypeError, etc.), resource limit hits, and Monty VM issues.
-fn classify_runtime_error(error_msg: &str) -> crate::types::step::CodeExecutionFailure {
-    use crate::types::step::CodeExecutionFailure;
+fn classify_runtime_error(error_msg: &str) -> CodeExecutionFailure {
+    let lower = error_msg.to_ascii_lowercase();
 
-    let lower = error_msg.to_lowercase();
-
-    if lower.contains("syntax") {
-        CodeExecutionFailure::SyntaxError
-    } else if lower.contains("timed out")
+    // Most specific checks first to avoid substring false positives.
+    if lower.contains("timed out")
         || lower.contains("timeout")
         || lower.contains("memory limit")
         || lower.contains("allocation limit")
@@ -848,11 +890,10 @@ fn classify_runtime_error(error_msg: &str) -> crate::types::step::CodeExecutionF
         || lower.contains("resource limit")
     {
         CodeExecutionFailure::ResourceLimit
-    } else if lower.contains("os operations are not permitted")
-        || lower.contains("oserror")
-        || (lower.contains("os") && lower.contains("denied"))
-    {
+    } else if lower.contains("os operations are not permitted") || lower.contains("oserror") {
         CodeExecutionFailure::OsDenied
+    } else if lower.contains("syntaxerror") {
+        CodeExecutionFailure::SyntaxError
     } else {
         // NameError, TypeError, ValueError, AttributeError, IndexError,
         // KeyError, ModuleNotFoundError, NotImplementedError, etc.
@@ -861,12 +902,19 @@ fn classify_runtime_error(error_msg: &str) -> crate::types::step::CodeExecutionF
 }
 
 /// Compute a short hash of Python code for dedup/correlation in events.
+///
+/// Uses FNV-1a (64-bit) which is stable across Rust versions, unlike
+/// `DefaultHasher`. Not cryptographic — collision probability is ~2^-32
+/// at typical usage levels, sufficient for dedup but not for security.
 pub fn code_hash(code: &str) -> String {
-    use std::collections::hash_map::DefaultHasher;
-    use std::hash::{Hash, Hasher};
-    let mut hasher = DefaultHasher::new();
-    code.hash(&mut hasher);
-    format!("{:016x}", hasher.finish())
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x00000100000001B3;
+    let mut hash = FNV_OFFSET;
+    for byte in code.as_bytes() {
+        hash ^= *byte as u64;
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    format!("{hash:016x}")
 }
 
 // ── Pending future tracking ─────────────────────────────────
@@ -1870,7 +1918,7 @@ FINAL(str(result))
             result.stdout
         );
         assert!(
-            !result.had_error,
+            !result.failure.is_some(),
             "should not error, stdout: {}",
             result.stdout
         );
@@ -1922,7 +1970,7 @@ FINAL(str(a + b))
             result.stdout
         );
         assert_eq!(result.action_results.len(), 2);
-        assert!(!result.had_error);
+        assert!(!result.failure.is_some());
     }
 
     // ── asyncio.gather three tools ──────────────────────────
@@ -1972,7 +2020,7 @@ FINAL(str(s) + "|" + str(h) + "|" + str(m))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.had_error, "stdout: {}", result.stdout);
+        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
         assert_eq!(result.action_results.len(), 3);
         let answer = result.final_answer.unwrap();
         assert!(answer.contains("search results"), "got: {answer}");
@@ -2012,7 +2060,7 @@ FINAL(str(b))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.had_error, "stdout: {}", result.stdout);
+        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
         assert_eq!(result.action_results.len(), 2);
         assert_eq!(result.final_answer.as_deref(), Some("final"));
     }
@@ -2047,7 +2095,7 @@ FINAL("should not reach")
         let result = run_code(code, effects, &thread).await.unwrap();
         // Error in gather propagates as exception — code should error
         assert!(
-            result.had_error,
+            result.failure.is_some(),
             "should have error, stdout: {}",
             result.stdout
         );
@@ -2091,7 +2139,7 @@ FINAL("hello from sync")
 
         let result = run_code(code, effects, &thread).await.unwrap();
         assert_eq!(result.final_answer.as_deref(), Some("hello from sync"));
-        assert!(!result.had_error);
+        assert!(!result.failure.is_some());
     }
 
     // ── globals() still works ───────────────────────────────
@@ -2112,7 +2160,7 @@ FINAL(str(has_search) + "|" + str(has_http))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.had_error, "stdout: {}", result.stdout);
+        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("True|True"));
     }
 
@@ -2130,7 +2178,7 @@ FINAL(str(len(results)))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.had_error, "stdout: {}", result.stdout);
+        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("0"));
     }
 
@@ -2157,7 +2205,7 @@ FINAL(str(results[0]))
 "#;
 
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(!result.had_error, "stdout: {}", result.stdout);
+        assert!(!result.failure.is_some(), "stdout: {}", result.stdout);
         assert_eq!(result.final_answer.as_deref(), Some("gathered"));
         assert_eq!(result.action_results.len(), 1);
     }
@@ -2204,7 +2252,7 @@ while True:
         // the key assertion is that it DOES NOT run forever.
         if let Ok(r) = result {
             assert!(
-                r.had_error || r.stdout.contains("Error") || r.stdout.contains("limit"),
+                r.failure.is_some() || r.stdout.contains("Error") || r.stdout.contains("limit"),
                 "resource limit should terminate infinite loop, got stdout: {}",
                 truncate_for_assert(&r.stdout, 500),
             );
@@ -2346,7 +2394,7 @@ while True:
         // Must terminate — either via error or resource limit
         if let Ok(r) = result {
             assert!(
-                r.had_error || r.stdout.contains("Error") || r.stdout.contains("limit"),
+                r.failure.is_some() || r.stdout.contains("Error") || r.stdout.contains("limit"),
                 "cpu-bound loop should be terminated, stdout: {}",
                 truncate_for_assert(&r.stdout, 500),
             );
@@ -2380,7 +2428,10 @@ FINAL(str(x))
 
         let code = "def broken(\nFINAL('nope')";
         let result = run_code(code, effects, &thread).await.unwrap();
-        assert!(result.had_error, "syntax error should set had_error");
+        assert!(
+            result.failure.is_some(),
+            "syntax error should set had_error"
+        );
         assert!(
             result.stdout.contains("SyntaxError") || result.stdout.contains("Error"),
             "should contain SyntaxError, got: {}",
@@ -2809,50 +2860,67 @@ FINAL(str(x))
     #[test]
     fn classify_syntax_error() {
         let cat = classify_runtime_error("SyntaxError: unexpected token");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::SyntaxError);
+        assert_eq!(cat, CodeExecutionFailure::SyntaxError);
     }
 
     #[test]
     fn classify_timeout() {
         let cat = classify_runtime_error("execution timed out after 30s");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+        assert_eq!(cat, CodeExecutionFailure::ResourceLimit);
     }
 
     #[test]
     fn classify_memory_limit() {
         let cat = classify_runtime_error("memory limit exceeded");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+        assert_eq!(cat, CodeExecutionFailure::ResourceLimit);
     }
 
     #[test]
     fn classify_fuel_exhaustion() {
         let cat = classify_runtime_error("fuel exhausted during execution");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::ResourceLimit);
+        assert_eq!(cat, CodeExecutionFailure::ResourceLimit);
     }
 
     #[test]
     fn classify_os_denied() {
         let cat = classify_runtime_error("OS operations are not permitted in CodeAct scripts");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::OsDenied);
+        assert_eq!(cat, CodeExecutionFailure::OsDenied);
     }
 
     #[test]
     fn classify_name_error_as_runtime() {
         // NameError from Monty (not NameLookup) is classified as RuntimeError
         let cat = classify_runtime_error("NameError: name 'foo' is not defined");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+        assert_eq!(cat, CodeExecutionFailure::RuntimeError);
     }
 
     #[test]
     fn classify_type_error_as_runtime() {
         let cat = classify_runtime_error("TypeError: unsupported operand");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+        assert_eq!(cat, CodeExecutionFailure::RuntimeError);
     }
 
     #[test]
     fn classify_module_not_found_as_runtime() {
         let cat = classify_runtime_error("ModuleNotFoundError: No module named 'csv'");
-        assert_eq!(cat, crate::types::step::CodeExecutionFailure::RuntimeError);
+        assert_eq!(cat, CodeExecutionFailure::RuntimeError);
+    }
+
+    #[test]
+    fn classify_syntax_word_is_not_syntaxerror() {
+        // "syntax" alone should not trigger SyntaxError — only "syntaxerror" should.
+        let cat = classify_runtime_error("unexpected syntax in expression");
+        assert_eq!(cat, CodeExecutionFailure::RuntimeError);
+    }
+
+    #[test]
+    fn vm_panic_variant_serializes_as_snake_case() {
+        // VmPanic is set directly by catch_unwind paths, not by classify_runtime_error.
+        // Verify it serializes consistently with Display (both snake_case).
+        let failure = CodeExecutionFailure::VmPanic;
+        assert_eq!(failure.to_string(), "vm_panic");
+        let json = serde_json::to_value(&failure).unwrap();
+        assert_eq!(json, serde_json::json!("vm_panic"));
     }
 
     #[test]

--- a/crates/ironclaw_engine/src/executor/trace.rs
+++ b/crates/ironclaw_engine/src/executor/trace.rs
@@ -195,30 +195,70 @@ fn analyze_trace(thread: &Thread) -> Vec<TraceIssue> {
         }
     }
 
-    // 4. Check for code execution errors in output messages.
-    // Code output appears as User-role messages (Monty stdout/stderr) with
-    // prefixes like "[stdout]" or "[stderr]". Skip the System prompt (index 0)
-    // and Assistant messages to avoid false positives from example text.
-    let error_patterns = [
-        "NameError",
-        "SyntaxError",
-        "TypeError",
-        "NotImplementedError",
-    ];
-    for (i, msg) in thread.messages.iter().enumerate() {
-        let is_code_output = msg.role == crate::types::message::MessageRole::User
-            && (msg.content.starts_with("[stdout]")
-                || msg.content.starts_with("[stderr]")
-                || msg.content.starts_with("[code ")
-                || msg.content.starts_with("Traceback"));
-        if is_code_output && error_patterns.iter().any(|p| msg.content.contains(p)) {
-            let preview: String = msg.content.chars().take(200).collect();
+    // 4. Check for code execution errors via structured CodeExecutionFailed events.
+    // These carry a classified failure category that tells us exactly what kind
+    // of error occurred (syntax, runtime, name lookup, VM panic, resource limit,
+    // tool error, OS denied, gate pause).
+    let code_failures: Vec<&ThreadEvent> = thread
+        .events
+        .iter()
+        .filter(|e| {
+            matches!(
+                e.kind,
+                crate::types::event::EventKind::CodeExecutionFailed { .. }
+            )
+        })
+        .collect();
+    for event in &code_failures {
+        if let crate::types::event::EventKind::CodeExecutionFailed {
+            category, error, ..
+        } = &event.kind
+        {
+            let preview: String = error.chars().take(200).collect();
+            let severity = match category {
+                crate::types::step::CodeExecutionFailure::VmPanic => IssueSeverity::Error,
+                crate::types::step::CodeExecutionFailure::ResourceLimit => IssueSeverity::Error,
+                _ => IssueSeverity::Warning,
+            };
             issues.push(TraceIssue {
-                severity: IssueSeverity::Warning,
-                category: "code_error".into(),
-                description: format!("Code execution error in message {i}: {preview}"),
+                severity,
+                category: format!("code_{category}"),
+                description: format!("Code execution failed ({category}): {preview}"),
                 step: None,
             });
+        }
+    }
+
+    // Fallback: also check message-level patterns for backward compatibility
+    // with threads that ran before the instrumentation was added.
+    if code_failures.is_empty() {
+        let error_patterns = [
+            "NameError",
+            "SyntaxError",
+            "TypeError",
+            "NotImplementedError",
+            "ValueError",
+            "AttributeError",
+            "IndexError",
+            "KeyError",
+            "ModuleNotFoundError",
+            "RuntimeError",
+        ];
+        for (i, msg) in thread.messages.iter().enumerate() {
+            let is_code_output = msg.role == crate::types::message::MessageRole::User
+                && (msg.content.starts_with("[stdout]")
+                    || msg.content.starts_with("[stderr]")
+                    || msg.content.starts_with("[code ")
+                    || msg.content.starts_with("Traceback"));
+            if is_code_output && error_patterns.iter().any(|p| msg.content.contains(p)) {
+                let preview: String = msg.content.chars().take(200).collect();
+                issues.push(TraceIssue {
+                    severity: IssueSeverity::Warning,
+                    category: "code_error".into(),
+                    description: format!("Code execution error in message {i}: {preview}"),
+                    step: None,
+                });
+            }
         }
     }
 
@@ -533,6 +573,77 @@ mod tests {
             empty_issues.len(),
             2,
             "should flag exactly the 2 empty call_ids"
+        );
+    }
+
+    // ── CodeExecutionFailed event detection ────────────────────
+
+    #[test]
+    fn detects_code_execution_failure_from_event() {
+        let mut thread = make_thread();
+        thread.add_message(ThreadMessage::system("sys"));
+        thread.add_message(ThreadMessage::assistant("```repl\nimport csv\n```"));
+        thread.events.push(ThreadEvent::new(
+            thread.id,
+            EventKind::CodeExecutionFailed {
+                step_id: StepId::new(),
+                category: crate::types::step::CodeExecutionFailure::RuntimeError,
+                error: "ModuleNotFoundError: No module named 'csv'".into(),
+                code_hash: Some("abc123".into()),
+                duration_ms: 42,
+            },
+        ));
+
+        let issues = analyze_trace(&thread);
+        let code_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.category.starts_with("code_"))
+            .collect();
+        assert_eq!(code_issues.len(), 1);
+        assert_eq!(code_issues[0].category, "code_runtime_error");
+        assert_eq!(code_issues[0].severity, IssueSeverity::Warning);
+        assert!(code_issues[0].description.contains("ModuleNotFoundError"));
+    }
+
+    #[test]
+    fn vm_panic_is_error_severity() {
+        let mut thread = make_thread();
+        thread.add_message(ThreadMessage::system("sys"));
+        thread.add_message(ThreadMessage::assistant("code"));
+        thread.events.push(ThreadEvent::new(
+            thread.id,
+            EventKind::CodeExecutionFailed {
+                step_id: StepId::new(),
+                category: crate::types::step::CodeExecutionFailure::VmPanic,
+                error: "Monty panicked: unreachable".into(),
+                code_hash: None,
+                duration_ms: 0,
+            },
+        ));
+
+        let issues = analyze_trace(&thread);
+        let panic_issues: Vec<_> = issues
+            .iter()
+            .filter(|i| i.category == "code_vm_panic")
+            .collect();
+        assert_eq!(panic_issues.len(), 1);
+        assert_eq!(panic_issues[0].severity, IssueSeverity::Error);
+    }
+
+    #[test]
+    fn fallback_message_detection_when_no_events() {
+        // Threads from before instrumentation should still be detected
+        let mut thread = make_thread();
+        thread.add_message(ThreadMessage::system("sys"));
+        thread.add_message(ThreadMessage::assistant("code"));
+        thread.add_message(ThreadMessage::user(
+            "[stdout]\nNameError: name 'foo' is not defined",
+        ));
+
+        let issues = analyze_trace(&thread);
+        assert!(
+            issues.iter().any(|i| i.category == "code_error"),
+            "should detect code error from message when no CodeExecutionFailed events exist"
         );
     }
 

--- a/crates/ironclaw_engine/src/executor/trace.rs
+++ b/crates/ironclaw_engine/src/executor/trace.rs
@@ -230,7 +230,10 @@ fn analyze_trace(thread: &Thread) -> Vec<TraceIssue> {
     }
 
     // Fallback: also check message-level patterns for backward compatibility
-    // with threads that ran before the instrumentation was added.
+    // with threads that ran before the CodeExecutionFailed instrumentation
+    // was added (PR #2483). Note: threads from mixed eras (some steps
+    // instrumented, some not) will only report structured events when any
+    // exist, silently skipping message-level errors from uninstrumented steps.
     if code_failures.is_empty() {
         let error_patterns = [
             "NameError",

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -46,7 +46,8 @@ pub use types::mission::{Mission, MissionCadence, MissionId, MissionStatus, Vali
 pub use types::project::{Project, ProjectId};
 pub use types::provenance::Provenance;
 pub use types::step::{
-    ActionCall, ActionResult, ExecutionTier, LlmResponse, Step, StepId, StepStatus, TokenUsage,
+    ActionCall, ActionResult, CodeExecutionFailure, ExecutionTier, LlmResponse, Step, StepId,
+    StepStatus, TokenUsage,
 };
 pub use types::thread::{
     ActiveSkillProvenance, Thread, ThreadConfig, ThreadId, ThreadState, ThreadType,

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -216,10 +216,10 @@ pub enum EventKind {
     },
 
     // ── Code execution instrumentation ────────────────────────
-    /// Emitted after every code (REPL) execution attempt, whether successful
-    /// or not. Enables aggregate analysis of code execution failure modes
-    /// to determine whether the runtime (Monty), the LLM, or tool dispatch
-    /// is the primary source of failures.
+    /// Emitted when a code (REPL) execution attempt fails. Enables aggregate
+    /// analysis of code execution failure modes to determine whether the
+    /// runtime (Monty), the LLM, or tool dispatch is the primary source of
+    /// failures.
     CodeExecutionFailed {
         step_id: StepId,
         /// Classified failure category.
@@ -240,4 +240,10 @@ pub enum EventKind {
         to_version: u64,
         reason: String,
     },
+
+    /// Unknown event kind — catch-all for forward compatibility during
+    /// rolling deploys. Older binaries deserializing events written by
+    /// newer binaries will produce this variant instead of failing.
+    #[serde(other)]
+    Unknown,
 }

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -215,6 +215,25 @@ pub enum EventKind {
         skill_names: Vec<String>,
     },
 
+    // ── Code execution instrumentation ────────────────────────
+    /// Emitted after every code (REPL) execution attempt, whether successful
+    /// or not. Enables aggregate analysis of code execution failure modes
+    /// to determine whether the runtime (Monty), the LLM, or tool dispatch
+    /// is the primary source of failures.
+    CodeExecutionFailed {
+        step_id: StepId,
+        /// Classified failure category.
+        category: crate::types::step::CodeExecutionFailure,
+        /// The error message text (truncated to 500 chars).
+        error: String,
+        /// Hash of the Python code that was executed, for dedup/correlation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        code_hash: Option<String>,
+        /// Duration of the code execution attempt in milliseconds.
+        #[serde(default)]
+        duration_ms: u64,
+    },
+
     // ── Orchestrator versioning ───────────────────────────────
     OrchestratorRollback {
         from_version: u64,

--- a/crates/ironclaw_engine/src/types/step.rs
+++ b/crates/ironclaw_engine/src/types/step.rs
@@ -138,6 +138,7 @@ pub struct ActionResult {
 /// from LLM logic errors, tool dispatch failures, and resource exhaustion.
 /// This data enables informed decisions about runtime alternatives.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum CodeExecutionFailure {
     /// Python parse error — LLM generated invalid syntax.
     SyntaxError,
@@ -153,8 +154,6 @@ pub enum CodeExecutionFailure {
     ResourceLimit,
     /// A tool call inside code returned an error.
     ToolError,
-    /// Execution was paused by an approval/auth gate.
-    GatePause,
     /// OS operation attempted (blocked by sandbox).
     OsDenied,
 }
@@ -168,7 +167,6 @@ impl std::fmt::Display for CodeExecutionFailure {
             Self::VmPanic => write!(f, "vm_panic"),
             Self::ResourceLimit => write!(f, "resource_limit"),
             Self::ToolError => write!(f, "tool_error"),
-            Self::GatePause => write!(f, "gate_pause"),
             Self::OsDenied => write!(f, "os_denied"),
         }
     }

--- a/crates/ironclaw_engine/src/types/step.rs
+++ b/crates/ironclaw_engine/src/types/step.rs
@@ -132,6 +132,48 @@ pub struct ActionResult {
     pub duration: Duration,
 }
 
+/// Classification of code execution failures.
+///
+/// Used by the instrumentation layer to distinguish Monty VM limitations
+/// from LLM logic errors, tool dispatch failures, and resource exhaustion.
+/// This data enables informed decisions about runtime alternatives.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CodeExecutionFailure {
+    /// Python parse error — LLM generated invalid syntax.
+    SyntaxError,
+    /// Python runtime error (NameError, TypeError, ValueError, etc.) —
+    /// LLM logic bug or use of unsupported feature.
+    RuntimeError,
+    /// Name lookup failed — function/variable not in scope and not a known tool.
+    NameLookup,
+    /// Monty VM panicked (catch_unwind caught it). Indicates a Monty bug,
+    /// not a user code issue.
+    VmPanic,
+    /// Resource limit hit (timeout, memory, or allocation cap).
+    ResourceLimit,
+    /// A tool call inside code returned an error.
+    ToolError,
+    /// Execution was paused by an approval/auth gate.
+    GatePause,
+    /// OS operation attempted (blocked by sandbox).
+    OsDenied,
+}
+
+impl std::fmt::Display for CodeExecutionFailure {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::SyntaxError => write!(f, "syntax_error"),
+            Self::RuntimeError => write!(f, "runtime_error"),
+            Self::NameLookup => write!(f, "name_lookup"),
+            Self::VmPanic => write!(f, "vm_panic"),
+            Self::ResourceLimit => write!(f, "resource_limit"),
+            Self::ToolError => write!(f, "tool_error"),
+            Self::GatePause => write!(f, "gate_pause"),
+            Self::OsDenied => write!(f, "os_denied"),
+        }
+    }
+}
+
 /// Token usage for a single LLM call.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct TokenUsage {

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -36,3 +36,4 @@ V20__pairing_requests = 17756233693090004940
 V21__backfill_conversation_source_channel = 4041142068103384561
 V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
+V24__llm_calls_created_at_index = 2650126284755685421

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -36,4 +36,3 @@ V20__pairing_requests = 17756233693090004940
 V21__backfill_conversation_source_channel = 4041142068103384561
 V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
-V24__llm_calls_created_at_index = 2650126284755685421


### PR DESCRIPTION
## Summary
- Adds `CodeExecutionFailure` enum (7 variants: SyntaxError, RuntimeError, NameLookup, VmPanic, ResourceLimit, ToolError, OsDenied) to classify why code execution fails
- Threads `failure` through `CodeExecutionResult` (replacing `had_error: bool`) and emits structured `CodeExecutionFailed` events for aggregate analysis of failure modes (Monty limitation vs LLM logic error vs tool dispatch failure)
- Upgrades trace analysis to use structured events with severity escalation (VmPanic/ResourceLimit → Error), with backward-compatible fallback for pre-instrumentation threads

### Caller audit (Err → Ok(failure=VmPanic) shift)
`execute_code` / `execute_code_with_skills` previously returned `Err(EngineError::Effect)` on VM panic; now returns `Ok(CodeExecutionResult { failure: Some(VmPanic) })`. The only production call site is `orchestrator.rs:handle_execute_code_step` which correctly dispatches on `result.failure`. Test-only callers in `scripting.rs` were also updated. No other callers exist.

### Known limitation: mixed-era fallback
The trace analyzer's backward-compatible fallback (message-scraping for pre-instrumentation threads) is all-or-nothing: if a thread has *any* `CodeExecutionFailed` event, message-scraping is skipped entirely. Errors from pre-instrumentation steps in a mixed-era thread will go unreported. This is acceptable during the transition period since all new threads will have full instrumentation.

## Test plan
- [x] 11 new unit tests for error classifier, code hash, and trace detection
- [x] `cargo test -p ironclaw_engine --lib` — 395 pass
- [x] `cargo clippy --all --all-features` — zero engine warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)