### PR TITLE
fix(telegram): emit chat_type metadata for group-safe prompt behavior

### DIFF
--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -302,6 +302,10 @@ struct TelegramMessageMetadata {
     /// Whether this is a private (DM) chat.
     is_private: bool,
 
+    /// Telegram chat type for downstream group/private detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    chat_type: Option<String>,
+
     /// Forum topic thread ID (for routing replies back to the correct topic).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     message_thread_id: Option<i64>,
@@ -2147,6 +2151,7 @@ fn handle_message(message: TelegramMessage) {
         message_id: message.message_id,
         user_id: from.id,
         is_private,
+        chat_type: Some(message.chat.chat_type.clone()),
         message_thread_id: message.message_thread_id,
     };
 
@@ -2776,6 +2781,26 @@ mod tests {
         .unwrap();
 
         assert!(webhook_mode(&config));
+    }
+
+    #[test]
+    fn test_telegram_message_metadata_deserializes_without_chat_type() {
+        let metadata: TelegramMessageMetadata = serde_json::from_str(
+            r#"{
+                "chat_id": 999,
+                "message_id": 701,
+                "user_id": 999,
+                "is_private": true
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(metadata.chat_id, 999);
+        assert_eq!(metadata.message_id, 701);
+        assert_eq!(metadata.user_id, 999);
+        assert!(metadata.is_private);
+        assert_eq!(metadata.chat_type, None);
+        assert_eq!(metadata.message_thread_id, None);
     }
 
     #[test]

--- a/tests/telegram_auth_integration.rs
+++ b/tests/telegram_auth_integration.rs
@@ -837,6 +837,50 @@ async fn test_group_message_with_bot_mention_emits_cleaned_content() {
 
 #[tokio::test]
 #[cfg(feature = "integration")]
+async fn test_group_message_emits_chat_type_metadata() {
+    require_telegram_wasm!();
+    let runtime = create_test_runtime();
+
+    let config = serde_json::json!({
+        "bot_username": null,
+        "owner_id": null,
+        "dm_policy": "open",
+        "allow_from": [],
+        "respond_to_all_group_messages": true
+    })
+    .to_string();
+
+    let channel = create_telegram_channel(runtime, &config).await;
+    let mut stream = channel
+        .start_message_stream_for_test()
+        .await
+        .expect("Failed to bootstrap test message stream");
+
+    let update = build_telegram_update(8, 108, -123456789, "group", 702, "User", "status please");
+
+    let response = channel
+        .call_on_http_request(
+            "POST",
+            "/webhook/telegram",
+            &HashMap::new(),
+            &HashMap::new(),
+            &update,
+            true,
+        )
+        .await
+        .expect("HTTP callback failed");
+
+    assert_eq!(response.status, 200);
+
+    let msg = timeout(Duration::from_secs(1), stream.next())
+        .await
+        .expect("message should arrive")
+        .expect("stream should yield a message");
+    assert_eq!(msg.metadata["chat_type"], serde_json::json!("group"));
+}
+
+#[tokio::test]
+#[cfg(feature = "integration")]
 async fn test_edited_message_emits_like_regular_message() {
     require_telegram_wasm!();
     let runtime = create_test_runtime();


### PR DESCRIPTION
## Summary
- emit `metadata.chat_type` for inbound Telegram messages using Telegram's source chat type
- keep `TelegramMessageMetadata` backward-compatible by making `chat_type` optional on deserialize
- add Telegram regression coverage for legacy metadata parsing and group message emission

## Linked Issue
Fixes #2482

## Change Type
- Bug fix

## Review Track
- B

## Validation
- `cargo fmt --all -- --check`
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- `cargo build`
- `cargo test test_telegram_message_metadata_deserializes_without_chat_type` (in `channels-src/telegram`)
- `cargo test --features integration --test telegram_auth_integration test_group_message_emits_chat_type_metadata -- --nocapture`
- `cargo test`

`cargo test` currently fails in an unrelated upstream e2e assertion:

`tests::tool_info_clarifies_message_and_channel_setup_roles` in `tests/e2e_builtin_tool_coverage.rs`

This failure is outside the Telegram diff.

## Impact
- Security Impact: none
- Database Impact: none
- Blast Radius: Telegram metadata emission and downstream group/private prompt detection
- Rollback Plan: revert this commit
