### PR TITLE
Hide external threads from browser active thread restore

### DIFF
--- a/src/channels/web/handlers/chat.rs
+++ b/src/channels/web/handlers/chat.rs
@@ -16,6 +16,8 @@ use axum::{
     response::IntoResponse,
 };
 use serde::Deserialize;
+
+use crate::channels::web::util::browser_active_thread;
 // ── SSE / WebSocket handlers ───────────────────────────────────────────
 
 pub async fn chat_events_handler(
@@ -153,7 +155,7 @@ pub async fn chat_threads_handler(
             // Read active thread while holding minimal lock (just before return)
             let active_thread = {
                 let sess = session.lock().await;
-                sess.active_thread
+                browser_active_thread(&sess)
             };
 
             return Ok(Json(ThreadListResponse {
@@ -182,7 +184,7 @@ pub async fn chat_threads_handler(
         })
         .collect();
 
-    let active_thread = sess.active_thread;
+    let active_thread = browser_active_thread(&sess);
     drop(sess); // Explicit drop to release lock
 
     Ok(Json(ThreadListResponse {
@@ -256,8 +258,64 @@ pub async fn chat_new_thread_handler(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
+    use crate::agent::SessionManager;
+    use crate::channels::web::auth::{AuthenticatedUser, UserIdentity};
+    use crate::channels::web::server::{
+        ActiveConfigSnapshot, GatewayState, PerUserRateLimiter, RateLimiter,
+    };
+    use crate::channels::web::sse::SseManager;
+    use crate::channels::web::ws::WsConnectionTracker;
     use crate::channels::web::util::build_turns_from_db_messages;
     use uuid::Uuid;
+
+    fn test_gateway_state(session_manager: Arc<SessionManager>) -> Arc<GatewayState> {
+        Arc::new(GatewayState {
+            msg_tx: tokio::sync::RwLock::new(None),
+            sse: Arc::new(SseManager::new()),
+            workspace: None,
+            workspace_pool: None,
+            session_manager: Some(session_manager),
+            log_broadcaster: None,
+            log_level_handle: None,
+            extension_manager: None,
+            tool_registry: None,
+            store: None,
+            settings_cache: None,
+            job_manager: None,
+            prompt_queue: None,
+            owner_id: "owner".to_string(),
+            shutdown_tx: tokio::sync::RwLock::new(None),
+            ws_tracker: Some(Arc::new(WsConnectionTracker::new())),
+            llm_provider: None,
+            skill_registry: None,
+            skill_catalog: None,
+            auth_manager: None,
+            scheduler: None,
+            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+            webhook_rate_limiter: RateLimiter::new(10, 60),
+            registry_entries: Vec::new(),
+            cost_guard: None,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            startup_time: std::time::Instant::now(),
+            active_config: ActiveConfigSnapshot::default(),
+            secrets_store: None,
+            db_auth: None,
+            pairing_store: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
+            frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            tool_dispatcher: None,
+        })
+    }
 
     #[test]
     fn test_build_turns_from_db_messages_complete() {
@@ -402,6 +460,29 @@ mod tests {
         assert_eq!(turns.len(), 1);
         assert!(turns[0].tool_calls.is_empty());
         assert_eq!(turns[0].response.as_deref(), Some("Done"));
+    }
+
+    #[tokio::test]
+    async fn test_chat_threads_handler_hides_external_active_thread() {
+        let session_manager = Arc::new(SessionManager::new());
+        let session = session_manager.get_or_create_session("user-1").await;
+        {
+            let mut sess = session.lock().await;
+            sess.create_thread(Some("telegram"));
+        }
+
+        let axum::Json(response) = super::chat_threads_handler(
+            axum::extract::State(test_gateway_state(session_manager)),
+            AuthenticatedUser(UserIdentity {
+                user_id: "user-1".to_string(),
+                role: "admin".to_string(),
+                workspace_read_scopes: Vec::new(),
+            }),
+        )
+        .await
+        .expect("thread list should load");
+
+        assert_eq!(response.active_thread, None);
     }
 
     #[test]

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -1,5 +1,8 @@
 //! Shared utility functions for the web gateway.
 
+use uuid::Uuid;
+
+use crate::agent::session::Session;
 use crate::channels::IncomingMessage;
 use crate::channels::web::types::{GeneratedImageInfo, ToolCallInfo, TurnInfo};
 use crate::generated_images::GeneratedImageSentinel;
@@ -8,6 +11,29 @@ pub use ironclaw_common::truncate_preview;
 
 const MAX_HISTORY_IMAGE_DATA_URL_BYTES_PER_IMAGE: usize = 512 * 1024;
 const MAX_HISTORY_IMAGE_DATA_URL_BYTES_PER_RESPONSE: usize = 1024 * 1024;
+
+fn is_web_writable_thread_channel(channel: Option<&str>) -> bool {
+    matches!(channel, None | Some("gateway" | "web" | "routine" | "heartbeat"))
+}
+
+/// Return the session active thread only when it is safe for the browser to
+/// reopen as the writable chat target.
+///
+/// External-channel threads are still listed in the sidebar, but exposing them
+/// as the browser's active thread causes refresh/load to reopen a read-only
+/// external conversation and disable normal web chat input.
+pub fn browser_active_thread(session: &Session) -> Option<Uuid> {
+    let active_thread_id = session.active_thread?;
+    let channel = session
+        .threads
+        .get(&active_thread_id)
+        .and_then(|thread| thread.source_channel.as_deref());
+    if is_web_writable_thread_channel(channel) {
+        Some(active_thread_id)
+    } else {
+        None
+    }
+}
 
 /// Build an incoming message with the metadata invariants expected by the web
 /// gateway and downstream status routing.
@@ -346,6 +372,23 @@ mod tests {
         assert_eq!(turns[0].tool_calls[1].name, "http");
         assert!(turns[0].tool_calls[1].has_error);
         assert_eq!(turns[0].response.as_deref(), Some("Done"));
+    }
+
+    #[test]
+    fn test_browser_active_thread_keeps_web_thread() {
+        let mut session = crate::agent::session::Session::new("user-1");
+        let thread_id = session.create_thread(Some("web")).id;
+
+        assert_eq!(browser_active_thread(&session), Some(thread_id));
+    }
+
+    #[test]
+    fn test_browser_active_thread_filters_external_thread() {
+        let mut session = crate::agent::session::Session::new("user-1");
+        let thread_id = session.create_thread(Some("telegram")).id;
+
+        assert_eq!(session.active_thread, Some(thread_id));
+        assert_eq!(browser_active_thread(&session), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `browser_active_thread()` to filter out non-browser-writable threads during restore
- update browser thread list responses to stop reopening external-channel threads as the active chat target
- add narrow unit coverage for the helper and the caller-level thread list behavior

## Verification
- `CARGO_TARGET_DIR=/Users/henry/near_ai/near_claw/ironclaw-ci-regression-fix-2/.shared-target cargo test browser_active_thread --lib`
- `CARGO_TARGET_DIR=/Users/henry/near_ai/near_claw/ironclaw-ci-regression-fix-2/.shared-target cargo test test_chat_threads_handler_hides_external_active_thread --lib`