### PR TITLE
test(e2e): harden tab_button selector against strict-mode duplicates

### DIFF
--- a/tests/e2e/helpers.py
+++ b/tests/e2e/helpers.py
@@ -20,7 +20,12 @@ SEL = {
     "auth_screen": "#auth-screen",
     "token_input": "#token-input",
     # Tabs
-    "tab_button": '.tab-bar button[data-tab="{tab}"]',
+    # Scope to the main tab-bar buttons only. `.status-logs-btn` covers the
+    # right-aligned auxiliary buttons (logs, docs link) and `.tab-btn` covers
+    # widget-injected tabs added by `_addWidgetTab`. Excluding both keeps the
+    # selector a single match under Playwright strict mode even if a widget
+    # or auxiliary button is ever introduced with a colliding `data-tab` id.
+    "tab_button": '.tab-bar > button[data-tab="{tab}"]:not(.status-logs-btn):not(.tab-btn)',
     "tab_panel": "#tab-{tab}",
     # Chat
     "chat_input": "#chat-input",


### PR DESCRIPTION
Closes #2626.

## Why

`tests/e2e/helpers.py` locates every main-nav tab button with
```css
.tab-bar button[data-tab="{tab}"]
```
which only stayed unique by accident. Commit 5058a1cf removed the duplicate right-side `status-logs-btn` Jobs button that was causing it to match 2 elements (the #2353 regression), so `test_connection.py` passes on current staging — but the next auxiliary button or `_addWidgetTab`-injected tab that reuses a built-in `data-tab` id will make the selector resolve to multiple elements and trip Playwright strict mode the next CI run. That's exactly the class of regression #2626 asks us to prevent at the test layer.

## Fix

Harden the selector in `tests/e2e/helpers.py` (issue's "scope to a more specific parent region" direction):

```
.tab-bar > button[data-tab="{tab}"]:not(.status-logs-btn):not(.tab-btn)
```

- `.tab-bar > button` — direct child; skips any hypothetical nested buttons (menus, popovers).
- `:not(.status-logs-btn)` — excludes the right-side logs/docs cluster, the class that actually caused the #2353 duplicate.
- `:not(.tab-btn)` — excludes widget-injected tabs added by `_addWidgetTab` in `crates/ironclaw_gateway/static/app.js`, which always carry this class.

No production HTML change — #2626's acceptance criteria explicitly forbids one.

## Acceptance criteria (from #2626)

- [x] `test_connection.py` passes in isolation on current `staging`
- [x] selector is stable under Playwright strict mode
- [x] no production UI change required solely to satisfy this outdated selector

## Verification

```
$ pytest tests/e2e/scenarios/test_connection.py -v
test_page_loads_and_connects PASSED
test_tab_navigation            PASSED
test_auth_rejection            PASSED
3 passed in 4.74s
```

Regression coverage — synthetic DOM with three colliding `data-tab="jobs"` buttons (the built-in one, a `status-logs-btn` duplicate like the #2353 one, and a widget-injected `.tab-btn` one):

| selector | match count | `.click()` strict-mode |
|---|---|---|
| old `.tab-bar button[data-tab="jobs"]` | 3 | raises |
| new `.tab-bar > button[data-tab="jobs"]:not(.status-logs-btn):not(.tab-btn)` | 1 | succeeds |

## Test-through-the-caller note

Every call site of `SEL["tab_button"]` in `tests/e2e/scenarios/` already drives real Playwright actions (`.click()`, `is_visible()`, `wait_for(...)`) against the gateway — so the scenario files themselves are the integration-tier coverage for the new selector; no separate helper-only unit test is needed.