### PR TITLE
feat(common): CredentialName + ExtensionName newtypes (PR 1/2)

### DIFF
--- a/.claude/rules/types.md
+++ b/.claude/rules/types.md
@@ -1,0 +1,129 @@
+---
+paths:
+  - "src/**"
+  - "crates/**"
+  - "tests/**"
+---
+# Typed Internals — No Stringly-Typed Values Inside the System
+
+**Internal values must have types that reflect what they mean.** Raw `String`
+is the boundary type — accepted from user input, JSON/HTTP payloads, the
+database, and untrusted external APIs — and it should be converted to a
+domain type as soon as possible. Everything that moves between internal
+modules should carry a type that makes misuse a compile error.
+
+Concretely:
+
+- **Identifiers** → newtypes (`CredentialName`, `ExtensionName`, `ThreadId`,
+  `UserId`). Never `String`, `&str`, or `uuid::Uuid` alone.
+- **Fixed small sets** → enums with `#[serde(rename_all = "snake_case")]`
+  or explicit `#[serde(rename = "...")]`. Never compare strings like
+  `status == "in_progress"`.
+- **Units, shapes, modes** → enums (`SandboxPolicy`, `ExecutionMode`,
+  `ThreadState`). Never booleans-plus-magic-strings.
+
+If two values have the same shape (`String`, `u64`, whatever) but different
+meanings, they must be different types. The compiler is the only durable
+enforcement of "don't mix these up" — comments, naming, and code review
+are not.
+
+## Why
+
+Identity confusion has shipped four times in recent history:
+
+| PR | Surface | What went wrong |
+|----|---------|-----------------|
+| #2561 | settings restart | `owner_id` round-tripped through a string, lost type on reload |
+| #2473 | Slack relay OAuth | nonce stored under wrong scope — wrong `user_id` vs gateway owner id |
+| #2512 | Slack relay OAuth | state lookup compared strings across two callers that had diverged |
+| #2574 | auth-gate display | inline fallback re-derived extension name, returned `telegram_bot_token` where `telegram` was expected |
+
+All four bugs are the same shape: a string-typed value passes through more
+than one layer, one layer treats it as one meaning, another treats it as a
+different meaning, and the compiler has nothing to say. Newtypes would
+have made each of these a type error.
+
+## The Extension/Auth identity invariant
+
+See `CLAUDE.md` → "Extension/Auth Invariants" for the routing rules. The
+types live in `crates/ironclaw_common/src/identity.rs`:
+
+- [`CredentialName`] — backend secret identity (e.g. `telegram_bot_token`,
+  `google_oauth_token`). Used for secrets-store keys, gate resume
+  payloads, credential injection.
+- [`ExtensionName`] — user-facing installed extension/channel identity
+  (e.g. `telegram`, `gmail`). Used for onboarding UI, setup/configure
+  routing, Python action dispatch. Hyphens fold to underscores at
+  construction time because extensions are invoked as Python attribute
+  accesses.
+
+Never cast between them. Never recompute one from the other by string
+manipulation — resolve through `AuthManager::resolve_extension_name_for_auth_flow`.
+
+## When to add a newtype
+
+Add one when **all** of the following are true:
+
+1. The value is a *name*, *id*, or *key* — something whose shape is
+   incidental to its meaning.
+2. It flows through **more than one module** or crosses a **type
+   boundary** (struct field, function parameter, return type).
+3. Mixing it up with another same-shape value would be a **silent
+   runtime bug**, not a compile error.
+
+If all three hold, make it a newtype. Put it in
+`crates/ironclaw_common/src/identity.rs` (or a module-local spot if its
+blast radius is genuinely one crate).
+
+### Newtype template
+
+Use `#[serde(transparent)]` so on-wire and on-disk representation stays a
+plain string — legacy persisted rows must keep deserializing cleanly.
+Validate at explicit construction sites (`new`, `try_from`, `from_str`),
+not on the wire. Provide a `from_trusted(String)` escape hatch for values
+sourced from a typed upstream (DB row, registry entry) where the caller
+already trusts the shape.
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MyId(String);
+
+impl MyId {
+    pub fn new(raw: impl AsRef<str>) -> Result<Self, MyIdError> { ... }
+    pub fn from_trusted(raw: String) -> Self { Self(raw) }
+    pub fn as_str(&self) -> &str { &self.0 }
+}
+
+impl TryFrom<String> for MyId { ... }   // validating
+impl From<MyId> for String { ... }      // infallible
+// Deliberately no `From<String>` — that would silently bypass validation.
+```
+
+## Don'ts
+
+- **Don't add `From<&str>` or `From<String>` for an identity newtype.**
+  That relaxes the invariant. If a caller has a raw string, they should
+  have to choose `new` (validate) or `from_trusted` (documented opt-out)
+  — the choice itself is the audit trail.
+- **Don't compare a newtype against a format-string-built `String`.**
+  If you find yourself writing `format!("{}_token", extension_name) ==
+  credential_name.as_str()`, you've rebuilt the bug #2574 fixed. Route
+  through the shared resolver instead.
+- **Don't use `#[serde(try_from = "String")]` for identity newtypes
+  without a migration plan.** Existing persisted rows may not satisfy the
+  current rule; `transparent` + explicit validation at construction
+  preserves them while still gaining type distinctness.
+- **Don't match on string literals for a value that should be an enum.**
+  `match status.as_str() { "ready" => ... }` means status should be an
+  enum. Fix the type.
+- **Don't downgrade a typed value back to `String` except at a system
+  boundary.** A `String` returned from an internal function is a
+  regression — return the type.
+
+## Applies to
+
+`src/**`, `crates/**`, `tests/**`. Any code inside the IronClaw
+workspace. The rule doesn't apply to wire payloads (which are `String`
+by virtue of JSON), log lines, or error messages — those *are* the
+boundary.

