### PR TITLE
ci: share rust-cache across clippy matrix legs

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -71,7 +71,11 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-${{ matrix.name }}
+        # Share a single cache across the clippy matrix. `target/` built for
+        # --all-features is a superset of the other two legs, so restoring
+        # from whichever variant saved last is still faster than a cold build
+        # and avoids storing three near-duplicate copies in the GHA cache.
+        shared-key: clippy
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -100,7 +104,7 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-windows-${{ matrix.name }}
+        shared-key: clippy-windows
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -49,6 +49,11 @@ jobs:
 
   clippy:
     name: Clippy (${{ matrix.name }})
+    # Push events only run the all-features leg. That leg builds a superset
+    # of artifacts, so it deterministically wins the shared cache slot on
+    # main/staging refreshes and PR legs always restore from a useful
+    # starting point. PRs still run all three to enforce lint coverage.
+    if: github.event_name == 'pull_request' || matrix.name == 'all-features'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

Switch the Linux and Windows clippy matrices from per-leg cache keys to a single `shared-key`, and pin the saver on push events to the `all-features` leg:

- `key: clippy-\${{ matrix.name }}` → `shared-key: clippy` (Linux, 3 variants)
- `key: clippy-windows-\${{ matrix.name }}` → `shared-key: clippy-windows` (Windows, 3 variants)
- New: `if: github.event_name == 'pull_request' || matrix.name == 'all-features'` on the Linux clippy job. Push events (main/staging) run only the all-features leg.

## Motivation

Each of the three clippy matrix entries (`all-features`, `default`, `libsql-only`) maintained its own multi-GB `target/` in the GitHub Actions cache. GHA caps per-repo cache at 10 GB and evicts LRU, so these three near-duplicates crowd out other useful entries (tests, benches, wasm-extensions) and force each leg to re-warm after eviction.

With `shared-key`, whichever leg finishes (and saves) first wins the slot; the other two restore from that cache on the next run. Because `--all-features` builds a superset of the artifacts needed by `default` / `libsql-only`, a shared cache is still incrementally useful for every leg even when the saver wasn't all-features.

### Interaction with #2609 (raised in review)

Once #2609 lands, saves are gated to `main`/`staging` refs. Combined with `shared-key`, whichever matrix leg finishes first on a `staging` push would own the cache slot. That could be `libsql-only` (the smallest, fastest build), leaving PR legs restoring from a subset of what `--all-features` needs.

Pinning push events to only the `all-features` leg (via the new `if`) eliminates the race: on push, only the superset build runs and saves. PRs still run all three legs to enforce lint coverage on every promotion path.

This is independent of and complementary to #2609. Together: fewer saves overall (save-if) × one slot instead of three (shared-key) × saver pinned to the superset leg (matrix if) = near-zero post-step wall clock on PR clippy runs after the first main/staging push refreshes the slot.

## Test plan

- [ ] First CI run: cold build on all three legs (no shared cache slot yet); verify they all succeed
- [ ] After merge, a push to `staging` should run only the `all-features` leg and save to the `clippy` slot
- [ ] Subsequent PRs should restore from that slot on all three legs
- [ ] Check the Actions cache listing in GitHub's repo settings — the three per-variant keys should collapse into one `clippy` entry over time as the old ones age out