### PR TITLE
fix: bump registry versions for promotion check

### DIFF
--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [

--- a/registry/tools/github.json
+++ b/registry/tools/github.json
@@ -2,7 +2,7 @@
   "name": "github",
   "display_name": "GitHub",
   "kind": "tool",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "wit_version": "0.3.0",
   "description": "GitHub integration for repos, issues, PRs, branches, files, releases, and workflows. Search actions: search_repositories, search_code, search_issues_pull_requests.",
   "keywords": [


### PR DESCRIPTION
## Summary
- bump `registry/tools/github.json` from `0.2.3` to `0.2.4`
- bump `registry/channels/feishu.json` from `0.2.0` to `0.2.1`
- fix the `Version Bump Check` failure on promotion PR #2604

## Why
The promotion merge in #2604 changes `tools-src/github/` and `channels-src/feishu/`, and `scripts/check-version-bumps.sh` requires the corresponding registry manifest versions to increase when those source directories change.

Failing job:
- https://github.com/nearai/ironclaw/actions/runs/24592871103/job/71917149162?pr=2604

## Validation
- ran `GITHUB_BASE_REF=main ./scripts/check-version-bumps.sh`
- result: all version checks passed

## Notes
- `registry/channels/telegram.json` already has the required version bump (`0.2.8` -> `0.2.9`) and was not part of the failure
- after this PR merges into `staging`, promotion PR #2604 should update once `staging` is refreshed into it