### PR TITLE
ci: drop duplicate matrix legs and consolidate caches

### DIFF
--- a/.github/actions/install-cargo-component/action.yml
+++ b/.github/actions/install-cargo-component/action.yml
@@ -1,0 +1,14 @@
+name: Install cargo-component
+description: Install cargo-component using a precompiled binary (taiki-e/install-action).
+
+# Replaces ad-hoc `cargo install cargo-component --locked || true` calls. The
+# precompiled-binary path takes a few seconds vs. several minutes for a source
+# install, and we no longer swallow install failures.
+
+runs:
+  using: composite
+  steps:
+    - name: Install cargo-component
+      uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # v2
+      with:
+        tool: cargo-component

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,6 +1,38 @@
 name: Code Style
 on:
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'COVERAGE_PLAN.md'
+      - 'FEATURE_PARITY.md'
+      - 'LICENSE-*'
+      - '*.png'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'docs/**'
+  # Long-lived branches: refresh shared rust-cache slots that PRs restore from
+  # (PR jobs only restore — they don't save — per the save-if guards below).
+  push:
+    branches:
+      - main
+      - staging
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'COVERAGE_PLAN.md'
+      - 'FEATURE_PARITY.md'
+      - 'LICENSE-*'
+      - '*.png'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'docs/**'
 
 permissions:
   contents: read
@@ -47,15 +79,44 @@ jobs:
     - name: Run cargo deny
       uses: EmbarkStudios/cargo-deny-action@3fd3802e88374d3fe9159b834c7714ec57d6c979 # v2
 
+  # PR-blocking lint job: only the all-features config runs on every PR.
+  # Lint findings are almost never feature-gated, and the all-features build
+  # is the largest superset, so other configs add little signal at high cost.
+  # The remaining configs run on push to long-lived branches via clippy-extra.
   clippy:
+    name: Clippy (all-features)
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        components: clippy
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        # Shared with `tests` in test.yml. Clippy and `cargo test` produce
+        # overlapping artifacts for the same feature set, so a single slot
+        # serves both jobs and avoids duplicating multi-GB target/ caches.
+        shared-key: build
+        # PR jobs restore-only; long-lived branch pushes refresh the slot.
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+    - name: Check lints
+      run: cargo clippy --all --benches --tests --examples --all-features -- -D warnings
+
+  # Verification matrix for the configs not covered by the PR-gated clippy
+  # job above. Push-only so PRs aren't slowed by feature-config permutations
+  # whose lint output rarely diverges from --all-features.
+  clippy-extra:
     name: Clippy (${{ matrix.name }})
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: all-features
-            flags: "--all-features"
           - name: default
             flags: ""
           - name: libsql-only
@@ -71,20 +132,41 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-${{ matrix.name }}
+        shared-key: build
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
   clippy-windows:
+    name: Clippy Windows (all-features)
+    # Run on PRs to main (developer feedback for Windows-specific issues) and
+    # on pushes to long-lived branches (cache refresh / staging gate).
+    if: github.event_name == 'push' || github.base_ref == 'main'
+    runs-on: windows-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      with:
+        components: clippy
+    - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      with:
+        shared-key: build-windows
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+    - name: Check lints
+      run: cargo clippy --all --benches --tests --examples --all-features -- -D warnings
+
+  clippy-windows-extra:
     name: Clippy Windows (${{ matrix.name }})
-    if: github.base_ref == 'main'
+    if: github.event_name == 'push'
     runs-on: windows-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: all-features
-            flags: "--all-features"
           - name: default
             flags: ""
           - name: libsql-only
@@ -100,12 +182,16 @@ jobs:
         components: clippy
     - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
       with:
-        key: clippy-windows-${{ matrix.name }}
+        shared-key: build-windows
+        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
     - name: Check lints
       run: cargo clippy --all --benches --tests --examples ${{ matrix.flags }} -- -D warnings
 
   no-panics:
     name: No panics in production code
