### PR TITLE
fix(web): aggregate visible missions across projects

### DIFF
--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -72,4 +72,7 @@ pub use router::reset_engine_state;
 
 // Exposed for caller-level testing of the cross-user thread_id guard
 #[cfg(test)]
-pub(crate) use router::handle_mission_notification;
+pub(crate) use router::{
+    handle_mission_notification, install_test_engine_state,
+    reset_engine_state as reset_test_engine_state, with_test_engine_state_lock,
+};

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -70,7 +70,7 @@ pub use router::{
 #[cfg(feature = "libsql")]
 pub use router::reset_engine_state;
 
-// Exposed for caller-level testing of the cross-user thread_id guard
+// Exposed for shared engine test harnesses and caller-level bridge tests.
 #[cfg(test)]
 pub(crate) use router::{
     handle_mission_notification, install_test_engine_state,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4019,16 +4019,20 @@ async fn load_visible_engine_missions(
             .list_projects(user_id)
             .await
             .map_err(|e| engine_err("list projects", e))?;
-        let mut missions = Vec::new();
-        for project in projects {
-            missions.extend(
+        futures::future::try_join_all(projects.into_iter().map(|project| {
+            let store = Arc::clone(store);
+            let user_id = user_id.to_string();
+            async move {
                 store
-                    .list_missions_with_shared(project.id, user_id)
+                    .list_missions_with_shared(project.id, &user_id)
                     .await
-                    .map_err(|e| engine_err("list missions", e))?,
-            );
-        }
-        missions
+                    .map_err(|e| engine_err("list missions", e))
+            }
+        }))
+        .await?
+        .into_iter()
+        .flatten()
+        .collect()
     };
 
     missions.sort_by(|a, b| {
@@ -4036,7 +4040,8 @@ async fn load_visible_engine_missions(
             .cmp(&a.updated_at)
             .then_with(|| a.id.0.cmp(&b.id.0))
     });
-    missions.dedup_by_key(|mission| mission.id);
+    let mut seen_ids = HashSet::new();
+    missions.retain(|mission| seen_ids.insert(mission.id));
 
     Ok(missions)
 }
@@ -6703,6 +6708,74 @@ mod tests {
 
         *lock.write().await = None;
         outcome.expect("list_engine_missions stays project scoped with filter");
+    }
+
+    #[tokio::test]
+    async fn list_engine_missions_without_project_id_deduplicates_by_newest_updated_at() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let state = make_expected_test_state(store.clone());
+
+            let project = ironclaw_engine::Project::new("alice", "research", "Research project");
+            let project_id = project.id;
+            store.save_project(&project).await.unwrap();
+
+            let shared_project =
+                ironclaw_engine::Project::new("alice", "shared", "Shared project view");
+            let shared_project_id = shared_project.id;
+            store.save_project(&shared_project).await.unwrap();
+
+            let duplicate_id = ironclaw_engine::MissionId(uuid::Uuid::new_v4());
+
+            let mut older_duplicate = ironclaw_engine::Mission::new(
+                project_id,
+                "alice",
+                "duplicate-mission",
+                "older copy",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            older_duplicate.id = duplicate_id;
+            older_duplicate.created_at = chrono::Utc::now() - chrono::Duration::hours(2);
+            older_duplicate.updated_at = chrono::Utc::now() - chrono::Duration::hours(1);
+
+            let mut newer_duplicate = ironclaw_engine::Mission::new(
+                shared_project_id,
+                ironclaw_engine::types::shared_owner_id(),
+                "duplicate-mission",
+                "newer copy",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            newer_duplicate.id = duplicate_id;
+            newer_duplicate.status = ironclaw_engine::MissionStatus::Paused;
+            newer_duplicate.current_focus = Some("newest".to_string());
+            newer_duplicate.created_at = chrono::Utc::now() - chrono::Duration::minutes(45);
+            newer_duplicate.updated_at = chrono::Utc::now() - chrono::Duration::minutes(5);
+
+            store
+                .missions
+                .write()
+                .await
+                .extend([older_duplicate.clone(), newer_duplicate.clone()]);
+
+            *lock.write().await = Some(state);
+
+            let missions = list_engine_missions(None, "alice").await.unwrap();
+
+            assert_eq!(missions.len(), 1);
+            assert_eq!(missions[0].id, duplicate_id.to_string());
+            assert_eq!(missions[0].status, "Paused");
+            assert_eq!(missions[0].current_focus.as_deref(), Some("newest"));
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("list_engine_missions keeps the newest copy when deduplicating");
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -3989,6 +3989,58 @@ fn thread_to_info(t: &ironclaw_engine::Thread) -> EngineThreadInfo {
     }
 }
 
+fn mission_to_info(m: &ironclaw_engine::Mission) -> EngineMissionInfo {
+    EngineMissionInfo {
+        id: m.id.to_string(),
+        name: m.name.clone(),
+        goal: m.goal.clone(),
+        status: format!("{:?}", m.status),
+        cadence_type: cadence_type_label(&m.cadence).to_string(),
+        cadence_description: cadence_description(&m.cadence),
+        thread_count: m.thread_history.len(),
+        current_focus: m.current_focus.clone(),
+        created_at: m.created_at.to_rfc3339(),
+        updated_at: m.updated_at.to_rfc3339(),
+    }
+}
+
+async fn load_visible_engine_missions(
+    store: &Arc<dyn Store>,
+    project_id: Option<ironclaw_engine::ProjectId>,
+    user_id: &str,
+) -> Result<Vec<ironclaw_engine::Mission>, Error> {
+    let mut missions = if let Some(project_id) = project_id {
+        store
+            .list_missions_with_shared(project_id, user_id)
+            .await
+            .map_err(|e| engine_err("list missions", e))?
+    } else {
+        let projects = store
+            .list_projects(user_id)
+            .await
+            .map_err(|e| engine_err("list projects", e))?;
+        let mut missions = Vec::new();
+        for project in projects {
+            missions.extend(
+                store
+                    .list_missions_with_shared(project.id, user_id)
+                    .await
+                    .map_err(|e| engine_err("list missions", e))?,
+            );
+        }
+        missions
+    };
+
+    missions.sort_by(|a, b| {
+        b.updated_at
+            .cmp(&a.updated_at)
+            .then_with(|| a.id.0.cmp(&b.id.0))
+    });
+    missions.dedup_by_key(|mission| mission.id);
+
+    Ok(missions)
+}
+
 /// List engine threads, optionally filtered by project.
 pub async fn list_engine_threads(
     project_id: Option<&str>,
@@ -4417,35 +4469,14 @@ pub async fn list_engine_missions(
         return Ok(Vec::new());
     };
 
-    let pid = match project_id {
-        Some(id) => {
-            let uuid = uuid::Uuid::parse_str(id).map_err(|e| engine_err("parse project_id", e))?;
-            ironclaw_engine::ProjectId(uuid)
-        }
-        None => state.default_project_id,
-    };
+    let pid = project_id
+        .map(|id| uuid::Uuid::parse_str(id).map(ironclaw_engine::ProjectId))
+        .transpose()
+        .map_err(|e| engine_err("parse project_id", e))?;
 
-    let missions = state
-        .store
-        .list_missions_with_shared(pid, user_id)
-        .await
-        .map_err(|e| engine_err("list missions", e))?;
+    let missions = load_visible_engine_missions(&state.store, pid, user_id).await?;
 
-    Ok(missions
-        .iter()
-        .map(|m| EngineMissionInfo {
-            id: m.id.to_string(),
-            name: m.name.clone(),
-            goal: m.goal.clone(),
-            status: format!("{:?}", m.status),
-            cadence_type: cadence_type_label(&m.cadence).to_string(),
-            cadence_description: cadence_description(&m.cadence),
-            thread_count: m.thread_history.len(),
-            current_focus: m.current_focus.clone(),
-            created_at: m.created_at.to_rfc3339(),
-            updated_at: m.updated_at.to_rfc3339(),
-        })
-        .collect())
+    Ok(missions.iter().map(mission_to_info).collect())
 }
 
 /// Get a single mission by ID.
@@ -4488,18 +4519,7 @@ pub async fn get_engine_mission(
     }
 
     Ok(Some(EngineMissionDetail {
-        info: EngineMissionInfo {
-            id: m.id.to_string(),
-            name: m.name.clone(),
-            goal: m.goal.clone(),
-            status: format!("{:?}", m.status),
-            cadence_type: cadence_type_label(&m.cadence).to_string(),
-            cadence_description: cadence_description(&m.cadence),
-            thread_count: m.thread_history.len(),
-            current_focus: m.current_focus.clone(),
-            created_at: m.created_at.to_rfc3339(),
-            updated_at: m.updated_at.to_rfc3339(),
-        },
+        info: mission_to_info(&m),
         cadence: cadence_json,
         approach_history: m.approach_history.clone(),
         notify_channels: m.notify_channels.clone(),
@@ -4606,6 +4626,105 @@ pub async fn reset_engine_state() {
     if let Some(lock) = ENGINE_STATE.get() {
         *lock.write().await = None;
     }
+}
+
+#[cfg(test)]
+static ENGINE_STATE_TEST_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+#[cfg(test)]
+pub(crate) async fn with_test_engine_state_lock<T>(fut: impl std::future::Future<Output = T>) -> T {
+    let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+    fut.await
+}
+
+#[cfg(test)]
+pub(crate) async fn install_test_engine_state(
+    store: Arc<dyn Store>,
+    default_project_id: ironclaw_engine::ProjectId,
+) {
+    use ironclaw_engine::{
+        CapabilityRegistry, ConversationManager, LeaseManager, PolicyEngine, ThreadManager,
+    };
+
+    struct NoopLlm;
+    #[async_trait::async_trait]
+    impl ironclaw_engine::LlmBackend for NoopLlm {
+        async fn complete(
+            &self,
+            _: &[ironclaw_engine::ThreadMessage],
+            _: &[ironclaw_engine::ActionDef],
+            _: &ironclaw_engine::LlmCallConfig,
+        ) -> Result<ironclaw_engine::LlmOutput, ironclaw_engine::EngineError> {
+            Ok(ironclaw_engine::LlmOutput {
+                response: ironclaw_engine::LlmResponse::Text("done".into()),
+                usage: ironclaw_engine::TokenUsage::default(),
+            })
+        }
+
+        fn model_name(&self) -> &str {
+            "noop"
+        }
+    }
+
+    struct NoopEffects;
+    #[async_trait::async_trait]
+    impl ironclaw_engine::EffectExecutor for NoopEffects {
+        async fn execute_action(
+            &self,
+            _: &str,
+            _: serde_json::Value,
+            _: &ironclaw_engine::CapabilityLease,
+            _: &ironclaw_engine::ThreadExecutionContext,
+        ) -> Result<ironclaw_engine::ActionResult, ironclaw_engine::EngineError> {
+            unreachable!()
+        }
+
+        async fn available_actions(
+            &self,
+            _: &[ironclaw_engine::CapabilityLease],
+        ) -> Result<Vec<ironclaw_engine::ActionDef>, ironclaw_engine::EngineError> {
+            Ok(vec![])
+        }
+    }
+
+    let effect_adapter = Arc::new(EffectBridgeAdapter::new(
+        Arc::new(crate::tools::ToolRegistry::new()),
+        Arc::new(ironclaw_safety::SafetyLayer::new(
+            &ironclaw_safety::SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            },
+        )),
+        Arc::new(crate::hooks::HookRegistry::default()),
+    ));
+
+    let thread_manager = Arc::new(ThreadManager::new(
+        Arc::new(NoopLlm),
+        Arc::new(NoopEffects),
+        store.clone(),
+        Arc::new(CapabilityRegistry::new()),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    ));
+    let conversation_manager = Arc::new(ConversationManager::new(
+        Arc::clone(&thread_manager),
+        store.clone(),
+    ));
+
+    let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+    *lock.write().await = Some(EngineState {
+        thread_manager,
+        conversation_manager,
+        effect_adapter,
+        store,
+        default_project_id,
+        pending_gates: Arc::new(crate::gate::store::PendingGateStore::in_memory()),
+        sse: None,
+        db: None,
+        secrets_store: None,
+        auth_manager: None,
+    });
 }
 
 /// Resolve the effective user_id for mission management operations.
@@ -4785,7 +4904,7 @@ mod clamp_tests {
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+    use std::sync::{Arc, Mutex as StdMutex};
     use std::time::Duration;
     use tokio::sync::Mutex as TokioMutex;
     use tokio::sync::RwLock as TokioRwLock;
@@ -4805,13 +4924,12 @@ mod tests {
     use ironclaw_safety::SafetyLayer;
     use rust_decimal::Decimal;
 
-    static ENGINE_STATE_TEST_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
-
     struct TestStore {
         conversations: TokioRwLock<Vec<ironclaw_engine::ConversationSurface>>,
         threads: TokioRwLock<HashMap<ironclaw_engine::ThreadId, ironclaw_engine::Thread>>,
         docs: TokioRwLock<Vec<ironclaw_engine::MemoryDoc>>,
         projects: TokioRwLock<Vec<ironclaw_engine::Project>>,
+        missions: TokioRwLock<Vec<ironclaw_engine::Mission>>,
     }
 
     impl TestStore {
@@ -4821,6 +4939,7 @@ mod tests {
                 threads: TokioRwLock::new(HashMap::new()),
                 docs: TokioRwLock::new(Vec::new()),
                 projects: TokioRwLock::new(Vec::new()),
+                missions: TokioRwLock::new(Vec::new()),
             }
         }
     }
@@ -5054,28 +5173,53 @@ mod tests {
         }
         async fn save_mission(
             &self,
-            _: &ironclaw_engine::Mission,
+            mission: &ironclaw_engine::Mission,
         ) -> Result<(), ironclaw_engine::EngineError> {
+            let mut missions = self.missions.write().await;
+            missions.retain(|existing| existing.id != mission.id);
+            missions.push(mission.clone());
             Ok(())
         }
         async fn load_mission(
             &self,
-            _: ironclaw_engine::MissionId,
+            id: ironclaw_engine::MissionId,
         ) -> Result<Option<ironclaw_engine::Mission>, ironclaw_engine::EngineError> {
-            Ok(None)
+            Ok(self
+                .missions
+                .read()
+                .await
+                .iter()
+                .find(|mission| mission.id == id)
+                .cloned())
         }
         async fn list_missions(
             &self,
-            _: ironclaw_engine::ProjectId,
-            _user_id: &str,
+            project_id: ironclaw_engine::ProjectId,
+            user_id: &str,
         ) -> Result<Vec<ironclaw_engine::Mission>, ironclaw_engine::EngineError> {
-            Ok(vec![])
+            Ok(self
+                .missions
+                .read()
+                .await
+                .iter()
+                .filter(|mission| mission.project_id == project_id && mission.user_id == user_id)
+                .cloned()
+                .collect())
         }
         async fn update_mission_status(
             &self,
-            _: ironclaw_engine::MissionId,
-            _: ironclaw_engine::MissionStatus,
+            id: ironclaw_engine::MissionId,
+            status: ironclaw_engine::MissionStatus,
         ) -> Result<(), ironclaw_engine::EngineError> {
+            if let Some(mission) = self
+                .missions
+                .write()
+                .await
+                .iter_mut()
+                .find(|mission| mission.id == id)
+            {
+                mission.status = status;
+            }
             Ok(())
         }
     }
@@ -5344,7 +5488,7 @@ mod tests {
                 request_id: status_request_id,
                 tool_name,
                 ..
-            } if status_request_id == &request_id && tool_name == "shell"
+            } if *status_request_id == request_id && tool_name == "shell"
         )));
 
         *lock.write().await = None;
@@ -6412,6 +6556,153 @@ mod tests {
         let result = find_most_recent_thread(&state, &Some(conv), "alice").await;
         assert!(result.is_some(), "should find thread via entry fallback");
         assert_eq!(result.unwrap().id, tid);
+    }
+
+    #[tokio::test]
+    async fn list_engine_missions_without_project_id_aggregates_visible_projects() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let state = make_expected_test_state(store.clone());
+
+            let mut default_project =
+                ironclaw_engine::Project::new("alice", "default", "Default project");
+            default_project.id = state.default_project_id;
+            store.save_project(&default_project).await.unwrap();
+
+            let research_project =
+                ironclaw_engine::Project::new("alice", "research", "Research project");
+            store.save_project(&research_project).await.unwrap();
+
+            let mut first = ironclaw_engine::Mission::new(
+                default_project.id,
+                "alice",
+                "default-mission",
+                "watch default",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            first.updated_at = chrono::Utc::now() - chrono::Duration::hours(2);
+            let first_id = first.id;
+            store.save_mission(&first).await.unwrap();
+
+            let mut second = ironclaw_engine::Mission::new(
+                research_project.id,
+                "alice",
+                "research-mission",
+                "watch research",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            second.status = ironclaw_engine::MissionStatus::Paused;
+            second.updated_at = chrono::Utc::now() - chrono::Duration::minutes(30);
+            let second_id = second.id;
+            store.save_mission(&second).await.unwrap();
+
+            let mut shared = ironclaw_engine::Mission::new(
+                research_project.id,
+                ironclaw_engine::types::shared_owner_id(),
+                "shared-mission",
+                "shared learning",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            shared.updated_at = chrono::Utc::now() - chrono::Duration::minutes(5);
+            let shared_id = shared.id;
+            store.save_mission(&shared).await.unwrap();
+
+            let hidden_project = ironclaw_engine::Project::new("bob", "bob-project", "Bob project");
+            let hidden_project_id = hidden_project.id;
+            store.save_project(&hidden_project).await.unwrap();
+
+            let hidden = ironclaw_engine::Mission::new(
+                hidden_project_id,
+                "bob",
+                "bob-mission",
+                "secret",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            store.save_mission(&hidden).await.unwrap();
+
+            *lock.write().await = Some(state);
+
+            let missions = list_engine_missions(None, "alice").await.unwrap();
+            let mission_ids: Vec<_> = missions.iter().map(|mission| mission.id.clone()).collect();
+
+            assert_eq!(mission_ids.len(), 3);
+            assert_eq!(
+                mission_ids,
+                vec![
+                    shared_id.to_string(),
+                    second_id.to_string(),
+                    first_id.to_string()
+                ]
+            );
+            assert!(missions.iter().any(|mission| mission.status == "Paused"));
+            assert!(!missions.iter().any(|mission| mission.name == "bob-mission"));
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("list_engine_missions aggregates visible projects");
+    }
+
+    #[tokio::test]
+    async fn list_engine_missions_with_project_id_remains_project_scoped() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let state = make_expected_test_state(store.clone());
+
+            let default_project =
+                ironclaw_engine::Project::new("alice", "default", "Default project");
+            let default_project_id = default_project.id;
+            store.save_project(&default_project).await.unwrap();
+
+            let focus_project = ironclaw_engine::Project::new("alice", "focus", "Focus project");
+            let focus_project_id = focus_project.id;
+            store.save_project(&focus_project).await.unwrap();
+
+            let default_mission = ironclaw_engine::Mission::new(
+                default_project_id,
+                "alice",
+                "default-mission",
+                "default goal",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            store.save_mission(&default_mission).await.unwrap();
+
+            let focus_mission = ironclaw_engine::Mission::new(
+                focus_project_id,
+                "alice",
+                "focus-mission",
+                "focus goal",
+                ironclaw_engine::MissionCadence::Manual,
+            );
+            let focus_mission_id = focus_mission.id;
+            store.save_mission(&focus_mission).await.unwrap();
+
+            *lock.write().await = Some(state);
+
+            let missions = list_engine_missions(Some(&focus_project_id.to_string()), "alice")
+                .await
+                .unwrap();
+
+            assert_eq!(missions.len(), 1);
+            assert_eq!(missions[0].id, focus_mission_id.to_string());
+            assert_eq!(missions[0].name, "focus-mission");
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("list_engine_missions stays project scoped with filter");
     }
 
     #[test]

--- a/src/channels/web/tests/engine_missions.rs
+++ b/src/channels/web/tests/engine_missions.rs
@@ -1,0 +1,497 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use axum::middleware;
+use axum::routing::get;
+use ironclaw_engine::Store;
+use tower::ServiceExt;
+
+use crate::bridge::{
+    install_test_engine_state, reset_test_engine_state, with_test_engine_state_lock,
+};
+use crate::channels::web::auth::{MultiAuthState, UserIdentity, auth_middleware};
+use crate::channels::web::handlers::engine::{
+    engine_missions_handler, engine_missions_summary_handler,
+};
+use crate::channels::web::server::{
+    ActiveConfigSnapshot, GatewayState, PerUserRateLimiter, RateLimiter,
+};
+use crate::channels::web::sse::SseManager;
+
+#[derive(Default)]
+struct MissionStore {
+    projects: tokio::sync::RwLock<Vec<ironclaw_engine::Project>>,
+    missions: tokio::sync::RwLock<Vec<ironclaw_engine::Mission>>,
+}
+
+#[async_trait]
+impl ironclaw_engine::Store for MissionStore {
+    async fn save_thread(
+        &self,
+        _thread: &ironclaw_engine::Thread,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_thread(
+        &self,
+        _id: ironclaw_engine::ThreadId,
+    ) -> Result<Option<ironclaw_engine::Thread>, ironclaw_engine::EngineError> {
+        Ok(None)
+    }
+
+    async fn list_threads(
+        &self,
+        _project_id: ironclaw_engine::ProjectId,
+        _user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::Thread>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn update_thread_state(
+        &self,
+        _id: ironclaw_engine::ThreadId,
+        _state: ironclaw_engine::ThreadState,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn save_step(
+        &self,
+        _step: &ironclaw_engine::Step,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_steps(
+        &self,
+        _thread_id: ironclaw_engine::ThreadId,
+    ) -> Result<Vec<ironclaw_engine::Step>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn append_events(
+        &self,
+        _events: &[ironclaw_engine::ThreadEvent],
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_events(
+        &self,
+        _thread_id: ironclaw_engine::ThreadId,
+    ) -> Result<Vec<ironclaw_engine::ThreadEvent>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn save_project(
+        &self,
+        project: &ironclaw_engine::Project,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        let mut projects = self.projects.write().await;
+        projects.retain(|existing| existing.id != project.id);
+        projects.push(project.clone());
+        Ok(())
+    }
+
+    async fn load_project(
+        &self,
+        id: ironclaw_engine::ProjectId,
+    ) -> Result<Option<ironclaw_engine::Project>, ironclaw_engine::EngineError> {
+        Ok(self
+            .projects
+            .read()
+            .await
+            .iter()
+            .find(|project| project.id == id)
+            .cloned())
+    }
+
+    async fn list_projects(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::Project>, ironclaw_engine::EngineError> {
+        Ok(self
+            .projects
+            .read()
+            .await
+            .iter()
+            .filter(|project| project.user_id == user_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn list_all_projects(
+        &self,
+    ) -> Result<Vec<ironclaw_engine::Project>, ironclaw_engine::EngineError> {
+        Ok(self.projects.read().await.clone())
+    }
+
+    async fn save_conversation(
+        &self,
+        _conversation: &ironclaw_engine::ConversationSurface,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_conversation(
+        &self,
+        _id: ironclaw_engine::ConversationId,
+    ) -> Result<Option<ironclaw_engine::ConversationSurface>, ironclaw_engine::EngineError> {
+        Ok(None)
+    }
+
+    async fn list_conversations(
+        &self,
+        _user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::ConversationSurface>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn save_memory_doc(
+        &self,
+        _doc: &ironclaw_engine::MemoryDoc,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_memory_doc(
+        &self,
+        _id: ironclaw_engine::DocId,
+    ) -> Result<Option<ironclaw_engine::MemoryDoc>, ironclaw_engine::EngineError> {
+        Ok(None)
+    }
+
+    async fn list_memory_docs(
+        &self,
+        _project_id: ironclaw_engine::ProjectId,
+        _user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::MemoryDoc>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn list_memory_docs_by_owner(
+        &self,
+        _user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::MemoryDoc>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn save_lease(
+        &self,
+        _lease: &ironclaw_engine::CapabilityLease,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn load_active_leases(
+        &self,
+        _thread_id: ironclaw_engine::ThreadId,
+    ) -> Result<Vec<ironclaw_engine::CapabilityLease>, ironclaw_engine::EngineError> {
+        Ok(vec![])
+    }
+
+    async fn revoke_lease(
+        &self,
+        _lease_id: ironclaw_engine::LeaseId,
+        _reason: &str,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        Ok(())
+    }
+
+    async fn save_mission(
+        &self,
+        mission: &ironclaw_engine::Mission,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        let mut missions = self.missions.write().await;
+        missions.retain(|existing| existing.id != mission.id);
+        missions.push(mission.clone());
+        Ok(())
+    }
+
+    async fn load_mission(
+        &self,
+        id: ironclaw_engine::MissionId,
+    ) -> Result<Option<ironclaw_engine::Mission>, ironclaw_engine::EngineError> {
+        Ok(self
+            .missions
+            .read()
+            .await
+            .iter()
+            .find(|mission| mission.id == id)
+            .cloned())
+    }
+
+    async fn list_missions(
+        &self,
+        project_id: ironclaw_engine::ProjectId,
+        user_id: &str,
+    ) -> Result<Vec<ironclaw_engine::Mission>, ironclaw_engine::EngineError> {
+        Ok(self
+            .missions
+            .read()
+            .await
+            .iter()
+            .filter(|mission| mission.project_id == project_id && mission.user_id == user_id)
+            .cloned()
+            .collect())
+    }
+
+    async fn update_mission_status(
+        &self,
+        id: ironclaw_engine::MissionId,
+        status: ironclaw_engine::MissionStatus,
+    ) -> Result<(), ironclaw_engine::EngineError> {
+        if let Some(mission) = self
+            .missions
+            .write()
+            .await
+            .iter_mut()
+            .find(|mission| mission.id == id)
+        {
+            mission.status = status;
+        }
+        Ok(())
+    }
+}
+
+fn auth_state() -> MultiAuthState {
+    let mut tokens = HashMap::new();
+    tokens.insert(
+        "tok-alice".to_string(),
+        UserIdentity {
+            user_id: "alice".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: vec![],
+        },
+    );
+    tokens.insert(
+        "tok-bob".to_string(),
+        UserIdentity {
+            user_id: "bob".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: vec![],
+        },
+    );
+    MultiAuthState::multi(tokens)
+}
+
+fn build_state() -> Arc<GatewayState> {
+    Arc::new(GatewayState {
+        msg_tx: tokio::sync::RwLock::new(None),
+        sse: Arc::new(SseManager::new()),
+        workspace: None,
+        workspace_pool: None,
+        session_manager: None,
+        log_broadcaster: None,
+        log_level_handle: None,
+        extension_manager: None,
+        tool_registry: None,
+        store: None,
+        settings_cache: None,
+        job_manager: None,
+        prompt_queue: None,
+        owner_id: "test".to_string(),
+        shutdown_tx: tokio::sync::RwLock::new(None),
+        ws_tracker: None,
+        llm_provider: None,
+        skill_registry: None,
+        skill_catalog: None,
+        auth_manager: None,
+        scheduler: None,
+        chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+        webhook_rate_limiter: RateLimiter::new(10, 60),
+        registry_entries: Vec::new(),
+        cost_guard: None,
+        routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+        startup_time: std::time::Instant::now(),
+        active_config: ActiveConfigSnapshot::default(),
+        secrets_store: None,
+        db_auth: None,
+        pairing_store: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
+        frontend_html_cache: std::sync::Arc::new(tokio::sync::RwLock::new(None)),
+        tool_dispatcher: None,
+    })
+}
+
+fn engine_missions_router() -> Router {
+    let state = build_state();
+    let auth = auth_state();
+
+    Router::new()
+        .route("/api/engine/missions", get(engine_missions_handler))
+        .route(
+            "/api/engine/missions/summary",
+            get(engine_missions_summary_handler),
+        )
+        .layer(middleware::from_fn_with_state(
+            crate::channels::web::auth::CombinedAuthState::from(auth),
+            auth_middleware,
+        ))
+        .with_state(state)
+}
+
+async fn setup_engine_state() -> Arc<MissionStore> {
+    let store = Arc::new(MissionStore::default());
+
+    let alice_default = ironclaw_engine::Project::new("alice", "default", "Default project");
+    let alice_default_id = alice_default.id;
+    store.save_project(&alice_default).await.unwrap();
+
+    let alice_research = ironclaw_engine::Project::new("alice", "research", "Research project");
+    let alice_research_id = alice_research.id;
+    store.save_project(&alice_research).await.unwrap();
+
+    let bob_default = ironclaw_engine::Project::new("bob", "default", "Bob project");
+    let bob_default_id = bob_default.id;
+    store.save_project(&bob_default).await.unwrap();
+
+    let mut default_mission = ironclaw_engine::Mission::new(
+        alice_default_id,
+        "alice",
+        "default-mission",
+        "watch default project",
+        ironclaw_engine::MissionCadence::Manual,
+    );
+    default_mission.updated_at = chrono::Utc::now() - chrono::Duration::hours(1);
+    store.save_mission(&default_mission).await.unwrap();
+
+    let mut research_mission = ironclaw_engine::Mission::new(
+        alice_research_id,
+        "alice",
+        "research-mission",
+        "watch research project",
+        ironclaw_engine::MissionCadence::Manual,
+    );
+    research_mission.status = ironclaw_engine::MissionStatus::Paused;
+    research_mission.updated_at = chrono::Utc::now() - chrono::Duration::minutes(20);
+    store.save_mission(&research_mission).await.unwrap();
+
+    let mut shared_mission = ironclaw_engine::Mission::new(
+        alice_research_id,
+        ironclaw_engine::types::shared_owner_id(),
+        "shared-mission",
+        "shared learning",
+        ironclaw_engine::MissionCadence::Manual,
+    );
+    shared_mission.status = ironclaw_engine::MissionStatus::Completed;
+    shared_mission.updated_at = chrono::Utc::now() - chrono::Duration::minutes(5);
+    store.save_mission(&shared_mission).await.unwrap();
+
+    let mut bob_mission = ironclaw_engine::Mission::new(
+        bob_default_id,
+        "bob",
+        "bob-mission",
+        "watch bob project",
+        ironclaw_engine::MissionCadence::Manual,
+    );
+    bob_mission.status = ironclaw_engine::MissionStatus::Failed;
+    store.save_mission(&bob_mission).await.unwrap();
+
+    install_test_engine_state(
+        Arc::clone(&store) as Arc<dyn ironclaw_engine::Store>,
+        alice_default_id,
+    )
+    .await;
+
+    store
+}
+
+#[tokio::test]
+async fn missions_api_lists_visible_missions_across_projects() {
+    with_test_engine_state_lock(async {
+        reset_test_engine_state().await;
+        let _store = setup_engine_state().await;
+
+        let app = engine_missions_router();
+        let req = Request::builder()
+            .uri("/api/engine/missions")
+            .header("Authorization", "Bearer tok-alice")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let missions = json["missions"].as_array().unwrap();
+
+        assert_eq!(missions.len(), 3);
+        assert_eq!(missions[0]["name"], "shared-mission");
+        assert_eq!(missions[1]["name"], "research-mission");
+        assert_eq!(missions[2]["name"], "default-mission");
+        assert!(
+            !missions
+                .iter()
+                .any(|mission| mission["name"] == "bob-mission")
+        );
+
+        reset_test_engine_state().await;
+    })
+    .await;
+}
+
+#[tokio::test]
+async fn missions_summary_api_matches_aggregated_visible_missions() {
+    with_test_engine_state_lock(async {
+        reset_test_engine_state().await;
+        let _store = setup_engine_state().await;
+
+        let app = engine_missions_router();
+
+        let alice_req = Request::builder()
+            .uri("/api/engine/missions/summary")
+            .header("Authorization", "Bearer tok-alice")
+            .body(Body::empty())
+            .unwrap();
+        let alice_resp = app.clone().oneshot(alice_req).await.unwrap();
+        assert_eq!(alice_resp.status(), StatusCode::OK);
+        let alice_body = axum::body::to_bytes(alice_resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let alice_json: serde_json::Value = serde_json::from_slice(&alice_body).unwrap();
+
+        assert_eq!(alice_json["total"], 3);
+        assert_eq!(alice_json["active"], 1);
+        assert_eq!(alice_json["paused"], 1);
+        assert_eq!(alice_json["completed"], 1);
+        assert_eq!(alice_json["failed"], 0);
+
+        let bob_req = Request::builder()
+            .uri("/api/engine/missions/summary")
+            .header("Authorization", "Bearer tok-bob")
+            .body(Body::empty())
+            .unwrap();
+        let bob_resp = app.oneshot(bob_req).await.unwrap();
+        assert_eq!(bob_resp.status(), StatusCode::OK);
+        let bob_body = axum::body::to_bytes(bob_resp.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let bob_json: serde_json::Value = serde_json::from_slice(&bob_body).unwrap();
+
+        assert_eq!(bob_json["total"], 1);
+        assert_eq!(bob_json["active"], 0);
+        assert_eq!(bob_json["paused"], 0);
+        assert_eq!(bob_json["completed"], 0);
+        assert_eq!(bob_json["failed"], 1);
+
+        reset_test_engine_state().await;
+    })
+    .await;
+}

--- a/src/channels/web/tests/engine_missions.rs
+++ b/src/channels/web/tests/engine_missions.rs
@@ -29,7 +29,7 @@ struct MissionStore {
 }
 
 #[async_trait]
-impl ironclaw_engine::Store for MissionStore {
+impl Store for MissionStore {
     async fn save_thread(
         &self,
         _thread: &ironclaw_engine::Thread,

--- a/src/channels/web/tests/mod.rs
+++ b/src/channels/web/tests/mod.rs
@@ -1,5 +1,6 @@
 //! Integration tests for the web gateway module.
 
+mod engine_missions;
 mod multi_tenant;
 mod no_silent_drop;
 mod rebuild_state_preserves_fields;


### PR DESCRIPTION
## Summary

This fixes the standalone Missions tab so `GET /api/engine/missions` without a `project_id` returns all missions visible to the authenticated user across that user's projects, instead of only looking at the user's default project.

The reported symptom was that the missions list rendered empty in the global Missions tab even though the active missions/jobs bar still showed activity. The bar is driven by a different path; the missing list was caused by the no-filter missions query being scoped too narrowly.

## Root Cause

The standalone Missions tab calls the no-filter missions endpoints:
- `GET /api/engine/missions`
- `GET /api/engine/missions/summary`

Before this change, the no-filter path eventually resolved to the default project. That meant a user could have active or historical missions in other projects that were still visible elsewhere in the UI, while the standalone missions list and summary returned an incomplete or empty result set.

## What Changed

### Bridge routing

In `src/bridge/router.rs`:
- Added `load_visible_engine_missions(...)` to centralize mission loading semantics.
- Kept explicit `project_id` behavior project-scoped.
- Changed the `project_id = None` path to:
  - load projects from `store.list_projects(user_id)`
  - aggregate missions from `store.list_missions_with_shared(project.id, user_id)` for each project
  - sort deterministically by `updated_at` descending, then mission id
  - deduplicate by mission id
- Added `mission_to_info(...)` so the route mapping remains consistent across the list path.

### Multi-tenant behavior

This change does **not** widen visibility across users.

When `project_id` is omitted, the API now aggregates only across projects returned for the authenticated user. That means:
- `userA` sees missions from `userA`'s projects
- shared missions remain visible when they are visible within those projects
- `userA` does not see `userB`'s missions unless those missions are already visible through an authorized shared-project path

The global Missions tab becomes cross-project for the current user, not cross-tenant.

### Test coverage

Added bridge-level coverage for the actual runtime behavior:
- no-filter mission listing aggregates visible projects for a single user
- explicit `project_id` remains project-scoped

Added route-level web coverage in `src/channels/web/tests/engine_missions.rs`:
- `/api/engine/missions` returns missions across the authenticated user's projects
- `/api/engine/missions/summary` matches the same aggregated visible set
- cross-user isolation is preserved

### Test harness fix

While adding route-level coverage, this also fixed a shared test-state race:
- exported a shared bridge test lock for `ENGINE_STATE`
- updated the new web tests to use that same lock instead of a separate mutex

That keeps caller-level tests serialized around the singleton test engine state and avoids parallel-test flakes.

## Why This Is Safe

- The project-scoped API contract is unchanged when `project_id` is provided.
- The no-filter route only broadens from default-project scope to all **visible** projects for the current authenticated user.
- No JSON shape changes were introduced.
- The summary endpoint now reflects the same underlying mission set as the list endpoint.

## Verification

Ran locally:
- `cargo fmt --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test engine_missions -- --nocapture`
- `cargo test missions_summary_api_matches_aggregated_visible_missions -- --nocapture`
- `cargo test --lib -- --test-threads=1`

Results:
- `clippy` passed with warnings denied
- missions-specific route and bridge tests passed
- serial library suite passed: `5002 passed; 0 failed; 6 ignored`
