### PR TITLE
fix(agent): prevent image_analyze calls on web-uploaded images

### DIFF
--- a/src/agent/attachments.rs
+++ b/src/agent/attachments.rs
@@ -215,7 +215,7 @@ mod tests {
         assert!(
             result
                 .text
-.contains("[Image attached — visual content not available in this conversation.]")
+                .contains("[Image attached — visual content not available in this conversation.]")
         );
         assert!(result.image_parts.is_empty());
     }

--- a/src/agent/attachments.rs
+++ b/src/agent/attachments.rs
@@ -215,7 +215,7 @@ mod tests {
         assert!(
             result
                 .text
-                .contains("visual content not available in this conversation.")
+.contains("[Image attached — visual content not available in this conversation.]")
         );
         assert!(result.image_parts.is_empty());
     }

--- a/src/agent/attachments.rs
+++ b/src/agent/attachments.rs
@@ -97,9 +97,9 @@ fn format_attachment(index: usize, att: &IncomingAttachment) -> String {
                 .unwrap_or_default();
 
             let body = if att.data.is_empty() {
-                "[Image attached — visual content not available in this conversation]"
+                "[Image attached — visual content not available in this conversation.]"
             } else {
-                "[Image attached — sent as visual content]"
+                "[Image attached — you can already see this image directly in the conversation. Do NOT use image_analyze or try to find this file on disk — it exists only in memory. Analyze it using your vision capabilities.]"
             };
 
             format!(
@@ -215,7 +215,7 @@ mod tests {
         assert!(
             result
                 .text
-                .contains("[Image attached — visual content not available in this conversation]")
+                .contains("visual content not available in this conversation.")
         );
         assert!(result.image_parts.is_empty());
     }
@@ -231,7 +231,7 @@ mod tests {
         assert!(
             result
                 .text
-                .contains("[Image attached — sent as visual content]")
+                .contains("you can already see this image directly")
         );
         assert_eq!(result.image_parts.len(), 1);
         match &result.image_parts[0] {


### PR DESCRIPTION
## Summary

When images are uploaded through the web UI, the agent would call `image_analyze` on them, which always failed because the images only exist in memory — never on disk.

**The flow:**
1. User uploads image via web UI → sent as base64
2. `images_to_attachments()` converts to `IncomingAttachment` with raw bytes
3. `augment_with_attachments()` creates multimodal `ContentPart::ImageUrl` data URLs — **the LLM can already see the image**
4. But the attachment metadata XML includes `filename="image-0.png"` with text `[Image attached — sent as visual content]`
5. The LLM sees the filename and calls `image_analyze` with it → tries `tokio::fs::read()` → **"No such file or directory (os error 2)"**
6. LLM falls back to `glob` and `list_dir` searching for the file → also fails
7. Eventually gives up and responds using the image it could already see

**The fix:** Update the attachment body text for images with inline data to explicitly tell the LLM it already has the image via vision and should not attempt filesystem access or tool calls.

- `src/agent/attachments.rs` — changed the `[Image attached — sent as visual content]` text to clearly instruct the model not to use `image_analyze`

## Test plan

- [x] All 10 `agent::attachments` unit tests pass
- [ ] Manual: upload an image through web UI, verify agent responds using vision without calling `image_analyze`

🤖 Generated with [Claude Code](https://claude.com/claude-code)