+    # Diff is computed against the PR base SHA, which is unavailable on
+    # push events. Gate to PRs only; the roll-up tolerates a skipped result.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
@@ -126,15 +212,42 @@ jobs:
     name: Code Style (fmt + gateway-js-syntax + clippy + deny)
     runs-on: ubuntu-latest
     if: always()
-    needs: [format, gateway-js-syntax, clippy, clippy-windows, deny-check, no-panics]
+    needs:
+      - format
+      - gateway-js-syntax
+      - clippy
+      - clippy-extra
+      - clippy-windows
+      - clippy-windows-extra
+      - deny-check
+      - no-panics
     steps:
       - run: |
-          if [[ "${{ needs.format.result }}" != "success" || "${{ needs.gateway-js-syntax.result }}" != "success" || "${{ needs.clippy.result }}" != "success" || "${{ needs.deny-check.result }}" != "success" || "${{ needs.no-panics.result }}" != "success" ]]; then
-            echo "One or more jobs failed"
-            exit 1
-          fi
-          # clippy-windows only runs on main PRs, so skipped is acceptable but failure is not
-          if [[ "${{ needs.clippy-windows.result }}" != "success" && "${{ needs.clippy-windows.result }}" != "skipped" ]]; then
-            echo "Windows clippy failed: ${{ needs.clippy-windows.result }}"
-            exit 1
-          fi
+          # Always-required jobs.
+          for job_result in \
+            "format=${{ needs.format.result }}" \
+            "gateway-js-syntax=${{ needs.gateway-js-syntax.result }}" \
+            "clippy=${{ needs.clippy.result }}" \
+            "deny-check=${{ needs.deny-check.result }}"; do
+            name="${job_result%%=*}"
+            result="${job_result##*=}"
+            if [[ "$result" != "success" ]]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done
+
+          # Conditional jobs: must succeed when run, may be skipped on
+          # events where their `if:` filter excludes them.
+          for job_result in \
+            "no-panics=${{ needs.no-panics.result }}" \
+            "clippy-extra=${{ needs.clippy-extra.result }}" \
+            "clippy-windows=${{ needs.clippy-windows.result }}" \
+            "clippy-windows-extra=${{ needs.clippy-windows-extra.result }}"; do
+            name="${job_result%%=*}"
+            result="${job_result##*=}"
+            if [[ "$result" != "success" && "$result" != "skipped" ]]; then
+              echo "$name failed: $result"
+              exit 1
+            fi
+          done

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,10 +86,7 @@ jobs:
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
       - name: Install cargo-component
-        run: |
-          if ! command -v cargo-component >/dev/null 2>&1; then
-            cargo install cargo-component --locked
-          fi
+        uses: ./.github/actions/install-cargo-component
 
       - name: Build WASM channels (for integration tests)
         run: ./scripts/build-wasm-extensions.sh --channels
@@ -150,10 +147,7 @@ jobs:
         uses: taiki-e/install-action@62b0f2dec647a8e604c6a0fda0e38530180dce20 # cargo-llvm-cov
 
       - name: Install cargo-component
-        run: |
-          if ! command -v cargo-component >/dev/null 2>&1; then
-            cargo install cargo-component --locked
-          fi
+        uses: ./.github/actions/install-cargo-component
 
       - name: Build WASM channels
         run: ./scripts/build-wasm-extensions.sh --channels

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -279,9 +279,9 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install Rust toolchain + wasm target
-        run: |
-          rustup target add wasm32-wasip2
-          cargo install cargo-component --locked || true
+        run: rustup target add wasm32-wasip2
+      - name: Install cargo-component
+        uses: ./.github/actions/install-cargo-component
       - uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: wasm-extensions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,9 +9,35 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'COVERAGE_PLAN.md'
+      - 'FEATURE_PARITY.md'
+      - 'LICENSE-*'
+      - '*.png'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'docs/**'
   push:
     branches:
       - main
