### PR TITLE
feat(gateway): show commit hash in version for non-tagged builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6635,7 +6635,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -6707,9 +6707,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,9 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let root = PathBuf::from(&manifest_dir);
 
+    // ── Git build metadata ─────────────────────────────────────────────
+    emit_git_metadata(&root);
+
     // ── Embed registry manifests ────────────────────────────────────────
     embed_registry_catalog(&root);
 
@@ -111,6 +114,69 @@ fn main() {
             let _ = std::fs::rename(&stripped, &wasm_out);
         }
     }
+}
+
+/// Emit `GIT_COMMIT_HASH` and `GIT_DIRTY` as compile-time env vars.
+///
+/// If the current HEAD is an exact tag match, `GIT_COMMIT_HASH` is empty
+/// (the Cargo version is sufficient). Otherwise it contains the short hash,
+/// and `GIT_DIRTY` is "true" if the working tree has uncommitted changes.
+fn emit_git_metadata(root: &Path) {
+    // Rerun when the git HEAD changes (commit, checkout, rebase).
+    let git_head = root.join(".git/HEAD");
+    if git_head.exists() {
+        println!("cargo:rerun-if-changed=.git/HEAD");
+        // Also watch the ref that HEAD points to (for branch commits).
+        if let Ok(head) = std::fs::read_to_string(&git_head)
+            && let Some(refpath) = head.trim().strip_prefix("ref: ")
+        {
+            let reffile = root.join(".git").join(refpath);
+            if reffile.exists() {
+                println!("cargo:rerun-if-changed=.git/{}", refpath);
+            }
+        }
+    }
+
+    // Check if HEAD is an exact version tag (e.g. v0.25.0).
+    let is_tagged = Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .current_dir(root)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if is_tagged {
+        // Tagged release — version string alone is enough.
+        println!("cargo:rustc-env=GIT_COMMIT_HASH=");
+        println!("cargo:rustc-env=GIT_DIRTY=false");
+        return;
+    }
+
+    // Short commit hash.
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    // Dirty flag.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(root)
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", hash);
+    println!("cargo:rustc-env=GIT_DIRTY={}", dirty);
 }
 
 /// Collect all registry manifests into a single JSON blob at compile time.

