### PR TITLE
fix(ci): unblock staging Docker Build and echo tool E2E test

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@
 FROM rust:1.92-bookworm AS chef
 
 RUN rustup target add wasm32-wasip2 \
-    && cargo install cargo-chef@0.1.77 wasm-tools@1.246.1
+    && cargo install --locked cargo-chef@0.1.77 wasm-tools@1.246.1
 
 WORKDIR /app
 

--- a/tests/e2e/scenarios/test_tool_execution.py
+++ b/tests/e2e/scenarios/test_tool_execution.py
@@ -50,7 +50,13 @@ async def _wait_for_turn(
                 for tool_call in turn.get("tool_calls", []):
                     if tool_call.get("name") != tool_name:
                         continue
-                    preview = (tool_call.get("result_preview") or "").lower()
+                    # In-memory turns populate `result`; DB-hydrated turns
+                    # populate `result_preview`. Accept either — see PR #2555.
+                    preview = (
+                        tool_call.get("result_preview")
+                        or tool_call.get("result")
+                        or ""
+                    ).lower()
                     tool_ok = tool_call.get("has_result") is True and (
                         result_fragment is None or result_fragment.lower() in preview
                     )


### PR DESCRIPTION
## Summary

Two independent regressions have been keeping the **Staging CI (Batched)** workflow red for ~24h. Both fixed here:

- **Docker Build** — `cargo install wasm-tools@1.246.1` in the chef stage re-resolved transitive deps to the newest compatible versions and picked up `constant_time_eq@0.4.3`, which requires rustc ≥ 1.95. The chef stage is pinned to `rust:1.92-bookworm`. Cargo itself emitted `Try re-running \`cargo install\` with \`--locked\`` — added that flag so cargo uses each crate's shipped `Cargo.lock`.
- **`test_builtin_echo_tool`** — PR #2555 (merged 2026-04-18) intentionally aligned the in-memory history path with DB semantics: tool previews now land in `tool_calls[*].result` with `result_preview` left as `None`. The test predated that change and only inspected `result_preview`, so it timed out despite the data being present. Updated `_wait_for_turn` to read the preview from either `result_preview` or `result`.

## Test plan

- [x] `cargo build --no-default-features --features libsql --bin ironclaw` succeeds locally
- [x] `pytest tests/e2e/scenarios/test_tool_execution.py` — 3 passed (was 1 failing)
- [x] Full CI `extensions` group run locally — 146 passed, 5 skipped (matches CI shape)
- [ ] CI Docker Build job goes green on this PR
- [ ] CI E2E (extensions) job goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)