### PR TITLE
fix: owner_id was stored as string when recovered from settings on restart

### DIFF
--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -855,6 +855,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn register_channel_injects_settings_owner_id_as_number() {
+        let (mut config, _temp_dir) = test_config();
+        config
+            .channels
+            .wasm_channel_owner_ids
+            .insert("telegram".to_string(), 176326495);
+        let loaded = test_loaded_channel("telegram", serde_json::json!({ "owner_id": null }));
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let pairing_store = Arc::new(PairingStore::new_noop());
+
+        let (_name, _channel) =
+            super::register_channel(loaded, &config, &None, None, &pairing_store, &wasm_router)
+                .await;
+
+        let registered = wasm_router
+            .get_channel_for_path("/webhook/telegram")
+            .await
+            .expect("telegram channel should be registered");
+        let runtime_config = registered.get_config().await;
+        let owner_id = runtime_config
+            .get("owner_id")
+            .expect("owner_id should be in config");
+        assert_eq!(
+            owner_id,
+            &serde_json::json!(176326495),
+            "owner_id recovered from settings must be a JSON number, not a string"
+        );
+    }
+
+    #[tokio::test]
     async fn register_channel_does_not_inject_null_owner_id_to_config() {
         let (config, _temp_dir) = test_config();
         let loaded = test_loaded_channel("telegram", serde_json::json!({ "owner_id": null }));

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -224,29 +224,11 @@ async fn register_channel(
 
     // Inject runtime config (tunnel URL, webhook secret, owner_id).
     {
-        let mut config_updates = std::collections::HashMap::new();
-
-        if let Some(ref tunnel_url) = config.tunnel.public_url {
-            config_updates.insert(
-                "tunnel_url".to_string(),
-                serde_json::Value::String(tunnel_url.clone()),
-            );
-        }
-
-        if let Some(ref secret) = webhook_secret {
-            config_updates.insert(
-                "webhook_secret".to_string(),
-                serde_json::Value::String(secret.clone()),
-            );
-        }
-
-        if let Some(ref resolved_owner_id) = owner_actor_id {
-            let owner_id_value = resolved_owner_id
-                .parse::<i64>()
-                .map(serde_json::Value::from)
-                .unwrap_or_else(|_| serde_json::Value::String(resolved_owner_id.clone()));
-            config_updates.insert("owner_id".to_string(), owner_id_value);
-        }
+        let mut config_updates = crate::pairing::approval::build_runtime_config_updates(
+            config.tunnel.public_url.as_deref(),
+            webhook_secret.as_deref(),
+            owner_actor_id.as_deref(),
+        );
 
         if channel_name == TELEGRAM_CHANNEL_NAME
             && let Some(store) = settings_store

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -241,10 +241,11 @@ async fn register_channel(
         }
 
         if let Some(ref resolved_owner_id) = owner_actor_id {
-            config_updates.insert(
-                "owner_id".to_string(),
-                serde_json::Value::String(resolved_owner_id.clone()),
-            );
+            let owner_id_value = resolved_owner_id
+                .parse::<i64>()
+                .map(serde_json::Value::from)
+                .unwrap_or_else(|_| serde_json::Value::String(resolved_owner_id.clone()));
+            config_updates.insert("owner_id".to_string(), owner_id_value);
         }
 
         if channel_name == TELEGRAM_CHANNEL_NAME
@@ -850,7 +851,7 @@ mod tests {
         let owner_id = runtime_config
             .get("owner_id")
             .expect("owner_id should be in config");
-        assert_eq!(owner_id, &serde_json::json!("12345"));
+        assert_eq!(owner_id, &serde_json::json!(12345));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Telegram channel stopped working on staging
- The issue is that we correctly store the owner-id (after pairing) as u64, but then recover it as a string, and that makes the channel unable to start:

```
00: 45:07.702 ERROR Failed to start channel telegram: Channel telegram failed to start: Channel telegram callback failed: Failed to parse config: invalid type: string "176326495", expected 164 at line 1 column 47
```

- This PR fixes this by correctly casting the stored value as u64 using an already existing function
- Regression test added 

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: I discovered this because my telegram stopped working, this fixes it
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

None

## Blast Radius

Fixes telegram channel

---

**Review track**: A (small fix)