--- a/.claude/rules/types.md
+++ b/.claude/rules/types.md
@@ -95,9 +95,15 @@ impl MyId {
     pub fn as_str(&self) -> &str { &self.0 }
 }
 
+impl AsRef<str> for MyId { ... }        // explicit via `.as_ref()`
 impl TryFrom<String> for MyId { ... }   // validating
 impl From<MyId> for String { ... }      // infallible
-// Deliberately no `From<String>` — that would silently bypass validation.
+// Deliberately no `From<String>` or `From<&str>` — infallible
+// conversion would silently bypass validation.
+// Deliberately no `Deref<Target = str>` — auto-deref would let
+// `&my_id` silently coerce to `&str`, which is the implicit-conversion
+// pattern this whole module exists to prevent. Use `.as_str()` /
+// `.as_ref()` at the call site so the boundary is visible.
 ```
 
 ## Don'ts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3981,6 +3981,7 @@ dependencies = [
  "chrono-tz",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tracing",
 ]
 

--- a/crates/ironclaw_common/Cargo.toml
+++ b/crates/ironclaw_common/Cargo.toml
@@ -16,4 +16,5 @@ dist = false
 chrono-tz = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "2"
 tracing = "0.1"

--- a/crates/ironclaw_common/src/identity.rs
+++ b/crates/ironclaw_common/src/identity.rs
@@ -15,10 +15,14 @@
 //!
 //! Both types use `#[serde(transparent)]` so the on-wire and on-disk
 //! representation is a plain JSON string — unchanged from when the fields
-//! were `String`. Validation runs at construction (`try_from` / `from_str`)
-//! and at any explicit `validate()` call, not at deserialize time. Legacy
-//! persisted rows therefore continue to deserialize cleanly; any invalid
-//! values surface the next time a typed accessor re-validates them.
+//! were `String`. Validation runs only when constructing through the
+//! validated entry points (`new` / `try_from` / `from_str`), not at
+//! deserialize time. Legacy persisted rows therefore continue to
+//! deserialize cleanly; an invalid value is only surfaced if a later
+//! code path re-constructs the name through a validated entry point.
+//! There is no re-validation API on an existing instance — by design,
+//! the type represents "something that passed validation at some point
+//! in its history" rather than "something guaranteed valid right now".
 
 use std::fmt;
 use std::str::FromStr;
