### PR TITLE
fix(e2e): resolve 12 E2E test failures across routines and features groups

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -3554,8 +3554,8 @@ function loadThreads() {
         // Skip external-channel threads (e.g. HTTP, Telegram) — they are
         // read-only in the web UI, so auto-switching to one would leave the
         // chat input disabled.  Fall through to the assistant thread instead.
-        var activeThread = threads.find(t => t.id === activeThreadId);
-        if (!activeThread || !isReadOnlyChannel(activeThread.channel)) {
+        const activeThread = threads.find(t => t.id === activeThreadId);
+        if (!isReadOnlyChannel(activeThread.channel)) {
           switchThread(activeThreadId);
           return;
         }

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -1311,6 +1311,7 @@ function enableChatInput() {
   const btn = document.getElementById('send-btn');
   if (input) {
     input.disabled = false;
+    input.placeholder = I18n.t('chat.inputPlaceholder');
   }
   if (btn) btn.disabled = false;
 }
@@ -3550,8 +3551,14 @@ function loadThreads() {
         return;
       }
       if (activeThreadId && threads.some(t => t.id === activeThreadId)) {
-        switchThread(activeThreadId);
-        return;
+        // Skip external-channel threads (e.g. HTTP, Telegram) — they are
+        // read-only in the web UI, so auto-switching to one would leave the
+        // chat input disabled.  Fall through to the assistant thread instead.
+        var activeThread = threads.find(t => t.id === activeThreadId);
+        if (!activeThread || !isReadOnlyChannel(activeThread.channel)) {
+          switchThread(activeThreadId);
+          return;
+        }
       }
       if (assistantThreadId) {
         switchToAssistant();

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1221,13 +1221,18 @@ impl Agent {
                 .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
 
             if thread.state != ThreadState::AwaitingApproval {
-                // Stale or duplicate approval (tool already executed) — silently ignore.
+                // No pending approval on this thread. Could be stale/duplicate
+                // (tool already executed) or a /approve typed on a thread with
+                // nothing pending.  Return a visible message so the user and
+                // UI-level tests know the command was processed.
                 tracing::debug!(
                     %thread_id,
                     state = ?thread.state,
-                    "Ignoring stale approval: thread not in AwaitingApproval state"
+                    "Ignoring approval: thread not in AwaitingApproval state"
                 );
-                return Ok(SubmissionResult::ok_with_message(""));
+                return Ok(SubmissionResult::ok_with_message(
+                    "No pending approval for this thread.",
+                ));
             }
 
             let pending = match thread.take_pending_approval() {

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -126,6 +126,58 @@ async def test_refresh_without_hash_reopens_active_thread_history(page):
     ).wait_for(state="visible", timeout=15000)
 
 
+async def test_refresh_skips_readonly_external_active_thread(page):
+    """When the server active_thread is an external-channel (HTTP/Telegram) thread,
+    a refresh without a hash should fall through to the assistant thread with
+    the chat input enabled, not land on the read-only thread."""
+
+    # 1. Create a secondary thread and send a message so it becomes active_thread
+    await page.locator("#thread-new-btn").click()
+    await page.wait_for_function(
+        "() => !!currentThreadId && currentThreadId !== assistantThreadId"
+    )
+    ext_thread_id = await page.evaluate("() => currentThreadId")
+
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "Readonly channel test message",
+    )
+    assert result["role"] == "assistant"
+
+    # 2. Strip the URL hash so reload relies on active_thread
+    await page.evaluate(
+        "() => history.replaceState(null, '', location.pathname + location.search)"
+    )
+
+    # 3. Intercept /api/chat/threads to mark the active thread as "http" channel
+    async def patch_threads_response(route):
+        response = await route.fetch()
+        body = await response.json()
+        for t in body.get("threads", []):
+            if t["id"] == ext_thread_id:
+                t["channel"] = "http"
+        await route.fulfill(response=response, json=body)
+
+    await page.route("**/api/chat/threads", patch_threads_response)
+
+    # 4. Reload — loadThreads() should skip the "http" active thread
+    await page.reload()
+    await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    await _wait_for_connected(page, timeout=15000)
+
+    # 5. Assert we landed on the assistant thread, not the external one
+    await page.wait_for_function(
+        "() => currentThreadId === assistantThreadId",
+        timeout=15000,
+    )
+
+    # 6. Chat input should be enabled (not disabled by read-only state)
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+    is_disabled = await chat_input.is_disabled()
+    assert not is_disabled, "Chat input should be enabled on the assistant thread"
+
+
 async def test_sse_keepalive_comments_arrive(managed_gateway_server):
     """Idle SSE connections should receive keepalive comments within 30 seconds."""
     async with sse_stream(managed_gateway_server.base_url, timeout=50) as response:

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -285,6 +285,70 @@ async def test_chat_reply_deny_rejects_pending_tool(ironclaw_server):
     assert "Tool 'http' was rejected" in response_text
 
 
+async def test_text_approval_resolves_real_tool_call(page):
+    """Typing 'yes' should resolve a real approval gate triggered by a tool call."""
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    # Trigger a real HTTP tool call that requires approval
+    await chat_input.fill("make approval post text-approval-e2e")
+    await chat_input.press("Enter")
+
+    # Wait for the approval card to appear (from the SSE event)
+    card = page.locator(SEL["approval_card"]).last
+    await card.wait_for(state="visible", timeout=15000)
+
+    tool_name = await card.locator(".approval-tool-name").text_content()
+    assert tool_name == "http"
+
+    # Type "yes" to approve — should be intercepted by the frontend
+    await chat_input.fill("yes")
+    await chat_input.press("Enter")
+
+    # Card should show resolved status
+    resolved = card.locator(".approval-resolved")
+    await resolved.wait_for(state="visible", timeout=5000)
+    assert await resolved.text_content() == "Approved"
+
+    # Card should be removed after brief delay
+    await card.wait_for(state="hidden", timeout=5000)
+
+
+async def test_slash_approve_is_thread_scoped_api(ironclaw_server):
+    """Sending '/approve' in thread A must not resolve a pending gate in thread B."""
+    thread_a = await _create_thread(ironclaw_server)
+    thread_b = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(
+        ironclaw_server,
+        thread_b,
+        "make approval post slash-approve-thread-scope",
+    )
+    await _wait_for_history(ironclaw_server, thread_b, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_a, "/approve")
+    await asyncio.sleep(1.0)
+
+    history_a = await _wait_for_history(
+        ironclaw_server,
+        thread_a,
+        expect_pending=False,
+        timeout=5.0,
+    )
+    assert history_a.get("pending_gate") is None
+
+    history_b = await _wait_for_history(
+        ironclaw_server,
+        thread_b,
+        expect_pending=True,
+        turn_count_at_least=1,
+        timeout=5.0,
+    )
+    assert history_b.get("pending_gate") is not None
+
+
+# NOTE: This test permanently auto-approves the `http` tool for the session.
+# All tests that need the http approval gate to fire MUST run before this one.
 async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
     """A plain chat reply of 'always' should auto-approve the same tool next time."""
     thread_id = await _create_thread(ironclaw_server)
@@ -561,35 +625,6 @@ async def test_normal_text_not_intercepted_with_approval_card(page):
     )
 
 
-async def test_text_approval_resolves_real_tool_call(page):
-    """Typing 'yes' should resolve a real approval gate triggered by a tool call."""
-    chat_input = page.locator(SEL["chat_input"])
-    await chat_input.wait_for(state="visible", timeout=5000)
-
-    # Trigger a real HTTP tool call that requires approval
-    await chat_input.fill("make approval post text-approval-e2e")
-    await chat_input.press("Enter")
-
-    # Wait for the approval card to appear (from the SSE event)
-    card = page.locator(SEL["approval_card"]).last
-    await card.wait_for(state="visible", timeout=15000)
-
-    tool_name = await card.locator(".approval-tool-name").text_content()
-    assert tool_name == "http"
-
-    # Type "yes" to approve — should be intercepted by the frontend
-    await chat_input.fill("yes")
-    await chat_input.press("Enter")
-
-    # Card should show resolved status
-    resolved = card.locator(".approval-resolved")
-    await resolved.wait_for(state="visible", timeout=5000)
-    assert await resolved.text_content() == "Approved"
-
-    # Card should be removed after brief delay
-    await card.wait_for(state="hidden", timeout=5000)
-
-
 # -- Regression: bare keywords without pending approval ----------------------
 
 
@@ -761,34 +796,3 @@ async def test_slash_approve_does_not_intercept_other_thread_card(page):
     )
 
 
-async def test_slash_approve_is_thread_scoped_api(ironclaw_server):
-    """Sending '/approve' in thread A must not resolve a pending gate in thread B."""
-    thread_a = await _create_thread(ironclaw_server)
-    thread_b = await _create_thread(ironclaw_server)
-
-    await _send_chat_message(
-        ironclaw_server,
-        thread_b,
-        "make approval post slash-approve-thread-scope",
-    )
-    await _wait_for_history(ironclaw_server, thread_b, expect_pending=True)
-
-    await _send_chat_message(ironclaw_server, thread_a, "/approve")
-    await asyncio.sleep(1.0)
-
-    history_a = await _wait_for_history(
-        ironclaw_server,
-        thread_a,
-        expect_pending=False,
-        timeout=5.0,
-    )
-    assert history_a.get("pending_gate") is None
-
-    history_b = await _wait_for_history(
-        ironclaw_server,
-        thread_b,
-        expect_pending=True,
-        turn_count_at_least=1,
-        timeout=5.0,
-    )
-    assert history_b.get("pending_gate") is not None


### PR DESCRIPTION
## Summary

Fixes 12 E2E test failures from [staging E2E run #24329804980](https://github.com/nearai/ironclaw/actions/runs/24329804980) across the **routines** (9 failures) and **features** (3 failures) groups.

Three distinct root causes:

- **Read-only thread regression (9 routines failures):** `ed2d6dc3` changed `loadThreads()` to follow the server's `active_thread` on page load. When a prior test creates an HTTP-channel thread, new browser pages auto-switch to it — disabling the chat input with "Read-only thread (external channel)". Fix: skip read-only channel threads when auto-switching; also restore placeholder text in `enableChatInput()`.

- **Tool approval state contamination (2 features failures):** `test_chat_reply_always` permanently auto-approves the `http` tool for the session. Tests that run after it (`test_text_approval_resolves_real_tool_call`, `test_slash_approve_is_thread_scoped_api`) find the tool pre-approved and never see the approval gate fire. Fix: reorder so real-approval-gate tests run before the "always" test.

- **Silent `/approve` on idle thread (1 features failure):** `/approve` is always routed as an approval command (starts with `/`). `process_approval()` returns an empty message when no approval is pending, producing `HandleOutcome::NoResponse`. `send_chat_and_wait_for_terminal_message` times out waiting for a visible response. Fix: return `"No pending approval for this thread."` so the response is visible.

## Test plan

- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Verify 105 approval-related unit tests pass (`cargo test --lib approval` — confirmed locally)
- [ ] Trigger E2E workflow and verify all 12 previously-failing tests pass
- [ ] Verify no regressions in passing tests (core, extensions groups)


🤖 Generated with [Claude Code](https://claude.com/claude-code)