### PR TITLE
fix(gateway): extend settings search to card, tool, and user sections

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -8498,6 +8498,18 @@ document.getElementById('settings-search-input').addEventListener('input', funct
     }
   });
 
+  // 2b. Provider cards (Inference)
+  var providerCards = activePanel.querySelectorAll('.provider-card');
+  providerCards.forEach(function(card) {
+    var text = card.textContent.toLowerCase();
+    if (query === '' || text.indexOf(query) !== -1) {
+      card.classList.remove('search-hidden');
+      visibleCount++;
+    } else {
+      card.classList.add('search-hidden');
+    }
+  });
+
   // 3. Tool permission rows (Tools)
   var toolRows = activePanel.querySelectorAll('.tool-permission-row');
   toolRows.forEach(function(row) {
@@ -8536,7 +8548,7 @@ document.getElementById('settings-search-input').addEventListener('input', funct
 
   var sections = activePanel.querySelectorAll('.extensions-section');
   sections.forEach(function(section) {
-    var visibleItems = section.querySelectorAll('.ext-card:not(.search-hidden), .tool-permission-row:not(.search-hidden)');
+    var visibleItems = section.querySelectorAll('.ext-card:not(.search-hidden), .tool-permission-row:not(.search-hidden), .provider-card:not(.search-hidden)');
     if (visibleItems.length === 0 && query !== '') {
       section.style.display = 'none';
     } else {

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -8470,9 +8470,12 @@ document.getElementById('settings-search-input').addEventListener('input', funct
   var query = this.value.toLowerCase();
   var activePanel = document.querySelector('.settings-subpanel.active');
   if (!activePanel) return;
-  var rows = activePanel.querySelectorAll('.settings-row');
-  if (rows.length === 0) return;
   var visibleCount = 0;
+
+  // --- Filter individual items ---
+
+  // 1. Structured settings rows (Agent, Inference, Networking)
+  var rows = activePanel.querySelectorAll('.settings-row');
   rows.forEach(function(row) {
     var text = row.textContent.toLowerCase();
     if (query === '' || text.indexOf(query) !== -1) {
@@ -8482,7 +8485,45 @@ document.getElementById('settings-search-input').addEventListener('input', funct
       row.classList.add('search-hidden');
     }
   });
-  // Show/hide group titles based on visible children
+
+  // 2. Extension/channel/MCP/skill cards (Channels, Extensions, MCP, Skills)
+  var cards = activePanel.querySelectorAll('.ext-card');
+  cards.forEach(function(card) {
+    var text = card.textContent.toLowerCase();
+    if (query === '' || text.indexOf(query) !== -1) {
+      card.classList.remove('search-hidden');
+      visibleCount++;
+    } else {
+      card.classList.add('search-hidden');
+    }
+  });
+
+  // 3. Tool permission rows (Tools)
+  var toolRows = activePanel.querySelectorAll('.tool-permission-row');
+  toolRows.forEach(function(row) {
+    var text = row.textContent.toLowerCase();
+    if (query === '' || text.indexOf(query) !== -1) {
+      row.classList.remove('search-hidden');
+      visibleCount++;
+    } else {
+      row.classList.add('search-hidden');
+    }
+  });
+
+  // 4. User table rows (User Management)
+  var userRows = activePanel.querySelectorAll('#users-tbody tr');
+  userRows.forEach(function(row) {
+    var text = row.textContent.toLowerCase();
+    if (query === '' || text.indexOf(query) !== -1) {
+      row.classList.remove('search-hidden');
+      visibleCount++;
+    } else {
+      row.classList.add('search-hidden');
+    }
+  });
+
+  // --- Update container visibility after all items are filtered ---
+
   var groups = activePanel.querySelectorAll('.settings-group');
   groups.forEach(function(group) {
     var visibleRows = group.querySelectorAll('.settings-row:not(.search-hidden):not(.hidden)');
@@ -8492,6 +8533,17 @@ document.getElementById('settings-search-input').addEventListener('input', funct
       group.style.display = '';
     }
   });
+
+  var sections = activePanel.querySelectorAll('.extensions-section');
+  sections.forEach(function(section) {
+    var visibleItems = section.querySelectorAll('.ext-card:not(.search-hidden), .tool-permission-row:not(.search-hidden)');
+    if (visibleItems.length === 0 && query !== '') {
+      section.style.display = 'none';
+    } else {
+      section.style.display = '';
+    }
+  });
+
   // Show/hide empty state
   var existingEmpty = activePanel.querySelector('.settings-search-empty');
   if (existingEmpty) existingEmpty.remove();

--- a/crates/ironclaw_gateway/static/style.css
+++ b/crates/ironclaw_gateway/static/style.css
@@ -5059,7 +5059,10 @@ mark {
   border-bottom: none;
 }
 
-.settings-row.search-hidden {
+.settings-row.search-hidden,
+.ext-card.search-hidden,
+.tool-permission-row.search-hidden,
+#users-tbody tr.search-hidden {
   display: none;
 }
 

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -142,6 +142,9 @@ SEL = {
     "plan_status_badge":        ".plan-status-badge",
     "plan_title":               ".plan-title",
     "plan_summary":             ".plan-summary",
+    # Settings search
+    "settings_search_input":    "#settings-search-input",
+    "settings_search_empty":    ".settings-search-empty",
     # Tool permissions (Settings → Tools tab)
     "tools_tab":                "button[data-settings-subtab='tools']",
     "tool_permission_row":      ".tool-permission-row",

--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -151,6 +151,9 @@ SEL = {
     "tool_permission_toggle":   ".tool-permission-toggle",
     "tool_lock_icon":           ".tool-lock-icon",
     "tool_default_badge":       ".tool-default-badge",
+    # User management (Settings → Users tab)
+    "users_tbody":              "#users-tbody",
+    "users_tbody_row":          "#users-tbody tr",
 }
 
 TABS = ["chat", "memory", "jobs", "routines", "settings"]

--- a/tests/e2e/scenarios/test_settings_search.py
+++ b/tests/e2e/scenarios/test_settings_search.py
@@ -3,13 +3,14 @@
 Covers:
   - Tool permission rows (Tools subtab)
   - Extension cards (Extensions subtab, via mocked API)
+  - User table rows (Users subtab)
   - Empty state when no results match
   - Clearing search restores all items
 """
 
 import json
 
-from helpers import SEL
+from helpers import SEL, api_post
 
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -174,3 +175,43 @@ async def test_search_filters_extension_cards(page):
     # "Beta" card should be hidden
     hidden = page.locator(f"#extensions-list .ext-card.search-hidden")
     assert await hidden.count() == 1
+
+
+async def test_search_filters_user_rows(page, ironclaw_server):
+    """Search filters user table rows in the Users subtab."""
+    # Seed two users via the admin API
+    await api_post(ironclaw_server, "/api/admin/users", json={
+        "display_name": "Alice Searchtest",
+        "email": "alice-searchtest@example.test",
+        "role": "member",
+    })
+    await api_post(ironclaw_server, "/api/admin/users", json={
+        "display_name": "Bob Searchtest",
+        "email": "bob-searchtest@example.test",
+        "role": "member",
+    })
+
+    await _open_settings_subtab(page, "users")
+
+    rows = page.locator(SEL["users_tbody_row"])
+    await rows.first.wait_for(state="visible", timeout=5000)
+    total = await rows.count()
+    assert total >= 2, f"Need at least 2 user rows, got {total}"
+
+    # Search for "Alice" — should hide Bob's row
+    await _type_search(page, "Alice")
+
+    visible = page.locator(f"{SEL['users_tbody_row']}:not(.search-hidden)")
+    await visible.first.wait_for(state="visible", timeout=5000)
+    visible_count = await visible.count()
+    assert visible_count >= 1, "Expected at least one visible row for 'Alice'"
+    assert visible_count < total, "Search should have hidden some rows"
+
+    first_text = await visible.first.text_content()
+    assert "alice" in first_text.lower(), f"Visible row should contain 'alice', got: {first_text}"
+
+    # Clear search restores all rows
+    await _type_search(page, "")
+    restored = page.locator(f"{SEL['users_tbody_row']}:not(.search-hidden)")
+    await restored.first.wait_for(state="visible", timeout=5000)
+    assert await restored.count() == total, "All user rows should be visible after clearing search"

--- a/tests/e2e/scenarios/test_settings_search.py
+++ b/tests/e2e/scenarios/test_settings_search.py
@@ -1,0 +1,176 @@
+"""Scenario: Settings search filters items across all section types.
+
+Covers:
+  - Tool permission rows (Tools subtab)
+  - Extension cards (Extensions subtab, via mocked API)
+  - Empty state when no results match
+  - Clearing search restores all items
+"""
+
+import json
+
+from helpers import SEL
+
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+async def _open_settings_subtab(page, subtab: str) -> None:
+    """Navigate to Settings and open the given subtab."""
+    settings_tab = page.locator(SEL["tab_button"].format(tab="settings"))
+    await settings_tab.click()
+    await page.locator(SEL["tab_panel"].format(tab="settings")).wait_for(
+        state="visible", timeout=5000
+    )
+    st = page.locator(SEL["settings_subtab"].format(subtab=subtab))
+    await st.wait_for(state="visible", timeout=5000)
+    await st.click()
+    await page.locator(SEL["settings_subpanel"].format(subtab=subtab)).wait_for(
+        state="visible", timeout=5000
+    )
+
+
+async def _type_search(page, query: str) -> None:
+    """Type into the settings search input."""
+    search = page.locator(SEL["settings_search_input"])
+    await search.fill(query)
+
+
+# ─── Mock data for extensions ─────────────────────────────────────────────────
+
+_EXT_ALPHA = {
+    "name": "alpha-tool",
+    "display_name": "Alpha Tool",
+    "kind": "wasm_tool",
+    "description": "First test extension",
+    "url": None,
+    "active": True,
+    "authenticated": True,
+    "has_auth": False,
+    "needs_setup": False,
+    "tools": ["alpha_search"],
+    "activation_status": None,
+    "activation_error": None,
+}
+
+_EXT_BETA = {
+    "name": "beta-widget",
+    "display_name": "Beta Widget",
+    "kind": "wasm_tool",
+    "description": "Second test extension",
+    "url": None,
+    "active": True,
+    "authenticated": True,
+    "has_auth": False,
+    "needs_setup": False,
+    "tools": ["beta_fetch"],
+    "activation_status": None,
+    "activation_error": None,
+}
+
+
+async def _mock_extension_apis(page):
+    """Intercept extension APIs to return deterministic card data."""
+    extensions_body = json.dumps({"extensions": [_EXT_ALPHA, _EXT_BETA]})
+    registry_body = json.dumps({"entries": []})
+
+    async def handler(route):
+        url = route.request.url.split("?")[0]
+        if url.endswith("/api/extensions/registry"):
+            await route.fulfill(status=200, content_type="application/json", body=registry_body)
+        elif url.endswith("/api/extensions"):
+            await route.fulfill(status=200, content_type="application/json", body=extensions_body)
+        else:
+            await route.continue_()
+
+    await page.route("**/api/extensions**", handler)
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+async def test_search_filters_tool_rows(page):
+    """Typing in search hides non-matching tool-permission-row elements."""
+    await _open_settings_subtab(page, "tools")
+
+    rows = page.locator(SEL["tool_permission_row"])
+    await rows.first.wait_for(state="visible", timeout=5000)
+    total = await rows.count()
+    assert total >= 2, f"Need at least 2 tool rows for this test, got {total}"
+
+    # Search for "echo" — should match the echo tool row
+    await _type_search(page, "echo")
+
+    visible = page.locator(f"{SEL['tool_permission_row']}:not(.search-hidden)")
+    await visible.first.wait_for(state="visible", timeout=5000)
+    visible_count = await visible.count()
+    assert visible_count >= 1, "Expected at least one visible tool row for 'echo'"
+    assert visible_count < total, "Search should have hidden some rows"
+
+    # The visible row should contain "echo"
+    first_text = await visible.first.text_content()
+    assert "echo" in first_text.lower(), f"Visible row should contain 'echo', got: {first_text}"
+
+
+async def test_search_shows_empty_state(page):
+    """Searching for a non-existent term shows the empty-state message."""
+    await _open_settings_subtab(page, "tools")
+
+    rows = page.locator(SEL["tool_permission_row"])
+    await rows.first.wait_for(state="visible", timeout=5000)
+
+    await _type_search(page, "zzz_nonexistent_tool_xyz")
+
+    empty = page.locator(SEL["settings_search_empty"])
+    await empty.wait_for(state="visible", timeout=5000)
+
+
+async def test_search_clear_restores_all(page):
+    """Clearing the search input makes all items visible again."""
+    await _open_settings_subtab(page, "tools")
+
+    rows = page.locator(SEL["tool_permission_row"])
+    await rows.first.wait_for(state="visible", timeout=5000)
+    total = await rows.count()
+
+    # Search to hide some rows
+    await _type_search(page, "echo")
+    visible = page.locator(f"{SEL['tool_permission_row']}:not(.search-hidden)")
+    await visible.first.wait_for(state="visible", timeout=5000)
+    assert await visible.count() < total
+
+    # Clear search
+    await _type_search(page, "")
+
+    restored = page.locator(f"{SEL['tool_permission_row']}:not(.search-hidden)")
+    await restored.first.wait_for(state="visible", timeout=5000)
+    assert await restored.count() == total, "All rows should be visible after clearing search"
+
+    # Empty state should be gone
+    empty = page.locator(SEL["settings_search_empty"])
+    assert await empty.count() == 0
+
+
+async def test_search_filters_extension_cards(page):
+    """Search filters ext-card elements in the Extensions subtab."""
+    await _mock_extension_apis(page)
+    await _open_settings_subtab(page, "extensions")
+
+    cards = page.locator(SEL["ext_card_installed"])
+    await cards.first.wait_for(state="visible", timeout=5000)
+    total = await cards.count()
+    assert total == 2, f"Expected 2 installed extension cards, got {total}"
+
+    # Search for "Alpha" — should show only the Alpha card
+    await _type_search(page, "Alpha")
+
+    visible = page.locator(f"#extensions-list .ext-card:not(.search-hidden)")
+    await visible.first.wait_for(state="visible", timeout=5000)
+    assert await visible.count() == 1
+
+    name_text = await visible.first.locator(SEL["ext_name"]).text_content()
+    assert "Alpha" in name_text
+
+    # "Beta" card should be hidden
+    hidden = page.locator(f"#extensions-list .ext-card.search-hidden")
+    assert await hidden.count() == 1


### PR DESCRIPTION
Settings search only filtered .settings-row elements, leaving Channels, Extensions, MCP, Skills, Tools, and User Management sections unsearchable. Add filtering for .ext-card, .tool-permission-row, and #users-tbody tr elements, and update CSS to hide matched elements.

## Summary

<!-- 2-5 bullet points: what changed and why -->

-

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
