### PR TITLE
ci: save rust-cache only on main/staging pushes

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,13 @@
 name: Code Style
 on:
   pull_request:
+  # Pushes to main/staging refresh the rust-cache entries that PR jobs
+  # restore from. PR jobs themselves are restore-only (see `save-if`
+  # on the rust-cache steps below).
+  push:
+    branches:
+      - main
+      - staging
 
 permissions:
   contents: read
@@ -81,6 +88,7 @@ jobs:
         # from whichever variant saved last is still faster than a cold build
         # and avoids storing three near-duplicate copies in the GHA cache.
         shared-key: clippy
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -109,12 +117,19 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        shared-key: clippy-windows
+        # Share the per-variant Windows target cache with test.yml's
+        # windows-build job. That job runs on `push` to main (where save-if
+        # allows writes), so clippy-windows — which only runs on main PRs —
+        # can restore from a warm cache instead of cold-building every time.
+        key: windows-${{ matrix.name }}
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
   no-panics:
     name: No panics in production code
+    # Compares the PR's changes against the PR base; not meaningful on push.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -138,8 +153,13 @@ jobs:
     needs: [format, gateway-js-syntax, clippy, clippy-windows, deny-check, no-panics]
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
+          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" ]]; then
             echo "One or more jobs failed"
+            exit 1
+          fi
+          # no-panics only runs on pull_request events, so skipped is acceptable on push but failure is not
+          if [[ "${{ needs.no-panics.result }}" != "success" && "${{ needs.no-panics.result }}" != "skipped" ]]; then
+            echo "no-panics failed: ${{ needs.no-panics.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.name }}
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM channels (for integration tests)
@@ -73,6 +74,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: heavy-integration
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Build Telegram WASM channel
         run: cargo build --manifest-path channels-src/telegram/Cargo.toml --target wasm32-wasip2 --release
       - name: Run thread scheduling integration tests
@@ -100,6 +102,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Run Telegram Channel Tests
         run: |
           timeout --signal=INT --kill-after=30s 10m \
@@ -132,6 +136,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: windows-${{ matrix.name }}
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Check compilation
         run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
 
@@ -155,6 +160,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: wasm-extensions
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build all WASM extensions against current WIT
@@ -178,6 +184,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Compile benchmarks
         run: cargo bench --all-features --no-run
 


### PR DESCRIPTION
## Summary

- Adds `save-if` gating to every `Swatinem/rust-cache` step in `code_style.yml` and `test.yml` so the cache is only written when `github.ref` is `refs/heads/main` or `refs/heads/staging`. PR jobs still **restore** — they just skip the upload.
- Adds push triggers on `main` and `staging` to `code_style.yml` so those pushes actually exercise each matrix leg and refresh the cache that PRs will restore from. Without this, the `save-if` guard would mean the cache is never refreshed.
- Gates `no-panics` on `pull_request` events (it diffs against `github.event.pull_request.base.sha`, which is empty on pushes) and teaches the `code-style` roll-up to accept \"skipped\" for it on push.

## Motivation

Right now on #2471's latest CI run, each Clippy matrix leg shows:

| Step | Duration |
|---|---|
| \`cargo clippy\` | ~5m 36s |
| Post rust-cache (save) | in progress, already > 5m |

The actions cache save step is compressing and uploading a multi-GB \`target/\` directory on every PR job, even though PR jobs have unique cache keys and no other PR will read them. Only pushes to long-lived branches should refresh the cache.

Expected impact: ~5 min saved per Clippy / Tests matrix leg on PRs. No change to cache hit rate for subsequent PRs — `main` / `staging` pushes refresh the same keys PRs restore from.

## Test plan

- [ ] This PR itself should show each Clippy matrix leg finishing roughly when \`cargo clippy\` finishes — no trailing cache-save wall clock
- [ ] After merge, a push to \`staging\` should run the code_style workflow and save each cache key
- [ ] Subsequent PRs should get warm cache restores on the main/staging-saved keys