### PR TITLE
Fix Slack relay OAuth callback state lookup

### DIFF
--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -2593,10 +2593,10 @@ fn collect_errors_and_actions(thread: &Thread) -> (Vec<String>, Vec<String>) {
                     actions.push(action_name.clone());
                 }
             }
-            crate::types::event::EventKind::ActionExecuted { action_name, .. } => {
-                if seen.insert(action_name.clone()) {
-                    actions.push(action_name.clone());
-                }
+            crate::types::event::EventKind::ActionExecuted { action_name, .. }
+                if seen.insert(action_name.clone()) =>
+            {
+                actions.push(action_name.clone());
             }
             _ => {}
         }

--- a/crates/ironclaw_skills/src/catalog.rs
+++ b/crates/ironclaw_skills/src/catalog.rs
@@ -461,7 +461,7 @@ impl SkillCatalog {
 
         let details = futures::future::join_all(futures).await;
 
-        for (entry, detail) in entries[..count].iter_mut().zip(details.into_iter()) {
+        for (entry, detail) in entries[..count].iter_mut().zip(details) {
             if let Some(detail) = detail {
                 if let Some(ref stats) = detail.stats {
                     entry.stars = stats.stars;

--- a/crates/ironclaw_skills/src/parser.rs
+++ b/crates/ironclaw_skills/src/parser.rs
@@ -62,6 +62,7 @@ pub fn parse_skill_md(content: &str) -> Result<ParsedSkill, SkillParseError> {
 /// This is intentionally crate-private and should remain limited to the
 /// install-recovery path. Normal discovery/loading must keep using
 /// [`parse_skill_md`] so invalid names are rejected.
+#[cfg(feature = "registry")]
 pub(crate) fn parse_skill_md_for_install_recovery(
     content: &str,
 ) -> Result<ParsedSkill, SkillParseError> {
@@ -73,6 +74,7 @@ pub(crate) fn parse_skill_md_for_install_recovery(
 ///
 /// Used by install recovery to mutate a single field (`name`) while preserving
 /// any unknown YAML keys that the typed `SkillManifest` would otherwise drop.
+#[cfg(feature = "registry")]
 pub(crate) fn split_skill_md_frontmatter(
     content: &str,
 ) -> Result<(String, String), SkillParseError> {

--- a/crates/ironclaw_tui/src/render.rs
+++ b/crates/ironclaw_tui/src/render.rs
@@ -169,12 +169,11 @@ pub fn render_markdown(text: &str, max_width: usize, theme: &Theme) -> Vec<Line<
                 ctx.first_block = false;
             }
 
-            Event::Start(Tag::Paragraph) => {
-                if ctx.need_blank_line && !ctx.first_block {
-                    ctx.lines.push(Line::from(""));
-                    ctx.need_blank_line = false;
-                }
+            Event::Start(Tag::Paragraph) if ctx.need_blank_line && !ctx.first_block => {
+                ctx.lines.push(Line::from(""));
+                ctx.need_blank_line = false;
             }
+            Event::Start(Tag::Paragraph) => {}
             Event::End(TagEnd::Paragraph) => {
                 ctx.flush(max_width, theme);
                 ctx.need_blank_line = true;
@@ -307,12 +306,11 @@ pub fn render_markdown(text: &str, max_width: usize, theme: &Theme) -> Vec<Line<
                 }
             }
 
-            Event::SoftBreak => {
-                if !ctx.in_code_block {
-                    let style = ctx.top_style();
-                    ctx.segments.push((" ".to_string(), style));
-                }
+            Event::SoftBreak if !ctx.in_code_block => {
+                let style = ctx.top_style();
+                ctx.segments.push((" ".to_string(), style));
             }
+            Event::SoftBreak => {}
             Event::HardBreak => {
                 ctx.flush(max_width, theme);
             }

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1185,16 +1185,14 @@ pub async fn get_response_handler(
     let mut output = Vec::new();
     for msg in &messages {
         match msg.role.as_str() {
-            "assistant" => {
-                if !msg.content.is_empty() {
-                    output.push(ResponseOutputItem::Message {
-                        id: format!("msg_{}", msg.id.simple()),
-                        role: "assistant".to_string(),
-                        content: vec![MessageContent::OutputText {
-                            text: msg.content.clone(),
-                        }],
-                    });
-                }
+            "assistant" if !msg.content.is_empty() => {
+                output.push(ResponseOutputItem::Message {
+                    id: format!("msg_{}", msg.id.simple()),
+                    role: "assistant".to_string(),
+                    content: vec![MessageContent::OutputText {
+                        text: msg.content.clone(),
+                    }],
+                });
             }
             "tool_calls" => {
                 // Tool calls may be stored as a plain JSON array (legacy) or

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -79,7 +79,7 @@ use crate::channels::web::util::{
 };
 use crate::db::Database;
 use crate::extensions::ExtensionManager;
-use crate::extensions::naming::{canonicalize_extension_name, legacy_extension_alias};
+use crate::extensions::naming::extension_name_candidates;
 use crate::orchestrator::job_manager::ContainerJobManager;
 use crate::tools::ToolRegistry;
 use crate::workspace::Workspace;
@@ -106,16 +106,6 @@ fn redact_oauth_state_for_logs(state: &str) -> String {
         let _ = write!(&mut short_hash, "{byte:02x}");
     }
     format!("sha256:{short_hash}:len={}", state.len())
-}
-
-fn relay_extension_name_candidates() -> Vec<String> {
-    let canonical = canonicalize_extension_name(DEFAULT_RELAY_NAME)
-        .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
-    let mut names = vec![canonical.clone()];
-    if let Some(legacy) = legacy_extension_alias(&canonical) {
-        names.push(legacy);
-    }
-    names
 }
 
 pub(crate) fn rate_limit_key_from_headers(headers: &HeaderMap) -> String {
@@ -2123,11 +2113,8 @@ async fn slack_relay_oauth_callback_handler(
         }
     };
 
-    let relay_names = relay_extension_name_candidates();
-    let relay_extension_name = relay_names
-        .first()
-        .cloned()
-        .unwrap_or_else(|| DEFAULT_RELAY_NAME.to_string());
+    let relay_names = extension_name_candidates(DEFAULT_RELAY_NAME);
+    let relay_extension_name = relay_names[0].clone();
     let mut stored_state = None;
     let mut resolved_state_key = None;
     let mut last_lookup_error = None;
@@ -2149,12 +2136,17 @@ async fn slack_relay_oauth_callback_handler(
         }
     }
     let Some(stored_state) = stored_state else {
-        let (state_key, error) = last_lookup_error.unwrap_or_else(|| {
-            (
-                format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME),
-                "no relay state lookup attempted".to_string(),
-            )
-        });
+        let attempted_state_keys = relay_names
+            .iter()
+            .map(|relay_name| format!("relay:{relay_name}:oauth_state"))
+            .collect::<Vec<_>>();
+        let (state_key, error) = match last_lookup_error {
+            Some((state_key, error)) => (state_key, error),
+            None => (
+                attempted_state_keys.join(","),
+                "relay lookup did not capture an error".to_string(),
+            ),
+        };
         tracing::warn!(
             owner_id = %state.owner_id,
             state_key = %state_key,

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -81,6 +81,7 @@ use crate::db::Database;
 use crate::extensions::ExtensionManager;
 use crate::extensions::naming::extension_name_candidates;
 use crate::orchestrator::job_manager::ContainerJobManager;
+use crate::secrets::SecretConsumeResult;
 use crate::tools::ToolRegistry;
 use crate::workspace::Workspace;
 
@@ -2115,27 +2116,34 @@ async fn slack_relay_oauth_callback_handler(
 
     let relay_names = extension_name_candidates(DEFAULT_RELAY_NAME);
     let relay_extension_name = relay_names[0].clone();
-    let mut stored_state = None;
-    let mut resolved_state_key = None;
+    let mut nonce_consumed = false;
     let mut last_lookup_error = None;
     for relay_name in &relay_names {
         let state_key = format!("relay:{relay_name}:oauth_state");
         match ext_mgr
             .secrets()
-            .get_decrypted(&state.owner_id, &state_key)
+            .consume_if_matches(&state.owner_id, &state_key, &state_param)
             .await
         {
-            Ok(secret) => {
-                stored_state = Some(secret.expose().to_string());
-                resolved_state_key = Some(state_key);
+            Ok(SecretConsumeResult::Matched) => {
+                nonce_consumed = true;
                 break;
             }
+            Ok(SecretConsumeResult::Mismatched) => {
+                return axum::response::Html(
+                    "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
+                     <h2>Error</h2><p>Invalid or expired authorization.</p></body></html>"
+                        .to_string(),
+                )
+                .into_response();
+            }
+            Ok(SecretConsumeResult::NotFound) => {}
             Err(e) => {
                 last_lookup_error = Some((state_key, e.to_string()));
             }
         }
     }
-    let Some(stored_state) = stored_state else {
+    if !nonce_consumed {
         let attempted_state_keys = relay_names
             .iter()
             .map(|relay_name| format!("relay:{relay_name}:oauth_state"))
@@ -2160,20 +2168,6 @@ async fn slack_relay_oauth_callback_handler(
                 .to_string(),
         )
         .into_response();
-    };
-
-    if state_param != stored_state {
-        return axum::response::Html(
-            "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
-             <h2>Error</h2><p>Invalid or expired authorization.</p></body></html>"
-                .to_string(),
-        )
-        .into_response();
-    }
-
-    // Delete the nonce (one-time use)
-    if let Some(state_key) = resolved_state_key.as_deref() {
-        let _ = ext_mgr.secrets().delete(&state.owner_id, state_key).await;
     }
 
     let result: Result<(), String> = async {
@@ -5672,7 +5666,7 @@ mod tests {
                 ))
                 .expect("crypto"),
             )));
-        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets);
+        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets.clone());
 
         let state = test_gateway_state(Some(ext_mgr));
         let app = test_oauth_router(state);
@@ -6554,7 +6548,7 @@ mod tests {
         use tower::ServiceExt;
 
         let secrets = test_secrets_store();
-        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets);
+        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets.clone());
         let state = test_gateway_state(Some(ext_mgr));
         let app = test_relay_oauth_router(state);
 
@@ -6598,7 +6592,7 @@ mod tests {
             .await
             .expect("store nonce");
 
-        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets);
+        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets.clone());
         let state = test_gateway_state(Some(ext_mgr));
         let app = test_relay_oauth_router(state);
 
@@ -6621,6 +6615,10 @@ mod tests {
             "Expected CSRF error for wrong nonce, got: {}",
             &html[..html.len().min(300)]
         );
+
+        let state_key = format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME);
+        let exists = secrets.exists("test", &state_key).await.unwrap_or(false);
+        assert!(exists, "Wrong nonce must not consume the stored CSRF nonce");
     }
 
     #[tokio::test]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -78,8 +78,8 @@ use crate::channels::web::util::{
     enforce_generated_image_history_budget, tool_error_for_display, tool_result_preview,
 };
 use crate::db::Database;
-use crate::extensions::naming::{canonicalize_extension_name, legacy_extension_alias};
 use crate::extensions::ExtensionManager;
+use crate::extensions::naming::{canonicalize_extension_name, legacy_extension_alias};
 use crate::orchestrator::job_manager::ContainerJobManager;
 use crate::tools::ToolRegistry;
 use crate::workspace::Workspace;

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2124,6 +2124,10 @@ async fn slack_relay_oauth_callback_handler(
     };
 
     let relay_names = relay_extension_name_candidates();
+    let relay_extension_name = relay_names
+        .first()
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_RELAY_NAME.to_string());
     let mut stored_state = None;
     let mut resolved_state_key = None;
     let mut last_lookup_error = None;
@@ -2185,8 +2189,6 @@ async fn slack_relay_oauth_callback_handler(
             "Relay activation requires persistent settings storage; no-db mode is unsupported."
                 .to_string()
         })?;
-        let relay_extension_name = canonicalize_extension_name(DEFAULT_RELAY_NAME)
-            .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
 
         // Store team_id in settings
         let team_id_key = format!("relay:{}:team_id", relay_extension_name);
@@ -2236,10 +2238,8 @@ async fn slack_relay_oauth_callback_handler(
     };
 
     // Broadcast event to notify the web UI
-    let relay_extension_name = canonicalize_extension_name(DEFAULT_RELAY_NAME)
-        .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
     state.sse.broadcast(AppEvent::AuthCompleted {
-        extension_name: relay_extension_name,
+        extension_name: relay_extension_name.clone(),
         success,
         message: message.clone(),
         thread_id: None,
@@ -6688,6 +6688,60 @@ mod tests {
         let state_key = format!("relay:{}:oauth_state", relay_name);
         let exists = secrets.exists("test", &state_key).await.unwrap_or(true);
         assert!(!exists, "CSRF nonce should be deleted after use");
+    }
+
+    #[tokio::test]
+    async fn test_relay_oauth_callback_legacy_state_proceeds_and_is_consumed() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let secrets = test_secrets_store();
+        let nonce = "legacy-test-nonce-12345";
+        let relay_name = crate::extensions::naming::canonicalize_extension_name(DEFAULT_RELAY_NAME)
+            .expect("canonical relay name");
+        let legacy_relay_name = crate::extensions::naming::legacy_extension_alias(&relay_name)
+            .expect("legacy relay alias");
+
+        secrets
+            .create(
+                "test",
+                crate::secrets::CreateSecretParams::new(
+                    format!("relay:{}:oauth_state", legacy_relay_name),
+                    nonce,
+                ),
+            )
+            .await
+            .expect("store legacy nonce");
+
+        let (ext_mgr, _wasm_tools_dir, _wasm_channels_dir) = test_ext_mgr(secrets.clone());
+        let state = test_gateway_state(Some(ext_mgr));
+        let app = test_relay_oauth_router(state);
+
+        let req = axum::http::Request::builder()
+            .uri(format!(
+                "/oauth/slack/callback?team_id=T123&provider=slack&state={}",
+                nonce
+            ))
+            .body(Body::empty())
+            .expect("request");
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let html = String::from_utf8_lossy(&body);
+        assert!(
+            !html.contains("Invalid or expired authorization"),
+            "Should have passed CSRF check with legacy nonce, got: {}",
+            &html[..html.len().min(300)]
+        );
+
+        let state_key = format!("relay:{}:oauth_state", legacy_relay_name);
+        let exists = secrets.exists("test", &state_key).await.unwrap_or(true);
+        assert!(!exists, "Legacy CSRF nonce should be deleted after use");
     }
 
     #[tokio::test]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2149,15 +2149,16 @@ async fn slack_relay_oauth_callback_handler(
             .map(|relay_name| format!("relay:{relay_name}:oauth_state"))
             .collect::<Vec<_>>();
         let (state_key, error) = match last_lookup_error {
-            Some((state_key, error)) => (state_key, error),
+            Some((state_key, error)) => (Some(state_key), error),
             None => (
-                attempted_state_keys.join(","),
-                "relay lookup did not capture an error".to_string(),
+                None,
+                "stored nonce not found under any relay state key".to_string(),
             ),
         };
         tracing::warn!(
             owner_id = %state.owner_id,
-            state_key = %state_key,
+            state_key = ?state_key,
+            attempted_state_keys = ?attempted_state_keys,
             state = %redact_oauth_state_for_logs(&state_param),
             error = %error,
             "relay OAuth callback: failed to retrieve stored nonce"

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -78,6 +78,7 @@ use crate::channels::web::util::{
     enforce_generated_image_history_budget, tool_error_for_display, tool_result_preview,
 };
 use crate::db::Database;
+use crate::extensions::naming::{canonicalize_extension_name, legacy_extension_alias};
 use crate::extensions::ExtensionManager;
 use crate::orchestrator::job_manager::ContainerJobManager;
 use crate::tools::ToolRegistry;
@@ -105,6 +106,16 @@ fn redact_oauth_state_for_logs(state: &str) -> String {
         let _ = write!(&mut short_hash, "{byte:02x}");
     }
     format!("sha256:{short_hash}:len={}", state.len())
+}
+
+fn relay_extension_name_candidates() -> Vec<String> {
+    let canonical = canonicalize_extension_name(DEFAULT_RELAY_NAME)
+        .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
+    let mut names = vec![canonical.clone()];
+    if let Some(legacy) = legacy_extension_alias(&canonical) {
+        names.push(legacy);
+    }
+    names
 }
 
 pub(crate) fn rate_limit_key_from_headers(headers: &HeaderMap) -> String {
@@ -2112,28 +2123,47 @@ async fn slack_relay_oauth_callback_handler(
         }
     };
 
-    let state_key = format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME);
-    let stored_state = match ext_mgr
-        .secrets()
-        .get_decrypted(&state.owner_id, &state_key)
-        .await
-    {
-        Ok(secret) => secret.expose().to_string(),
-        Err(e) => {
-            tracing::warn!(
-                owner_id = %state.owner_id,
-                state_key = %state_key,
-                state = %redact_oauth_state_for_logs(&state_param),
-                error = %e,
-                "relay OAuth callback: failed to retrieve stored nonce"
-            );
-            return axum::response::Html(
-                "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
-                 <h2>Error</h2><p>Invalid or expired authorization.</p></body></html>"
-                    .to_string(),
-            )
-            .into_response();
+    let relay_names = relay_extension_name_candidates();
+    let mut stored_state = None;
+    let mut resolved_state_key = None;
+    let mut last_lookup_error = None;
+    for relay_name in &relay_names {
+        let state_key = format!("relay:{relay_name}:oauth_state");
+        match ext_mgr
+            .secrets()
+            .get_decrypted(&state.owner_id, &state_key)
+            .await
+        {
+            Ok(secret) => {
+                stored_state = Some(secret.expose().to_string());
+                resolved_state_key = Some(state_key);
+                break;
+            }
+            Err(e) => {
+                last_lookup_error = Some((state_key, e.to_string()));
+            }
         }
+    }
+    let Some(stored_state) = stored_state else {
+        let (state_key, error) = last_lookup_error.unwrap_or_else(|| {
+            (
+                format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME),
+                "no relay state lookup attempted".to_string(),
+            )
+        });
+        tracing::warn!(
+            owner_id = %state.owner_id,
+            state_key = %state_key,
+            state = %redact_oauth_state_for_logs(&state_param),
+            error = %error,
+            "relay OAuth callback: failed to retrieve stored nonce"
+        );
+        return axum::response::Html(
+            "<html><body style='font-family: system-ui; text-align: center; padding: 60px;'>\
+             <h2>Error</h2><p>Invalid or expired authorization.</p></body></html>"
+                .to_string(),
+        )
+        .into_response();
     };
 
     if state_param != stored_state {
@@ -2146,18 +2176,22 @@ async fn slack_relay_oauth_callback_handler(
     }
 
     // Delete the nonce (one-time use)
-    let _ = ext_mgr.secrets().delete(&state.owner_id, &state_key).await;
+    if let Some(state_key) = resolved_state_key.as_deref() {
+        let _ = ext_mgr.secrets().delete(&state.owner_id, state_key).await;
+    }
 
     let result: Result<(), String> = async {
         let store = state.store.as_ref().ok_or_else(|| {
             "Relay activation requires persistent settings storage; no-db mode is unsupported."
                 .to_string()
         })?;
+        let relay_extension_name = canonicalize_extension_name(DEFAULT_RELAY_NAME)
+            .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
 
         // Store team_id in settings
-        let team_id_key = format!("relay:{}:team_id", DEFAULT_RELAY_NAME);
+        let team_id_key = format!("relay:{}:team_id", relay_extension_name);
         tracing::info!(
-            relay = DEFAULT_RELAY_NAME,
+            relay = %relay_extension_name,
             owner_id = %state.owner_id,
             team_id_key = %team_id_key,
             "relay OAuth callback: storing team_id in settings"
@@ -2167,7 +2201,7 @@ async fn slack_relay_oauth_callback_handler(
             .await
             .map_err(|e| {
                 tracing::error!(
-                    relay = DEFAULT_RELAY_NAME,
+                    relay = %relay_extension_name,
                     owner_id = %state.owner_id,
                     error = %e,
                     "relay OAuth callback: failed to persist team_id to settings store"
@@ -2177,12 +2211,12 @@ async fn slack_relay_oauth_callback_handler(
 
         // Activate the relay channel
         tracing::info!(
-            relay = DEFAULT_RELAY_NAME,
+            relay = %relay_extension_name,
             owner_id = %state.owner_id,
             "relay OAuth callback: activating relay channel"
         );
         ext_mgr
-            .activate_stored_relay(DEFAULT_RELAY_NAME, &state.owner_id)
+            .activate_stored_relay(&relay_extension_name, &state.owner_id)
             .await
             .map_err(|e| format!("Failed to activate relay channel: {}", e))?;
 
@@ -2202,8 +2236,10 @@ async fn slack_relay_oauth_callback_handler(
     };
 
     // Broadcast event to notify the web UI
+    let relay_extension_name = canonicalize_extension_name(DEFAULT_RELAY_NAME)
+        .unwrap_or_else(|_| DEFAULT_RELAY_NAME.to_string());
     state.sse.broadcast(AppEvent::AuthCompleted {
-        extension_name: DEFAULT_RELAY_NAME.to_string(),
+        extension_name: relay_extension_name,
         success,
         message: message.clone(),
         thread_id: None,
@@ -6596,19 +6632,22 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_relay_oauth_callback_correct_state_proceeds() {
+    async fn test_relay_oauth_callback_correct_canonical_state_proceeds() {
         use axum::body::Body;
         use tower::ServiceExt;
 
         let secrets = test_secrets_store();
         let nonce = "valid-test-nonce-12345";
+        let relay_name = crate::extensions::naming::canonicalize_extension_name(DEFAULT_RELAY_NAME)
+            .expect("canonical relay name");
 
-        // Store the correct nonce
+        // Store the correct nonce under the canonical extension name used by
+        // install/auth/activate flows (`slack_relay`).
         secrets
             .create(
                 "test",
                 crate::secrets::CreateSecretParams::new(
-                    format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME),
+                    format!("relay:{}:oauth_state", relay_name),
                     nonce,
                 ),
             )
@@ -6646,7 +6685,7 @@ mod tests {
         );
 
         // Verify the nonce was consumed (deleted)
-        let state_key = format!("relay:{}:oauth_state", DEFAULT_RELAY_NAME);
+        let state_key = format!("relay:{}:oauth_state", relay_name);
         let exists = secrets.exists("test", &state_key).await.unwrap_or(true);
         assert!(!exists, "CSRF nonce should be deleted after use");
     }

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -1099,12 +1099,10 @@ fn read_hidden_input() -> anyhow::Result<String> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        print!("\x08 \x08");
-                        std::io::stdout().flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    print!("\x08 \x08");
+                    std::io::stdout().flush()?;
                 }
                 KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                     terminal::disable_raw_mode()?;

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -27,7 +27,7 @@ use crate::extensions::{
     ExtensionError, ExtensionKind, ExtensionPhase, ExtensionSource, InstallResult,
     InstalledExtension, LatentProviderAction, RegistryEntry, ResultSource, SearchResult,
     ToolAuthState, UpgradeOutcome, UpgradeResult,
-    naming::{canonicalize_extension_name, legacy_extension_alias},
+    naming::{canonicalize_extension_name, extension_name_candidates, legacy_extension_alias},
 };
 use crate::hooks::HookRegistry;
 use crate::pairing::PairingStore;
@@ -583,22 +583,12 @@ fn sanitize_url_for_logging(url: &str) -> String {
 }
 
 impl ExtensionManager {
-    fn extension_name_candidates(name: &str) -> Vec<String> {
-        let mut candidates = vec![name.to_string()];
-        if let Some(legacy) = legacy_extension_alias(name)
-            && legacy != name
-        {
-            candidates.push(legacy);
-        }
-        candidates
-    }
-
     fn existing_extension_file_path(
         dir: &std::path::Path,
         name: &str,
         suffix: &str,
     ) -> std::path::PathBuf {
-        for candidate in Self::extension_name_candidates(name) {
+        for candidate in extension_name_candidates(name) {
             let path = dir.join(format!("{}{}", candidate, suffix));
             if path.exists() {
                 return path;
@@ -2248,7 +2238,7 @@ impl ExtensionManager {
                 self.activation_errors.write().await.remove(&name);
 
                 // Revoke credential mappings from the shared registry
-                for candidate in Self::extension_name_candidates(&name) {
+                for candidate in extension_name_candidates(&name) {
                     let cap_path = self
                         .wasm_tools_dir
                         .join(format!("{}.capabilities.json", candidate));
@@ -2271,7 +2261,7 @@ impl ExtensionManager {
                 }
 
                 // Delete files
-                for candidate in Self::extension_name_candidates(&name) {
+                for candidate in extension_name_candidates(&name) {
                     let wasm_path = self.wasm_tools_dir.join(format!("{}.wasm", candidate));
                     let cap_path = self
                         .wasm_tools_dir
@@ -2306,7 +2296,7 @@ impl ExtensionManager {
                 self.activation_errors.write().await.remove(&name);
 
                 // Delete channel files
-                for candidate in Self::extension_name_candidates(&name) {
+                for candidate in extension_name_candidates(&name) {
                     let wasm_path = self.wasm_channels_dir.join(format!("{}.wasm", candidate));
                     let cap_path = self
                         .wasm_channels_dir
@@ -2334,7 +2324,7 @@ impl ExtensionManager {
                 ))
             }
             ExtensionKind::ChannelRelay => {
-                let candidate_names = Self::extension_name_candidates(&name);
+                let candidate_names = extension_name_candidates(&name);
 
                 // Remove from installed set
                 {

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -6076,10 +6076,10 @@ impl ExtensionManager {
         // Use self.user_id (the gateway owner) — NOT the caller's user_id —
         // because the OAuth callback handler looks up the nonce under
         // state.owner_id which matches self.user_id.
-        let _ = self.secrets.delete(user_id, &state_key).await;
+        let _ = self.secrets.delete(&self.user_id, &state_key).await;
         // Also best-effort delete any legacy caller-scoped entry so older
         // per-user nonces don't remain in the secrets table after upgrading.
-        let _ = self.secrets.delete(&self.user_id, &state_key).await;
+        let _ = self.secrets.delete(user_id, &state_key).await;
         self.secrets
             .create(
                 &self.user_id,

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -6076,10 +6076,9 @@ impl ExtensionManager {
         // Use self.user_id (the gateway owner) — NOT the caller's user_id —
         // because the OAuth callback handler looks up the nonce under
         // state.owner_id which matches self.user_id.
-        //
+        let _ = self.secrets.delete(user_id, &state_key).await;
         // Also best-effort delete any legacy caller-scoped entry so older
         // per-user nonces don't remain in the secrets table after upgrading.
-        let _ = self.secrets.delete(user_id, &state_key).await;
         let _ = self.secrets.delete(&self.user_id, &state_key).await;
         self.secrets
             .create(

--- a/src/extensions/naming.rs
+++ b/src/extensions/naming.rs
@@ -52,9 +52,7 @@ pub fn legacy_extension_alias(name: &str) -> Option<String> {
 pub fn extension_name_candidates(name: &str) -> Vec<String> {
     let canonical = canonicalize_extension_name(name).unwrap_or_else(|_| name.to_string());
     let mut candidates = vec![canonical.clone()];
-    if let Some(legacy) = legacy_extension_alias(&canonical)
-        && legacy != canonical
-    {
+    if let Some(legacy) = legacy_extension_alias(&canonical) {
         candidates.push(legacy);
     }
     candidates

--- a/src/extensions/naming.rs
+++ b/src/extensions/naming.rs
@@ -49,6 +49,17 @@ pub fn legacy_extension_alias(name: &str) -> Option<String> {
     (alias != name).then_some(alias)
 }
 
+pub fn extension_name_candidates(name: &str) -> Vec<String> {
+    let canonical = canonicalize_extension_name(name).unwrap_or_else(|_| name.to_string());
+    let mut candidates = vec![canonical.clone()];
+    if let Some(legacy) = legacy_extension_alias(&canonical)
+        && legacy != canonical
+    {
+        candidates.push(legacy);
+    }
+    candidates
+}
+
 /// Filenames to look for when extracting a WASM archive for an extension.
 ///
 /// Returns the canonical filenames (underscores) and, when the name contains
@@ -130,6 +141,22 @@ mod tests {
         assert!(af.is_caps("gmail.capabilities.json"));
         assert!(!af.is_wasm("other.wasm"));
         assert!(af.alias_wasm.is_none());
+    }
+
+    #[test]
+    fn extension_name_candidates_include_legacy_alias() {
+        assert_eq!(
+            extension_name_candidates("google_calendar"),
+            vec!["google_calendar", "google-calendar"]
+        );
+    }
+
+    #[test]
+    fn extension_name_candidates_canonicalize_hyphenated_name() {
+        assert_eq!(
+            extension_name_candidates("slack-relay"),
+            vec!["slack_relay", "slack-relay"]
+        );
     }
 
     #[test]

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -841,10 +841,8 @@ fn extract_response(
 
     for content in choice.iter() {
         match content {
-            AssistantContent::Text(t) => {
-                if !t.text.is_empty() {
-                    text_parts.push(t.text.clone());
-                }
+            AssistantContent::Text(t) if !t.text.is_empty() => {
+                text_parts.push(t.text.clone());
             }
             AssistantContent::ToolCall(tc) => {
                 tool_calls.push(IronToolCall {

--- a/src/secrets/mod.rs
+++ b/src/secrets/mod.rs
@@ -68,7 +68,7 @@ pub use crypto::SecretsCrypto;
 pub use store::LibSqlSecretsStore;
 #[cfg(feature = "postgres")]
 pub use store::PostgresSecretsStore;
-pub use store::SecretsStore;
+pub use store::{SecretConsumeResult, SecretsStore};
 pub use types::{
     CreateSecretParams, CredentialLocation, CredentialMapping, DecryptedSecret, Secret,
     SecretError, SecretRef,

--- a/src/secrets/store.rs
+++ b/src/secrets/store.rs
@@ -18,6 +18,13 @@ use uuid::Uuid;
 use crate::secrets::crypto::SecretsCrypto;
 use crate::secrets::types::{CreateSecretParams, DecryptedSecret, Secret, SecretError, SecretRef};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SecretConsumeResult {
+    Matched,
+    Mismatched,
+    NotFound,
+}
+
 /// Trait for secret storage operations.
 ///
 /// Allows for different implementations (PostgreSQL, in-memory for testing).
@@ -39,6 +46,29 @@ pub trait SecretsStore: Send + Sync {
         user_id: &str,
         name: &str,
     ) -> Result<DecryptedSecret, SecretError>;
+
+    /// Atomically consume a secret only when its decrypted plaintext matches
+    /// the provided expected value.
+    ///
+    /// Backends should override this to eliminate read-then-delete races.
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        match self.get_decrypted(user_id, name).await {
+            Ok(secret) => {
+                if secret.expose() != expected_value {
+                    return Ok(SecretConsumeResult::Mismatched);
+                }
+                self.delete(user_id, name).await?;
+                Ok(SecretConsumeResult::Matched)
+            }
+            Err(SecretError::NotFound(_)) => Ok(SecretConsumeResult::NotFound),
+            Err(e) => Err(e),
+        }
+    }
 
     /// Check if a secret exists.
     async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError>;
@@ -174,6 +204,69 @@ impl SecretsStore for PostgresSecretsStore {
         let secret = self.get(user_id, name).await?;
         self.crypto
             .decrypt(&secret.encrypted_value, &secret.key_salt)
+    }
+
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let name = name.to_lowercase();
+        let mut client = self
+            .pool
+            .get()
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+        let tx = client
+            .transaction()
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+
+        let row = tx
+            .query_opt(
+                r#"
+                SELECT id, user_id, name, encrypted_value, key_salt, provider, expires_at,
+                       last_used_at, usage_count, created_at, updated_at
+                FROM secrets
+                WHERE user_id = $1 AND name = $2
+                FOR UPDATE
+                "#,
+                &[&user_id, &name],
+            )
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+
+        let Some(row) = row else {
+            return Ok(SecretConsumeResult::NotFound);
+        };
+
+        let secret = row_to_secret(&row);
+        if let Some(expires_at) = secret.expires_at
+            && expires_at < Utc::now()
+        {
+            return Err(SecretError::Expired);
+        }
+
+        let decrypted = self
+            .crypto
+            .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+        if decrypted.expose() != expected_value {
+            return Ok(SecretConsumeResult::Mismatched);
+        }
+
+        tx.execute(
+            "DELETE FROM secrets WHERE user_id = $1 AND name = $2",
+            &[&user_id, &name],
+        )
+        .await
+        .map_err(|e| SecretError::Database(e.to_string()))?;
+
+        tx.commit()
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+
+        Ok(SecretConsumeResult::Matched)
     }
 
     async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
@@ -465,6 +558,82 @@ impl SecretsStore for LibSqlSecretsStore {
             .decrypt(&secret.encrypted_value, &secret.key_salt)
     }
 
+    async fn consume_if_matches(
+        &self,
+        user_id: &str,
+        name: &str,
+        expected_value: &str,
+    ) -> Result<SecretConsumeResult, SecretError> {
+        let name = name.to_lowercase();
+        let conn = self.connect().await?;
+
+        // safety: BEGIN IMMEDIATE acquires a write lock up front so the
+        // compare-and-delete flow cannot race with another callback.
+        conn.execute("BEGIN IMMEDIATE", ())
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+
+        let result = async {
+            let mut rows = conn
+                .query(
+                    r#"
+                    SELECT id, user_id, name, encrypted_value, key_salt, provider, expires_at,
+                           last_used_at, usage_count, created_at, updated_at
+                    FROM secrets
+                    WHERE user_id = ?1 AND name = ?2
+                    "#,
+                    libsql::params![user_id, name.as_str()],
+                )
+                .await
+                .map_err(|e| SecretError::Database(e.to_string()))?;
+
+            let Some(row) = rows
+                .next()
+                .await
+                .map_err(|e| SecretError::Database(e.to_string()))?
+            else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+
+            let secret = libsql_row_to_secret(&row)?;
+            if let Some(expires_at) = secret.expires_at
+                && expires_at < Utc::now()
+            {
+                return Err(SecretError::Expired);
+            }
+
+            let decrypted = self
+                .crypto
+                .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+            if decrypted.expose() != expected_value {
+                return Ok(SecretConsumeResult::Mismatched);
+            }
+
+            conn.execute(
+                "DELETE FROM secrets WHERE user_id = ?1 AND name = ?2",
+                libsql::params![user_id, name.as_str()],
+            )
+            .await
+            .map_err(|e| SecretError::Database(e.to_string()))?;
+
+            Ok(SecretConsumeResult::Matched)
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                conn.execute("COMMIT", ())
+                    .await
+                    .map_err(|e| SecretError::Database(e.to_string()))?;
+                Ok(outcome)
+            }
+            Err(e) => {
+                let _ = conn.execute("ROLLBACK", ()).await;
+                Err(e)
+            }
+        }
+    }
+
     async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
         let name = name.to_lowercase();
         let conn = self.connect().await?;
@@ -659,6 +828,7 @@ pub mod in_memory {
     use uuid::Uuid;
 
     use crate::secrets::crypto::SecretsCrypto;
+    use crate::secrets::store::SecretConsumeResult;
     use crate::secrets::store::SecretsStore;
     use crate::secrets::types::{
         CreateSecretParams, DecryptedSecret, Secret, SecretError, SecretRef,
@@ -739,6 +909,36 @@ pub mod in_memory {
                 .decrypt(&secret.encrypted_value, &secret.key_salt)
         }
 
+        async fn consume_if_matches(
+            &self,
+            user_id: &str,
+            name: &str,
+            expected_value: &str,
+        ) -> Result<SecretConsumeResult, SecretError> {
+            let name = name.to_lowercase();
+            let mut secrets = self.secrets.write().await;
+            let key = (user_id.to_string(), name.clone());
+            let Some(secret) = secrets.get(&key).cloned() else {
+                return Ok(SecretConsumeResult::NotFound);
+            };
+
+            if let Some(expires_at) = secret.expires_at
+                && expires_at < Utc::now()
+            {
+                return Err(SecretError::Expired);
+            }
+
+            let decrypted = self
+                .crypto
+                .decrypt(&secret.encrypted_value, &secret.key_salt)?;
+            if decrypted.expose() != expected_value {
+                return Ok(SecretConsumeResult::Mismatched);
+            }
+
+            secrets.remove(&key);
+            Ok(SecretConsumeResult::Matched)
+        }
+
         async fn exists(&self, user_id: &str, name: &str) -> Result<bool, SecretError> {
             Ok(self
                 .secrets
@@ -802,7 +1002,7 @@ pub mod in_memory {
 
 #[cfg(test)]
 mod tests {
-    use crate::secrets::store::SecretsStore;
+    use crate::secrets::store::{SecretConsumeResult, SecretsStore};
     use crate::secrets::types::CreateSecretParams;
     use crate::testing::credentials::{
         TEST_OPENAI_API_KEY_SHORT, TEST_SECRET_VALUE, TEST_STRIPE_KEY, test_secrets_store,
@@ -843,6 +1043,28 @@ mod tests {
 
         store.delete("user1", "to_delete").await.unwrap();
         assert!(!store.exists("user1", "to_delete").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_consume_if_matches_deletes_only_on_match() {
+        let store = test_store();
+        let params = CreateSecretParams::new("oauth_state", "expected-nonce");
+
+        store.create("user1", params).await.unwrap();
+
+        let mismatched = store
+            .consume_if_matches("user1", "oauth_state", "wrong-nonce")
+            .await
+            .unwrap();
+        assert_eq!(mismatched, SecretConsumeResult::Mismatched);
+        assert!(store.exists("user1", "oauth_state").await.unwrap());
+
+        let matched = store
+            .consume_if_matches("user1", "oauth_state", "expected-nonce")
+            .await
+            .unwrap();
+        assert_eq!(matched, SecretConsumeResult::Matched);
+        assert!(!store.exists("user1", "oauth_state").await.unwrap());
     }
 
     #[tokio::test]

--- a/src/setup/prompts.rs
+++ b/src/setup/prompts.rs
@@ -167,10 +167,8 @@ pub fn select_many(prompt: &str, options: &[(&str, bool)]) -> io::Result<Vec<usi
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if cursor_pos < options.len() - 1 {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Down if cursor_pos < options.len() - 1 => {
+                        cursor_pos += 1;
                     }
                     KeyCode::Char(' ') => {
                         selected[cursor_pos] = !selected[cursor_pos];
@@ -250,12 +248,10 @@ fn read_secret_line() -> io::Result<SecretString> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        execute!(stdout, Print("\x08 \x08"))?;
-                        stdout.flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    execute!(stdout, Print("\x08 \x08"))?;
+                    stdout.flush()?;
                 }
                 KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                     return Err(io::Error::new(io::ErrorKind::Interrupted, "Ctrl-C"));

--- a/src/tools/builtin/glob_tool.rs
+++ b/src/tools/builtin/glob_tool.rs
@@ -173,7 +173,7 @@ impl Tool for GlobTool {
 
         // Sort by mtime descending (newest first)
         let mut files = files;
-        files.sort_by(|a, b| b.1.cmp(&a.1));
+        files.sort_by_key(|b| std::cmp::Reverse(b.1));
 
         // Truncate
         let truncated = files.len() > max_results;

--- a/src/tools/builtin/grep_tool.rs
+++ b/src/tools/builtin/grep_tool.rs
@@ -352,7 +352,7 @@ impl Tool for GrepTool {
                     }
                 }
 
-                file_entries.sort_by(|a, b| b.1.cmp(&a.1));
+                file_entries.sort_by_key(|b| std::cmp::Reverse(b.1));
 
                 // Apply pagination after sorting
                 let total_count = file_entries.len();


### PR DESCRIPTION
## Summary
- store relay OAuth nonce under the gateway owner scope while cleaning up legacy caller-scoped entries
- make the Slack relay callback accept canonical and legacy relay secret keys and persist the canonical relay setting key
- add/update relay callback coverage for the canonical state storage path

## Testing
- cargo test test_relay_oauth_callback -- --nocapture
- cargo test test_relay_oauth_callback_correct_canonical_state_proceeds -- --exact --nocapture