### PR TITLE
fix: mission (routine) creation

### DIFF
--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -33,10 +33,12 @@ This is much faster than calling tools sequentially. Use `asyncio.gather()` when
 - `llm_query_batched(prompts, context=None, model=None, models=None)` — Same but for multiple prompts in parallel. Returns a list of strings. Pass `model="gpt-4o"` to apply one model to every prompt, or `models=["gpt-4o", "claude-sonnet-4-20250514", ...]` (parallel array, must match `prompts` length) to send each prompt to a different model. The "LLM council" pattern is `prompts=[same_question]*N, models=[m1, m2, ...]`.
 - `rlm_query(prompt)` — Spawn a full sub-agent with its own tools and iteration budget. Use for complex sub-tasks that need tool access. Returns the sub-agent's final answer as a string. More powerful but more expensive than llm_query.
 - `FINAL(answer)` — Call this when you have the final answer. The argument is returned to the user.
-- `mission_create(name, goal, cadence="manual", success_criteria=None)` — Create a long-running mission that spawns threads over time. Cadence: "manual", cron expression (e.g. "0 9 * * *"), "event:pattern", or "webhook:path". Cron expressions accept 5-field (`min hr dom mon dow`), 6-field (`sec min hr dom mon dow` — NOT Quartz-style with year), or 7-field (`sec min hr dom mon dow year`). Cron missions default to the user's timezone from `user_timezone`; pass an explicit `timezone` param to override. Returns {"mission_id": "...", "name": "...", "status": "created"}. When telling the user about a created mission, refer to it by `name`, not by `mission_id` (the UUID is internal).
-- `mission_list()` — List all missions with their status, goal, and current focus.
+- `mission_create(name, goal, trigger, ...)` — Create a routine that runs on a schedule, in reaction to an event, or only when fired by hand.
+- `mission_list()` — List all missions with their status, goal, trigger, and guardrails.
 - `mission_fire(id)` — Manually trigger a mission to spawn a thread now.
 - `mission_pause(id)` / `mission_resume(id)` — Pause or resume a mission.
+- `mission_update(id, ...)` — Update any mission field (name, goal, trigger, notify_channels, cooldown_secs, max_concurrent, max_threads_per_day, dedup_window_secs, success_criteria). Omit fields to leave them unchanged.
+- `mission_delete(id)` — Delete a mission permanently.
 
 ## Context variables
 

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -42,7 +42,9 @@ pub use types::error::{CapabilityError, EngineError, StepError, ThreadError};
 pub use types::event::{EventId, EventKind, ThreadEvent};
 pub use types::memory::{DocId, DocType, MemoryDoc};
 pub use types::message::{MessageRole, ThreadMessage};
