### PR TITLE
ci: build ironclaw docker image hourly

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,9 +17,9 @@ on:
         required: false
         type: string
         default: ""
-  # Daily staging build from the staging branch
+  # Staging build from the staging branch every hour
   schedule:
-    - cron: '0 6 * * *'
+    - cron: '0 * * * *'
 
 env:
   IMAGE_NAME: nearaidev/ironclaw
@@ -39,6 +39,13 @@ jobs:
         with:
           ref: ${{ github.event_name == 'schedule' && 'staging' || '' }}
           persist-credentials: false
+
+      - name: Resolve source git commit
+        id: source_sha
+        run: |
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          echo "sha=${SOURCE_SHA}" >> "$GITHUB_OUTPUT"
+          echo "Source commit: ${SOURCE_SHA}"
 
       - name: Extract version from Cargo.toml
         id: version
@@ -101,30 +108,59 @@ jobs:
           username: ${{ vars.DOCKER_REGISTRY_USER }}
           password: ${{ secrets.DOCKER_REGISTRY_TOKEN }}
 
+      - name: Check if current staging commit is already built
+        id: check
+        if: steps.tags.outputs.target == 'runtime-staging'
+        env:
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
+        run: |
+          CURRENT_BUILT_SHA=""
+          if docker pull "${IMAGE_NAME}:staging" > /dev/null 2>&1; then
+            CURRENT_BUILT_SHA=$(docker inspect --format='{{index .Config.Labels "ironclaw.git.sha"}}' "${IMAGE_NAME}:staging" 2>/dev/null || echo "")
+          fi
+
+          echo "Current built commit: ${CURRENT_BUILT_SHA:-<none>}"
+          echo "Current source commit: ${SOURCE_SHA}"
+
+          if [[ -n "${CURRENT_BUILT_SHA}" && "${CURRENT_BUILT_SHA}" == "${SOURCE_SHA}" ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Current commit already built — skipping."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Current commit not built yet — proceeding."
+          fi
+
       - name: Build and push (ironclaw)
+        if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
           tags: ${{ steps.tags.outputs.tags }}
           target: ${{ steps.tags.outputs.target }}
+          labels: |
+            ironclaw.git.sha=${{ steps.source_sha.outputs.sha }}
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
       - name: Build and push (ironclaw-worker)
+        if: steps.check.outputs.skip != 'true'
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: Dockerfile.worker
           push: true
           tags: ${{ steps.tags.outputs.worker_tags }}
+          labels: |
+            ironclaw.git.sha=${{ steps.source_sha.outputs.sha }}
           platforms: linux/amd64
           cache-from: type=gha,scope=worker
           cache-to: type=gha,mode=max,scope=worker
 
       - name: Create releases-manager app token
         id: app-token
+        if: steps.check.outputs.skip != 'true'
         continue-on-error: true
         uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         with:
@@ -134,7 +170,7 @@ jobs:
           repositories: ironclaw-dind
 
       - name: Trigger ironclaw-dind Build & Push
-        if: steps.app-token.outcome == 'success'
+        if: steps.app-token.outcome == 'success' && steps.check.outputs.skip != 'true'
         continue-on-error: true
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -154,6 +190,7 @@ jobs:
           fi
 
       - name: Summary
+        if: steps.check.outputs.skip != 'true'
         run: |
           {
             echo "## Docker Images"
@@ -169,5 +206,15 @@ jobs:
             echo '```'
             echo ""
             echo "- version: \`${{ steps.version.outputs.version }}\`"
-            echo "- sha: \`${GITHUB_SHA::7}\`"
+            echo "- sha: \`${{ steps.source_sha.outputs.sha }}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summary (skipped)
+        if: steps.check.outputs.skip == 'true'
+        run: |
+          {
+            echo "## Docker Images — skipped"
+            echo ""
+            echo "Current commit already built for \`${IMAGE_NAME}:staging\`."
+            echo "- sha: \`${{ steps.source_sha.outputs.sha }}\`"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -100,9 +100,6 @@ jobs:
             echo "target=runtime" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
-
       - name: Log in to Docker Hub
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
@@ -116,20 +113,30 @@ jobs:
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
           CURRENT_BUILT_SHA=""
+          WORKER_BUILT_SHA=""
+
           if docker pull "${IMAGE_NAME}:staging" > /dev/null 2>&1; then
             CURRENT_BUILT_SHA=$(docker inspect --format='{{index .Config.Labels "ironclaw.git.sha"}}' "${IMAGE_NAME}:staging" 2>/dev/null || echo "")
           fi
+          if docker pull "${WORKER_IMAGE_NAME}:staging" > /dev/null 2>&1; then
+            WORKER_BUILT_SHA=$(docker inspect --format='{{index .Config.Labels "ironclaw.git.sha"}}' "${WORKER_IMAGE_NAME}:staging" 2>/dev/null || echo "")
+          fi
 
-          echo "Current built commit: ${CURRENT_BUILT_SHA:-<none>}"
+          echo "Current built commit (ironclaw): ${CURRENT_BUILT_SHA:-<none>}"
+          echo "Current built commit (ironclaw-worker): ${WORKER_BUILT_SHA:-<none>}"
           echo "Current source commit: ${SOURCE_SHA}"
 
-          if [[ -n "${CURRENT_BUILT_SHA}" && "${CURRENT_BUILT_SHA}" == "${SOURCE_SHA}" ]]; then
+          if [[ -n "${CURRENT_BUILT_SHA}" && "${CURRENT_BUILT_SHA}" == "${SOURCE_SHA}" && -n "${WORKER_BUILT_SHA}" && "${WORKER_BUILT_SHA}" == "${SOURCE_SHA}" ]]; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
-            echo "Current commit already built — skipping."
+            echo "Current commit already built for both images — skipping."
           else
             echo "skip=false" >> "$GITHUB_OUTPUT"
-            echo "Current commit not built yet — proceeding."
+            echo "At least one image is missing or out of date — proceeding."
           fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.skip != 'true'
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build and push (ironclaw)
         if: steps.check.outputs.skip != 'true'

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -60,8 +60,9 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_TAG: ${{ inputs.tag }}
+          SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
-          SHA="sha-${GITHUB_SHA::7}"
+          SHA="sha-${SOURCE_SHA::7}"
           echo "sha_tag=${SHA}" >> "$GITHUB_OUTPUT"
 
           if [[ "${EVENT_NAME}" == "workflow_call" ]]; then


### PR DESCRIPTION
## Summary

- Update Docker image CI schedule to run hourly for staging builds.
- Add a staging commit guard so scheduled/staging-target builds are skipped if the current source commit is already published on `nearaidev/ironclaw:staging`.
- Record source commit provenance on built images via `ironclaw.git.sha` label and use the checked-out commit SHA for `sha-*` tags to avoid schedule/ref mismatch.
- Ensure downstream steps (app token creation, `ironclaw-dind` dispatch, and summaries) are skipped when a build is skipped.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: N/A (workflow-only change; no Rust test suite run in this session).
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Reviewed workflow logic and verified conditions/outputs locally in file checks (schedule cron, staging-target guard, label/tag source SHA usage, and skip-gated downstream steps).
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches `ironclaw` CI only (`.github/workflows/docker.yml`). Risk is limited to Docker image build/publish cadence and skip behavior for staging-target builds, plus downstream dispatch timing to `ironclaw-dind`.

## Rollback Plan

Revert workflow changes in `.github/workflows/docker.yml` to restore previous schedule and unconditional staging build behavior.

## Review Follow-Through

Reviewer focus requested on:
- Whether skipping based on `nearaidev/ironclaw:staging` label `ironclaw.git.sha` matches release expectations for all staging build paths.
- Whether any additional observability is desired when a build is skipped (for example explicit metric/log hooks beyond step summary).

---

**Review track**: C
