### PR TITLE
fix(secrets): auto-generate master key via .env on every startup (#1820)

### DIFF
--- a/src/config/secrets.rs
+++ b/src/config/secrets.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use secrecy::{ExposeSecret, SecretString};
 
 use crate::config::helpers::optional_env;
@@ -25,28 +27,88 @@ impl std::fmt::Debug for SecretsConfig {
 }
 
 impl SecretsConfig {
-    /// Auto-detect secrets master key from env var, then OS keychain.
+    /// Resolve the secrets master key.
     ///
-    /// Sequential probe: SECRETS_MASTER_KEY env var first, then OS keychain.
-    /// No saved "source" needed; just try each source in order.
+    /// Order:
+    /// 1. `SECRETS_MASTER_KEY` env var (process env or `.env` overlay)
+    /// 2. OS keychain entry
+    /// 3. Auto-generate and persist: OS keychain first, `~/.ironclaw/.env`
+    ///    fallback when the keychain is unavailable.
+    ///
+    /// Running this on every startup (not only onboarding) closes #1820:
+    /// users who skipped or partially completed onboarding, or who run on
+    /// headless Linux without secret-service, previously ended up with no
+    /// secrets store and saw "secrets store is not available" when
+    /// configuring API keys. The generate-and-persist step is the same path
+    /// the onboarding wizard's quick mode already uses; calling it from
+    /// here means there is exactly one place that writes the master key.
     pub(crate) async fn resolve() -> Result<Self, ConfigError> {
+        Self::resolve_with_env_path(&crate::bootstrap::ironclaw_env_path()).await
+    }
+
+    /// Testable variant of [`Self::resolve`] that writes its `.env`
+    /// fallback to an explicit path. Production code calls
+    /// [`Self::resolve`], which targets `~/.ironclaw/.env`.
+    pub(crate) async fn resolve_with_env_path(env_path: &Path) -> Result<Self, ConfigError> {
         use crate::settings::KeySource;
 
-        let (master_key, source) = if let Some(env_key) = optional_env("SECRETS_MASTER_KEY")? {
-            (Some(SecretString::from(env_key)), KeySource::Env)
-        } else {
-            // Probe the OS keychain; if a key is stored, use it
-            match crate::secrets::keychain::get_master_key().await {
-                Ok(key_bytes) => {
-                    let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
-                    (Some(SecretString::from(key_hex)), KeySource::Keychain)
-                }
-                Err(_) => (None, KeySource::None),
-            }
-        };
+        if let Some(env_key) = optional_env("SECRETS_MASTER_KEY")? {
+            return Self::build(Some(SecretString::from(env_key)), KeySource::Env);
+        }
 
-        let enabled = master_key.is_some();
+        if let Ok(key_bytes) = crate::secrets::keychain::get_master_key().await {
+            let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+            return Self::build(Some(SecretString::from(key_hex)), KeySource::Keychain);
+        }
 
+        let (key_hex, source) = Self::auto_generate_and_persist(env_path).await?;
+        Self::build(Some(SecretString::from(key_hex)), source)
+    }
+
+    /// Generate a new master key and persist it.
+    ///
+    /// Tries the OS keychain first. If the keychain is unavailable
+    /// (headless Linux, CI without secret-service, macOS without keychain
+    /// access), writes the key to `env_path` as `SECRETS_MASTER_KEY=…`
+    /// via `upsert_bootstrap_vars_to` (the same writer the onboarding
+    /// wizard uses) and injects it into the process env overlay so the
+    /// current run sees it immediately.
+    async fn auto_generate_and_persist(
+        env_path: &Path,
+    ) -> Result<(String, crate::settings::KeySource), ConfigError> {
+        use crate::settings::KeySource;
+
+        let key_bytes = crate::secrets::keychain::generate_master_key();
+        let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
+
+        if crate::secrets::keychain::store_master_key(&key_bytes)
+            .await
+            .is_ok()
+        {
+            tracing::debug!("Auto-generated secrets master key; stored in OS keychain");
+            return Ok((key_hex, KeySource::Keychain));
+        }
+
+        crate::bootstrap::upsert_bootstrap_vars_to(env_path, &[("SECRETS_MASTER_KEY", &key_hex)])
+            .map_err(|e| ConfigError::InvalidValue {
+            key: "SECRETS_MASTER_KEY".to_string(),
+            message: format!(
+                "failed to persist auto-generated master key to {}: {e}",
+                env_path.display()
+            ),
+        })?;
+        crate::config::inject_single_var("SECRETS_MASTER_KEY", &key_hex);
+        tracing::debug!(
+            "Auto-generated secrets master key; stored in {}",
+            env_path.display()
+        );
+        Ok((key_hex, KeySource::Env))
+    }
+
+    fn build(
+        master_key: Option<SecretString>,
+        source: crate::settings::KeySource,
+    ) -> Result<Self, ConfigError> {
         if let Some(ref key) = master_key
             && key.expose_secret().len() < 32
         {
@@ -55,7 +117,7 @@ impl SecretsConfig {
                 message: "must be at least 32 bytes for AES-256-GCM".to_string(),
             });
         }
-
+        let enabled = master_key.is_some();
         Ok(Self {
             master_key,
             enabled,
@@ -66,5 +128,159 @@ impl SecretsConfig {
     /// Get the master key if configured.
     pub fn master_key(&self) -> Option<&SecretString> {
         self.master_key.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::KeySource;
+
+    /// Regression test for #1820: when neither the env var nor the OS
+    /// keychain yield a key, `resolve_with_env_path` must auto-generate
+    /// one and persist it so the caller gets a usable secrets store
+    /// without requiring onboarding.
+    ///
+    /// The test gracefully skips when the host keychain already holds
+    /// a master key for the `ironclaw` service — that would make the
+    /// generate-and-persist branch unreachable and we'd otherwise
+    /// wipe/overwrite a developer's real key.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // env guard must span the entire test
+    async fn resolve_persists_generated_key_when_keychain_empty() {
+        let _guard = lock_env();
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        let prior = std::env::var("SECRETS_MASTER_KEY").ok();
+        unsafe {
+            std::env::remove_var("SECRETS_MASTER_KEY");
+        }
+
+        let result = async {
+            if crate::secrets::keychain::get_master_key().await.is_ok() {
+                eprintln!(
+                    "skipping: host keychain already holds a master key; \
+                     cannot exercise the generate-and-persist path"
+                );
+                return;
+            }
+
+            let dir = tempfile::tempdir().unwrap();
+            let env_path = dir.path().join(".env");
+
+            let cfg = SecretsConfig::resolve_with_env_path(&env_path)
+                .await
+                .expect("resolve must succeed and auto-generate a key");
+
+            assert!(cfg.enabled, "secrets must be enabled after auto-generate");
+            assert!(cfg.master_key.is_some(), "master key must be populated");
+
+            match cfg.source {
+                KeySource::Env => {
+                    let contents = std::fs::read_to_string(&env_path).unwrap();
+                    assert!(
+                        contents.contains("SECRETS_MASTER_KEY="),
+                        ".env must carry the generated key; got: {contents}"
+                    );
+                    let key = cfg.master_key.unwrap().expose_secret().to_string();
+                    assert_eq!(key.len(), 64, "32-byte AES-256 key = 64 hex chars");
+                    assert!(
+                        contents.contains(&key),
+                        "persisted value must match the returned master key"
+                    );
+                }
+                KeySource::Keychain => {
+                    // Keychain accepted the write. Clean up so we don't
+                    // leave a generated key in the dev machine's real
+                    // keychain.
+                    let _ = crate::secrets::keychain::delete_master_key().await;
+                }
+                other => panic!("unexpected source after auto-generate: {other:?}"),
+            }
+        }
+        .await;
+
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        unsafe {
+            if let Some(ref v) = prior {
+                std::env::set_var("SECRETS_MASTER_KEY", v);
+            } else {
+                std::env::remove_var("SECRETS_MASTER_KEY");
+            }
+        }
+        result
+    }
+
+    /// When `SECRETS_MASTER_KEY` is set, resolve must not touch the
+    /// keychain and must not write to `.env`.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // env guard must span the entire test
+    async fn env_var_is_used_directly_without_generating() {
+        let _guard = lock_env();
+        let prior = std::env::var("SECRETS_MASTER_KEY").ok();
+        let key_hex = "a".repeat(64);
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        unsafe {
+            std::env::set_var("SECRETS_MASTER_KEY", &key_hex);
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+
+        let cfg = SecretsConfig::resolve_with_env_path(&env_path)
+            .await
+            .expect("env-var path must succeed");
+
+        assert_eq!(cfg.source, KeySource::Env);
+        assert_eq!(
+            cfg.master_key
+                .as_ref()
+                .map(|k| k.expose_secret().to_string()),
+            Some(key_hex)
+        );
+        assert!(
+            !env_path.exists(),
+            "resolve must not create .env when the env var is already set"
+        );
+
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        unsafe {
+            if let Some(ref v) = prior {
+                std::env::set_var("SECRETS_MASTER_KEY", v);
+            } else {
+                std::env::remove_var("SECRETS_MASTER_KEY");
+            }
+        }
+    }
+
+    /// A too-short master key is rejected even when supplied via env.
+    /// AES-256-GCM requires 32 bytes; accepting a shorter key would
+    /// silently break decryption.
+    #[tokio::test]
+    #[allow(clippy::await_holding_lock)] // env guard must span the entire test
+    async fn short_env_key_is_rejected() {
+        let _guard = lock_env();
+        let prior = std::env::var("SECRETS_MASTER_KEY").ok();
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        unsafe {
+            std::env::set_var("SECRETS_MASTER_KEY", "too-short");
+        }
+
+        let dir = tempfile::tempdir().unwrap();
+        let env_path = dir.path().join(".env");
+
+        let err = SecretsConfig::resolve_with_env_path(&env_path)
+            .await
+            .expect_err("short key must fail");
+        assert!(err.to_string().contains("32 bytes"));
+
+        // SAFETY: serialized via ENV_MUTEX (lock_env).
+        unsafe {
+            if let Some(ref v) = prior {
+                std::env::set_var("SECRETS_MASTER_KEY", v);
+            } else {
+                std::env::remove_var("SECRETS_MASTER_KEY");
+            }
+        }
     }
 }

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -1193,63 +1193,48 @@ impl SetupWizard {
 
     /// Auto-setup security with zero prompts (quick mode).
     ///
-    /// Silently configures the master key: uses existing env var or keychain
-    /// key if available, otherwise generates and stores one automatically
-    /// (keychain on macOS, env var fallback).
+    /// Thin caller over [`SecretsConfig::resolve`], which owns the
+    /// env-var → keychain → generate-and-persist chain. The wizard's
+    /// only remaining responsibilities here are building the
+    /// `SecretsCrypto` instance that subsequent wizard steps use to
+    /// encrypt credentials before the DB is available, mirroring the
+    /// resolved source into settings so `write_bootstrap_env()` picks
+    /// up the hex when in env-var mode, and printing a user-visible
+    /// status line.
     async fn auto_setup_security(&mut self) -> Result<(), SetupError> {
-        // Check env var first
-        if std::env::var("SECRETS_MASTER_KEY").is_ok() {
-            self.settings.secrets_master_key_source = KeySource::Env;
-            print_success("Security configured (env var)");
-            return Ok(());
-        }
-
-        // Try existing keychain key (no prompts — get_master_key may show
-        // OS dialogs on macOS, but that's unavoidable for keychain access)
-        if let Ok(keychain_key_bytes) = crate::secrets::keychain::get_master_key().await {
-            let key_hex: String = keychain_key_bytes
-                .iter()
-                .map(|b| format!("{:02x}", b))
-                .collect();
-            self.secrets_crypto = Some(Arc::new(
-                SecretsCrypto::new(SecretString::from(key_hex))
-                    .map_err(|e| SetupError::Config(e.to_string()))?,
-            ));
-            self.settings.secrets_master_key_source = KeySource::Keychain;
-            print_success("Security configured (keychain)");
-            return Ok(());
-        }
-
-        // No existing key — generate one
-        // Try keychain first (preferred on macOS)
-        let key = crate::secrets::keychain::generate_master_key();
-        if crate::secrets::keychain::store_master_key(&key)
+        let cfg = crate::config::SecretsConfig::resolve()
             .await
-            .is_ok()
-        {
-            let key_hex: String = key.iter().map(|b| format!("{:02x}", b)).collect();
-            self.secrets_crypto = Some(Arc::new(
-                SecretsCrypto::new(SecretString::from(key_hex))
-                    .map_err(|e| SetupError::Config(e.to_string()))?,
-            ));
-            self.settings.secrets_master_key_source = KeySource::Keychain;
-            print_success("Master key stored in OS keychain");
-            return Ok(());
-        }
+            .map_err(|e| SetupError::Config(e.to_string()))?;
 
-        // Keychain unavailable — fall back to env var mode
-        let key_hex = crate::secrets::keychain::generate_master_key_hex();
+        let master_key = cfg.master_key.clone().ok_or_else(|| {
+            SetupError::Config("secrets resolve returned no master key".to_string())
+        })?;
+
         self.secrets_crypto = Some(Arc::new(
-            SecretsCrypto::new(SecretString::from(key_hex.clone()))
+            SecretsCrypto::new(master_key.clone())
                 .map_err(|e| SetupError::Config(e.to_string()))?,
         ));
-        crate::config::inject_single_var("SECRETS_MASTER_KEY", &key_hex);
-        self.settings.secrets_master_key_hex = Some(key_hex);
-        self.settings.secrets_master_key_source = KeySource::Env;
-        print_success(&format!(
-            "Master key stored in {}",
-            crate::bootstrap::ironclaw_env_path().display()
-        ));
+        self.settings.secrets_master_key_source = cfg.source;
+
+        // In env-var mode the hex is needed by `bootstrap_env_vars()` so
+        // that the wizard's idempotent final `.env` write includes
+        // `SECRETS_MASTER_KEY=…` alongside the rest of the bootstrap
+        // vars. `resolve()` has already persisted the key on its own,
+        // but the wizard's full-set rewrite happens after DB settings
+        // merge in and must carry the key forward.
+        if matches!(cfg.source, KeySource::Env) {
+            self.settings.secrets_master_key_hex = Some(master_key.expose_secret().to_string());
+        }
+
+        let msg = match cfg.source {
+            KeySource::Env => format!(
+                "Master key stored in {}",
+                crate::bootstrap::ironclaw_env_path().display()
+            ),
+            KeySource::Keychain => "Master key stored in OS keychain".to_string(),
+            KeySource::None => "Security not configured".to_string(),
+        };
+        print_success(&msg);
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Closes #1820 and supersedes #2312.

The "secrets store is not available" error fired when `require_secrets_store` was hit (e.g. web settings → save API key) but `SecretsConfig::resolve()` had returned `KeySource::None` — the normal state on headless Linux, in a container without secret-service, or after a partial onboarding that wrote `ONBOARD_COMPLETED=true` without persisting a key.

The onboarding wizard's quick-mode `auto_setup_security()` already handled this chain correctly (env → keychain read → keychain write → generate + persist to `~/.ironclaw/.env` as `SECRETS_MASTER_KEY=…`). The bug was simply that the chain only ran during onboarding. If `check_onboard_needed()` returned `None` (e.g. because `ONBOARD_COMPLETED=true` was set), nothing re-ran it.

## What changed

- `src/config/secrets.rs` — `SecretsConfig::resolve()` now owns the full chain. When neither env var nor keychain yield a key, it generates one and persists it via `upsert_bootstrap_vars_to()` (same writer the wizard uses), then injects the key into the process env overlay so the current run sees it immediately. One persistence format (`.env`), one `KeySource` (`Env`) for the keychain-unavailable path.
- `src/setup/wizard.rs::auto_setup_security()` — collapses from the full chain to a thin caller: `SecretsConfig::resolve()` → build `SecretsCrypto` → mirror resolved source/hex into settings → print status line.

## Why not PR #2312's approach

That PR added a **second** persistence format (`~/.ironclaw/master.key` + `KeySource::File` + a new `Keystore` trait) alongside the existing `.env` path. Security review flagged a divergence-on-recovery bug between the two stores that the PR didn't actually fix. Option B here reuses the single existing `.env` path instead — no new variants, no new trait, no divergence surface.

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] 3 new unit tests in `src/config/secrets.rs`:
  - `resolve_persists_generated_key_when_keychain_empty` — regression test drives `resolve_with_env_path()` with a tempfile and asserts `.env` carries the generated key. Skips gracefully when the host keychain already holds a key (developer machines)
  - `env_var_is_used_directly_without_generating` — env-var path bypasses keychain and `.env` write
  - `short_env_key_is_rejected` — AES-256-GCM length invariant upheld
- [x] All 82 existing `setup::wizard` tests still pass
- [ ] Manual: on headless Linux without secret-service, run `ironclaw` once without onboarding and confirm `~/.ironclaw/.env` now contains `SECRETS_MASTER_KEY=…` and web settings can save API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)