### PR TITLE
refactor(events): collapse three PairingRequired emission sites into one constructor

### DIFF
--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -54,6 +54,37 @@ pub enum OnboardingStateDto {
     Failed,
 }
 
+impl OnboardingStateDto {
+    /// Build the canonical `AppEvent::OnboardingState` for a
+    /// pairing-required transition.
+    ///
+    /// `auth_url` and `setup_url` are always `None` for pairing —
+    /// forcing construction through this function prevents the three
+    /// emit sites (auth-token submit, setup-handler submit, activation
+    /// post-pairing) from silently disagreeing when new fields land on
+    /// `AppEvent::OnboardingState`.
+    pub fn pairing_required(
+        extension_name: impl Into<String>,
+        request_id: Option<String>,
+        thread_id: Option<String>,
+        message: Option<String>,
+        instructions: Option<String>,
+        onboarding: Option<serde_json::Value>,
+    ) -> AppEvent {
+        AppEvent::OnboardingState {
+            extension_name: extension_name.into(),
+            state: Self::PairingRequired,
+            request_id,
+            message,
+            instructions,
+            auth_url: None,
+            setup_url: None,
+            onboarding,
+            thread_id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AppEvent {
@@ -540,6 +571,57 @@ mod tests {
                 variant
             );
         }
+    }
+
+    #[test]
+    fn pairing_required_constructor_sets_invariant_fields() {
+        let event = OnboardingStateDto::pairing_required(
+            "telegram",
+            Some("req-1".to_string()),
+            Some("thread-1".to_string()),
+            Some("Paired!".to_string()),
+            Some("Send /start to the bot.".to_string()),
+            Some(serde_json::json!({ "pairing_code": "ABC123" })),
+        );
+
+        match event {
+            AppEvent::OnboardingState {
+                extension_name,
+                state,
+                request_id,
+                message,
+                instructions,
+                auth_url,
+                setup_url,
+                onboarding,
+                thread_id,
+            } => {
+                assert_eq!(extension_name, "telegram");
+                assert_eq!(state, OnboardingStateDto::PairingRequired);
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+                assert_eq!(thread_id.as_deref(), Some("thread-1"));
+                assert_eq!(message.as_deref(), Some("Paired!"));
+                assert_eq!(instructions.as_deref(), Some("Send /start to the bot."));
+                assert!(auth_url.is_none(), "auth_url must be None for pairing");
+                assert!(setup_url.is_none(), "setup_url must be None for pairing");
+                assert_eq!(
+                    onboarding,
+                    Some(serde_json::json!({ "pairing_code": "ABC123" }))
+                );
+            }
+            other => panic!("expected OnboardingState, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pairing_required_constructor_serializes_to_onboarding_state_event() {
+        let event = OnboardingStateDto::pairing_required("telegram", None, None, None, None, None);
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "onboarding_state");
+        assert_eq!(json["state"], "pairing_required");
+        assert_eq!(json["extension_name"], "telegram");
+        assert!(json.get("auth_url").is_none());
+        assert!(json.get("setup_url").is_none());
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2077,20 +2077,17 @@ pub async fn resolve_gate(
                             if let Some(ref sse) = state.sse {
                                 sse.broadcast_for_user(
                                     &message.user_id,
-                                    AppEvent::OnboardingState {
-                                        extension_name: display_name.clone(),
-                                        state: ironclaw_common::OnboardingStateDto::PairingRequired,
-                                        request_id: Some(next_pending.request_id.to_string()),
-                                        message: Some(result.message.clone()),
-                                        instructions,
-                                        auth_url: None,
-                                        setup_url: None,
-                                        onboarding,
-                                        thread_id: pending
+                                    ironclaw_common::OnboardingStateDto::pairing_required(
+                                        display_name.clone(),
+                                        Some(next_pending.request_id.to_string()),
+                                        pending
                                             .scope_thread_id
                                             .clone()
                                             .or_else(|| Some(pending.thread_id.to_string())),
-                                        },
+                                        Some(result.message.clone()),
+                                        instructions,
+                                        onboarding,
+                                    ),
                                 );
                             }
                             return Ok(BridgeOutcome::Pending);

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4007,18 +4007,15 @@ async fn extensions_setup_submit_handler(
                             .await
                             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
                         {
-                            onboarding_event = AppEvent::OnboardingState {
-                                extension_name: name.clone(),
-                                state:
-                                    crate::channels::web::types::OnboardingStateDto::PairingRequired,
-                                request_id: Some(next_request_id),
-                                message: Some(result.message.clone()),
-                                instructions,
-                                auth_url: None,
-                                setup_url: None,
-                                onboarding,
-                                thread_id: Some(thread_id.to_string()),
-                            };
+                            onboarding_event =
+                                crate::channels::web::types::OnboardingStateDto::pairing_required(
+                                    name.clone(),
+                                    Some(next_request_id),
+                                    Some(thread_id.to_string()),
+                                    Some(result.message.clone()),
+                                    instructions,
+                                    onboarding,
+                                );
                         }
                     }
                     crate::channels::web::onboarding::ConfigureFlowOutcome::Ready => {

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -7062,23 +7062,20 @@ impl ExtensionManager {
                     );
                     sse.broadcast_for_user(
                         user_id,
-                        ironclaw_common::AppEvent::OnboardingState {
-                            extension_name: name.clone(),
-                            state: ironclaw_common::OnboardingStateDto::PairingRequired,
-                            request_id: None,
-                            message: None,
-                            instructions: Some(format!(
+                        ironclaw_common::OnboardingStateDto::pairing_required(
+                            name.clone(),
+                            None,
+                            None,
+                            None,
+                            Some(format!(
                                 "Send a message to your {} bot, then paste the pairing code here.",
                                 name
                             )),
-                            auth_url: None,
-                            setup_url: None,
-                            onboarding: onboarding
+                            onboarding
                                 .1
                                 .as_ref()
                                 .and_then(|o| serde_json::to_value(o).ok()),
-                            thread_id: None,
-                        },
+                        ),
                     );
                 }
 


### PR DESCRIPTION
## Summary

- Three call sites (`src/bridge/router.rs:2080`, `src/channels/web/server.rs:4010`, `src/extensions/manager.rs:7065`) hand-construct `AppEvent::OnboardingState { state: PairingRequired, ... }` with identical 8-field payloads. Any new field added to `OnboardingState` requires touching all three, and they can silently disagree on invariants.
- Add `OnboardingStateDto::pairing_required(extension_name, request_id, thread_id, message, instructions, onboarding)` to `crates/ironclaw_common/src/event.rs` as the single construction path. `auth_url`, `setup_url`, and `state` become invariant inside the constructor; callers only supply what genuinely varies between sites.
- Follow-up to #2515, which flagged the leak in its own PR body: *"backend onboarding transition knowledge still lives across `server.rs`, `router.rs`, and extension/pairing code"*. This is the smallest, most isolated slice of that consolidation.

## Why now

After #2515 merged, #2574 (a6443dd4) had to undo a duplication that landed 2 days later in `pending_gate_extension_name` — evidence the leak is live. The pair-emit path is the next-highest-pain boundary: `requeue_pairing_pending_gate` (router) and the `/api/extensions/{name}/setup` submit handler (server) compute `request_id` and `thread_id` via different helpers, so a field rename or new optional field lands in one place and not the other.

## Notes

- Naming: placed as `OnboardingStateDto::pairing_required(...) -> AppEvent` per the original consolidation proposal. Slightly unusual (an associated function on the state DTO returning an `AppEvent`), but it keeps the discoverability at the `OnboardingStateDto::` path where the variant itself lives.
- Scope intentionally narrow: does **not** touch `AuthRequired` / `SetupRequired` / `Ready` / `Failed` emissions. Those have fewer duplicate sites and less invariant surface; a follow-up can consolidate them once this pattern is established.
- No wire-format change. Existing serialization tests in `src/channels/web/types.rs` (`test_app_event_onboarding_state_pairing_required_serialize`) continue to pass unchanged.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib -p ironclaw_common` — 2 new constructor tests pass (field invariants + serialization)
- [x] `cargo test --lib --features libsql` — all 4,998 unit tests pass, including existing `test_app_event_onboarding_state_pairing_required_serialize` and the 10 onboarding/handler tests
- [ ] Manual smoke: pairing flow end-to-end on a Telegram-style channel (not performed locally — relying on CI + staging)

## Regression test

The commit adds `pairing_required_constructor_sets_invariant_fields` and `pairing_required_constructor_serializes_to_onboarding_state_event` in `crates/ironclaw_common/src/event.rs`. Per `.claude/rules/testing.md` the rule is to test through the caller for helper-gated side effects — here the existing `test_app_event_onboarding_state_pairing_required_serialize` in `src/channels/web/types.rs` continues to exercise the wire format, and the three call-site refactors are covered by existing integration tests that round-trip `AppEvent::OnboardingState` over SSE (e.g. `test_chat_auth_token_handler_expired_auth_broadcasts_failed_onboarding_state` pattern). No behavior change — pure compile-time refactor.