### PR TITLE
fix(gateway): restore web login bootstrap

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -21,6 +21,21 @@ jobs:
     - name: Check formatting
       run: cargo fmt --all -- --check
 
+  gateway-js-syntax:
+    name: Gateway JS syntax
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - name: Install Node.js
+      uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
+      with:
+        node-version: "22"
+    - name: Check gateway app.js syntax
+      run: node --check crates/ironclaw_gateway/static/app.js
+
   deny-check:
     name: cargo-deny
     runs-on: ubuntu-latest
@@ -111,10 +126,10 @@ jobs:
     name: Code Style (fmt + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, clippy, clippy-windows, deny-check, no-panics]
+    needs: [format, gateway-js-syntax, clippy, clippy-windows, deny-check, no-panics]
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
+          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
             echo "One or more jobs failed"
             exit 1
           fi

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -123,7 +123,7 @@ jobs:
 
   # Roll-up job for branch protection
   code-style:
-    name: Code Style (fmt + clippy + deny)
+    name: Code Style (fmt + gateway-js-syntax + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
     needs: [format, gateway-js-syntax, clippy, clippy-windows, deny-check, no-panics]

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -7716,7 +7716,6 @@ function refreshMissionView(missionId) {
     drillIntoProject(crCurrentProjectId);
   }
 }
-}
 
 function fireMission(id) {
   apiFetch('/api/engine/missions/' + id + '/fire', { method: 'POST' })

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -48,8 +48,10 @@ resolve_base_ref() {
 # Run before the .rs-focused checks so it fires even when no .rs files change.
 if git diff --cached --quiet 2>/dev/null; then
     I18N_CHANGED=$(git diff --name-only -- 'crates/ironclaw_gateway/static/i18n/*.js' 2>/dev/null || true)
+    GATEWAY_APP_JS_CHANGED=$(git diff --name-only -- 'crates/ironclaw_gateway/static/app.js' 2>/dev/null || true)
 else
     I18N_CHANGED=$(git diff --cached --name-only -- 'crates/ironclaw_gateway/static/i18n/*.js' 2>/dev/null || true)
+    GATEWAY_APP_JS_CHANGED=$(git diff --cached --name-only -- 'crates/ironclaw_gateway/static/app.js' 2>/dev/null || true)
 fi
 if [ -n "$I18N_CHANGED" ]; then
     # Resolve script location even when invoked via a symlink (the
@@ -71,6 +73,17 @@ if [ -n "$I18N_CHANGED" ]; then
         echo "Every key added to en.js must also be added to all other language files (zh-CN.js, ko.js, ...)."
         echo "Placeholder tokens like {name} must match across all languages."
         echo "To bypass: git commit --no-verify"
+        exit 1
+    fi
+fi
+
+# Gateway frontend JS must parse cleanly; a syntax error leaves the auth shell
+# visible and prevents the app bootstrap from running at all.
+if [ -n "$GATEWAY_APP_JS_CHANGED" ]; then
+    if ! node --check crates/ironclaw_gateway/static/app.js >/dev/null; then
+        echo ""
+        echo "Commit blocked: gateway app.js failed syntax validation."
+        echo "Fix the parse error in crates/ironclaw_gateway/static/app.js or bypass with git commit --no-verify"
         exit 1
     fi
 fi

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -21,6 +21,9 @@
 
 set -euo pipefail
 
+TEST_BOUNDARIES_FILE=""
+GATEWAY_APP_JS_TMP=""
+
 # Determine a suitable base ref for standalone diffs.
 resolve_base_ref() {
     local candidates=(
@@ -47,9 +50,11 @@ resolve_base_ref() {
 # i18n parity: when any language pack changes, all languages must stay in sync.
 # Run before the .rs-focused checks so it fires even when no .rs files change.
 if git diff --cached --quiet 2>/dev/null; then
+    HAS_STAGED_CHANGES=0
     I18N_CHANGED=$(git diff --name-only -- 'crates/ironclaw_gateway/static/i18n/*.js' 2>/dev/null || true)
     GATEWAY_APP_JS_CHANGED=$(git diff --name-only -- 'crates/ironclaw_gateway/static/app.js' 2>/dev/null || true)
 else
+    HAS_STAGED_CHANGES=1
     I18N_CHANGED=$(git diff --cached --name-only -- 'crates/ironclaw_gateway/static/i18n/*.js' 2>/dev/null || true)
     GATEWAY_APP_JS_CHANGED=$(git diff --cached --name-only -- 'crates/ironclaw_gateway/static/app.js' 2>/dev/null || true)
 fi
@@ -80,7 +85,22 @@ fi
 # Gateway frontend JS must parse cleanly; a syntax error leaves the auth shell
 # visible and prevents the app bootstrap from running at all.
 if [ -n "$GATEWAY_APP_JS_CHANGED" ]; then
-    if ! node --check crates/ironclaw_gateway/static/app.js >/dev/null; then
+    if ! command -v node >/dev/null 2>&1; then
+        echo ""
+        echo "Commit blocked: Node.js is required to validate gateway app.js syntax."
+        echo "Install Node.js and rerun the commit, or bypass with git commit --no-verify"
+        exit 1
+    fi
+
+    GATEWAY_APP_JS_TMP=$(mktemp "${TMPDIR:-/tmp}/gateway-app-js.XXXXXX.js")
+    trap 'rm -f "${TEST_BOUNDARIES_FILE:-}" "${GATEWAY_APP_JS_TMP:-}"' EXIT
+    if [ "$HAS_STAGED_CHANGES" -eq 1 ]; then
+        git show ":crates/ironclaw_gateway/static/app.js" > "$GATEWAY_APP_JS_TMP"
+    else
+        cp crates/ironclaw_gateway/static/app.js "$GATEWAY_APP_JS_TMP"
+    fi
+
+    if ! node --check "$GATEWAY_APP_JS_TMP" >/dev/null; then
         echo ""
         echo "Commit blocked: gateway app.js failed syntax validation."
         echo "Fix the parse error in crates/ironclaw_gateway/static/app.js or bypass with git commit --no-verify"
@@ -110,7 +130,7 @@ fi
 # for tiny edits inside a known test fn — and never for brand-new files added
 # in a merge. Reading the file directly catches both cases.
 TEST_BOUNDARIES_FILE=$(mktemp)
-trap 'rm -f "$TEST_BOUNDARIES_FILE"' EXIT
+trap 'rm -f "${TEST_BOUNDARIES_FILE:-}" "${GATEWAY_APP_JS_TMP:-}"' EXIT
 for f in $CHANGED_FILES; do
     [ -f "$f" ] || continue
     test_line=$(awk '


### PR DESCRIPTION
## Summary
- remove the stray closing brace in `crates/ironclaw_gateway/static/app.js` that broke the gateway bundle parse on `staging`
- add a local pre-commit syntax check for gateway `app.js`
- add a CI `node --check` job so frontend parse errors fail fast before E2E

## Root cause
A recent `staging` merge introduced an extra `}` near `refreshMissionView(...)` in the gateway frontend. Because `app.js` is embedded and served directly, the browser failed to parse the entire script, so auth/bootstrap handlers never ran and the UI stayed on the static "Secure Assistant" shell.

## Verification
- `node --check crates/ironclaw_gateway/static/app.js`
- `bash scripts/pre-commit-safety.sh`
- `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_v2_activity_shell.py -v`

## Notes
- `tests/e2e/.venv/bin/pytest tests/e2e/scenarios/test_connection.py -v` still hits an unrelated pre-existing Playwright selector ambiguity because the page currently renders two `Jobs` buttons in the tab bar.
