### PR TITLE
Promote Staging to Main

### DIFF
--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -49,6 +49,11 @@ jobs:
 
   clippy:
     name: Clippy (${{ matrix.name }})
+    # Push events only run the all-features leg. That leg builds a superset
+    # of artifacts, so it deterministically wins the shared cache slot on
+    # main/staging refreshes and PR legs always restore from a useful
+    # starting point. PRs still run all three to enforce lint coverage.
+    if: github.event_name == 'pull_request' || matrix.name == 'all-features'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -71,7 +76,11 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-${{ matrix.name }}
+        # Share a single cache across the clippy matrix. `target/` built for
+        # --all-features is a superset of the other two legs, so restoring
+        # from whichever variant saved last is still faster than a cold build
+        # and avoids storing three near-duplicate copies in the GHA cache.
+        shared-key: clippy
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -100,7 +109,7 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-windows-${{ matrix.name }}
+        shared-key: clippy-windows
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,13 @@
 name: Code Style
 on:
   pull_request:
+  # Pushes to main/staging refresh the rust-cache entries that PR jobs
+  # restore from. PR jobs themselves are restore-only (see `save-if`
+  # on the rust-cache steps below).
+  push:
+    branches:
+      - main
+      - staging
 
 permissions:
   contents: read
@@ -81,6 +88,7 @@ jobs:
         # from whichever variant saved last is still faster than a cold build
         # and avoids storing three near-duplicate copies in the GHA cache.
         shared-key: clippy
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
@@ -109,12 +117,19 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        shared-key: clippy-windows
+        # Share the per-variant Windows target cache with test.yml's
+        # windows-build job. That job runs on `push` to main (where save-if
+        # allows writes), so clippy-windows — which only runs on main PRs —
+        # can restore from a warm cache instead of cold-building every time.
+        key: windows-${{ matrix.name }}
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
   no-panics:
     name: No panics in production code
+    # Compares the PR's changes against the PR base; not meaningful on push.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -138,8 +153,13 @@ jobs:
     needs: [format, gateway-js-syntax, clippy, clippy-windows, deny-check, no-panics]
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
+          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" ]]; then
             echo "One or more jobs failed"
+            exit 1
+          fi
+          # no-panics only runs on pull_request events, so skipped is acceptable on push but failure is not
+          if [[ "${{ needs.no-panics.result }}" != "success" && "${{ needs.no-panics.result }}" != "skipped" ]]; then
+            echo "no-panics failed: ${{ needs.no-panics.result }}"
             exit 1
           fi
           # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.name }}
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build WASM channels (for integration tests)
@@ -73,6 +74,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: heavy-integration
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Build Telegram WASM channel
         run: cargo build --manifest-path channels-src/telegram/Cargo.toml --target wasm32-wasip2 --release
       - name: Run thread scheduling integration tests
@@ -100,6 +102,8 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Run Telegram Channel Tests
         run: |
           timeout --signal=INT --kill-after=30s 10m \
@@ -132,6 +136,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: windows-${{ matrix.name }}
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Check compilation
         run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
 
@@ -155,6 +160,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: wasm-extensions
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
         run: cargo install cargo-component --locked || true
       - name: Build all WASM extensions against current WIT
@@ -178,6 +184,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Compile benchmarks
         run: cargo bench --all-features --no-run
 

--- a/build.rs
+++ b/build.rs
@@ -17,6 +17,9 @@ fn main() {
     let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
     let root = PathBuf::from(&manifest_dir);
 
+    // ── Git build metadata ─────────────────────────────────────────────
+    emit_git_metadata(&root);
+
     // ── Embed registry manifests ────────────────────────────────────────
     embed_registry_catalog(&root);
 
@@ -111,6 +114,101 @@ fn main() {
             let _ = std::fs::rename(&stripped, &wasm_out);
         }
     }
