### PR TITLE
Fix gateway auth and Telegram pairing flow handling

### DIFF
--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -3177,16 +3177,17 @@ function showJobCard(data) {
 // --- Auth card ---
 
 function handleAuthRequired(data) {
+  const shouldBlockChat = data.block_chat !== false;
   if (data.thread_id && !isCurrentThread(data.thread_id)) {
     unreadThreads.set(data.thread_id, (unreadThreads.get(data.thread_id) || 0) + 1);
     debouncedLoadThreads();
     return;
   }
   if (data.extension_name && getConfigureOverlay(data.extension_name)) {
-    setAuthFlowPending(true, data.instructions);
+    if (shouldBlockChat) setAuthFlowPending(true, data.instructions);
     return;
   }
-  setAuthFlowPending(true, data.instructions);
+  if (shouldBlockChat) setAuthFlowPending(true, data.instructions);
   if (data.auth_url || !data.extension_name || !data.request_id) {
     showAuthCard(data);
   } else {
@@ -3242,6 +3243,7 @@ function handleOnboardingState(data) {
       onboarding: data.onboarding || null,
       thread_id: data.thread_id || currentThreadId,
     });
+    if (currentTab === 'settings') refreshCurrentSettingsTab();
     return;
   }
 
@@ -5008,9 +5010,11 @@ function renderAvailableExtensionCard(entry) {
         showToast(I18n.t('extensions.installedSuccess', {name: entry.display_name}), 'success');
         // OAuth popup if auth started during install (builtin creds)
         if (res.auth_url) {
-          showAuthCard({
+          handleAuthRequired({
             extension_name: entry.name,
             auth_url: res.auth_url,
+            display_name: entry.display_name || entry.name,
+            block_chat: false,
           });
           showToast(I18n.t('extensions.openingAuth', { name: entry.display_name }), 'info');
           openOAuthUrl(res.auth_url);
@@ -5416,9 +5420,11 @@ function activateExtension(name) {
       if (res.success) {
         // Even on success, the tool may need OAuth (e.g., WASM loaded but no token yet)
         if (res.auth_url) {
-          showAuthCard({
+          handleAuthRequired({
             extension_name: name,
             auth_url: res.auth_url,
+            display_name: name,
+            block_chat: false,
           });
           showToast(I18n.t('extensions.openingAuth', { name: name }), 'info');
           openOAuthUrl(res.auth_url);
@@ -5428,9 +5434,11 @@ function activateExtension(name) {
       }
 
       if (res.auth_url) {
-        showAuthCard({
+        handleAuthRequired({
           extension_name: name,
           auth_url: res.auth_url,
+          display_name: name,
+          block_chat: false,
         });
         showToast(I18n.t('extensions.openingAuth', { name: name }), 'info');
         openOAuthUrl(res.auth_url);
@@ -5699,21 +5707,14 @@ function submitConfigureModal(name, fields, options) {
         if (overlay) overlay.removeAttribute('data-auth-flow');
         closeConfigureModal();
         if (res.auth_url) {
-          showAuthCard({
+          handleAuthRequired({
             extension_name: name,
             auth_url: res.auth_url,
+            display_name: name,
+            block_chat: false,
           });
           showToast(I18n.t('extensions.openingOAuth', { name: name }), 'info');
           openOAuthUrl(res.auth_url);
-          refreshCurrentSettingsTab();
-        }
-        // Transition to pairing if the channel requires it.
-        if (res.onboarding_state === 'pairing_required') {
-          showPairingCard({
-            channel: name,
-            instructions: res.onboarding && res.onboarding.pairing_instructions,
-            onboarding: res.onboarding || null,
-          });
           refreshCurrentSettingsTab();
         }
         // For non-OAuth success: the server always broadcasts onboarding_state SSE,

--- a/tests/e2e/scenarios/test_extensions.py
+++ b/tests/e2e/scenarios/test_extensions.py
@@ -731,6 +731,7 @@ async def test_install_with_auth_url_opens_popup_and_shows_auth_prompt(page):
     await page.locator(SEL["auth_card"] + '[data-extension-name="registry-tool"]').wait_for(
         state="visible", timeout=5000
     )
+    assert await page.locator(SEL["chat_input"]).is_enabled()
 
 
 # ─── Group F: Remove flow ─────────────────────────────────────────────────────
@@ -919,6 +920,7 @@ async def test_configure_modal_save_oauth(page):
     await page.locator(SEL["auth_card"] + '[data-extension-name="test-ext"]').wait_for(
         state="visible", timeout=5000
     )
+    assert await page.locator(SEL["chat_input"]).is_enabled()
 
 
 async def test_configure_modal_save_failure(page):
@@ -992,14 +994,20 @@ async def _show_pairing_card(page, **kwargs):
     await page.locator(SEL["pairing_card"]).wait_for(state="visible", timeout=5000)
 
 
+async def _active_thread_id(page):
+    await page.wait_for_function("() => !!currentThreadId", timeout=10000)
+    return await page.evaluate("() => currentThreadId")
+
+
 async def test_auth_card_token_only(page):
     """Gate-backed auth card with no auth_url shows token input, Submit, Cancel, but no OAuth button."""
+    thread_id = await _active_thread_id(page)
     await _show_auth_card(
         page,
         extension_name="github",
         instructions="Paste your GitHub token",
         request_id="req-github",
-        thread_id="thread-1",
+        thread_id=thread_id,
     )
 
     card = page.locator(SEL["auth_card"])
@@ -1035,6 +1043,7 @@ async def test_auth_card_with_setup_url(page):
 async def test_auth_card_submit_success(page):
     """Submitting a valid token via click or Enter removes the auth card."""
     submit_bodies = []
+    thread_id = await _active_thread_id(page)
 
     async def handle_auth(route):
         submit_bodies.append(json.loads(route.request.post_data or "{}"))
@@ -1043,26 +1052,36 @@ async def test_auth_card_submit_success(page):
     await page.route("**/api/chat/gate/resolve", handle_auth)
 
     # Test click submit
-    await _show_auth_card(page, extension_name="myext", instructions="Enter token", request_id="req-1", thread_id="thread-1")
+    await _show_auth_card(page, extension_name="myext", instructions="Enter token", request_id="req-1", thread_id=thread_id)
     await page.locator(SEL["auth_token_input"]).fill("valid-token-123")
     await page.locator(SEL["auth_submit_btn"]).click()
     await page.locator(SEL["auth_card"]).wait_for(state="hidden", timeout=5000)
     assert submit_bodies[0] == {
         "request_id": "req-1",
-        "thread_id": "thread-1",
+        "thread_id": thread_id,
         "resolution": "credential_provided",
         "token": "valid-token-123",
     }
 
     # Test Enter key submit (re-show card for a different extension)
-    await page.evaluate("showAuthCard({extension_name: 'myext2', instructions: 'Again', request_id: 'req-2', thread_id: 'thread-2'})")
+    await page.evaluate(
+        """(threadId) => {
+          showAuthCard({
+            extension_name: 'myext2',
+            instructions: 'Again',
+            request_id: 'req-2',
+            thread_id: threadId,
+          });
+        }""",
+        thread_id,
+    )
     await page.locator(SEL["auth_card"]).wait_for(state="visible", timeout=5000)
     await page.locator(SEL["auth_token_input"]).fill("another-token")
     await page.locator(SEL["auth_token_input"]).press("Enter")
     await page.locator(SEL["auth_card"]).wait_for(state="hidden", timeout=5000)
     assert submit_bodies[1] == {
         "request_id": "req-2",
-        "thread_id": "thread-2",
+        "thread_id": thread_id,
         "resolution": "credential_provided",
         "token": "another-token",
     }
@@ -1070,18 +1089,20 @@ async def test_auth_card_submit_success(page):
 
 async def test_auth_card_submit_empty_noop(page):
     """Clicking Submit with an empty token does nothing (card stays)."""
-    await _show_auth_card(page, extension_name="myext", request_id="req-empty", thread_id="thread-empty")
+    await _show_auth_card(page, extension_name="myext", request_id="req-empty")
     await page.locator(SEL["auth_submit_btn"]).click()
     assert await page.locator(SEL["auth_card"]).count() == 1, "Card should remain for empty submit"
 
 
 async def test_auth_card_submit_error(page):
     """A failed token submission shows the error message and re-enables buttons."""
+    thread_id = await _active_thread_id(page)
+
     async def handle_auth(route):
         await route.fulfill(status=200, content_type="application/json", body=json.dumps({"success": False, "message": "Bad token"}))
 
     await page.route("**/api/chat/gate/resolve", handle_auth)
-    await _show_auth_card(page, extension_name="myext", request_id="req-bad", thread_id="thread-bad")
+    await _show_auth_card(page, extension_name="myext", request_id="req-bad", thread_id=thread_id)
     await page.locator(SEL["auth_token_input"]).fill("wrong-token")
     await page.locator(SEL["auth_submit_btn"]).click()
 
@@ -1096,18 +1117,19 @@ async def test_auth_card_submit_error(page):
 async def test_auth_card_cancel_removes_card(page):
     """Clicking Cancel resolves the active gate and removes the auth card."""
     cancel_bodies = []
+    thread_id = await _active_thread_id(page)
 
     async def handle_cancel(route):
         cancel_bodies.append(json.loads(route.request.post_data or "{}"))
         await route.fulfill(status=200, content_type="application/json", body="{}")
 
     await page.route("**/api/chat/gate/resolve", handle_cancel)
-    await _show_auth_card(page, extension_name="myext", request_id="req-cancel", thread_id="thread-cancel")
+    await _show_auth_card(page, extension_name="myext", request_id="req-cancel", thread_id=thread_id)
     await page.locator(SEL["auth_cancel_btn"]).click()
     await page.locator(SEL["auth_card"]).wait_for(state="hidden", timeout=3000)
     assert cancel_bodies == [{
         "request_id": "req-cancel",
-        "thread_id": "thread-cancel",
+        "thread_id": thread_id,
         "resolution": "cancelled",
     }]
 
@@ -1194,7 +1216,8 @@ async def test_auth_required_does_not_reopen_existing_configure_modal(page):
 
 async def test_onboarding_ready_sse_dismisses_card(page):
     """Simulating the ready onboarding event removes the auth card."""
-    await _show_auth_card(page, extension_name="myext", request_id="req-ready", thread_id="thread-ready")
+    thread_id = await _active_thread_id(page)
+    await _show_auth_card(page, extension_name="myext", request_id="req-ready", thread_id=thread_id)
 
     # Simulate the unified onboarding_state event being fired
     await page.evaluate("""
@@ -1286,6 +1309,7 @@ async def test_onboarding_failed_sse_shows_error_toast_and_reloads_extensions(pa
 async def test_pairing_card_submit_success(page):
     """Submitting a valid pairing code removes the chat pairing card."""
     submit_bodies = []
+    thread_id = await _active_thread_id(page)
 
     async def handle_pairing(route):
         submit_bodies.append(json.loads(route.request.post_data or "{}"))
@@ -1301,6 +1325,7 @@ async def test_pairing_card_submit_success(page):
         page,
         channel="telegram",
         instructions="Paste the pairing code from Telegram.",
+        thread_id=thread_id,
     )
     await page.locator(SEL["pairing_card"]).locator(SEL["auth_token_input"]).fill("pair-1234")
     await page.locator(SEL["pairing_submit_btn"]).click()
@@ -1310,16 +1335,22 @@ async def test_pairing_card_submit_success(page):
         page,
         channel="telegram",
         instructions="Paste the pairing code from Telegram.",
+        thread_id=thread_id,
     )
     await page.locator(SEL["pairing_card"]).locator(SEL["auth_token_input"]).fill("pair-5678")
     await page.locator(SEL["pairing_card"]).locator(SEL["auth_token_input"]).press("Enter")
     await page.locator(SEL["pairing_card"]).wait_for(state="hidden", timeout=5000)
 
-    assert submit_bodies == [{"code": "PAIR-1234"}, {"code": "PAIR-5678"}]
+    assert submit_bodies == [
+        {"code": "PAIR-1234", "thread_id": thread_id},
+        {"code": "PAIR-5678", "thread_id": thread_id},
+    ]
 
 
 async def test_pairing_card_submit_error(page):
     """A failed pairing submission keeps the card open and shows inline error text."""
+    thread_id = await _active_thread_id(page)
+
     async def handle_pairing(route):
         await route.fulfill(
             status=200,
@@ -1332,6 +1363,7 @@ async def test_pairing_card_submit_error(page):
         page,
         channel="telegram",
         instructions="Paste the pairing code from Telegram.",
+        thread_id=thread_id,
     )
     await page.locator(SEL["pairing_card"]).locator(SEL["auth_token_input"]).fill("bad-code")
     await page.locator(SEL["pairing_submit_btn"]).click()
@@ -1354,6 +1386,30 @@ async def test_pairing_card_cancel_shows_restart_hint(page):
     await page.locator(SEL["toast"], has_text="Message the channel again to get a new pairing code.").wait_for(
         state="visible", timeout=5000
     )
+
+
+async def test_auth_required_for_foreign_thread_marks_unread_without_rendering(page):
+    active_thread_id = await _active_thread_id(page)
+    foreign_thread_id = "11111111-1111-1111-1111-111111111111"
+    assert foreign_thread_id != active_thread_id
+
+    await page.evaluate(
+        """(threadId) => {
+          handleOnboardingState({
+            extension_name: 'telegram',
+            state: 'auth_required',
+            instructions: 'Enter your Telegram Bot API token',
+            request_id: 'req-foreign-auth',
+            thread_id: threadId,
+          });
+        }""",
+        foreign_thread_id,
+    )
+
+    assert await page.locator(SEL["configure_overlay"]).count() == 0
+    assert await page.locator(SEL["auth_card"]).count() == 0
+    unread_count = await page.evaluate("(threadId) => unreadThreads.get(threadId) || 0", foreign_thread_id)
+    assert unread_count == 1
 
 
 # ─── Group I: Activate flow ────────────────────────────────────────────────────
@@ -1447,6 +1503,7 @@ async def test_activate_with_auth_url_opens_popup_and_shows_auth_prompt(page):
     await page.locator(
         SEL["auth_card"] + '[data-extension-name="test-mcp-inactive"]'
     ).wait_for(state="visible", timeout=5000)
+    assert await page.locator(SEL["chat_input"]).is_enabled()
 
 
 # ─── Group J: Tab reload behaviour ────────────────────────────────────────────

--- a/tests/e2e/scenarios/test_telegram_hot_activation.py
+++ b/tests/e2e/scenarios/test_telegram_hot_activation.py
@@ -113,6 +113,11 @@ async def wait_for_toast(page, text: str, *, timeout: int = 5000):
     )
 
 
+async def _active_thread_id(page):
+    await page.wait_for_function("() => !!currentThreadId", timeout=10000)
+    return await page.evaluate("() => currentThreadId")
+
+
 async def test_telegram_setup_card_shows_bot_token_field(page):
     async def handle_ext_list(route):
         await route.fulfill(
@@ -162,6 +167,7 @@ async def test_telegram_setup_card_shows_bot_token_field(page):
 async def test_telegram_hot_activation_transitions_installed_to_pairing(page):
     phase = {"value": "installed"}
     captured_setup_payloads = []
+    thread_id = await _active_thread_id(page)
 
     async def handle_ext_list(route):
         extensions = {
@@ -227,6 +233,26 @@ async def test_telegram_hot_activation_transitions_installed_to_pairing(page):
     await input_el.wait_for(state="visible", timeout=5000)
     await input_el.fill("123456789:ABCdefGhI")
     await card.locator(".ext-onboarding .btn-ext.activate", has_text="Save").click()
+
+    await page.evaluate(
+        """(threadId) => {
+          handleOnboardingState({
+            extension_name: 'telegram',
+            state: 'pairing_required',
+            request_id: 'req-telegram-hot-activation',
+            thread_id: threadId,
+            instructions: 'Open your Telegram bot, send it any message, then paste the pairing code here.',
+            onboarding: {
+              state: 'pairing_required',
+              requires_pairing: true,
+              pairing_title: 'Claim ownership for Telegram',
+              pairing_instructions: 'Open your Telegram bot, send it any message, then paste the pairing code here.',
+              restart_instructions: 'If you close this claim step, send another message in the channel to get a new pairing code.'
+            }
+          });
+        }""",
+        thread_id,
+    )
 
     await page.locator(SEL["pairing_card"]).wait_for(state="attached", timeout=5000)
     await card.locator(SEL["ext_pairing_label"]).wait_for(state="visible", timeout=5000)
@@ -382,6 +408,8 @@ async def test_telegram_auth_gate_uses_extension_name_for_configure_modal(page):
 
 async def test_telegram_configure_modal_submit_then_cancel_pairing_and_restart(page):
     setup_payloads = []
+    pairing_request_id = "req-telegram-pairing"
+    thread_id = await _active_thread_id(page)
 
     async def handle_setup(route):
         if route.request.method == "GET":
@@ -445,10 +473,31 @@ async def test_telegram_configure_modal_submit_then_cancel_pairing_and_restart(p
     await modal.locator(".btn-ext.activate").click()
     await modal.wait_for(state="hidden", timeout=5000)
 
+    await page.evaluate(
+        """({ threadId, requestId }) => {
+          handleOnboardingState({
+            extension_name: 'telegram',
+            state: 'pairing_required',
+            request_id: requestId,
+            thread_id: threadId,
+            instructions: 'Open your Telegram bot, send it any message such as hi or /start, wait for the pairing code reply, then paste that code here.',
+            onboarding: {
+              state: 'pairing_required',
+              requires_pairing: true,
+              pairing_title: 'Claim ownership for Telegram',
+              pairing_instructions: 'Open your Telegram bot, send it any message such as hi or /start, wait for the pairing code reply, then paste that code into IronClaw. Telegram bots cannot message you first.',
+              restart_instructions: 'If you close this claim step, send another message in the channel to get a new pairing code.'
+            }
+          });
+        }""",
+        {"threadId": thread_id, "requestId": pairing_request_id},
+    )
+
     pairing_card = page.locator(SEL["pairing_card"])
     await pairing_card.wait_for(state="visible", timeout=5000)
     assert "pairing code" in await pairing_card.text_content()
     assert await pairing_card.locator(SEL["pairing_restart"]).count() == 1
+    assert await pairing_card.get_attribute("data-request-id") == pairing_request_id
 
     await pairing_card.locator(SEL["pairing_cancel_btn"]).click()
     await pairing_card.wait_for(state="hidden", timeout=5000)
@@ -472,5 +521,122 @@ async def test_telegram_configure_modal_submit_then_cancel_pairing_and_restart(p
     )
     await page.locator(SEL["pairing_card"]).wait_for(state="visible", timeout=5000)
     assert setup_payloads == [
-        {"secrets": {"telegram_bot_token": "123456789:ABCdefGhI"}, "fields": {}}
+        {
+            "request_id": "req-telegram-configure",
+            "thread_id": thread_id,
+            "secrets": {"telegram_bot_token": "123456789:ABCdefGhI"},
+            "fields": {},
+        }
+    ]
+
+
+async def test_telegram_pairing_sse_request_id_wins_over_setup_response(page):
+    captured_pairing_payloads = []
+    thread_id = await _active_thread_id(page)
+    pairing_request_id = "req-telegram-pairing-sse"
+
+    async def handle_setup(route):
+        if route.request.method == "GET":
+            await route.fulfill(
+                status=200,
+                content_type="application/json",
+                body=json.dumps(
+                    {
+                        "name": "telegram",
+                        "kind": "wasm_channel",
+                        "secrets": [
+                            {
+                                "name": "telegram_bot_token",
+                                "prompt": "Enter your Telegram Bot API token (from @BotFather)",
+                                "provided": False,
+                                "optional": False,
+                                "auto_generate": False,
+                            }
+                        ],
+                        "fields": [],
+                        "onboarding_state": "setup_required",
+                        "onboarding": _TELEGRAM_INSTALLED["onboarding"],
+                    }
+                ),
+            )
+            return
+
+        await page.evaluate(
+            """({ threadId, requestId }) => {
+              handleOnboardingState({
+                extension_name: 'telegram',
+                state: 'pairing_required',
+                request_id: requestId,
+                thread_id: threadId,
+                instructions: 'Open your Telegram bot and enter the pairing code.',
+                onboarding: {
+                  state: 'pairing_required',
+                  requires_pairing: true,
+                  pairing_title: 'Claim ownership for Telegram',
+                  pairing_instructions: 'Open your Telegram bot and enter the pairing code.',
+                  restart_instructions: 'Send another Telegram message to get a new code.'
+                }
+              });
+            }""",
+            {"threadId": thread_id, "requestId": pairing_request_id},
+        )
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "success": True,
+                    "activated": True,
+                    "message": "Configuration saved and 'telegram' activated.",
+                    "onboarding_state": "pairing_required",
+                    "onboarding": _TELEGRAM_PAIRING["onboarding"],
+                }
+            ),
+        )
+
+    async def handle_pairing_approve(route):
+        captured_pairing_payloads.append(json.loads(route.request.post_data or "{}"))
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"success": True, "message": "Pairing approved."}),
+        )
+
+    await page.route("**/api/extensions/telegram/setup", handle_setup)
+    await page.route("**/api/pairing/telegram/approve", handle_pairing_approve)
+
+    await page.evaluate(
+        """(threadId) => {
+          handleOnboardingState({
+            extension_name: 'telegram',
+            state: 'auth_required',
+            instructions: 'Enter your Telegram Bot API token (from @BotFather)',
+            auth_url: null,
+            request_id: 'req-telegram-configure-race',
+            thread_id: threadId,
+          });
+        }""",
+        thread_id,
+    )
+
+    modal = page.locator(SEL["configure_overlay"])
+    await modal.wait_for(state="visible", timeout=5000)
+    await modal.locator(SEL["configure_input"]).fill("123456789:ABCdefGhI")
+    await modal.locator(".btn-ext.activate").click()
+    await modal.wait_for(state="hidden", timeout=5000)
+
+    pairing_card = page.locator(SEL["pairing_card"])
+    await pairing_card.wait_for(state="visible", timeout=5000)
+    assert await pairing_card.get_attribute("data-request-id") == pairing_request_id
+
+    await pairing_card.locator(SEL["auth_token_input"]).fill("PAIR-1234")
+    await pairing_card.locator(SEL["pairing_submit_btn"]).click()
+    await pairing_card.wait_for(state="hidden", timeout=5000)
+
+    assert captured_pairing_payloads == [
+        {
+            "code": "PAIR-1234",
+            "thread_id": thread_id,
+            "request_id": pairing_request_id,
+        }
     ]


### PR DESCRIPTION
Summary:
- rely on authoritative onboarding SSE for gate-backed Telegram pairing so the pairing card keeps the rotated request id
- keep settings-initiated OAuth on the unified auth UI path without blocking unrelated chat input
- realign E2E coverage around current thread scoping, pairing request/thread payloads, and the pairing SSE overwrite regression

Testing:
- reviewer pass: no discrete correctness or security regressions found in the final diff
- full local Playwright run failed due pre-existing shared selector breakage; representative failure is test_connection.py::test_page_loads_and_connects because the jobs tab selector now matches two elements