+    paths-ignore:
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - 'CONTRIBUTING.md'
+      - 'CLAUDE.md'
+      - 'AGENTS.md'
+      - 'COVERAGE_PLAN.md'
+      - 'FEATURE_PARITY.md'
+      - 'LICENSE-*'
+      - '*.png'
+      - '.github/ISSUE_TEMPLATE/**'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+      - 'docs/**'
 
 permissions:
   contents: read
@@ -46,9 +72,14 @@ jobs:
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: ${{ matrix.name }}
+          # Share the target/ slot with code_style.yml's clippy job. Clippy and
+          # `cargo test` produce overlapping artifacts for the same feature set,
+          # so a single shared slot beats two near-duplicate caches that fight
+          # for GHA's per-repo cache budget.
+          shared-key: build
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
-        run: cargo install cargo-component --locked || true
+        uses: ./.github/actions/install-cargo-component
       - name: Build WASM channels (for integration tests)
         run: ./scripts/build-wasm-extensions.sh --channels
       - name: Run Tests
@@ -73,6 +104,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: heavy-integration
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Build Telegram WASM channel
         run: cargo build --manifest-path channels-src/telegram/Cargo.toml --target wasm32-wasip2 --release
       - name: Run thread scheduling integration tests
@@ -100,40 +132,12 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Run Telegram Channel Tests
         run: |
           timeout --signal=INT --kill-after=30s 10m \
             cargo test --manifest-path channels-src/telegram/Cargo.toml -- --nocapture
-
-  windows-build:
-    name: Windows Build (${{ matrix.name }})
-    if: >
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'staging'
-    runs-on: windows-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: all-features
-            flags: "--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import"
-          - name: default
-            flags: ""
-          - name: libsql-only
-            flags: "--no-default-features --features libsql"
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-          persist-credentials: false
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          key: windows-${{ matrix.name }}
-      - name: Check compilation
-        run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
 
   wasm-wit-compat:
     name: WASM WIT Compatibility
@@ -154,9 +158,10 @@ jobs:
           targets: wasm32-wasip2
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          key: wasm-extensions
+          shared-key: wasm-extensions
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Install cargo-component
-        run: cargo install cargo-component --locked || true
+        uses: ./.github/actions/install-cargo-component
       - name: Build all WASM extensions against current WIT
         run: ./scripts/build-wasm-extensions.sh
       - name: Instantiation test (host linker compatibility)
@@ -178,6 +183,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench
+          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
       - name: Compile benchmarks
         run: cargo bench --all-features --no-run
 
@@ -217,7 +223,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
     if: always()
-    needs: [tests, heavy-integration-tests, telegram-tests, wasm-wit-compat, docker-build, windows-build, version-check, bench-compile]
+    # Windows compilation is covered by the clippy-windows job in
+    # code_style.yml (clippy implies cargo check), so no Windows job is needed
+    # here.
+    needs: [tests, heavy-integration-tests, telegram-tests, wasm-wit-compat, docker-build, version-check, bench-compile]
     steps:
       - run: |
           # Unit tests must always pass
@@ -230,12 +239,11 @@ jobs:
             exit 1
           fi
           # Gated jobs: must pass on promotion PRs / push, skipped on developer PRs
-          for job in telegram-tests wasm-wit-compat docker-build windows-build version-check bench-compile; do
+          for job in telegram-tests wasm-wit-compat docker-build version-check bench-compile; do
             case "$job" in
               telegram-tests) result="${{ needs.telegram-tests.result }}" ;;
               wasm-wit-compat) result="${{ needs.wasm-wit-compat.result }}" ;;
               docker-build) result="${{ needs.docker-build.result }}" ;;
-              windows-build) result="${{ needs.windows-build.result }}" ;;
               version-check) result="${{ needs.version-check.result }}" ;;
               bench-compile) result="${{ needs.bench-compile.result }}" ;;
             esac


### PR DESCRIPTION
## Summary