+}
+
+/// Emit `GIT_COMMIT_HASH` and `GIT_DIRTY` as compile-time env vars.
+///
+/// If the current HEAD is an exact tag match, `GIT_COMMIT_HASH` is empty
+/// (the Cargo version is sufficient). Otherwise it contains the short hash,
+/// and `GIT_DIRTY` is "true" if the working tree has uncommitted changes.
+fn emit_git_metadata(root: &Path) {
+    // Rerun when the git HEAD changes (commit, checkout, rebase).
+    // Use `git rev-parse --git-dir` so this works inside git worktrees
+    // (where `.git` is a file pointing elsewhere, not a directory).
+    // Use `--git-common-dir` to find branch refs, which live in the
+    // shared common dir rather than the per-worktree git dir.
+    if let Ok(output) = Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(root)
+        .output()
+        && output.status.success()
+    {
+        let git_dir = std::path::PathBuf::from(String::from_utf8_lossy(&output.stdout).trim());
+        let git_common_dir = Command::new("git")
+            .args(["rev-parse", "--git-common-dir"])
+            .current_dir(root)
+            .output()
+            .ok()
+            .filter(|o| o.status.success())
+            .map(|o| {
+                std::path::PathBuf::from(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            })
+            .unwrap_or_else(|| git_dir.clone());
+
+        // Watch the per-worktree HEAD.
+        let git_head = git_dir.join("HEAD");
+        if git_head.exists() {
+            println!("cargo:rerun-if-changed={}", git_head.display());
+            // Also watch the ref that HEAD points to (for branch commits).
+            // In worktrees, branch refs (e.g. refs/heads/main) live under
+            // the common dir, not the per-worktree git dir.
+            if let Ok(head) = std::fs::read_to_string(&git_head)
+                && let Some(refpath) = head.trim().strip_prefix("ref: ")
+            {
+                let reffile = git_common_dir.join(refpath);
+                if reffile.exists() {
+                    println!("cargo:rerun-if-changed={}", reffile.display());
+                } else {
+                    // Fallback for non-worktree repos where common == git dir.
+                    let reffile_fallback = git_dir.join(refpath);
+                    if reffile_fallback.exists() {
+                        println!("cargo:rerun-if-changed={}", reffile_fallback.display());
+                    }
+                }
+            }
+        }
+    }
+
+    // Check if HEAD is an exact version tag (e.g. v0.25.0).
+    let is_tagged = Command::new("git")
+        .args(["describe", "--exact-match", "--tags", "HEAD"])
+        .current_dir(root)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+
+    if is_tagged {
+        // Tagged release — version string alone is enough.
+        println!("cargo:rustc-env=GIT_COMMIT_HASH=");
+        println!("cargo:rustc-env=GIT_DIRTY=false");
+        return;
+    }
+
+    // Short commit hash.
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .current_dir(root)
+        .output()
+        .ok()
+        .and_then(|o| {
+            if o.status.success() {
+                Some(String::from_utf8_lossy(&o.stdout).trim().to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    // Dirty flag.
+    let dirty = Command::new("git")
+        .args(["status", "--porcelain"])
+        .current_dir(root)
+        .output()
+        .map(|o| o.status.success() && !o.stdout.is_empty())
+        .unwrap_or(false);
+
+    println!("cargo:rustc-env=GIT_COMMIT_HASH={}", hash);
+    println!("cargo:rustc-env=GIT_DIRTY={}", dirty);
 }
 
 /// Collect all registry manifests into a single JSON blob at compile time.

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -302,6 +302,10 @@ struct TelegramMessageMetadata {
     /// Whether this is a private (DM) chat.
     is_private: bool,
 
+    /// Telegram chat type for downstream group/private detection.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    chat_type: Option<String>,
+
     /// Forum topic thread ID (for routing replies back to the correct topic).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     message_thread_id: Option<i64>,
@@ -2147,6 +2151,7 @@ fn handle_message(message: TelegramMessage) {
         message_id: message.message_id,
         user_id: from.id,
         is_private,
+        chat_type: Some(message.chat.chat_type.clone()),
         message_thread_id: message.message_thread_id,
     };
 
@@ -2776,6 +2781,26 @@ mod tests {
         .unwrap();
 
         assert!(webhook_mode(&config));
+    }
+
+    #[test]
+    fn test_telegram_message_metadata_deserializes_without_chat_type() {
+        let metadata: TelegramMessageMetadata = serde_json::from_str(
+            r#"{
+                "chat_id": 999,
+                "message_id": 701,
+                "user_id": 999,
+                "is_private": true
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(metadata.chat_id, 999);
+        assert_eq!(metadata.message_id, 701);
+        assert_eq!(metadata.user_id, 999);
+        assert!(metadata.is_private);
+        assert_eq!(metadata.chat_type, None);
+        assert_eq!(metadata.message_thread_id, None);
     }
 
     #[test]

--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -311,6 +311,28 @@ struct TelegramMessageMetadata {
     message_thread_id: Option<i64>,
 }
 
+/// Deserialize a value that may be a JSON string or number into `Option<String>`.
+fn deserialize_string_or_number<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::Deserialize;
+    let value = Option::<serde_json::Value>::deserialize(deserializer)?;
+    match value {
+        None | Some(serde_json::Value::Null) => Ok(None),
+        Some(serde_json::Value::String(s)) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                Ok(None)
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
+        Some(serde_json::Value::Number(n)) => Ok(n.as_i64().map(|id| id.to_string())),
+        Some(_) => Ok(None),
+    }
+}
+
 /// Channel configuration injected by host.
 ///
 /// The host injects runtime values like tunnel_url and webhook_secret.
@@ -323,8 +345,10 @@ struct TelegramConfig {
 
     /// Telegram user ID of the bot owner. When set, only messages from this
     /// user are processed. All others are silently dropped.
-    #[serde(default)]
-    owner_id: Option<i64>,
+    /// Accepts both JSON string ("12345") and number (12345) for compatibility
+    /// with both boot-path and hot-activation config injection.
+    #[serde(default, deserialize_with = "deserialize_string_or_number")]
+    owner_id: Option<String>,
 
     /// DM policy: "pairing" (default), "allowlist", or "open".
     #[serde(default)]
@@ -548,8 +572,8 @@ impl Guest for TelegramChannel {
         }
 
         // Persist owner_id so subsequent callbacks (on_http_request, on_poll) can read it
-        if let Some(owner_id) = config.owner_id {
-            if let Err(e) = channel_host::workspace_write(OWNER_ID_PATH, &owner_id.to_string()) {
+        if let Some(ref owner_id) = config.owner_id {
+            if let Err(e) = channel_host::workspace_write(OWNER_ID_PATH, owner_id) {
                 channel_host::log(
                     channel_host::LogLevel::Error,
                     &format!("Failed to persist owner_id: {}", e),
@@ -2559,10 +2583,17 @@ mod tests {
     }
 
     #[test]
-    fn test_config_with_owner_id() {
+    fn test_config_with_numeric_owner_id() {
         let json = r#"{"owner_id": 123456789}"#;
         let config: TelegramConfig = serde_json::from_str(json).unwrap();
-        assert_eq!(config.owner_id, Some(123456789));
+        assert_eq!(config.owner_id, Some("123456789".to_string()));
+    }
+
+    #[test]
+    fn test_config_with_string_owner_id() {
+        let json = r#"{"owner_id": "123456789"}"#;
+        let config: TelegramConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.owner_id, Some("123456789".to_string()));
     }
 
     #[test]

--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -54,6 +54,37 @@ pub enum OnboardingStateDto {
     Failed,
 }
 
+impl OnboardingStateDto {
+    /// Build the canonical `AppEvent::OnboardingState` for a
+    /// pairing-required transition.
+    ///
+    /// `auth_url` and `setup_url` are always `None` for pairing —
+    /// forcing construction through this function prevents the three
+    /// emit sites (auth-token submit, setup-handler submit, activation
+    /// post-pairing) from silently disagreeing when new fields land on
+    /// `AppEvent::OnboardingState`.
+    pub fn pairing_required(
+        extension_name: impl Into<String>,
+        request_id: Option<String>,
+        thread_id: Option<String>,
+        message: Option<String>,
+        instructions: Option<String>,
+        onboarding: Option<serde_json::Value>,
+    ) -> AppEvent {
+        AppEvent::OnboardingState {
+            extension_name: extension_name.into(),
+            state: Self::PairingRequired,
+            request_id,
+            message,
+            instructions,
+            auth_url: None,
+            setup_url: None,
+            onboarding,
+            thread_id,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum AppEvent {
@@ -540,6 +571,57 @@ mod tests {
                 variant
             );
         }
+    }
+
+    #[test]
+    fn pairing_required_constructor_sets_invariant_fields() {
+        let event = OnboardingStateDto::pairing_required(
+            "telegram",
+            Some("req-1".to_string()),
+            Some("thread-1".to_string()),
+            Some("Paired!".to_string()),
+            Some("Send /start to the bot.".to_string()),
+            Some(serde_json::json!({ "pairing_code": "ABC123" })),
+        );
+
+        match event {
+            AppEvent::OnboardingState {
+                extension_name,
+                state,
+                request_id,
+                message,
+                instructions,
+                auth_url,
+                setup_url,
+                onboarding,
+                thread_id,
+            } => {
+                assert_eq!(extension_name, "telegram");
+                assert_eq!(state, OnboardingStateDto::PairingRequired);
+                assert_eq!(request_id.as_deref(), Some("req-1"));
+                assert_eq!(thread_id.as_deref(), Some("thread-1"));
+                assert_eq!(message.as_deref(), Some("Paired!"));
+                assert_eq!(instructions.as_deref(), Some("Send /start to the bot."));
+                assert!(auth_url.is_none(), "auth_url must be None for pairing");
+                assert!(setup_url.is_none(), "setup_url must be None for pairing");
+                assert_eq!(
+                    onboarding,
+                    Some(serde_json::json!({ "pairing_code": "ABC123" }))
+                );
+            }
+            other => panic!("expected OnboardingState, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn pairing_required_constructor_serializes_to_onboarding_state_event() {
+        let event = OnboardingStateDto::pairing_required("telegram", None, None, None, None, None);
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(json["type"], "onboarding_state");
+        assert_eq!(json["state"], "pairing_required");
+        assert_eq!(json["extension_name"], "telegram");
+        assert!(json.get("auth_url").is_none());
+        assert!(json.get("setup_url").is_none());
     }
 
     #[test]

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -7989,9 +7989,13 @@ function fetchGatewayStatus() {
     var popover = document.getElementById('gateway-popover');
     var html = '';
 
-    // Version
+    // Version — show commit hash when not a tagged release
     if (data.version) {
-      html += '<div class="gw-section-label">IronClaw v' + escapeHtml(data.version) + '</div>';
+      var versionText = 'IronClaw v' + escapeHtml(data.version);
+      if (data.commit_hash) {
+        versionText += ' (' + escapeHtml(data.commit_hash) + ')';
+      }
+      html += '<div class="gw-section-label">' + versionText + '</div>';
       html += '<div class="gw-divider"></div>';
     }
 

--- a/crates/ironclaw_gateway/static/app.js
+++ b/crates/ironclaw_gateway/static/app.js
@@ -1917,6 +1917,7 @@ function enableChatInput() {
   const btn = document.getElementById('send-btn');
   if (input) {
     input.disabled = false;
+    input.placeholder = I18n.t('chat.inputPlaceholder');
   }
   if (btn) btn.disabled = false;
 }
@@ -4220,8 +4221,14 @@ function loadThreads() {
         return;
       }
       if (activeThreadId && threads.some(t => t.id === activeThreadId)) {
-        switchThread(activeThreadId);
-        return;
+        // Skip external-channel threads (e.g. HTTP, Telegram) — they are
+        // read-only in the web UI, so auto-switching to one would leave the
+        // chat input disabled.  Fall through to the assistant thread instead.
+        const activeThread = threads.find(t => t.id === activeThreadId);
+        if (!isReadOnlyChannel(activeThread.channel)) {
+          switchThread(activeThreadId);
+          return;
+        }
       }
       if (assistantThreadId) {
         switchToAssistant();

--- a/crates/ironclaw_skills/src/catalog.rs
+++ b/crates/ironclaw_skills/src/catalog.rs
@@ -454,14 +454,15 @@ impl SkillCatalog {
             return;
         }
 
-        let futures: Vec<_> = entries[..count]
+        let futures: Vec<_> = entries
             .iter()
+            .take(count)
             .map(|e| self.fetch_skill_detail(&e.slug))
             .collect();
 
         let details = futures::future::join_all(futures).await;
 
-        for (entry, detail) in entries[..count].iter_mut().zip(details) {
+        for (entry, detail) in entries.iter_mut().take(count).zip(details) {
             if let Some(detail) = detail {
                 if let Some(ref stats) = detail.stats {
                     entry.stars = stats.stars;

--- a/deny.toml
+++ b/deny.toml
@@ -17,9 +17,6 @@ ignore = [
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",
-    # rustls-webpki URI/wildcard name constraint bypass — 0.102.x/0.103.x pinned by libsql transitive dep
-    "RUSTSEC-2026-0098",
-    "RUSTSEC-2026-0099",
 ]
 
 [licenses]

--- a/deny.toml
+++ b/deny.toml
@@ -64,3 +64,4 @@ allow-git = [
     "https://github.com/pydantic/monty.git",
     "https://github.com/astral-sh/ruff.git",
 ]
+

--- a/profiles/local-sandbox.toml
+++ b/profiles/local-sandbox.toml
@@ -1,7 +1,8 @@
 # IronClaw Profile: local-sandbox
 #
 # Solo developer setup with Docker sandbox enabled for secure tool execution.
-# Same as 'local' but tools run inside isolated containers.
+# Same as 'local' but tools run inside isolated containers. Background tasks
+# remain enabled for the personal-assistant experience.
 #
 # Prerequisites:
 #   - Docker daemon running
@@ -19,10 +20,10 @@ enabled = true
 policy = "readonly"
 
 [heartbeat]
-enabled = false
+enabled = true
 
 [routines]
-enabled = false
+enabled = true
 
 [hygiene]
-enabled = false
+enabled = true

--- a/profiles/local.toml
+++ b/profiles/local.toml
@@ -1,8 +1,8 @@
 # IronClaw Profile: local
 #
-# Stripped-down configuration for solo developers working locally.
-# Disables server-oriented features (gateway, heartbeat, routines, sandbox)
-# and enables the rich TUI for an interactive terminal experience.
+# Configuration for solo developers working locally.
+# Disables server-oriented gateway and Docker sandbox features while keeping
+# personal-assistant background tasks enabled.
 #
 # Usage: set IRONCLAW_PROFILE=local in your environment or .env file.
 #
@@ -19,10 +19,10 @@ cli_mode = "tui"
 enabled = false
 
 [heartbeat]
-enabled = false
+enabled = true
 
 [routines]
-enabled = false
+enabled = true
 
 [hygiene]
-enabled = false
+enabled = true

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -167,7 +167,7 @@ strip_test_mod_lines() {
         /^\+\+\+ b\// {
             cur_file = substr($0, 7)
             cur_start = (cur_file in test_start) ? test_start[cur_file] : 0
-            cur_skip_all = (cur_file ~ /^tests\//)
+            cur_skip_all = (cur_file ~ /(^|\/)tests\//)
             new_line = 0
             print
             next

--- a/src/agent/thread_ops.rs
+++ b/src/agent/thread_ops.rs
@@ -1220,13 +1220,18 @@ impl Agent {
                 .ok_or_else(|| Error::from(crate::error::JobError::NotFound { id: thread_id }))?;
 
             if thread.state != ThreadState::AwaitingApproval {
-                // Stale or duplicate approval (tool already executed) — silently ignore.
+                // No pending approval on this thread. Could be stale/duplicate
+                // (tool already executed) or a /approve typed on a thread with
+                // nothing pending.  Return a visible message so the user and
+                // UI-level tests know the command was processed.
                 tracing::debug!(
                     %thread_id,
                     state = ?thread.state,
-                    "Ignoring stale approval: thread not in AwaitingApproval state"
+                    "Ignoring approval: thread not in AwaitingApproval state"
                 );
-                return Ok(SubmissionResult::ok_with_message(""));
+                return Ok(SubmissionResult::ok_with_message(
+                    "No pending approval for this thread.",
+                ));
             }
 
             let pending = match thread.take_pending_approval() {

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -2077,20 +2077,17 @@ pub async fn resolve_gate(
                             if let Some(ref sse) = state.sse {
                                 sse.broadcast_for_user(
                                     &message.user_id,
-                                    AppEvent::OnboardingState {
-                                        extension_name: display_name.clone(),
-                                        state: ironclaw_common::OnboardingStateDto::PairingRequired,
-                                        request_id: Some(next_pending.request_id.to_string()),
-                                        message: Some(result.message.clone()),
-                                        instructions,
-                                        auth_url: None,
-                                        setup_url: None,
-                                        onboarding,
-                                        thread_id: pending
+                                    ironclaw_common::OnboardingStateDto::pairing_required(
+                                        display_name.clone(),
+                                        Some(next_pending.request_id.to_string()),
+                                        pending
                                             .scope_thread_id
                                             .clone()
                                             .or_else(|| Some(pending.thread_id.to_string())),
-                                        },
+                                        Some(result.message.clone()),
+                                        instructions,
+                                        onboarding,
+                                    ),
                                 );
                             }
                             return Ok(BridgeOutcome::Pending);

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4739,49 +4739,6 @@ fn clamp_always_to_resume_kind(always: bool, resume_kind: &ironclaw_engine::Resu
 }
 
 #[cfg(test)]
-mod clamp_tests {
-    use super::clamp_always_to_resume_kind;
-
-    #[test]
-    fn approval_with_allow_always_passes_through() {
-        let rk = ironclaw_engine::ResumeKind::Approval { allow_always: true };
-        assert!(clamp_always_to_resume_kind(true, &rk));
-        assert!(!clamp_always_to_resume_kind(false, &rk));
-    }
-
-    #[test]
-    fn approval_without_allow_always_clamps_to_false() {
-        // Regression: PR #1958 round-4 review — caller-supplied `always: true`
-        // on an `Approval { allow_always: false }` gate (orchestrator self-
-        // modify write) must not install a session-wide auto-approval.
-        let rk = ironclaw_engine::ResumeKind::Approval {
-            allow_always: false,
-        };
-        assert!(!clamp_always_to_resume_kind(true, &rk));
-        assert!(!clamp_always_to_resume_kind(false, &rk));
-    }
-
-    #[test]
-    fn auth_resume_kind_clamps_to_false() {
-        // Auth resumes have no "always" semantics; clamp regardless.
-        let rk = ironclaw_engine::ResumeKind::Authentication {
-            credential_name: "github_token".into(),
-            instructions: String::new(),
-            auth_url: None,
-        };
-        assert!(!clamp_always_to_resume_kind(true, &rk));
-    }
-
-    #[test]
-    fn external_callback_clamps_to_false() {
-        let rk = ironclaw_engine::ResumeKind::External {
-            callback_id: "cb-123".into(),
-        };
-        assert!(!clamp_always_to_resume_kind(true, &rk));
-    }
-}
-
-#[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
@@ -7089,5 +7046,45 @@ mod tests {
 
         let prior = super::persist_always_allow(&agent, &state, &pending).await;
         assert!(prior.is_none(), "Should return None when no settings_store");
+    }
+
+    // ── clamp_always_to_resume_kind ────────────────────────────────────
+
+    #[test]
+    fn clamp_approval_with_allow_always_passes_through() {
+        let rk = ironclaw_engine::ResumeKind::Approval { allow_always: true };
+        assert!(super::clamp_always_to_resume_kind(true, &rk));
+        assert!(!super::clamp_always_to_resume_kind(false, &rk));
+    }
+
+    #[test]
+    fn clamp_approval_without_allow_always_clamps_to_false() {
+        // Regression: PR #1958 round-4 review — caller-supplied `always: true`
+        // on an `Approval { allow_always: false }` gate (orchestrator self-
+        // modify write) must not install a session-wide auto-approval.
+        let rk = ironclaw_engine::ResumeKind::Approval {
+            allow_always: false,
+        };
+        assert!(!super::clamp_always_to_resume_kind(true, &rk));
+        assert!(!super::clamp_always_to_resume_kind(false, &rk));
+    }
+
+    #[test]
+    fn clamp_auth_resume_kind_clamps_to_false() {
+        // Auth resumes have no "always" semantics; clamp regardless.
+        let rk = ironclaw_engine::ResumeKind::Authentication {
+            credential_name: "github_token".into(),
+            instructions: String::new(),
+            auth_url: None,
+        };
+        assert!(!super::clamp_always_to_resume_kind(true, &rk));
+    }
+
+    #[test]
+    fn clamp_external_callback_clamps_to_false() {
+        let rk = ironclaw_engine::ResumeKind::External {
+            callback_id: "cb-123".into(),
+        };
+        assert!(!super::clamp_always_to_resume_kind(true, &rk));
     }
 }

--- a/src/bridge/store_adapter.rs
+++ b/src/bridge/store_adapter.rs
@@ -1780,7 +1780,7 @@ impl Store for HybridStore {
 }
 
 #[cfg(test)]
-mod helper_tests {
+mod tests {
     use super::*;
     use ironclaw_engine::types::shared_owner_id;
 

--- a/src/channels/wasm/mod.rs
+++ b/src/channels/wasm/mod.rs
@@ -107,7 +107,7 @@ pub use runtime::{PreparedChannelModule, WasmChannelRuntime, WasmChannelRuntimeC
 pub use schema::{
     ChannelCapabilitiesFile, ChannelConfig, SecretSetupSchema, SetupSchema, WebhookSchema,
 };
-pub(crate) use setup::is_reserved_wasm_channel_name;
 pub use setup::{WasmChannelSetup, inject_channel_credentials, setup_wasm_channels};
+pub(crate) use setup::{is_reserved_wasm_channel_name, owner_id_from_capabilities};
 pub(crate) use telegram_host_config::{TELEGRAM_CHANNEL_NAME, bot_username_setting_key};
 pub use wrapper::{HttpResponse, SharedWasmChannel, WasmChannel};

--- a/src/channels/wasm/setup.rs
+++ b/src/channels/wasm/setup.rs
@@ -391,42 +391,49 @@ fn owner_actor_id_for_channel(
         .wasm_channel_owner_ids
         .get(channel_name)
         .map(ToString::to_string)
-        .or_else(|| {
-            let value = loaded
-                .capabilities_file
-                .as_ref()
-                .and_then(|file| file.config.get("owner_id"))?;
-            match value {
-                serde_json::Value::Number(n) => {
-                    let id = n.as_i64();
-                    if id.is_none() {
-                        tracing::debug!(
-                            channel = %channel_name,
-                            value = %n,
-                            "Non-integer numeric owner_id in capabilities config"
-                        );
-                    }
-                    id.map(|id| id.to_string())
-                }
-                serde_json::Value::String(s) => {
-                    let trimmed = s.trim();
-                    if trimmed.is_empty() {
-                        None
-                    } else {
-                        Some(trimmed.to_string())
-                    }
-                }
-                serde_json::Value::Null => None,
-                other => {
-                    tracing::debug!(
-                        channel = %channel_name,
-                        value = ?other,
-                        "Ignoring non-scalar owner_id in capabilities config"
-                    );
-                    None
-                }
+        .or_else(|| owner_id_from_capabilities(loaded.capabilities_file.as_ref(), channel_name))
+}
+
+/// Extract `owner_id` from a channel's capabilities file config.
+///
+/// Handles Number, String, Null, and non-scalar JSON values. Shared between
+/// the boot path (`register_channel`) and the hot-activation path
+/// (`ExtensionManager::complete_loaded_wasm_channel_activation`).
+pub(crate) fn owner_id_from_capabilities(
+    cap_file: Option<&super::schema::ChannelCapabilitiesFile>,
+    channel_name: &str,
+) -> Option<String> {
+    let value = cap_file.and_then(|file| file.config.get("owner_id"))?;
+    match value {
+        serde_json::Value::Number(n) => {
+            let id = n.as_i64();
+            if id.is_none() {
+                tracing::debug!(
+                    channel = %channel_name,
+                    value = %n,
+                    "Non-integer numeric owner_id in capabilities config"
+                );
             }
-        })
+            id.map(|id| id.to_string())
+        }
+        serde_json::Value::String(s) => {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                Some(trimmed.to_string())
+            }
+        }
+        serde_json::Value::Null => None,
+        other => {
+            tracing::debug!(
+                channel = %channel_name,
+                value = ?other,
+                "Ignoring non-scalar owner_id in capabilities config"
+            );
+            None
+        }
+    }
 }
 
 async fn resolve_owner_actor_id_for_channel(

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -1150,15 +1150,11 @@ impl WasmChannel {
         .await;
     }
 
-    /// Load broadcast metadata from settings store on startup.
+    /// Load broadcast metadata from the owner-scoped settings store on startup.
     ///
-    /// # Legacy migration (remove after ownership model rollout — tracked in #2100)
-    ///
-    /// If no metadata is found under `self.owner_scope_id`, a second lookup
-    /// under `"default"` is attempted for backward compatibility with instances
-    /// that stored broadcast metadata before the ownership model migration.
-    /// Remove this fallback once all deployments have run the
-    /// `migrate_default_owner` bootstrap step and restarted at least once.
+    /// Broadcast metadata is owner-scoped runtime state. If the configured
+    /// owner scope has no stored value, we intentionally leave the in-memory
+    /// state empty rather than falling back to `default`.
     async fn load_broadcast_metadata(&self) {
         if let Some(ref store) = self.settings_store {
             match store
@@ -1173,29 +1169,11 @@ impl WasmChannel {
                     );
                 }
                 Ok(_) => {
-                    // LEGACY MIGRATION: remove after ownership model rollout — tracked in #2100
-                    if self.owner_scope_id != "default" {
-                        match store
-                            .get_setting("default", &self.broadcast_metadata_key())
-                            .await
-                        {
-                            Ok(Some(serde_json::Value::String(meta))) => {
-                                *self.last_broadcast_metadata.write().await = Some(meta);
-                                tracing::debug!(
-                                    channel = %self.name,
-                                    "Restored legacy owner broadcast metadata from default scope"
-                                );
-                            }
-                            Ok(_) => {}
-                            Err(e) => {
-                                tracing::warn!(
-                                    channel = %self.name,
-                                    "Failed to load legacy broadcast metadata: {}",
-                                    e
-                                );
-                            }
-                        }
-                    }
+                    tracing::debug!(
+                        channel = %self.name,
+                        owner_scope_id = %self.owner_scope_id,
+                        "No owner-scoped broadcast metadata stored"
+                    );
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -4469,6 +4447,7 @@ fn read_attachments(paths: &[String]) -> Result<Vec<wit_channel::Attachment>, St
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashMap;
     use std::sync::Arc;
     use std::time::Duration;
 
@@ -4533,6 +4512,13 @@ mod tests {
     }
 
     fn create_test_channel_with_owner_scope(owner_scope_id: &str) -> WasmChannel {
+        create_test_channel_with_owner_scope_and_settings(owner_scope_id, None)
+    }
+
+    fn create_test_channel_with_owner_scope_and_settings(
+        owner_scope_id: &str,
+        settings_store: Option<Arc<dyn crate::db::SettingsStore>>,
+    ) -> WasmChannel {
         let config = WasmChannelRuntimeConfig::for_testing();
         let runtime = Arc::new(WasmChannelRuntime::new(config).unwrap());
 
@@ -4552,8 +4538,119 @@ mod tests {
             owner_scope_id,
             "{}".to_string(),
             Arc::new(PairingStore::new_noop()),
-            None,
+            settings_store,
         )
+    }
+
+    struct RecordingSettingsStore {
+        values: tokio::sync::RwLock<HashMap<String, HashMap<String, serde_json::Value>>>,
+        lookups: tokio::sync::RwLock<Vec<(String, String)>>,
+    }
+
+    impl RecordingSettingsStore {
+        fn new() -> Self {
+            Self {
+                values: tokio::sync::RwLock::new(HashMap::new()),
+                lookups: tokio::sync::RwLock::new(Vec::new()),
+            }
+        }
+
+        async fn seed(&self, user_id: &str, key: &str, value: serde_json::Value) {
+            self.values
+                .write()
+                .await
+                .entry(user_id.to_string())
+                .or_default()
+                .insert(key.to_string(), value);
+        }
+
+        async fn lookups(&self) -> Vec<(String, String)> {
+            self.lookups.read().await.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::db::SettingsStore for RecordingSettingsStore {
+        async fn get_setting(
+            &self,
+            user_id: &str,
+            key: &str,
+        ) -> Result<Option<serde_json::Value>, crate::error::DatabaseError> {
+            self.lookups
+                .write()
+                .await
+                .push((user_id.to_string(), key.to_string()));
+            Ok(self
+                .values
+                .read()
+                .await
+                .get(user_id)
+                .and_then(|row| row.get(key).cloned()))
+        }
+
+        async fn get_setting_full(
+            &self,
+            _user_id: &str,
+            _key: &str,
+        ) -> Result<Option<crate::history::SettingRow>, crate::error::DatabaseError> {
+            Err(crate::error::DatabaseError::Query(
+                "RecordingSettingsStore::get_setting_full not implemented".into(),
+            ))
+        }
+
+        async fn set_setting(
+            &self,
+            user_id: &str,
+            key: &str,
+            value: &serde_json::Value,
+        ) -> Result<(), crate::error::DatabaseError> {
+            self.seed(user_id, key, value.clone()).await;
+            Ok(())
+        }
+
+        async fn delete_setting(
+            &self,
+            user_id: &str,
+            key: &str,
+        ) -> Result<bool, crate::error::DatabaseError> {
+            let mut rows = self.values.write().await;
+            Ok(rows
+                .get_mut(user_id)
+                .map(|row| row.remove(key).is_some())
+                .unwrap_or(false))
+        }
+
+        async fn list_settings(
+            &self,
+            _user_id: &str,
+        ) -> Result<Vec<crate::history::SettingRow>, crate::error::DatabaseError> {
+            Err(crate::error::DatabaseError::Query(
+                "RecordingSettingsStore::list_settings not implemented".into(),
+            ))
+        }
+
+        async fn get_all_settings(
+            &self,
+            _user_id: &str,
+        ) -> Result<HashMap<String, serde_json::Value>, crate::error::DatabaseError> {
+            Err(crate::error::DatabaseError::Query(
+                "RecordingSettingsStore::get_all_settings not implemented".into(),
+            ))
+        }
+
+        async fn set_all_settings(
+            &self,
+            _user_id: &str,
+            _settings: &HashMap<String, serde_json::Value>,
+        ) -> Result<(), crate::error::DatabaseError> {
+            Err(crate::error::DatabaseError::Query(
+                "RecordingSettingsStore::set_all_settings not implemented".into(),
+            ))
+        }
+
+        async fn has_settings(&self, user_id: &str) -> Result<bool, crate::error::DatabaseError> {
+            Ok(self.values.read().await.contains_key(user_id))
+        }
     }
 
     #[test]
@@ -6395,6 +6492,40 @@ mod tests {
         assert_eq!(msg.conversation_scope(), Some("12345")); // safety: test-only assertion
         let stored_metadata = last_broadcast_metadata.read().await.clone();
         assert_eq!(stored_metadata.as_deref(), Some(r#"{"chat_id":12345}"#)); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_start_does_not_fallback_to_default_broadcast_metadata_scope() {
+        let store = Arc::new(RecordingSettingsStore::new());
+        store
+            .seed(
+                "default",
+                "channel_broadcast_metadata_test",
+                serde_json::json!(r#"{"chat_id":12345}"#),
+            )
+            .await;
+
+        let channel = create_test_channel_with_owner_scope_and_settings(
+            "owner-scope",
+            Some(store.clone() as Arc<dyn crate::db::SettingsStore>),
+        );
+
+        let _stream = channel.start().await.expect("Channel should start");
+
+        assert!(
+            channel.last_broadcast_metadata.read().await.is_none(),
+            "owner-scoped metadata should stay empty when only default scope has a value"
+        );
+        assert_eq!(
+            store.lookups().await,
+            vec![(
+                "owner-scope".to_string(),
+                "channel_broadcast_metadata_test".to_string()
+            )],
+            "load_broadcast_metadata must not probe default scope"
+        );
+
+        channel.shutdown().await.expect("Shutdown should succeed");
     }
 
     #[tokio::test]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4007,18 +4007,15 @@ async fn extensions_setup_submit_handler(
                             .await
                             .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
                         {
-                            onboarding_event = AppEvent::OnboardingState {
-                                extension_name: name.clone(),
-                                state:
-                                    crate::channels::web::types::OnboardingStateDto::PairingRequired,
-                                request_id: Some(next_request_id),
-                                message: Some(result.message.clone()),
-                                instructions,
-                                auth_url: None,
-                                setup_url: None,
-                                onboarding,
-                                thread_id: Some(thread_id.to_string()),
-                            };
+                            onboarding_event =
+                                crate::channels::web::types::OnboardingStateDto::pairing_required(
+                                    name.clone(),
+                                    Some(next_request_id),
+                                    Some(thread_id.to_string()),
+                                    Some(result.message.clone()),
+                                    instructions,
+                                    onboarding,
+                                );
                         }
                     }
                     crate::channels::web::onboarding::ConfigureFlowOutcome::Ready => {

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -4287,8 +4287,24 @@ async fn gateway_status_handler(
         .map(|v| v.to_lowercase() == "true")
         .unwrap_or(false);
 
+    // Show commit hash when not a tagged release.
+    let commit_hash = {
+        let h = env!("GIT_COMMIT_HASH");
+        if h.is_empty() {
+            None
+        } else {
+            let dirty = env!("GIT_DIRTY") == "true";
+            Some(if dirty {
+                format!("{h}-dirty")
+            } else {
+                h.to_string()
+            })
+        }
+    };
+
     Json(GatewayStatusResponse {
         version: env!("CARGO_PKG_VERSION").to_string(),
+        commit_hash,
         sse_connections,
         ws_connections,
         total_connections: sse_connections + ws_connections,
@@ -4316,6 +4332,8 @@ struct ModelUsageEntry {
 #[derive(serde::Serialize)]
 struct GatewayStatusResponse {
     version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    commit_hash: Option<String>,
     sse_connections: u64,
     ws_connections: u64,
     total_connections: u64,

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -166,11 +166,8 @@ pub async fn run_status_command() -> anyhow::Result<()> {
             settings.channels.http_port.unwrap_or(3000)
         ));
     }
-    if channels_dir.exists() {
-        let wasm_count = count_wasm_files(&channels_dir);
-        if wasm_count > 0 {
-            channel_info.push(format!("{} wasm", wasm_count));
-        }
+    if let Some(wasm_summary) = format_wasm_channels_summary(&settings, &channels_dir) {
+        channel_info.push(wasm_summary);
     }
     println!("{}", fmt::kv_line("Channels", &channel_info.join(", "), 12));
 
@@ -263,6 +260,32 @@ fn count_wasm_files(dir: &std::path::Path) -> usize {
         .unwrap_or(0)
 }
 
+fn format_wasm_channels_summary(
+    settings: &Settings,
+    channels_dir: &std::path::Path,
+) -> Option<String> {
+    if settings.channels.wasm_channels_enabled && !settings.channels.wasm_channels.is_empty() {
+        let mut channels = settings.channels.wasm_channels.clone();
+        channels.sort();
+        return Some(format!("{} wasm ({})", channels.len(), channels.join(", ")));
+    }
+
+    let wasm_count = count_wasm_files(channels_dir);
+    if wasm_count > 0 {
+        if settings.channels.wasm_channels_enabled {
+            return Some(format!("{} wasm", wasm_count));
+        } else {
+            return Some(format!(
+                "{} wasm installed ({})",
+                wasm_count,
+                channels_dir.display()
+            ));
+        }
+    }
+
+    None
+}
+
 fn default_tools_dir() -> PathBuf {
     ironclaw_base_dir().join("tools")
 }
@@ -273,7 +296,8 @@ fn default_channels_dir() -> PathBuf {
 
 #[cfg(test)]
 mod tests {
-    use super::load_settings_from;
+    use super::{format_wasm_channels_summary, load_settings_from};
+    use crate::settings::Settings;
 
     /// Regression test for #354: load_settings_from must read config.toml.
     #[test]
@@ -364,5 +388,31 @@ mod tests {
         // Should fall back to JSON values, not crash
         assert!(settings.heartbeat.enabled);
         assert_eq!(settings.heartbeat.interval_secs, 500);
+    }
+
+    #[test]
+    fn formats_enabled_wasm_channels_with_names() {
+        let mut settings = Settings::default();
+        settings.channels.wasm_channels_enabled = true;
+        settings.channels.wasm_channels = vec!["telegram".to_string(), "slack".to_string()];
+        let dir = tempfile::tempdir().expect("tempdir");
+
+        let summary = format_wasm_channels_summary(&settings, dir.path());
+
+        assert_eq!(summary.as_deref(), Some("2 wasm (slack, telegram)"));
+    }
+
+    #[test]
+    fn formats_installed_wasm_channels_when_enabled_list_is_empty() {
+        let mut settings = Settings::default();
+        settings.channels.wasm_channels_enabled = false;
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::File::create(dir.path().join("telegram.wasm")).expect("write wasm");
+        std::fs::File::create(dir.path().join("slack.wasm")).expect("write wasm");
+
+        let summary = format_wasm_channels_summary(&settings, dir.path());
+        let expected = format!("2 wasm installed ({})", dir.path().display());
+
+        assert_eq!(summary.as_deref(), Some(expected.as_str()));
     }
 }

--- a/src/config/profile.rs
+++ b/src/config/profile.rs
@@ -231,7 +231,7 @@ mod tests {
     }
 
     #[test]
-    fn local_profile_disables_gateway() {
+    fn local_profile_disables_gateway_and_sandbox() {
         let _guard = lock_env();
         unsafe { std::env::set_var("IRONCLAW_PROFILE", "local") };
 
@@ -242,9 +242,9 @@ mod tests {
 
         assert!(!settings.channels.gateway_enabled);
         assert!(!settings.sandbox.enabled);
-        assert!(!settings.heartbeat.enabled);
-        assert!(!settings.routines.enabled);
-        assert!(!settings.hygiene.enabled);
+        assert!(settings.heartbeat.enabled);
+        assert!(settings.routines.enabled);
+        assert!(settings.hygiene.enabled);
         assert_eq!(settings.channels.cli_mode.as_deref(), Some("tui"));
         assert_eq!(settings.database_backend.as_deref(), Some("libsql"));
     }
@@ -292,6 +292,9 @@ mod tests {
         assert!(settings.sandbox.enabled);
         assert_eq!(settings.sandbox.policy, "readonly");
         assert!(!settings.channels.gateway_enabled);
+        assert!(settings.heartbeat.enabled);
+        assert!(settings.routines.enabled);
+        assert!(settings.hygiene.enabled);
     }
 
     #[test]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -18,6 +18,7 @@ use crate::channels::ChannelManager;
 use crate::channels::wasm::{
     LoadedChannel, RegisteredEndpoint, SharedWasmChannel, TELEGRAM_CHANNEL_NAME, WasmChannelLoader,
     WasmChannelRouter, WasmChannelRuntime, bot_username_setting_key, is_reserved_wasm_channel_name,
+    owner_id_from_capabilities,
 };
 use crate::extensions::discovery::OnlineDiscovery;
 use crate::extensions::registry::ExtensionRegistry;
@@ -5688,11 +5689,16 @@ impl ExtensionManager {
             )));
         }
 
+        // Resolve owner with full fallback: explicit arg -> runtime HashMap -> settings store
+        // -> pairing_store external id -> capabilities file.
         let owner_actor_id = if let Some(owner_id) = owner_id {
             Some(owner_id.to_string())
+        } else if let Some(id) = self.current_channel_owner_actor_id(&channel_name).await {
+            Some(id)
         } else {
-            self.current_channel_owner_actor_id(&channel_name).await
+            owner_id_from_capabilities(loaded.capabilities_file.as_ref(), &channel_name)
         };
+
         let webhook_secret_name = loaded.webhook_secret_name();
         let secret_header = loaded.webhook_secret_header().map(|s| s.to_string());
         let webhook_secret_managed_by_host = loaded.webhook_secret_managed_by_host();
@@ -5933,7 +5939,10 @@ impl ExtensionManager {
             .as_ref()
             .and_then(|f| f.hmac_secret_name().map(|s| s.to_string()));
 
-        let owner_actor_id = self.current_channel_owner_actor_id(name).await;
+        let owner_actor_id = self
+            .current_channel_owner_actor_id(name)
+            .await
+            .or_else(|| owner_id_from_capabilities(capabilities_file.as_ref(), name));
         let mut config_updates = build_wasm_channel_runtime_config_updates(
             self.tunnel_url.as_deref(),
             None,
@@ -7658,8 +7667,8 @@ mod tests {
 
     use crate::channels::ChannelManager;
     use crate::channels::wasm::{
-        ChannelCapabilities, LoadedChannel, PreparedChannelModule, WasmChannel, WasmChannelRouter,
-        WasmChannelRuntime, WasmChannelRuntimeConfig,
+        ChannelCapabilities, ChannelCapabilitiesFile, LoadedChannel, PreparedChannelModule,
+        WasmChannel, WasmChannelRouter, WasmChannelRuntime, WasmChannelRuntimeConfig,
     };
     use crate::extensions::ExtensionManager;
     use crate::extensions::manager::{
@@ -9506,6 +9515,42 @@ mod tests {
         }
     }
 
+    fn make_test_loaded_channel_with_capabilities(
+        runtime: Arc<WasmChannelRuntime>,
+        name: &str,
+        pairing_store: Arc<PairingStore>,
+        config_json: serde_json::Value,
+    ) -> LoadedChannel {
+        let prepared = Arc::new(PreparedChannelModule::for_testing(
+            name,
+            format!("Mock channel: {}", name),
+        ));
+        let capabilities =
+            ChannelCapabilities::for_channel(name).with_path(format!("/webhook/{}", name));
+
+        let cap_file_json = serde_json::json!({
+            "type": "channel",
+            "name": name,
+            "setup": { "required_secrets": [] },
+            "capabilities": { "channel": { "allowed_paths": [format!("/webhook/{}", name)] } },
+            "config": config_json
+        });
+        let cap_file = ChannelCapabilitiesFile::from_json(&cap_file_json.to_string()).unwrap();
+
+        LoadedChannel {
+            channel: WasmChannel::new(
+                runtime,
+                prepared,
+                capabilities,
+                "default",
+                "{}".to_string(),
+                pairing_store,
+                None,
+            ),
+            capabilities_file: Some(cap_file),
+        }
+    }
+
     #[test]
     fn test_telegram_hot_activation_runtime_config_includes_owner_id() -> Result<(), String> {
         let updates = build_wasm_channel_runtime_config_updates(
@@ -9526,8 +9571,76 @@ mod tests {
         )?;
         require_eq(
             updates.get("owner_id"),
-            Some(&serde_json::json!(424242)),
-            "owner_id",
+            Some(&serde_json::json!(424242_i64)),
+            "integer-compatible owner_id is injected as a JSON number",
+        )
+    }
+
+    #[tokio::test]
+    async fn test_hot_activation_uses_capabilities_owner_id_fallback() -> Result<(), String> {
+        let manager = make_manager_with_temp_dirs();
+        let channel_manager = Arc::new(ChannelManager::new());
+        let runtime = Arc::new(
+            WasmChannelRuntime::new(WasmChannelRuntimeConfig::for_testing())
+                .map_err(|err| format!("runtime: {err}"))?,
+        );
+        let pairing_store = Arc::new(PairingStore::new_noop());
+        let router = Arc::new(WasmChannelRouter::new());
+        manager
+            .set_channel_runtime(
+                Arc::clone(&channel_manager),
+                Arc::clone(&runtime),
+                Arc::clone(&pairing_store),
+                Arc::clone(&router),
+                std::collections::HashMap::new(),
+            )
+            .await;
+
+        // LoadedChannel with capabilities config containing owner_id
+        let loaded = make_test_loaded_channel_with_capabilities(
+            Arc::clone(&runtime),
+            "telegram",
+            Arc::clone(&pairing_store),
+            serde_json::json!({ "owner_id": 99887766 }),
+        );
+
+        // Activate with no runtime owner_id — should fall back to capabilities
+        let result = manager
+            .complete_loaded_wasm_channel_activation(
+                "telegram",
+                loaded,
+                &channel_manager,
+                &router,
+                None,
+            )
+            .await
+            .map_err(|e| format!("activation failed: {e}"))?;
+
+        require_eq(
+            result.name,
+            "telegram".to_string(),
+            "activation result name",
+        )?;
+
+        // Verify the channel got the capabilities-derived owner_actor_id
+        let channel = router
+            .get_channel_for_path("/webhook/telegram")
+            .await
+            .ok_or_else(|| "telegram channel not registered".to_string())?;
+        require_eq(
+            channel.owner_actor_id_for_test().await,
+            Some("99887766".to_string()),
+            "owner_actor_id should come from capabilities fallback",
+        )?;
+
+        // Verify config was injected. The shared `build_runtime_config_updates`
+        // helper parses integer-compatible owner ids back to a JSON number, so
+        // assert the numeric representation the helper produces today.
+        let config = channel.get_config().await;
+        require_eq(
+            config.get("owner_id"),
+            Some(&serde_json::json!(99887766_i64)),
+            "config owner_id should be restored from capabilities fallback",
         )
     }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -7227,23 +7227,20 @@ impl ExtensionManager {
                     );
                     sse.broadcast_for_user(
                         user_id,
-                        ironclaw_common::AppEvent::OnboardingState {
-                            extension_name: name.clone(),
-                            state: ironclaw_common::OnboardingStateDto::PairingRequired,
-                            request_id: None,
-                            message: None,
-                            instructions: Some(format!(
+                        ironclaw_common::OnboardingStateDto::pairing_required(
+                            name.clone(),
+                            None,
+                            None,
+                            None,
+                            Some(format!(
                                 "Send a message to your {} bot, then paste the pairing code here.",
                                 name
                             )),
-                            auth_url: None,
-                            setup_url: None,
-                            onboarding: onboarding
+                            onboarding
                                 .1
                                 .as_ref()
                                 .and_then(|o| serde_json::to_value(o).ok()),
-                            thread_id: None,
-                        },
+                        ),
                     );
                 }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -468,6 +468,101 @@ fn sanitize_url_for_logging(url: &str) -> String {
     }
 }
 
+/// Whether the install-time `kind_hint` permits falling back to local tool
+/// source discovery. Only WASM kinds are buildable from a local Cargo source;
+/// MCP servers, channel relays, and ACP agents must come from the registry or
+/// an explicit URL.
+fn kind_allows_local_discovery(kind_hint: Option<ExtensionKind>) -> bool {
+    matches!(
+        kind_hint,
+        None | Some(ExtensionKind::WasmTool) | Some(ExtensionKind::WasmChannel)
+    )
+}
+
+/// Search common directories relative to the current working directory for a
+/// tool source directory matching `name`.
+///
+/// Checks these patterns (both hyphen and underscore variants):
+/// - `tools-src/<name>/`
+/// - `tool-src/<name>/`
+/// - `<name>/` (direct subdirectory)
+///
+/// A directory is considered a match if it contains a `Cargo.toml`.
+fn find_local_tool_source(name: &str) -> Option<std::path::PathBuf> {
+    let cwd = std::env::current_dir().ok()?;
+    find_local_tool_source_in(name, &cwd)
+}
+
+/// Inner implementation that accepts an explicit search root (for testability).
+fn find_local_tool_source_in(
+    name: &str,
+    search_root: &std::path::Path,
+) -> Option<std::path::PathBuf> {
+    // Build a stable, priority-ordered list of name variants. Order matters:
+    // when multiple variants exist in the same search directory, the first
+    // match wins. Prefer the exact/underscore form over hyphen and
+    // suffix-stripped/added variants so behavior is reproducible across runs.
+    let underscore_name = name.replace('-', "_");
+    let hyphen_name = name.replace('_', "-");
+
+    let mut candidates: Vec<String> = Vec::with_capacity(4);
+    candidates.push(underscore_name.clone());
+    candidates.push(hyphen_name.clone());
+
+    // If the name ends with a tool suffix, also try stripped variants.
+    // Otherwise, try suffixed variants. `underscore_name` has all `-`
+    // replaced with `_`, so checking `_tool` covers both `name_tool` and
+    // `name-tool` inputs.
+    if let Some(base) = underscore_name.strip_suffix("_tool") {
+        candidates.push(base.to_string());
+        candidates.push(base.replace('_', "-"));
+    } else {
+        candidates.push(format!("{}_tool", underscore_name));
+        candidates.push(format!("{}-tool", hyphen_name));
+    }
+
+    // Remove duplicates while preserving priority order (e.g. when
+    // underscore_name == hyphen_name).
+    let mut seen = std::collections::HashSet::new();
+    candidates.retain(|c| seen.insert(c.clone()));
+
+    let search_dirs = ["tools-src", "tool-src", "."];
+
+    for dir_prefix in &search_dirs {
+        let base = if *dir_prefix == "." {
+            search_root.to_path_buf()
+        } else {
+            search_root.join(dir_prefix)
+        };
+
+        if !base.is_dir() {
+            continue;
+        }
+
+        for candidate_name in &candidates {
+            let candidate = base.join(candidate_name);
+            if candidate.is_dir() && candidate.join("Cargo.toml").is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+
+    None
+}
+
+/// Read `[package].name` from the `Cargo.toml` at `source_dir`. Returns
+/// `None` if the file is missing, unparseable, or lacks a package name —
+/// callers fall back to the extension name in that case.
+fn read_crate_name_from_cargo_toml(source_dir: &std::path::Path) -> Option<String> {
+    let contents = std::fs::read_to_string(source_dir.join("Cargo.toml")).ok()?;
+    let value: toml::Value = contents.parse().ok()?;
+    value
+        .get("package")?
+        .get("name")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
 impl ExtensionManager {
     fn existing_extension_file_path(
         dir: &std::path::Path,
@@ -1425,11 +1520,24 @@ impl ExtensionManager {
             });
         }
 
+        // Try to discover a local tool source directory in the working directory.
+        // Only applies to WASM kinds — MCP servers, channel relays, and ACP agents
+        // can't be built from a local Cargo-based source.
+        if kind_allows_local_discovery(kind_hint)
+            && let Some(source_dir) = find_local_tool_source(&name)
+        {
+            return self
+                .install_from_local_source(&name, &source_dir, kind_hint)
+                .await;
+        }
+
         let err = ExtensionError::NotFound(format!(
-            "'{}' not found in registry. Try searching with discover:true or provide a URL.",
+            "'{}' not found in registry or local directories. \
+             Try searching with discover:true, provide a URL, \
+             or ensure tool source exists in tools-src/{0}/, tool-src/{0}/, or ./{0}/.",
             name
         ));
-        tracing::warn!(extension = %name, "Extension not found in registry");
+        tracing::warn!(extension = %name, "Extension not found in registry or locally");
         Err(err)
     }
 
@@ -3367,6 +3475,63 @@ impl ExtensionManager {
         }
 
         Ok(())
+    }
+
+    /// Install a WASM extension from a locally-discovered source directory.
+    ///
+    /// Used when `tool_install` is called with a name that isn't in the registry
+    /// but matches a local source directory found by `find_local_tool_source`.
+    /// Annotates the install message with the source path so the caller can
+    /// verify provenance (the tool came from the local filesystem, not the
+    /// verified registry).
+    async fn install_from_local_source(
+        &self,
+        name: &str,
+        source_dir: &std::path::Path,
+        kind_hint: Option<ExtensionKind>,
+    ) -> Result<InstallResult, ExtensionError> {
+        tracing::debug!(
+            extension = %name,
+            source_dir = %source_dir.display(),
+            "Found local tool source directory"
+        );
+        let kind = kind_hint.unwrap_or(ExtensionKind::WasmTool);
+        let target_dir = match kind {
+            ExtensionKind::WasmChannel => &self.wasm_channels_dir,
+            _ => &self.wasm_tools_dir,
+        };
+        // Convert the discovered source path to UTF-8. A lossy conversion
+        // would silently substitute replacement chars and the downstream
+        // build-dir resolution would point at a non-existent path, so reject
+        // non-UTF-8 paths with a clear error instead.
+        let source_str = source_dir.to_str().ok_or_else(|| {
+            ExtensionError::InstallFailed(format!(
+                "local source path '{}' is not valid UTF-8",
+                source_dir.display(),
+            ))
+        })?;
+        // Parse the discovered Cargo.toml to learn the actual crate name. The
+        // installed extension name may differ from the crate name when suffix
+        // stripping/adding matched a directory (e.g. input `portfolio_tool`
+        // matching `tools-src/portfolio/` whose crate is `portfolio`). The
+        // compiled artifact is `<crate_name>.wasm`, so we must pass the real
+        // crate name to the artifact lookup.
+        let crate_name = read_crate_name_from_cargo_toml(source_dir);
+        let mut result = self
+            .install_wasm_from_buildable(
+                name,
+                Some(source_str),
+                crate_name.as_deref(),
+                target_dir,
+                kind,
+            )
+            .await?;
+        result.message = format!(
+            "{} (installed from LOCAL source at {})",
+            result.message,
+            source_dir.display(),
+        );
+        Ok(result)
     }
 
     /// Install a WASM extension from local build artifacts (WasmBuildable source).
@@ -7502,8 +7667,9 @@ mod tests {
     use crate::extensions::ExtensionManager;
     use crate::extensions::manager::{
         FallbackDecision, TELEGRAM_TEST_API_BASE_ENV, build_wasm_channel_runtime_config_updates,
-        combine_install_errors, fallback_decision, infer_kind_from_url,
-        normalize_hosted_callback_url, send_telegram_text_message, telegram_bot_api_url,
+        combine_install_errors, fallback_decision, find_local_tool_source_in, infer_kind_from_url,
+        kind_allows_local_discovery, normalize_hosted_callback_url,
+        read_crate_name_from_cargo_toml, send_telegram_text_message, telegram_bot_api_url,
     };
     use crate::extensions::{
         AuthHint, ExtensionError, ExtensionKind, ExtensionSource, InstallResult, RegistryEntry,
@@ -11839,5 +12005,389 @@ mod tests {
         );
 
         Ok(())
+    }
+
+    // ── find_local_tool_source_in ──────────────────────────────────────
+
+    #[test]
+    fn find_local_tool_source_finds_tools_src_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tools-src").join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_finds_tool_src_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tool-src").join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_finds_hyphenated_variant() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tools-src").join("my-portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"my_portfolio\"",
+        )
+        .unwrap();
+
+        // Search with underscored name should find hyphenated directory
+        let result = find_local_tool_source_in("my_portfolio", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_finds_direct_subdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_returns_none_without_cargo_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tools-src").join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        // No Cargo.toml
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_local_tool_source_ignores_cargo_toml_directory() {
+        // Regression: a directory named `Cargo.toml` must not satisfy the
+        // manifest check — only a real file should qualify the candidate.
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tools-src").join("portfolio");
+        std::fs::create_dir_all(tool_dir.join("Cargo.toml")).unwrap();
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_local_tool_source_returns_none_when_not_present() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let result = find_local_tool_source_in("nonexistent", dir.path());
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn find_local_tool_source_strips_tool_suffix() {
+        let dir = tempfile::tempdir().unwrap();
+        // Name is "portfolio_tool" but directory is just "portfolio"
+        let tool_dir = dir.path().join("tools-src").join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio_tool", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_strips_hyphen_tool_suffix() {
+        // Regression: input `portfolio-tool` (hyphen form) must still match
+        // `tools-src/portfolio/` after suffix stripping. Internally the
+        // candidate list is built from the underscore-normalized name, so a
+        // single `_tool` strip must cover both `_tool` and `-tool` inputs.
+        let dir = tempfile::tempdir().unwrap();
+        let tool_dir = dir.path().join("tools-src").join("portfolio");
+        std::fs::create_dir_all(&tool_dir).unwrap();
+        std::fs::write(
+            tool_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio-tool", dir.path());
+        assert_eq!(result, Some(tool_dir));
+    }
+
+    #[test]
+    fn find_local_tool_source_prefers_tools_src_over_direct() {
+        let dir = tempfile::tempdir().unwrap();
+        let tools_src_dir = dir.path().join("tools-src").join("portfolio");
+        let direct_dir = dir.path().join("portfolio");
+        std::fs::create_dir_all(&tools_src_dir).unwrap();
+        std::fs::create_dir_all(&direct_dir).unwrap();
+        std::fs::write(
+            tools_src_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+        std::fs::write(
+            direct_dir.join("Cargo.toml"),
+            "[package]\nname = \"portfolio\"",
+        )
+        .unwrap();
+
+        let result = find_local_tool_source_in("portfolio", dir.path());
+        // tools-src/ should be preferred since it's checked first
+        assert_eq!(result, Some(tools_src_dir));
+    }
+
+    // ── kind_allows_local_discovery ────────────────────────────────────
+
+    #[test]
+    fn kind_allows_local_discovery_accepts_wasm_kinds() {
+        assert!(kind_allows_local_discovery(None));
+        assert!(kind_allows_local_discovery(Some(ExtensionKind::WasmTool)));
+        assert!(kind_allows_local_discovery(Some(
+            ExtensionKind::WasmChannel
+        )));
+    }
+
+    #[test]
+    fn kind_allows_local_discovery_rejects_non_wasm_kinds() {
+        assert!(!kind_allows_local_discovery(Some(ExtensionKind::McpServer)));
+        assert!(!kind_allows_local_discovery(Some(
+            ExtensionKind::ChannelRelay
+        )));
+        assert!(!kind_allows_local_discovery(Some(ExtensionKind::AcpAgent)));
+    }
+
+    // ── install_from_local_source (caller-level) ───────────────────────
+
+    /// Stage a buildable WASM source layout and return (source_dir, tools_dir).
+    fn stage_buildable_source(dir: &std::path::Path, crate_name: &str) -> std::path::PathBuf {
+        stage_buildable_source_at(dir, "portfolio", crate_name)
+    }
+
+    /// Stage a buildable WASM source layout under `<dir>/<source_subdir>/`
+    /// with a `Cargo.toml` declaring `[package] name = <crate_name>` and a
+    /// `<crate_name>.wasm` artifact. Returns the source directory.
+    fn stage_buildable_source_at(
+        dir: &std::path::Path,
+        source_subdir: &str,
+        crate_name: &str,
+    ) -> std::path::PathBuf {
+        let source_dir = dir.join(source_subdir);
+        let artifact_dir = source_dir.join("target/wasm32-wasip2/release");
+        std::fs::create_dir_all(&artifact_dir).expect("artifact dir");
+        let wasm_path = artifact_dir.join(format!("{}.wasm", crate_name));
+        // Minimal valid wasm header (`\x00asm` + version 1).
+        std::fs::write(&wasm_path, b"\x00asm\x01\x00\x00\x00").expect("write wasm");
+        let caps_path = source_dir.join(format!("{}.capabilities.json", crate_name));
+        std::fs::write(&caps_path, "{}").expect("write capabilities");
+        std::fs::write(
+            source_dir.join("Cargo.toml"),
+            format!("[package]\nname = \"{}\"\n", crate_name),
+        )
+        .expect("write Cargo.toml");
+        source_dir
+    }
+
+    /// Caller-level test: driving `install_from_local_source` end-to-end
+    /// verifies the wrapper logic (kind defaulting, target_dir selection,
+    /// source_str conversion, message annotation) — none of which is
+    /// exercised by unit tests on `find_local_tool_source_in`.
+    #[tokio::test]
+    async fn install_from_local_source_installs_wasm_tool_with_provenance_message() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = dir.path().join("channels");
+        let source_dir = stage_buildable_source(dir.path(), "portfolio");
+
+        let manager = make_test_manager_with_dirs(None, tools_dir.clone(), channels_dir, None);
+
+        let result = manager
+            .install_from_local_source("portfolio", &source_dir, None)
+            .await
+            .expect("install from local source");
+
+        assert_eq!(result.name, "portfolio");
+        assert_eq!(result.kind, ExtensionKind::WasmTool);
+        // Message must include "LOCAL" and the source path so provenance is visible.
+        assert!(
+            result.message.contains("LOCAL"),
+            "message should mark source as LOCAL: {}",
+            result.message
+        );
+        assert!(
+            result.message.contains(&source_dir.display().to_string()),
+            "message should include source path: {}",
+            result.message
+        );
+        // Wasm artifact must have been copied to the tools dir.
+        assert!(
+            tools_dir.join("portfolio.wasm").exists(),
+            "install should copy wasm to tools dir"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_from_local_source_routes_wasm_channel_to_channels_dir() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = dir.path().join("channels");
+        let source_dir = stage_buildable_source(dir.path(), "portfolio");
+
+        let manager =
+            make_test_manager_with_dirs(None, tools_dir.clone(), channels_dir.clone(), None);
+
+        let result = manager
+            .install_from_local_source("portfolio", &source_dir, Some(ExtensionKind::WasmChannel))
+            .await
+            .expect("install from local source");
+
+        assert_eq!(result.kind, ExtensionKind::WasmChannel);
+        // Channel kind must install into the channels dir, not the tools dir.
+        assert!(
+            channels_dir.join("portfolio.wasm").exists(),
+            "wasm channel should land in channels dir"
+        );
+        assert!(
+            !tools_dir.join("portfolio.wasm").exists(),
+            "wasm channel should NOT land in tools dir"
+        );
+    }
+
+    /// Regression test for the suffix-stripping name-mismatch bug: when
+    /// `find_local_tool_source` matches a directory via suffix stripping
+    /// (input `portfolio_tool` -> dir `portfolio/`), the compiled binary
+    /// on disk is named after the Cargo crate (`portfolio.wasm`), not the
+    /// extension name (`portfolio_tool.wasm`). `install_from_local_source`
+    /// must parse `Cargo.toml` and pass the real crate name to the artifact
+    /// lookup, otherwise every suffix-matched install fails.
+    #[tokio::test]
+    async fn install_from_local_source_resolves_artifact_via_crate_name() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = dir.path().join("channels");
+        // Crate name differs from the requested install name: crate is
+        // `portfolio`, install is requested as `portfolio_tool`.
+        let source_dir = stage_buildable_source_at(dir.path(), "portfolio", "portfolio");
+
+        let manager = make_test_manager_with_dirs(None, tools_dir.clone(), channels_dir, None);
+
+        let result = manager
+            .install_from_local_source("portfolio_tool", &source_dir, None)
+            .await
+            .expect("install should resolve artifact via Cargo.toml crate name");
+
+        assert_eq!(result.name, "portfolio_tool");
+        // The installed wasm is named after the install name, not the crate.
+        assert!(
+            tools_dir.join("portfolio_tool.wasm").exists(),
+            "install should copy wasm under the requested extension name"
+        );
+    }
+
+    /// Regression test: a non-UTF-8 source path must produce a clear
+    /// `InstallFailed` error rather than being silently lossy-converted into
+    /// a build dir that does not exist.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn install_from_local_source_rejects_non_utf8_path() {
+        use std::ffi::OsStr;
+        use std::os::unix::ffi::OsStrExt;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = dir.path().join("channels");
+        // 0x80 is an invalid UTF-8 start byte.
+        let bad: &OsStr = OsStr::from_bytes(b"/tmp/\x80not-utf8");
+        let bad_path = std::path::Path::new(bad);
+
+        let manager = make_test_manager_with_dirs(None, tools_dir, channels_dir, None);
+
+        let err = manager
+            .install_from_local_source("portfolio", bad_path, None)
+            .await
+            .expect_err("non-UTF-8 source path must be rejected");
+
+        match err {
+            ExtensionError::InstallFailed(msg) => {
+                assert!(
+                    msg.contains("UTF-8"),
+                    "error message should mention UTF-8: {msg}"
+                );
+            }
+            other => panic!("expected InstallFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn read_crate_name_from_cargo_toml_returns_package_name() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("Cargo.toml"),
+            "[package]\nname = \"my_crate\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            read_crate_name_from_cargo_toml(dir.path()),
+            Some("my_crate".to_string())
+        );
+    }
+
+    #[test]
+    fn read_crate_name_from_cargo_toml_returns_none_on_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(read_crate_name_from_cargo_toml(dir.path()), None);
+    }
+
+    #[test]
+    fn find_local_tool_source_prefers_underscore_over_hyphen() {
+        // Determinism regression: when both underscore and hyphen variants
+        // exist as real directories in the same search dir, the underscore
+        // (canonical) form must win on every run.
+        let dir = tempfile::tempdir().unwrap();
+        let underscore_dir = dir.path().join("tools-src").join("my_tool");
+        let hyphen_dir = dir.path().join("tools-src").join("my-tool");
+        std::fs::create_dir_all(&underscore_dir).unwrap();
+        std::fs::create_dir_all(&hyphen_dir).unwrap();
+        std::fs::write(
+            underscore_dir.join("Cargo.toml"),
+            "[package]\nname = \"my_tool\"",
+        )
+        .unwrap();
+        std::fs::write(
+            hyphen_dir.join("Cargo.toml"),
+            "[package]\nname = \"my-tool\"",
+        )
+        .unwrap();
+
+        for _ in 0..5 {
+            let result = find_local_tool_source_in("my_tool", dir.path());
+            assert_eq!(
+                result,
+                Some(underscore_dir.clone()),
+                "underscore variant must win deterministically"
+            );
+        }
     }
 }

--- a/src/history/store.rs
+++ b/src/history/store.rs
@@ -3311,6 +3311,7 @@ mod tests {
         );
 
         // Clean up test data.
+        // safety: idempotent test-cleanup deletes in an `#[ignore]` integration test — no atomicity requirement
         let conn = store.conn().await.unwrap();
         for job_id in [ctx_a1.job_id, ctx_a2.job_id, ctx_b1.job_id] {
             conn.execute("DELETE FROM llm_calls WHERE job_id = $1", &[&job_id])

--- a/src/llm/CLAUDE.md
+++ b/src/llm/CLAUDE.md
@@ -92,6 +92,8 @@ ID, migrate to it immediately. Advanced users can override headers via
 
 **Tool message flattening:** NEAR AI's API doesn't support `role: "tool"` messages in the standard format. `nearai_chat.rs` defaults `flatten_tool_messages = true`, converting tool results to user messages with `[Tool result from <name>]: <content>` format. Use `NearAiChatProvider::new_with_flatten(..., false)` to disable for compliant endpoints.
 
+**Tool schema normalization:** `nearai_chat.rs` applies the same `normalize_schema_strict()` boundary normalization as `RigAdapter::convert_tools` and `openai_codex_provider.rs` before sending tool definitions. Top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` schemas are flattened into a permissive object envelope so providers that reject those shapes do not fail with HTTP 400.
+
 **Pricing auto-fetch:** On startup, `NearAiChatProvider` fires a background task to fetch per-model pricing from `/v1/model/list`. If the fetch fails, it silently falls back to `costs::model_cost()` / `costs::default_cost()`. Pricing is stored in-memory only.
 
 **HTTP request timeout:** The NEAR AI HTTP client has a 120-second timeout per request. Rate limit `Retry-After` headers are parsed (both delay-seconds and HTTP-date formats) and forwarded as `LlmError::RateLimited { retry_after }` for the `RetryProvider` to honor.

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -22,7 +22,7 @@ use crate::llm::provider::{
     ChatMessage, CompletionRequest, CompletionResponse, FinishReason, LlmProvider, Role, ToolCall,
     ToolCompletionRequest, ToolCompletionResponse,
 };
-use crate::llm::{costs, session::SessionManager};
+use crate::llm::{costs, rig_adapter::normalize_schema_strict, session::SessionManager};
 
 /// Information about an available model from NEAR AI API.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -572,28 +572,15 @@ impl LlmProvider for NearAiChatProvider {
             messages
         };
 
-        let tools: Vec<ChatCompletionTool> = req
-            .tools
-            .into_iter()
-            .map(|t| ChatCompletionTool {
-                tool_type: "function".to_string(),
-                function: ChatCompletionFunction {
-                    name: t.name,
-                    description: Some(t.description),
-                    parameters: Some(t.parameters),
-                },
-            })
-            .collect();
-
-        let request = ChatCompletionRequest {
+        let request = build_chat_completion_request(
             model,
             messages,
-            temperature: req.temperature,
-            max_tokens: req.max_tokens,
-            stop: req.stop_sequences,
-            tools: if tools.is_empty() { None } else { Some(tools) },
-            tool_choice: req.tool_choice,
-        };
+            req.tools,
+            req.temperature,
+            req.max_tokens,
+            req.stop_sequences,
+            req.tool_choice,
+        );
 
         let response: ChatCompletionResponse = self.send_request(&request).await?;
 
@@ -1059,6 +1046,47 @@ struct ChatCompletionFunction {
     parameters: Option<serde_json::Value>,
 }
 
+/// Convert a `ToolDefinition` to NEAR AI Chat Completions tool format.
+///
+/// Applies the same strict schema normalization used by the other OpenAI-compatible
+/// provider adapters so that top-level `oneOf`/`anyOf`/`allOf`/`enum`/`not` schemas
+/// are flattened before request serialization.
+fn convert_tool_definition(tool: crate::llm::provider::ToolDefinition) -> ChatCompletionTool {
+    let mut description = tool.description.clone();
+    let parameters = normalize_schema_strict(&tool.parameters, &mut description);
+
+    ChatCompletionTool {
+        tool_type: "function".to_string(),
+        function: ChatCompletionFunction {
+            name: tool.name,
+            description: Some(description),
+            parameters: Some(parameters),
+        },
+    }
+}
+
+fn build_chat_completion_request(
+    model: String,
+    messages: Vec<ChatCompletionMessage>,
+    tools: Vec<crate::llm::provider::ToolDefinition>,
+    temperature: Option<f32>,
+    max_tokens: Option<u32>,
+    stop: Option<Vec<String>>,
+    tool_choice: Option<String>,
+) -> ChatCompletionRequest {
+    let tools: Vec<ChatCompletionTool> = tools.into_iter().map(convert_tool_definition).collect();
+
+    ChatCompletionRequest {
+        model,
+        messages,
+        temperature,
+        max_tokens,
+        stop,
+        tools: if tools.is_empty() { None } else { Some(tools) },
+        tool_choice,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct ChatCompletionResponse {
     #[allow(dead_code)]
@@ -1251,6 +1279,44 @@ mod tests {
         let msg = ChatMessage::assistant("Hello");
         let chat_msg: ChatCompletionMessage = msg.into();
         assert!(chat_msg.tool_calls.is_none());
+    }
+
+    #[test]
+    fn test_convert_tool_definition_normalizes_top_level_oneof() {
+        use crate::llm::provider::ToolDefinition;
+
+        let tool = ToolDefinition {
+            name: "github".to_string(),
+            description: "Search GitHub".to_string(),
+            parameters: serde_json::json!({
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {
+                            "repo": { "type": "string" }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "properties": {
+                            "owner": { "type": "string" }
+                        }
+                    }
+                ]
+            }),
+        };
+
+        let converted = convert_tool_definition(tool);
+        let params = converted.function.parameters.expect("parameters");
+
+        assert_eq!(params["type"], "object");
+        assert!(params.get("oneOf").is_none());
+        let description = converted
+            .function
+            .description
+            .expect("description")
+            .to_lowercase();
+        assert!(description.contains("oneof"));
     }
 
     #[test]
@@ -1837,6 +1903,47 @@ mod tests {
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
         }
+    }
+
+    #[test]
+    fn test_build_chat_completion_request_normalizes_top_level_oneof() {
+        use crate::llm::provider::ToolDefinition;
+
+        let request = build_chat_completion_request(
+            "test-model".to_string(),
+            vec![ChatMessage::user("Use the github tool").into()],
+            vec![ToolDefinition {
+                name: "github".to_string(),
+                description: "Search GitHub".to_string(),
+                parameters: serde_json::json!({
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "repo": { "type": "string" }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "properties": {
+                                "owner": { "type": "string" }
+                            }
+                        }
+                    ]
+                }),
+            }],
+            Some(0.2),
+            Some(16),
+            None,
+            Some("auto".to_string()),
+        );
+
+        let tools = request.tools.expect("tools present");
+        assert_eq!(tools.len(), 1);
+        let parameters = tools[0].function.parameters.as_ref().expect("parameters");
+        assert_eq!(parameters["type"], "object");
+        assert!(parameters.get("oneOf").is_none());
+        assert!(parameters.get("properties").is_some());
     }
 
     // -- ModelInfo serde alias tests ------------------------------------------

--- a/src/llm/recording.rs
+++ b/src/llm/recording.rs
@@ -195,11 +195,266 @@ impl HttpInterceptor for RecordingHttpInterceptor {
     }
 
     async fn after_response(&self, request: &HttpExchangeRequest, response: &HttpExchangeResponse) {
+        // Scrub request/response before persisting. Traces ship with the
+        // repo (replay mode fixtures) — leaking an `Authorization: Bearer
+        // ghp_...` into a committed JSON file is a credential compromise.
+        // Redaction runs on every recorded exchange unconditionally, so a
+        // future caller cannot opt out by accident.
+        let mut sanitized_req = request.clone();
+        redact_exchange_request(&mut sanitized_req);
+        let mut sanitized_resp = response.clone();
+        redact_exchange_response(&mut sanitized_resp);
         self.exchanges.lock().await.push(HttpExchange {
-            request: request.clone(),
-            response: response.clone(),
+            request: sanitized_req,
+            response: sanitized_resp,
         });
     }
+}
+
+/// Header names whose values must never land in a recorded trace.
+///
+/// Matched case-insensitively. Keep this list short and focused on the
+/// well-known credential-carrying headers — anything broader risks
+/// scrubbing fields that the replay matcher actually needs. This set
+/// catches the headers that specifically carry bearer tokens, cookies,
+/// and API keys.
+///
+/// `ironclaw_safety::LeakDetector` runs on response bodies before they
+/// reach the LLM (see `src/tools/builtin/http.rs`), but only as a hard
+/// block when `should_block` fires; values that match a pattern under
+/// that threshold still flow through to the recorder, so this
+/// allowlist is the last line before the fixture file.
+const SENSITIVE_HEADER_NAMES: &[&str] = &[
+    "authorization",
+    "proxy-authorization",
+    "cookie",
+    "set-cookie",
+    "x-api-key",
+    "x-auth-token",
+    "x-goog-api-key",
+    "openai-organization",
+    "anthropic-api-key",
+];
+
+/// Query-parameter names whose values must never land in a recorded
+/// trace. Tokens sometimes ride in the URL (e.g.
+/// `?access_token=...`) — redact those in place while preserving the
+/// rest of the URL so loose URL matching during replay still works.
+const SENSITIVE_QUERY_PARAMS: &[&str] = &[
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "auth",
+    "jwt",
+    "session",
+];
+
+/// JSON/form body keys whose values must be redacted. Superset of
+/// `SENSITIVE_QUERY_PARAMS` plus body-specific credential fields
+/// (`secret`, `private_key`, `authorization`) that appear in JSON/form
+/// bodies but are uncommon as naked URL query parameters.
+const SENSITIVE_BODY_KEYS: &[&str] = &[
+    "access_token",
+    "refresh_token",
+    "id_token",
+    "token",
+    "api_key",
+    "apikey",
+    "client_secret",
+    "password",
+    "secret",
+    "private_key",
+    "auth",
+    "jwt",
+    "session",
+    "authorization",
+];
+
+fn is_sensitive_header(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    SENSITIVE_HEADER_NAMES.iter().any(|h| *h == lower)
+}
+
+fn redact_headers(headers: &mut [(String, String)]) {
+    for (name, value) in headers.iter_mut() {
+        if is_sensitive_header(name) {
+            *value = "[REDACTED]".to_string();
+        }
+    }
+}
+
+fn redact_url(url: &str) -> String {
+    let Ok(mut parsed) = url::Url::parse(url) else {
+        tracing::trace!(url, "redact_url: unparseable URL — returning verbatim");
+        return url.to_string();
+    };
+
+    // Scrub basic-auth credentials from URL userinfo
+    // (e.g. `https://user:pat@api.example.com/...`).
+    let had_userinfo = parsed.password().is_some() || !parsed.username().is_empty();
+    if parsed.password().is_some() {
+        let _ = parsed.set_password(None);
+    }
+    if !parsed.username().is_empty() {
+        let _ = parsed.set_username("");
+    }
+
+    // Skip the query-rewrite roundtrip when there's no query, otherwise
+    // the URL crate normalizes `https://host` to `https://host/?`.
+    if parsed.query().is_none() {
+        // Only return the parsed form if we actually modified userinfo;
+        // otherwise return the original to avoid URL normalization
+        // artifacts (e.g. trailing `/`).
+        return if had_userinfo {
+            strip_stale_at(parsed.to_string())
+        } else {
+            url.to_string()
+        };
+    }
+    let pairs: Vec<(String, String)> = parsed
+        .query_pairs()
+        .map(|(k, v)| {
+            let lower = k.to_ascii_lowercase();
+            let redacted = SENSITIVE_QUERY_PARAMS.iter().any(|p| *p == lower);
+            let new_value = if redacted {
+                "[REDACTED]".to_string()
+            } else {
+                v.into_owned()
+            };
+            (k.into_owned(), new_value)
+        })
+        .collect();
+    // NOTE: The clear()+append_pair() roundtrip may percent-encode
+    // query values differently from the original URL. The replay
+    // matcher (`ReplayingHttpInterceptor`) compares by method + URL
+    // string equality, so this could cause false misses if the
+    // original URL had unusual encoding. In practice, credential-
+    // bearing URLs use standard encoding, so this is acceptable.
+    parsed.query_pairs_mut().clear();
+    for (k, v) in &pairs {
+        parsed.query_pairs_mut().append_pair(k, v);
+    }
+    strip_stale_at(parsed.to_string())
+}
+
+/// The `url` crate may leave a stale `@` separator after clearing both
+/// username and password (e.g. `https://@host/path`). Strip it.
+fn strip_stale_at(url: String) -> String {
+    url.replace("://@", "://")
+}
+
+/// Recursively walk a JSON value and redact any key matching
+/// `SENSITIVE_BODY_KEYS` (exact, case-insensitive match).
+///
+/// This only redacts by key name. Value-shape detection (e.g. spotting
+/// a raw token under an unusual key name) is not attempted here —
+/// `ironclaw_safety::LeakDetector` runs on response bodies upstream in
+/// `HttpTool::execute` but only as a hard-block filter, so
+/// token-shaped values that fall below its block threshold can still
+/// reach this layer under an unrecognized key name.
+fn redact_json_value(value: &mut serde_json::Value) {
+    match value {
+        serde_json::Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                let lower = key.to_ascii_lowercase();
+                if SENSITIVE_BODY_KEYS.iter().any(|s| *s == lower) {
+                    *val = serde_json::Value::String("[REDACTED]".to_string());
+                } else {
+                    redact_json_value(val);
+                }
+            }
+        }
+        serde_json::Value::Array(arr) => {
+            for item in arr.iter_mut() {
+                redact_json_value(item);
+            }
+        }
+        _ => {}
+    }
+}
+
+pub(crate) fn redact_body(body: &str) -> String {
+    // Try JSON first (most common body format for API calls).
+    if let Ok(mut parsed) = serde_json::from_str::<serde_json::Value>(body) {
+        redact_json_value(&mut parsed);
+        return serde_json::to_string(&parsed).unwrap_or_else(|_| body.to_string());
+    }
+    // Try form-urlencoded (OAuth token exchanges, login forms).
+    if let Some(redacted) = redact_form_urlencoded(body) {
+        return redacted;
+    }
+    // Not a recognized format — return as-is. Opaque bodies fall back
+    // to the upstream `LeakDetector::scan` hard-block in HttpTool for
+    // token-shaped values; anything under that threshold ships
+    // verbatim.
+    body.to_string()
+}
+
+/// Attempt to parse `body` as `application/x-www-form-urlencoded` and
+/// redact any key matching `SENSITIVE_BODY_KEYS`. Returns `None` if the
+/// body doesn't look like form-urlencoded data.
+fn redact_form_urlencoded(body: &str) -> Option<String> {
+    // Quick heuristic: form-urlencoded bodies contain `=` and no `{`.
+    // This avoids the cost of a full parse for clearly non-form content.
+    if !body.contains('=') || body.starts_with('{') || body.starts_with('[') {
+        return None;
+    }
+    let pairs: Vec<(String, String)> = url::form_urlencoded::parse(body.as_bytes())
+        .map(|(k, v)| (k.into_owned(), v.into_owned()))
+        .collect();
+    // If parsing produced zero pairs, or a single pair with an empty key,
+    // it's not actually form-urlencoded.
+    if pairs.is_empty() || (pairs.len() == 1 && pairs[0].0.is_empty()) {
+        return None;
+    }
+    let mut any_redacted = false;
+    let redacted_pairs: Vec<(String, String)> = pairs
+        .into_iter()
+        .map(|(k, v)| {
+            let lower = k.to_ascii_lowercase();
+            if SENSITIVE_BODY_KEYS.iter().any(|s| *s == lower) {
+                any_redacted = true;
+                (k, "[REDACTED]".to_string())
+            } else {
+                (k, v)
+            }
+        })
+        .collect();
+    // Only return the form-encoded path if we actually recognized at
+    // least one sensitive key — otherwise the body might be plain text
+    // that happened to parse as a single k=v pair.
+    if !any_redacted {
+        return None;
+    }
+    Some(
+        url::form_urlencoded::Serializer::new(String::new())
+            .extend_pairs(&redacted_pairs)
+            .finish(),
+    )
+}
+
+fn redact_exchange_request(req: &mut HttpExchangeRequest) {
+    redact_headers(&mut req.headers);
+    req.url = redact_url(&req.url);
+    if let Some(body) = &req.body {
+        req.body = Some(redact_body(body));
+    }
+}
+
+fn redact_exchange_response(resp: &mut HttpExchangeResponse) {
+    redact_headers(&mut resp.headers);
+    // OAuth token endpoints reply with JSON/form-encoded bodies like
+    // `{"access_token":"..."}` — the most common credential-leak path
+    // into a fixture — so redact response bodies on the same allowlist
+    // used for requests. Request bodies already flow through
+    // `redact_body` in `redact_exchange_request`; responses were the
+    // gap.
+    resp.body = redact_body(&resp.body);
 }
 
 /// Replays recorded HTTP exchanges during test runs.
@@ -224,11 +479,16 @@ impl HttpInterceptor for ReplayingHttpInterceptor {
     async fn before_request(&self, request: &HttpExchangeRequest) -> Option<HttpExchangeResponse> {
         let mut queue = self.exchanges.lock().await;
         if let Some(exchange) = queue.pop_front() {
-            // Soft-check: warn if the request doesn't match
-            if exchange.request.url != request.url || exchange.request.method != request.method {
+            // Soft-check: warn if the request doesn't match. Redact the
+            // incoming URL the same way stored URLs are redacted so
+            // sensitive query params don't cause false mismatches.
+            let redacted_incoming_url = redact_url(&request.url);
+            if exchange.request.url != redacted_incoming_url
+                || exchange.request.method != request.method
+            {
                 tracing::warn!(
                     expected_url = %exchange.request.url,
-                    actual_url = %request.url,
+                    actual_url = %redacted_incoming_url,
                     expected_method = %exchange.request.method,
                     actual_method = %request.method,
                     "HTTP replay: request mismatch (returning recorded response anyway)"
@@ -1103,6 +1363,103 @@ mod tests {
         assert!(result.is_none());
     }
 
+    /// Regression: credentials must never land in a recorded trace.
+    ///
+    /// An earlier run committed `Authorization: Bearer ghp_...` straight
+    /// into a fixture, leaking a live GitHub PAT. The recording
+    /// interceptor now scrubs every recorded exchange in place. This
+    /// test pins that behavior across the header set, URL query params,
+    /// and response `Set-Cookie`.
+    #[tokio::test]
+    async fn recording_http_interceptor_redacts_credentials() {
+        let interceptor = RecordingHttpInterceptor::new();
+
+        let req = HttpExchangeRequest {
+            method: "GET".to_string(),
+            url: "https://api.example.com/data?access_token=secret&user=alice".to_string(),
+            headers: vec![
+                (
+                    "Authorization".to_string(),
+                    "Bearer ghp_thisIsAFakeTokenThatMustNotBeCommitted".to_string(),
+                ),
+                ("Cookie".to_string(), "session=abc".to_string()),
+                ("Accept".to_string(), "application/json".to_string()),
+                (
+                    "x-api-key".to_string(),
+                    "sk-very-secret-api-key".to_string(),
+                ),
+            ],
+            body: None,
+        };
+        let resp = HttpExchangeResponse {
+            status: 200,
+            headers: vec![
+                (
+                    "Set-Cookie".to_string(),
+                    "session=xyz; HttpOnly".to_string(),
+                ),
+                ("Content-Type".to_string(), "application/json".to_string()),
+            ],
+            body: r#"{"ok":true}"#.to_string(),
+        };
+
+        interceptor.after_response(&req, &resp).await;
+        let recorded = interceptor.take_exchanges().await;
+        assert_eq!(recorded.len(), 1);
+        let stored = &recorded[0];
+
+        // Authorization, Cookie, X-Api-Key redacted (case-insensitive).
+        let req_header = |name: &str| {
+            stored
+                .request
+                .headers
+                .iter()
+                .find_map(|(n, v)| (n.eq_ignore_ascii_case(name)).then(|| v.clone()))
+                .unwrap_or_default()
+        };
+        assert_eq!(req_header("Authorization"), "[REDACTED]");
+        assert_eq!(req_header("Cookie"), "[REDACTED]");
+        assert_eq!(req_header("x-api-key"), "[REDACTED]");
+        // Non-sensitive headers untouched so replay matching still works.
+        assert_eq!(req_header("Accept"), "application/json");
+
+        // Response Set-Cookie redacted.
+        let resp_header = |name: &str| {
+            stored
+                .response
+                .headers
+                .iter()
+                .find_map(|(n, v)| (n.eq_ignore_ascii_case(name)).then(|| v.clone()))
+                .unwrap_or_default()
+        };
+        assert_eq!(resp_header("Set-Cookie"), "[REDACTED]");
+        assert_eq!(resp_header("Content-Type"), "application/json");
+
+        // URL: access_token value replaced, user kept.
+        assert!(
+            stored.request.url.contains("access_token=%5BREDACTED%5D"),
+            "expected redacted access_token, got: {}",
+            stored.request.url
+        );
+        assert!(
+            stored.request.url.contains("user=alice"),
+            "non-sensitive query params should remain, got: {}",
+            stored.request.url
+        );
+
+        // Defense in depth: the original secret string must not appear
+        // anywhere in the serialized exchange.
+        let serialized = serde_json::to_string(stored).unwrap();
+        assert!(
+            !serialized.contains("ghp_thisIsAFakeTokenThatMustNotBeCommitted"),
+            "raw token leaked into serialized exchange: {serialized}"
+        );
+        assert!(
+            !serialized.contains("sk-very-secret-api-key"),
+            "raw api key leaked into serialized exchange: {serialized}"
+        );
+    }
+
     #[tokio::test]
     async fn recording_http_interceptor_passes_through_and_records() {
         let interceptor = RecordingHttpInterceptor::new();
@@ -1303,5 +1660,303 @@ mod tests {
         assert_eq!(coerce_python_repr_to_json("{'flag': '🚀'}"), None);
         // Sanity: an empty string still returns None for an unrelated reason.
         assert_eq!(coerce_python_repr_to_json(""), None);
+    }
+
+    #[test]
+    fn redact_url_scrubs_userinfo() {
+        let url = "https://user:pat_secret@api.example.com/v1/repos";
+        let redacted = redact_url(url);
+        assert!(
+            !redacted.contains("pat_secret"),
+            "password leaked: {redacted}"
+        );
+        assert!(!redacted.contains("user@"), "username leaked: {redacted}");
+        assert!(
+            redacted.contains("api.example.com"),
+            "host lost: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redact_url_preserves_plain_urls() {
+        assert_eq!(redact_url("https://example.com"), "https://example.com");
+        assert_eq!(
+            redact_url("https://example.com/path"),
+            "https://example.com/path"
+        );
+    }
+
+    #[test]
+    fn redact_body_scrubs_sensitive_json_keys() {
+        let body = r#"{"username":"alice","password":"s3cret","api_key":"sk-123","data":"safe"}"#;
+        let redacted = redact_body(body);
+        assert!(!redacted.contains("s3cret"), "password leaked: {redacted}");
+        assert!(!redacted.contains("sk-123"), "api_key leaked: {redacted}");
+        assert!(
+            redacted.contains("alice"),
+            "non-sensitive data lost: {redacted}"
+        );
+        assert!(
+            redacted.contains("safe"),
+            "non-sensitive data lost: {redacted}"
+        );
+    }
+
+    /// Regression: body-key redaction must use exact match, not substring.
+    /// Fields like `token_count`, `input_tokens`, `session_id` are
+    /// non-sensitive and must survive redaction.
+    #[test]
+    fn redact_body_does_not_over_redact_substring_matches() {
+        let body = r#"{
+            "token_count": 42,
+            "input_tokens": 100,
+            "output_tokens": 50,
+            "token_type": "Bearer",
+            "session_id": "abc-123",
+            "session_state": "active",
+            "auth_method": "oauth",
+            "auth_url": "https://example.com/auth",
+            "authorization_type": "bearer"
+        }"#;
+        let redacted = redact_body(body);
+        let parsed: serde_json::Value = serde_json::from_str(&redacted).unwrap();
+        let obj = parsed.as_object().unwrap();
+
+        // These fields contain sensitive substrings but are NOT sensitive themselves
+        assert_eq!(obj["token_count"], 42, "token_count over-redacted");
+        assert_eq!(obj["input_tokens"], 100, "input_tokens over-redacted");
+        assert_eq!(obj["output_tokens"], 50, "output_tokens over-redacted");
+        assert_eq!(obj["token_type"], "Bearer", "token_type over-redacted");
+        assert_eq!(obj["session_id"], "abc-123", "session_id over-redacted");
+        assert_eq!(
+            obj["session_state"], "active",
+            "session_state over-redacted"
+        );
+        assert_eq!(obj["auth_method"], "oauth", "auth_method over-redacted");
+        assert_eq!(
+            obj["auth_url"], "https://example.com/auth",
+            "auth_url over-redacted"
+        );
+        assert_eq!(
+            obj["authorization_type"], "bearer",
+            "authorization_type over-redacted"
+        );
+    }
+
+    /// Exact-match body keys that ARE sensitive must still be redacted.
+    #[test]
+    fn redact_body_still_redacts_exact_sensitive_keys() {
+        let body = r#"{"token":"secret_val","auth":"cred","session":"sess_tok","jwt":"eyJ..."}"#;
+        let redacted = redact_body(body);
+        let parsed: serde_json::Value = serde_json::from_str(&redacted).unwrap();
+        let obj = parsed.as_object().unwrap();
+        assert_eq!(obj["token"], "[REDACTED]");
+        assert_eq!(obj["auth"], "[REDACTED]");
+        assert_eq!(obj["session"], "[REDACTED]");
+        assert_eq!(obj["jwt"], "[REDACTED]");
+    }
+
+    #[test]
+    fn redact_body_handles_nested_json() {
+        let body = r#"{"outer":{"secret":"hidden","ok":"visible"}}"#;
+        let redacted = redact_body(body);
+        assert!(
+            !redacted.contains("hidden"),
+            "nested secret leaked: {redacted}"
+        );
+        assert!(
+            redacted.contains("visible"),
+            "non-sensitive lost: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redact_body_returns_non_json_unchanged() {
+        let body = "not json at all";
+        assert_eq!(redact_body(body), body);
+    }
+
+    #[test]
+    fn redact_body_scrubs_form_urlencoded() {
+        let body = "grant_type=authorization_code&client_secret=shhh&code=abc&redirect_uri=http%3A%2F%2Flocalhost";
+        let redacted = redact_body(body);
+        assert!(
+            !redacted.contains("shhh"),
+            "client_secret leaked: {redacted}"
+        );
+        assert!(
+            redacted.contains("authorization_code"),
+            "non-sensitive grant_type lost: {redacted}"
+        );
+        assert!(
+            redacted.contains("abc"),
+            "non-sensitive code should remain: {redacted}"
+        );
+    }
+
+    #[test]
+    fn redact_url_strips_stale_at_from_userinfo() {
+        let url = "https://user:pat_secret@api.example.com/v1/repos";
+        let redacted = redact_url(url);
+        assert!(
+            !redacted.contains('@'),
+            "stale @ separator should be removed: {redacted}"
+        );
+        assert!(
+            redacted.starts_with("https://api.example.com"),
+            "host should follow scheme directly: {redacted}"
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_interceptor_redacts_body_credentials() {
+        let interceptor = RecordingHttpInterceptor::new();
+        let req = HttpExchangeRequest {
+            method: "POST".to_string(),
+            url: "https://api.example.com/auth".to_string(),
+            headers: Vec::new(),
+            body: Some(r#"{"password":"hunter2","user":"bob"}"#.to_string()),
+        };
+        let resp = HttpExchangeResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: "ok".to_string(),
+        };
+        interceptor.after_response(&req, &resp).await;
+        let exchanges = interceptor.take_exchanges().await;
+        let serialized = serde_json::to_string(&exchanges[0]).unwrap();
+        assert!(
+            !serialized.contains("hunter2"),
+            "body password leaked: {serialized}"
+        );
+        assert!(
+            serialized.contains("bob"),
+            "non-sensitive body data lost: {serialized}"
+        );
+    }
+
+    /// Regression: response bodies are the most common OAuth credential
+    /// leak path — a `POST /token` exchange returns
+    /// `{"access_token":"...","refresh_token":"..."}` and without
+    /// redaction the raw tokens ship into the committed fixture file.
+    #[tokio::test]
+    async fn recording_interceptor_redacts_response_body_credentials() {
+        let interceptor = RecordingHttpInterceptor::new();
+        let req = HttpExchangeRequest {
+            method: "POST".to_string(),
+            url: "https://oauth.example.com/token".to_string(),
+            headers: Vec::new(),
+            body: None,
+        };
+        let resp = HttpExchangeResponse {
+            status: 200,
+            headers: Vec::new(),
+            body: r#"{"access_token":"atk_live_abcdef","refresh_token":"rtk_live_xyz","expires_in":3600,"token_type":"Bearer"}"#.to_string(),
+        };
+        interceptor.after_response(&req, &resp).await;
+        let recorded = interceptor.take_exchanges().await;
+        let stored = &recorded[0];
+        assert!(
+            !stored.response.body.contains("atk_live_abcdef"),
+            "response access_token leaked: {}",
+            stored.response.body
+        );
+        assert!(
+            !stored.response.body.contains("rtk_live_xyz"),
+            "response refresh_token leaked: {}",
+            stored.response.body
+        );
+        // Non-sensitive fields preserved for replay determinism.
+        assert!(
+            stored.response.body.contains("3600"),
+            "non-sensitive expires_in lost: {}",
+            stored.response.body
+        );
+        assert!(
+            stored.response.body.contains("Bearer"),
+            "non-sensitive token_type lost: {}",
+            stored.response.body
+        );
+    }
+
+    #[tokio::test]
+    async fn recording_http_interceptor_redacts_url_userinfo() {
+        let interceptor = RecordingHttpInterceptor::new();
+
+        let req = HttpExchangeRequest {
+            method: "GET".to_string(),
+            url: "https://deploy:ghp_fakeToken@api.example.com/repos".to_string(),
+            headers: vec![],
+            body: None,
+        };
+        let resp = HttpExchangeResponse {
+            status: 200,
+            headers: vec![],
+            body: r#"{"ok":true}"#.to_string(),
+        };
+
+        interceptor.after_response(&req, &resp).await;
+        let recorded = interceptor.take_exchanges().await;
+        let stored = &recorded[0];
+        assert!(
+            !stored.request.url.contains("deploy"),
+            "username leaked into recorded URL: {}",
+            stored.request.url
+        );
+        assert!(
+            !stored.request.url.contains("ghp_fakeToken"),
+            "password leaked into recorded URL: {}",
+            stored.request.url
+        );
+        assert!(
+            stored.request.url.contains("api.example.com/repos"),
+            "host/path should remain: {}",
+            stored.request.url
+        );
+    }
+
+    /// Regression: replay matcher must redact the incoming URL before
+    /// comparing against stored (already-redacted) URLs, so sensitive
+    /// query params like `access_token` don't cause false mismatches.
+    ///
+    /// This test exercises the full roundtrip invariant: a raw URL is
+    /// redacted via `redact_url()` to produce the stored form (matching
+    /// what the recorder does), then the replayer is given the same raw
+    /// URL and must match after its own internal redaction.
+    #[tokio::test]
+    async fn replaying_interceptor_matches_redacted_query_params() {
+        // Simulate the recording side: raw URL gets redacted before storage.
+        let raw_url = "https://api.example.com/data?access_token=real_secret_token&page=1";
+        let stored_url = redact_url(raw_url);
+
+        let exchanges = vec![HttpExchange {
+            request: HttpExchangeRequest {
+                method: "GET".to_string(),
+                url: stored_url.clone(),
+                headers: vec![],
+                body: None,
+            },
+            response: HttpExchangeResponse {
+                status: 200,
+                headers: vec![],
+                body: r#"{"ok":true}"#.to_string(),
+            },
+        }];
+        let interceptor = ReplayingHttpInterceptor::new(exchanges);
+
+        // Replay with the same raw URL — redaction should produce a matching URL
+        let incoming = HttpExchangeRequest {
+            method: "GET".to_string(),
+            url: raw_url.to_string(),
+            headers: vec![],
+            body: None,
+        };
+
+        let resp = interceptor.before_request(&incoming).await;
+        assert!(
+            resp.is_some(),
+            "replay should match after URL redaction roundtrip"
+        );
+        assert_eq!(resp.unwrap().status, 200);
     }
 }

--- a/src/secrets/types.rs
+++ b/src/secrets/types.rs
@@ -195,7 +195,7 @@ impl CreateSecretParams {
 }
 
 /// Where a credential should be injected in an HTTP request.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum CredentialLocation {
     /// Inject as Authorization header (e.g., "Bearer {secret}")
     #[default]

--- a/src/setup/README.md
+++ b/src/setup/README.md
@@ -56,16 +56,27 @@ The `--no-onboard` CLI flag suppresses auto-detection.
 
 Quick mode (`--quick` flag, or auto-triggered on first run) provides a
 near-instant onboarding experience by auto-defaulting everything except
-the LLM provider and model selection.
+the local deployment profile, LLM provider, and model selection.
 
 ```
+Local Usage Profile     ← choose local or local-sandbox when unset
 auto_setup_database()    → libsql at ~/.ironclaw/ironclaw.db (zero prompts)
 auto_setup_security()    → keychain or env var (zero prompts)
-Step 1/2: Inference Provider  ← only interactive step
-Step 2/2: Model Selection     ← only interactive step
+Step 1/2: Inference Provider  ← interactive unless provider env is detected
+Step 2/2: Model Selection     ← interactive unless defaulted by detected provider
        ↓
    save_and_summarize()      → includes tip to run `ironclaw onboard`
 ```
+
+**Local usage profile:** If `IRONCLAW_PROFILE` is already set, quick mode
+respects it and does not prompt. On a true first run with no profile and no
+existing DB settings, quick mode asks whether the user wants:
+- `local`: TUI, local libSQL, background tasks enabled, no Docker sandbox
+- `local-sandbox`: TUI, local libSQL, background tasks enabled, Docker sandbox enabled with read-only policy
+
+The selected profile is written to `~/.ironclaw/.env` as `IRONCLAW_PROFILE`
+so subsequent startups apply the same built-in profile before database-backed
+settings are loaded.
 
 **`auto_setup_database()`:** Uses existing env vars if set (`DATABASE_URL`
 for postgres, `LIBSQL_PATH` for libsql) without prompting. Otherwise
@@ -423,9 +434,10 @@ Settings are persisted in two places:
 **Layer 1: `~/.ironclaw/.env`** (bootstrap vars)
 
 Contains only the settings needed BEFORE database connection. Written by
-`save_bootstrap_env()` in `bootstrap.rs`.
+`write_bootstrap_env()` in `wizard.rs` via `upsert_bootstrap_vars()`.
 
 ```env
+IRONCLAW_PROFILE="local"
 DATABASE_BACKEND="libsql"
 LIBSQL_PATH="/Users/name/.ironclaw/ironclaw.db"
 SECRETS_MASTER_KEY="..."   # only if env key source selected
@@ -434,6 +446,7 @@ ONBOARD_COMPLETED="true"
 
 Or for PostgreSQL:
 ```env
+IRONCLAW_PROFILE="local"
 DATABASE_BACKEND="postgres"
 DATABASE_URL="postgres://user:pass@localhost/ironclaw"
 SECRETS_MASTER_KEY="..."
@@ -441,8 +454,9 @@ ONBOARD_COMPLETED="true"
 ```
 
 **Why separate?** Chicken-and-egg: you need `DATABASE_BACKEND` to know
-which database to connect to, and `SECRETS_MASTER_KEY` to decrypt the
-secrets store — neither can be stored in the database. LLM settings
+which database to connect to, `IRONCLAW_PROFILE` to apply built-in defaults
+before DB overlays, and `SECRETS_MASTER_KEY` to decrypt the
+secrets store; none of these can rely on database settings. LLM settings
 (`LLM_BACKEND`, base URLs, model names) are persisted to the DB via
 `persist_settings()` and loaded after connection. API keys are stored
 encrypted in the secrets DB.
@@ -509,6 +523,7 @@ Final step of the wizard:
 
 Bootstrap vars written to `~/.ironclaw/.env` (only true chicken-and-egg vars
 that are needed before the DB is connected):
+- `IRONCLAW_PROFILE` (when quick first-run setup selected a profile)
 - `DATABASE_BACKEND` (always)
 - `DATABASE_URL` (if postgres)
 - `LIBSQL_PATH` (if libsql)

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -44,6 +44,8 @@ use crate::setup::prompts::{
 // const CHANNEL_INDEX_CLI: usize = 0;
 const CHANNEL_INDEX_HTTP: usize = 1;
 const CHANNEL_INDEX_SIGNAL: usize = 2;
+const QUICK_PROFILE_LOCAL: &str = "local";
+const QUICK_PROFILE_LOCAL_SANDBOX: &str = "local-sandbox";
 
 /// Setup wizard error.
 #[derive(Debug, thiserror::Error)]
@@ -95,6 +97,7 @@ pub struct SetupConfig {
 pub struct SetupWizard {
     config: SetupConfig,
     settings: Settings,
+    selected_deployment_profile: Option<String>,
     owner_id: String,
     session_manager: Option<Arc<SessionManager>>,
     /// Database pool (created during setup, postgres only).
@@ -123,6 +126,7 @@ impl SetupWizard {
         Self {
             config,
             settings,
+            selected_deployment_profile: None,
             owner_id: "default".to_string(),
             session_manager: None,
             #[cfg(feature = "postgres")]
@@ -142,6 +146,7 @@ impl SetupWizard {
         Ok(Self {
             config,
             settings,
+            selected_deployment_profile: None,
             owner_id,
             session_manager: None,
             #[cfg(feature = "postgres")]
@@ -260,7 +265,15 @@ impl SetupWizard {
             self.persist_after_step().await;
         } else if self.config.quick {
             // Quick mode: auto-default database + security, only ask for
-            // LLM provider + model. Designed for first-run experience.
+            // the local usage profile (on true first run), LLM provider,
+            // and model. Designed for first-run experience.
+
+            // Profile selection runs first so that `apply_profile()` can set
+            // `database_backend` before `auto_setup_database()` connects.
+            // The subsequent clone → try_load → merge_from cycle preserves
+            // these wizard-chosen values over any stale DB values.
+            self.step_quick_local_profile()?;
+
             self.auto_setup_database().await?;
 
             // Load existing settings from DB (if any prior partial run)
@@ -1131,6 +1144,51 @@ impl SetupWizard {
         {
             self.step_database().await
         }
+    }
+
+    /// Quick first-run local deployment profile selection.
+    ///
+    /// Existing `IRONCLAW_PROFILE` values are respected because
+    /// `load_bootstrap_settings()` has already applied them before the wizard
+    /// starts. This prompt only fills in the missing first-run local default.
+    fn step_quick_local_profile(&mut self) -> Result<(), SetupError> {
+        if crate::config::env_or_override("IRONCLAW_PROFILE").is_some() {
+            return Ok(());
+        }
+
+        let options = [
+            "Local (TUI + background tasks, no Docker sandbox)",
+            "Local sandbox (TUI + background tasks + Docker sandbox)",
+        ];
+        let choice = select_one("How should IronClaw run on this machine?", &options)
+            .map_err(SetupError::Io)?;
+        let profile = match choice {
+            0 => QUICK_PROFILE_LOCAL,
+            1 => QUICK_PROFILE_LOCAL_SANDBOX,
+            _ => unreachable!("select_one only returns 0 or 1 for a two-option menu"),
+        };
+
+        self.apply_quick_local_profile(profile)?;
+        print_success(&format!("Using '{profile}' deployment profile"));
+        Ok(())
+    }
+
+    fn apply_quick_local_profile(&mut self, profile: &str) -> Result<(), SetupError> {
+        match profile {
+            QUICK_PROFILE_LOCAL | QUICK_PROFILE_LOCAL_SANDBOX => {}
+            other => {
+                return Err(SetupError::Config(format!(
+                    "unsupported quick local profile: {other}"
+                )));
+            }
+        }
+
+        crate::config::set_runtime_env("IRONCLAW_PROFILE", profile);
+        crate::config::profile::apply_profile(&mut self.settings)
+            .map_err(|e| SetupError::Config(e.to_string()))?;
+
+        self.selected_deployment_profile = Some(profile.to_string());
+        Ok(())
     }
 
     /// Auto-setup security with zero prompts (quick mode).
@@ -3203,8 +3261,8 @@ impl SetupWizard {
     /// Write bootstrap environment variables to `~/.ironclaw/.env`.
     ///
     /// Only true chicken-and-egg settings are written here — things needed
-    /// before the database is connected: `DATABASE_BACKEND`, `DATABASE_URL`,
-    /// `LIBSQL_PATH`, `SECRETS_MASTER_KEY`, `ONBOARD_COMPLETED`, and
+    /// before the database is connected: `IRONCLAW_PROFILE`, `DATABASE_BACKEND`,
+    /// `DATABASE_URL`, `LIBSQL_PATH`, `SECRETS_MASTER_KEY`, `ONBOARD_COMPLETED`, and
     /// channel config vars (Signal, Claude Code sandbox).
     ///
     /// **LLM settings and credentials are NOT written here.** `LLM_BACKEND`,
@@ -3212,8 +3270,12 @@ impl SetupWizard {
     /// `persist_settings()` and loaded by `Config::from_db_with_toml()`.
     /// API keys live only in the encrypted secrets DB and are injected via
     /// `inject_llm_keys_from_secrets()` after DB init.
-    fn write_bootstrap_env(&self) -> Result<(), SetupError> {
+    fn bootstrap_env_vars(&self) -> Vec<(String, String)> {
         let mut env_vars: Vec<(String, String)> = Vec::new();
+
+        if let Some(ref profile) = self.selected_deployment_profile {
+            env_vars.push(("IRONCLAW_PROFILE".to_string(), profile.clone()));
+        }
 
         if let Some(ref backend) = self.settings.database_backend {
             env_vars.push(("DATABASE_BACKEND".to_string(), backend.clone()));
@@ -3277,6 +3339,12 @@ impl SetupWizard {
                 group_allow_from.clone(),
             ));
         }
+
+        env_vars
+    }
+
+    fn write_bootstrap_env(&self) -> Result<(), SetupError> {
+        let env_vars = self.bootstrap_env_vars();
 
         if !env_vars.is_empty() {
             let pairs: Vec<(&str, &str)> = env_vars
@@ -3389,7 +3457,12 @@ impl SetupWizard {
     /// via `self.settings.merge_from(&step_settings)`, since `merge_from`
     /// prefers the `other` argument's non-default values. Without this,
     /// stale DB values would overwrite fresh user choices.
-    async fn try_load_existing_settings(&mut self) {
+    async fn try_load_existing_settings(&mut self) -> bool {
+        // NB: `loaded` starts false and is only reassigned inside feature-gated
+        // blocks below.  When *neither* `postgres` nor `libsql` is enabled the
+        // function always returns false (no DB backend → nothing to load).
+        // Each block shadows `loaded` via `let loaded = …` so the compiler
+        // sees a use on every path; this is intentional, not accidental shadowing.
         let loaded = false;
 
         #[cfg(feature = "postgres")]
@@ -3440,8 +3513,7 @@ impl SetupWizard {
             loaded
         };
 
-        // Suppress unused variable warning when only one backend is compiled.
-        let _ = loaded;
+        loaded
     }
 
     /// Save settings to the database and `~/.ironclaw/.env`, then print
@@ -3936,6 +4008,105 @@ mod tests {
         let wizard = SetupWizard::try_with_config_and_toml(Default::default(), Some(&path))
             .expect("wizard should load owner_id from TOML"); // safety: test-only assertion
         assert_eq!(wizard.owner_id(), "toml-owner"); // safety: test-only assertion
+    }
+
+    #[test]
+    fn test_bootstrap_env_vars_include_selected_deployment_profile() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::clear("IRONCLAW_PROFILE");
+        let mut wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+        wizard.selected_deployment_profile = Some(QUICK_PROFILE_LOCAL_SANDBOX.to_string());
+        wizard.settings.database_backend = Some("libsql".to_string());
+
+        let vars = wizard.bootstrap_env_vars();
+
+        assert!(
+            vars.iter().any(|(key, value)| {
+                key == "IRONCLAW_PROFILE" && value == QUICK_PROFILE_LOCAL_SANDBOX
+            }),
+            "selected deployment profile should be persisted to bootstrap env"
+        );
+        assert!(
+            vars.iter()
+                .any(|(key, value)| key == "DATABASE_BACKEND" && value == "libsql"),
+            "existing bootstrap vars should still be written"
+        );
+    }
+
+    #[test]
+    fn test_bootstrap_env_vars_do_not_persist_unselected_profile() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::set("IRONCLAW_PROFILE", QUICK_PROFILE_LOCAL);
+        let wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+
+        let vars = wizard.bootstrap_env_vars();
+
+        assert!(
+            !vars.iter().any(|(key, _)| key == "IRONCLAW_PROFILE"),
+            "only a wizard-selected profile should be written back"
+        );
+    }
+
+    #[test]
+    fn test_apply_quick_local_profile_sets_profile_and_preserves_db_config_on_merge() {
+        let _guard = lock_env();
+        let _profile = EnvGuard::clear("IRONCLAW_PROFILE");
+
+        let mut wizard = SetupWizard::with_config(SetupConfig {
+            quick: true,
+            ..Default::default()
+        });
+        // Simulate a pre-existing database_url chosen earlier in the wizard
+        // (e.g. by auto_setup_database before profile selection was reordered).
+        wizard.settings.database_url = Some("postgres://my-host/db".to_string());
+        wizard.settings.database_backend = Some("postgres".to_string());
+
+        // Snapshot settings *before* profile application — mimics the
+        // `let step1_settings = self.settings.clone()` line in quick mode.
+        let step1_settings = wizard.settings.clone();
+
+        wizard
+            .apply_quick_local_profile(QUICK_PROFILE_LOCAL)
+            .expect("apply_quick_local_profile should succeed");
+
+        // Profile applies its own database_backend (libsql) which overwrites
+        // the wizard-chosen value.
+        assert_eq!(
+            wizard.settings.database_backend.as_deref(),
+            Some("libsql"),
+            "profile should overwrite database_backend"
+        );
+
+        // After merge_from, the wizard-chosen values should win back.
+        wizard.settings.merge_from(&step1_settings);
+
+        assert_eq!(
+            wizard.settings.database_backend.as_deref(),
+            Some("postgres"),
+            "merge_from should restore the wizard-chosen database_backend"
+        );
+        assert_eq!(
+            wizard.settings.database_url.as_deref(),
+            Some("postgres://my-host/db"),
+            "merge_from should restore the wizard-chosen database_url"
+        );
+        // Profile-applied non-DB settings should still be present since
+        // step1_settings had defaults for them.
+        assert!(
+            wizard.settings.heartbeat.enabled,
+            "profile-set heartbeat.enabled should survive merge"
+        );
+        assert_eq!(
+            wizard.selected_deployment_profile.as_deref(),
+            Some("local"),
+            "selected_deployment_profile should be set"
+        );
     }
 
     #[test]

--- a/src/tools/builtin/extension_tools.rs
+++ b/src/tools/builtin/extension_tools.rs
@@ -179,7 +179,9 @@ impl Tool for ToolInstallTool {
 
     fn description(&self) -> &str {
         "Install an extension (channel, tool, or MCP server). \
-         Use the name from tool_search results, or provide an explicit URL."
+         Use the name from tool_search results, or provide an explicit URL. \
+         Also discovers tool source code in the working directory \
+         (tools-src/, tool-src/, or direct subdirectories with Cargo.toml)."
     }
 
     fn parameters_schema(&self) -> serde_json::Value {

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -409,6 +409,24 @@ pub fn extract_host_from_params(params: &serde_json::Value) -> Option<String> {
         .and_then(|u| u.host_str().map(|h| h.to_string()))
 }
 
+/// Deduplicate credential mappings by `(secret_name, location)`.
+///
+/// The same secret can be declared by both a WASM tool's capabilities
+/// and a skill's `credentials` block, producing duplicates. Without
+/// dedup the HTTP client sends multiple identical `Authorization`
+/// headers which some servers (e.g. GitHub) reject as 401 Bad
+/// credentials.
+pub(crate) fn dedup_credential_mappings(
+    mappings: Vec<crate::secrets::CredentialMapping>,
+) -> Vec<crate::secrets::CredentialMapping> {
+    let mut seen: std::collections::HashSet<(String, crate::secrets::CredentialLocation)> =
+        std::collections::HashSet::new();
+    mappings
+        .into_iter()
+        .filter(|m| seen.insert((m.secret_name.clone(), m.location.clone())))
+        .collect()
+}
+
 impl Default for HttpTool {
     fn default() -> Self {
         Self::new()
@@ -497,8 +515,23 @@ impl Tool for HttpTool {
             reqwest::redirect::Policy::none(),
         )?;
 
-        // Parse headers
+        // Parse headers. `headers_vec` collects both the caller-supplied
+        // headers AND any credential-injection results appended later.
+        // We keep a separate snapshot of just the caller-supplied set so
+        // the trace recorder never sees injected `Authorization` / API-key
+        // values. Recording must happen at the pre-injection boundary —
+        // see the `intercept_req` construction below.
         let mut headers_vec = parse_headers_param(params.get("headers"))?;
+        let caller_headers: Vec<(String, String)> = headers_vec.clone();
+        // Symmetric URL snapshot. `parsed_url` is mutated in the credential
+        // injection loop below (`parsed_url.query_pairs_mut().append_pair`)
+        // for `CredentialLocation::QueryParam`, and future `UrlPath`
+        // substitution would also mutate it. Handing the post-injection
+        // URL to the recorder would ship the raw credential into fixture
+        // files for any QueryParam/UrlPath mapping whose parameter name
+        // isn't in the recorder's `SENSITIVE_QUERY_PARAMS` allowlist.
+        // Snapshot once here and hand this to the interceptor instead.
+        let caller_url = parsed_url.clone();
 
         // Block LLM-provided authorization headers when the host has registered
         // credential mappings. Credentials must come from the registry, not from
@@ -614,7 +647,10 @@ impl Tool for HttpTool {
                 url = %parsed_url,
                 "HTTP tool credential lookup"
             );
-            for mapping in &matched {
+            // Dedupe mappings by (secret_name, location) — see
+            // `dedup_credential_mappings` doc comment for rationale.
+            let dedup_matched = dedup_credential_mappings(matched);
+            for mapping in &dedup_matched {
                 let oauth_refresh = registry.oauth_refresh_for_secret(&mapping.secret_name);
                 match resolve_secret_for_runtime(
                     store.as_ref(),
@@ -629,10 +665,25 @@ impl Tool for HttpTool {
                     Ok(secret) => {
                         injected_any_credential = true;
                         missing_credential = None;
+                        // Redacted preview for triage: first and last 4 chars
+                        // only, never the middle. Lets an operator tell at a
+                        // glance whether the decrypted value even looks like
+                        // the expected token (e.g. `ghp_…`, `github_pat_…`)
+                        // without leaking it to logs.
+                        let secret_str = secret.expose();
+                        let char_count = secret_str.chars().count();
+                        let preview = if char_count <= 8 {
+                            "<short>".to_string()
+                        } else {
+                            let head: String = secret_str.chars().take(4).collect();
+                            let tail: String = secret_str.chars().skip(char_count - 4).collect();
+                            format!("{head}…{tail}")
+                        };
                         tracing::debug!(
                             user_id = %ctx.user_id,
                             secret_name = %mapping.secret_name,
                             secret_len = secret.len(),
+                            secret_preview = %preview,
                             "HTTP tool: credential found and injecting"
                         );
                         let mut injected = InjectedCredentials::empty();
@@ -672,14 +723,19 @@ impl Tool for HttpTool {
             }
         }
 
-        // Build the interceptor request descriptor for recording/replay
+        // Build the interceptor request descriptor for recording/replay.
+        // Use `caller_headers` and `caller_url` (snapshots taken before
+        // credential injection) so injected `Authorization: Bearer ...`,
+        // API keys, and injected query-param/URL-path credentials never
+        // reach the recorder. Replay matching uses `method` + `url` only,
+        // so omitting the injected values is safe for determinism.
         let intercept_req = crate::llm::recording::HttpExchangeRequest {
             method: method_upper,
-            url: parsed_url.to_string(),
-            headers: headers_vec.clone(),
+            url: caller_url.to_string(),
+            headers: caller_headers,
             body: body_bytes
                 .as_ref()
-                .map(|b| String::from_utf8_lossy(b).into_owned()),
+                .map(|b| crate::llm::recording::redact_body(&String::from_utf8_lossy(b))),
         };
 
         // Check HTTP interceptor (replay mode returns pre-recorded response)
@@ -1738,5 +1794,251 @@ mod tests {
         // Host has NO registered credentials, so LLM-provided auth headers are fine
         let cred_host = "api.example.com";
         assert!(!registry.has_credentials_for_host(cred_host));
+    }
+
+    // ── Caller-level recording hygiene ────────────────────────────────
+
+    /// Spy interceptor that captures the request descriptor passed by
+    /// `HttpTool` to `before_request` and returns a canned response so
+    /// no real HTTP call is made.
+    #[derive(Debug)]
+    struct SpyInterceptor {
+        captured: tokio::sync::Mutex<Option<crate::llm::recording::HttpExchangeRequest>>,
+    }
+
+    impl SpyInterceptor {
+        fn new() -> Self {
+            Self {
+                captured: tokio::sync::Mutex::new(None),
+            }
+        }
+
+        async fn captured_request(&self) -> Option<crate::llm::recording::HttpExchangeRequest> {
+            self.captured.lock().await.clone()
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::llm::recording::HttpInterceptor for SpyInterceptor {
+        async fn before_request(
+            &self,
+            request: &crate::llm::recording::HttpExchangeRequest,
+        ) -> Option<crate::llm::recording::HttpExchangeResponse> {
+            *self.captured.lock().await = Some(request.clone());
+            Some(crate::llm::recording::HttpExchangeResponse {
+                status: 200,
+                headers: vec![],
+                body: r#"{"ok":true}"#.to_string(),
+            })
+        }
+
+        async fn after_response(
+            &self,
+            _request: &crate::llm::recording::HttpExchangeRequest,
+            _response: &crate::llm::recording::HttpExchangeResponse,
+        ) {
+        }
+    }
+
+    /// Regression: the request descriptor passed to the HTTP interceptor
+    /// must use `caller_url` (pre-injection snapshot), NOT the mutated
+    /// `parsed_url` which includes injected query-param credentials.
+    ///
+    /// The recorder's `SENSITIVE_QUERY_PARAMS` allowlist is a fixed set
+    /// (`access_token`, `api_key`, `token`, …), so a credential mapping
+    /// with an arbitrary parameter name (e.g. `signature`, `auth_v2`)
+    /// would previously ship raw into the fixture file despite
+    /// downstream redaction. The fix is to snapshot the URL *before*
+    /// the injection loop mutates it.
+    #[tokio::test]
+    async fn http_tool_interceptor_does_not_see_injected_query_param_credentials() {
+        use crate::secrets::{CredentialLocation, CredentialMapping};
+        use crate::tools::wasm::SharedCredentialRegistry;
+
+        let registry = Arc::new(SharedCredentialRegistry::new());
+        // Use an unusual parameter name that is NOT in SENSITIVE_QUERY_PARAMS,
+        // so post-hoc redaction would miss it — the snapshot is the only
+        // defense.
+        registry.add_mappings(vec![CredentialMapping {
+            secret_name: "signing_key".to_string(),
+            location: CredentialLocation::QueryParam {
+                name: "signature".to_string(),
+            },
+            host_patterns: vec!["api.github.com".to_string()],
+            optional: false,
+        }]);
+
+        let store = Arc::new(test_secrets_store());
+        store
+            .create(
+                "default",
+                crate::secrets::CreateSecretParams::new(
+                    "signing_key",
+                    "sig_supersecretvalue1234567890",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let tool = HttpTool::new().with_credentials(registry, store);
+
+        let spy = Arc::new(SpyInterceptor::new());
+        let mut ctx = crate::context::JobContext::new("test", "test");
+        ctx.http_interceptor = Some(spy.clone() as Arc<dyn crate::llm::recording::HttpInterceptor>);
+
+        // `api.github.com` chosen because DNS resolution runs before the
+        // interceptor short-circuits (see `validate_and_resolve_url` in
+        // http.rs). The spy short-circuits the actual network round-trip.
+        let params = serde_json::json!({
+            "method": "GET",
+            "url": "https://api.github.com/data?page=1"
+        });
+
+        let result = tool.execute(params, &ctx).await;
+        assert!(
+            result.is_ok(),
+            "tool should succeed via spy interceptor; got {:?}",
+            result.err()
+        );
+
+        let req = spy
+            .captured_request()
+            .await
+            .expect("spy should have captured a request");
+
+        // The captured URL must NOT contain the injected signature param
+        // or its value — neither the raw token nor a `[REDACTED]` marker
+        // (the snapshot is taken before injection, so the param is
+        // simply absent).
+        assert!(
+            !req.url.contains("signature"),
+            "interceptor URL must not contain injected query-param name; got: {}",
+            req.url
+        );
+        assert!(
+            !req.url.contains("sig_supersecretvalue1234567890"),
+            "raw credential leaked into interceptor URL: {}",
+            req.url
+        );
+        // Non-credential query params from the caller URL must survive.
+        assert!(
+            req.url.contains("page=1"),
+            "caller-supplied query param should be preserved: {}",
+            req.url
+        );
+    }
+
+    /// Regression: the request descriptor passed to the HTTP interceptor
+    /// must use `caller_headers` (pre-injection snapshot), NOT `headers_vec`
+    /// which includes injected `Authorization` / API-key headers.
+    #[tokio::test]
+    async fn http_tool_interceptor_sees_caller_headers_not_injected() {
+        use crate::secrets::CredentialMapping;
+        use crate::tools::wasm::SharedCredentialRegistry;
+
+        let registry = Arc::new(SharedCredentialRegistry::new());
+        registry.add_mappings(vec![CredentialMapping::bearer(
+            "github_token",
+            "api.github.com",
+        )]);
+
+        // Store a secret so credential injection actually fires
+        let store = Arc::new(test_secrets_store());
+        store
+            .create(
+                "default",
+                crate::secrets::CreateSecretParams::new(
+                    "github_token",
+                    "ghp_supersecretvalue1234567890",
+                ),
+            )
+            .await
+            .unwrap();
+
+        let tool = HttpTool::new().with_credentials(registry, store);
+
+        let spy = Arc::new(SpyInterceptor::new());
+        let mut ctx = crate::context::JobContext::new("test", "test");
+        ctx.http_interceptor = Some(spy.clone() as Arc<dyn crate::llm::recording::HttpInterceptor>);
+
+        let params = serde_json::json!({
+            "method": "GET",
+            "url": "https://api.github.com/repos/test/test"
+        });
+
+        let result = tool.execute(params, &ctx).await;
+        assert!(result.is_ok(), "tool should succeed via spy interceptor");
+
+        let captured = spy.captured_request().await;
+        assert!(captured.is_some(), "spy should have captured a request");
+
+        let req = captured.unwrap();
+        // The captured headers must NOT contain injected Authorization
+        let has_auth = req
+            .headers
+            .iter()
+            .any(|(name, _)| name.eq_ignore_ascii_case("authorization"));
+        assert!(
+            !has_auth,
+            "interceptor request must not contain injected Authorization header; got: {:?}",
+            req.headers
+        );
+        // The raw token must not appear anywhere in the serialized request
+        let serialized = serde_json::to_string(&req).unwrap();
+        assert!(
+            !serialized.contains("ghp_supersecretvalue1234567890"),
+            "raw token leaked into interceptor request: {serialized}"
+        );
+    }
+
+    // ── Credential dedup regression ───────────────────────────────────
+
+    /// Regression: duplicate `CredentialMapping` entries with the same
+    /// `(secret_name, location)` must be deduped so only one
+    /// `Authorization` header is injected. The original bug caused
+    /// GitHub 401 "Bad credentials" when both a WASM tool's capabilities
+    /// and a skill's `credentials` block declared the same secret.
+    ///
+    /// Calls the production `dedup_credential_mappings` function — if the
+    /// function is removed, this test fails to compile.
+    #[test]
+    fn credential_mapping_dedup_removes_duplicates() {
+        use crate::secrets::CredentialMapping;
+
+        let mappings = vec![
+            CredentialMapping::bearer("github_token", "api.github.com"),
+            CredentialMapping::bearer("github_token", "api.github.com"),
+            CredentialMapping::bearer("github_token", "*.github.com"), // same secret, same location type
+        ];
+
+        let dedup = super::dedup_credential_mappings(mappings);
+
+        assert_eq!(
+            dedup.len(),
+            1,
+            "duplicate (secret_name, location) pairs should be deduped to one entry; got {}",
+            dedup.len()
+        );
+        assert_eq!(dedup[0].secret_name, "github_token");
+    }
+
+    /// Dedup must preserve entries with different locations for the same secret.
+    #[test]
+    fn credential_mapping_dedup_preserves_different_locations() {
+        use crate::secrets::CredentialMapping;
+
+        let mappings = vec![
+            CredentialMapping::bearer("my_token", "api.example.com"),
+            CredentialMapping::header("my_token", "X-Api-Key", "api.example.com"),
+        ];
+
+        let dedup = super::dedup_credential_mappings(mappings);
+
+        assert_eq!(
+            dedup.len(),
+            2,
+            "different locations for the same secret must be preserved; got {}",
+            dedup.len()
+        );
     }
 }

--- a/src/tools/mcp/config.rs
+++ b/src/tools/mcp/config.rs
@@ -165,6 +165,27 @@ impl McpServerConfig {
             });
         }
 
+        // Allowlist: alphanumeric, dash, underscore.
+        // Rejects shell metacharacters (;|&`$), path separators (/\),
+        // dots (LLM providers require tool names match ^[a-zA-Z0-9_-]+$
+        // and server names are used as tool name prefixes), null bytes,
+        // spaces, and other dangerous characters that could cause injection
+        // when names are interpolated into secret keys, tool name prefixes,
+        // or provider tags.
+        if !self
+            .name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+        {
+            return Err(ConfigError::InvalidConfig {
+                reason: format!(
+                    "Server name '{}' contains invalid characters \
+                     (only alphanumeric, dash, underscore are allowed)",
+                    self.name
+                ),
+            });
+        }
+
         match self.effective_transport() {
             EffectiveTransport::Http => {
                 if self.url.is_empty() {
@@ -543,14 +564,23 @@ pub async fn load_mcp_servers_from(path: impl AsRef<Path>) -> Result<McpServersF
     }
 
     let content = fs::read_to_string(path).await?;
-    let config: McpServersFile = serde_json::from_str(&content)?;
+    let mut config: McpServersFile = serde_json::from_str(&content)?;
 
-    // Validate every server on load so corrupted configs are caught early
-    for server in &config.servers {
-        server.validate().map_err(|e| ConfigError::InvalidConfig {
-            reason: format!("Server '{}': {}", server.name, e),
-        })?;
-    }
+    // Validate every server on load. Invalid entries are skipped with a
+    // warning instead of failing the entire config — this prevents legacy
+    // names (e.g. "My Server") from disabling all MCP integrations after
+    // an upgrade that tightened validation.
+    config.servers.retain(|server| {
+        if let Err(e) = server.validate() {
+            tracing::warn!(
+                server_name = %server.name,
+                "Skipping MCP server with invalid config: {e}"
+            );
+            false
+        } else {
+            true
+        }
+    });
 
     Ok(config)
 }
@@ -632,13 +662,21 @@ pub async fn load_mcp_servers_from_db(
 ) -> Result<McpServersFile, ConfigError> {
     match store.get_setting(user_id, "mcp_servers").await {
         Ok(Some(value)) => {
-            let config: McpServersFile = serde_json::from_value(value)?;
-            // Validate every server on load so corrupted DB configs are caught early
-            for server in &config.servers {
-                server.validate().map_err(|e| ConfigError::InvalidConfig {
-                    reason: format!("Server '{}': {}", server.name, e),
-                })?;
-            }
+            let mut config: McpServersFile = serde_json::from_value(value)?;
+            // Validate every server on load. Invalid entries are skipped
+            // with a warning to avoid breaking all MCP integrations when
+            // legacy names don't pass tightened validation.
+            config.servers.retain(|server| {
+                if let Err(e) = server.validate() {
+                    tracing::warn!(
+                        server_name = %server.name,
+                        "Skipping MCP server with invalid DB config: {e}"
+                    );
+                    false
+                } else {
+                    true
+                }
+            });
             Ok(config)
         }
         Ok(None) => {
@@ -891,31 +929,36 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_load_rejects_corrupted_headers() {
+    async fn test_load_skips_corrupted_headers() {
         let dir = tempdir().unwrap();
         let path = dir.path().join("mcp-servers.json");
 
         // Write a config with an invalid header name directly to disk,
         // bypassing the add_mcp_server() validation path.
         let corrupted = serde_json::json!({
-            "servers": [{
-                "name": "bad-server",
-                "url": "https://mcp.example.com",
-                "enabled": true,
-                "headers": { "X Bad": "value" }
-            }]
+            "servers": [
+                {
+                    "name": "bad-server",
+                    "url": "https://mcp.example.com",
+                    "enabled": true,
+                    "headers": { "X Bad": "value" }
+                },
+                {
+                    "name": "good-server",
+                    "url": "https://mcp.good.com",
+                    "enabled": true,
+                    "headers": {}
+                }
+            ]
         });
         tokio::fs::write(&path, corrupted.to_string())
             .await
             .unwrap();
 
-        let result = load_mcp_servers_from(&path).await;
-        assert!(result.is_err(), "Load should reject corrupted headers");
-        let err = result.unwrap_err().to_string();
-        assert!(
-            err.contains("bad-server"),
-            "Error should name the offending server, got: {err}"
-        );
+        // Invalid entries are skipped, valid ones are kept
+        let result = load_mcp_servers_from(&path).await.unwrap();
+        assert_eq!(result.servers.len(), 1);
+        assert_eq!(result.servers[0].name, "good-server");
     }
 
     #[test]
@@ -1450,6 +1493,134 @@ mod tests {
             std::env::remove_var("NEARAI_BASE_URL");
             std::env::remove_var("NEARAI_API_KEY");
         }
+    }
+
+    #[test]
+    fn test_server_name_valid_characters_accepted() {
+        // Alphanumeric, dashes, and underscores are all valid
+        for name in ["notion", "my-server", "my_server", "MCP-1"] {
+            let config = McpServerConfig::new(name, "https://mcp.example.com");
+            assert!(
+                config.validate().is_ok(),
+                "Name '{}' should be accepted",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_server_name_shell_metacharacters_rejected() {
+        let dangerous_names = [
+            "server; rm -rf /",
+            "server$(whoami)",
+            "server`id`",
+            "server|cat /etc/passwd",
+            "server&bg",
+            "server>out",
+            "server<in",
+            "name with spaces",
+        ];
+        for name in dangerous_names {
+            let config = McpServerConfig::new(name, "https://mcp.example.com");
+            assert!(
+                config.validate().is_err(),
+                "Name '{}' should be rejected",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_server_name_path_separators_rejected() {
+        for name in ["../etc/passwd", "server/name", "server\\name"] {
+            let config = McpServerConfig::new(name, "https://mcp.example.com");
+            assert!(
+                config.validate().is_err(),
+                "Name '{}' should be rejected",
+                name
+            );
+        }
+    }
+
+    #[test]
+    fn test_server_name_null_byte_rejected() {
+        let config = McpServerConfig::new("server\0name", "https://mcp.example.com");
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_server_name_dot_rejected() {
+        // Dots are rejected because server names are used as tool name
+        // prefixes and LLM providers require ^[a-zA-Z0-9_-]+$
+        let config = McpServerConfig::new("my.server", "https://mcp.example.com");
+        assert!(
+            config.validate().is_err(),
+            "Dot in server name should be rejected"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_load_skips_invalid_server_names() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mcp-servers.json");
+
+        // Write a config with one invalid name and one valid name
+        let mixed = serde_json::json!({
+            "servers": [
+                {
+                    "name": "bad;server",
+                    "url": "https://mcp.evil.com",
+                    "enabled": true,
+                    "headers": {}
+                },
+                {
+                    "name": "good-server",
+                    "url": "https://mcp.good.com",
+                    "enabled": true,
+                    "headers": {}
+                }
+            ]
+        });
+        tokio::fs::write(&path, mixed.to_string()).await.unwrap();
+
+        // Invalid entry is skipped, valid one is kept
+        let result = load_mcp_servers_from(&path).await.unwrap();
+        assert_eq!(result.servers.len(), 1);
+        assert_eq!(result.servers[0].name, "good-server");
+    }
+
+    #[tokio::test]
+    async fn test_load_preserves_schema_version() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("mcp-servers.json");
+
+        // Write a config with schema_version explicitly set
+        let config = serde_json::json!({
+            "servers": [
+                {
+                    "name": "good-server",
+                    "url": "https://mcp.good.com",
+                    "enabled": true,
+                    "headers": {}
+                },
+                {
+                    "name": "bad;server",
+                    "url": "https://mcp.evil.com",
+                    "enabled": true,
+                    "headers": {}
+                }
+            ],
+            "schema_version": 1
+        });
+        tokio::fs::write(&path, config.to_string()).await.unwrap();
+
+        // Filtering invalid servers must preserve the original schema_version
+        let result = load_mcp_servers_from(&path).await.unwrap();
+        assert_eq!(result.servers.len(), 1);
+        assert_eq!(
+            result.schema_version, 1,
+            "schema_version must be preserved when filtering invalid servers"
+        );
     }
 
     #[test]

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -1255,11 +1255,11 @@ impl Tool for WasmToolWrapper {
         // Pre-resolve host credentials from secrets store (async, before blocking task).
         // This decrypts the secrets once so the sync http_request() host function
         // can inject them without needing async access.
-        let credential_user_id = &ctx.user_id;
+        let credential_user_id = ctx.user_id.clone();
         let resolution = resolve_host_credentials(
             &self.capabilities,
             self.secrets_store.as_deref(),
-            credential_user_id,
+            &credential_user_id,
             self.role_lookup.as_deref(),
             self.oauth_refresh.as_ref(),
         )
@@ -1274,9 +1274,10 @@ impl Tool for WasmToolWrapper {
         // mapping `optional = true` in their capabilities manifest.
         if !resolution.missing_required.is_empty() {
             return Err(ToolError::ExecutionFailed(format!(
-                "WASM tool '{}' requires credentials that are not configured: {}. \
-                 Configure the missing credentials before re-running the tool.",
+                "WASM tool '{}' requires credentials that are not configured for user '{}': {}. \
+                 Configure the missing credentials with `ironclaw secrets set` and re-run the tool.",
                 self.name(),
+                credential_user_id,
                 resolution.missing_required.join(", ")
             )));
         }
@@ -1375,16 +1376,14 @@ impl std::fmt::Debug for WasmToolWrapper {
 /// so that the synchronous WASM host function can inject credentials
 /// without needing async access to the secrets store.
 ///
-/// Silently skips credentials that can't be resolved (e.g., missing secrets).
-/// The tool will get a 401/403 from the API, which is the expected UX when
-/// auth hasn't been configured yet.
-/// Outcome of pre-resolving WASM tool host credentials. Carries both the
-/// successfully-resolved set and any *required* credentials that could not
-/// be resolved. The caller is responsible for refusing to execute the tool
-/// when `missing_required` is non-empty — proceeding would let the tool
-/// issue requests without the credentials it declared, which a malicious
-/// or misconfigured tool can use to exfiltrate user context to an
-/// unauthenticated endpoint.
+/// Resolves the host credentials declared by a WASM tool for the current user.
+///
+/// Optional mappings may be skipped when unavailable. Required mappings are
+/// tracked in `missing_required` so the caller can fail closed before
+/// execution instead of letting the tool run without the credentials it
+/// declared. That prevents a malicious or misconfigured tool from issuing
+/// requests that silently borrow another scope's secrets or exfiltrate user
+/// context to an unauthenticated endpoint.
 struct HostCredentialsResolution {
     resolved: Vec<ResolvedHostCredential>,
     missing_required: Vec<String>,
@@ -1479,7 +1478,7 @@ async fn resolve_host_credentials(
             &mapping.secret_name,
             role_lookup,
             oauth_refresh.filter(|config| config.secret_name == mapping.secret_name),
-            crate::auth::DefaultFallback::AdminOnly,
+            crate::auth::DefaultFallback::Denied,
         )
         .await
         {
@@ -3464,7 +3463,7 @@ mod tests {
 
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn test_resolve_host_credentials_fallback_to_default_for_admin_user() {
+    async fn test_resolve_host_credentials_denies_default_fallback_for_admin_user() {
         use crate::secrets::{CredentialLocation, CredentialMapping, SecretsStore};
         use crate::tools::wasm::capabilities::HttpCapability;
         use crate::tools::wasm::wrapper::resolve_host_credentials;
@@ -3504,8 +3503,9 @@ mod tests {
             ..Default::default()
         };
 
-        // Resolve credentials for a different user (routine context)
-        // Should fallback to "default" and find the token
+        // Resolve credentials for a different user (routine context).
+        // The WASM tool path must fail closed and refuse to borrow the
+        // admin-only default scope.
         let result = resolve_host_credentials(
             &caps,
             Some(&store),
@@ -3515,8 +3515,15 @@ mod tests {
         )
         .await;
 
-        assert!(!result.is_empty(), "fallback to default"); // safety: test code only
-        assert_eq!(result[0].secret_value, "global_token_value"); // safety: test code only
+        assert!(
+            result.is_empty(),
+            "WASM tool credential resolution must not borrow the default scope"
+        );
+        assert_eq!(
+            result.missing_required,
+            vec!["google_oauth_token".to_string()],
+            "missing required credential should still be reported"
+        );
     }
 
     #[cfg(feature = "libsql")]

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -126,6 +126,58 @@ async def test_refresh_without_hash_reopens_active_thread_history(page):
     ).wait_for(state="visible", timeout=15000)
 
 
+async def test_refresh_skips_readonly_external_active_thread(page):
+    """When the server active_thread is an external-channel (HTTP/Telegram) thread,
+    a refresh without a hash should fall through to the assistant thread with
+    the chat input enabled, not land on the read-only thread."""
+
+    # 1. Create a secondary thread and send a message so it becomes active_thread
+    await page.locator("#thread-new-btn").click()
+    await page.wait_for_function(
+        "() => !!currentThreadId && currentThreadId !== assistantThreadId"
+    )
+    ext_thread_id = await page.evaluate("() => currentThreadId")
+
+    result = await send_chat_and_wait_for_terminal_message(
+        page,
+        "Readonly channel test message",
+    )
+    assert result["role"] == "assistant"
+
+    # 2. Strip the URL hash so reload relies on active_thread
+    await page.evaluate(
+        "() => history.replaceState(null, '', location.pathname + location.search)"
+    )
+
+    # 3. Intercept /api/chat/threads to mark the active thread as "http" channel
+    async def patch_threads_response(route):
+        response = await route.fetch()
+        body = await response.json()
+        for t in body.get("threads", []):
+            if t["id"] == ext_thread_id:
+                t["channel"] = "http"
+        await route.fulfill(response=response, json=body)
+
+    await page.route("**/api/chat/threads", patch_threads_response)
+
+    # 4. Reload — loadThreads() should skip the "http" active thread
+    await page.reload()
+    await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
+    await _wait_for_connected(page, timeout=15000)
+
+    # 5. Assert we landed on the assistant thread, not the external one
+    await page.wait_for_function(
+        "() => currentThreadId === assistantThreadId",
+        timeout=15000,
+    )
+
+    # 6. Chat input should be enabled (not disabled by read-only state)
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+    is_disabled = await chat_input.is_disabled()
+    assert not is_disabled, "Chat input should be enabled on the assistant thread"
+
+
 async def test_sse_keepalive_comments_arrive(managed_gateway_server):
     """Idle SSE connections should receive keepalive comments within 30 seconds."""
     async with sse_stream(managed_gateway_server.base_url, timeout=50) as response:

--- a/tests/e2e/scenarios/test_tool_approval.py
+++ b/tests/e2e/scenarios/test_tool_approval.py
@@ -285,6 +285,70 @@ async def test_chat_reply_deny_rejects_pending_tool(ironclaw_server):
     assert "Tool 'http' was rejected" in response_text
 
 
+async def test_text_approval_resolves_real_tool_call(page):
+    """Typing 'yes' should resolve a real approval gate triggered by a tool call."""
+    chat_input = page.locator(SEL["chat_input"])
+    await chat_input.wait_for(state="visible", timeout=5000)
+
+    # Trigger a real HTTP tool call that requires approval
+    await chat_input.fill("make approval post text-approval-e2e")
+    await chat_input.press("Enter")
+
+    # Wait for the approval card to appear (from the SSE event)
+    card = page.locator(SEL["approval_card"]).last
+    await card.wait_for(state="visible", timeout=15000)
+
+    tool_name = await card.locator(".approval-tool-name").text_content()
+    assert tool_name == "http"
+
+    # Type "yes" to approve — should be intercepted by the frontend
+    await chat_input.fill("yes")
+    await chat_input.press("Enter")
+
+    # Card should show resolved status
+    resolved = card.locator(".approval-resolved")
+    await resolved.wait_for(state="visible", timeout=5000)
+    assert await resolved.text_content() == "Approved"
+
+    # Card should be removed after brief delay
+    await card.wait_for(state="hidden", timeout=5000)
+
+
+async def test_slash_approve_is_thread_scoped_api(ironclaw_server):
+    """Sending '/approve' in thread A must not resolve a pending gate in thread B."""
+    thread_a = await _create_thread(ironclaw_server)
+    thread_b = await _create_thread(ironclaw_server)
+
+    await _send_chat_message(
+        ironclaw_server,
+        thread_b,
+        "make approval post slash-approve-thread-scope",
+    )
+    await _wait_for_history(ironclaw_server, thread_b, expect_pending=True)
+
+    await _send_chat_message(ironclaw_server, thread_a, "/approve")
+    await asyncio.sleep(1.0)
+
+    history_a = await _wait_for_history(
+        ironclaw_server,
+        thread_a,
+        expect_pending=False,
+        timeout=5.0,
+    )
+    assert history_a.get("pending_gate") is None
+
+    history_b = await _wait_for_history(
+        ironclaw_server,
+        thread_b,
+        expect_pending=True,
+        turn_count_at_least=1,
+        timeout=5.0,
+    )
+    assert history_b.get("pending_gate") is not None
+
+
+# NOTE: This test permanently auto-approves the `http` tool for the session.
+# All tests that need the http approval gate to fire MUST run before this one.
 async def test_chat_reply_always_auto_approves_next_same_tool(ironclaw_server):
     """A plain chat reply of 'always' should auto-approve the same tool next time."""
     thread_id = await _create_thread(ironclaw_server)
@@ -561,35 +625,6 @@ async def test_normal_text_not_intercepted_with_approval_card(page):
     )
 
 
-async def test_text_approval_resolves_real_tool_call(page):
-    """Typing 'yes' should resolve a real approval gate triggered by a tool call."""
-    chat_input = page.locator(SEL["chat_input"])
-    await chat_input.wait_for(state="visible", timeout=5000)
-
-    # Trigger a real HTTP tool call that requires approval
-    await chat_input.fill("make approval post text-approval-e2e")
-    await chat_input.press("Enter")
-
-    # Wait for the approval card to appear (from the SSE event)
-    card = page.locator(SEL["approval_card"]).last
-    await card.wait_for(state="visible", timeout=15000)
-
-    tool_name = await card.locator(".approval-tool-name").text_content()
-    assert tool_name == "http"
-
-    # Type "yes" to approve — should be intercepted by the frontend
-    await chat_input.fill("yes")
-    await chat_input.press("Enter")
-
-    # Card should show resolved status
-    resolved = card.locator(".approval-resolved")
-    await resolved.wait_for(state="visible", timeout=5000)
-    assert await resolved.text_content() == "Approved"
-
-    # Card should be removed after brief delay
-    await card.wait_for(state="hidden", timeout=5000)
-
-
 # -- Regression: bare keywords without pending approval ----------------------
 
 
@@ -761,34 +796,3 @@ async def test_slash_approve_does_not_intercept_other_thread_card(page):
     )
 
 
-async def test_slash_approve_is_thread_scoped_api(ironclaw_server):
-    """Sending '/approve' in thread A must not resolve a pending gate in thread B."""
-    thread_a = await _create_thread(ironclaw_server)
-    thread_b = await _create_thread(ironclaw_server)
-
-    await _send_chat_message(
-        ironclaw_server,
-        thread_b,
-        "make approval post slash-approve-thread-scope",
-    )
-    await _wait_for_history(ironclaw_server, thread_b, expect_pending=True)
-
-    await _send_chat_message(ironclaw_server, thread_a, "/approve")
-    await asyncio.sleep(1.0)
-
-    history_a = await _wait_for_history(
-        ironclaw_server,
-        thread_a,
-        expect_pending=False,
-        timeout=5.0,
-    )
-    assert history_a.get("pending_gate") is None
-
-    history_b = await _wait_for_history(
-        ironclaw_server,
-        thread_b,
-        expect_pending=True,
-        turn_count_at_least=1,
-        timeout=5.0,
-    )
-    assert history_b.get("pending_gate") is not None

--- a/tests/e2e_builtin_tool_coverage.rs
+++ b/tests/e2e_builtin_tool_coverage.rs
@@ -1227,7 +1227,9 @@ mod tests {
              tool_activate: {tool_search_description}"
         );
         assert!(
-            tool_search_description.contains("use the `message` tool for proactive outbound sends"),
+            tool_search_description
+                .to_ascii_lowercase()
+                .contains("use the `message` tool for proactive outbound sends"),
             "tool_search description should point outbound sends to message: {tool_search_description}"
         );
 

--- a/tests/status_cli.rs
+++ b/tests/status_cli.rs
@@ -1,0 +1,35 @@
+use std::process::Command;
+
+#[test]
+fn status_lists_enabled_wasm_channel_names() {
+    let tempdir = tempfile::tempdir().expect("tempdir");
+    let base_dir = tempdir.path();
+    let channels_dir = base_dir.join("channels");
+    std::fs::create_dir_all(&channels_dir).expect("create channels dir");
+    std::fs::File::create(channels_dir.join("telegram.wasm")).expect("write wasm");
+    std::fs::write(
+        base_dir.join("config.toml"),
+        "[channels]\nwasm_channels_enabled = true\nwasm_channels = [\"telegram\"]\n",
+    )
+    .expect("write config");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_ironclaw"))
+        .arg("status")
+        .env("IRONCLAW_BASE_DIR", base_dir)
+        .current_dir(base_dir)
+        .output()
+        .expect("run ironclaw status");
+
+    assert!(
+        output.status.success(),
+        "status command failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Channels") && stdout.contains("telegram"),
+        "status output did not include enabled WASM channel names:\n{}",
+        stdout
+    );
+}

--- a/tests/telegram_auth_integration.rs
+++ b/tests/telegram_auth_integration.rs
@@ -837,6 +837,50 @@ async fn test_group_message_with_bot_mention_emits_cleaned_content() {
 
 #[tokio::test]
 #[cfg(feature = "integration")]
+async fn test_group_message_emits_chat_type_metadata() {
+    require_telegram_wasm!();
+    let runtime = create_test_runtime();
+
+    let config = serde_json::json!({
+        "bot_username": null,
+        "owner_id": null,
+        "dm_policy": "open",
+        "allow_from": [],
+        "respond_to_all_group_messages": true
+    })
+    .to_string();
+
+    let channel = create_telegram_channel(runtime, &config).await;
+    let mut stream = channel
+        .start_message_stream_for_test()
+        .await
+        .expect("Failed to bootstrap test message stream");
+
+    let update = build_telegram_update(8, 108, -123456789, "group", 702, "User", "status please");
+
+    let response = channel
+        .call_on_http_request(
+            "POST",
+            "/webhook/telegram",
+            &HashMap::new(),
+            &HashMap::new(),
+            &update,
+            true,
+        )
+        .await
+        .expect("HTTP callback failed");
+
+    assert_eq!(response.status, 200);
+
+    let msg = timeout(Duration::from_secs(1), stream.next())
+        .await
+        .expect("message should arrive")
+        .expect("stream should yield a message");
+    assert_eq!(msg.metadata["chat_type"], serde_json::json!("group"));
+}
+
+#[tokio::test]
+#[cfg(feature = "integration")]
 async fn test_edited_message_emits_like_regular_message() {
     require_telegram_wasm!();
     let runtime = create_test_runtime();


### PR DESCRIPTION
## Summary

Promote 14 commits from `staging` to `main`, most importantly the case-insensitive `tool_search` e2e assertion fix (#2608) that will unblock release-plz PR #2606.

## Included commits (oldest → newest)

- #2396 — feat: discover tool source in working directory during install
- #2529 — fix(security): redact credentials in HTTP tool + recording interceptor
- #2463 — fix(llm): normalize NEAR AI tool schemas
- #2420 — fix(status): report active WASM channels accurately
- #2465 — fix(ownership): fail closed on WASM default-scope fallback
- #2607 — refactor(events): add `OnboardingStateDto::pairing_required` constructor
- #2503 — fix(e2e): resolve 12 E2E test failures across routines and features groups
- #2486 — feat(gateway): show commit hash in version for non-tagged builds
- #2513 — fix(telegram): emit chat_type metadata for group-safe prompt behavior
- #2389 — Prompt for local profile during quick onboarding
- #2471 — fix(channels): unify hot-activation owner_id type and capabilities fallback
- #2608 — fix(test): case-insensitive tool_search description assertion ← **unblocks #2606**
- #2400 — fix(mcp): validate server names with strict allowlist
- #2610 — ci: share rust-cache across clippy matrix legs

## Change Type

- [x] Bug fix
- [x] New feature
- [x] CI/Infrastructure
- [x] Security

## Validation

- [x] All included PRs merged to staging after individual review + CI
- [ ] Promotion CI green
- [ ] After merge: release-plz PR #2606 auto-refreshes green

## Rollback Plan

Revert this merge commit on main if any individual promoted PR regresses. Each underlying PR is independently revertable upstream if needed.

---

**Review track**: C (multi-PR promotion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)