--- a/build.rs
+++ b/build.rs
@@ -129,20 +129,19 @@ fn emit_git_metadata(root: &Path) {
         .args(["rev-parse", "--git-dir"])
         .current_dir(root)
         .output()
+        && output.status.success()
     {
-        if output.status.success() {
-            let git_dir = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
-            let git_head = git_dir.join("HEAD");
-            if git_head.exists() {
-                println!("cargo:rerun-if-changed={}", git_head.display());
-                // Also watch the ref that HEAD points to (for branch commits).
-                if let Ok(head) = std::fs::read_to_string(&git_head)
-                    && let Some(refpath) = head.trim().strip_prefix("ref: ")
-                {
-                    let reffile = git_dir.join(refpath);
-                    if reffile.exists() {
-                        println!("cargo:rerun-if-changed={}", reffile.display());
-                    }
+        let git_dir = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        let git_head = git_dir.join("HEAD");
+        if git_head.exists() {
+            println!("cargo:rerun-if-changed={}", git_head.display());
+            // Also watch the ref that HEAD points to (for branch commits).
+            if let Ok(head) = std::fs::read_to_string(&git_head)
+                && let Some(refpath) = head.trim().strip_prefix("ref: ")
+            {
+                let reffile = git_dir.join(refpath);
+                if reffile.exists() {
+                    println!("cargo:rerun-if-changed={}", reffile.display());
                 }
             }
         }

--- a/build.rs
+++ b/build.rs
@@ -123,16 +123,27 @@ fn main() {
 /// and `GIT_DIRTY` is "true" if the working tree has uncommitted changes.
 fn emit_git_metadata(root: &Path) {
     // Rerun when the git HEAD changes (commit, checkout, rebase).
-    let git_head = root.join(".git/HEAD");
-    if git_head.exists() {
-        println!("cargo:rerun-if-changed=.git/HEAD");
-        // Also watch the ref that HEAD points to (for branch commits).
-        if let Ok(head) = std::fs::read_to_string(&git_head)
-            && let Some(refpath) = head.trim().strip_prefix("ref: ")
-        {
-            let reffile = root.join(".git").join(refpath);
-            if reffile.exists() {
-                println!("cargo:rerun-if-changed=.git/{}", refpath);
+    // Use `git rev-parse --git-dir` so this works inside git worktrees
+    // (where `.git` is a file pointing elsewhere, not a directory).
+    if let Ok(output) = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(root)
+        .output()
+    {
+        if output.status.success() {
+            let git_dir = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+            let git_head = git_dir.join("HEAD");
+            if git_head.exists() {
+                println!("cargo:rerun-if-changed={}", git_head.display());
+                // Also watch the ref that HEAD points to (for branch commits).
+                if let Ok(head) = std::fs::read_to_string(&git_head)
+                    && let Some(refpath) = head.trim().strip_prefix("ref: ")
+                {
+                    let reffile = git_dir.join(refpath);
+                    if reffile.exists() {
+                        println!("cargo:rerun-if-changed={}", reffile.display());
+                    }
+                }
             }
         }
     }

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -6524,9 +6524,13 @@ function fetchGatewayStatus() {
     var popover = document.getElementById('gateway-popover');
     var html = '';
 
-    // Version
+    // Version — show commit hash when not a tagged release
     if (data.version) {
-      html += '<div class="gw-section-label">IronClaw v' + escapeHtml(data.version) + '</div>';
+      var versionText = 'IronClaw v' + escapeHtml(data.version);
+      if (data.commit_hash) {
+        versionText += ' (' + escapeHtml(data.commit_hash) + ')';
+      }
+      html += '<div class="gw-section-label">' + versionText + '</div>';
       html += '<div class="gw-divider"></div>';
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,10 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rustls-webpki URI name constraints — 0.101.7 pinned by aws-smithy (rustls 0.21), 0.102.8 pinned by libsql
+    "RUSTSEC-2026-0098",
+    # rustls-webpki wildcard name constraints — 0.102.8 pinned by libsql transitive dep
+    "RUSTSEC-2026-0099",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",
@@ -64,3 +68,4 @@ allow-git = [
     "https://github.com/pydantic/monty.git",
     "https://github.com/astral-sh/ruff.git",
 ]
+

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -3877,8 +3877,24 @@ async fn gateway_status_handler(
         .map(|v| v.to_lowercase() == "true")
         .unwrap_or(false);
 
+    // Show commit hash when not a tagged release.
+    let commit_hash = {
+        let h = env!("GIT_COMMIT_HASH");
+        if h.is_empty() {
+            None
+        } else {
+            let dirty = env!("GIT_DIRTY") == "true";
+            Some(if dirty {
+                format!("{h}-dirty")
+            } else {
+                h.to_string()
+            })
+        }
+    };
+
     Json(GatewayStatusResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
+        commit_hash,
         sse_connections,
         ws_connections,
         total_connections: sse_connections + ws_connections,
@@ -3904,6 +3920,8 @@ struct ModelUsageEntry {
 #[derive(serde::Serialize)]
 struct GatewayStatusResponse {
     version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_hash: Option<String>,
     sse_connections: u64,
     ws_connections: u64,
     total_connections: u64,


### PR DESCRIPTION
## Summary

- Emit `GIT_COMMIT_HASH` and `GIT_DIRTY` from `build.rs` so the gateway version display includes the short commit hash for non-tagged builds
- Uses `git rev-parse --git-dir` for worktree-safe git directory resolution
- Frontend displays the hash suffix in the version string

## Changes from original PR #2486

- Fixed worktree-incompatible `.git/HEAD` path (review feedback from gemini-code-assist)
- Fixed clippy `collapsible_if` lint
- Bumped `rustls-webpki` 0.103.10 → 0.103.12 and added ignore entries for RUSTSEC-2026-{0098,0099} (transitive deps pinned by aws-smithy and libsql)

## Test plan

- [x] `cargo fmt` passes
- [x] `cargo clippy --all --all-features` passes
- [x] `cargo test --lib` passes (no regressions)
- [x] `cargo deny check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)