### PR TITLE
fix(telegram): String owner_id test + registry bump

### DIFF
--- a/channels-src/telegram/src/lib.rs
+++ b/channels-src/telegram/src/lib.rs
@@ -2619,7 +2619,7 @@ mod tests {
         }"#;
         let config: TelegramConfig = serde_json::from_str(json).unwrap();
         assert_eq!(config.bot_username, Some("my_bot".to_string()));
-        assert_eq!(config.owner_id, Some(42));
+        assert_eq!(config.owner_id, Some("42".to_string()));
         assert!(config.respond_to_all_group_messages);
     }
 

--- a/registry/channels/telegram.json
+++ b/registry/channels/telegram.json
@@ -2,7 +2,7 @@
   "name": "telegram",
   "display_name": "Telegram Channel",
   "kind": "channel",
-  "version": "0.2.9",
+  "version": "0.2.10",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Telegram bot",
   "keywords": [


### PR DESCRIPTION
## Summary

PR #2471 (hot-activation `owner_id` unification) changed `TelegramConfig::owner_id` from `Option<i64>` to `Option<String>` with a `deserialize_string_or_number` deserializer, but missed the `test_config_full` case in `channels-src/telegram/src/lib.rs:2622` which still asserts `Some(42)` (integer). That breaks the Telegram Channel Tests CI job and is one of four blockers on the staging→main promotion PR #2612.

Bumped `registry/channels/telegram.json` 0.2.9 → 0.2.10 so the Version Bump Check passes as well.

## Change Type

- [x] Bug fix

## Linked Issue

Unblocks #2612.

## Validation

- [x] `cargo test --lib test_config_full` (in `channels-src/telegram/`) passes locally
- [ ] CI green on this PR

## Security Impact

None.

## Database Impact

None.

## Blast Radius

`channels-src/telegram` test-only change + registry patch version bump.

## Rollback Plan

Revert this commit on staging.

---

**Review track**: A (test + version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)