### PR TITLE
fix(test): case-insensitive tool_search description assertion

### DIFF
--- a/tests/e2e_builtin_tool_coverage.rs
+++ b/tests/e2e_builtin_tool_coverage.rs
@@ -1228,7 +1228,7 @@ mod tests {
         );
         assert!(
             tool_search_description
-                .to_lowercase()
+                .to_ascii_lowercase()
                 .contains("use the `message` tool for proactive outbound sends"),
             "tool_search description should point outbound sends to message: {tool_search_description}"
         );

--- a/tests/e2e_builtin_tool_coverage.rs
+++ b/tests/e2e_builtin_tool_coverage.rs
@@ -1227,7 +1227,9 @@ mod tests {
              tool_activate: {tool_search_description}"
         );
         assert!(
-            tool_search_description.contains("use the `message` tool for proactive outbound sends"),
+            tool_search_description
+                .to_lowercase()
+                .contains("use the `message` tool for proactive outbound sends"),
             "tool_search description should point outbound sends to message: {tool_search_description}"
         );
 


### PR DESCRIPTION
## Summary
- `tests/e2e_builtin_tool_coverage.rs:1230` asserted the lowercase `"use the \`message\` tool ..."` substring, but PR #2515 capitalized the first word in `src/tools/builtin/extension_tools.rs:110`.
- The local unit test in `extension_tools.rs` was updated; this e2e test was missed.
- That's been failing the `Run Tests` job on main ever since, which is why release-plz PR #2606 shows all-red CI — the release-plz PR is otherwise fine (it only bumps `ironclaw_common` and `ironclaw_skills`, the main `ironclaw` crate is untouched).
- Normalize to lowercase before substring match so a future copy-edit doesn't silently break CI again.

## Test plan
- [x] `cargo test --test e2e_builtin_tool_coverage tool_info_clarifies_message_and_channel_setup_roles` passes locally
- [ ] CI green on this PR
- [ ] After promotion to main, #2606 `Run Tests` job goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)