### PR TITLE
feat(engine): execution obligation -- require tool attempt on explicit user commands

### DIFF
--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -469,6 +469,8 @@ def run_loop(context, goal, actions, state, config):
     nudge_enabled = config.get("enable_tool_intent_nudge", True)
     # None means "no limit" — callers can disable the guard explicitly.
     max_consecutive_errors = config.get("max_consecutive_errors", 5)
+    obligation_enabled = config.get("require_action_attempt", False)
+    max_obligation_nudges = config.get("max_action_requirement_nudges", 2)
     consecutive_nudges = 0
     consecutive_errors = 0
     consecutive_action_errors = 0
@@ -574,15 +576,36 @@ def run_loop(context, goal, actions, state, config):
                 )
                 continue
 
-            # Non-intent text response — reset nudge counter and finish
+            # Non-intent text response — reset nudge counter
             if not signals_tool_intent(text):
                 consecutive_nudges = 0
+
+            # Check execution obligation: user asked for execution but model
+            # gave text without attempting any action/code. Fires only when
+            # no action/code has been attempted this turn, the obligation
+            # has not been resolved (e.g. by a gate on a prior step), and
+            # the tool-intent nudge did not already fire this step (the two
+            # mechanisms are mutually exclusive to avoid double-nudging).
+            if (obligation_enabled
+                    and consecutive_nudges == 0
+                    and not state.get("_obligation_resolved", False)
+                    and state.get("_obligation_nudge_count", 0) < max_obligation_nudges):
+                state["_obligation_nudge_count"] = state.get("_obligation_nudge_count", 0) + 1
+                append_message(
+                    working_messages,
+                    "User",
+                    "You were asked to perform an action, but you responded with text only.\n"
+                    "Do NOT describe or explain — call the appropriate tool now.\n"
+                    "Use the tool_calls mechanism to invoke the tool.",
+                )
+                continue
 
             # Plain text response - done
             __transition_to__("completed", "text response")
             return complete_result(state, "completed", text)
 
         elif resp_type == "code":
+            state["_obligation_resolved"] = True  # code attempt satisfies obligation
             code = response.get("code", "")
             append_message(working_messages, "Assistant", "```repl\n" + code + "\n```")
 
@@ -615,6 +638,7 @@ def run_loop(context, goal, actions, state, config):
                     "consecutive_errors": consecutive_errors,
                     "consecutive_action_errors": consecutive_action_errors,
                     "compaction_count": state.get("compaction_count", 0),
+                    "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
                 })
                 __transition_to__("waiting", "gate paused: " + gate.get("gate_name", "unknown"))
                 return {
@@ -635,6 +659,7 @@ def run_loop(context, goal, actions, state, config):
                     "consecutive_errors": consecutive_errors,
                     "consecutive_action_errors": consecutive_action_errors,
                     "compaction_count": state.get("compaction_count", 0),
+                    "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
                 })
                 if approval.get("need_authentication"):
                     __transition_to__("waiting", "authentication needed")
@@ -673,9 +698,11 @@ def run_loop(context, goal, actions, state, config):
                 "consecutive_errors": consecutive_errors,
                 "consecutive_action_errors": consecutive_action_errors,
                 "compaction_count": state.get("compaction_count", 0),
+                "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
             })
 
         elif resp_type == "actions":
+            state["_obligation_resolved"] = True  # action attempt satisfies obligation
             # Tier 0: structured tool calls.
             # NOTE: consecutive_nudges is NOT reset here (V1 semantics).
             # Only non-intent text responses reset the counter.
@@ -773,6 +800,7 @@ def run_loop(context, goal, actions, state, config):
                         "consecutive_errors": consecutive_errors,
                         "consecutive_action_errors": consecutive_action_errors,
                         "compaction_count": state.get("compaction_count", 0),
+                        "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
                     })
                     gate = r
                     # Get action info from the original call or the result
@@ -794,6 +822,7 @@ def run_loop(context, goal, actions, state, config):
                         "consecutive_errors": consecutive_errors,
                         "consecutive_action_errors": consecutive_action_errors,
                         "compaction_count": state.get("compaction_count", 0),
+                        "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
                     })
                     __transition_to__("waiting", "authentication needed")
                     return {
@@ -811,6 +840,7 @@ def run_loop(context, goal, actions, state, config):
                         "consecutive_errors": consecutive_errors,
                         "consecutive_action_errors": consecutive_action_errors,
                         "compaction_count": state.get("compaction_count", 0),
+                        "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
                     })
                     __transition_to__("waiting", "approval needed")
                     return {
@@ -894,6 +924,7 @@ def run_loop(context, goal, actions, state, config):
                 "consecutive_errors": consecutive_errors,
                 "consecutive_action_errors": consecutive_action_errors,
                 "compaction_count": state.get("compaction_count", 0),
+                "obligation_nudge_count": state.get("_obligation_nudge_count", 0),
             })
 
     # Max iterations reached

--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -496,16 +496,6 @@ def run_loop(context, goal, actions, state, config):
     obligation_enabled = config.get("require_action_attempt", False)
     max_obligation_nudges = config.get("max_action_requirement_nudges", 2)
 
-    # Enable obligation from the latest user message in context, not just
-    # thread config. This covers the resume path where a suspended thread is
-    # restarted with a new user message that signals execution intent — the
-    # thread's original config may not have had require_action_attempt set.
-    if not obligation_enabled and context:
-        for msg in reversed(context):
-            if msg.get("role") in ("User", "user"):
-                if signals_execution_intent(msg.get("content", "")):
-                    obligation_enabled = True
-                break
     consecutive_nudges = 0
     consecutive_errors = 0
     consecutive_action_errors = 0