@@ -60,19 +64,29 @@ pub enum IdentityError {
 /// - not start or end with `_`
 /// - no consecutive `__`
 /// - no path separators (`/`, `\`), parent-traversal (`..`), or NUL
+///
+/// Checks are ordered cheapest-first against the trimmed slice so that an
+/// invalid input rejects without allocating a canonicalized `String`.
+/// `replace('-', "_")` runs only after the structural checks pass; since
+/// `-` and `_` are both one byte, it cannot change the already-checked
+/// length, so the fast-path length check stays valid.
 fn canonicalize(raw: &str) -> Result<String, IdentityError> {
-    if raw.contains('/') || raw.contains('\\') || raw.contains("..") || raw.contains('\0') {
-        return Err(IdentityError::PathTraversal(raw.to_string()));
-    }
-
-    let canonical = raw.trim().replace('-', "_");
-    if canonical.is_empty() {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
         return Err(IdentityError::Empty);
     }
-    if canonical.len() > MAX_NAME_LEN {
-        return Err(IdentityError::TooLong(canonical));
+    if trimmed.len() > MAX_NAME_LEN {
+        return Err(IdentityError::TooLong(trimmed.to_string()));
+    }
+    if trimmed.contains('/')
+        || trimmed.contains('\\')
+        || trimmed.contains("..")
+        || trimmed.contains('\0')
+    {
+        return Err(IdentityError::PathTraversal(trimmed.to_string()));
     }
 
+    let canonical = trimmed.replace('-', "_");
     let bytes = canonical.as_bytes();
     if bytes.first() == Some(&b'_') || bytes.last() == Some(&b'_') {
         return Err(IdentityError::EdgeUnderscore(canonical));
@@ -148,15 +162,14 @@ macro_rules! identity_newtype {
             }
         }
 
+        // `AsRef<str>` is intentionally implemented so callers can opt into
+        // a `&str` view through a method call (`.as_ref()` / `.as_str()`),
+        // which makes the boundary crossing visible in the source. We do
+        // *not* implement `Deref<Target = str>`: auto-deref would let
+        // `&credential_name` silently coerce to `&str`, which is exactly the
+        // implicit-conversion behaviour these newtypes exist to prevent.
         impl AsRef<str> for $name {
             fn as_ref(&self) -> &str {
-                &self.0
-            }
-        }
-
-        impl std::ops::Deref for $name {
-            type Target = str;
-            fn deref(&self) -> &str {
                 &self.0
             }
         }
@@ -394,6 +407,22 @@ mod tests {
         let ext = ExtensionName::new("gmail").unwrap();
         assert_eq!(ext, *"gmail");
         assert_eq!(ext, "gmail");
+    }
+
+    /// Guards the decision to *not* implement `Deref<Target = str>`:
+    /// auto-deref would let `&ext_name` silently coerce to `&str`, which
+    /// is the implicit-conversion pattern the newtypes exist to prevent.
+    /// Callers must go through `.as_str()` / `.as_ref()` — both explicit.
+    /// If a future edit adds `Deref`, this test will still compile but
+    /// the doc contract is broken; the rule lives in
+    /// `.claude/rules/types.md`.
+    #[test]
+    fn explicit_accessors_work() {
+        let ext = ExtensionName::new("gmail").unwrap();
+        let via_as_str: &str = ext.as_str();
+        let via_as_ref: &str = ext.as_ref();
+        assert_eq!(via_as_str, "gmail");
+        assert_eq!(via_as_ref, "gmail");
     }
 
     #[test]

--- a/crates/ironclaw_common/src/identity.rs
+++ b/crates/ironclaw_common/src/identity.rs
@@ -1,0 +1,415 @@
+//! Typed identifiers for internal names.
+//!
+//! Two string-shaped values that must not be confused:
+//!
+//! - [`CredentialName`] — backend secret identity used for storage, injection,
+//!   and gate resume (e.g. `telegram_bot_token`, `google_oauth_token`).
+//! - [`ExtensionName`] — user-facing installed extension/channel identity used
+//!   for setup routing, UI, and Python action dispatch (e.g. `telegram`,
+//!   `gmail`).
+//!
+//! See `.claude/rules/types.md` for why these are newtypes and
+//! `CLAUDE.md` → "Extension/Auth Invariants" for the routing rules.
+//!
+//! # Wire compatibility
+//!
+//! Both types use `#[serde(transparent)]` so the on-wire and on-disk
+//! representation is a plain JSON string — unchanged from when the fields
+//! were `String`. Validation runs at construction (`try_from` / `from_str`)
+//! and at any explicit `validate()` call, not at deserialize time. Legacy
+//! persisted rows therefore continue to deserialize cleanly; any invalid
+//! values surface the next time a typed accessor re-validates them.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+/// Shared maximum length for both credential and extension names.
+///
+/// Matches the pre-newtype `is_valid_credential_name` bound; extension names
+/// had no explicit length cap but fit comfortably within this limit in
+/// practice.
+pub const MAX_NAME_LEN: usize = 64;
+
+/// Why a candidate string is not a valid identity name.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum IdentityError {
+    #[error("identity name must not be empty")]
+    Empty,
+    #[error("identity name '{0}' exceeds {MAX_NAME_LEN} characters")]
+    TooLong(String),
+    #[error("identity name '{0}': must not contain path separators or traversal characters")]
+    PathTraversal(String),
+    #[error("identity name '{0}': only lowercase letters, digits, and underscores are allowed")]
+    InvalidChar(String),
+    #[error("identity name '{0}': must start and end with a lowercase letter or digit")]
+    EdgeUnderscore(String),
+    #[error("identity name '{0}': consecutive underscores are not allowed")]
+    ConsecutiveUnderscores(String),
+}
+
+/// Validate `raw` against the shared rule and return its canonical form.
+///
+/// The canonical form trims surrounding whitespace and replaces `-` with `_`
+/// (extension names are invoked as Python attribute accesses, which forbid
+/// hyphens). After that normalization the result must be:
+///
+/// - non-empty, at most [`MAX_NAME_LEN`] bytes
+/// - ASCII lowercase letters, digits, and `_` only
+/// - not start or end with `_`
+/// - no consecutive `__`
+/// - no path separators (`/`, `\`), parent-traversal (`..`), or NUL
+fn canonicalize(raw: &str) -> Result<String, IdentityError> {
+    if raw.contains('/') || raw.contains('\\') || raw.contains("..") || raw.contains('\0') {
+        return Err(IdentityError::PathTraversal(raw.to_string()));
+    }
+
+    let canonical = raw.trim().replace('-', "_");
+    if canonical.is_empty() {
+        return Err(IdentityError::Empty);
+    }
+    if canonical.len() > MAX_NAME_LEN {
+        return Err(IdentityError::TooLong(canonical));
+    }
+
+    let bytes = canonical.as_bytes();
+    if bytes.first() == Some(&b'_') || bytes.last() == Some(&b'_') {
+        return Err(IdentityError::EdgeUnderscore(canonical));
+    }
+
+    let mut prev_underscore = false;
+    for ch in canonical.chars() {
+        let is_valid = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_';
+        if !is_valid {
+            return Err(IdentityError::InvalidChar(canonical));
+        }
+        if ch == '_' {
+            if prev_underscore {
+                return Err(IdentityError::ConsecutiveUnderscores(canonical));
+            }
+            prev_underscore = true;
+        } else {
+            prev_underscore = false;
+        }
+    }
+
+    Ok(canonical)
+}
+
+macro_rules! identity_newtype {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(
+            Debug,
+            Clone,
+            PartialEq,
+            Eq,
+            Hash,
+            PartialOrd,
+            Ord,
+            Serialize,
+            Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Construct from any string-like value, validating + canonicalizing.
+            pub fn new(raw: impl AsRef<str>) -> Result<Self, IdentityError> {
+                canonicalize(raw.as_ref()).map(Self)
+            }
+
+            /// Construct without validation.
+            ///
+            /// Use for values sourced from a typed upstream that the caller
+            /// already trusts — a DB row, a skill-manifest registry entry,
+            /// a `#[serde(transparent)]` deserialization whose wire contract
+            /// predates the newtype. Prefer [`Self::new`] for anything
+            /// touching user input, free-form text, or external-tool output.
+            pub fn from_trusted(raw: String) -> Self {
+                Self(raw)
+            }
+
+            /// Borrow the inner canonical string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            /// Consume and return the inner `String`.
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl std::ops::Deref for $name {
+            type Target = str;
+            fn deref(&self) -> &str {
+                &self.0
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = IdentityError;
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = IdentityError;
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdentityError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(s)
+            }
+        }
+
+        impl From<$name> for String {
+            fn from(value: $name) -> String {
+                value.0
+            }
+        }
+
+        impl PartialEq<str> for $name {
+            fn eq(&self, other: &str) -> bool {
+                self.0 == other
+            }
+        }
+
+        impl PartialEq<&str> for $name {
+            fn eq(&self, other: &&str) -> bool {
+                self.0 == *other
+            }
+        }
+    };
+}
+
+identity_newtype! {
+    /// Backend secret identity — e.g. `telegram_bot_token`, `google_oauth_token`.
+    ///
+    /// Used as the lookup key in the secrets store, in gate resume payloads,
+    /// and anywhere the system needs to refer to *which* credential slot is
+    /// being filled. Must not be used as a UI routing key — that is
+    /// [`ExtensionName`]'s job.
+    CredentialName
+}
+
+identity_newtype! {
+    /// User-facing extension/channel identity — e.g. `telegram`, `gmail`.
+    ///
+    /// Used to route onboarding UI, setup/configure modals, and Python action
+    /// dispatch. Hyphens in input are folded to underscores at construction
+    /// time because extensions are invoked as attribute accesses in the
+    /// embedded Python interpreter. Must not be used as a secrets-store key —
+    /// that is [`CredentialName`]'s job.
+    ExtensionName
+}
+
+impl ExtensionName {
+    /// The pre-v0.23 hyphenated variant of this name, if one exists.
+    ///
+    /// Returns `Some("google-calendar")` for `google_calendar`, `None` for
+    /// names without underscores. Used when locating older release artifacts
+    /// on disk.
+    pub fn legacy_alias(&self) -> Option<String> {
+        let alias = self.0.replace('_', "-");
+        (alias != self.0).then_some(alias)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accepts_snake_case() {
+        assert_eq!(
+            ExtensionName::new("google_drive").unwrap().as_str(),
+            "google_drive"
+        );
+        assert_eq!(
+            CredentialName::new("telegram_bot_token").unwrap().as_str(),
+            "telegram_bot_token"
+        );
+    }
+
+    #[test]
+    fn folds_hyphens_to_underscores() {
+        assert_eq!(
+            ExtensionName::new("web-search").unwrap().as_str(),
+            "web_search"
+        );
+        assert_eq!(
+            CredentialName::new("github-token").unwrap().as_str(),
+            "github_token"
+        );
+    }
+
+    #[test]
+    fn trims_whitespace() {
+        assert_eq!(ExtensionName::new("  gmail  ").unwrap().as_str(), "gmail");
+    }
+
+    #[test]
+    fn rejects_empty_and_whitespace_only() {
+        assert_eq!(ExtensionName::new(""), Err(IdentityError::Empty));
+        assert_eq!(ExtensionName::new("   "), Err(IdentityError::Empty));
+    }
+
+    #[test]
+    fn rejects_uppercase() {
+        assert!(matches!(
+            ExtensionName::new("WebSearch"),
+            Err(IdentityError::InvalidChar(_))
+        ));
+        assert!(matches!(
+            CredentialName::new("GitHub_Token"),
+            Err(IdentityError::InvalidChar(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_consecutive_underscores() {
+        assert!(matches!(
+            ExtensionName::new("bad__name"),
+            Err(IdentityError::ConsecutiveUnderscores(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_edge_underscores() {
+        assert!(matches!(
+            ExtensionName::new("_leading"),
+            Err(IdentityError::EdgeUnderscore(_))
+        ));
+        assert!(matches!(
+            ExtensionName::new("trailing_"),
+            Err(IdentityError::EdgeUnderscore(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(matches!(
+            ExtensionName::new("../bad"),
+            Err(IdentityError::PathTraversal(_))
+        ));
+        assert!(matches!(
+            ExtensionName::new("a/b"),
+            Err(IdentityError::PathTraversal(_))
+        ));
+        assert!(matches!(
+            ExtensionName::new("with\0nul"),
+            Err(IdentityError::PathTraversal(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_too_long() {
+        let long = "a".repeat(MAX_NAME_LEN + 1);
+        assert!(matches!(
+            ExtensionName::new(&long),
+            Err(IdentityError::TooLong(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_chars() {
+        assert!(matches!(
+            CredentialName::new("foo bar"),
+            Err(IdentityError::InvalidChar(_))
+        ));
+        assert!(matches!(
+            CredentialName::new("foo.bar"),
+            Err(IdentityError::InvalidChar(_))
+        ));
+    }
+
+    #[test]
+    fn serde_is_transparent() {
+        let ext = ExtensionName::new("gmail").unwrap();
+        let json = serde_json::to_string(&ext).unwrap();
+        assert_eq!(json, "\"gmail\"");
+
+        let round: ExtensionName = serde_json::from_str("\"gmail\"").unwrap();
+        assert_eq!(round.as_str(), "gmail");
+    }
+
+    /// `#[serde(transparent)]` means we do not re-validate at deserialize
+    /// time — legacy persisted rows must keep loading. Validation happens at
+    /// construction sites, not on the wire.
+    #[test]
+    fn serde_does_not_revalidate() {
+        let legacy: ExtensionName = serde_json::from_str("\"Bad__Name\"").unwrap();
+        assert_eq!(legacy.as_str(), "Bad__Name");
+    }
+
+    #[test]
+    fn credential_and_extension_are_distinct_types() {
+        let cred = CredentialName::new("github_token").unwrap();
+        let ext = ExtensionName::new("github").unwrap();
+
+        // Compile-time check — passing one where the other is expected must
+        // not compile. We assert the runtime shape and trust the type system
+        // for the rest.
+        assert_eq!(cred.as_str(), "github_token");
+        assert_eq!(ext.as_str(), "github");
+    }
+
+    #[test]
+    fn legacy_alias_roundtrip() {
+        let ext = ExtensionName::new("google_calendar").unwrap();
+        assert_eq!(ext.legacy_alias().as_deref(), Some("google-calendar"));
+
+        let no_underscore = ExtensionName::new("gmail").unwrap();
+        assert_eq!(no_underscore.legacy_alias(), None);
+    }
+
+    #[test]
+    fn display_matches_inner() {
+        let ext = ExtensionName::new("gmail").unwrap();
+        assert_eq!(format!("{ext}"), "gmail");
+    }
+
+    #[test]
+    fn partial_eq_with_str() {
+        let ext = ExtensionName::new("gmail").unwrap();
+        assert_eq!(ext, *"gmail");
+        assert_eq!(ext, "gmail");
+    }
+
+    #[test]
+    fn preserves_existing_credential_shape() {
+        // Every credential name used in the codebase today (as of the
+        // pre-newtype `parse_credential_name` tests) must still validate.
+        for ok in [
+            "github_token",
+            "github_pat",
+            "slack_token",
+            "gmail_oauth",
+            "linear_token",
+            "telegram_bot_token",
+            "google_oauth_token",
+        ] {
+            assert!(CredentialName::new(ok).is_ok(), "expected {ok} to validate",);
+        }
+    }
+}

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -1,10 +1,12 @@
 //! Shared types and utilities for the IronClaw workspace.
 
 mod event;
+mod identity;
 mod timezone;
 mod util;
 
 pub use event::{AppEvent, OnboardingStateDto, PlanStepDto, ToolDecisionDto};
+pub use identity::{CredentialName, ExtensionName, IdentityError, MAX_NAME_LEN};
 pub use timezone::{ValidTimezone, deserialize_option_lenient};
 pub use util::truncate_preview;
 

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -858,7 +858,7 @@ mod tests {
                 call_id: "call_auth_1".into(),
                 parameters: Box::new(serde_json::json!({"url": "https://api.github.com/repos"})),
                 resume_kind: Box::new(crate::gate::ResumeKind::Authentication {
-                    credential_name: "github_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github_token").unwrap(),
                     instructions: "Provide your github_token token".into(),
                     auth_url: None,
                 }),
@@ -941,7 +941,7 @@ mod tests {
                     call_id: "call_1".into(),
                     parameters: Box::new(serde_json::json!({})),
                     resume_kind: Box::new(crate::gate::ResumeKind::Authentication {
-                        credential_name: "api_key".into(),
+                        credential_name: ironclaw_common::CredentialName::new("api_key").unwrap(),
                         instructions: "Provide your api_key token".into(),
                         auth_url: None,
                     }),

--- a/crates/ironclaw_engine/src/gate/mod.rs
+++ b/crates/ironclaw_engine/src/gate/mod.rs
@@ -17,6 +17,7 @@ pub mod tool_tier;
 use std::collections::HashSet;
 
 use async_trait::async_trait;
+use ironclaw_common::CredentialName;
 use serde::{Deserialize, Serialize};
 
 use crate::types::capability::ActionDef;
@@ -49,7 +50,7 @@ pub enum ResumeKind {
     /// User must provide a credential (token, API key, OAuth flow).
     Authentication {
         /// Name of the credential that is missing.
-        credential_name: String,
+        credential_name: CredentialName,
         /// User-facing setup instructions.
         instructions: String,
         /// Optional OAuth URL for browser-based flows.
@@ -161,7 +162,7 @@ mod tests {
         );
         assert_eq!(
             ResumeKind::Authentication {
-                credential_name: "x".into(),
+                credential_name: CredentialName::new("x").unwrap(),
                 instructions: "y".into(),
                 auth_url: None,
             }

--- a/src/bridge/auth_manager.rs
+++ b/src/bridge/auth_manager.rs
@@ -22,6 +22,7 @@ use crate::secrets::SecretsStore;
 use crate::tools::ToolRegistry;
 use crate::tools::builtin::extract_host_from_params;
 use crate::tools::wasm::SharedCredentialRegistry;
+use ironclaw_common::CredentialName;
 use ironclaw_skills::{SkillCredentialSpec, SkillRegistry};
 
 /// Result of checking whether a tool call has the credentials it needs.
@@ -39,7 +40,7 @@ pub enum AuthCheckResult {
 #[derive(Debug, Clone)]
 pub struct MissingCredential {
     /// Secret name in the secrets store (e.g., "github_token").
-    pub credential_name: String,
+    pub credential_name: CredentialName,
     /// Human-readable setup instructions from the skill spec.
     pub setup_instructions: Option<String>,
     /// Optional OAuth URL that should be opened in the browser.
@@ -53,7 +54,7 @@ pub enum ToolReadiness {
     Ready,
     /// Tool needs auth (OAuth or manual token) before it can work.
     NeedsAuth {
-        credential_name: String,
+        credential_name: CredentialName,
         instructions: Option<String>,
         auth_url: Option<String>,
     },
@@ -78,7 +79,7 @@ pub enum LatentActionExecution {
         available_actions: Vec<String>,
     },
     NeedsAuth {
-        credential_name: String,
+        credential_name: CredentialName,
         instructions: String,
         auth_url: Option<String>,
     },
@@ -220,7 +221,7 @@ impl AuthManager {
                         "Failed to resolve credential during pre-flight auth — assuming missing"
                     );
                     missing.push(MissingCredential {
-                        credential_name: mapping.secret_name.clone(),
+                        credential_name: CredentialName::from_trusted(mapping.secret_name.clone()),
                         setup_instructions: None,
                         auth_url: None,
                     });
@@ -414,7 +415,9 @@ impl AuthManager {
                     credential_name,
                     ..
                 }) => Ok(LatentActionExecution::NeedsAuth {
-                    credential_name: credential_name.unwrap_or(latent.provider_extension),
+                    credential_name: CredentialName::from_trusted(
+                        credential_name.unwrap_or(latent.provider_extension),
+                    ),
                     instructions: auth
                         .instructions()
                         .unwrap_or("Complete authentication to continue.")
@@ -450,7 +453,7 @@ impl AuthManager {
         };
 
         MissingCredential {
-            credential_name: credential_name.to_string(),
+            credential_name: CredentialName::from_trusted(credential_name.to_string()),
             setup_instructions,
             auth_url,
         }

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -161,11 +161,13 @@ impl EffectBridgeAdapter {
                 context.current_call_id.as_deref(),
                 parameters,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: output_value
-                        .get("credential_name")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or(name)
-                        .to_string(),
+                    credential_name: ironclaw_common::CredentialName::from_trusted(
+                        output_value
+                            .get("credential_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or(name)
+                            .to_string(),
+                    ),
                     instructions: output_value
                         .get("instructions")
                         .and_then(|v| v.as_str())
@@ -1076,7 +1078,9 @@ impl EffectBridgeAdapter {
                         context.current_call_id.as_deref(),
                         parameters,
                         ironclaw_engine::ResumeKind::Authentication {
-                            credential_name: cred_name.clone(),
+                            credential_name: ironclaw_common::CredentialName::from_trusted(
+                                cred_name.clone(),
+                            ),
                             instructions: format!("Provide your {} token", cred_name),
                             auth_url: None,
                         },

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -161,13 +161,21 @@ impl EffectBridgeAdapter {
                 context.current_call_id.as_deref(),
                 parameters,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: ironclaw_common::CredentialName::from_trusted(
-                        output_value
-                            .get("credential_name")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or(name)
-                            .to_string(),
-                    ),
+                    // Validate the tool-declared credential name — it is
+                    // external/untrusted input. Fall back to the tool's
+                    // own name (structurally trusted, from the registry)
+                    // if the external value fails validation; if even the
+                    // tool name fails (shouldn't happen in practice),
+                    // preserve the legacy passthrough so the gate can
+                    // still reach the user.
+                    credential_name: output_value
+                        .get("credential_name")
+                        .and_then(|v| v.as_str())
+                        .and_then(|raw| ironclaw_common::CredentialName::new(raw).ok())
+                        .or_else(|| ironclaw_common::CredentialName::new(name).ok())
+                        .unwrap_or_else(|| {
+                            ironclaw_common::CredentialName::from_trusted(name.to_string())
+                        }),
                     instructions: output_value
                         .get("instructions")
                         .and_then(|v| v.as_str())

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2138,7 +2138,8 @@ pub async fn resolve_gate(
                         }
                     }
                 } else if let Some(ref ss) = state.secrets_store {
-                    let params = crate::secrets::CreateSecretParams::new(credential_name, &token);
+                    let params =
+                        crate::secrets::CreateSecretParams::new(credential_name.as_str(), &token);
                     ss.create(&message.user_id, params)
                         .await
                         .map_err(|e| engine_err("secrets", e))?;
@@ -3200,7 +3201,9 @@ async fn await_thread_outcome(
                     display_parameters: None,
                     description: format!("Authentication required for '{}'.", cred_name),
                     resume_kind: ironclaw_engine::ResumeKind::Authentication {
-                        credential_name: cred_name.clone(),
+                        credential_name: ironclaw_common::CredentialName::from_trusted(
+                            cred_name.clone(),
+                        ),
                         instructions: setup_hint.clone(),
                         auth_url: None,
                     },
@@ -5214,7 +5217,8 @@ mod tests {
             "alice",
             thread_id,
             ironclaw_engine::ResumeKind::Authentication {
-                credential_name: expected_extension_name.clone(),
+                credential_name: ironclaw_common::CredentialName::new(&expected_extension_name)
+                    .unwrap(),
                 instructions: "Sign in with Google".to_string(),
                 auth_url: Some("https://example.test/oauth".to_string()),
             },
@@ -5371,7 +5375,7 @@ mod tests {
                 "alice",
                 thread_id,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "github".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5607,7 +5611,7 @@ mod tests {
                 "alice",
                 thread_a,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "github_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github_token").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5620,7 +5624,7 @@ mod tests {
                 "alice",
                 thread_b,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "linear_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("linear_token").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5657,7 +5661,7 @@ mod tests {
                 "alice",
                 thread_a,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "github_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github_token").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5670,7 +5674,7 @@ mod tests {
                 "alice",
                 thread_b,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "linear_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("linear_token").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5708,7 +5712,8 @@ mod tests {
                 thread_a,
                 auth_request_id,
                 ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "telegram_bot_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("telegram_bot_token")
+                        .unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -5760,7 +5765,8 @@ mod tests {
             thread_id,
             request_id,
             ironclaw_engine::ResumeKind::Authentication {
-                credential_name: "telegram_bot_token".into(),
+                credential_name: ironclaw_common::CredentialName::new("telegram_bot_token")
+                    .unwrap(),
                 instructions: "paste token".into(),
                 auth_url: None,
             },
@@ -5797,7 +5803,8 @@ mod tests {
             thread_id,
             request_id,
             ironclaw_engine::ResumeKind::Authentication {
-                credential_name: "telegram_bot_token".into(),
+                credential_name: ironclaw_common::CredentialName::new("telegram_bot_token")
+                    .unwrap(),
                 instructions: "paste token".into(),
                 auth_url: None,
             },
@@ -6225,7 +6232,7 @@ mod tests {
                 action_name: "shell".into(),
                 parameters: serde_json::json!({"cmd": "ls"}),
                 resume_kind: ironclaw_engine::ResumeKind::Authentication {
-                    credential_name: "github_token".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github_token").unwrap(),
                     instructions: "paste token".into(),
                     auth_url: None,
                 },
@@ -6234,7 +6241,8 @@ mod tests {
                     "alice",
                     thread.id,
                     ironclaw_engine::ResumeKind::Authentication {
-                        credential_name: "github_token".into(),
+                        credential_name: ironclaw_common::CredentialName::new("github_token")
+                            .unwrap(),
                         instructions: "paste token".into(),
                         auth_url: None,
                     },
@@ -7073,7 +7081,7 @@ mod tests {
     fn clamp_auth_resume_kind_clamps_to_false() {
         // Auth resumes have no "always" semantics; clamp regardless.
         let rk = ironclaw_engine::ResumeKind::Authentication {
-            credential_name: "github_token".into(),
+            credential_name: ironclaw_common::CredentialName::new("github_token").unwrap(),
             instructions: String::new(),
             auth_url: None,
         };

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -122,7 +122,7 @@ async fn resolve_auth_gate_display_name(
             tools,
             &pending.action_name,
             &pending.parameters,
-            credential_name,
+            credential_name.as_str(),
             &pending.user_id,
         )
         .await
@@ -2018,7 +2018,7 @@ pub async fn resolve_gate(
                     state.effect_adapter.tools(),
                     &pending.action_name,
                     &pending.parameters,
-                    credential_name,
+                    credential_name.as_str(),
                     &message.user_id,
                 )
                 .await;

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2898,7 +2898,7 @@ async fn pending_gate_extension_name(
                 .resolve_extension_name_for_auth_flow(
                     tool_name,
                     &parsed_parameters,
-                    credential_name,
+                    credential_name.as_str(),
                     user_id,
                 )
                 .await,

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -2908,7 +2908,7 @@ async fn pending_gate_extension_name(
     // auth_manager is None only when no secrets backend exists (e.g. bare
     // test harness). Fall back to the raw credential name rather than
     // duplicating AuthManager resolution logic here.
-    Some(credential_name.clone())
+    Some(credential_name.as_str().to_string())
 }
 
 async fn engine_pending_gate_info(
@@ -4654,7 +4654,8 @@ mod tests {
             "tool_install",
             r#"{"name":"telegram"}"#,
             &ironclaw_engine::ResumeKind::Authentication {
-                credential_name: "telegram_bot_token".to_string(),
+                credential_name: ironclaw_common::CredentialName::new("telegram_bot_token")
+                    .unwrap(),
                 instructions: "paste token".to_string(),
                 auth_url: None,
             },
@@ -4709,7 +4710,7 @@ mod tests {
             "notion_search",
             "{}",
             &ironclaw_engine::ResumeKind::Authentication {
-                credential_name: "notion_token".to_string(),
+                credential_name: ironclaw_common::CredentialName::new("notion_token").unwrap(),
                 instructions: "paste token".to_string(),
                 auth_url: None,
             },

--- a/src/extensions/naming.rs
+++ b/src/extensions/naming.rs
@@ -1,47 +1,16 @@
+use ironclaw_common::ExtensionName;
+
 use crate::extensions::ExtensionError;
 
+/// Validate and canonicalize an extension name.
+///
+/// Thin wrapper around [`ExtensionName::new`] that adapts the identity-layer
+/// error to [`ExtensionError::InstallFailed`] so existing callers don't
+/// change. New code should prefer [`ExtensionName`] directly.
 pub fn canonicalize_extension_name(name: &str) -> Result<String, ExtensionError> {
-    if name.contains('/') || name.contains('\\') || name.contains("..") || name.contains('\0') {
-        return Err(ExtensionError::InstallFailed(format!(
-            "Invalid extension name '{name}': contains path separator or traversal characters"
-        )));
-    }
-
-    let canonical = name.trim().replace('-', "_");
-    if canonical.is_empty() {
-        return Err(ExtensionError::InstallFailed(
-            "Invalid extension name: must not be empty".to_string(),
-        ));
-    }
-
-    let bytes = canonical.as_bytes();
-    if bytes.first() == Some(&b'_') || bytes.last() == Some(&b'_') {
-        return Err(ExtensionError::InstallFailed(format!(
-            "Invalid extension name '{name}': must start and end with a lowercase letter or digit"
-        )));
-    }
-
-    let mut prev_underscore = false;
-    for ch in canonical.chars() {
-        let is_valid = ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_';
-        if !is_valid {
-            return Err(ExtensionError::InstallFailed(format!(
-                "Invalid extension name '{name}': only lowercase letters, digits, and underscores are allowed"
-            )));
-        }
-        if ch == '_' {
-            if prev_underscore {
-                return Err(ExtensionError::InstallFailed(format!(
-                    "Invalid extension name '{name}': consecutive underscores are not allowed"
-                )));
-            }
-            prev_underscore = true;
-        } else {
-            prev_underscore = false;
-        }
-    }
-
-    Ok(canonical)
+    ExtensionName::new(name)
+        .map(String::from)
+        .map_err(|e| ExtensionError::InstallFailed(format!("Invalid extension name: {e}")))
 }
 
 pub fn normalize_extension_names<I>(names: I) -> Vec<String>

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -215,7 +215,7 @@ impl EffectExecutor for InstallThenAliasEffects {
                 call_id: "call_install_1".into(),
                 parameters: Box::new(parameters),
                 resume_kind: Box::new(ResumeKind::Authentication {
-                    credential_name: "github".into(),
+                    credential_name: ironclaw_common::CredentialName::new("github").unwrap(),
                     instructions: "Authenticate GitHub".into(),
                     auth_url: None,
                 }),
@@ -294,7 +294,7 @@ impl EffectExecutor for GateMockEffects {
                     call_id: "call_gate_2".into(),
                     parameters: Box::new(parameters),
                     resume_kind: Box::new(ResumeKind::Authentication {
-                        credential_name: "notion".into(),
+                        credential_name: ironclaw_common::CredentialName::new("notion").unwrap(),
                         instructions: "Authenticate your Notion workspace".into(),
                         auth_url: None,
                     }),
@@ -323,7 +323,7 @@ impl EffectExecutor for GateMockEffects {
                 call_id: "call_gate_2".into(),
                 parameters: Box::new(parameters),
                 resume_kind: Box::new(ResumeKind::Authentication {
-                    credential_name: "test_api_key".into(),
+                    credential_name: ironclaw_common::CredentialName::new("test_api_key").unwrap(),
                     instructions: "Provide your API key".into(),
                     auth_url: None,
                 }),


### PR DESCRIPTION
## Summary

- Introduces `CredentialName` and `ExtensionName` newtypes in `ironclaw_common::identity`, replacing the stringly-typed `credential_name` / `extension_name` values that have caused four recent identity-confusion bugs (#2561, #2473, #2512, #2574).
- `ExtensionName` absorbs the existing hyphen→underscore canonicalization from `src/extensions/naming.rs` so extensions can be used as Python attribute accesses.
- Wire format is unchanged — both newtypes use `#[serde(transparent)]`, so SSE frames, DB rows, and existing JSON payloads keep the same shape. Legacy persisted rows continue to deserialize.
- Adds `.claude/rules/types.md` — the "no stringly-typed internals" rule.

## Scope (this PR)

Core auth seam only — the surface where the four repatch PRs kept bouncing:

- `ResumeKind::Authentication.credential_name`
- `MissingCredential`, `ToolReadiness::NeedsAuth`, `LatentActionExecution::NeedsAuth`
- `src/extensions/naming.rs` → thin wrapper over `ExtensionName::new`

## Deferred to PR 2

- `AppEvent::OnboardingState.extension_name`, `AppEvent::GateRequired.extension_name`
- OAuth / pending-flow stores (`src/auth/mod.rs`, `src/auth/oauth.rs`)
- TUI events (`AuthRequired`, `AuthCompleted`)
- Remaining `extension_name: String` fields throughout the codebase
- Reconsidering `parse_credential_name` → `Option<CredentialName>` (current parser has narrower anti-injection semantics than `CredentialName::new`; needs a deliberate strict-parse constructor)

## Design notes

- **No `From<&str>` / `From<String>`** — relaxes the invariant. Callers must pick `::new` (validating) or `::from_trusted` (documented opt-out for values from a trusted upstream like DB rows or skill-manifest registry entries). The choice is itself the audit trail.
- **`#[serde(transparent)]`, not `#[serde(try_from = "String")]`** — wire stability and legacy-row compatibility are worth more than deserialize-time validation. Validation fires at construction sites.
- **Shared validator** — both types enforce ≤64 chars, lowercase alnum + underscore, no leading/trailing `_`, no `__`, no path separators. Extension names need the stricter rule for Python dispatch; credential names inherit it for consistency.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test -p ironclaw_common` — 40/40 (17 new in `identity.rs`)
- [x] `cargo test --lib bridge::auth_manager` — 16/16
- [x] `cargo test --lib bridge::router` — 41/41
- [x] `cargo test --lib` — 5035/5035
- [x] `cargo test -p ironclaw_engine --lib gate::` — 20/20
- [ ] Integration + e2e smoke after merge