### PR TITLE
Fix WASM channel startup restore semantics

### DIFF
--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -65,6 +65,7 @@ pub async fn setup_wasm_channels(
     extension_manager: Option<&Arc<ExtensionManager>>,
     database: Option<&Arc<dyn Database>>,
     registered_channel_names: &[String],
+    startup_active_channel_names: &HashSet<String>,
     ownership_cache: Arc<crate::ownership::OwnershipCache>,
 ) -> Option<WasmChannelSetup> {
     let runtime = match WasmChannelRuntime::new(WasmChannelRuntimeConfig::default()) {
@@ -105,52 +106,17 @@ pub async fn setup_wasm_channels(
     };
 
     let wasm_router = Arc::new(WasmChannelRouter::new());
-    let mut channels: Vec<(String, Box<dyn crate::channels::Channel>)> = Vec::new();
-    let mut channel_names: Vec<String> = Vec::new();
-
-    // Reserved channel names that WASM modules must not claim.
-    // A malicious module could otherwise register as a trusted built-in
-    // channel and bypass cross-channel authorization checks.
-    //
-    // This list includes:
-    // - All native/built-in channel names (prevent impersonation)
-    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
-    // - The bootstrap sentinel (universal approval wildcard)
-    for loaded in results.loaded {
-        let name_lower = loaded.name().to_ascii_lowercase();
-        if is_reserved_wasm_channel_name(&name_lower) {
-            tracing::warn!(
-                channel = %loaded.name(),
-                "Rejected WASM channel with reserved name"
-            );
-            continue;
-        }
-        // Also reject any name that collides with an already-registered
-        // channel to prevent a WASM module from shadowing a channel that
-        // was registered earlier in the startup sequence.
-        if registered_channel_names
-            .iter()
-            .any(|n| n.to_ascii_lowercase() == name_lower)
-        {
-            tracing::warn!(
-                channel = %loaded.name(),
-                "Rejected WASM channel that collides with already-registered channel"
-            );
-            continue;
-        }
-
-        let (name, channel) = register_channel(
-            loaded,
-            config,
-            secrets_store,
-            settings_store.as_ref(),
-            &pairing_store,
-            &wasm_router,
-        )
-        .await;
-        channel_names.push(name.clone());
-        channels.push((name, channel));
-    }
+    let (channels, channel_names) = register_startup_channels(
+        results.loaded,
+        config,
+        secrets_store,
+        settings_store.as_ref(),
+        registered_channel_names,
+        startup_active_channel_names,
+        &pairing_store,
+        &wasm_router,
+    )
+    .await;
 
     for (path, err) in &results.errors {
         tracing::warn!("Failed to load WASM channel {}: {}", path.display(), err);
@@ -173,6 +139,78 @@ pub async fn setup_wasm_channels(
         pairing_store,
         wasm_channel_router: wasm_router,
     })
+}
+
+async fn register_startup_channels(
+    loaded_channels: Vec<LoadedChannel>,
+    config: &Config,
+    secrets_store: &Option<Arc<dyn SecretsStore + Send + Sync>>,
+    settings_store: Option<&Arc<dyn crate::db::SettingsStore>>,
+    registered_channel_names: &[String],
+    startup_active_channel_names: &HashSet<String>,
+    pairing_store: &Arc<PairingStore>,
+    wasm_router: &Arc<WasmChannelRouter>,
+) -> (
+    Vec<(String, Box<dyn crate::channels::Channel>)>,
+    Vec<String>,
+) {
+    let mut channels: Vec<(String, Box<dyn crate::channels::Channel>)> = Vec::new();
+    let mut channel_names: Vec<String> = Vec::new();
+
+    // Reserved channel names that WASM modules must not claim.
+    // A malicious module could otherwise register as a trusted built-in
+    // channel and bypass cross-channel authorization checks.
+    //
+    // This list includes:
+    // - All native/built-in channel names (prevent impersonation)
+    // - Trusted approval channels from session::TRUSTED_APPROVAL_CHANNELS
+    // - The bootstrap sentinel (universal approval wildcard)
+    for loaded in loaded_channels {
+        let channel_name = loaded.name().to_string();
+        if !startup_active_channel_names.contains(&channel_name) {
+            tracing::debug!(
+                channel = %channel_name,
+                "Skipping installed but inactive WASM channel during startup restore"
+            );
+            continue;
+        }
+
+        let name_lower = channel_name.to_ascii_lowercase();
+        if is_reserved_wasm_channel_name(&name_lower) {
+            tracing::warn!(
+                channel = %channel_name,
+                "Rejected WASM channel with reserved name"
+            );
+            continue;
+        }
+        // Also reject any name that collides with an already-registered
+        // channel to prevent a WASM module from shadowing a channel that
+        // was registered earlier in the startup sequence.
+        if registered_channel_names
+            .iter()
+            .any(|n| n.to_ascii_lowercase() == name_lower)
+        {
+            tracing::warn!(
+                channel = %channel_name,
+                "Rejected WASM channel that collides with already-registered channel"
+            );
+            continue;
+        }
+
+        let (name, channel) = register_channel(
+            loaded,
+            config,
+            secrets_store,
+            settings_store,
+            pairing_store,
+            wasm_router,
+        )
+        .await;
+        channel_names.push(name.clone());
+        channels.push((name, channel));
+    }
+
+    (channels, channel_names)
 }
 
 /// Process a single loaded WASM channel: retrieve secrets, inject config,
@@ -593,7 +631,7 @@ async fn inject_channel_secrets_into_config(
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashMap;
+    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
 
     use super::reserved_wasm_channel_names;
@@ -872,6 +910,52 @@ mod tests {
             registered.owner_actor_id_for_test().await,
             None,
             "null owner_id from capabilities should not resolve"
+        );
+    }
+
+    #[tokio::test]
+    async fn register_startup_channels_only_restores_persisted_active_channels() {
+        let (config, _temp_dir) = test_config();
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let pairing_store = Arc::new(PairingStore::new_noop());
+        let loaded_channels = vec![
+            test_loaded_channel("telegram", serde_json::json!({ "owner_id": 12345 })),
+            test_loaded_channel("discord", serde_json::json!({ "owner_id": 67890 })),
+        ];
+        let startup_active_channel_names =
+            HashSet::from([String::from("telegram"), String::from("missing_channel")]);
+
+        let (channels, channel_names) = super::register_startup_channels(
+            loaded_channels,
+            &config,
+            &None,
+            None,
+            &[],
+            &startup_active_channel_names,
+            &pairing_store,
+            &wasm_router,
+        )
+        .await;
+
+        assert_eq!(
+            channels.len(),
+            1,
+            "only the persisted active channel should restore"
+        );
+        assert_eq!(channel_names, vec!["telegram"]);
+        assert!(
+            wasm_router
+                .get_channel_for_path("/webhook/telegram")
+                .await
+                .is_some(),
+            "persisted active channel should be registered on the webhook router"
+        );
+        assert!(
+            wasm_router
+                .get_channel_for_path("/webhook/discord")
+                .await
+                .is_none(),
+            "installed but inactive channel should not be registered on the webhook router"
         );
     }
 

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -5855,6 +5855,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extensions_list_handler_reports_installed_inactive_wasm_channel_as_inactive() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let secrets = test_secrets_store();
+        let (ext_mgr, _wasm_tools_dir, wasm_channels_dir) = test_ext_mgr(secrets);
+        std::fs::write(wasm_channels_dir.path().join("telegram.wasm"), b"fake-wasm")
+            .expect("write fake telegram wasm");
+        std::fs::write(
+            wasm_channels_dir.path().join("telegram.capabilities.json"),
+            serde_json::json!({
+                "type": "channel",
+                "name": "telegram",
+                "description": "Telegram",
+                "capabilities": {
+                    "channel": {
+                        "allowed_paths": ["/webhook/telegram"]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write telegram capabilities");
+
+        let state = test_gateway_state(Some(ext_mgr));
+        let app = Router::new()
+            .route("/api/extensions", get(extensions_list_handler))
+            .with_state(state);
+
+        let mut req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("json response");
+        let telegram = parsed["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("telegram extensions entry");
+
+        assert_eq!(telegram["kind"], "wasm_channel");
+        assert_eq!(telegram["active"], false);
+        assert_eq!(telegram["activation_status"], "installed");
+    }
+
+    #[tokio::test]
     async fn test_llm_test_connection_allows_admin_private_base_url() {
         use axum::body::Body;
         use tower::ServiceExt;

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -23,6 +23,12 @@ pub struct ChannelsConfig {
     pub wasm_channels_dir: std::path::PathBuf,
     /// Whether WASM channels are enabled.
     pub wasm_channels_enabled: bool,
+    /// Channel names that the setup wizard explicitly configured for startup.
+    ///
+    /// This is separate from runtime `activated_channels`, which is managed by
+    /// extension activation flows. Startup uses this list only as a fallback
+    /// before any runtime activation state has been persisted.
+    pub configured_wasm_channels: Vec<String>,
     /// Per-channel owner user IDs. When set, the channel only responds to this user.
     /// Key: channel name (e.g., "telegram"), Value: owner user ID.
     pub wasm_channel_owner_ids: HashMap<String, i64>,
@@ -424,6 +430,7 @@ impl ChannelsConfig {
                 defaults.wasm_channels_enabled,
                 "WASM_CHANNELS_ENABLED",
             )?,
+            configured_wasm_channels: cs.wasm_channels.clone(),
             wasm_channel_owner_ids: {
                 let mut ids = cs.wasm_channel_owner_ids.clone();
                 // Backwards compat: TELEGRAM_OWNER_ID env var
@@ -617,6 +624,7 @@ mod tests {
             tui: None,
             wasm_channels_dir: PathBuf::from("/tmp/channels"),
             wasm_channels_enabled: true,
+            configured_wasm_channels: Vec::new(),
             wasm_channel_owner_ids: HashMap::new(),
         };
         assert!(cfg.cli.enabled);
@@ -642,11 +650,13 @@ mod tests {
             tui: None,
             wasm_channels_dir: PathBuf::from("/opt/channels"),
             wasm_channels_enabled: false,
+            configured_wasm_channels: vec!["telegram".to_string()],
             wasm_channel_owner_ids: ids,
         };
         assert_eq!(cfg.wasm_channel_owner_ids.get("telegram"), Some(&12345));
         assert_eq!(cfg.wasm_channel_owner_ids.get("slack"), Some(&67890));
         assert!(!cfg.wasm_channels_enabled);
+        assert_eq!(cfg.configured_wasm_channels, vec!["telegram"]);
     }
 
     #[test]
@@ -676,6 +686,7 @@ mod tests {
         settings.channels.signal_allow_from = Some("+15551234567,+15557654321".to_string());
         settings.channels.wasm_channels_dir = Some(PathBuf::from("/tmp/settings-channels"));
         settings.channels.wasm_channels_enabled = false;
+        settings.channels.wasm_channels = vec!["telegram".to_string(), "discord".to_string()];
 
         let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
 
@@ -698,6 +709,10 @@ mod tests {
             PathBuf::from("/tmp/settings-channels")
         );
         assert!(!cfg.wasm_channels_enabled);
+        assert_eq!(
+            cfg.configured_wasm_channels,
+            vec!["telegram".to_string(), "discord".to_string()]
+        );
 
         // SAFETY: under ENV_MUTEX
         unsafe { std::env::remove_var("GATEWAY_AUTH_TOKEN") };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -186,6 +186,7 @@ impl Config {
                 tui: None,
                 wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),
                 wasm_channels_enabled: false,
+                configured_wasm_channels: Vec::new(),
                 wasm_channel_owner_ids: HashMap::new(),
             },
             agent: AgentConfig::for_testing(),

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -26,7 +26,10 @@ use crate::extensions::{
     ExtensionError, ExtensionKind, ExtensionPhase, ExtensionSource, InstallResult,
     InstalledExtension, LatentProviderAction, RegistryEntry, ResultSource, SearchResult,
     ToolAuthState, UpgradeOutcome, UpgradeResult,
-    naming::{canonicalize_extension_name, extension_name_candidates, legacy_extension_alias},
+    naming::{
+        canonicalize_extension_name, extension_name_candidates, legacy_extension_alias,
+        normalize_extension_names,
+    },
 };
 use crate::hooks::HookRegistry;
 use crate::pairing::PairingStore;
@@ -392,7 +395,10 @@ pub struct ExtensionManager {
     /// When set, settings reads/writes go through this cache-backed store
     /// instead of the raw `Database`. Populated via `with_settings_store()`.
     settings_override: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
-    /// Names of WASM channels that were successfully loaded at startup.
+    /// Names of channels that are currently running in the process.
+    ///
+    /// For WASM channels this is no longer seeded from on-disk discovery at
+    /// boot; startup only records channels that were actually restored.
     active_channel_names: RwLock<HashSet<String>>,
     /// Installed channel-relay extensions (no on-disk artifact, tracked in memory).
     installed_relay_extensions: RwLock<HashSet<String>>,
@@ -1060,8 +1066,10 @@ impl ExtensionManager {
         self.mcp_clients.write().await.insert(name, client);
     }
 
-    /// Register channel names that were loaded at startup.
-    /// Called after WASM channels are loaded so `list()` reports accurate active status.
+    /// Register channels that are already running.
+    ///
+    /// Called after startup restore so `list()` reports actual active status
+    /// rather than mere on-disk installation.
     pub async fn set_active_channels(&self, names: Vec<String>) {
         let mut active = self.active_channel_names.write().await;
         active.extend(names);
@@ -1099,14 +1107,45 @@ impl ExtensionManager {
             return Vec::new();
         };
         match store.get_setting(user_id, "activated_channels").await {
-            Ok(Some(value)) => match serde_json::from_value(value) {
-                Ok(names) => names,
+            Ok(Some(value)) => match serde_json::from_value::<Vec<String>>(value) {
+                Ok(names) => normalize_extension_names(names),
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to deserialize activated_channels");
                     Vec::new()
                 }
             },
             Ok(None) => Vec::new(),
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load activated_channels setting");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Resolve which channels should be restored at startup.
+    ///
+    /// `activated_channels` is authoritative once present, including an empty
+    /// list after the user deactivates everything. The setup wizard's
+    /// `channels.wasm_channels` list is only a first-run fallback before any
+    /// runtime activation state has been persisted.
+    pub async fn load_startup_active_channels(
+        &self,
+        user_id: &str,
+        configured_names: Vec<String>,
+    ) -> Vec<String> {
+        let Some(store) = self.settings_store() else {
+            return normalize_extension_names(configured_names);
+        };
+
+        match store.get_setting(user_id, "activated_channels").await {
+            Ok(Some(value)) => match serde_json::from_value::<Vec<String>>(value) {
+                Ok(names) => normalize_extension_names(names),
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to deserialize activated_channels");
+                    Vec::new()
+                }
+            },
+            Ok(None) => normalize_extension_names(configured_names),
             Err(e) => {
                 tracing::warn!(error = %e, "Failed to load activated_channels setting");
                 Vec::new()
@@ -7798,6 +7837,52 @@ mod tests {
         )
         .expect("capabilities");
         channels_dir
+    }
+
+    #[tokio::test]
+    async fn load_startup_active_channels_falls_back_to_configured_when_unset() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        let manager = make_test_manager_with_dirs(
+            None,
+            temp_dir.path().join("tools"),
+            temp_dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+
+        let actual = manager
+            .load_startup_active_channels(
+                "test",
+                vec!["telegram".to_string(), "discord-bot".to_string()],
+            )
+            .await;
+
+        assert_eq!(actual, vec!["telegram", "discord_bot"]);
+    }
+
+    #[tokio::test]
+    async fn load_startup_active_channels_prefers_persisted_empty_state_over_configured() {
+        let temp_dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        store
+            .set_setting("test", "activated_channels", &serde_json::json!([]))
+            .await
+            .expect("seed activated_channels");
+        let manager = make_test_manager_with_dirs(
+            None,
+            temp_dir.path().join("tools"),
+            temp_dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+
+        let actual = manager
+            .load_startup_active_channels("test", vec!["telegram".to_string()])
+            .await;
+
+        assert!(
+            actual.is_empty(),
+            "an explicit empty activated_channels setting should keep all channels inactive"
+        );
     }
 
     fn make_test_tar_gz(entries: &[(&str, &[u8])]) -> Vec<u8> {

--- a/src/extensions/naming.rs
+++ b/src/extensions/naming.rs
@@ -44,6 +44,33 @@ pub fn canonicalize_extension_name(name: &str) -> Result<String, ExtensionError>
     Ok(canonical)
 }
 
+pub fn normalize_extension_names<I>(names: I) -> Vec<String>
+where
+    I: IntoIterator<Item = String>,
+{
+    let mut normalized = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    for name in names {
+        match canonicalize_extension_name(&name) {
+            Ok(name) => {
+                if seen.insert(name.clone()) {
+                    normalized.push(name);
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    channel = %name,
+                    error = %error,
+                    "Skipping invalid startup channel name"
+                );
+            }
+        }
+    }
+
+    normalized
+}
+
 pub fn legacy_extension_alias(name: &str) -> Option<String> {
     let alias = name.replace('_', "-");
     (alias != name).then_some(alias)
@@ -130,6 +157,20 @@ mod tests {
         assert!(canonicalize_extension_name("WebSearch").is_err());
         assert!(canonicalize_extension_name("bad__name").is_err());
         assert!(canonicalize_extension_name("../bad").is_err());
+    }
+
+    #[test]
+    fn normalize_extension_names_canonicalizes_deduplicates_and_skips_invalid() {
+        assert_eq!(
+            normalize_extension_names(vec![
+                "telegram".to_string(),
+                "my-channel".to_string(),
+                "my_channel".to_string(),
+                "BadName".to_string(),
+                "../bad".to_string(),
+            ]),
+            vec!["telegram", "my_channel"]
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! IronClaw - Main entry point.
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -19,6 +20,7 @@ use ironclaw::{
         run_service_command, run_status_command, run_tool_command,
     },
     config::Config,
+    extensions::naming::normalize_extension_names,
     hooks::bootstrap_hooks,
     llm::create_session_manager,
     orchestrator::{ReaperConfig, SandboxReaper},
@@ -410,6 +412,18 @@ async fn async_main() -> anyhow::Result<()> {
     let channels = ChannelManager::new();
     let mut channel_names: Vec<String> = Vec::new();
     let mut loaded_wasm_channel_names: Vec<String> = Vec::new();
+    let startup_active_channel_names = if let Some(ref ext_mgr) = components.extension_manager {
+        ext_mgr
+            .load_startup_active_channels(
+                &config.owner_id,
+                config.channels.configured_wasm_channels.clone(),
+            )
+            .await
+    } else {
+        normalize_extension_names(config.channels.configured_wasm_channels.clone())
+    };
+    let startup_active_channel_name_set: HashSet<String> =
+        startup_active_channel_names.iter().cloned().collect();
     #[allow(clippy::type_complexity)]
     let mut wasm_channel_runtime_state: Option<(
         Arc<WasmChannelRuntime>,
@@ -589,6 +603,7 @@ async fn async_main() -> anyhow::Result<()> {
             components.extension_manager.as_ref(),
             components.db.as_ref(),
             &channel_names,
+            &startup_active_channel_name_set,
             Arc::clone(&components.ownership_cache),
         )
         .await;
@@ -1004,7 +1019,7 @@ async fn async_main() -> anyhow::Result<()> {
     if let Some(ref ext_mgr) = components.extension_manager
         && let Some((rt, ps, router)) = wasm_channel_runtime_state.take()
     {
-        let active_at_startup: std::collections::HashSet<String> =
+        let active_at_startup: HashSet<String> =
             loaded_wasm_channel_names.iter().cloned().collect();
         ext_mgr.set_active_channels(loaded_wasm_channel_names).await;
         ext_mgr
@@ -1020,8 +1035,7 @@ async fn async_main() -> anyhow::Result<()> {
 
         // Auto-activate WASM channels that were active in a previous session.
         // Relay channels are handled separately below via restore_relay_channels().
-        let persisted = ext_mgr.load_persisted_active_channels(&ext_user_id).await;
-        for name in &persisted {
+        for name in &startup_active_channel_names {
             if active_at_startup.contains(name)
                 || ext_mgr.is_relay_channel(name, &ext_user_id).await
             {

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -411,8 +411,10 @@ pub struct ChannelSettings {
     pub wasm_channel_owner_ids: std::collections::HashMap<String, i64>,
 
     /// Enabled WASM channels by name.
-    /// Channels not in this list but present in the channels directory will still load.
-    /// This is primarily used by the setup wizard to track which channels were configured.
+    /// Primarily used by the setup wizard to track which channels were configured.
+    ///
+    /// Startup treats this as a fallback restore source only until
+    /// `activated_channels` has been persisted by the runtime.
     #[serde(default)]
     pub wasm_channels: Vec<String>,
 

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -346,6 +346,10 @@ key first, then falls back to the standard env var.
 - Reads `capabilities.json` for `setup.required_secrets`
 - For each secret: check existing, prompt or auto-generate, validate regex
 - Save each secret via `SecretsContext`
+- Persist selected channel names in `settings.channels.wasm_channels` as a
+  first-run startup fallback. Once the running app writes
+  `activated_channels`, that runtime state becomes the authoritative restore
+  source, including an explicit empty list after deactivation.
 
 **Telegram special case** (`setup_telegram`):
 - Validates bot token via Telegram `getMe` API

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -414,6 +414,7 @@ mod tests {
             tui: None,
             wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),
             wasm_channels_enabled: false,
+            configured_wasm_channels: Vec::new(),
             wasm_channel_owner_ids: std::collections::HashMap::new(),
         }
     }


### PR DESCRIPTION
## Summary
- restore only startup-active WASM channels instead of treating every installed channel as active
- make startup use activated_channels as the authoritative source once persisted, with setup-selected channels as a first-run fallback
- keep extension list status accurate for installed but inactive WASM channels and document the fallback behavior

## Testing
- cargo fmt --all
- cargo test --lib load_startup_active_channels
- cargo test --lib register_startup_channels_only_restores_persisted_active_channels
- cargo test --lib test_extensions_list_handler_reports_installed_inactive_wasm_channel_as_inactive
- cargo test --lib normalize_extension_names_canonicalizes_deduplicates_and_skips_invalid