Combines five reductions targeting the duplicate compile work the analysis flagged: clippy and \`cargo check\` were running the same compile multiple times across matrix legs and platforms.

| # | Change |
|---|--------|
| 1 | Drop \`windows-build\` from \`test.yml\` — its \`cargo check\` matrix is fully subsumed by \`clippy-windows\`, which already type-checks \`--all --benches --tests --examples\` on the same configs. |
| 2 | Collapse PR-blocking clippy to \`--all-features\` only (Linux + Windows). \`default\` and \`libsql-only\` move to \`clippy-extra\` / \`clippy-windows-extra\` jobs, gated to \`push\` on \`main\`/\`staging\`. |
| 3 | Share rust-cache slot between clippy and tests via \`shared-key: build\` / \`shared-key: build-windows\`. They produce overlapping artifacts for the same feature set; one slot beats two near-duplicates. |
| 6 | Replace \`cargo install cargo-component --locked \|\| true\` with a composite action wrapping \`taiki-e/install-action\` (precompiled binary). Applied to \`test.yml\`, \`coverage.yml\`, \`release.yml\`. |
| 7 | Add \`paths-ignore\` for top-level docs, LICENSE, PNGs, issue/PR templates, and \`docs/**\`. Conservative — any \`.md\` actually \`include_str!()\`'d by the binary (workspace seeds, engine prompts, channel READMEs) is **not** filtered. |

## Interaction with #2609 / #2610

Independent and complementary. This PR includes \`save-if\` guards on every rust-cache step (so it's self-contained if those land later) and changes cache keys (\`clippy\` → \`build\` for Linux; \`clippy-windows\` + \`windows-build\` → \`build-windows\` for Windows). Expect trivial line-level merge conflicts in the rust-cache blocks; the intent layers cleanly:

- #2609: PR jobs restore-only (save-if gating)
- #2610: clippy matrix legs share one slot (\`shared-key: clippy\`)
- This PR: tests + clippy share *the same* slot (\`shared-key: build\`), and the matrix shrinks to 1 leg on PRs

Also: gates \`no-panics\` to PR-only (it diffs against the PR base SHA, empty on push) and updates the \`code-style\` roll-up to accept \`skipped\` for the push-only / PR-only conditional jobs.

## Expected impact per PR

- 3 Windows runners removed (\`windows-build\` matrix gone)
- Clippy goes from 3 Linux + 3 Windows legs → 1 Linux + 1 Windows on PRs
- Tests reuse the clippy-warmed \`target/\` slot when their matrix runs
- \`cargo-component\` install drops from minutes to seconds across 5 jobs

## Test plan

- [ ] CI on this PR: confirm \`Clippy (all-features)\` and \`Clippy Windows (all-features)\` are the only clippy jobs running; \`clippy-extra\` and \`clippy-windows-extra\` show \`skipped\`; \`Windows Build (...)\` is gone
- [ ] \`Code Style (fmt + ...)\` roll-up reports success despite skipped legs
- [ ] After merge, push to \`staging\` runs the full clippy matrix (\`clippy-extra\` / \`clippy-windows-extra\` succeed) and refreshes the \`build\` / \`build-windows\` cache slots
- [ ] Subsequent PR shows clippy with cache restore from the \`build\` slot

## Watch-outs

- The \`clippy\` (all-features) job uses \`--all-features\` while \`tests\` (all-features) uses \`--no-default-features --features postgres,libsql,html-to-markdown,bedrock,import\` (excluding the test-only \`integration\` feature). Sharing the cache slot still helps because the bulk of the compile graph overlaps, but the diff will be rebuilt — by design, not a regression.
- \`paths-ignore\` triggers a workflow-level skip when only filtered paths change. The Main ruleset's required checks (\`Run Tests\`, \`Code Style (fmt + clippy)\`) currently don't strictly enforce on developer PRs (the latter's name doesn't even match the actual job name), and the Staging ruleset has no required checks. So docs-only PRs to staging won't be blocked. If branch protection tightens later, we'll need a no-op stub workflow to satisfy required checks on filtered paths.