-pub use types::mission::{Mission, MissionCadence, MissionId, MissionStatus, ValidTimezone};
+pub use types::mission::{
+    Mission, MissionCadence, MissionCadenceInput, MissionId, MissionStatus, ValidTimezone,
+};
 pub use types::project::{Project, ProjectId};
 pub use types::provenance::Provenance;
 pub use types::step::{

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -82,7 +82,8 @@ pub use runtime::conversation::ConversationManager;
 pub use runtime::manager::ThreadManager;
 pub use runtime::messaging::ThreadOutcome;
 pub use runtime::mission::{
-    BudgetGate, FireRateLimit, MissionManager, MissionNotification, MissionUpdate,
+    BudgetGate, FireRateLimit, MissionGuardrails, MissionManager, MissionNotification,
+    MissionUpdate,
 };
 pub use runtime::tree::ThreadTree;
 

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -102,6 +102,16 @@ pub struct MissionNotification {
     pub is_error: bool,
 }
 
+/// Fire-rate guardrails that limit how often a mission may spawn threads.
+/// `None` on any field keeps the cadence default from `Mission::new`.
+#[derive(Debug, Default, Clone)]
+pub struct MissionGuardrails {
+    pub max_threads_per_day: Option<u32>,
+    pub cooldown_secs: Option<u64>,
+    pub max_concurrent: Option<u32>,
+    pub dedup_window_secs: Option<u64>,
+}
+
 /// Optional updates to apply to a mission via [`MissionManager::update_mission`].
 #[derive(Debug, Default, Clone)]
 pub struct MissionUpdate {
@@ -318,7 +328,9 @@ impl MissionManager {
         Ok(count)
     }
 
-    /// Create and persist a new mission. Returns the mission ID.
+    /// Create and persist a new mission. `guardrails = None` keeps the
+    /// cadence defaults from `Mission::new`.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_mission(
         &self,
         project_id: ProjectId,
@@ -327,7 +339,9 @@ impl MissionManager {
         goal: impl Into<String>,
         cadence: MissionCadence,
         notify_channels: Vec<String>,
+        guardrails: Option<MissionGuardrails>,
     ) -> Result<MissionId, EngineError> {
+        let guardrails = guardrails.unwrap_or_default();
         let mut mission = Mission::new(project_id, user_id, name, goal, cadence);
         if let MissionCadence::Cron {
             ref expression,
@@ -339,6 +353,18 @@ impl MissionManager {
             mission.next_fire_at = Some(next_cron_fire_required(expression, timezone.as_ref())?);
         }
         mission.notify_channels = notify_channels;
+        if let Some(v) = guardrails.max_threads_per_day {
+            mission.max_threads_per_day = v;
+        }
+        if let Some(v) = guardrails.cooldown_secs {
+            mission.cooldown_secs = v;
+        }
+        if let Some(v) = guardrails.max_concurrent {
+            mission.max_concurrent = v;
+        }
+        if let Some(v) = guardrails.dedup_window_secs {
+            mission.dedup_window_secs = v;
+        }
         let id = mission.id;
         self.store.save_mission(&mission).await?;
         self.active.write().await.push(id);
@@ -3281,6 +3307,7 @@ mod tests {
                 "do the thing",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3292,6 +3319,87 @@ mod tests {
         assert_eq!(mission.goal, "do the thing");
         assert_eq!(mission.status, MissionStatus::Active);
         assert_eq!(mission.project_id, project_id);
+    }
+
+    /// Guardrail overrides must land on the first `save_mission` write
+    /// so a partial-failure follow-up update can't leave the mission
+    /// silently stuck on reactive defaults.
+    #[tokio::test]
+    async fn create_mission_with_zeroed_guardrails_persists_on_first_write() {
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        let id = mgr
+            .create_mission(
+                project_id,
+                "test-user",
+                "event sink",
+                "record every matching event",
+                MissionCadence::OnEvent {
+                    event_pattern: ".*".into(),
+                    channel: Some("gateway".into()),
+                },
+                Vec::new(),
+                Some(MissionGuardrails {
+                    max_threads_per_day: Some(0),
+                    cooldown_secs: Some(0),
+                    max_concurrent: Some(0),
+                    dedup_window_secs: Some(0),
+                }),
+            )
+            .await
+            .unwrap();
+
+        let mission = mgr.get_mission(id).await.unwrap().unwrap();
+        assert_eq!(
+            mission.cooldown_secs, 0,
+            "cooldown must be zero on the first persisted write"
+        );
+        assert_eq!(
+            mission.max_concurrent, 0,
+            "max_concurrent must be zero on the first persisted write"
+        );
+        assert_eq!(
+            mission.max_threads_per_day, 0,
+            "max_threads_per_day must be zero on the first persisted write"
+        );
+        assert_eq!(
+            mission.dedup_window_secs, 0,
+            "dedup_window_secs must be zero on the first persisted write"
+        );
+    }
+
+    /// `guardrails = None` leaves the cadence defaults from `Mission::new`
+    /// untouched — the common-case call.
+    #[tokio::test]
+    async fn create_mission_with_none_guardrails_keeps_cadence_defaults() {
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        let id = mgr
+            .create_mission(
+                project_id,
+                "test-user",
+                "reactive defaults",
+                "goal",
+                MissionCadence::OnEvent {
+                    event_pattern: ".*".into(),
+                    channel: None,
+                },
+                Vec::new(),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let mission = mgr.get_mission(id).await.unwrap().unwrap();
+        // Matches the reactive defaults in `Mission::new`.
+        assert_eq!(mission.cooldown_secs, 300);
+        assert_eq!(mission.max_concurrent, 1);
+        assert_eq!(mission.max_threads_per_day, 24);
+        assert_eq!(mission.dedup_window_secs, 0);
     }
 
     #[tokio::test]
@@ -3308,6 +3416,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3339,6 +3448,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3384,6 +3494,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3413,6 +3524,7 @@ mod tests {
                 "build something",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3450,6 +3562,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3482,6 +3595,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3550,6 +3664,7 @@ mod tests {
                 "Deliver daily tech news briefing",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3582,6 +3697,7 @@ mod tests {
                 "Increase test coverage to 80%",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3618,6 +3734,7 @@ mod tests {
                 "Get to 80% coverage",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3732,6 +3849,7 @@ mod tests {
                     secret: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -3775,6 +3893,7 @@ mod tests {
                 filters: std::collections::HashMap::new(),
             },
             Vec::new(),
+            None,
         )
         .await
         .unwrap();
@@ -3809,6 +3928,7 @@ mod tests {
                 filters: std::collections::HashMap::new(),
             },
             Vec::new(),
+            None,
         )
         .await
         .unwrap();
@@ -3833,6 +3953,7 @@ mod tests {
             "goal",
             MissionCadence::Manual,
             Vec::new(),
+            None,
         )
         .await
         .unwrap();
@@ -3846,6 +3967,7 @@ mod tests {
                 timezone: None,
             },
             Vec::new(),
+            None,
         )
         .await
         .unwrap();
@@ -4023,6 +4145,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4103,6 +4226,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4116,6 +4240,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4203,6 +4328,7 @@ mod tests {
                 "monitor uptime",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4216,6 +4342,7 @@ mod tests {
                 "do stuff",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4270,6 +4397,7 @@ mod tests {
                 "shared goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4322,6 +4450,7 @@ mod tests {
                 "private goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4432,6 +4561,7 @@ mod tests {
                     channel: channel.map(String::from),
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4586,6 +4716,7 @@ mod tests {
                 secret: None,
             },
             Vec::new(),
+            None,
         )
         .await
         .unwrap();
@@ -4670,6 +4801,7 @@ mod tests {
                     channel: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4689,6 +4821,47 @@ mod tests {
         );
     }
 
+    /// Zeroed guardrails on a reactive mission let it fire on every
+    /// matching event — the 5-minute reactive cooldown default is skipped.
+    #[tokio::test]
+    async fn reactive_mission_guardrails_are_respected_on_every_fire() {
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        let id = mgr
+            .create_mission(
+                project_id,
+                "alice",
+                "telegram logger",
+                "log every telegram message",
+                MissionCadence::OnEvent {
+                    event_pattern: ".*".into(),
+                    channel: Some("telegram".into()),
+                },
+                Vec::new(),
+                Some(MissionGuardrails {
+                    cooldown_secs: Some(0),
+                    max_concurrent: Some(0),
+                    max_threads_per_day: Some(0),
+                    dedup_window_secs: Some(0),
+                }),
+            )
+            .await
+            .unwrap();
+
+        for msg in ["first", "second", "third"] {
+            let spawned = mgr
+                .fire_on_message_event("telegram", msg, "alice", None)
+                .await
+                .unwrap();
+            assert_eq!(spawned.len(), 1, "event {msg:?} must spawn a thread");
+        }
+
+        let mission = mgr.get_mission(id).await.unwrap().unwrap();
+        assert_eq!(mission.thread_history.len(), 3);
+    }
+
     /// Manual / Cron missions retain the prior generous defaults — they
     /// are self-paced and don't risk flooding from external events.
     #[tokio::test]
@@ -4705,6 +4878,7 @@ mod tests {
                 "do it on demand",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4724,6 +4898,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4880,6 +5055,7 @@ mod tests {
                 "do exactly one thing at a time",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -4926,6 +5102,69 @@ mod tests {
             after.thread_history.len(),
             1,
             "blocked fire must not record a new thread"
+        );
+    }
+
+    /// Complement to `fire_mission_blocks_when_max_concurrent_reached`:
+    /// `max_concurrent = 0` is the caller-visible "disable the cap"
+    /// value and must skip the running-thread check even when an
+    /// in-flight thread is still sitting in the mission's history.
+    #[tokio::test]
+    async fn fire_mission_allows_unlimited_concurrency_when_max_concurrent_is_zero() {
+        use crate::types::thread::{Thread, ThreadConfig, ThreadType};
+        let store = Arc::new(TestStore::new());
+        let mgr = make_mission_manager(Arc::clone(&store) as Arc<dyn Store>);
+        let project_id = ProjectId::new();
+
+        let id = mgr
+            .create_mission(
+                project_id,
+                "alice",
+                "unbounded fan-out",
+                "fire as often as events arrive",
+                MissionCadence::Manual,
+                Vec::new(),
+                // All three gates use the same `> 0` sentinel.
+                Some(MissionGuardrails {
+                    max_concurrent: Some(0),
+                    cooldown_secs: Some(0),
+                    max_threads_per_day: Some(0),
+                    dedup_window_secs: Some(0),
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Pre-seed a non-terminal thread so count_running_threads() > 0.
+        let thread = Thread::new(
+            "preseeded-in-flight",
+            ThreadType::Mission,
+            project_id,
+            "alice",
+            ThreadConfig::default(),
+        );
+        let preseeded_id = thread.id;
+        store.save_thread(&thread).await.unwrap();
+        let mut mission = mgr.get_mission(id).await.unwrap().unwrap();
+        mission.thread_history.push(preseeded_id);
+        store.save_mission(&mission).await.unwrap();
+
+        let first = mgr.fire_mission(id, "alice", None).await.unwrap();
+        assert!(
+            first.is_some(),
+            "max_concurrent=0 must not block fires even with an in-flight thread"
+        );
+        let second = mgr.fire_mission(id, "alice", None).await.unwrap();
+        assert!(
+            second.is_some(),
+            "max_concurrent=0 must keep allowing fires across successive calls"
+        );
+
+        let after = mgr.get_mission(id).await.unwrap().unwrap();
+        assert_eq!(
+            after.thread_history.len(),
+            3,
+            "pre-seeded thread + two successful fires = 3 entries in history"
         );
     }
 
@@ -5040,6 +5279,7 @@ mod tests {
                 "do the risky thing",
                 MissionCadence::Manual,
                 vec!["gateway".to_string()],
+                None,
             )
             .await
             .unwrap();
@@ -5119,6 +5359,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -5270,6 +5511,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5299,6 +5541,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5327,6 +5570,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5371,6 +5615,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5416,6 +5661,7 @@ mod tests {
                 "goal",
                 MissionCadence::Manual,
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5467,6 +5713,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5521,6 +5768,7 @@ mod tests {
                     timezone: Some(tz),
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5536,6 +5784,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5586,6 +5835,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5639,6 +5889,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -5720,6 +5971,7 @@ mod tests {
                     timezone: None,
                 },
                 Vec::new(),
+                None,
             )
             .await
             .unwrap();
@@ -6322,6 +6574,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .expect_err("create_mission must reject cron with no upcoming fire time");
@@ -6349,6 +6602,7 @@ mod tests {
                 "g",
                 MissionCadence::Manual,
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6393,6 +6647,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6443,6 +6698,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6466,6 +6722,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6503,6 +6760,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6563,6 +6821,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6639,6 +6898,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();
@@ -6715,6 +6975,7 @@ mod tests {
                     timezone: None,
                 },
                 vec![],
+                None,
             )
             .await
             .unwrap();

--- a/crates/ironclaw_engine/src/types/mission.rs
+++ b/crates/ironclaw_engine/src/types/mission.rs
@@ -60,9 +60,11 @@ pub enum MissionStatus {
 /// actual trigger infrastructure (cron tickers, webhook endpoints, event
 /// matchers). The engine just needs to be told "fire this mission now."
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum MissionCadence {
     /// Spawn on a cron schedule (e.g., "0 */6 * * *" for every 6 hours).
     Cron {
+        #[serde(rename = "schedule")]
         expression: String,
         #[serde(
             default,
@@ -73,7 +75,9 @@ pub enum MissionCadence {
     /// Spawn in response to a channel message matching a regex pattern.
     /// `channel`, when set, restricts firing to messages from a specific
     /// channel name (case-insensitive).
+    #[serde(rename = "message_event")]
     OnEvent {
+        #[serde(rename = "pattern")]
         event_pattern: String,
         #[serde(default)]
         channel: Option<String>,
@@ -81,6 +85,7 @@ pub enum MissionCadence {
     /// Spawn in response to a structured system event (from tools or external).
     /// `filters`, when non-empty, requires every key/value pair to match
     /// against the event payload's top-level fields exactly.
+    #[serde(rename = "system_event")]
     OnSystemEvent {
         source: String,
         event_type: String,
@@ -91,10 +96,25 @@ pub enum MissionCadence {
     /// The bridge registers the webhook endpoint and routes payloads here.
     Webhook {
         path: String,
+        #[serde(default)]
         secret: Option<String>,
     },
     /// Only spawn when manually triggered (via mission_fire tool or API).
     Manual,
+}
+
+impl MissionCadence {
+    /// Return a clone with the webhook secret cleared, for safe
+    /// serialization in tool output (e.g. `mission_list`).
+    pub fn redacted(&self) -> Self {
+        match self {
+            Self::Webhook { path, .. } => Self::Webhook {
+                path: path.clone(),
+                secret: None,
+            },
+            other => other.clone(),
+        }
+    }
 }
 
 /// A mission — a long-running goal that spawns threads over time.

--- a/crates/ironclaw_engine/src/types/mission.rs
+++ b/crates/ironclaw_engine/src/types/mission.rs
@@ -97,6 +97,83 @@ pub enum MissionCadence {
     Manual,
 }
 
+/// LLM-facing input shape for `MissionCadence`.
+///
+/// The LLM sends `{"kind": "cron", "schedule": "..."}` (internally tagged,
+/// snake_case variants, renamed fields). This type deserializes that format
+/// and converts into the canonical `MissionCadence` via `Into`.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum MissionCadenceInput {
+    Cron {
+        schedule: String,
+        #[serde(
+            default,
+            deserialize_with = "ironclaw_common::deserialize_option_lenient"
+        )]
+        timezone: Option<ValidTimezone>,
+    },
+    #[serde(rename = "message_event")]
+    OnEvent {
+        #[serde(default)]
+        pattern: String,
+        #[serde(default)]
+        channel: Option<String>,
+    },
+    #[serde(rename = "system_event")]
+    OnSystemEvent {
+        #[serde(default)]
+        source: String,
+        #[serde(default)]
+        event_type: String,
+        #[serde(default)]
+        filters: HashMap<String, serde_json::Value>,
+    },
+    Webhook {
+        #[serde(default)]
+        path: String,
+        #[serde(default)]
+        secret: Option<String>,
+    },
+    Manual,
+}
+
+impl MissionCadenceInput {
+    /// Apply a fallback timezone when the input didn't specify one.
+    pub fn with_timezone_fallback(self, fallback: Option<ValidTimezone>) -> Self {
+        match self {
+            Self::Cron {
+                schedule,
+                timezone: None,
+            } => Self::Cron {
+                schedule,
+                timezone: fallback,
+            },
+            other => other,
+        }
+    }
+}
+
+impl From<MissionCadenceInput> for MissionCadence {
+    fn from(input: MissionCadenceInput) -> Self {
+        match input {
+            MissionCadenceInput::Cron { schedule, timezone } => {
+                Self::Cron { expression: schedule, timezone }
+            }
+            MissionCadenceInput::OnEvent { pattern, channel } => {
+                Self::OnEvent { event_pattern: pattern, channel }
+            }
+            MissionCadenceInput::OnSystemEvent { source, event_type, filters } => {
+                Self::OnSystemEvent { source, event_type, filters }
+            }
+            MissionCadenceInput::Webhook { path, secret } => {
+                Self::Webhook { path, secret }
+            }
+            MissionCadenceInput::Manual => Self::Manual,
+        }
+    }
+}
+
 /// A mission — a long-running goal that spawns threads over time.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Mission {

--- a/skills/github-workflow/SKILL.md
+++ b/skills/github-workflow/SKILL.md
@@ -61,7 +61,7 @@ Before installing missions, verify:
 2. For each template block:
    - Replace placeholders (`{{repository}}`, `{{maintainers}}`, branch names)
    - Namespace mission names with the repo slug (e.g. `wf-issue-plan-nearai-ironclaw`)
-   - Call `mission_create` with `name`, `goal` (the prompt), and `cadence` (cron expression or `event:<pattern>`)
+   - Call `mission_create` (see `workflow-routines.md` for the exact shape per template)
 3. If a mission already exists (check `mission_list`), update rather than duplicate.
 4. If `staging_branch` is null, skip `wf-staging-batch-review`.
 5. Write installation status to `projects/<owner>-<repo>/project.md`.

--- a/skills/github-workflow/references/workflow-routines.md
+++ b/skills/github-workflow/references/workflow-routines.md
@@ -1,6 +1,8 @@
 # Workflow Mission Templates
 
-Replace `{{...}}` placeholders before use. Use `mission_create` with `name`, `goal`, and `cadence`.
+Replace `{{...}}` placeholders before use. Use `mission_create` with `name`, `goal`, and `trigger` (a dict — see each template for the shape).
+
+GitHub events are delivered via `event_emit` and fire `system_event` triggers; repository / maintainer / merge filters go inside `trigger.filters`. Only the cron template (#5) uses a different trigger kind.
 
 ## 1) Issue → Plan
 
@@ -8,11 +10,14 @@ Replace `{{...}}` placeholders before use. Use `mission_create` with `name`, `go
 {
   "name": "wf-issue-plan-{{slug}}",
   "goal": "For issue #{{issue_number}} in {{repository}}, produce a concrete implementation plan with milestones, edge cases, and tests. Post/update an issue comment with the plan.",
-  "cadence": "event:issue.opened"
+  "trigger": {
+    "kind": "system_event",
+    "source": "github",
+    "event_type": "issue.opened",
+    "filters": { "repository_name": "{{repository}}" }
+  }
 }
 ```
-
-Filter: `repository_name: "{{repository}}"`
 
 ## 2) Maintainer Comment Gate
 
@@ -22,11 +27,17 @@ Create one per maintainer handle, or use a shared convention.
 {
   "name": "wf-maintainer-gate-{{slug}}-{{maintainer}}",
   "goal": "Read the maintainer comment on {{repository}} and decide: update plan or start/continue implementation. If plan changes are requested, edit the plan artifact first. If implementation is requested, continue on the feature branch and update PR status/comment.",
-  "cadence": "event:pr.comment.created"
+  "trigger": {
+    "kind": "system_event",
+    "source": "github",
+    "event_type": "pr.comment.created",
+    "filters": {
+      "repository_name": "{{repository}}",
+      "comment_author": "{{maintainer}}"
+    }
+  }
 }
 ```
-
-Filter: `repository_name: "{{repository}}"`, `comment_author: "{{maintainer}}"`
 
 ## 3) PR Monitor Loop
 
@@ -34,11 +45,14 @@ Filter: `repository_name: "{{repository}}"`, `comment_author: "{{maintainer}}"`
 {
   "name": "wf-pr-monitor-{{slug}}",
   "goal": "For PRs in {{repository}}, collect open review comments and unresolved threads, apply fixes, push branch updates, and summarize remaining blockers. If conflict with {{main_branch}}, rebase/merge from origin/{{main_branch}} and resolve safely.",
-  "cadence": "event:pr.synchronize"
+  "trigger": {
+    "kind": "system_event",
+    "source": "github",
+    "event_type": "pr.synchronize",
+    "filters": { "repository_name": "{{repository}}" }
+  }
 }
 ```
-
-Filter: `repository_name: "{{repository}}"`
 
 ## 4) CI Failure Fix Loop
 
@@ -46,21 +60,27 @@ Filter: `repository_name: "{{repository}}"`
 {
   "name": "wf-ci-fix-{{slug}}",
   "goal": "Find failing check details for PRs in {{repository}}, implement minimal safe fixes, rerun or await CI, and post concise status updates. Prioritize deterministic and test-backed fixes.",
-  "cadence": "event:ci.check_run.completed"
+  "trigger": {
+    "kind": "system_event",
+    "source": "github",
+    "event_type": "ci.check_run.completed",
+    "filters": {
+      "repository_name": "{{repository}}",
+      "ci_conclusion": "failure"
+    }
+  }
 }
 ```
 
-Filter: `repository_name: "{{repository}}"`, `ci_conclusion: "failure"`
-
 ## 5) Staging Batch Review
 
-Skip if no staging branch is configured.
+Skip if no staging branch is configured. This one runs on a cron, not a GitHub event.
 
 ```json
 {
   "name": "wf-staging-review-{{slug}}",
   "goal": "Every cycle: list ready PRs in {{repository}}, merge ready ones into {{staging_branch}}, run deep correctness analysis in batch, fix discovered issues on affected branches, ensure CI green, then merge {{staging_branch}} into {{main_branch}} if clean.",
-  "cadence": "0 */{{batch_interval_hours}} * * *"
+  "trigger": { "kind": "cron", "schedule": "0 */{{batch_interval_hours}} * * *" }
 }
 ```
 
@@ -70,11 +90,17 @@ Skip if no staging branch is configured.
 {
   "name": "wf-learning-{{slug}}",
   "goal": "From merged PRs in {{repository}}, extract preventable mistakes, reviewer themes, CI failure causes, and successful patterns. Write/update a shared memory doc at context/intel/{{slug}}-learnings.md with actionable rules to reduce cycle time and regressions.",
-  "cadence": "event:pr.closed"
+  "trigger": {
+    "kind": "system_event",
+    "source": "github",
+    "event_type": "pr.closed",
+    "filters": {
+      "repository_name": "{{repository}}",
+      "pr_merged": "true"
+    }
+  }
 }
 ```
-
-Filter: `repository_name: "{{repository}}"`, `pr_merged: "true"`
 
 ## Synthetic Event Test
 

--- a/skills/project-setup/SKILL.md
+++ b/skills/project-setup/SKILL.md
@@ -81,7 +81,7 @@ Follow the `github-workflow` skill's install procedure. For each of the 6 missio
 3. Replace `{{maintainers}}` with the maintainer list
 4. Replace `{{main_branch}}` and `{{staging_branch}}` with the configured branches
 5. Replace `{{batch_interval_hours}}` with `8` (default)
-6. Call `mission_create(name, goal, cadence)` for each
+6. Call `mission_create` for each (see `github-workflow/references/workflow-routines.md`)
 
 If `staging_branch` is null, skip `wf-staging-review-<slug>`.
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -193,6 +193,7 @@ impl EffectBridgeAdapter {
         // collapses it into mission fields plus a follow-up update for the
         // non-execution guardrails (cooldown, max_concurrent, dedup_window,
         // notify_user, context_paths, description).
+        let original_action_name = action_name;
         let routine_alias = routine_to_mission_alias(action_name, params);
         let (effective_action, effective_params, post_create_update) =
             if let Some(alias) = routine_alias.as_ref() {
@@ -206,6 +207,62 @@ impl EffectBridgeAdapter {
             };
         let action_name = effective_action;
         let params = effective_params.as_ref();
+
+        // Reject malformed triggers before dispatch — an unvalidated bad
+        // shape silently falls back to Manual and inert-ifies the mission.
+        // Error text names the caller's own surface (routine_* → `request`,
+        // mission_* → `trigger`).
+        let (caller_tool, caller_field) = if original_action_name == "routine_create" {
+            ("routine_create", "request")
+        } else if original_action_name == "routine_update" {
+            ("routine_update", "request")
+        } else {
+            (original_action_name, "trigger")
+        };
+        let trigger_pre_check_reason = match action_name {
+            "mission_create" => {
+                let trigger_val = params
+                    .get("trigger")
+                    .or_else(|| params.get("_args").and_then(|a| a.get(2)));
+                validate_trigger_value(trigger_val, /* required = */ true)
+            }
+            "mission_update" => {
+                // trigger is optional on update, but if present must be valid.
+                let trigger_val = params.get("trigger");
+                if trigger_val.is_some() {
+                    validate_trigger_value(trigger_val, /* required = */ false)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        };
+        if let Some(reason) = trigger_pre_check_reason {
+            return Some(Ok(ActionResult {
+                call_id: context
+                    .current_call_id
+                    .clone()
+                    .unwrap_or_else(|| synthetic_action_call_id(original_action_name)),
+                action_name: original_action_name.to_string(),
+                output: serde_json::json!({
+                    "error": format!(
+                        "{caller_tool}: invalid `{caller_field}` argument ({reason}). \
+                         `{caller_field}` must be a dict with a `kind` field set to one of \
+                         \"manual\", \"cron\", \"message_event\", \"system_event\", or \
+                         \"webhook\". Examples: \
+                         {{\"kind\": \"message_event\", \"pattern\": \".*\", \
+                         \"channel\": \"telegram\"}} to run every time a telegram \
+                         message arrives; \
+                         {{\"kind\": \"cron\", \"schedule\": \"0 9 * * *\"}} for \
+                         scheduled runs; \
+                         {{\"kind\": \"manual\"}} if it should only run when fired \
+                         explicitly."
+                    )
+                }),
+                is_error: true,
+                duration: std::time::Duration::ZERO,
+            }));
+        }
 
         let mgr = self.mission_manager.read().await;
         let mgr = mgr.as_ref()?;
@@ -222,18 +279,20 @@ impl EffectBridgeAdapter {
                     .or_else(|| params.get("_args").and_then(|a| a.get(1)))
                     .and_then(|v| v.as_str())
                     .unwrap_or("");
-                let cadence_str = params
-                    .get("cadence")
-                    .or_else(|| params.get("_args").and_then(|a| a.get(2)))
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("manual");
-                // Use explicit timezone param, fall back to user's channel timezone.
+                // Explicit timezone param, fall back to user's channel timezone.
                 // ValidTimezone::parse filters empty/invalid strings.
                 let timezone = params
                     .get("timezone")
                     .and_then(|v| v.as_str())
                     .and_then(ironclaw_engine::ValidTimezone::parse)
                     .or(context.user_timezone);
+                // Validated above — one branch is guaranteed Some.
+                let trigger_value = params
+                    .get("trigger")
+                    .or_else(|| params.get("_args").and_then(|a| a.get(2)))
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let cadence = parse_trigger_object(&trigger_value, timezone);
                 // notify_channels: explicit array, or default to current channel
                 let notify_channels =
                     if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
@@ -245,32 +304,49 @@ impl EffectBridgeAdapter {
                     } else {
                         vec![]
                     };
+                // Guardrail overrides. `0` on any field disables that gate;
+                // `None` on every field leaves the cadence defaults alone.
+                let guardrails = {
+                    let g = ironclaw_engine::MissionGuardrails {
+                        max_threads_per_day: params
+                            .get("max_threads_per_day")
+                            .and_then(|v| v.as_u64())
+                            .map(|v| v as u32),
+                        cooldown_secs: params.get("cooldown_secs").and_then(|v| v.as_u64()),
+                        max_concurrent: params
+                            .get("max_concurrent")
+                            .and_then(|v| v.as_u64())
+                            .map(|v| v as u32),
+                        dedup_window_secs: params.get("dedup_window_secs").and_then(|v| v.as_u64()),
+                    };
+                    if g.max_threads_per_day.is_some()
+                        || g.cooldown_secs.is_some()
+                        || g.max_concurrent.is_some()
+                        || g.dedup_window_secs.is_some()
+                    {
+                        Some(g)
+                    } else {
+                        None
+                    }
+                };
                 match mgr
                     .create_mission(
                         context.project_id,
                         &context.user_id,
                         name,
                         goal,
-                        parse_cadence(cadence_str, timezone),
+                        cadence,
                         notify_channels,
+                        guardrails,
                     )
                     .await
                 {
                     Ok(id) => {
-                        // Routine alias post-create update: apply the
-                        // non-execution routine fields (description,
-                        // context_paths, notify_user, cooldown, max_concurrent,
-                        // dedup_window) via update_mission. Mission_create's
-                        // signature doesn't take these directly.
-                        //
-                        // We don't have a `delete_mission` to roll back on
-                        // partial failure, so the next-best contract is to
-                        // surface the failure clearly: status flips to
-                        // `created_with_warnings` and the warning text goes
-                        // into a `warnings` array. The LLM (or downstream
-                        // code) sees the partial-success signal and can
-                        // call `update_mission` directly to retry, instead
-                        // of believing the routine was fully configured.
+                        // Routine-only fields (description, context_paths,
+                        // notify_user) need a second write since mission_create
+                        // doesn't accept them. On partial failure the caller
+                        // sees `created_with_warnings` and can retry via
+                        // update_mission — no rollback path exists.
                         let mut warnings: Vec<String> = Vec::new();
                         if let Some(updates) = post_create_update.clone()
                             && let Err(e) = mgr.update_mission(id, &context.user_id, updates).await
@@ -317,6 +393,13 @@ impl EffectBridgeAdapter {
                                 "name": m.name,
                                 "goal": m.goal,
                                 "status": format!("{:?}", m.status),
+                                "trigger": cadence_to_json(&m.cadence),
+                                "guardrails": {
+                                    "cooldown_secs": m.cooldown_secs,
+                                    "max_concurrent": m.max_concurrent,
+                                    "max_threads_per_day": m.max_threads_per_day,
+                                    "dedup_window_secs": m.dedup_window_secs,
+                                },
                                 "threads": m.thread_history.len(),
                                 "current_focus": m.current_focus,
                                 "notify_channels": m.notify_channels,
@@ -410,38 +493,15 @@ impl EffectBridgeAdapter {
                     });
                 match id {
                     Ok(id) => {
-                        let mut updates = ironclaw_engine::MissionUpdate::default();
-                        if let Some(name) = params.get("name").and_then(|v| v.as_str()) {
-                            updates.name = Some(name.to_string());
-                        }
-                        if let Some(goal) = params.get("goal").and_then(|v| v.as_str()) {
-                            updates.goal = Some(goal.to_string());
-                        }
-                        if let Some(cadence) = params.get("cadence").and_then(|v| v.as_str()) {
-                            let tz = params
-                                .get("timezone")
-                                .and_then(|v| v.as_str())
-                                .and_then(ironclaw_engine::ValidTimezone::parse)
-                                .or(context.user_timezone);
-                            updates.cadence = Some(parse_cadence(cadence, tz));
-                        }
-                        if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array())
+                        let mut updates =
+                            build_mission_update_from_params(params, context.user_timezone);
+                        // mission_list strips webhook secrets, so a
+                        // list→update round-trip must preserve the existing
+                        // secret when the new trigger omits one.
+                        if needs_webhook_secret_preserve(updates.cadence.as_ref())
+                            && let Ok(Some(current)) = mgr.get_mission(id).await
                         {
-                            updates.notify_channels = Some(
-                                arr.iter()
-                                    .filter_map(|v| v.as_str().map(String::from))
-                                    .collect(),
-                            );
-                        }
-                        if let Some(max) =
-                            params.get("max_threads_per_day").and_then(|v| v.as_u64())
-                        {
-                            updates.max_threads_per_day = Some(max as u32);
-                        }
-                        if let Some(criteria) =
-                            params.get("success_criteria").and_then(|v| v.as_str())
-                        {
-                            updates.success_criteria = Some(criteria.to_string());
+                            preserve_webhook_secret(&mut updates, &current.cadence);
                         }
                         match mgr.update_mission(id, &context.user_id, updates).await {
                             Ok(()) => Ok(serde_json::json!({"status": "updated"})),
@@ -1082,6 +1142,88 @@ impl EffectExecutor for EffectBridgeAdapter {
     }
 }
 
+/// Gate for `preserve_webhook_secret` — skip the `get_mission` lookup
+/// unless the update would replace the cadence with a secret-less webhook.
+fn needs_webhook_secret_preserve(
+    new_cadence: Option<&ironclaw_engine::types::mission::MissionCadence>,
+) -> bool {
+    matches!(
+        new_cadence,
+        Some(ironclaw_engine::types::mission::MissionCadence::Webhook { secret: None, .. })
+    )
+}
+
+/// Carry an existing webhook secret forward when the update omits one.
+/// Callers wanting to clear the secret must pass `secret: ""` explicitly.
+fn preserve_webhook_secret(
+    updates: &mut ironclaw_engine::MissionUpdate,
+    current_cadence: &ironclaw_engine::types::mission::MissionCadence,
+) {
+    use ironclaw_engine::types::mission::MissionCadence;
+    let Some(MissionCadence::Webhook {
+        secret: new_secret @ None,
+        ..
+    }) = updates.cadence.as_mut()
+    else {
+        return;
+    };
+    if let MissionCadence::Webhook {
+        secret: Some(existing),
+        ..
+    } = current_cadence
+    {
+        *new_secret = Some(existing.clone());
+    }
+}
+
+/// Build a `MissionUpdate` from a `mission_update` params object.
+fn build_mission_update_from_params(
+    params: &serde_json::Value,
+    fallback_timezone: Option<ironclaw_engine::ValidTimezone>,
+) -> ironclaw_engine::MissionUpdate {
+    let mut updates = ironclaw_engine::MissionUpdate::default();
+    if let Some(name) = params.get("name").and_then(|v| v.as_str()) {
+        updates.name = Some(name.to_string());
+    }
+    if let Some(goal) = params.get("goal").and_then(|v| v.as_str()) {
+        updates.goal = Some(goal.to_string());
+    }
+    let tz = params
+        .get("timezone")
+        .and_then(|v| v.as_str())
+        .and_then(ironclaw_engine::ValidTimezone::parse)
+        .or(fallback_timezone);
+    if let Some(trigger) = params.get("trigger") {
+        updates.cadence = Some(parse_trigger_object(trigger, tz));
+    } else if let Some(cadence) = params.get("cadence").and_then(|v| v.as_str()) {
+        // Legacy flat string cadence, kept for backward compat.
+        updates.cadence = Some(parse_cadence(cadence, tz));
+    }
+    if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
+        updates.notify_channels = Some(
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect(),
+        );
+    }
+    if let Some(max) = params.get("max_threads_per_day").and_then(|v| v.as_u64()) {
+        updates.max_threads_per_day = Some(max as u32);
+    }
+    if let Some(secs) = params.get("cooldown_secs").and_then(|v| v.as_u64()) {
+        updates.cooldown_secs = Some(secs);
+    }
+    if let Some(max) = params.get("max_concurrent").and_then(|v| v.as_u64()) {
+        updates.max_concurrent = Some(max as u32);
+    }
+    if let Some(secs) = params.get("dedup_window_secs").and_then(|v| v.as_u64()) {
+        updates.dedup_window_secs = Some(secs);
+    }
+    if let Some(criteria) = params.get("success_criteria").and_then(|v| v.as_str()) {
+        updates.success_criteria = Some(criteria.to_string());
+    }
+    updates
+}
+
 /// Parse a cadence string into a MissionCadence.
 ///
 /// When cadence is a cron expression, `timezone` is used as the scheduling
@@ -1172,20 +1314,14 @@ fn routine_to_mission_alias(
                 .filter(|s| !s.is_empty())
                 .map(String::from);
 
-            // Translate the routine `request` block into a MissionCadence
-            // serialized as the cadence string parse_cadence understands. We
-            // serialize as a structured string when possible, otherwise we
-            // hand the cadence variant directly through metadata that
-            // mission_create can't read — so we instead build the cadence
-            // here and store it via the post_create_update path.
-            let cadence = parse_routine_request(params);
-            // We carry cadence + the new fields via the update path so we
-            // don't need to change mission_create's flat-args contract.
+            // Routine-only fields (description, context_paths, notify_user)
+            // go through a post-create update since mission_create doesn't
+            // accept them. Guardrails are forwarded as top-level mission_params
+            // below so they land on the initial save.
             let mut updates = ironclaw_engine::MissionUpdate {
                 description: description.clone(),
                 ..Default::default()
             };
-            updates.cadence = Some(cadence);
 
             // execution.context_paths
             if let Some(arr) = params
@@ -1219,50 +1355,60 @@ fn routine_to_mission_alias(
                 notify_channels.push(ch.to_string());
             }
 
-            // advanced.cooldown_secs (also accepts top-level cooldown_secs)
-            if let Some(secs) = params
+            // Flatten routine `advanced.*` / `guardrails.*` sub-objects
+            // into the flat guardrail keys mission_create reads.
+            let cooldown_secs = params
                 .get("advanced")
                 .and_then(|a| a.get("cooldown_secs"))
                 .or_else(|| params.get("cooldown_secs"))
-                .and_then(|v| v.as_u64())
-            {
-                updates.cooldown_secs = Some(secs);
-            }
-            // guardrails.max_concurrent
-            if let Some(max) = params
+                .and_then(|v| v.as_u64());
+            let max_concurrent = params
                 .get("guardrails")
                 .and_then(|g| g.get("max_concurrent"))
                 .or_else(|| params.get("max_concurrent"))
-                .and_then(|v| v.as_u64())
-            {
-                updates.max_concurrent = Some(max as u32);
-            }
-            // guardrails.dedup_window_secs
-            if let Some(secs) = params
+                .and_then(|v| v.as_u64());
+            let dedup_window_secs = params
                 .get("guardrails")
                 .and_then(|g| g.get("dedup_window_secs"))
                 .or_else(|| params.get("dedup_window_secs"))
-                .and_then(|v| v.as_u64())
-            {
-                updates.dedup_window_secs = Some(secs);
-            }
+                .and_then(|v| v.as_u64());
+            let max_threads_per_day = params
+                .get("guardrails")
+                .and_then(|g| g.get("max_threads_per_day"))
+                .or_else(|| params.get("max_threads_per_day"))
+                .and_then(|v| v.as_u64());
 
-            // mission_create takes a `cadence` string as a flat param. We
-            // pass "manual" here as a placeholder — the real cadence is
-            // applied immediately afterward via update_mission. This keeps
-            // the mission_create signature unchanged.
+            // Forward `request` as `trigger` (same shape). Absent request
+            // stays absent so the mission_create pre-check rejects it
+            // instead of silently defaulting to Manual.
             let mut mission_params = serde_json::json!({
                 "name": name,
                 "goal": goal,
-                "cadence": "manual",
             });
-            if !notify_channels.is_empty()
+            if let Some(request) = params.get("request")
                 && let Some(obj) = mission_params.as_object_mut()
             {
-                obj.insert(
-                    "notify_channels".to_string(),
-                    serde_json::json!(notify_channels),
-                );
+                obj.insert("trigger".to_string(), request.clone());
+            }
+            if let Some(obj) = mission_params.as_object_mut() {
+                if !notify_channels.is_empty() {
+                    obj.insert(
+                        "notify_channels".to_string(),
+                        serde_json::json!(notify_channels),
+                    );
+                }
+                if let Some(v) = cooldown_secs {
+                    obj.insert("cooldown_secs".to_string(), serde_json::json!(v));
+                }
+                if let Some(v) = max_concurrent {
+                    obj.insert("max_concurrent".to_string(), serde_json::json!(v));
+                }
+                if let Some(v) = dedup_window_secs {
+                    obj.insert("dedup_window_secs".to_string(), serde_json::json!(v));
+                }
+                if let Some(v) = max_threads_per_day {
+                    obj.insert("max_threads_per_day".to_string(), serde_json::json!(v));
+                }
             }
 
             Some(RoutineMissionAlias {
@@ -1389,65 +1535,81 @@ fn routine_to_mission_alias(
     }
 }
 
-/// Parse the routine `request` sub-object into a `MissionCadence`.
-/// Falls back to `Manual` when the kind is missing or unrecognized.
-fn parse_routine_request(
-    params: &serde_json::Value,
+/// Validate a structured trigger. Returns `None` when acceptable, or a
+/// short reason string (`"missing"`, `"unknown-kind"`, ...) otherwise.
+/// `required=false` allows an absent value for partial updates.
+fn validate_trigger_value(
+    trigger_val: Option<&serde_json::Value>,
+    required: bool,
+) -> Option<&'static str> {
+    match trigger_val {
+        None | Some(serde_json::Value::Null) => required.then_some("missing"),
+        Some(v) if !v.is_object() => Some("not-an-object"),
+        Some(v) => {
+            let kind = v.get("kind").and_then(|k| k.as_str()).unwrap_or("");
+            match kind {
+                "manual" | "cron" | "message_event" | "system_event" | "webhook" => None,
+                "" => Some("missing-kind"),
+                _ => Some("unknown-kind"),
+            }
+        }
+    }
+}
+
+/// Parse a structured trigger object into a `MissionCadence`. Falls
+/// back to `Manual` on unknown/missing kind — side-effect gated callers
+/// must run [`validate_trigger_value`] first.
+fn parse_trigger_object(
+    trigger: &serde_json::Value,
+    fallback_timezone: Option<ironclaw_common::ValidTimezone>,
 ) -> ironclaw_engine::types::mission::MissionCadence {
     use ironclaw_engine::types::mission::MissionCadence;
 
-    let request = params.get("request");
-    let kind = request
-        .and_then(|r| r.get("kind"))
+    let kind = trigger
+        .get("kind")
         .and_then(|v| v.as_str())
         .unwrap_or("manual");
 
     match kind {
         "cron" => MissionCadence::Cron {
-            expression: request
-                .and_then(|r| r.get("schedule"))
+            expression: trigger
+                .get("schedule")
                 .and_then(|v| v.as_str())
                 .unwrap_or("0 0 * * * *")
                 .to_string(),
-            // Validate the timezone string at the bridge boundary so an
-            // invalid value never enters the engine. An empty/invalid value
-            // is silently dropped (None) — the engine then resolves the
-            // schedule in UTC, matching the previous string-based behaviour
-            // for unknown zones.
-            timezone: request
-                .and_then(|r| r.get("timezone"))
+            // Invalid zones drop to None (engine resolves in UTC).
+            timezone: trigger
+                .get("timezone")
                 .and_then(|v| v.as_str())
-                .and_then(ironclaw_common::ValidTimezone::parse),
+                .and_then(ironclaw_common::ValidTimezone::parse)
+                .or(fallback_timezone),
         },
         "message_event" => MissionCadence::OnEvent {
-            event_pattern: request
-                .and_then(|r| r.get("pattern"))
+            event_pattern: trigger
+                .get("pattern")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-            channel: request
-                .and_then(|r| r.get("channel"))
+            channel: trigger
+                .get("channel")
                 .and_then(|v| v.as_str())
                 .map(String::from),
         },
         "system_event" => {
             let mut filters = std::collections::HashMap::new();
-            if let Some(map) = request
-                .and_then(|r| r.get("filters"))
-                .and_then(|v| v.as_object())
-            {
+            if let Some(map) = trigger.get("filters").and_then(|v| v.as_object()) {
                 for (k, v) in map {
                     filters.insert(k.clone(), v.clone());
                 }
             }
             MissionCadence::OnSystemEvent {
-                source: request
-                    .and_then(|r| r.get("source"))
+                source: trigger
+                    .get("source")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string(),
-                event_type: request
-                    .and_then(|r| r.get("event_type"))
+                event_type: trigger
+                    .get("event_type")
                     .and_then(|v| v.as_str())
                     .unwrap_or("")
                     .to_string(),
@@ -1455,17 +1617,73 @@ fn parse_routine_request(
             }
         }
         "webhook" => MissionCadence::Webhook {
-            path: request
-                .and_then(|r| r.get("path"))
+            path: trigger
+                .get("path")
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string(),
-            secret: request
-                .and_then(|r| r.get("secret"))
+            secret: trigger
+                .get("secret")
                 .and_then(|v| v.as_str())
                 .map(String::from),
         },
         _ => MissionCadence::Manual,
+    }
+}
+
+/// Parse the routine `request` sub-object into a `MissionCadence`.
+/// Falls back to `Manual` when absent. Thin wrapper around
+/// [`parse_trigger_object`] — routines nest the trigger under `request`.
+fn parse_routine_request(
+    params: &serde_json::Value,
+) -> ironclaw_engine::types::mission::MissionCadence {
+    use ironclaw_engine::types::mission::MissionCadence;
+
+    match params.get("request") {
+        Some(request) => parse_trigger_object(request, None),
+        None => MissionCadence::Manual,
+    }
+}
+
+/// Encode a `MissionCadence` as the same `{kind, ...}` shape
+/// [`parse_trigger_object`] consumes, so `mission_list` output can
+/// round-trip through `mission_update` without a string intermediate.
+fn cadence_to_json(cadence: &ironclaw_engine::types::mission::MissionCadence) -> serde_json::Value {
+    use ironclaw_engine::types::mission::MissionCadence;
+    match cadence {
+        MissionCadence::Manual => serde_json::json!({"kind": "manual"}),
+        MissionCadence::Cron {
+            expression,
+            timezone,
+        } => serde_json::json!({
+            "kind": "cron",
+            "schedule": expression,
+            "timezone": timezone.as_ref().map(|tz| tz.name()),
+        }),
+        MissionCadence::OnEvent {
+            event_pattern,
+            channel,
+        } => serde_json::json!({
+            "kind": "message_event",
+            "pattern": event_pattern,
+            "channel": channel,
+        }),
+        MissionCadence::OnSystemEvent {
+            source,
+            event_type,
+            filters,
+        } => serde_json::json!({
+            "kind": "system_event",
+            "source": source,
+            "event_type": event_type,
+            "filters": filters,
+        }),
+        // Webhook secret is a credential, we deliberately do NOT expose it.
+        MissionCadence::Webhook { path, secret } => serde_json::json!({
+            "kind": "webhook",
+            "path": path,
+            "has_secret": secret.is_some(),
+        }),
     }
 }
 
@@ -1579,6 +1797,141 @@ mod tests {
                 .call_count
                 .load(std::sync::atomic::Ordering::Relaxed),
             0
+        );
+    }
+
+    /// Regression: an absent `trigger` must produce a structured schema
+    /// error instead of silently creating an inert Manual mission.
+    #[tokio::test]
+    async fn mission_create_without_trigger_returns_schema_error() {
+        let adapter = make_adapter();
+
+        let result = adapter
+            .execute_action(
+                "mission_create",
+                serde_json::json!({
+                    "name": "Message Logger",
+                    "goal": "Log every incoming message",
+                    "notify_channels": ["tui"],
+                }),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_mission_create_no_trigger"),
+                ),
+            )
+            .await
+            .expect("mission_create should return a tool result, not an engine error");
+
+        assert!(
+            result.is_error,
+            "mission_create without trigger must be flagged as a tool error"
+        );
+        let error_text = result
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error output should carry an `error` string");
+        assert!(
+            error_text.contains("invalid `trigger` argument (missing)"),
+            "error should name the missing argument, got: {error_text}"
+        );
+        assert!(
+            error_text.contains("message_event"),
+            "error should show the message_event shape as an example, got: {error_text}"
+        );
+    }
+
+    /// Non-object triggers (string, null, array, number, unknown kind)
+    /// must be rejected rather than falling through to Manual.
+    #[tokio::test]
+    async fn mission_create_rejects_non_object_trigger_shapes() {
+        let adapter = make_adapter();
+        let bad_triggers = vec![
+            serde_json::json!("message_event"),
+            serde_json::json!(null),
+            serde_json::json!(["message_event"]),
+            serde_json::json!(42),
+            serde_json::json!({}),
+            serde_json::json!({"kind": "telegram"}),
+        ];
+        for bad in bad_triggers {
+            let result = adapter
+                .execute_action(
+                    "mission_create",
+                    serde_json::json!({
+                        "name": "bad",
+                        "goal": "bad",
+                        "trigger": bad.clone(),
+                    }),
+                    &lease(),
+                    &exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_bad_trigger")),
+                )
+                .await
+                .expect("tool result expected");
+            assert!(
+                result.is_error,
+                "trigger {bad:?} must be rejected as a tool error"
+            );
+            let err = result
+                .output
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            assert!(
+                err.contains("invalid `trigger` argument"),
+                "error should come from the mission_create pre-check, got: {err}"
+            );
+        }
+    }
+
+    /// The trigger pre-check error on a `routine_create` call must name
+    /// the routine surface (`request`), not leak the internal
+    /// `mission_create` / `trigger` names the caller never used.
+    #[tokio::test]
+    async fn routine_create_without_request_returns_routine_shaped_error() {
+        let adapter = make_adapter();
+
+        let result = adapter
+            .execute_action(
+                "routine_create",
+                serde_json::json!({
+                    "name": "daily-summary",
+                    "prompt": "Summarize the day",
+                }),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_routine_create_alias"),
+                ),
+            )
+            .await
+            .expect("routine_create should return a tool result, not an engine error");
+
+        assert!(
+            result.is_error,
+            "routine_create without request must be flagged as a tool error"
+        );
+        assert_eq!(
+            result.action_name, "routine_create",
+            "error must be reported under the tool the caller actually invoked"
+        );
+        let err_text = result
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .expect("error output should carry an `error` string");
+        assert!(
+            err_text.contains("routine_create: invalid `request` argument"),
+            "error must name the routine_create surface (tool + field), got: {err_text}"
+        );
+        assert!(
+            !err_text.contains("mission_create:"),
+            "error must not leak the internal mission_create tool name, got: {err_text}"
+        );
+        assert!(
+            !err_text.contains("`trigger`"),
+            "error must not reference the internal `trigger` field name, got: {err_text}"
         );
     }
 
@@ -2067,11 +2420,30 @@ mod tests {
             alias.mission_params.get("goal").and_then(|v| v.as_str()),
             Some("Summarize open PRs needing review")
         );
-        // mission_create receives a placeholder cadence; the real cadence is
-        // applied via the post_create_update.
+        // mission_create receives the real trigger from the request block.
         assert_eq!(
-            alias.mission_params.get("cadence").and_then(|v| v.as_str()),
-            Some("manual")
+            alias
+                .mission_params
+                .get("trigger")
+                .and_then(|t| t.get("kind"))
+                .and_then(|v| v.as_str()),
+            Some("cron")
+        );
+        assert_eq!(
+            alias
+                .mission_params
+                .get("trigger")
+                .and_then(|t| t.get("schedule"))
+                .and_then(|v| v.as_str()),
+            Some("0 9 * * *")
+        );
+        assert_eq!(
+            alias
+                .mission_params
+                .get("trigger")
+                .and_then(|t| t.get("timezone"))
+                .and_then(|v| v.as_str()),
+            Some("America/New_York")
         );
         assert_eq!(
             alias
@@ -2080,6 +2452,33 @@ mod tests {
                 .and_then(|v| v.as_array())
                 .map(|a| a.iter().filter_map(|v| v.as_str()).collect::<Vec<_>>()),
             Some(vec!["gateway"])
+        );
+
+        // Guardrails ride on mission_create's flat fields so they land
+        // on the initial save, not via the post-create update.
+        assert_eq!(
+            alias
+                .mission_params
+                .get("cooldown_secs")
+                .and_then(|v| v.as_u64()),
+            Some(300),
+            "cooldown_secs must be forwarded to mission_create"
+        );
+        assert_eq!(
+            alias
+                .mission_params
+                .get("max_concurrent")
+                .and_then(|v| v.as_u64()),
+            Some(1),
+            "max_concurrent must be forwarded to mission_create"
+        );
+        assert_eq!(
+            alias
+                .mission_params
+                .get("dedup_window_secs")
+                .and_then(|v| v.as_u64()),
+            Some(60),
+            "dedup_window_secs must be forwarded to mission_create"
         );
 
         let updates = alias
@@ -2095,22 +2494,24 @@ mod tests {
             Some(&["context/profile.json".to_string(), "MEMORY.md".to_string()][..])
         );
         assert_eq!(updates.notify_user.as_deref(), Some("alice"));
-        assert_eq!(updates.cooldown_secs, Some(300));
-        assert_eq!(updates.max_concurrent, Some(1));
-        assert_eq!(updates.dedup_window_secs, Some(60));
-        match updates.cadence.as_ref().expect("cadence in updates") {
-            ironclaw_engine::types::mission::MissionCadence::Cron {
-                expression,
-                timezone,
-            } => {
-                assert_eq!(expression, "0 9 * * *");
-                assert_eq!(
-                    timezone.as_ref().map(|tz| tz.tz().name()),
-                    Some("America/New_York")
-                );
-            }
-            other => panic!("expected Cron cadence, got {:?}", other),
-        }
+        // Guardrails must NOT ride on the post-create update struct —
+        // see the asserts above.
+        assert_eq!(
+            updates.cooldown_secs, None,
+            "cooldown_secs must NOT be routed through post_create_update"
+        );
+        assert_eq!(
+            updates.max_concurrent, None,
+            "max_concurrent must NOT be routed through post_create_update"
+        );
+        assert_eq!(
+            updates.dedup_window_secs, None,
+            "dedup_window_secs must NOT be routed through post_create_update"
+        );
+        assert_eq!(
+            updates.max_threads_per_day, None,
+            "max_threads_per_day must NOT be routed through post_create_update"
+        );
     }
 
     #[test]
@@ -2126,17 +2527,19 @@ mod tests {
         });
         let alias =
             routine_to_mission_alias("routine_create", &params).expect("alias for message_event");
-        let updates = alias.post_create_update.expect("updates");
-        match updates.cadence.as_ref().expect("cadence") {
-            ironclaw_engine::types::mission::MissionCadence::OnEvent {
-                event_pattern,
-                channel,
-            } => {
-                assert_eq!(event_pattern, "review requested");
-                assert_eq!(channel.as_deref(), Some("github"));
-            }
-            other => panic!("expected OnEvent cadence, got {:?}", other),
-        }
+        let trigger = alias.mission_params.get("trigger").expect("trigger");
+        assert_eq!(
+            trigger.get("kind").and_then(|v| v.as_str()),
+            Some("message_event")
+        );
+        assert_eq!(
+            trigger.get("pattern").and_then(|v| v.as_str()),
+            Some("review requested")
+        );
+        assert_eq!(
+            trigger.get("channel").and_then(|v| v.as_str()),
+            Some("github")
+        );
     }
 
     #[test]
@@ -2155,27 +2558,28 @@ mod tests {
             },
         });
         let alias = routine_to_mission_alias("routine_create", &params).expect("alias");
-        let updates = alias.post_create_update.expect("updates");
-        match updates.cadence.as_ref().expect("cadence") {
-            ironclaw_engine::types::mission::MissionCadence::OnSystemEvent {
-                source,
-                event_type,
-                filters,
-            } => {
-                assert_eq!(source, "github");
-                assert_eq!(event_type, "issue.opened");
-                assert_eq!(filters.len(), 2);
-                assert_eq!(
-                    filters.get("repository_name").and_then(|v| v.as_str()),
-                    Some("nearai/ironclaw")
-                );
-                assert_eq!(
-                    filters.get("sender_login").and_then(|v| v.as_str()),
-                    Some("ilblackdragon")
-                );
-            }
-            other => panic!("expected OnSystemEvent cadence, got {:?}", other),
-        }
+        let trigger = alias.mission_params.get("trigger").expect("trigger");
+        assert_eq!(
+            trigger.get("kind").and_then(|v| v.as_str()),
+            Some("system_event")
+        );
+        assert_eq!(
+            trigger.get("source").and_then(|v| v.as_str()),
+            Some("github")
+        );
+        assert_eq!(
+            trigger.get("event_type").and_then(|v| v.as_str()),
+            Some("issue.opened")
+        );
+        let filters = trigger.get("filters").expect("filters");
+        assert_eq!(
+            filters.get("repository_name").and_then(|v| v.as_str()),
+            Some("nearai/ironclaw")
+        );
+        assert_eq!(
+            filters.get("sender_login").and_then(|v| v.as_str()),
+            Some("ilblackdragon")
+        );
     }
 
     #[test]
@@ -2190,14 +2594,13 @@ mod tests {
             },
         });
         let alias = routine_to_mission_alias("routine_create", &params).expect("alias");
-        let updates = alias.post_create_update.expect("updates");
-        match updates.cadence.as_ref().expect("cadence") {
-            ironclaw_engine::types::mission::MissionCadence::Webhook { path, secret } => {
-                assert_eq!(path, "github");
-                assert_eq!(secret.as_deref(), Some("shh"));
-            }
-            other => panic!("expected Webhook cadence, got {:?}", other),
-        }
+        let trigger = alias.mission_params.get("trigger").expect("trigger");
+        assert_eq!(
+            trigger.get("kind").and_then(|v| v.as_str()),
+            Some("webhook")
+        );
+        assert_eq!(trigger.get("path").and_then(|v| v.as_str()), Some("github"));
+        assert_eq!(trigger.get("secret").and_then(|v| v.as_str()), Some("shh"));
     }
 
     #[test]
@@ -2229,18 +2632,36 @@ mod tests {
         ));
     }
 
+    /// Missing `request` must NOT produce a hardcoded manual placeholder;
+    /// the alias omits `trigger` and lets the pre-check reject it.
     #[test]
-    fn routine_create_alias_defaults_to_manual_when_request_missing() {
+    fn routine_create_alias_without_request_omits_trigger() {
         let params = serde_json::json!({
-            "name": "Manual mission",
+            "name": "No request",
             "prompt": "Run on demand",
         });
         let alias = routine_to_mission_alias("routine_create", &params).expect("alias");
-        let updates = alias.post_create_update.expect("updates");
-        match updates.cadence.as_ref().expect("cadence") {
-            ironclaw_engine::types::mission::MissionCadence::Manual => {}
-            other => panic!("expected Manual cadence, got {:?}", other),
-        }
+        assert!(
+            alias.mission_params.get("trigger").is_none(),
+            "alias must not hardcode a default trigger when request is absent"
+        );
+    }
+
+    /// An explicit `request: {"kind": "manual"}` passes through as
+    /// `trigger` in a single-write create.
+    #[test]
+    fn routine_create_alias_passes_explicit_manual_request_through() {
+        let params = serde_json::json!({
+            "name": "Explicit manual",
+            "prompt": "Run on demand",
+            "request": {"kind": "manual"},
+        });
+        let alias = routine_to_mission_alias("routine_create", &params).expect("alias");
+        let trigger = alias
+            .mission_params
+            .get("trigger")
+            .expect("trigger should be present when request is explicit");
+        assert_eq!(trigger.get("kind").and_then(|v| v.as_str()), Some("manual"));
     }
 
     #[test]
@@ -2319,6 +2740,564 @@ mod tests {
         assert!(routine_to_mission_alias("http", &params).is_none());
         assert!(routine_to_mission_alias("mission_create", &params).is_none());
         assert!(routine_to_mission_alias("web_search", &params).is_none());
+    }
+
+    // ── parse_trigger_object tests ─────────────────────────────
+
+    #[test]
+    fn parse_trigger_object_cron_reads_schedule_and_timezone() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let trigger = serde_json::json!({
+            "kind": "cron",
+            "schedule": "0 9 * * MON-FRI",
+            "timezone": "America/New_York",
+        });
+        match parse_trigger_object(&trigger, None) {
+            MissionCadence::Cron {
+                expression,
+                timezone,
+            } => {
+                assert_eq!(expression, "0 9 * * MON-FRI");
+                assert_eq!(
+                    timezone.as_ref().map(|tz| tz.tz().name()),
+                    Some("America/New_York")
+                );
+            }
+            other => panic!("expected Cron, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_trigger_object_cron_uses_fallback_timezone_when_absent() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let trigger = serde_json::json!({
+            "kind": "cron",
+            "schedule": "*/30 * * * *",
+        });
+        let fallback = ironclaw_common::ValidTimezone::parse("UTC");
+        assert!(fallback.is_some());
+        match parse_trigger_object(&trigger, fallback) {
+            MissionCadence::Cron { timezone, .. } => {
+                assert_eq!(timezone.as_ref().map(|tz| tz.tz().name()), Some("UTC"));
+            }
+            other => panic!("expected Cron, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_trigger_object_message_event_preserves_channel_filter() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let trigger = serde_json::json!({
+            "kind": "message_event",
+            "pattern": ".*",
+            "channel": "telegram",
+        });
+        match parse_trigger_object(&trigger, None) {
+            MissionCadence::OnEvent {
+                event_pattern,
+                channel,
+            } => {
+                assert_eq!(event_pattern, ".*");
+                assert_eq!(channel.as_deref(), Some("telegram"));
+            }
+            other => panic!("expected OnEvent, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_trigger_object_system_event_preserves_filters() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let trigger = serde_json::json!({
+            "kind": "system_event",
+            "source": "github",
+            "event_type": "issue.opened",
+            "filters": { "repository": "nearai/ironclaw" },
+        });
+        match parse_trigger_object(&trigger, None) {
+            MissionCadence::OnSystemEvent {
+                source,
+                event_type,
+                filters,
+            } => {
+                assert_eq!(source, "github");
+                assert_eq!(event_type, "issue.opened");
+                assert_eq!(
+                    filters.get("repository").and_then(|v| v.as_str()),
+                    Some("nearai/ironclaw")
+                );
+            }
+            other => panic!("expected OnSystemEvent, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_trigger_object_webhook_preserves_path_and_secret() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let trigger = serde_json::json!({
+            "kind": "webhook",
+            "path": "/github-issues",
+            "secret": "shhh",
+        });
+        match parse_trigger_object(&trigger, None) {
+            MissionCadence::Webhook { path, secret } => {
+                assert_eq!(path, "/github-issues");
+                assert_eq!(secret.as_deref(), Some("shhh"));
+            }
+            other => panic!("expected Webhook, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn parse_trigger_object_manual_is_default_for_unknown_kind() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        assert!(matches!(
+            parse_trigger_object(&serde_json::json!({ "kind": "manual" }), None),
+            MissionCadence::Manual
+        ));
+        assert!(matches!(
+            parse_trigger_object(&serde_json::json!({}), None),
+            MissionCadence::Manual
+        ));
+        assert!(matches!(
+            parse_trigger_object(&serde_json::json!({ "kind": "not_a_real_kind" }), None),
+            MissionCadence::Manual
+        ));
+    }
+
+    // ── cadence_to_json round-trip tests ───────────────────────
+
+    /// `cadence_to_json` and `parse_trigger_object` must share a shape
+    /// so a cadence can round-trip `mission_list → mission_update`.
+    #[test]
+    fn cadence_to_json_round_trips_through_parse_trigger_object() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let cases: Vec<MissionCadence> = vec![
+            MissionCadence::Manual,
+            MissionCadence::Cron {
+                expression: "0 9 * * MON-FRI".into(),
+                timezone: ironclaw_common::ValidTimezone::parse("America/New_York"),
+            },
+            MissionCadence::OnEvent {
+                event_pattern: ".*".into(),
+                channel: Some("telegram".into()),
+            },
+            MissionCadence::OnSystemEvent {
+                source: "github".into(),
+                event_type: "issue.opened".into(),
+                filters: std::collections::HashMap::from([(
+                    "repository".to_string(),
+                    serde_json::json!("nearai/ironclaw"),
+                )]),
+            },
+            // Webhook secret is stripped in JSON output, so round-trip
+            // only covers `secret: None`.
+            MissionCadence::Webhook {
+                path: "/github-issues".into(),
+                secret: None,
+            },
+        ];
+        for original in cases {
+            let encoded = cadence_to_json(&original);
+            let decoded = parse_trigger_object(&encoded, None);
+            assert_eq!(
+                format!("{:?}", decoded),
+                format!("{:?}", original),
+                "cadence must round-trip through cadence_to_json → parse_trigger_object: {encoded}"
+            );
+        }
+    }
+
+    /// Webhook secrets must not appear in `mission_list` output —
+    /// neither raw nor masked. `cadence_to_json` emits a `has_secret`
+    /// boolean instead, and `parse_trigger_object` ignores it so a
+    /// list → update round-trip leaves `secret` as `None`.
+    #[test]
+    fn cadence_to_json_strips_webhook_secret_and_reports_presence() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let encoded = cadence_to_json(&MissionCadence::Webhook {
+            path: "/github-issues".into(),
+            secret: Some("super-secret-value".into()),
+        });
+        assert!(
+            encoded.get("secret").is_none(),
+            "the structured webhook output must not contain a `secret` field at all, got: {encoded}"
+        );
+        let encoded_str = encoded.to_string();
+        assert!(
+            !encoded_str.contains("super-secret-value"),
+            "raw secret must not leak into mission_list output, got: {encoded_str}"
+        );
+        assert!(
+            !encoded_str.contains("***"),
+            "legacy '***' mask must not reappear, got: {encoded_str}"
+        );
+        assert_eq!(
+            encoded.get("has_secret").and_then(|v| v.as_bool()),
+            Some(true),
+            "has_secret should be true when a secret is configured, got: {encoded}"
+        );
+
+        let encoded_no_secret = cadence_to_json(&MissionCadence::Webhook {
+            path: "/x".into(),
+            secret: None,
+        });
+        assert_eq!(
+            encoded_no_secret
+                .get("has_secret")
+                .and_then(|v| v.as_bool()),
+            Some(false),
+            "has_secret should be false when no secret is configured"
+        );
+
+        match parse_trigger_object(&encoded, None) {
+            MissionCadence::Webhook { path, secret } => {
+                assert_eq!(path, "/github-issues");
+                assert_eq!(
+                    secret, None,
+                    "parse_trigger_object must not read `has_secret` as a real secret"
+                );
+            }
+            other => panic!("expected Webhook after round-trip, got {other:?}"),
+        }
+    }
+
+    /// Legacy flat `cadence` string on `mission_update` still works for
+    /// callers that haven't migrated to the structured `trigger` field.
+    #[test]
+    fn build_mission_update_accepts_legacy_cadence_string() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let updates =
+            build_mission_update_from_params(&serde_json::json!({ "cadence": "0 9 * * *" }), None);
+        match updates.cadence.expect("cadence should be set") {
+            MissionCadence::Cron { expression, .. } => assert_eq!(expression, "0 9 * * *"),
+            other => panic!("legacy cadence string should yield Cron, got {other:?}"),
+        }
+    }
+
+    /// Legacy prefix forms (`event:`, `webhook:`, `manual`) still work.
+    #[test]
+    fn build_mission_update_accepts_legacy_cadence_prefixes() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let event_upd = build_mission_update_from_params(
+            &serde_json::json!({ "cadence": "event:deploy" }),
+            None,
+        );
+        assert!(matches!(
+            event_upd.cadence,
+            Some(MissionCadence::OnEvent { .. })
+        ));
+
+        let webhook_upd = build_mission_update_from_params(
+            &serde_json::json!({ "cadence": "webhook:/gh" }),
+            None,
+        );
+        assert!(matches!(
+            webhook_upd.cadence,
+            Some(MissionCadence::Webhook { .. })
+        ));
+
+        let manual_upd =
+            build_mission_update_from_params(&serde_json::json!({ "cadence": "manual" }), None);
+        assert!(matches!(manual_upd.cadence, Some(MissionCadence::Manual)));
+    }
+
+    /// When both legacy `cadence` and structured `trigger` are present,
+    /// the structured `trigger` wins. This is the migration contract: a
+    /// caller that updates to the new field can leave the old one around
+    /// without changing behavior. A future refactor can't silently flip
+    /// this without the test failing.
+    #[test]
+    fn build_mission_update_trigger_takes_precedence_over_legacy_cadence() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let updates = build_mission_update_from_params(
+            &serde_json::json!({
+                "cadence": "0 9 * * *",
+                "trigger": {
+                    "kind": "message_event",
+                    "pattern": "deploy",
+                    "channel": "gateway",
+                },
+            }),
+            None,
+        );
+        match updates.cadence.expect("cadence should be set") {
+            MissionCadence::OnEvent {
+                event_pattern,
+                channel,
+            } => {
+                assert_eq!(event_pattern, "deploy");
+                assert_eq!(channel.as_deref(), Some("gateway"));
+            }
+            other => panic!("structured trigger should win, got {other:?}"),
+        }
+    }
+
+    /// Partial update with neither field must leave cadence untouched
+    /// (otherwise every rename/retune silently becomes Manual).
+    #[test]
+    fn build_mission_update_leaves_cadence_untouched_when_both_absent() {
+        let updates = build_mission_update_from_params(
+            &serde_json::json!({ "name": "just rename me" }),
+            None,
+        );
+        assert!(
+            updates.cadence.is_none(),
+            "no trigger/cadence input must not touch cadence"
+        );
+        assert_eq!(updates.name.as_deref(), Some("just rename me"));
+    }
+
+    /// All flat fields (guardrails + name/goal/notify/etc.) land on
+    /// the update struct.
+    #[test]
+    fn build_mission_update_reads_all_flat_fields() {
+        let updates = build_mission_update_from_params(
+            &serde_json::json!({
+                "name": "n",
+                "goal": "g",
+                "notify_channels": ["gateway", "repl"],
+                "cooldown_secs": 0,
+                "max_concurrent": 0,
+                "max_threads_per_day": 0,
+                "dedup_window_secs": 30,
+                "success_criteria": "done",
+            }),
+            None,
+        );
+        assert_eq!(updates.name.as_deref(), Some("n"));
+        assert_eq!(updates.goal.as_deref(), Some("g"));
+        assert_eq!(
+            updates.notify_channels.as_deref(),
+            Some(&["gateway".to_string(), "repl".to_string()][..])
+        );
+        assert_eq!(updates.cooldown_secs, Some(0));
+        assert_eq!(updates.max_concurrent, Some(0));
+        assert_eq!(updates.max_threads_per_day, Some(0));
+        assert_eq!(updates.dedup_window_secs, Some(30));
+        assert_eq!(updates.success_criteria.as_deref(), Some("done"));
+    }
+
+    // ── preserve_webhook_secret tests ──────────────────────────
+    // These drive the helper directly; the full `mission_update` path
+    // is covered by `routine_reactive_integration`.
+
+    #[test]
+    fn preserve_webhook_secret_carries_existing_secret_when_update_omits_it() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let current = MissionCadence::Webhook {
+            path: "/gh".into(),
+            secret: Some("s3cret".into()),
+        };
+        let mut updates = ironclaw_engine::MissionUpdate {
+            cadence: Some(MissionCadence::Webhook {
+                path: "/gh-renamed".into(),
+                secret: None,
+            }),
+            ..Default::default()
+        };
+        assert!(needs_webhook_secret_preserve(updates.cadence.as_ref()));
+        preserve_webhook_secret(&mut updates, &current);
+        match updates.cadence.expect("cadence should still be set") {
+            MissionCadence::Webhook { path, secret } => {
+                assert_eq!(path, "/gh-renamed", "path change must still apply");
+                assert_eq!(
+                    secret.as_deref(),
+                    Some("s3cret"),
+                    "existing secret must survive the partial update"
+                );
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserve_webhook_secret_respects_explicit_new_secret() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let current = MissionCadence::Webhook {
+            path: "/gh".into(),
+            secret: Some("old".into()),
+        };
+        let mut updates = ironclaw_engine::MissionUpdate {
+            cadence: Some(MissionCadence::Webhook {
+                path: "/gh".into(),
+                secret: Some("new".into()),
+            }),
+            ..Default::default()
+        };
+        // Guard skips preserve — update already has a secret.
+        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
+        preserve_webhook_secret(&mut updates, &current);
+        match updates.cadence.expect("cadence should still be set") {
+            MissionCadence::Webhook { secret, .. } => {
+                assert_eq!(
+                    secret.as_deref(),
+                    Some("new"),
+                    "explicit new secret must not be overwritten"
+                );
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserve_webhook_secret_is_noop_when_current_has_no_secret() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let current = MissionCadence::Webhook {
+            path: "/gh".into(),
+            secret: None,
+        };
+        let mut updates = ironclaw_engine::MissionUpdate {
+            cadence: Some(MissionCadence::Webhook {
+                path: "/gh".into(),
+                secret: None,
+            }),
+            ..Default::default()
+        };
+        preserve_webhook_secret(&mut updates, &current);
+        match updates.cadence.expect("cadence should still be set") {
+            MissionCadence::Webhook { secret, .. } => {
+                assert_eq!(secret, None, "no preserved secret exists");
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn preserve_webhook_secret_is_noop_when_switching_away_from_webhook() {
+        // Switching a webhook mission to cron drops the secret by design.
+        use ironclaw_engine::types::mission::MissionCadence;
+        let current = MissionCadence::Webhook {
+            path: "/gh".into(),
+            secret: Some("old".into()),
+        };
+        let mut updates = ironclaw_engine::MissionUpdate {
+            cadence: Some(MissionCadence::Cron {
+                expression: "0 9 * * *".into(),
+                timezone: None,
+            }),
+            ..Default::default()
+        };
+        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
+        preserve_webhook_secret(&mut updates, &current);
+        assert!(matches!(
+            updates.cadence.expect("cadence still set"),
+            MissionCadence::Cron { .. }
+        ));
+    }
+
+    /// Full list→update round-trip: a webhook secret survives when the
+    /// LLM pipes `mission_list` output into `mission_update`.
+    #[test]
+    fn mission_list_to_update_round_trip_preserves_webhook_secret() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let current = MissionCadence::Webhook {
+            path: "/github-issues".into(),
+            secret: Some("super-secret-value".into()),
+        };
+
+        let listed_trigger = cadence_to_json(&current);
+        let listed_str = listed_trigger.to_string();
+        assert!(!listed_str.contains("super-secret-value"));
+        assert!(!listed_str.contains("***"));
+
+        let params = serde_json::json!({
+            "id": "00000000-0000-0000-0000-000000000000",
+            "trigger": listed_trigger,
+        });
+        let mut updates = build_mission_update_from_params(&params, None);
+
+        if needs_webhook_secret_preserve(updates.cadence.as_ref()) {
+            preserve_webhook_secret(&mut updates, &current);
+        }
+
+        match updates.cadence.expect("cadence should be set") {
+            MissionCadence::Webhook { path, secret } => {
+                assert_eq!(path, "/github-issues");
+                assert_eq!(
+                    secret.as_deref(),
+                    Some("super-secret-value"),
+                    "real secret must survive the list → update round trip"
+                );
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+    }
+
+    // ── mission_update trigger pre-check tests ─────────────────
+
+    /// An unknown/bad trigger kind on `mission_update` must error out
+    /// instead of silently converting the mission to Manual.
+    #[tokio::test]
+    async fn mission_update_rejects_unknown_trigger_kind() {
+        let adapter = make_adapter();
+        let bad_triggers = vec![
+            serde_json::json!({"kind": "telgram"}),
+            serde_json::json!({"kind": ""}),
+            serde_json::json!("cron"),
+            serde_json::json!(["cron"]),
+            serde_json::json!(42),
+        ];
+        for bad in bad_triggers {
+            let result = adapter
+                .execute_action(
+                    "mission_update",
+                    serde_json::json!({
+                        "id": "00000000-0000-0000-0000-000000000000",
+                        "trigger": bad.clone(),
+                    }),
+                    &lease(),
+                    &exec_ctx(
+                        ironclaw_engine::ThreadId::new(),
+                        Some("call_mission_update_bad_trigger"),
+                    ),
+                )
+                .await
+                .expect("tool result expected");
+            assert!(
+                result.is_error,
+                "mission_update trigger {bad:?} must be rejected as a tool error"
+            );
+            let err = result
+                .output
+                .get("error")
+                .and_then(|v| v.as_str())
+                .unwrap_or_default();
+            assert!(
+                err.contains("mission_update: invalid `trigger` argument"),
+                "error should name the mission_update surface, got: {err}"
+            );
+        }
+    }
+
+    /// An absent `trigger` on `mission_update` must not trip the
+    /// pre-check — callers legitimately omit it for partial updates.
+    #[tokio::test]
+    async fn mission_update_without_trigger_does_not_trip_pre_check() {
+        let adapter = make_adapter();
+        let result = adapter
+            .execute_action(
+                "mission_update",
+                serde_json::json!({
+                    "id": "00000000-0000-0000-0000-000000000000",
+                    "name": "just rename me",
+                }),
+                &lease(),
+                &exec_ctx(
+                    ironclaw_engine::ThreadId::new(),
+                    Some("call_mission_update_no_trigger"),
+                ),
+            )
+            .await
+            .expect("tool result expected");
+        let err = result
+            .output
+            .get("error")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        assert!(
+            !err.contains("invalid `trigger` argument"),
+            "absent trigger must not trip the mission_update pre-check, got: {err}"
+        );
     }
 
     // ── extract_credential_name tests ──────────────────────────

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -292,7 +292,11 @@ impl EffectBridgeAdapter {
                     .or_else(|| params.get("_args").and_then(|a| a.get(2)))
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
-                let cadence = parse_trigger_object(&trigger_value, timezone);
+                let cadence: ironclaw_engine::types::mission::MissionCadence =
+                    serde_json::from_value::<ironclaw_engine::MissionCadenceInput>(trigger_value)
+                        .unwrap_or(ironclaw_engine::MissionCadenceInput::Manual)
+                        .with_timezone_fallback(timezone)
+                        .into();
                 // notify_channels: explicit array, or default to current channel
                 let notify_channels =
                     if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
@@ -498,9 +502,7 @@ impl EffectBridgeAdapter {
                         // mission_list strips webhook secrets, so a
                         // list→update round-trip must preserve the existing
                         // secret when the new trigger omits one.
-                        if needs_webhook_secret_preserve(updates.cadence.as_ref())
-                            && let Ok(Some(current)) = mgr.get_mission(id).await
-                        {
+                        if let Ok(Some(current)) = mgr.get_mission(id).await {
                             preserve_webhook_secret(&mut updates, &current.cadence);
                         }
                         match mgr.update_mission(id, &context.user_id, updates).await {
@@ -1142,17 +1144,6 @@ impl EffectExecutor for EffectBridgeAdapter {
     }
 }
 
-/// Gate for `preserve_webhook_secret` — skip the `get_mission` lookup
-/// unless the update would replace the cadence with a secret-less webhook.
-fn needs_webhook_secret_preserve(
-    new_cadence: Option<&ironclaw_engine::types::mission::MissionCadence>,
-) -> bool {
-    matches!(
-        new_cadence,
-        Some(ironclaw_engine::types::mission::MissionCadence::Webhook { secret: None, .. })
-    )
-}
-
 /// Carry an existing webhook secret forward when the update omits one.
 /// Callers wanting to clear the secret must pass `secret: ""` explicitly.
 fn preserve_webhook_secret(
@@ -1193,11 +1184,13 @@ fn build_mission_update_from_params(
         .and_then(|v| v.as_str())
         .and_then(ironclaw_engine::ValidTimezone::parse)
         .or(fallback_timezone);
-    if let Some(trigger) = params.get("trigger") {
-        updates.cadence = Some(parse_trigger_object(trigger, tz));
-    } else if let Some(cadence) = params.get("cadence").and_then(|v| v.as_str()) {
-        // Legacy flat string cadence, kept for backward compat.
-        updates.cadence = Some(parse_cadence(cadence, tz));
+    if let Some(trigger) = params.get("trigger").cloned() {
+        updates.cadence = Some(
+            serde_json::from_value::<ironclaw_engine::MissionCadenceInput>(trigger)
+                .unwrap_or(ironclaw_engine::MissionCadenceInput::Manual)
+                .with_timezone_fallback(tz)
+                .into(),
+        );
     }
     if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
         updates.notify_channels = Some(
@@ -1222,54 +1215,6 @@ fn build_mission_update_from_params(
         updates.success_criteria = Some(criteria.to_string());
     }
     updates
-}
-
-/// Parse a cadence string into a MissionCadence.
-///
-/// When cadence is a cron expression, `timezone` is used as the scheduling
-/// timezone. This is typically the user's channel timezone, auto-injected
-/// from `ThreadExecutionContext::user_timezone`.
-fn parse_cadence(
-    s: &str,
-    timezone: Option<ironclaw_engine::ValidTimezone>,
-) -> ironclaw_engine::types::mission::MissionCadence {
-    use ironclaw_engine::types::mission::MissionCadence;
-    let trimmed = s.trim().to_lowercase();
-    // Check explicit prefixes BEFORE the cron heuristic. Otherwise an input
-    // like `event: a b c d e` matches `split_whitespace().count() >= 5` and
-    // is silently misclassified as a cron expression — the user said
-    // "event:..." and gets a Cron cadence with a parse error downstream.
-    if trimmed == "manual" {
-        MissionCadence::Manual
-    } else if trimmed.starts_with("event:") {
-        MissionCadence::OnEvent {
-            event_pattern: trimmed
-                .strip_prefix("event:")
-                .unwrap_or("")
-                .trim()
-                .to_string(),
-            channel: None,
-        }
-    } else if trimmed.starts_with("webhook:") {
-        MissionCadence::Webhook {
-            path: trimmed
-                .strip_prefix("webhook:")
-                .unwrap_or("")
-                .trim()
-                .to_string(),
-            secret: None,
-        }
-    } else if trimmed.split_whitespace().count() >= 5 {
-        // Looks like a cron expression (5+ fields). `split_whitespace` handles
-        // tabs and newlines, not just spaces.
-        MissionCadence::Cron {
-            expression: s.trim().to_string(),
-            timezone,
-        }
-    } else {
-        // Default to manual if unrecognized
-        MissionCadence::Manual
-    }
 }
 
 /// Translation result from a `routine_*` call into mission_* dispatch.
@@ -1505,23 +1450,8 @@ fn routine_to_mission_alias(
             {
                 translated.insert("max_concurrent".to_string(), max);
             }
-            // Cadence: derive from the request block if present.
-            if params.get("request").is_some() {
-                let cadence = parse_routine_request(params);
-                // We can't pass a structured cadence through the
-                // mission_update arm, which only reads a "cadence" string.
-                // Encode it back into the cadence string the parser
-                // recognizes (cron expr / "event:..." / "webhook:..." /
-                // "manual"). Structured filters and channel filters that
-                // can't round-trip into a string fall back through the
-                // post-create update path on `routine_create`, but for
-                // `routine_update` we can't fully express them today —
-                // log a debug and drop the structured pieces.
-                let cadence_str = cadence_to_round_trip_string(&cadence);
-                translated.insert(
-                    "cadence".to_string(),
-                    serde_json::Value::String(cadence_str),
-                );
+            if let Some(request) = params.get("request") {
+                translated.insert("trigger".to_string(), request.clone());
             }
 
             Some(RoutineMissionAlias {
@@ -1556,98 +1486,9 @@ fn validate_trigger_value(
     }
 }
 
-/// Parse a structured trigger object into a `MissionCadence`. Falls
-/// back to `Manual` on unknown/missing kind — side-effect gated callers
-/// must run [`validate_trigger_value`] first.
-fn parse_trigger_object(
-    trigger: &serde_json::Value,
-    fallback_timezone: Option<ironclaw_common::ValidTimezone>,
-) -> ironclaw_engine::types::mission::MissionCadence {
-    use ironclaw_engine::types::mission::MissionCadence;
-
-    let kind = trigger
-        .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("manual");
-
-    match kind {
-        "cron" => MissionCadence::Cron {
-            expression: trigger
-                .get("schedule")
-                .and_then(|v| v.as_str())
-                .unwrap_or("0 0 * * * *")
-                .to_string(),
-            // Invalid zones drop to None (engine resolves in UTC).
-            timezone: trigger
-                .get("timezone")
-                .and_then(|v| v.as_str())
-                .and_then(ironclaw_common::ValidTimezone::parse)
-                .or(fallback_timezone),
-        },
-        "message_event" => MissionCadence::OnEvent {
-            event_pattern: trigger
-                .get("pattern")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            channel: trigger
-                .get("channel")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-        },
-        "system_event" => {
-            let mut filters = std::collections::HashMap::new();
-            if let Some(map) = trigger.get("filters").and_then(|v| v.as_object()) {
-                for (k, v) in map {
-                    filters.insert(k.clone(), v.clone());
-                }
-            }
-            MissionCadence::OnSystemEvent {
-                source: trigger
-                    .get("source")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-                event_type: trigger
-                    .get("event_type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-                filters,
-            }
-        }
-        "webhook" => MissionCadence::Webhook {
-            path: trigger
-                .get("path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            secret: trigger
-                .get("secret")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-        },
-        _ => MissionCadence::Manual,
-    }
-}
-
-/// Parse the routine `request` sub-object into a `MissionCadence`.
-/// Falls back to `Manual` when absent. Thin wrapper around
-/// [`parse_trigger_object`] — routines nest the trigger under `request`.
-fn parse_routine_request(
-    params: &serde_json::Value,
-) -> ironclaw_engine::types::mission::MissionCadence {
-    use ironclaw_engine::types::mission::MissionCadence;
-
-    match params.get("request") {
-        Some(request) => parse_trigger_object(request, None),
-        None => MissionCadence::Manual,
-    }
-}
-
-/// Encode a `MissionCadence` as the same `{kind, ...}` shape
-/// [`parse_trigger_object`] consumes, so `mission_list` output can
-/// round-trip through `mission_update` without a string intermediate.
+/// Encode a `MissionCadence` as the `{kind, ...}` shape that
+/// `MissionCadenceInput` deserializes, so `mission_list` output can
+/// round-trip through `mission_update`.
 fn cadence_to_json(cadence: &ironclaw_engine::types::mission::MissionCadence) -> serde_json::Value {
     use ironclaw_engine::types::mission::MissionCadence;
     match cadence {
@@ -1684,27 +1525,6 @@ fn cadence_to_json(cadence: &ironclaw_engine::types::mission::MissionCadence) ->
             "path": path,
             "has_secret": secret.is_some(),
         }),
-    }
-}
-
-/// Encode a `MissionCadence` into a string that `parse_cadence` can round-trip.
-/// Structured features (channel filter, system event filters, webhook secret)
-/// are lossy through this path; callers that need full fidelity should use
-/// `update_mission` with a typed `MissionUpdate` instead.
-fn cadence_to_round_trip_string(
-    cadence: &ironclaw_engine::types::mission::MissionCadence,
-) -> String {
-    use ironclaw_engine::types::mission::MissionCadence;
-    match cadence {
-        MissionCadence::Cron { expression, .. } => expression.clone(),
-        MissionCadence::OnEvent { event_pattern, .. } => format!("event:{event_pattern}"),
-        MissionCadence::OnSystemEvent {
-            source, event_type, ..
-        } => {
-            format!("system_event:{source}/{event_type}")
-        }
-        MissionCadence::Webhook { path, .. } => format!("webhook:{path}"),
-        MissionCadence::Manual => "manual".to_string(),
     }
 }
 
@@ -2603,35 +2423,6 @@ mod tests {
         assert_eq!(trigger.get("secret").and_then(|v| v.as_str()), Some("shh"));
     }
 
-    #[test]
-    fn parse_cadence_event_prefix_with_multi_token_pattern() {
-        // Regression: `parse_cadence` previously checked the cron heuristic
-        // (`split_whitespace().count() >= 5`) BEFORE the explicit prefixes,
-        // so an `event:`-prefixed pattern containing 5+ tokens was silently
-        // misclassified as a Cron cadence with a parse error downstream.
-        let cadence = parse_cadence("event: a b c d e", None);
-        match cadence {
-            ironclaw_engine::types::mission::MissionCadence::OnEvent { event_pattern, .. } => {
-                assert_eq!(event_pattern, "a b c d e");
-            }
-            other => panic!("expected OnEvent, got {other:?}"),
-        }
-
-        // Same hazard for `webhook:` — verify the prefix wins.
-        let cadence = parse_cadence("webhook: a b c d e", None);
-        assert!(matches!(
-            cadence,
-            ironclaw_engine::types::mission::MissionCadence::Webhook { .. }
-        ));
-
-        // Sanity: a real cron expression still parses as cron.
-        let cadence = parse_cadence("0 9 * * *", None);
-        assert!(matches!(
-            cadence,
-            ironclaw_engine::types::mission::MissionCadence::Cron { .. }
-        ));
-    }
-
     /// Missing `request` must NOT produce a hardcoded manual placeholder;
     /// the alias omits `trigger` and lets the pre-check reject it.
     #[test]
@@ -2728,8 +2519,10 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("NOTES.md")
         );
+        let trigger = mp.get("trigger").expect("trigger should be present");
+        assert_eq!(trigger.get("kind").and_then(|v| v.as_str()), Some("cron"));
         assert_eq!(
-            mp.get("cadence").and_then(|v| v.as_str()),
+            trigger.get("schedule").and_then(|v| v.as_str()),
             Some("0 12 * * *")
         );
     }
@@ -2740,296 +2533,6 @@ mod tests {
         assert!(routine_to_mission_alias("http", &params).is_none());
         assert!(routine_to_mission_alias("mission_create", &params).is_none());
         assert!(routine_to_mission_alias("web_search", &params).is_none());
-    }
-
-    // ── parse_trigger_object tests ─────────────────────────────
-
-    #[test]
-    fn parse_trigger_object_cron_reads_schedule_and_timezone() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "cron",
-            "schedule": "0 9 * * MON-FRI",
-            "timezone": "America/New_York",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::Cron {
-                expression,
-                timezone,
-            } => {
-                assert_eq!(expression, "0 9 * * MON-FRI");
-                assert_eq!(
-                    timezone.as_ref().map(|tz| tz.tz().name()),
-                    Some("America/New_York")
-                );
-            }
-            other => panic!("expected Cron, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_cron_uses_fallback_timezone_when_absent() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "cron",
-            "schedule": "*/30 * * * *",
-        });
-        let fallback = ironclaw_common::ValidTimezone::parse("UTC");
-        assert!(fallback.is_some());
-        match parse_trigger_object(&trigger, fallback) {
-            MissionCadence::Cron { timezone, .. } => {
-                assert_eq!(timezone.as_ref().map(|tz| tz.tz().name()), Some("UTC"));
-            }
-            other => panic!("expected Cron, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_message_event_preserves_channel_filter() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "message_event",
-            "pattern": ".*",
-            "channel": "telegram",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::OnEvent {
-                event_pattern,
-                channel,
-            } => {
-                assert_eq!(event_pattern, ".*");
-                assert_eq!(channel.as_deref(), Some("telegram"));
-            }
-            other => panic!("expected OnEvent, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_system_event_preserves_filters() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "system_event",
-            "source": "github",
-            "event_type": "issue.opened",
-            "filters": { "repository": "nearai/ironclaw" },
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::OnSystemEvent {
-                source,
-                event_type,
-                filters,
-            } => {
-                assert_eq!(source, "github");
-                assert_eq!(event_type, "issue.opened");
-                assert_eq!(
-                    filters.get("repository").and_then(|v| v.as_str()),
-                    Some("nearai/ironclaw")
-                );
-            }
-            other => panic!("expected OnSystemEvent, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_webhook_preserves_path_and_secret() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "webhook",
-            "path": "/github-issues",
-            "secret": "shhh",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::Webhook { path, secret } => {
-                assert_eq!(path, "/github-issues");
-                assert_eq!(secret.as_deref(), Some("shhh"));
-            }
-            other => panic!("expected Webhook, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_manual_is_default_for_unknown_kind() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({ "kind": "manual" }), None),
-            MissionCadence::Manual
-        ));
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({}), None),
-            MissionCadence::Manual
-        ));
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({ "kind": "not_a_real_kind" }), None),
-            MissionCadence::Manual
-        ));
-    }
-
-    // ── cadence_to_json round-trip tests ───────────────────────
-
-    /// `cadence_to_json` and `parse_trigger_object` must share a shape
-    /// so a cadence can round-trip `mission_list → mission_update`.
-    #[test]
-    fn cadence_to_json_round_trips_through_parse_trigger_object() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let cases: Vec<MissionCadence> = vec![
-            MissionCadence::Manual,
-            MissionCadence::Cron {
-                expression: "0 9 * * MON-FRI".into(),
-                timezone: ironclaw_common::ValidTimezone::parse("America/New_York"),
-            },
-            MissionCadence::OnEvent {
-                event_pattern: ".*".into(),
-                channel: Some("telegram".into()),
-            },
-            MissionCadence::OnSystemEvent {
-                source: "github".into(),
-                event_type: "issue.opened".into(),
-                filters: std::collections::HashMap::from([(
-                    "repository".to_string(),
-                    serde_json::json!("nearai/ironclaw"),
-                )]),
-            },
-            // Webhook secret is stripped in JSON output, so round-trip
-            // only covers `secret: None`.
-            MissionCadence::Webhook {
-                path: "/github-issues".into(),
-                secret: None,
-            },
-        ];
-        for original in cases {
-            let encoded = cadence_to_json(&original);
-            let decoded = parse_trigger_object(&encoded, None);
-            assert_eq!(
-                format!("{:?}", decoded),
-                format!("{:?}", original),
-                "cadence must round-trip through cadence_to_json → parse_trigger_object: {encoded}"
-            );
-        }
-    }
-
-    /// Webhook secrets must not appear in `mission_list` output —
-    /// neither raw nor masked. `cadence_to_json` emits a `has_secret`
-    /// boolean instead, and `parse_trigger_object` ignores it so a
-    /// list → update round-trip leaves `secret` as `None`.
-    #[test]
-    fn cadence_to_json_strips_webhook_secret_and_reports_presence() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let encoded = cadence_to_json(&MissionCadence::Webhook {
-            path: "/github-issues".into(),
-            secret: Some("super-secret-value".into()),
-        });
-        assert!(
-            encoded.get("secret").is_none(),
-            "the structured webhook output must not contain a `secret` field at all, got: {encoded}"
-        );
-        let encoded_str = encoded.to_string();
-        assert!(
-            !encoded_str.contains("super-secret-value"),
-            "raw secret must not leak into mission_list output, got: {encoded_str}"
-        );
-        assert!(
-            !encoded_str.contains("***"),
-            "legacy '***' mask must not reappear, got: {encoded_str}"
-        );
-        assert_eq!(
-            encoded.get("has_secret").and_then(|v| v.as_bool()),
-            Some(true),
-            "has_secret should be true when a secret is configured, got: {encoded}"
-        );
-
-        let encoded_no_secret = cadence_to_json(&MissionCadence::Webhook {
-            path: "/x".into(),
-            secret: None,
-        });
-        assert_eq!(
-            encoded_no_secret
-                .get("has_secret")
-                .and_then(|v| v.as_bool()),
-            Some(false),
-            "has_secret should be false when no secret is configured"
-        );
-
-        match parse_trigger_object(&encoded, None) {
-            MissionCadence::Webhook { path, secret } => {
-                assert_eq!(path, "/github-issues");
-                assert_eq!(
-                    secret, None,
-                    "parse_trigger_object must not read `has_secret` as a real secret"
-                );
-            }
-            other => panic!("expected Webhook after round-trip, got {other:?}"),
-        }
-    }
-
-    /// Legacy flat `cadence` string on `mission_update` still works for
-    /// callers that haven't migrated to the structured `trigger` field.
-    #[test]
-    fn build_mission_update_accepts_legacy_cadence_string() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let updates =
-            build_mission_update_from_params(&serde_json::json!({ "cadence": "0 9 * * *" }), None);
-        match updates.cadence.expect("cadence should be set") {
-            MissionCadence::Cron { expression, .. } => assert_eq!(expression, "0 9 * * *"),
-            other => panic!("legacy cadence string should yield Cron, got {other:?}"),
-        }
-    }
-
-    /// Legacy prefix forms (`event:`, `webhook:`, `manual`) still work.
-    #[test]
-    fn build_mission_update_accepts_legacy_cadence_prefixes() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let event_upd = build_mission_update_from_params(
-            &serde_json::json!({ "cadence": "event:deploy" }),
-            None,
-        );
-        assert!(matches!(
-            event_upd.cadence,
-            Some(MissionCadence::OnEvent { .. })
-        ));
-
-        let webhook_upd = build_mission_update_from_params(
-            &serde_json::json!({ "cadence": "webhook:/gh" }),
-            None,
-        );
-        assert!(matches!(
-            webhook_upd.cadence,
-            Some(MissionCadence::Webhook { .. })
-        ));
-
-        let manual_upd =
-            build_mission_update_from_params(&serde_json::json!({ "cadence": "manual" }), None);
-        assert!(matches!(manual_upd.cadence, Some(MissionCadence::Manual)));
-    }
-
-    /// When both legacy `cadence` and structured `trigger` are present,
-    /// the structured `trigger` wins. This is the migration contract: a
-    /// caller that updates to the new field can leave the old one around
-    /// without changing behavior. A future refactor can't silently flip
-    /// this without the test failing.
-    #[test]
-    fn build_mission_update_trigger_takes_precedence_over_legacy_cadence() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let updates = build_mission_update_from_params(
-            &serde_json::json!({
-                "cadence": "0 9 * * *",
-                "trigger": {
-                    "kind": "message_event",
-                    "pattern": "deploy",
-                    "channel": "gateway",
-                },
-            }),
-            None,
-        );
-        match updates.cadence.expect("cadence should be set") {
-            MissionCadence::OnEvent {
-                event_pattern,
-                channel,
-            } => {
-                assert_eq!(event_pattern, "deploy");
-                assert_eq!(channel.as_deref(), Some("gateway"));
-            }
-            other => panic!("structured trigger should win, got {other:?}"),
-        }
     }
 
     /// Partial update with neither field must leave cadence untouched
@@ -3095,7 +2598,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert!(needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         match updates.cadence.expect("cadence should still be set") {
             MissionCadence::Webhook { path, secret } => {
@@ -3124,8 +2626,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        // Guard skips preserve — update already has a secret.
-        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         match updates.cadence.expect("cadence should still be set") {
             MissionCadence::Webhook { secret, .. } => {
@@ -3177,7 +2677,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         assert!(matches!(
             updates.cadence.expect("cadence still set"),
@@ -3206,9 +2705,7 @@ mod tests {
         });
         let mut updates = build_mission_update_from_params(&params, None);
 
-        if needs_webhook_secret_preserve(updates.cadence.as_ref()) {
-            preserve_webhook_secret(&mut updates, &current);
-        }
+        preserve_webhook_secret(&mut updates, &current);
 
         match updates.cadence.expect("cadence should be set") {
             MissionCadence::Webhook { path, secret } => {

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -292,7 +292,11 @@ impl EffectBridgeAdapter {
                     .or_else(|| params.get("_args").and_then(|a| a.get(2)))
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
-                let cadence = parse_trigger_object(&trigger_value, timezone);
+                let mut cadence: ironclaw_engine::types::mission::MissionCadence =
+                    serde_json::from_value(trigger_value).unwrap_or(
+                        ironclaw_engine::types::mission::MissionCadence::Manual,
+                    );
+                apply_timezone_fallback(&mut cadence, timezone);
                 // notify_channels: explicit array, or default to current channel
                 let notify_channels =
                     if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
@@ -393,7 +397,7 @@ impl EffectBridgeAdapter {
                                 "name": m.name,
                                 "goal": m.goal,
                                 "status": format!("{:?}", m.status),
-                                "trigger": cadence_to_json(&m.cadence),
+                                "trigger": serde_json::to_value(m.cadence.redacted()).unwrap_or_default(),
                                 "guardrails": {
                                     "cooldown_secs": m.cooldown_secs,
                                     "max_concurrent": m.max_concurrent,
@@ -498,9 +502,7 @@ impl EffectBridgeAdapter {
                         // mission_list strips webhook secrets, so a
                         // list→update round-trip must preserve the existing
                         // secret when the new trigger omits one.
-                        if needs_webhook_secret_preserve(updates.cadence.as_ref())
-                            && let Ok(Some(current)) = mgr.get_mission(id).await
-                        {
+                        if let Ok(Some(current)) = mgr.get_mission(id).await {
                             preserve_webhook_secret(&mut updates, &current.cadence);
                         }
                         match mgr.update_mission(id, &context.user_id, updates).await {
@@ -1142,17 +1144,6 @@ impl EffectExecutor for EffectBridgeAdapter {
     }
 }
 
-/// Gate for `preserve_webhook_secret` — skip the `get_mission` lookup
-/// unless the update would replace the cadence with a secret-less webhook.
-fn needs_webhook_secret_preserve(
-    new_cadence: Option<&ironclaw_engine::types::mission::MissionCadence>,
-) -> bool {
-    matches!(
-        new_cadence,
-        Some(ironclaw_engine::types::mission::MissionCadence::Webhook { secret: None, .. })
-    )
-}
-
 /// Carry an existing webhook secret forward when the update omits one.
 /// Callers wanting to clear the secret must pass `secret: ""` explicitly.
 fn preserve_webhook_secret(
@@ -1194,7 +1185,11 @@ fn build_mission_update_from_params(
         .and_then(ironclaw_engine::ValidTimezone::parse)
         .or(fallback_timezone);
     if let Some(trigger) = params.get("trigger") {
-        updates.cadence = Some(parse_trigger_object(trigger, tz));
+        let mut cadence: ironclaw_engine::types::mission::MissionCadence =
+            serde_json::from_value(trigger.clone())
+                .unwrap_or(ironclaw_engine::types::mission::MissionCadence::Manual);
+        apply_timezone_fallback(&mut cadence, tz);
+        updates.cadence = Some(cadence);
     } else if let Some(cadence) = params.get("cadence").and_then(|v| v.as_str()) {
         // Legacy flat string cadence, kept for backward compat.
         updates.cadence = Some(parse_cadence(cadence, tz));
@@ -1505,23 +1500,8 @@ fn routine_to_mission_alias(
             {
                 translated.insert("max_concurrent".to_string(), max);
             }
-            // Cadence: derive from the request block if present.
-            if params.get("request").is_some() {
-                let cadence = parse_routine_request(params);
-                // We can't pass a structured cadence through the
-                // mission_update arm, which only reads a "cadence" string.
-                // Encode it back into the cadence string the parser
-                // recognizes (cron expr / "event:..." / "webhook:..." /
-                // "manual"). Structured filters and channel filters that
-                // can't round-trip into a string fall back through the
-                // post-create update path on `routine_create`, but for
-                // `routine_update` we can't fully express them today —
-                // log a debug and drop the structured pieces.
-                let cadence_str = cadence_to_round_trip_string(&cadence);
-                translated.insert(
-                    "cadence".to_string(),
-                    serde_json::Value::String(cadence_str),
-                );
+            if let Some(request) = params.get("request") {
+                translated.insert("trigger".to_string(), request.clone());
             }
 
             Some(RoutineMissionAlias {
@@ -1556,155 +1536,18 @@ fn validate_trigger_value(
     }
 }
 
-/// Parse a structured trigger object into a `MissionCadence`. Falls
-/// back to `Manual` on unknown/missing kind — side-effect gated callers
-/// must run [`validate_trigger_value`] first.
-fn parse_trigger_object(
-    trigger: &serde_json::Value,
-    fallback_timezone: Option<ironclaw_common::ValidTimezone>,
-) -> ironclaw_engine::types::mission::MissionCadence {
-    use ironclaw_engine::types::mission::MissionCadence;
-
-    let kind = trigger
-        .get("kind")
-        .and_then(|v| v.as_str())
-        .unwrap_or("manual");
-
-    match kind {
-        "cron" => MissionCadence::Cron {
-            expression: trigger
-                .get("schedule")
-                .and_then(|v| v.as_str())
-                .unwrap_or("0 0 * * * *")
-                .to_string(),
-            // Invalid zones drop to None (engine resolves in UTC).
-            timezone: trigger
-                .get("timezone")
-                .and_then(|v| v.as_str())
-                .and_then(ironclaw_common::ValidTimezone::parse)
-                .or(fallback_timezone),
-        },
-        "message_event" => MissionCadence::OnEvent {
-            event_pattern: trigger
-                .get("pattern")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            channel: trigger
-                .get("channel")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-        },
-        "system_event" => {
-            let mut filters = std::collections::HashMap::new();
-            if let Some(map) = trigger.get("filters").and_then(|v| v.as_object()) {
-                for (k, v) in map {
-                    filters.insert(k.clone(), v.clone());
-                }
-            }
-            MissionCadence::OnSystemEvent {
-                source: trigger
-                    .get("source")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-                event_type: trigger
-                    .get("event_type")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
-                filters,
-            }
-        }
-        "webhook" => MissionCadence::Webhook {
-            path: trigger
-                .get("path")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string(),
-            secret: trigger
-                .get("secret")
-                .and_then(|v| v.as_str())
-                .map(String::from),
-        },
-        _ => MissionCadence::Manual,
-    }
-}
-
-/// Parse the routine `request` sub-object into a `MissionCadence`.
-/// Falls back to `Manual` when absent. Thin wrapper around
-/// [`parse_trigger_object`] — routines nest the trigger under `request`.
-fn parse_routine_request(
-    params: &serde_json::Value,
-) -> ironclaw_engine::types::mission::MissionCadence {
-    use ironclaw_engine::types::mission::MissionCadence;
-
-    match params.get("request") {
-        Some(request) => parse_trigger_object(request, None),
-        None => MissionCadence::Manual,
-    }
-}
-
-/// Encode a `MissionCadence` as the same `{kind, ...}` shape
-/// [`parse_trigger_object`] consumes, so `mission_list` output can
-/// round-trip through `mission_update` without a string intermediate.
-fn cadence_to_json(cadence: &ironclaw_engine::types::mission::MissionCadence) -> serde_json::Value {
-    use ironclaw_engine::types::mission::MissionCadence;
-    match cadence {
-        MissionCadence::Manual => serde_json::json!({"kind": "manual"}),
-        MissionCadence::Cron {
-            expression,
-            timezone,
-        } => serde_json::json!({
-            "kind": "cron",
-            "schedule": expression,
-            "timezone": timezone.as_ref().map(|tz| tz.name()),
-        }),
-        MissionCadence::OnEvent {
-            event_pattern,
-            channel,
-        } => serde_json::json!({
-            "kind": "message_event",
-            "pattern": event_pattern,
-            "channel": channel,
-        }),
-        MissionCadence::OnSystemEvent {
-            source,
-            event_type,
-            filters,
-        } => serde_json::json!({
-            "kind": "system_event",
-            "source": source,
-            "event_type": event_type,
-            "filters": filters,
-        }),
-        // Webhook secret is a credential, we deliberately do NOT expose it.
-        MissionCadence::Webhook { path, secret } => serde_json::json!({
-            "kind": "webhook",
-            "path": path,
-            "has_secret": secret.is_some(),
-        }),
-    }
-}
-
-/// Encode a `MissionCadence` into a string that `parse_cadence` can round-trip.
-/// Structured features (channel filter, system event filters, webhook secret)
-/// are lossy through this path; callers that need full fidelity should use
-/// `update_mission` with a typed `MissionUpdate` instead.
-fn cadence_to_round_trip_string(
-    cadence: &ironclaw_engine::types::mission::MissionCadence,
-) -> String {
-    use ironclaw_engine::types::mission::MissionCadence;
-    match cadence {
-        MissionCadence::Cron { expression, .. } => expression.clone(),
-        MissionCadence::OnEvent { event_pattern, .. } => format!("event:{event_pattern}"),
-        MissionCadence::OnSystemEvent {
-            source, event_type, ..
-        } => {
-            format!("system_event:{source}/{event_type}")
-        }
-        MissionCadence::Webhook { path, .. } => format!("webhook:{path}"),
-        MissionCadence::Manual => "manual".to_string(),
+/// Apply a fallback timezone to a `Cron` cadence when the trigger
+/// JSON omitted the timezone field. No-op for other cadence variants.
+fn apply_timezone_fallback(
+    cadence: &mut ironclaw_engine::types::mission::MissionCadence,
+    fallback: Option<ironclaw_common::ValidTimezone>,
+) {
+    if let ironclaw_engine::types::mission::MissionCadence::Cron {
+        timezone: tz @ None,
+        ..
+    } = cadence
+    {
+        *tz = fallback;
     }
 }
 
@@ -2728,8 +2571,13 @@ mod tests {
                 .and_then(|v| v.as_str()),
             Some("NOTES.md")
         );
+        let trigger = mp.get("trigger").expect("trigger should be forwarded");
         assert_eq!(
-            mp.get("cadence").and_then(|v| v.as_str()),
+            trigger.get("kind").and_then(|v| v.as_str()),
+            Some("cron")
+        );
+        assert_eq!(
+            trigger.get("schedule").and_then(|v| v.as_str()),
             Some("0 12 * * *")
         );
     }
@@ -2742,134 +2590,11 @@ mod tests {
         assert!(routine_to_mission_alias("web_search", &params).is_none());
     }
 
-    // ── parse_trigger_object tests ─────────────────────────────
+    // ── serde round-trip tests ─────────────────────────────────
 
+    /// `MissionCadence` must round-trip through serde (serialize → deserialize).
     #[test]
-    fn parse_trigger_object_cron_reads_schedule_and_timezone() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "cron",
-            "schedule": "0 9 * * MON-FRI",
-            "timezone": "America/New_York",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::Cron {
-                expression,
-                timezone,
-            } => {
-                assert_eq!(expression, "0 9 * * MON-FRI");
-                assert_eq!(
-                    timezone.as_ref().map(|tz| tz.tz().name()),
-                    Some("America/New_York")
-                );
-            }
-            other => panic!("expected Cron, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_cron_uses_fallback_timezone_when_absent() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "cron",
-            "schedule": "*/30 * * * *",
-        });
-        let fallback = ironclaw_common::ValidTimezone::parse("UTC");
-        assert!(fallback.is_some());
-        match parse_trigger_object(&trigger, fallback) {
-            MissionCadence::Cron { timezone, .. } => {
-                assert_eq!(timezone.as_ref().map(|tz| tz.tz().name()), Some("UTC"));
-            }
-            other => panic!("expected Cron, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_message_event_preserves_channel_filter() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "message_event",
-            "pattern": ".*",
-            "channel": "telegram",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::OnEvent {
-                event_pattern,
-                channel,
-            } => {
-                assert_eq!(event_pattern, ".*");
-                assert_eq!(channel.as_deref(), Some("telegram"));
-            }
-            other => panic!("expected OnEvent, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_system_event_preserves_filters() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "system_event",
-            "source": "github",
-            "event_type": "issue.opened",
-            "filters": { "repository": "nearai/ironclaw" },
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::OnSystemEvent {
-                source,
-                event_type,
-                filters,
-            } => {
-                assert_eq!(source, "github");
-                assert_eq!(event_type, "issue.opened");
-                assert_eq!(
-                    filters.get("repository").and_then(|v| v.as_str()),
-                    Some("nearai/ironclaw")
-                );
-            }
-            other => panic!("expected OnSystemEvent, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_webhook_preserves_path_and_secret() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        let trigger = serde_json::json!({
-            "kind": "webhook",
-            "path": "/github-issues",
-            "secret": "shhh",
-        });
-        match parse_trigger_object(&trigger, None) {
-            MissionCadence::Webhook { path, secret } => {
-                assert_eq!(path, "/github-issues");
-                assert_eq!(secret.as_deref(), Some("shhh"));
-            }
-            other => panic!("expected Webhook, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn parse_trigger_object_manual_is_default_for_unknown_kind() {
-        use ironclaw_engine::types::mission::MissionCadence;
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({ "kind": "manual" }), None),
-            MissionCadence::Manual
-        ));
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({}), None),
-            MissionCadence::Manual
-        ));
-        assert!(matches!(
-            parse_trigger_object(&serde_json::json!({ "kind": "not_a_real_kind" }), None),
-            MissionCadence::Manual
-        ));
-    }
-
-    // ── cadence_to_json round-trip tests ───────────────────────
-
-    /// `cadence_to_json` and `parse_trigger_object` must share a shape
-    /// so a cadence can round-trip `mission_list → mission_update`.
-    #[test]
-    fn cadence_to_json_round_trips_through_parse_trigger_object() {
+    fn mission_cadence_serde_round_trip() {
         use ironclaw_engine::types::mission::MissionCadence;
         let cases: Vec<MissionCadence> = vec![
             MissionCadence::Manual,
@@ -2889,75 +2614,62 @@ mod tests {
                     serde_json::json!("nearai/ironclaw"),
                 )]),
             },
-            // Webhook secret is stripped in JSON output, so round-trip
-            // only covers `secret: None`.
             MissionCadence::Webhook {
                 path: "/github-issues".into(),
-                secret: None,
+                secret: Some("shhh".into()),
             },
         ];
-        for original in cases {
-            let encoded = cadence_to_json(&original);
-            let decoded = parse_trigger_object(&encoded, None);
+        for original in &cases {
+            let json = serde_json::to_value(original).expect("serialize");
+            let decoded: MissionCadence =
+                serde_json::from_value(json.clone()).expect("deserialize");
             assert_eq!(
                 format!("{:?}", decoded),
                 format!("{:?}", original),
-                "cadence must round-trip through cadence_to_json → parse_trigger_object: {encoded}"
+                "round-trip failed for: {json}"
             );
         }
     }
 
-    /// Webhook secrets must not appear in `mission_list` output —
-    /// neither raw nor masked. `cadence_to_json` emits a `has_secret`
-    /// boolean instead, and `parse_trigger_object` ignores it so a
-    /// list → update round-trip leaves `secret` as `None`.
+    /// `redacted()` strips the webhook secret but keeps the path.
     #[test]
-    fn cadence_to_json_strips_webhook_secret_and_reports_presence() {
+    fn mission_cadence_redacted_strips_webhook_secret() {
         use ironclaw_engine::types::mission::MissionCadence;
-        let encoded = cadence_to_json(&MissionCadence::Webhook {
-            path: "/github-issues".into(),
-            secret: Some("super-secret-value".into()),
-        });
-        assert!(
-            encoded.get("secret").is_none(),
-            "the structured webhook output must not contain a `secret` field at all, got: {encoded}"
-        );
-        let encoded_str = encoded.to_string();
-        assert!(
-            !encoded_str.contains("super-secret-value"),
-            "raw secret must not leak into mission_list output, got: {encoded_str}"
-        );
-        assert!(
-            !encoded_str.contains("***"),
-            "legacy '***' mask must not reappear, got: {encoded_str}"
-        );
-        assert_eq!(
-            encoded.get("has_secret").and_then(|v| v.as_bool()),
-            Some(true),
-            "has_secret should be true when a secret is configured, got: {encoded}"
-        );
-
-        let encoded_no_secret = cadence_to_json(&MissionCadence::Webhook {
-            path: "/x".into(),
-            secret: None,
-        });
-        assert_eq!(
-            encoded_no_secret
-                .get("has_secret")
-                .and_then(|v| v.as_bool()),
-            Some(false),
-            "has_secret should be false when no secret is configured"
-        );
-
-        match parse_trigger_object(&encoded, None) {
+        let cadence = MissionCadence::Webhook {
+            path: "/gh".into(),
+            secret: Some("super-secret".into()),
+        };
+        let redacted = cadence.redacted();
+        match redacted {
             MissionCadence::Webhook { path, secret } => {
-                assert_eq!(path, "/github-issues");
+                assert_eq!(path, "/gh");
+                assert_eq!(secret, None);
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+        // Serialized form must not contain the secret.
+        let json_str = serde_json::to_string(&cadence.redacted()).unwrap();
+        assert!(!json_str.contains("super-secret"));
+    }
+
+    /// `apply_timezone_fallback` fills in a missing timezone on Cron.
+    #[test]
+    fn apply_timezone_fallback_fills_cron_timezone() {
+        use ironclaw_engine::types::mission::MissionCadence;
+        let mut cadence = MissionCadence::Cron {
+            expression: "0 9 * * *".into(),
+            timezone: None,
+        };
+        let fallback = ironclaw_common::ValidTimezone::parse("America/New_York");
+        apply_timezone_fallback(&mut cadence, fallback);
+        match cadence {
+            MissionCadence::Cron { timezone, .. } => {
                 assert_eq!(
-                    secret, None,
-                    "parse_trigger_object must not read `has_secret` as a real secret"
+                    timezone.as_ref().map(|tz| tz.tz().name()),
+                    Some("America/New_York")
                 );
             }
-            other => panic!("expected Webhook after round-trip, got {other:?}"),
+            other => panic!("expected Cron, got {other:?}"),
         }
     }
 
@@ -3095,7 +2807,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert!(needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         match updates.cadence.expect("cadence should still be set") {
             MissionCadence::Webhook { path, secret } => {
@@ -3124,8 +2835,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        // Guard skips preserve — update already has a secret.
-        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         match updates.cadence.expect("cadence should still be set") {
             MissionCadence::Webhook { secret, .. } => {
@@ -3177,7 +2886,6 @@ mod tests {
             }),
             ..Default::default()
         };
-        assert!(!needs_webhook_secret_preserve(updates.cadence.as_ref()));
         preserve_webhook_secret(&mut updates, &current);
         assert!(matches!(
             updates.cadence.expect("cadence still set"),
@@ -3195,7 +2903,7 @@ mod tests {
             secret: Some("super-secret-value".into()),
         };
 
-        let listed_trigger = cadence_to_json(&current);
+        let listed_trigger = serde_json::to_value(current.redacted()).unwrap();
         let listed_str = listed_trigger.to_string();
         assert!(!listed_str.contains("super-secret-value"));
         assert!(!listed_str.contains("***"));
@@ -3206,9 +2914,7 @@ mod tests {
         });
         let mut updates = build_mission_update_from_params(&params, None);
 
-        if needs_webhook_secret_preserve(updates.cadence.as_ref()) {
-            preserve_webhook_secret(&mut updates, &current);
-        }
+        preserve_webhook_secret(&mut updates, &current);
 
         match updates.cadence.expect("cadence should be set") {
             MissionCadence::Webhook { path, secret } => {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -774,16 +774,104 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         actions: vec![
             ironclaw_engine::ActionDef {
                 name: "mission_create".into(),
-                description: "Create a new mission (routine). Use when the user wants to set up a recurring task, scheduled check, or periodic routine. Results are delivered to the current channel by default.".into(),
+                description: "Create a new mission (scheduled, reactive, or goal-pursuing task). \
+                    Use this when the user wants something to happen on a schedule \
+                    ('every weekday at 9am summarize...'), in response to an event \
+                    ('every time a telegram message arrives matching X, do Y'), on an \
+                    incoming webhook, or as an ongoing goal. The `trigger` field's \
+                    `kind` determines how the mission fires — see the `trigger` field \
+                    description. Results are delivered to the current channel by default."
+                    .into(),
                 parameters_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
                         "name": {"type": "string", "description": "Short name for the mission/routine"},
                         "goal": {"type": "string", "description": "What this mission should accomplish each run"},
-                        "cadence": {"type": "string", "description": "How often to run: 'hourly', '30m', '6h', 'daily', 'manual'"},
-                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl']). Defaults to current channel."}
+                        "trigger": {
+                            "type": "object",
+                            "description": "Structured trigger config. Set `kind` first, \
+                                then fill only the fields that apply to that variant.",
+                            "properties": {
+                                "kind": {
+                                    "type": "string",
+                                    "enum": ["cron", "message_event", "system_event", "webhook", "manual"],
+                                    "description": "Required. Picks which other fields apply: \
+                                        'cron' uses schedule+timezone; 'message_event' uses pattern+channel; \
+                                        'system_event' uses source+event_type+filters; 'webhook' uses path+secret; \
+                                        'manual' uses no other fields and only runs when mission_fire is called."
+                                },
+                                "schedule": {
+                                    "type": "string",
+                                    "description": "kind='cron': cron expression with 5+ whitespace-separated fields. Example: '0 9 * * MON-FRI' (every weekday at 9am)."
+                                },
+                                "timezone": {
+                                    "type": "string",
+                                    "description": "kind='cron': optional IANA timezone, e.g. 'America/New_York'. Defaults to the user's channel timezone."
+                                },
+                                "pattern": {
+                                    "type": "string",
+                                    "description": "kind='message_event': regex matched against incoming channel message text. Use '.*' to match every message."
+                                },
+                                "channel": {
+                                    "type": "string",
+                                    "description": "kind='message_event': optional channel filter, e.g. 'telegram'. Omit to match messages from all channels."
+                                },
+                                "source": {
+                                    "type": "string",
+                                    "description": "kind='system_event': event source namespace, e.g. 'github'."
+                                },
+                                "event_type": {
+                                    "type": "string",
+                                    "description": "kind='system_event': event type, e.g. 'issue.opened'."
+                                },
+                                "filters": {
+                                    "type": "object",
+                                    "additionalProperties": {"type": ["string", "number", "boolean"]},
+                                    "description": "kind='system_event': optional exact-match filters over top-level payload fields."
+                                },
+                                "path": {
+                                    "type": "string",
+                                    "description": "kind='webhook': HTTP path where the webhook is registered, e.g. '/github-issues'."
+                                },
+                                "secret": {
+                                    "type": "string",
+                                    "description": "kind='webhook': optional shared secret for HMAC validation."
+                                }
+                            },
+                            "required": ["kind"],
+                            "examples": [
+                                {"kind": "cron", "schedule": "0 9 * * MON-FRI", "timezone": "UTC"},
+                                {"kind": "message_event", "pattern": ".*", "channel": "telegram"},
+                                {"kind": "system_event", "source": "github", "event_type": "issue.opened"},
+                                {"kind": "webhook", "path": "/github-issues"},
+                                {"kind": "manual"}
+                            ]
+                        },
+                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl']). Defaults to current channel."},
+                        "cooldown_secs": {
+                            "type": "integer",
+                            "description": "Minimum seconds between two fires of the same mission. \
+                                Reactive cadences default to 300 (5 minutes); set 0 to disable. \
+                                Disable for append-only sinks that must record every event \
+                                (e.g. 'log every telegram message')."
+                        },
+                        "max_concurrent": {
+                            "type": "integer",
+                            "description": "Max threads from this mission running at once. \
+                                Reactive cadences default to 1; set 0 to disable the cap."
+                        },
+                        "max_threads_per_day": {
+                            "type": "integer",
+                            "description": "Hard cap on fires per 24h window. \
+                                Reactive cadences default to 24; set 0 to disable the cap."
+                        },
+                        "dedup_window_secs": {
+                            "type": "integer",
+                            "description": "Suppress repeat fires with the same payload within N seconds (default 0 = disabled). \
+                                Raise when the upstream event stream is known to emit duplicates."
+                        }
                     },
-                    "required": ["name", "goal"]
+                    "required": ["name", "goal", "trigger"]
                 }),
                 effects: vec![],
                 requires_approval: false,
@@ -836,16 +924,29 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
             },
             ironclaw_engine::ActionDef {
                 name: "mission_update".into(),
-                description: "Update a mission/routine. Change name, goal, cadence, notification channels, daily budget, or success criteria.".into(),
+                description: "Update a mission/routine. Any field may be omitted to leave it unchanged. `trigger` uses the same shape as `mission_create`.".into(),
                 parameters_schema: serde_json::json!({
                     "type": "object",
                     "properties": {
                         "id": {"type": "string", "description": "Mission/routine ID to update"},
                         "name": {"type": "string", "description": "New name"},
                         "goal": {"type": "string", "description": "New goal"},
-                        "cadence": {"type": "string", "description": "New cadence: 'hourly', '30m', '6h', 'daily', 'manual'"},
-                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl'])"},
-                        "max_threads_per_day": {"type": "integer", "description": "Max threads per day (0 = unlimited)"},
+                        "trigger": {
+                            "type": "object",
+                            "description": "New trigger — same `{kind, ...}` shape as mission_create. See mission_create for the per-kind fields.",
+                            "properties": {
+                                "kind": {
+                                    "type": "string",
+                                    "enum": ["cron", "message_event", "system_event", "webhook", "manual"]
+                                }
+                            },
+                            "required": ["kind"]
+                        },
+                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to"},
+                        "cooldown_secs": {"type": "integer", "description": "Minimum seconds between fires (0 = disabled)"},
+                        "max_concurrent": {"type": "integer", "description": "Max concurrent threads (0 = disabled)"},
+                        "max_threads_per_day": {"type": "integer", "description": "Daily fire cap (0 = disabled)"},
+                        "dedup_window_secs": {"type": "integer", "description": "Suppress repeat payloads within N seconds (0 = disabled)"},
                         "success_criteria": {"type": "string", "description": "Criteria for declaring mission complete"}
                     },
                     "required": ["id"]

--- a/tests/fixtures/llm_traces/live/mission_daily_news_digest.json
+++ b/tests/fixtures/llm_traces/live/mission_daily_news_digest.json
@@ -62,7 +62,7 @@
     {
       "response": {
         "type": "user_input",
-        "content": "Create a long-running mission for me using the `mission_create` tool. Use exactly these parameters:\n- name: \"daily-news-digest\"\n- goal: \"Fetch the current Hacker News front page from https://news.ycombinator.com/ (use whichever fetch tool is available — http, web_fetch, or shell with curl) and produce a digest of the top 3 stories. Return the result as a markdown bullet list with exactly 3 bullets, one per story, each bullet starting with '- ' and containing the story title verbatim followed by a one-line summary. After the bullet list, write exactly: 'Mission complete.'\"\n- cadence: \"manual\"\nAfter the mission is created, immediately call `mission_fire` with its id so it runs once for testing. Then reply to me with: the mission name and a one-sentence confirmation that you fired it. Do not include the mission UUID."
+        "content": "Create a long-running mission for me using the `mission_create` tool. Use exactly these parameters:\n- name: \"daily-news-digest\"\n- goal: \"Fetch the current Hacker News front page from https://news.ycombinator.com/ (use whichever fetch tool is available — http, web_fetch, or shell with curl) and produce a digest of the top 3 stories. Return the result as a markdown bullet list with exactly 3 bullets, one per story, each bullet starting with '- ' and containing the story title verbatim followed by a one-line summary. After the bullet list, write exactly: 'Mission complete.'\"\n- trigger: {\"kind\": \"manual\"}\nAfter the mission is created, immediately call `mission_fire` with its id so it runs once for testing. Then reply to me with: the mission name and a one-sentence confirmation that you fired it. Do not include the mission UUID."
       }
     },
     {
@@ -77,7 +77,7 @@
             "id": "chatcmpl-tool-b2447dcfc98fcc1a",
             "name": "mission_create",
             "arguments": {
-              "cadence": "manual",
+              "trigger": { "kind": "manual" },
               "goal": "Fetch the current Hacker News front page from https://news.ycombinator.com/ (use whichever fetch tool is available — http, web_fetch, or shell with curl) and produce a digest of the top 3 stories. Return the result as a markdown bullet list with exactly 3 bullets, one per story, each bullet starting with '- ' and containing the story title verbatim followed by a one-line summary. After the bullet list, write exactly: 'Mission complete.'",
               "name": "daily-news-digest"
             }

--- a/tests/routine_reactive_integration.rs
+++ b/tests/routine_reactive_integration.rs
@@ -1,0 +1,437 @@
+//! Integration test: `routine_create` → reactive fire end-to-end.
+//!
+//! Drives the full chain (alias → effect adapter → mission manager →
+//! `fire_on_message_event`) with zeroed guardrails and three inbound
+//! events, asserting every event spawns a thread. Complements the
+//! engine-level `reactive_mission_guardrails_are_respected_on_every_fire`
+//! unit test, which bypasses the alias and guardrail-forwarding paths.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::sync::RwLock;
+
+use ironclaw::bridge::EffectBridgeAdapter;
+use ironclaw::hooks::HookRegistry;
+use ironclaw::tools::ToolRegistry;
+use ironclaw_engine::types::capability::LeaseId;
+use ironclaw_engine::{
+    ActionDef, ActionResult, CapabilityLease, CapabilityRegistry, DocId, EffectExecutor,
+    EngineError, GrantedActions, LeaseManager, LlmBackend, LlmCallConfig, LlmOutput, LlmResponse,
+    MemoryDoc, Mission, MissionCadence, MissionId, MissionManager, MissionStatus, PolicyEngine,
+    Project, ProjectId, Step, Store, Thread, ThreadEvent, ThreadId, ThreadManager, ThreadMessage,
+    ThreadState, TokenUsage,
+};
+use ironclaw_safety::{SafetyConfig, SafetyLayer};
+
+// ── Minimal in-memory Store impl ─────────────────────────────
+
+struct TestStore {
+    threads: RwLock<HashMap<ThreadId, Thread>>,
+    events: RwLock<Vec<ThreadEvent>>,
+    steps: RwLock<Vec<Step>>,
+    missions: RwLock<Vec<Mission>>,
+    leases: RwLock<Vec<CapabilityLease>>,
+    docs: RwLock<Vec<MemoryDoc>>,
+}
+
+impl TestStore {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            threads: RwLock::new(HashMap::new()),
+            events: RwLock::new(Vec::new()),
+            steps: RwLock::new(Vec::new()),
+            missions: RwLock::new(Vec::new()),
+            leases: RwLock::new(Vec::new()),
+            docs: RwLock::new(Vec::new()),
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl Store for TestStore {
+    async fn save_thread(&self, thread: &Thread) -> Result<(), EngineError> {
+        self.threads.write().await.insert(thread.id, thread.clone());
+        Ok(())
+    }
+    async fn load_thread(&self, id: ThreadId) -> Result<Option<Thread>, EngineError> {
+        Ok(self.threads.read().await.get(&id).cloned())
+    }
+    async fn list_threads(
+        &self,
+        pid: ProjectId,
+        _user_id: &str,
+    ) -> Result<Vec<Thread>, EngineError> {
+        Ok(self
+            .threads
+            .read()
+            .await
+            .values()
+            .filter(|t| t.project_id == pid)
+            .cloned()
+            .collect())
+    }
+    async fn update_thread_state(
+        &self,
+        id: ThreadId,
+        state: ThreadState,
+    ) -> Result<(), EngineError> {
+        if let Some(t) = self.threads.write().await.get_mut(&id) {
+            t.state = state;
+        }
+        Ok(())
+    }
+    async fn save_step(&self, step: &Step) -> Result<(), EngineError> {
+        let mut steps = self.steps.write().await;
+        steps.retain(|s| s.id != step.id);
+        steps.push(step.clone());
+        Ok(())
+    }
+    async fn load_steps(&self, thread_id: ThreadId) -> Result<Vec<Step>, EngineError> {
+        Ok(self
+            .steps
+            .read()
+            .await
+            .iter()
+            .filter(|s| s.thread_id == thread_id)
+            .cloned()
+            .collect())
+    }
+    async fn append_events(&self, events: &[ThreadEvent]) -> Result<(), EngineError> {
+        self.events.write().await.extend(events.iter().cloned());
+        Ok(())
+    }
+    async fn load_events(&self, thread_id: ThreadId) -> Result<Vec<ThreadEvent>, EngineError> {
+        Ok(self
+            .events
+            .read()
+            .await
+            .iter()
+            .filter(|e| e.thread_id == thread_id)
+            .cloned()
+            .collect())
+    }
+    async fn save_project(&self, _: &Project) -> Result<(), EngineError> {
+        Ok(())
+    }
+    async fn load_project(&self, _: ProjectId) -> Result<Option<Project>, EngineError> {
+        Ok(None)
+    }
+    async fn list_projects(&self, _: &str) -> Result<Vec<Project>, EngineError> {
+        Ok(vec![])
+    }
+    async fn list_all_projects(&self) -> Result<Vec<Project>, EngineError> {
+        Ok(vec![])
+    }
+    async fn save_conversation(
+        &self,
+        _: &ironclaw_engine::ConversationSurface,
+    ) -> Result<(), EngineError> {
+        Ok(())
+    }
+    async fn load_conversation(
+        &self,
+        _: ironclaw_engine::ConversationId,
+    ) -> Result<Option<ironclaw_engine::ConversationSurface>, EngineError> {
+        Ok(None)
+    }
+    async fn list_conversations(
+        &self,
+        _: &str,
+    ) -> Result<Vec<ironclaw_engine::ConversationSurface>, EngineError> {
+        Ok(vec![])
+    }
+    async fn save_memory_doc(&self, doc: &MemoryDoc) -> Result<(), EngineError> {
+        let mut docs = self.docs.write().await;
+        docs.retain(|d| d.id != doc.id);
+        docs.push(doc.clone());
+        Ok(())
+    }
+    async fn load_memory_doc(&self, id: DocId) -> Result<Option<MemoryDoc>, EngineError> {
+        Ok(self.docs.read().await.iter().find(|d| d.id == id).cloned())
+    }
+    async fn list_memory_docs(&self, _: ProjectId, _: &str) -> Result<Vec<MemoryDoc>, EngineError> {
+        Ok(self.docs.read().await.clone())
+    }
+    async fn save_lease(&self, lease: &CapabilityLease) -> Result<(), EngineError> {
+        let mut leases = self.leases.write().await;
+        leases.retain(|l| l.id != lease.id);
+        leases.push(lease.clone());
+        Ok(())
+    }
+    async fn load_active_leases(
+        &self,
+        thread_id: ThreadId,
+    ) -> Result<Vec<CapabilityLease>, EngineError> {
+        Ok(self
+            .leases
+            .read()
+            .await
+            .iter()
+            .filter(|l| l.thread_id == thread_id && !l.revoked)
+            .cloned()
+            .collect())
+    }
+    async fn revoke_lease(&self, lease_id: LeaseId, _: &str) -> Result<(), EngineError> {
+        if let Some(l) = self
+            .leases
+            .write()
+            .await
+            .iter_mut()
+            .find(|l| l.id == lease_id)
+        {
+            l.revoked = true;
+        }
+        Ok(())
+    }
+    async fn save_mission(&self, mission: &Mission) -> Result<(), EngineError> {
+        let mut missions = self.missions.write().await;
+        missions.retain(|m| m.id != mission.id);
+        missions.push(mission.clone());
+        Ok(())
+    }
+    async fn load_mission(&self, id: MissionId) -> Result<Option<Mission>, EngineError> {
+        Ok(self
+            .missions
+            .read()
+            .await
+            .iter()
+            .find(|m| m.id == id)
+            .cloned())
+    }
+    async fn list_missions(&self, _: ProjectId, _: &str) -> Result<Vec<Mission>, EngineError> {
+        Ok(self.missions.read().await.clone())
+    }
+    async fn update_mission_status(
+        &self,
+        _: MissionId,
+        _: MissionStatus,
+    ) -> Result<(), EngineError> {
+        Ok(())
+    }
+}
+
+// ── Mock LLM that returns "done" immediately ─────────────────
+
+struct MockLlm;
+
+#[async_trait::async_trait]
+impl LlmBackend for MockLlm {
+    async fn complete(
+        &self,
+        _: &[ThreadMessage],
+        _: &[ActionDef],
+        _: &LlmCallConfig,
+    ) -> Result<LlmOutput, EngineError> {
+        Ok(LlmOutput {
+            response: LlmResponse::Text("done".into()),
+            usage: TokenUsage::default(),
+        })
+    }
+    fn model_name(&self) -> &str {
+        "mock"
+    }
+}
+
+struct NoopEffects;
+
+#[async_trait::async_trait]
+impl EffectExecutor for NoopEffects {
+    async fn execute_action(
+        &self,
+        _: &str,
+        _: serde_json::Value,
+        _: &CapabilityLease,
+        _: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<ActionResult, EngineError> {
+        Ok(ActionResult {
+            call_id: String::new(),
+            action_name: String::new(),
+            output: serde_json::json!({}),
+            is_error: false,
+            duration: Duration::from_millis(1),
+        })
+    }
+    async fn available_actions(
+        &self,
+        _: &[CapabilityLease],
+    ) -> Result<Vec<ActionDef>, EngineError> {
+        Ok(vec![])
+    }
+}
+
+fn make_lease() -> CapabilityLease {
+    CapabilityLease {
+        id: LeaseId::new(),
+        thread_id: ThreadId::new(),
+        capability_name: "tools".into(),
+        granted_actions: GrantedActions::All,
+        granted_at: chrono::Utc::now(),
+        expires_at: None,
+        max_uses: None,
+        uses_remaining: None,
+        revoked: false,
+        revoked_reason: None,
+    }
+}
+
+fn make_ctx(
+    project_id: ProjectId,
+    user_id: &str,
+    call_id: &str,
+) -> ironclaw_engine::ThreadExecutionContext {
+    ironclaw_engine::ThreadExecutionContext {
+        thread_id: ThreadId::new(),
+        thread_type: ironclaw_engine::types::thread::ThreadType::Foreground,
+        project_id,
+        user_id: user_id.to_string(),
+        step_id: ironclaw_engine::StepId::new(),
+        current_call_id: Some(call_id.to_string()),
+        source_channel: None,
+        user_timezone: None,
+    }
+}
+
+/// End-to-end: `routine_create` wires up a reactive mission with
+/// zeroed guardrails, and subsequent `fire_on_message_event` calls spawn
+/// a thread on every match.
+#[tokio::test]
+async fn routine_create_reactive_mission_fires_on_every_message() {
+    // 1. Mission manager backed by an in-memory store.
+    let store = TestStore::new();
+    let store_dyn: Arc<dyn Store> = Arc::clone(&store) as Arc<dyn Store>;
+    let thread_manager = Arc::new(ThreadManager::new(
+        Arc::new(MockLlm),
+        Arc::new(NoopEffects),
+        Arc::clone(&store_dyn),
+        Arc::new(CapabilityRegistry::new()),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    ));
+    let mission_manager = Arc::new(MissionManager::new(
+        Arc::clone(&store_dyn),
+        Arc::clone(&thread_manager),
+    ));
+
+    // 2. Adapter + mission manager.
+    let adapter = EffectBridgeAdapter::new(
+        Arc::new(ToolRegistry::new()),
+        Arc::new(SafetyLayer::new(&SafetyConfig {
+            max_output_length: 10_000,
+            injection_check_enabled: false,
+        })),
+        Arc::new(HookRegistry::default()),
+    );
+    adapter
+        .set_mission_manager(Arc::clone(&mission_manager))
+        .await;
+
+    // 3. Call routine_create. Zeroed guardrails + `.*` on telegram model
+    // the "log every telegram message" case.
+    let project_id = ProjectId::new();
+    let params = serde_json::json!({
+        "name": "telegram-logger",
+        "prompt": "log every incoming telegram message",
+        "request": {
+            "kind": "message_event",
+            "pattern": ".*",
+            "channel": "telegram",
+        },
+        "advanced": {
+            "cooldown_secs": 0,
+        },
+        "guardrails": {
+            "max_concurrent": 0,
+            "max_threads_per_day": 0,
+            "dedup_window_secs": 0,
+        },
+    });
+
+    let create_result = adapter
+        .execute_action(
+            "routine_create",
+            params,
+            &make_lease(),
+            &make_ctx(project_id, "alice", "call_routine_create_1"),
+        )
+        .await
+        .expect("routine_create should return a tool result, not an engine error");
+
+    assert!(
+        !create_result.is_error,
+        "routine_create must succeed. output = {:?}",
+        create_result.output
+    );
+    let created_status = create_result
+        .output
+        .get("status")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    assert!(
+        created_status.starts_with("created"),
+        "expected created/created_with_warnings, got: {created_status:?} (full output: {:?})",
+        create_result.output
+    );
+
+    // 4. Mission persisted with real cadence and guardrails.
+    let missions = mission_manager
+        .list_missions(project_id, "alice")
+        .await
+        .expect("list_missions");
+    let mission = missions
+        .iter()
+        .find(|m| m.name == "telegram-logger")
+        .expect("mission must have been persisted under its name");
+    match &mission.cadence {
+        MissionCadence::OnEvent {
+            event_pattern,
+            channel,
+        } => {
+            assert_eq!(event_pattern, ".*");
+            assert_eq!(channel.as_deref(), Some("telegram"));
+        }
+        other => panic!("expected OnEvent cadence, got {other:?}"),
+    }
+    assert_eq!(
+        mission.cooldown_secs, 0,
+        "cooldown_secs=0 must land on the first persisted save"
+    );
+    assert_eq!(
+        mission.max_concurrent, 0,
+        "max_concurrent=0 must land on the first persisted save"
+    );
+    assert_eq!(
+        mission.max_threads_per_day, 0,
+        "max_threads_per_day=0 must land on the first persisted save"
+    );
+    assert_eq!(
+        mission.dedup_window_secs, 0,
+        "dedup_window_secs=0 must land on the first persisted save"
+    );
+
+    // 5. Three inbound events must each spawn a thread.
+    for msg in ["first", "second", "third"] {
+        let spawned = mission_manager
+            .fire_on_message_event("telegram", msg, "alice", None)
+            .await
+            .expect("fire_on_message_event should not error");
+        assert_eq!(
+            spawned.len(),
+            1,
+            "event {msg:?} must spawn exactly one thread (zeroed guardrails should not gate fires)"
+        );
+    }
+
+    // 6. Thread history reflects all three fires.
+    let after = mission_manager
+        .get_mission(mission.id)
+        .await
+        .expect("get_mission")
+        .expect("mission still present");
+    assert_eq!(
+        after.thread_history.len(),
+        3,
+        "three inbound events should produce three threads in the mission history"
+    );
+}


### PR DESCRIPTION
## Summary
Agents were not able to create reactive missions (e.g. "log every telegram message") because of two major shortcomings:

1. the mission cadence (e.g. cron / event / manual) was a simple string, and when malformed - which was incredibly often - ironclaw was defaulting to "manual"
2. A default 5-minute cooldown was applied between triggers, with no way to changing it, so even when correctly created, the event would only trigger every 5min

This PR addresses this issues and:
- Replaces "cadence" with a strict `trigger` structure, which is now required
- Rejects invalid `trigger` shapes with a redable error so the LLM can correct the call
- Forward guardrail fields (cooldown_secs, max_concurrent, etc.) to mission_create as top-level params so LLMs can decide how often a mission triggers
- Expose trigger and guardrails in mission_list output so misconfigured missions are visible
- Add mission_update and mission_delete to the CodeAct preamble so the LLM knows they exist
- Add regression tests and end-to-end integration test

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Closes #2524


## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass:
```
cargo test -p ironclaw_engine --lib runtime::mission
cargo test --lib bridge::effect_adapter
cargo test --test routine_reactive_integration
```

- [x] Manual testing: 
  - I have requested my ironclaw (QLM 3.5 / haiku 4.5) to create a trigger routine (log every telegram message that arrives) and it succeeded
  - Without this update my ironclaw was consistently failing to do so.

- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

`missions` are stored with a new trigger format, but I have added tests to ensure retro-compatibility

## Blast Radius

`routines`

## Rollback Plan

We would need to return routines to use the old `cadence` string

---

**Review track**: B? C?