@@ -514,6 +504,23 @@ def run_loop(context, goal, actions, state, config):
         state = {}
     state.setdefault("history", [])
     state.setdefault("compaction_count", 0)
+
+    # Enable obligation from the latest user message in context, not just
+    # thread config. This covers the resume path where a suspended thread is
+    # restarted with a new user message that signals execution intent -- the
+    # thread's original config may not have had require_action_attempt set.
+    # Reset persisted state flags too: _obligation_resolved and
+    # _obligation_nudge_count carry over from prior runs via
+    # orchestrator_state in thread metadata, so a stale "resolved" from a
+    # previous tool call would silently suppress the new obligation.
+    if not obligation_enabled and context:
+        for msg in reversed(context):
+            if msg.get("role") in ("User", "user"):
+                if signals_execution_intent(msg.get("content", "")):
+                    obligation_enabled = True
+                    state["_obligation_resolved"] = False
+                    state["_obligation_nudge_count"] = 0
+                break
     working_messages = ensure_working_messages(state, context)
 
     for step in range(step_count, max_iterations):

--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -576,18 +576,15 @@ def run_loop(context, goal, actions, state, config):
                 )
                 continue
 
-            # Non-intent text response — reset nudge counter
-            if not signals_tool_intent(text):
-                consecutive_nudges = 0
-
-            # Check execution obligation: user asked for execution but model
-            # gave text without attempting any action/code. Fires only when
-            # no action/code has been attempted this turn, the obligation
-            # has not been resolved (e.g. by a gate on a prior step), and
-            # the tool-intent nudge did not already fire this step (the two
-            # mechanisms are mutually exclusive to avoid double-nudging).
+            # Check execution obligation BEFORE resetting consecutive_nudges.
+            # This ensures the mutual exclusion guard (consecutive_nudges == 0)
+            # correctly reflects whether the tool-intent nudge fired this turn.
+            # If tool-intent nudge fired and exhausted its budget, consecutive_nudges > 0
+            # and the obligation is skipped. The reset happens after.
+            available_actions = __get_actions__()
             if (obligation_enabled
                     and consecutive_nudges == 0
+                    and len(available_actions) > 0
                     and not state.get("_obligation_resolved", False)
                     and state.get("_obligation_nudge_count", 0) < max_obligation_nudges):
                 state["_obligation_nudge_count"] = state.get("_obligation_nudge_count", 0) + 1
@@ -599,6 +596,10 @@ def run_loop(context, goal, actions, state, config):
                     "Use the tool_calls mechanism to invoke the tool.",
                 )
                 continue
+
+            # Non-intent text response — reset nudge counter
+            if not signals_tool_intent(text):
+                consecutive_nudges = 0
 
             # Plain text response - done
             __transition_to__("completed", "text response")

--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -140,6 +140,30 @@ def signals_tool_intent(text):
     return False
 
 
+def signals_execution_intent(text):
+    """Detect explicit execution commands in user messages.
+
+    Ported from Rust user_signals_execution_intent(): strips code blocks and
+    quoted strings, then checks for imperative verb phrases that require action.
+    Deliberately excludes context-dependent phrases ("go ahead", "yes do it")
+    that require multi-turn understanding.
+    """
+    stripped = strip_code_blocks(text)
+    lower = stripped.lower()
+
+    EXEC_PHRASES = [
+        "run it", "run that", "run them", "run this", "run the ",
+        "execute it", "execute that", "execute them", "execute this",
+        "execute the ",
+        "ship it", "deploy it", "deploy that", "deploy this", "deploy the ",
+        "send it", "send that", "send the ",
+        "fetch it", "fetch that", "fetch the ",
+        "please run ", "please execute ", "please fetch ",
+        "please send ", "please deploy ",
+    ]
+    return any(phrase in lower for phrase in EXEC_PHRASES)
+
+
 def format_output(result, max_chars=8000):
     """Format code execution result for the next LLM context message."""
     parts = []
@@ -471,6 +495,17 @@ def run_loop(context, goal, actions, state, config):
     max_consecutive_errors = config.get("max_consecutive_errors", 5)
     obligation_enabled = config.get("require_action_attempt", False)
     max_obligation_nudges = config.get("max_action_requirement_nudges", 2)
+
+    # Enable obligation from the latest user message in context, not just
+    # thread config. This covers the resume path where a suspended thread is
+    # restarted with a new user message that signals execution intent — the
+    # thread's original config may not have had require_action_attempt set.
+    if not obligation_enabled and context:
+        for msg in reversed(context):
+            if msg.get("role") in ("User", "user"):
+                if signals_execution_intent(msg.get("content", "")):
+                    obligation_enabled = True
+                break
     consecutive_nudges = 0
     consecutive_errors = 0
     consecutive_action_errors = 0
@@ -488,7 +523,15 @@ def run_loop(context, goal, actions, state, config):
             __transition_to__("completed", "stopped by signal")
             return complete_result(state, "stopped")
         if signal and isinstance(signal, dict) and "inject" in signal:
-            append_message(working_messages, "User", signal["inject"])
+            injected_text = signal["inject"]
+            append_message(working_messages, "User", injected_text)
+            # Enable obligation if follow-up message signals execution intent.
+            # This covers the inject-into-running-thread path where the thread
+            # was spawned without require_action_attempt in its config.
+            if signals_execution_intent(injected_text):
+                obligation_enabled = True
+                state["_obligation_resolved"] = False
+                state["_obligation_nudge_count"] = 0
 
         # 2. Check budget
         budget = __check_budget__()

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -2131,6 +2131,8 @@ fn build_orchestrator_inputs(
         "max_iterations": thread.config.max_iterations,
         "max_tool_intent_nudges": thread.config.max_tool_intent_nudges,
         "enable_tool_intent_nudge": thread.config.enable_tool_intent_nudge,
+        "require_action_attempt": thread.config.require_action_attempt,
+        "max_action_requirement_nudges": thread.config.max_action_requirement_nudges,
         "max_consecutive_errors": thread.config.max_consecutive_errors,
         "max_tokens_total": thread.config.max_tokens_total,
         "max_budget_usd": thread.config.max_budget_usd,

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -124,6 +124,16 @@ pub struct ThreadConfig {
     /// Maximum number of tool intent nudges per thread.
     pub max_tool_intent_nudges: u32,
 
+    // ── Execution obligation ──
+    /// Whether to require at least one action/code attempt before accepting
+    /// a text response. Set by the router when explicit execution intent is
+    /// detected in the user's message (e.g. "run it", "fetch the data").
+    #[serde(default)]
+    pub require_action_attempt: bool,
+    /// Maximum corrective nudges when require_action_attempt is true.
+    #[serde(default = "default_max_action_requirement_nudges")]
+    pub max_action_requirement_nudges: u32,
+
     // ── Budget controls (Phase 4, from RLM cross-reference) ──
     /// Maximum cumulative input+output tokens before termination.
     pub max_tokens_total: Option<u64>,
@@ -155,6 +165,8 @@ impl Default for ThreadConfig {
             max_duration: None,
             enable_tool_intent_nudge: true,
             max_tool_intent_nudges: 2,
+            require_action_attempt: false,
+            max_action_requirement_nudges: 2,
             max_tokens_total: None,
             max_consecutive_errors: Some(5),
             max_budget_usd: None,
@@ -165,6 +177,10 @@ impl Default for ThreadConfig {
             max_depth: 1,
         }
     }
+}
+
+fn default_max_action_requirement_nudges() -> u32 {
+    2
 }
 
 /// Provenance for a skill that was active during thread execution.

--- a/crates/ironclaw_skills/src/catalog.rs
+++ b/crates/ironclaw_skills/src/catalog.rs
@@ -461,7 +461,7 @@ impl SkillCatalog {
 
         let details = futures::future::join_all(futures).await;
 
-        for (entry, detail) in entries[..count].iter_mut().zip(details.into_iter()) {
+        for (entry, detail) in entries[..count].iter_mut().zip(details) {
             if let Some(detail) = detail {
                 if let Some(ref stats) = detail.stats {
                     entry.stars = stats.stars;

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2576,6 +2576,15 @@ async fn handle_with_engine_inner(
         .as_deref()
         .and_then(ironclaw_engine::ValidTimezone::parse);
 
+    // Detect execution intent and configure obligation accordingly
+    let thread_config = {
+        let mut cfg = ThreadConfig::default();
+        if crate::llm::user_signals_execution_intent(content) {
+            cfg.require_action_attempt = true;
+        }
+        cfg
+    };
+
     // Handle the message — spawns a new thread or injects into active one
     let thread_id = state
         .conversation_manager
@@ -2584,7 +2593,7 @@ async fn handle_with_engine_inner(
             content,
             project_id,
             &message.user_id,
-            ThreadConfig::default(),
+            thread_config,
             validated_tz.as_ref().map(|tz| tz.name()),
         )
         .await

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -66,6 +66,7 @@ pub use reasoning::{
     ActionPlan, Reasoning, ReasoningContext, RespondOutput, RespondResult, ResponseAnomaly,
     ResponseMetadata, SILENT_REPLY_TOKEN, TOOL_INTENT_NUDGE, TRUNCATED_TOOL_CALL_NOTICE,
     TokenUsage, ToolSelection, is_silent_reply, llm_signals_tool_intent,
+    user_signals_execution_intent,
 };
 pub use recording::RecordingLlm;
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -108,16 +108,14 @@ pub fn llm_signals_tool_intent(response: &str) -> bool {
     false
 }
 
-/// Strip fenced code blocks (``` ... ```), indented code lines (4+ spaces / tab),
-/// and double-quoted strings so that tool-intent detection only fires on prose.
 /// Detect explicit execution intent in a user message.
 ///
 /// Returns `true` for imperative requests like "run it", "execute the script",
-/// "fetch the data", "please check the logs". Strips code blocks and quoted
+/// "fetch the data", "please deploy the service". Strips code blocks and quoted
 /// strings before matching to avoid false positives from examples.
 ///
 /// Deliberately excludes context-dependent phrases ("go ahead", "yes do it")
-/// that require multi-turn understanding — those belong in a classifier tier.
+/// that require multi-turn understanding -- those belong in a classifier tier.
 pub fn user_signals_execution_intent(text: &str) -> bool {
     let stripped = strip_code_blocks(text);
     let lower = stripped.to_lowercase();
@@ -156,6 +154,8 @@ pub fn user_signals_execution_intent(text: &str) -> bool {
     EXEC_PHRASES.iter().any(|phrase| lower.contains(phrase))
 }
 
+/// Strip fenced code blocks (``` ... ```), indented code lines (4+ spaces / tab),
+/// and double-quoted strings so that tool-intent detection only fires on prose.
 fn strip_code_blocks(text: &str) -> String {
     let mut result = String::new();
     let mut in_fence = false;

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -110,6 +110,56 @@ pub fn llm_signals_tool_intent(response: &str) -> bool {
 
 /// Strip fenced code blocks (``` ... ```), indented code lines (4+ spaces / tab),
 /// and double-quoted strings so that tool-intent detection only fires on prose.
+/// Detect explicit execution intent in a user message.
+///
+/// Returns `true` for imperative requests like "run it", "execute the script",
+/// "fetch the data", "please check the logs". Strips code blocks and quoted
+/// strings before matching to avoid false positives from examples.
+///
+/// Deliberately excludes context-dependent phrases ("go ahead", "yes do it")
+/// that require multi-turn understanding — those belong in a classifier tier.
+pub fn user_signals_execution_intent(text: &str) -> bool {
+    let stripped = strip_code_blocks(text);
+    let lower = stripped.to_lowercase();
+
+    // Imperative verb phrases that require action, not description.
+    // Trailing space on "verb the " prevents partial matches like "fetch them".
+    const EXEC_PHRASES: &[&str] = &[
+        "run it",
+        "run that",
+        "run them",
+        "run this",
+        "run the ",
+        "execute it",
+        "execute that",
+        "execute them",
+        "execute this",
+        "execute the ",
+        "ship it",
+        "deploy it",
+        "deploy that",
+        "deploy this",
+        "deploy the ",
+        "send it",
+        "send that",
+        "send the ",
+        "fetch it",
+        "fetch that",
+        "fetch the ",
+        "check it",
+        "check that",
+        "check the ",
+        "please run ",
+        "please execute ",
+        "please fetch ",
+        "please check ",
+        "please send ",
+        "please deploy ",
+    ];
+
+    EXEC_PHRASES.iter().any(|phrase| lower.contains(phrase))
+}
+
 fn strip_code_blocks(text: &str) -> String {
     let mut result = String::new();
     let mut in_fence = false;
@@ -3744,5 +3794,76 @@ That's my plan."#;
         let selections = reasoning.select_tools(&ctx).await.unwrap();
         assert_eq!(selections.len(), 1);
         assert_eq!(selections[0].tool_name, "memory_write");
+    }
+
+    // ── user_signals_execution_intent tests ──
+
+    #[test]
+    fn execution_intent_imperative_with_pronoun() {
+        assert!(user_signals_execution_intent("run it"));
+        assert!(user_signals_execution_intent("Run That"));
+        assert!(user_signals_execution_intent("execute them"));
+        assert!(user_signals_execution_intent("ship it"));
+        assert!(user_signals_execution_intent("deploy it"));
+        assert!(user_signals_execution_intent("send it"));
+        assert!(user_signals_execution_intent("fetch that"));
+        assert!(user_signals_execution_intent("check it"));
+    }
+
+    #[test]
+    fn execution_intent_imperative_with_object() {
+        assert!(user_signals_execution_intent("run the tests"));
+        assert!(user_signals_execution_intent("execute the script"));
+        assert!(user_signals_execution_intent("fetch the data from the API"));
+        assert!(user_signals_execution_intent("check the logs"));
+        assert!(user_signals_execution_intent("deploy the latest build"));
+        assert!(user_signals_execution_intent("send the message to Bob"));
+    }
+
+    #[test]
+    fn execution_intent_with_please() {
+        assert!(user_signals_execution_intent("please run the tests"));
+        assert!(user_signals_execution_intent("please check the status"));
+        assert!(user_signals_execution_intent("Please Execute the migration"));
+        assert!(user_signals_execution_intent("please fetch the latest data"));
+    }
+
+    #[test]
+    fn execution_intent_negatives() {
+        assert!(!user_signals_execution_intent("what do you think?"));
+        assert!(!user_signals_execution_intent("go ahead"));
+        assert!(!user_signals_execution_intent("yes do it"));
+        assert!(!user_signals_execution_intent("sounds good"));
+        assert!(!user_signals_execution_intent("tell me about the weather"));
+        assert!(!user_signals_execution_intent("how does this work?"));
+        assert!(!user_signals_execution_intent("can you explain the architecture?"));
+        // "try" is too broad — "try this approach" is conversational, not execution
+        assert!(!user_signals_execution_intent("try this approach instead"));
+        assert!(!user_signals_execution_intent("try that library"));
+    }
+
+    #[test]
+    fn execution_intent_ignores_code_blocks() {
+        let msg = "Here is how to test:\n```\nrun the tests\n```\nWhat do you think?";
+        assert!(!user_signals_execution_intent(msg));
+    }
+
+    #[test]
+    fn execution_intent_ignores_quoted_strings() {
+        let msg = "The user said \"run the tests\" but I'm not sure what they meant.";
+        assert!(!user_signals_execution_intent(msg));
+    }
+
+    #[test]
+    fn execution_intent_case_insensitive() {
+        assert!(user_signals_execution_intent("RUN IT"));
+        assert!(user_signals_execution_intent("Execute The Script"));
+        assert!(user_signals_execution_intent("PLEASE CHECK THE LOGS"));
+    }
+
+    #[test]
+    fn execution_intent_embedded_in_longer_message() {
+        assert!(user_signals_execution_intent("ok I think we're ready, run the tests now"));
+        assert!(user_signals_execution_intent("after fixing the bug, please deploy the service"));
     }
 }

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -146,13 +146,9 @@ pub fn user_signals_execution_intent(text: &str) -> bool {
         "fetch it",
         "fetch that",
         "fetch the ",
-        "check it",
-        "check that",
-        "check the ",
         "please run ",
         "please execute ",
         "please fetch ",
-        "please check ",
         "please send ",
         "please deploy ",
     ];
@@ -3807,7 +3803,6 @@ That's my plan."#;
         assert!(user_signals_execution_intent("deploy it"));
         assert!(user_signals_execution_intent("send it"));
         assert!(user_signals_execution_intent("fetch that"));
-        assert!(user_signals_execution_intent("check it"));
     }
 
     #[test]
@@ -3815,7 +3810,6 @@ That's my plan."#;
         assert!(user_signals_execution_intent("run the tests"));
         assert!(user_signals_execution_intent("execute the script"));
         assert!(user_signals_execution_intent("fetch the data from the API"));
-        assert!(user_signals_execution_intent("check the logs"));
         assert!(user_signals_execution_intent("deploy the latest build"));
         assert!(user_signals_execution_intent("send the message to Bob"));
     }
@@ -3823,7 +3817,6 @@ That's my plan."#;
     #[test]
     fn execution_intent_with_please() {
         assert!(user_signals_execution_intent("please run the tests"));
-        assert!(user_signals_execution_intent("please check the status"));
         assert!(user_signals_execution_intent("Please Execute the migration"));
         assert!(user_signals_execution_intent("please fetch the latest data"));
     }
@@ -3840,6 +3833,9 @@ That's my plan."#;
         // "try" is too broad — "try this approach" is conversational, not execution
         assert!(!user_signals_execution_intent("try this approach instead"));
         assert!(!user_signals_execution_intent("try that library"));
+        // "check" is too broad for a personal assistant — "check the schedule" is a query
+        assert!(!user_signals_execution_intent("check the logs"));
+        assert!(!user_signals_execution_intent("check the calendar"));
     }
 
     #[test]
@@ -3858,7 +3854,7 @@ That's my plan."#;
     fn execution_intent_case_insensitive() {
         assert!(user_signals_execution_intent("RUN IT"));
         assert!(user_signals_execution_intent("Execute The Script"));
-        assert!(user_signals_execution_intent("PLEASE CHECK THE LOGS"));
+        assert!(user_signals_execution_intent("PLEASE FETCH THE DATA"));
     }
 
     #[test]

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -3817,8 +3817,12 @@ That's my plan."#;
     #[test]
     fn execution_intent_with_please() {
         assert!(user_signals_execution_intent("please run the tests"));
-        assert!(user_signals_execution_intent("Please Execute the migration"));
-        assert!(user_signals_execution_intent("please fetch the latest data"));
+        assert!(user_signals_execution_intent(
+            "Please Execute the migration"
+        ));
+        assert!(user_signals_execution_intent(
+            "please fetch the latest data"
+        ));
     }
 
     #[test]
@@ -3829,7 +3833,9 @@ That's my plan."#;
         assert!(!user_signals_execution_intent("sounds good"));
         assert!(!user_signals_execution_intent("tell me about the weather"));
         assert!(!user_signals_execution_intent("how does this work?"));
-        assert!(!user_signals_execution_intent("can you explain the architecture?"));
+        assert!(!user_signals_execution_intent(
+            "can you explain the architecture?"
+        ));
         // "try" is too broad — "try this approach" is conversational, not execution
         assert!(!user_signals_execution_intent("try this approach instead"));
         assert!(!user_signals_execution_intent("try that library"));
@@ -3859,7 +3865,11 @@ That's my plan."#;
 
     #[test]
     fn execution_intent_embedded_in_longer_message() {
-        assert!(user_signals_execution_intent("ok I think we're ready, run the tests now"));
-        assert!(user_signals_execution_intent("after fixing the bug, please deploy the service"));
+        assert!(user_signals_execution_intent(
+            "ok I think we're ready, run the tests now"
+        ));
+        assert!(user_signals_execution_intent(
+            "after fixing the bug, please deploy the service"
+        ));
     }
 }

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -348,4 +348,69 @@ mod engine_v2_tests {
         assert_v2_tool_used(&rig.tool_calls_started(), "http");
         rig.shutdown();
     }
+
+    /// Execution obligation: user says "run the echo tool", model first responds
+    /// with a false capability refusal (text only), obligation nudge fires, then
+    /// the model makes the tool call on the second attempt.
+    #[tokio::test]
+    async fn v2_execution_obligation_nudge_fires() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace =
+            LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_nudge.json")).unwrap();
+        let rig = TestRigBuilder::new()
+            .with_engine_v2()
+            .with_trace(trace.clone())
+            .build()
+            .await;
+
+        // "run the echo tool" triggers user_signals_execution_intent → require_action_attempt
+        rig.send_message("run the echo tool with 'obligation echo test'")
+            .await;
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+
+        rig.verify_trace_expects(&trace, &responses);
+        assert_v2_tool_used(&rig.tool_calls_started(), "echo");
+
+        // Verify the nudge message was injected (LLM was called at least twice:
+        // once for the text refusal, once after the nudge)
+        let llm_requests = rig.captured_llm_requests();
+        assert!(
+            llm_requests.len() >= 2,
+            "expected at least 2 LLM calls (refusal + post-nudge), got {}",
+            llm_requests.len()
+        );
+
+        rig.shutdown();
+    }
+
+    /// No obligation nudge on conversational messages that don't signal
+    /// execution intent. The model responds with plain text and it's accepted.
+    #[tokio::test]
+    async fn v2_execution_obligation_no_nudge_on_conversational() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace =
+            LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_no_nudge.json")).unwrap();
+        let rig = TestRigBuilder::new()
+            .with_engine_v2()
+            .with_trace(trace.clone())
+            .build()
+            .await;
+
+        // "What's the weather?" has no execution intent → no obligation
+        rig.send_message("What's the weather like today?").await;
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+
+        rig.verify_trace_expects(&trace, &responses);
+
+        // Only 1 LLM call — no nudge injected
+        let llm_requests = rig.captured_llm_requests();
+        assert_eq!(
+            llm_requests.len(),
+            1,
+            "expected exactly 1 LLM call (no nudge), got {}",
+            llm_requests.len()
+        );
+
+        rig.shutdown();
+    }
 }

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -456,13 +456,14 @@ mod engine_v2_tests {
         rig.shutdown();
     }
 
-    /// Execution obligation on follow-up: first message is conversational (no
-    /// obligation), second message says "run the echo tool" (obligation fires
-    /// via per-message intent detection in the orchestrator). This tests the
-    /// inject-into-running-thread path where the thread config did not have
-    /// require_action_attempt set at spawn time.
+    /// Execution obligation on multi-turn: first message is conversational (no
+    /// obligation), second message says "run the echo tool" and obligation fires.
+    /// The test rig processes messages sequentially, so turn 2 spawns a new
+    /// thread (the spawn path, where ThreadConfig.require_action_attempt is set
+    /// by the router). The inject and resume paths are tested separately in
+    /// engine_v2_gate_integration.rs (gate_resume_with_execution_obligation).
     #[tokio::test]
-    async fn v2_execution_obligation_followup_inject() {
+    async fn v2_execution_obligation_multi_turn() {
         let _guard = engine_v2_test_lock().lock().await;
         let trace =
             LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_followup.json")).unwrap();

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -420,9 +420,8 @@ mod engine_v2_tests {
     #[tokio::test]
     async fn v2_execution_obligation_exhaustion_terminates() {
         let _guard = engine_v2_test_lock().lock().await;
-        let trace =
-            LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_exhaustion.json"))
-                .unwrap();
+        let trace = LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_exhaustion.json"))
+            .unwrap();
         let rig = TestRigBuilder::new()
             .with_engine_v2()
             .with_trace(trace.clone())

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -455,4 +455,43 @@ mod engine_v2_tests {
 
         rig.shutdown();
     }
+
+    /// Execution obligation on follow-up: first message is conversational (no
+    /// obligation), second message says "run the echo tool" (obligation fires
+    /// via per-message intent detection in the orchestrator). This tests the
+    /// inject-into-running-thread path where the thread config did not have
+    /// require_action_attempt set at spawn time.
+    #[tokio::test]
+    async fn v2_execution_obligation_followup_inject() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace =
+            LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_followup.json")).unwrap();
+        let rig = TestRigBuilder::new()
+            .with_engine_v2()
+            .with_trace(trace.clone())
+            .build()
+            .await;
+
+        let all_responses = rig.run_and_verify_trace(&trace, TIMEOUT).await;
+
+        // Turn 1: conversational, no tools
+        assert!(
+            !all_responses[0].is_empty(),
+            "turn 1 should produce a response"
+        );
+
+        // Turn 2: obligation should have fired — echo tool was used
+        assert_v2_tool_used(&rig.tool_calls_started(), "echo");
+
+        // The nudge should have been injected (at least 2 LLM calls for turn 2:
+        // text refusal + post-nudge tool call). Turn 1 had 1 LLM call.
+        let llm_requests = rig.captured_llm_requests();
+        assert!(
+            llm_requests.len() >= 3,
+            "expected at least 3 LLM calls (1 for turn 1 + 2+ for turn 2 with nudge), got {}",
+            llm_requests.len()
+        );
+
+        rig.shutdown();
+    }
 }

--- a/tests/e2e_engine_v2.rs
+++ b/tests/e2e_engine_v2.rs
@@ -413,4 +413,47 @@ mod engine_v2_tests {
 
         rig.shutdown();
     }
+
+    /// Execution obligation exhaustion: model refuses to call tools on every
+    /// attempt, hitting max_action_requirement_nudges. The final text response
+    /// is accepted as completed (the feature terminates, no infinite loop).
+    #[tokio::test]
+    async fn v2_execution_obligation_exhaustion_terminates() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace =
+            LlmTrace::from_file(format!("{FIXTURES}/execution_obligation_exhaustion.json"))
+                .unwrap();
+        let rig = TestRigBuilder::new()
+            .with_engine_v2()
+            .with_trace(trace.clone())
+            .build()
+            .await;
+
+        // "run the echo tool" triggers obligation, but model refuses every time
+        rig.send_message("run the echo tool please").await;
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+
+        // Should get a response (not hang or error)
+        assert!(
+            !responses.is_empty(),
+            "should get a response even after nudge exhaustion"
+        );
+
+        // LLM called 3 times: initial refusal + 2 nudges (max_action_requirement_nudges=2)
+        let llm_requests = rig.captured_llm_requests();
+        assert_eq!(
+            llm_requests.len(),
+            3,
+            "expected 3 LLM calls (1 refusal + 2 nudges), got {}",
+            llm_requests.len()
+        );
+
+        // No tools were called
+        assert!(
+            rig.tool_calls_started().is_empty(),
+            "no tools should have been called"
+        );
+
+        rig.shutdown();
+    }
 }

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -2128,9 +2128,7 @@ async fn gate_resume_with_execution_obligation() {
         // refusal. The orchestrator should detect "run the echo tool" intent from
         // the injected resume message and fire the obligation nudge.
         LlmOutput {
-            response: LlmResponse::Text(
-                "I cannot execute tools from this reply path.".into(),
-            ),
+            response: LlmResponse::Text("I cannot execute tools from this reply path.".into()),
             usage: TokenUsage::default(),
         },
         // After obligation nudge: echo tool call

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -2097,3 +2097,130 @@ async fn auto_approve_mode_still_pauses_always_tools() {
     // Verify the mode is correctly propagated
     assert_eq!(ctx.execution_mode, ExecutionMode::InteractiveAutoApprove);
 }
+
+/// Execution obligation fires on the resume path: a thread hits a gate,
+/// is resumed with a user message that signals execution intent ("run the
+/// echo tool"), and the orchestrator's per-message intent detection enables
+/// the obligation nudge even though the thread config did not have
+/// `require_action_attempt` set at spawn time.
+#[tokio::test]
+async fn gate_resume_with_execution_obligation() {
+    let project_id = ProjectId::new();
+    let effects = GateMockEffects::new(vec!["http".into()], vec![]);
+
+    // LLM responses for both phases:
+    // Phase 1 (initial): tool_call(http) → gate fires
+    // Phase 2 (resume):  text refusal → obligation nudge → tool_call(echo) → text done
+    let llm = ScriptedLlm::new(vec![
+        // Phase 1: triggers the http gate
+        LlmOutput {
+            response: LlmResponse::ActionCalls {
+                calls: vec![ironclaw_engine::ActionCall {
+                    id: "call_http_1".into(),
+                    action_name: "http".into(),
+                    parameters: serde_json::json!({"url": "https://example.com"}),
+                }],
+                content: None,
+            },
+            usage: TokenUsage::default(),
+        },
+        // Phase 2 after resume: http succeeds (approved), then LLM returns text
+        // refusal. The orchestrator should detect "run the echo tool" intent from
+        // the injected resume message and fire the obligation nudge.
+        LlmOutput {
+            response: LlmResponse::Text(
+                "I cannot execute tools from this reply path.".into(),
+            ),
+            usage: TokenUsage::default(),
+        },
+        // After obligation nudge: echo tool call
+        LlmOutput {
+            response: LlmResponse::ActionCalls {
+                calls: vec![ironclaw_engine::ActionCall {
+                    id: "call_echo_1".into(),
+                    action_name: "echo".into(),
+                    parameters: serde_json::json!({"message": "obligation resume test"}),
+                }],
+                content: None,
+            },
+            usage: TokenUsage::default(),
+        },
+        // Final text
+        LlmOutput {
+            response: LlmResponse::Text("Echo returned: obligation resume test".into()),
+            usage: TokenUsage::default(),
+        },
+    ]);
+
+    let store = TestStore::new();
+    let mgr = ThreadManager::new(
+        llm,
+        effects.clone(),
+        store.clone() as Arc<dyn Store>,
+        Arc::new(make_caps(false)),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    );
+
+    // Phase 1: spawn with NO execution intent in the goal
+    let tid = mgr
+        .spawn_thread(
+            "check the api status",
+            ThreadType::Foreground,
+            project_id,
+            ThreadConfig::default(), // require_action_attempt = false
+            None,
+            "test-user",
+        )
+        .await
+        .expect("spawn_thread");
+
+    let first = mgr.join_thread(tid).await.expect("first join");
+    assert!(
+        matches!(first, ThreadOutcome::GatePaused { .. }),
+        "expected GatePaused, got: {first:?}"
+    );
+    assert_eq!(
+        store.load_thread(tid).await.unwrap().unwrap().state,
+        ThreadState::Waiting,
+    );
+
+    // Phase 2: approve the gate, resume with execution intent message.
+    // "run the echo tool" triggers signals_execution_intent() in the Python
+    // orchestrator's context check on run_loop startup.
+    effects.mark_approved("http").await;
+    mgr.resume_thread(
+        tid,
+        "test-user",
+        Some(ThreadMessage::user(
+            "run the echo tool with 'obligation resume test'",
+        )),
+        Some(("call_gate_1".into(), true)),
+        None,
+    )
+    .await
+    .expect("resume_thread");
+
+    let resumed = mgr.join_thread(tid).await.expect("second join");
+    assert!(
+        matches!(resumed, ThreadOutcome::Completed { .. }),
+        "expected Completed, got: {resumed:?}"
+    );
+
+    // Verify the echo tool was called — proves obligation worked.
+    // Without the per-message intent detection fix, the LLM's text refusal
+    // would have been accepted as the final response (no nudge), and the
+    // echo tool would never execute.
+    let thread = store.load_thread(tid).await.unwrap().unwrap();
+    let echo_executed = thread.events.iter().any(|e| {
+        matches!(
+            &e.kind,
+            ironclaw_engine::types::event::EventKind::ActionExecuted { action_name, .. }
+                if action_name == "echo"
+        )
+    });
+    assert!(
+        echo_executed,
+        "echo tool should have been called after obligation nudge on resume"
+    );
+}

--- a/tests/fixtures/llm_traces/engine_v2/execution_obligation_exhaustion.json
+++ b/tests/fixtures/llm_traces/engine_v2/execution_obligation_exhaustion.json
@@ -1,0 +1,42 @@
+{
+  "model_name": "v2-execution-obligation-exhaustion",
+  "expects": {
+    "response_contains": ["cannot"],
+    "min_responses": 1
+  },
+  "steps": [
+    {
+      "request_hint": {
+        "last_user_message_contains": "run"
+      },
+      "response": {
+        "type": "text",
+        "content": "I cannot run that tool right now because it is not available.",
+        "input_tokens": 100,
+        "output_tokens": 20
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "asked to perform"
+      },
+      "response": {
+        "type": "text",
+        "content": "I still cannot run the tool. It does not appear to be available in my current configuration.",
+        "input_tokens": 200,
+        "output_tokens": 25
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "asked to perform"
+      },
+      "response": {
+        "type": "text",
+        "content": "I cannot execute this tool. Please verify the tool is installed and try again.",
+        "input_tokens": 300,
+        "output_tokens": 20
+      }
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/engine_v2/execution_obligation_followup.json
+++ b/tests/fixtures/llm_traces/engine_v2/execution_obligation_followup.json
@@ -1,0 +1,75 @@
+{
+  "model_name": "v2-execution-obligation-followup",
+  "expects": {
+    "min_responses": 2
+  },
+  "turns": [
+    {
+      "user_input": "What tools do you have available?",
+      "steps": [
+        {
+          "request_hint": {
+            "last_user_message_contains": "tools"
+          },
+          "response": {
+            "type": "text",
+            "content": "I have several tools available including echo, time, and http.",
+            "input_tokens": 100,
+            "output_tokens": 20
+          }
+        }
+      ],
+      "expects": {
+        "response_contains": ["echo"],
+        "min_responses": 1
+      }
+    },
+    {
+      "user_input": "run the echo tool with 'followup obligation test'",
+      "steps": [
+        {
+          "request_hint": {
+            "last_user_message_contains": "run"
+          },
+          "response": {
+            "type": "text",
+            "content": "I can describe what the echo tool does but I cannot execute it from this context.",
+            "input_tokens": 200,
+            "output_tokens": 25
+          }
+        },
+        {
+          "request_hint": {
+            "last_user_message_contains": "asked to perform"
+          },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_followup_echo_1",
+                "name": "echo",
+                "arguments": {
+                  "message": "followup obligation test"
+                }
+              }
+            ],
+            "input_tokens": 300,
+            "output_tokens": 30
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The echo tool returned: followup obligation test",
+            "input_tokens": 350,
+            "output_tokens": 15
+          }
+        }
+      ],
+      "expects": {
+        "response_contains": ["followup obligation test"],
+        "min_responses": 1
+      }
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/engine_v2/execution_obligation_no_nudge.json
+++ b/tests/fixtures/llm_traces/engine_v2/execution_obligation_no_nudge.json
@@ -1,0 +1,17 @@
+{
+  "model_name": "v2-execution-obligation-no-nudge",
+  "expects": {
+    "response_contains": ["weather"],
+    "min_responses": 1
+  },
+  "steps": [
+    {
+      "response": {
+        "type": "text",
+        "content": "The weather today is sunny with a high of 22 degrees.",
+        "input_tokens": 100,
+        "output_tokens": 20
+      }
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/engine_v2/execution_obligation_nudge.json
+++ b/tests/fixtures/llm_traces/engine_v2/execution_obligation_nudge.json
@@ -1,0 +1,47 @@
+{
+  "model_name": "v2-execution-obligation-nudge",
+  "expects": {
+    "response_contains": ["echo test"],
+    "min_responses": 1
+  },
+  "steps": [
+    {
+      "request_hint": {
+        "last_user_message_contains": "run"
+      },
+      "response": {
+        "type": "text",
+        "content": "I cannot execute tools from this reply path. Let me explain what would happen if I ran the echo tool.",
+        "input_tokens": 100,
+        "output_tokens": 30
+      }
+    },
+    {
+      "request_hint": {
+        "last_user_message_contains": "asked to perform"
+      },
+      "response": {
+        "type": "tool_calls",
+        "tool_calls": [
+          {
+            "id": "call_obligation_echo_1",
+            "name": "echo",
+            "arguments": {
+              "message": "obligation echo test"
+            }
+          }
+        ],
+        "input_tokens": 200,
+        "output_tokens": 30
+      }
+    },
+    {
+      "response": {
+        "type": "text",
+        "content": "The echo tool returned: obligation echo test",
+        "input_tokens": 250,
+        "output_tokens": 15
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

When a user explicitly asks the v2 engine to execute something ("run the tests", "fetch the data"), the model can respond with a false capability refusal without ever attempting a tool call. This adds an execution obligation that nudges the model to actually try before accepting text-only responses.

## Problem

In v2, `tool_choice("auto")` lets the model decide whether to call tools. The existing `signals_tool_intent()` nudge catches cases where the model says "I'll search for..." without calling a tool, but doesn't catch outright refusals. User says "run the echo tool", model responds "I cannot execute tools from this reply path", engine accepts that as final.

## Approach

1. **Intent detection** (`reasoning.rs`): `user_signals_execution_intent()` detects imperative execution phrases in user messages. Strips code blocks and quoted strings. Deliberately conservative -- excludes context-dependent phrases ("go ahead"), ambiguous verbs ("try", "check"), and question framing ("can you run"). The heuristic is intentionally narrow. The obligation infrastructure (`require_action_attempt` on ThreadConfig, set by the router) is detection-strategy-agnostic, so a more sophisticated classifier can be swapped in without changing the enforcement side.

2. **Obligation enforcement** (`default.py`): When `require_action_attempt` is set, the orchestrator refuses text-only FINAL until the model attempts at least one action/code path. Only fires when tools are available (`__get_actions__()`). Mutually exclusive with existing tool-intent nudge. Resolves on entering action/code branch (before execution) so approval gates don't cause retry loops. Bounded by `max_action_requirement_nudges` (default 2).

**Open question:** Is this the right level of conservatism for the heuristic, or should it cast a wider net? The nudge budget bounds the downside of false positives, so being more aggressive has a low cost. Context-dependent phrases ("go ahead", "yes do it") and ambiguous verbs ("check the ...") were excluded because they produced false positives in testing, but reasonable people could disagree.

## Test plan

8 unit tests for the heuristic (positives, negatives, code block/quote immunity, case insensitivity). 3 e2e tests through the full engine pipeline (router -> thread -> Python orchestrator -> trace LLM):

- **Nudge fires:** "run the echo tool" -> model text refusal -> nudge injected -> model calls tool on retry. Asserts tool called and >= 2 LLM invocations.
- **No nudge on conversational:** "What's the weather?" -> text accepted in 1 LLM call.
- **Exhaustion terminates:** "run the echo tool" -> model refuses 3 times -> nudge budget exhausted -> text accepted as final. Asserts 3 LLM calls, no tools called. Proves the feature terminates.

```
$ cargo test --lib -- reasoning::tests::execution_intent
test result: ok. 8 passed; 0 failed

$ cargo test --features libsql --test e2e_engine_v2
test result: ok. 12 passed; 0 failed (9 existing + 3 new)
```

Addresses #2447