### PR TITLE
fix(ci): three staging regressions — skill chain-load, duplicate Jobs tab, onboarding E2E

### DIFF
--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -163,8 +163,6 @@
       <button data-tab="routines" data-v1-only data-tab-role="routines" data-i18n="tab.routines">Routines</button>
       <button data-tab="settings" data-i18n="tab.settings">Settings</button>
       <div class="spacer"></div>
-      <button class="status-logs-btn" data-tab="jobs" data-i18n="tab.jobs" title="Jobs">Jobs</button>
-
       <button class="status-logs-btn" data-tab="logs" data-i18n="tab.logs" title="Logs">Logs</button>
 
       <a class="status-logs-btn docs-link-btn" href="https://docs.ironclaw.com/" target="_blank" rel="noopener noreferrer" data-i18n="tab.docs" title="Docs">Docs</a>

--- a/tests/e2e/scenarios/test_extensions.py
+++ b/tests/e2e/scenarios/test_extensions.py
@@ -1282,7 +1282,11 @@ async def test_onboarding_failed_sse_shows_error_toast_and_reloads_extensions(pa
     await go_to_extensions(page)
     count_before = len(reload_count)
 
-    await _show_auth_card(page, extension_name="gmail", auth_url="https://example.com/oauth", request_id="req-fail", thread_id="thread-fail")
+    # Use the real active thread id so showAuthCard's isCurrentThread gate
+    # lets the card render. A synthetic "thread-fail" id is rejected once
+    # the page has initialized currentThreadId.
+    thread_id = await _active_thread_id(page)
+    await _show_auth_card(page, extension_name="gmail", auth_url="https://example.com/oauth", request_id="req-fail", thread_id=thread_id)
     assert await page.locator(SEL["auth_card"] + '[data-extension-name="gmail"]').count() == 1
 
     # Inject a counter to confirm refreshCurrentSettingsTab is called

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -1161,14 +1161,24 @@ impl TestRigBuilder {
                     .register_routine_tools(Arc::clone(db_arc), engine);
             }
 
-            // Skills tools: use the config-resolved skills dirs so that a
-            // custom `with_skills_dir()` path propagates all the way to
-            // the registry (instead of always pointing at an empty temp dir).
+            // Skills tools: rebuild the registry against the test's tempdir.
+            //
+            // `AppBuilder::init_database()` re-resolves `config` from
+            // DB/TOML/env, which clobbers `config.skills.local_dir` back
+            // to the default (`~/.ironclaw/skills/`). Any registry
+            // `build_all()` already constructed therefore points at the
+            // user's real skills dir, not the tempdir the test laid
+            // down. Rebuild here from the in-scope `skills_dir` /
+            // `installed_skills_dir`, actually run discovery, and write
+            // the paths back onto `components.config` so downstream
+            // consumers (AgentDeps::skills_config) see the same dirs.
             if enable_skills {
-                let registry = Arc::new(std::sync::RwLock::new(
-                    ironclaw_skills::SkillRegistry::new(components.config.skills.local_dir.clone())
-                        .with_installed_dir(components.config.skills.installed_dir.clone()),
-                ));
+                components.config.skills.local_dir = skills_dir.clone();
+                components.config.skills.installed_dir = installed_skills_dir.clone();
+                let mut registry = ironclaw_skills::SkillRegistry::new(skills_dir.clone())
+                    .with_installed_dir(installed_skills_dir.clone());
+                let _loaded = registry.discover_all().await;
+                let registry = Arc::new(std::sync::RwLock::new(registry));
                 let catalog = ironclaw_skills::catalog::shared_catalog();
                 components
                     .tools


### PR DESCRIPTION
## Summary

Scheduled batched CI on `staging` (run [24599776857](https://github.com/nearai/ironclaw/actions/runs/24599776857)) was red across three unrelated paths after recent merges. This PR fixes all three in-place; the existing tests that surfaced the regressions are the regression coverage.

### 1. Rust: `skill_chain_load_lifecycle::v1_chain_load_pulls_in_required_companions`

`tests/support/test_rig.rs` — rebuild the `SkillRegistry` against the test's `with_skills_dir()` tempdir and actually call `discover_all()`.

`AppBuilder::init_database()` reloads `config` from DB/TOML/env at the top of `build_all()`, which clobbered `config.skills.local_dir` back to the default (`~/.ironclaw/skills/`). Any registry `build_all()` already constructed therefore pointed at the user's real skills dir, not the tempdir the test laid down — so `loaded_skill_names()` came back empty and the v1 chain-load assertion panicked with `skill 'parent-setup-test' must load from tempdir. Loaded: []`. The fix reapplies the tempdir paths to `components.config.skills.*` so `AgentDeps::skills_config` agrees with the registry.

Fails on all three cargo test variants in CI (default, libsql-only, all-features); fixed once here.

### 2. Frontend: duplicate Jobs button

`crates/ironclaw_gateway/static/index.html` — drop the duplicate right-side `status-logs-btn` Jobs button added in #2353.

The main tab-bar already has `<button data-tab=\"jobs\">Jobs</button>`, and the duplicate had no `data-v1-only`/`data-v2-only` marker, so both rendered simultaneously. Playwright's strict-mode rejected `.tab-bar button[data-tab=\"jobs\"]` because it resolved to two elements, breaking `test_connection.py::test_page_loads_and_connects` and `::test_tab_navigation`. It also left both buttons visually `active` whenever the Jobs tab was open, since `switchTab('jobs')` toggles `.active` on every `button[data-tab]` match.

### 3. E2E: onboarding-failed auth-card never rendered

`tests/e2e/scenarios/test_extensions.py::test_onboarding_failed_sse_shows_error_toast_and_reloads_extensions` — resolve the real thread id via `_active_thread_id(page)` before calling `_show_auth_card`, matching every other auth-card test in the file.

`showAuthCard` short-circuits on `if (data.thread_id && !isCurrentThread(data.thread_id)) return;`. The synthetic `\"thread-fail\"` id fails that check once `currentThreadId` is populated (which happens during `go_to_extensions(page)`), so the card was never rendered and the subsequent `wait_for(\".auth-card\")` hit its 5s timeout.

## Test plan

- [x] `cargo test --features libsql --test skill_chain_load_lifecycle` — green
- [x] `cargo test --features libsql --test skill_setup_marker_lifecycle` — green (adjacent coverage unchanged)
- [x] `cargo clippy --tests --features libsql` — zero warnings
- [x] `cargo fmt --all --check` — clean
- [ ] Batched staging CI on this branch exercises the E2E suites that flagged #2 and #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)