### PR TITLE
test(e2e): fix Slack fixture boot path

### DIFF
--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -62,13 +62,13 @@ use crate::tools::wasm::{
 };
 use ironclaw_safety::LeakDetector;
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 const TEST_HTTP_REWRITE_MAP_ENV: &str = "IRONCLAW_TEST_HTTP_REWRITE_MAP";
 
 const WEBSOCKET_EVENT_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue";
 const WEBSOCKET_EVENT_PROCESSING_QUEUE_RELATIVE_PATH: &str = "state/gateway_event_queue_processing";
 const WEBSOCKET_EVENT_QUEUE_MAX_ITEMS: usize = 100;
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 const TELEGRAM_TEST_API_BASE_ENV: &str = "IRONCLAW_TEST_TELEGRAM_API_BASE_URL";
 
 // Generate component model bindings from the WIT file
@@ -386,7 +386,7 @@ impl near::agent::channel_host::Host for ChannelStoreData {
         }
 
         let (transport_url, allow_private_test_target) = {
-            #[cfg(test)]
+            #[cfg(any(test, debug_assertions))]
             {
                 let rewritten = rewrite_http_url_for_testing(&logical_url)
                     .or_else(|| rewrite_telegram_api_url_for_testing(&logical_url));
@@ -401,7 +401,7 @@ impl near::agent::channel_host::Host for ChannelStoreData {
                 }
                 (url, is_rewritten)
             }
-            #[cfg(not(test))]
+            #[cfg(not(any(test, debug_assertions)))]
             {
                 (logical_url.clone(), false)
             }
@@ -4205,7 +4205,9 @@ fn extract_host_from_url(url: &str) -> Option<String> {
 ///
 /// The replacement preserves the original path and query string so tests can
 /// point production hosts at local fakes without adding channel-specific code.
-#[cfg(test)]
+/// Replacement bases must be loopback URLs because credentials are injected
+/// before transport rewrite.
+#[cfg(any(test, debug_assertions))]
 fn rewrite_http_url_for_testing(url: &str) -> Option<String> {
     let parsed = url::Url::parse(url).ok()?;
     if !matches!(parsed.scheme(), "http" | "https") {
@@ -4226,7 +4228,7 @@ fn rewrite_http_url_for_testing(url: &str) -> Option<String> {
     Some(rewritten)
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
 fn parse_test_http_rewrite_map(raw: &str) -> HashMap<String, String> {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
@@ -4240,6 +4242,15 @@ fn parse_test_http_rewrite_map(raw: &str) -> HashMap<String, String> {
                 let host = host.trim().to_lowercase();
                 let base = base.trim().trim_end_matches('/').to_string();
                 if host.is_empty() || base.is_empty() {
+                    return None;
+                }
+                if !is_loopback_test_rewrite_base(&base) {
+                    tracing::warn!(
+                        env_var = TEST_HTTP_REWRITE_MAP_ENV,
+                        %host,
+                        %base,
+                        "Ignoring non-loopback test HTTP rewrite target"
+                    );
                     return None;
                 }
                 Some((host, base))
@@ -4256,7 +4267,24 @@ fn parse_test_http_rewrite_map(raw: &str) -> HashMap<String, String> {
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, debug_assertions))]
+fn is_loopback_test_rewrite_base(base: &str) -> bool {
+    let Ok(parsed) = url::Url::parse(base) else {
+        return false;
+    };
+    if !matches!(parsed.scheme(), "http" | "https") {
+        return false;
+    }
+    let Some(host) = parsed.host_str() else {
+        return false;
+    };
+    host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|ip| ip.is_loopback())
+}
+
+#[cfg(any(test, debug_assertions))]
 fn rewrite_telegram_api_url_for_testing(url: &str) -> Option<String> {
     let override_base = crate::config::helpers::env_or_override(TELEGRAM_TEST_API_BASE_ENV)
         .map(|value| value.trim().trim_end_matches('/').to_string())
@@ -6839,6 +6867,17 @@ mod tests {
         );
         // Non-Slack URL should not be rewritten
         let result = rewrite_http_url_for_testing("https://api.telegram.org/bot123/getMe");
+        assert!(result.is_none());
+
+        // Non-loopback rewrite targets are ignored because credential injection
+        // happens before test transport rewrite.
+        unsafe {
+            std::env::set_var(
+                TEST_HTTP_REWRITE_MAP_ENV,
+                r#"{"slack.com":"https://example.com"}"#,
+            );
+        }
+        let result = rewrite_http_url_for_testing("https://slack.com/api/chat.postMessage");
         assert!(result.is_none());
 
         // SAFETY: guarded by ENV_MUTEX — restore original state.

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1177,38 +1177,58 @@ async def fake_slack_server():
 
 
 @pytest.fixture(scope="session")
-async def slack_e2e_server(ironclaw_binary, mock_llm_server, fake_slack_server):
+async def slack_e2e_server(
+    ironclaw_binary,
+    mock_llm_server,
+    fake_slack_server,
+    wasm_tools_dir,
+):
     """IronClaw instance wired to the fake Slack API for E2E Slack tests."""
-    tmp = tempfile.mkdtemp(prefix="ic-slack-e2e-")
-    db_path = os.path.join(tmp, "slack_e2e.db")
-    home_dir = os.path.join(tmp, "home")
-    channels_dir = os.path.join(tmp, "channels")
-    os.makedirs(home_dir, exist_ok=True)
-    os.makedirs(channels_dir, exist_ok=True)
+    reserved = _reserve_loopback_sockets(2)
+    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-db-")
+    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-home-")
+    channels_tmpdir = tempfile.TemporaryDirectory(
+        prefix="ironclaw-e2e-slack-channels-"
+    )
 
-    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    sock.bind(("127.0.0.1", 0))
-    port = sock.getsockname()[1]
-    sock.close()
+    gateway_port = reserved[0].getsockname()[1]
+    http_port = reserved[1].getsockname()[1]
+    for sock in reserved:
+        if sock.fileno() != -1:
+            sock.close()
 
+    home_dir = home_tmpdir.name
     env = {
+        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+        "HOME": home_dir,
+        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+        "RUST_LOG": "ironclaw=debug",
+        "RUST_BACKTRACE": "1",
+        "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
         "GATEWAY_ENABLED": "true",
         "GATEWAY_HOST": "127.0.0.1",
-        "GATEWAY_PORT": str(port),
+        "GATEWAY_PORT": str(gateway_port),
         "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
-        "GATEWAY_USER_ID": "e2e-tester",
+        "GATEWAY_USER_ID": OWNER_SCOPE_ID,
+        "HTTP_HOST": "127.0.0.1",
+        "HTTP_PORT": str(http_port),
         "CLI_ENABLED": "false",
         "LLM_BACKEND": "openai_compatible",
         "LLM_BASE_URL": mock_llm_server,
         "LLM_MODEL": "mock-model",
         "DATABASE_BACKEND": "libsql",
-        "LIBSQL_PATH": db_path,
-        "HOME_DIR": home_dir,
-        "CHANNELS_DIR": channels_dir,
+        "LIBSQL_PATH": os.path.join(db_tmpdir.name, "slack-e2e.db"),
+        "SECRETS_MASTER_KEY": (
+            "0123456789abcdef0123456789abcdef"
+            "0123456789abcdef0123456789abcdef"
+        ),
         "SANDBOX_ENABLED": "false",
         "ROUTINES_ENABLED": "false",
         "HEARTBEAT_ENABLED": "false",
         "EMBEDDING_ENABLED": "false",
+        "WASM_ENABLED": "true",
+        "WASM_TOOLS_DIR": wasm_tools_dir,
+        "WASM_CHANNELS_DIR": channels_tmpdir.name,
         "SKILLS_ENABLED": "false",
         "ONBOARD_COMPLETED": "true",
         "IRONCLAW_TEST_HTTP_REWRITE_MAP": json.dumps(
@@ -1217,32 +1237,56 @@ async def slack_e2e_server(ironclaw_binary, mock_llm_server, fake_slack_server):
                 "files.slack.com": fake_slack_server,
             }
         ),
-        "SECRETS_MASTER_KEY": "dGVzdC1zbGFjay1tYXN0ZXIta2V5LTMyYnl0ZXM=",
-        "PATH": os.environ.get("PATH", ""),
     }
+    _forward_coverage_env(env)
 
     proc = await asyncio.create_subprocess_exec(
         str(ironclaw_binary),
         "--no-onboard",
+        stdin=asyncio.subprocess.DEVNULL,
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         env=env,
     )
 
-    base_url = f"http://127.0.0.1:{port}"
-    http_url = f"{base_url}/webhook/slack"
-    await wait_for_ready(f"{base_url}/api/health", timeout=60)
-    yield {
-        "base_url": base_url,
-        "http_url": http_url,
-        "fake_slack_url": fake_slack_server,
-        "channels_dir": channels_dir,
-    }
-    proc.send_signal(signal.SIGINT)
+    startup_kill_attempted = False
+    base_url = f"http://127.0.0.1:{gateway_port}"
+    http_url = f"http://127.0.0.1:{http_port}"
     try:
-        await asyncio.wait_for(proc.wait(), timeout=10)
-    except asyncio.TimeoutError:
-        proc.kill()
+        await wait_for_ready(f"{base_url}/api/health", timeout=60)
+        yield {
+            "base_url": base_url,
+            "http_url": http_url,
+            "fake_slack_url": fake_slack_server,
+            "channels_dir": channels_tmpdir.name,
+        }
+    except TimeoutError:
+        if proc.returncode is None:
+            startup_kill_attempted = True
+            await _stop_process(proc, timeout=2)
+        returncode = proc.returncode
+        stderr_bytes = b""
+        if proc.stderr:
+            try:
+                stderr_bytes = await asyncio.wait_for(
+                    proc.stderr.read(8192), timeout=2
+                )
+            except asyncio.TimeoutError:
+                pass
+        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+        pytest.fail(
+            f"slack_e2e_server failed to start on gateway port {gateway_port} "
+            f"and webhook port {http_port} (returncode={returncode}).\n"
+            f"stderr:\n{stderr_text}"
+        )
+    finally:
+        if proc.returncode is None and not startup_kill_attempted:
+            await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+        if proc.returncode is None:
+            await _stop_process(proc, timeout=2)
+        db_tmpdir.cleanup()
+        home_tmpdir.cleanup()
+        channels_tmpdir.cleanup()
 
 # ── Telegram E2E fixtures ────────────────────────────────────────────────
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1185,108 +1185,116 @@ async def slack_e2e_server(
 ):
     """IronClaw instance wired to the fake Slack API for E2E Slack tests."""
     reserved = _reserve_loopback_sockets(2)
-    db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-db-")
-    home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-home-")
-    channels_tmpdir = tempfile.TemporaryDirectory(
-        prefix="ironclaw-e2e-slack-channels-"
-    )
-
-    gateway_port = reserved[0].getsockname()[1]
-    http_port = reserved[1].getsockname()[1]
-    for sock in reserved:
-        if sock.fileno() != -1:
-            sock.close()
-
-    home_dir = home_tmpdir.name
-    env = {
-        "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
-        "HOME": home_dir,
-        "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
-        "RUST_LOG": "ironclaw=debug",
-        "RUST_BACKTRACE": "1",
-        "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
-        "GATEWAY_ENABLED": "true",
-        "GATEWAY_HOST": "127.0.0.1",
-        "GATEWAY_PORT": str(gateway_port),
-        "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
-        "GATEWAY_USER_ID": OWNER_SCOPE_ID,
-        "HTTP_HOST": "127.0.0.1",
-        "HTTP_PORT": str(http_port),
-        "CLI_ENABLED": "false",
-        "LLM_BACKEND": "openai_compatible",
-        "LLM_BASE_URL": mock_llm_server,
-        "LLM_MODEL": "mock-model",
-        "DATABASE_BACKEND": "libsql",
-        "LIBSQL_PATH": os.path.join(db_tmpdir.name, "slack-e2e.db"),
-        "SECRETS_MASTER_KEY": (
-            "0123456789abcdef0123456789abcdef"
-            "0123456789abcdef0123456789abcdef"
-        ),
-        "SANDBOX_ENABLED": "false",
-        "ROUTINES_ENABLED": "false",
-        "HEARTBEAT_ENABLED": "false",
-        "EMBEDDING_ENABLED": "false",
-        "WASM_ENABLED": "true",
-        "WASM_TOOLS_DIR": wasm_tools_dir,
-        "WASM_CHANNELS_DIR": channels_tmpdir.name,
-        "SKILLS_ENABLED": "false",
-        "ONBOARD_COMPLETED": "true",
-        "IRONCLAW_TEST_HTTP_REWRITE_MAP": json.dumps(
-            {
-                "slack.com": fake_slack_server,
-                "files.slack.com": fake_slack_server,
-            }
-        ),
-    }
-    _forward_coverage_env(env)
-
-    proc = await asyncio.create_subprocess_exec(
-        str(ironclaw_binary),
-        "--no-onboard",
-        stdin=asyncio.subprocess.DEVNULL,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-        env=env,
-    )
-
-    startup_kill_attempted = False
-    base_url = f"http://127.0.0.1:{gateway_port}"
-    http_url = f"http://127.0.0.1:{http_port}"
     try:
-        await wait_for_ready(f"{base_url}/api/health", timeout=60)
-        yield {
-            "base_url": base_url,
-            "http_url": http_url,
-            "fake_slack_url": fake_slack_server,
-            "channels_dir": channels_tmpdir.name,
-        }
-    except TimeoutError:
-        if proc.returncode is None:
-            startup_kill_attempted = True
-            await _stop_process(proc, timeout=2)
-        returncode = proc.returncode
-        stderr_bytes = b""
-        if proc.stderr:
-            try:
-                stderr_bytes = await asyncio.wait_for(
-                    proc.stderr.read(8192), timeout=2
-                )
-            except asyncio.TimeoutError:
-                pass
-        stderr_text = stderr_bytes.decode("utf-8", errors="replace")
-        pytest.fail(
-            f"slack_e2e_server failed to start on gateway port {gateway_port} "
-            f"and webhook port {http_port} (returncode={returncode}).\n"
-            f"stderr:\n{stderr_text}"
+        db_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-db-")
+        home_tmpdir = tempfile.TemporaryDirectory(prefix="ironclaw-e2e-slack-home-")
+        channels_tmpdir = tempfile.TemporaryDirectory(
+            prefix="ironclaw-e2e-slack-channels-"
         )
+
+        gateway_port = reserved[0].getsockname()[1]
+        http_port = reserved[1].getsockname()[1]
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
+
+        home_dir = home_tmpdir.name
+        env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "HOME": home_dir,
+            "IRONCLAW_BASE_DIR": os.path.join(home_dir, ".ironclaw"),
+            "RUST_LOG": "ironclaw=debug",
+            "RUST_BACKTRACE": "1",
+            "IRONCLAW_OWNER_ID": OWNER_SCOPE_ID,
+            "GATEWAY_ENABLED": "true",
+            "GATEWAY_HOST": "127.0.0.1",
+            "GATEWAY_PORT": str(gateway_port),
+            "GATEWAY_AUTH_TOKEN": AUTH_TOKEN,
+            "GATEWAY_USER_ID": OWNER_SCOPE_ID,
+            "HTTP_HOST": "127.0.0.1",
+            "HTTP_PORT": str(http_port),
+            "CLI_ENABLED": "false",
+            "LLM_BACKEND": "openai_compatible",
+            "LLM_BASE_URL": mock_llm_server,
+            "LLM_MODEL": "mock-model",
+            "DATABASE_BACKEND": "libsql",
+            "LIBSQL_PATH": os.path.join(db_tmpdir.name, "slack-e2e.db"),
+            "SECRETS_MASTER_KEY": (
+                "0123456789abcdef0123456789abcdef"
+                "0123456789abcdef0123456789abcdef"
+            ),
+            "SANDBOX_ENABLED": "false",
+            "ROUTINES_ENABLED": "false",
+            "HEARTBEAT_ENABLED": "false",
+            "EMBEDDING_ENABLED": "false",
+            "WASM_ENABLED": "true",
+            "WASM_TOOLS_DIR": wasm_tools_dir,
+            "WASM_CHANNELS_DIR": channels_tmpdir.name,
+            "SKILLS_ENABLED": "false",
+            "ONBOARD_COMPLETED": "true",
+            "IRONCLAW_TEST_HTTP_REWRITE_MAP": json.dumps(
+                {
+                    "slack.com": fake_slack_server,
+                    "files.slack.com": fake_slack_server,
+                }
+            ),
+        }
+        _forward_coverage_env(env)
+
+        proc = await asyncio.create_subprocess_exec(
+            str(ironclaw_binary),
+            "--no-onboard",
+            stdin=asyncio.subprocess.DEVNULL,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+
+        startup_kill_attempted = False
+        base_url = f"http://127.0.0.1:{gateway_port}"
+        http_url = f"http://127.0.0.1:{http_port}"
+        try:
+            await wait_for_ready(f"{base_url}/api/health", timeout=60)
+            yield {
+                "base_url": base_url,
+                "http_url": http_url,
+                "fake_slack_url": fake_slack_server,
+                "channels_dir": channels_tmpdir.name,
+            }
+        except TimeoutError:
+            if proc.returncode is None:
+                startup_kill_attempted = True
+                await _stop_process(proc, timeout=2)
+            returncode = proc.returncode
+            stderr_bytes = b""
+            if proc.stderr:
+                try:
+                    stderr_bytes = await asyncio.wait_for(
+                        proc.stderr.read(8192), timeout=2
+                    )
+                except asyncio.TimeoutError:
+                    pass
+            stderr_text = stderr_bytes.decode("utf-8", errors="replace")
+            pytest.fail(
+                f"slack_e2e_server failed to start on gateway port {gateway_port} "
+                f"and webhook port {http_port} (returncode={returncode}).\n"
+                f"stderr:\n{stderr_text}"
+            )
+        finally:
+            if proc.returncode is None:
+                if startup_kill_attempted:
+                    await _stop_process(proc, timeout=2)
+                else:
+                    await _stop_process(proc, sig=signal.SIGINT, timeout=10)
+                    if proc.returncode is None:
+                        await _stop_process(proc, timeout=2)
+            db_tmpdir.cleanup()
+            home_tmpdir.cleanup()
+            channels_tmpdir.cleanup()
     finally:
-        if proc.returncode is None and not startup_kill_attempted:
-            await _stop_process(proc, sig=signal.SIGINT, timeout=10)
-        if proc.returncode is None:
-            await _stop_process(proc, timeout=2)
-        db_tmpdir.cleanup()
-        home_tmpdir.cleanup()
-        channels_tmpdir.cleanup()
+        for sock in reserved:
+            if sock.fileno() != -1:
+                sock.close()
 
 # ── Telegram E2E fixtures ────────────────────────────────────────────────
 

--- a/tests/e2e/scenarios/test_slack_e2e.py
+++ b/tests/e2e/scenarios/test_slack_e2e.py
@@ -12,6 +12,7 @@ import os
 import time
 
 import httpx
+import pytest
 
 from helpers import api_post, auth_headers
 
@@ -65,6 +66,7 @@ def _patch_slack_capabilities_for_testing(channels_dir: str):
 
     1. Add files.slack.com to HTTP allowlist for file download tests.
     2. Add files.slack.com to credential host_patterns.
+    3. Bind the test Slack owner so DM tests do not depend on pairing state.
     """
     cap_path = os.path.join(channels_dir, "slack.capabilities.json")
     assert os.path.exists(cap_path), (
@@ -89,6 +91,9 @@ def _patch_slack_capabilities_for_testing(channels_dir: str):
     host_patterns = slack_bot_cred.setdefault("host_patterns", [])
     if "files.slack.com" not in host_patterns:
         host_patterns.append("files.slack.com")
+
+    config = caps.setdefault("config", {})
+    config["owner_id"] = OWNER_USER_ID
 
     with open(cap_path, "w") as f:
         json.dump(caps, f, indent=2)
@@ -126,6 +131,18 @@ async def activate_slack(
     assert body.get("activated") or body.get("success"), (
         f"Slack setup failed: {body}"
     )
+
+
+@pytest.fixture
+async def active_slack(slack_e2e_server):
+    """Ensure Slack is installed, configured, and clean for each test."""
+    base_url = slack_e2e_server["base_url"]
+    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    channels_dir = slack_e2e_server["channels_dir"]
+
+    await activate_slack(base_url, fake_slack_url, channels_dir)
+    await reset_fake_slack(fake_slack_url)
+    return slack_e2e_server
 
 
 def build_slack_dm_event(
@@ -254,17 +271,11 @@ async def get_api_calls(fake_slack_url: str) -> list[dict]:
 # -- tests -----------------------------------------------------------------
 
 
-async def test_slack_setup_and_dm_roundtrip(slack_e2e_server):
+async def test_slack_setup_and_dm_roundtrip(active_slack):
     """Full DM round-trip: setup -> webhook -> mock LLM -> chat.postMessage."""
-    base_url = slack_e2e_server["base_url"]
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
-    channels_dir = slack_e2e_server["channels_dir"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
-    # Reset fake API and activate the Slack channel
-    await activate_slack(base_url, fake_slack_url, channels_dir)
-
-    # Clear fake API state to only capture round-trip messages
     await reset_fake_slack(fake_slack_url)
 
     # POST a DM webhook event as the verified owner
@@ -276,13 +287,14 @@ async def test_slack_setup_and_dm_roundtrip(slack_e2e_server):
     messages = await wait_for_sent_messages(fake_slack_url, min_count=1, timeout=30)
     reply_text = messages[-1].get("text", "")
     assert reply_text, f"Empty reply text. All sent messages: {messages}"
+    assert "Hello! How can I help you today?" in reply_text
     assert messages[-1]["channel"] == f"D{OWNER_USER_ID}"
 
 
-async def test_slack_app_mention_roundtrip(slack_e2e_server):
+async def test_slack_app_mention_roundtrip(active_slack):
     """app_mention in channel -> reply with correct channel + thread_ts."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -303,9 +315,9 @@ async def test_slack_app_mention_roundtrip(slack_e2e_server):
     assert reply.get("thread_ts") == ts or reply.get("thread_ts") is not None
 
 
-async def test_slack_url_verification_challenge(slack_e2e_server):
+async def test_slack_url_verification_challenge(active_slack):
     """url_verification event -> response contains challenge echo."""
-    http_url = slack_e2e_server["http_url"]
+    http_url = active_slack["http_url"]
 
     challenge_value = "test-challenge-token-12345"
     payload = {
@@ -314,14 +326,7 @@ async def test_slack_url_verification_challenge(slack_e2e_server):
         "challenge": challenge_value,
     }
 
-    # url_verification doesn't use HMAC signing
-    async with httpx.AsyncClient() as c:
-        resp = await c.post(
-            f"{http_url}/webhook/slack",
-            json=payload,
-            headers={"Content-Type": "application/json"},
-            timeout=10,
-        )
+    resp = await post_slack_webhook(http_url, payload)
 
     assert resp.status_code == 200
     body = resp.text
@@ -331,10 +336,10 @@ async def test_slack_url_verification_challenge(slack_e2e_server):
     )
 
 
-async def test_slack_unauthorized_user_rejected(slack_e2e_server):
+async def test_slack_unauthorized_user_rejected(active_slack):
     """A webhook from a non-owner user should not produce a chat.postMessage reply."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -358,9 +363,9 @@ async def test_slack_unauthorized_user_rejected(slack_e2e_server):
         )
 
 
-async def test_slack_invalid_hmac_signature_rejected(slack_e2e_server):
+async def test_slack_invalid_hmac_signature_rejected(active_slack):
     """Webhook with wrong HMAC signature is rejected."""
-    http_url = slack_e2e_server["http_url"]
+    http_url = active_slack["http_url"]
 
     payload = build_slack_dm_event(OWNER_USER_ID, "should be rejected")
     resp = await post_slack_webhook(
@@ -371,9 +376,9 @@ async def test_slack_invalid_hmac_signature_rejected(slack_e2e_server):
     )
 
 
-async def test_slack_missing_hmac_headers_rejected(slack_e2e_server):
+async def test_slack_missing_hmac_headers_rejected(active_slack):
     """Webhook with no signature headers is rejected."""
-    http_url = slack_e2e_server["http_url"]
+    http_url = active_slack["http_url"]
 
     payload = build_slack_dm_event(OWNER_USER_ID, "should be rejected")
     # signing_secret=None means no HMAC headers are sent
@@ -383,10 +388,10 @@ async def test_slack_missing_hmac_headers_rejected(slack_e2e_server):
     )
 
 
-async def test_slack_bot_message_ignored(slack_e2e_server):
+async def test_slack_bot_message_ignored(active_slack):
     """Event with bot_id is silently dropped (no reply)."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -407,10 +412,10 @@ async def test_slack_bot_message_ignored(slack_e2e_server):
     )
 
 
-async def test_slack_message_subtype_ignored(slack_e2e_server):
+async def test_slack_message_subtype_ignored(active_slack):
     """Event with subtype is silently dropped (no reply)."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -431,10 +436,10 @@ async def test_slack_message_subtype_ignored(slack_e2e_server):
     )
 
 
-async def test_slack_bot_mention_stripped(slack_e2e_server):
+async def test_slack_bot_mention_stripped(active_slack):
     """<@UBOTUSER> hello -> LLM sees 'hello' (mention stripped)."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -452,10 +457,10 @@ async def test_slack_bot_mention_stripped(slack_e2e_server):
     assert len(messages) >= 1, f"Expected a reply, got: {messages}"
 
 
-async def test_slack_thread_reply_includes_thread_ts(slack_e2e_server):
+async def test_slack_thread_reply_includes_thread_ts(active_slack):
     """DM with thread_ts -> reply includes thread_ts in chat.postMessage."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -475,10 +480,10 @@ async def test_slack_thread_reply_includes_thread_ts(slack_e2e_server):
     )
 
 
-async def test_slack_malformed_payload_resilience(slack_e2e_server):
+async def test_slack_malformed_payload_resilience(active_slack):
     """Bad JSON -> 200/400 (not 500), bot still works after."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 
@@ -524,10 +529,10 @@ async def test_slack_malformed_payload_resilience(slack_e2e_server):
     )
 
 
-async def test_slack_file_attachment_with_dm(slack_e2e_server):
+async def test_slack_file_attachment_with_dm(active_slack):
     """DM with files array -> file download attempted, message still processed."""
-    http_url = slack_e2e_server["http_url"]
-    fake_slack_url = slack_e2e_server["fake_slack_url"]
+    http_url = active_slack["http_url"]
+    fake_slack_url = active_slack["fake_slack_url"]
 
     await reset_fake_slack(fake_slack_url)
 

--- a/tests/e2e/scenarios/test_slack_e2e.py
+++ b/tests/e2e/scenarios/test_slack_e2e.py
@@ -276,8 +276,6 @@ async def test_slack_setup_and_dm_roundtrip(active_slack):
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
 
-    await reset_fake_slack(fake_slack_url)
-
     # POST a DM webhook event as the verified owner
     payload = build_slack_dm_event(OWNER_USER_ID, "hello")
     resp = await post_slack_webhook(http_url, payload)
@@ -295,8 +293,6 @@ async def test_slack_app_mention_roundtrip(active_slack):
     """app_mention in channel -> reply with correct channel + thread_ts."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     ts = f"{time.time():.6f}"
     payload = build_slack_mention_event(
@@ -340,8 +336,6 @@ async def test_slack_unauthorized_user_rejected(active_slack):
     """A webhook from a non-owner user should not produce a chat.postMessage reply."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     # Send a DM from a different user (not the owner)
     payload = build_slack_dm_event("U99STRANGER", "hello from stranger")
@@ -393,8 +387,6 @@ async def test_slack_bot_message_ignored(active_slack):
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
 
-    await reset_fake_slack(fake_slack_url)
-
     payload = build_slack_dm_event(
         OWNER_USER_ID,
         "I am a bot message",
@@ -416,8 +408,6 @@ async def test_slack_message_subtype_ignored(active_slack):
     """Event with subtype is silently dropped (no reply)."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     payload = build_slack_dm_event(
         OWNER_USER_ID,
@@ -441,8 +431,6 @@ async def test_slack_bot_mention_stripped(active_slack):
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
 
-    await reset_fake_slack(fake_slack_url)
-
     payload = build_slack_mention_event(
         OWNER_USER_ID,
         f"<@{BOT_USER_ID}> hello",
@@ -461,8 +449,6 @@ async def test_slack_thread_reply_includes_thread_ts(active_slack):
     """DM with thread_ts -> reply includes thread_ts in chat.postMessage."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     thread_ts = "1234567890.000001"
     payload = build_slack_dm_event(
@@ -484,8 +470,6 @@ async def test_slack_malformed_payload_resilience(active_slack):
     """Bad JSON -> 200/400 (not 500), bot still works after."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     # Send a completely malformed payload
     body_bytes = b'{"not_a_valid_slack_event": true}'
@@ -533,8 +517,6 @@ async def test_slack_file_attachment_with_dm(active_slack):
     """DM with files array -> file download attempted, message still processed."""
     http_url = active_slack["http_url"]
     fake_slack_url = active_slack["fake_slack_url"]
-
-    await reset_fake_slack(fake_slack_url)
 
     payload = build_slack_dm_event(
         OWNER_USER_ID,


### PR DESCRIPTION
## Summary

Fixes #2623.

- Start the Slack E2E fixture with the current WASM channel env contract (`WASM_CHANNELS_DIR`, `WASM_TOOLS_DIR`) and a dedicated webhook server port.
- Enable debug/E2E HTTP host rewrites for WASM channel outbound Slack calls while restricting rewrite targets to loopback URLs.
- Activate Slack per test and bind the test owner so Slack DM roundtrip assertions do not depend on pairing state or test order.

## Verification

- `cd tests/e2e && .venv/bin/pytest scenarios/test_slack_e2e.py -q -x`
- `cargo test --no-default-features --features libsql test_rewrite_http_url_for_testing_uses_host_map`