### PR TITLE
fix(engine): recover negative max_tokens overflows across bridge/orchestrator

### DIFF
--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -678,6 +678,10 @@ def run_loop(context, goal, actions, state, config):
         # 4. Call LLM
         __emit_event__("step_started", step=step)
         response = __llm_complete__(working_messages, actions, None)
+        compacted_messages = response.get("compacted_messages")
+        if isinstance(compacted_messages, list):
+            state["working_messages"] = compacted_messages
+            working_messages = state["working_messages"]
         __emit_event__("step_completed", step=step,
                        input_tokens=response.get("usage", {}).get("input_tokens", 0),
                        output_tokens=response.get("usage", {}).get("output_tokens", 0))

--- a/crates/ironclaw_engine/orchestrator/default.py
+++ b/crates/ironclaw_engine/orchestrator/default.py
@@ -682,6 +682,11 @@ def run_loop(context, goal, actions, state, config):
         if isinstance(compacted_messages, list):
             state["working_messages"] = compacted_messages
             working_messages = state["working_messages"]
+            __emit_event__(
+                "message_added",
+                role="System",
+                content_preview="overflow retry compacted working_messages",
+            )
         __emit_event__("step_completed", step=step,
                        input_tokens=response.get("usage", {}).get("input_tokens", 0),
                        output_tokens=response.get("usage", {}).get("output_tokens", 0))

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -39,7 +39,7 @@ use crate::traits::llm::{LlmBackend, LlmCallConfig};
 use crate::traits::store::Store;
 use crate::types::error::EngineError;
 use crate::types::event::{EventKind, ThreadEvent, summarize_params};
-use crate::types::message::ThreadMessage;
+use crate::types::message::{MessageRole, ThreadMessage};
 use crate::types::project::ProjectId;
 use crate::types::shared_owner_id;
 use crate::types::step::{ActionCall, StepId, TokenUsage};
@@ -601,6 +601,7 @@ async fn handle_llm_complete(
         .as_ref()
         .and_then(json_to_thread_messages)
         .unwrap_or_else(|| thread.messages.clone());
+    let has_explicit_messages = explicit_messages.is_some();
 
     if let Err(e) = reconcile_dynamic_tool_lease(
         thread,
@@ -646,45 +647,94 @@ async fn handle_llm_complete(
         metadata: HashMap::new(),
     };
 
-    match deps.llm.complete(&messages, &actions, &config).await {
-        Ok(output) => {
-            total_tokens.input_tokens += output.usage.input_tokens;
-            total_tokens.output_tokens += output.usage.output_tokens;
-            total_tokens.cost_usd += output.usage.cost_usd;
+    let mut compacted_messages = None;
+    let output = match deps.llm.complete(&messages, &actions, &config).await {
+        Ok(output) => output,
+        Err(EngineError::TokenLimitExceeded { used, limit }) => {
+            let retry_messages = compact_thread_messages_for_retry(&messages);
+            let tokens_before = crate::executor::compaction::estimate_tokens(&messages);
+            let tokens_after = crate::executor::compaction::estimate_tokens(&retry_messages);
+            if !has_explicit_messages
+                || (retry_messages.len() >= messages.len() && tokens_after >= tokens_before)
+            {
+                return ExtFunctionResult::Error(monty::MontyException::new(
+                    monty::ExcType::RuntimeError,
+                    Some(format!(
+                        "LLM call failed: {}",
+                        EngineError::TokenLimitExceeded { used, limit }
+                    )),
+                ));
+            }
 
-            let usage = serde_json::json!({
-                "input_tokens": output.usage.input_tokens,
-                "output_tokens": output.usage.output_tokens,
-                "cost_usd": output.usage.cost_usd,
-            });
+            tracing::warn!(
+                used,
+                limit,
+                tokens_before,
+                tokens_after,
+                messages_before = messages.len(),
+                messages_after = retry_messages.len(),
+                "orchestrator llm call exceeded context window, compacting and retrying"
+            );
 
-            let result = match output.response {
-                LlmResponse::Text(text) => {
-                    serde_json::json!({"type": "text", "content": text, "usage": usage})
+            match deps.llm.complete(&retry_messages, &actions, &config).await {
+                Ok(output) => {
+                    compacted_messages = Some(retry_messages);
+                    output
                 }
-                LlmResponse::Code { code, .. } => {
-                    serde_json::json!({"type": "code", "code": code, "usage": usage})
+                Err(retry_err) => {
+                    return ExtFunctionResult::Error(monty::MontyException::new(
+                        monty::ExcType::RuntimeError,
+                        Some(format!(
+                            "LLM call failed after compaction retry: {retry_err}"
+                        )),
+                    ));
                 }
-                LlmResponse::ActionCalls { calls, content } => {
-                    // Single source of truth for the Python interchange
-                    // shape — must round-trip via `python_json_to_action_calls`.
-                    let calls_json = action_calls_to_python_json(&calls);
-                    serde_json::json!({
-                        "type": "actions",
-                        "content": content,
-                        "calls": calls_json,
-                        "usage": usage
-                    })
-                }
-            };
-
-            ExtFunctionResult::Return(json_to_monty(&result))
+            }
         }
-        Err(e) => ExtFunctionResult::Error(monty::MontyException::new(
-            monty::ExcType::RuntimeError,
-            Some(format!("LLM call failed: {e}")),
-        )),
+        Err(e) => {
+            return ExtFunctionResult::Error(monty::MontyException::new(
+                monty::ExcType::RuntimeError,
+                Some(format!("LLM call failed: {e}")),
+            ));
+        }
+    };
+
+    total_tokens.input_tokens += output.usage.input_tokens;
+    total_tokens.output_tokens += output.usage.output_tokens;
+    total_tokens.cost_usd += output.usage.cost_usd;
+
+    let usage = serde_json::json!({
+        "input_tokens": output.usage.input_tokens,
+        "output_tokens": output.usage.output_tokens,
+        "cost_usd": output.usage.cost_usd,
+    });
+
+    let mut result = match output.response {
+        LlmResponse::Text(text) => {
+            serde_json::json!({"type": "text", "content": text, "usage": usage})
+        }
+        LlmResponse::Code { code, .. } => {
+            serde_json::json!({"type": "code", "code": code, "usage": usage})
+        }
+        LlmResponse::ActionCalls { calls, content } => {
+            // Single source of truth for the Python interchange
+            // shape — must round-trip via `python_json_to_action_calls`.
+            let calls_json = action_calls_to_python_json(&calls);
+            serde_json::json!({
+                "type": "actions",
+                "content": content,
+                "calls": calls_json,
+                "usage": usage
+            })
+        }
+    };
+
+    if let Some(compacted) = compacted_messages {
+        result["compacted_messages"] =
+            serde_json::Value::Array(thread_messages_to_python_json(&compacted));
     }
+
+    ExtFunctionResult::Return(json_to_monty(&result))
 }
 
 /// Handle `__execute_code_step__(code, state)`.
@@ -2180,33 +2230,7 @@ fn build_orchestrator_inputs(
     } else {
         &thread.internal_messages
     };
-    let context: Vec<serde_json::Value> = bootstrap_messages
-        .iter()
-        .map(|m| {
-            // Serialize action_calls through the Python interchange shape
-            // (`{name, call_id, params}`) so the bootstrap context is
-            // round-trip compatible with `python_json_to_action_calls`.
-            // Using bare `m.action_calls` here produces the canonical Rust
-            // serde format (`{action_name, id, parameters}`), which the
-            // Python orchestrator passes back verbatim on the next
-            // `__llm_complete__` call — and `python_json_to_action_calls`
-            // then fails with "missing field `name`", orphaning every
-            // subsequent tool result. This is the SECOND code path (after
-            // `handle_llm_complete`) that feeds action_calls into the
-            // Python working transcript; both must use the same shape.
-            let calls_json = m
-                .action_calls
-                .as_ref()
-                .map(|calls| serde_json::Value::Array(action_calls_to_python_json(calls)));
-            serde_json::json!({
-                "role": format!("{:?}", m.role),
-                "content": m.content,
-                "action_name": m.action_name,
-                "action_call_id": m.action_call_id,
-                "action_calls": calls_json,
-            })
-        })
-        .collect();
+    let context = thread_messages_to_python_json(bootstrap_messages);
 
     // Build config
     let config = serde_json::json!({
@@ -2312,6 +2336,76 @@ fn action_calls_to_python_json(calls: &[ActionCall]) -> Vec<serde_json::Value> {
             }
         })
         .collect()
+}
+
+/// Serialize engine thread messages into the Python orchestrator transcript shape.
+fn thread_messages_to_python_json(messages: &[ThreadMessage]) -> Vec<serde_json::Value> {
+    messages
+        .iter()
+        .map(|m| {
+            // Serialize action_calls through the Python interchange shape
+            // (`{name, call_id, params}`) so the bootstrap context and any
+            // caller-level compaction retries stay round-trip compatible with
+            // `python_json_to_action_calls`.
+            let calls_json = m
+                .action_calls
+                .as_ref()
+                .map(|calls| serde_json::Value::Array(action_calls_to_python_json(calls)));
+            serde_json::json!({
+                "role": format!("{:?}", m.role),
+                "content": m.content,
+                "action_name": m.action_name,
+                "action_call_id": m.action_call_id,
+                "action_calls": calls_json,
+            })
+        })
+        .collect()
+}
+
+/// Compact thread messages for a single retry after a context-overflow error.
+///
+/// Keeps all `System` messages that appeared before the last `User` message,
+/// inserts a short note, then preserves the last `User` message and everything
+/// after it (the current turn's assistant/action-result context).
+fn compact_thread_messages_for_retry(messages: &[ThreadMessage]) -> Vec<ThreadMessage> {
+    let mut compacted = Vec::new();
+    let last_user_idx = messages.iter().rposition(|m| m.role == MessageRole::User);
+
+    if let Some(idx) = last_user_idx {
+        for msg in &messages[..idx] {
+            if msg.role == MessageRole::System {
+                compacted.push(msg.clone());
+            }
+        }
+
+        if idx > 0 {
+            compacted.push(ThreadMessage::system(
+                "[Note: Earlier conversation history was automatically compacted \
+                 to fit within the context window. The most recent exchange is preserved below.]",
+            ));
+        }
+
+        compacted.extend_from_slice(&messages[idx..]);
+    } else {
+        for msg in messages {
+            if msg.role == MessageRole::System {
+                compacted.push(msg.clone());
+            }
+        }
+        if compacted.len() < messages.len() {
+            compacted.push(ThreadMessage::system(
+                "[Note: Earlier conversation history was automatically compacted \
+                 to fit within the context window.]",
+            ));
+        }
+        for msg in messages {
+            if msg.role != MessageRole::System {
+                compacted.push(msg.clone());
+            }
+        }
+    }
+
+    compacted
 }
 
 /// Extract the last `n` characters from `s`.
@@ -3337,6 +3431,259 @@ mod tests {
         let captured = concrete.captured.lock().await;
         assert_eq!(captured.len(), 1);
         assert_eq!(captured[0], None);
+    }
+
+    struct ContextOverflowRetryLlm {
+        captured: tokio::sync::Mutex<Vec<Vec<ThreadMessage>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for ContextOverflowRetryLlm {
+        fn model_name(&self) -> &str {
+            "context-overflow-retry"
+        }
+
+        async fn complete(
+            &self,
+            messages: &[ThreadMessage],
+            _actions: &[crate::types::capability::ActionDef],
+            _config: &LlmCallConfig,
+        ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
+            self.captured.lock().await.push(messages.to_vec());
+
+            let compacted = messages.iter().any(|msg| {
+                msg.role == MessageRole::System
+                    && msg
+                        .content
+                        .contains("automatically compacted to fit within the context window")
+            });
+
+            if compacted {
+                Ok(crate::traits::llm::LlmOutput {
+                    response: crate::types::step::LlmResponse::Text("FINAL(\"done\")".into()),
+                    usage: crate::types::step::TokenUsage::default(),
+                })
+            } else {
+                Err(EngineError::TokenLimitExceeded {
+                    used: 150_000,
+                    limit: 128_000,
+                })
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_complete_retries_after_context_overflow_with_compacted_messages() {
+        let concrete = Arc::new(ContextOverflowRetryLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let messages = serde_json::json!([
+            {"role": "System", "content": "You are helpful."},
+            {"role": "User", "content": "First question"},
+            {"role": "Assistant", "content": "First answer"},
+            {"role": "User", "content": "Second question"},
+            {"role": "Assistant", "content": "Second answer"},
+            {"role": "User", "content": "Current request"}
+        ]);
+
+        let mut total_tokens = TokenUsage::default();
+        let result = handle_llm_complete(
+            &[
+                json_to_monty(&messages),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        let response = match result {
+            ExtFunctionResult::Return(obj) => monty_to_json(&obj),
+            other => panic!("expected successful retry result, got {other:?}"),
+        };
+
+        assert_eq!(response["type"], "text");
+        assert_eq!(response["content"], "FINAL(\"done\")");
+        let compacted = response["compacted_messages"]
+            .as_array()
+            .expect("compacted messages should be returned to the orchestrator state");
+        assert!(
+            compacted.len() < messages.as_array().unwrap().len(),
+            "retry payload should be smaller than the original transcript"
+        );
+        assert_eq!(compacted[0]["role"], "System");
+        assert!(
+            compacted.iter().any(|msg| msg["content"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("automatically compacted to fit within the context window")),
+            "compaction note should be preserved for the retry"
+        );
+        assert_eq!(
+            compacted.last().and_then(|msg| msg["content"].as_str()),
+            Some("Current request")
+        );
+
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 2, "LLM should be retried exactly once");
+        assert_eq!(
+            captured[0].last().map(|m| m.content.as_str()),
+            Some("Current request")
+        );
+        assert!(
+            captured[1]
+                .iter()
+                .any(|msg| msg.content.contains("automatically compacted")),
+            "second call should receive the compacted retry transcript"
+        );
+    }
+
+    struct StatefulOverflowOrchestratorLlm {
+        captured: tokio::sync::Mutex<Vec<Vec<ThreadMessage>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for StatefulOverflowOrchestratorLlm {
+        fn model_name(&self) -> &str {
+            "stateful-overflow-orchestrator"
+        }
+
+        async fn complete(
+            &self,
+            messages: &[ThreadMessage],
+            _actions: &[crate::types::capability::ActionDef],
+            _config: &LlmCallConfig,
+        ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
+            self.captured.lock().await.push(messages.to_vec());
+
+            let has_compaction_note = messages.iter().any(|msg| {
+                msg.role == MessageRole::System
+                    && msg
+                        .content
+                        .contains("automatically compacted to fit within the context window")
+            });
+            let has_progress_message = messages
+                .iter()
+                .any(|msg| msg.role == MessageRole::Assistant && msg.content == "Still working");
+
+            if !has_compaction_note {
+                return Err(EngineError::TokenLimitExceeded {
+                    used: 150_000,
+                    limit: 128_000,
+                });
+            }
+
+            let text = if has_progress_message {
+                "FINAL(\"done\")"
+            } else {
+                "Still working"
+            };
+
+            Ok(crate::traits::llm::LlmOutput {
+                response: crate::types::step::LlmResponse::Text(text.into()),
+                usage: crate::types::step::TokenUsage::default(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_orchestrator_persists_compacted_messages_after_retry() {
+        let concrete = Arc::new(StatefulOverflowOrchestratorLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let (_tx, mut signal_rx) = crate::runtime::messaging::signal_channel(8);
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let persisted_state = serde_json::json!({
+            "working_messages": [
+                {"role": "System", "content": "You are helpful."},
+                {"role": "User", "content": "First question"},
+                {"role": "Assistant", "content": "First answer"},
+                {"role": "User", "content": "Second question"},
+                {"role": "Assistant", "content": "Second answer"},
+                {"role": "User", "content": "Current request"}
+            ]
+        });
+
+        let result = execute_orchestrator(
+            DEFAULT_ORCHESTRATOR,
+            &mut thread,
+            &llm,
+            &effects,
+            &leases,
+            &policy,
+            &mut signal_rx,
+            None,
+            None,
+            None,
+            &persisted_state,
+        )
+        .await
+        .expect("orchestrator should recover after context overflow");
+
+        match result.outcome {
+            ThreadOutcome::Completed { response } => {
+                assert_eq!(response.as_deref(), Some("Still working"));
+            }
+            other => panic!("expected completed outcome, got {other:?}"),
+        }
+
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 2, "expected overflow + retry");
+        assert!(
+            captured[1]
+                .iter()
+                .any(|msg| msg.content.contains("automatically compacted")),
+            "retry call should receive compacted messages"
+        );
+        assert!(
+            thread
+                .internal_messages
+                .iter()
+                .any(|msg| msg.content.contains("automatically compacted")),
+            "compacted transcript should be persisted back into orchestrator state"
+        );
+        assert!(
+            thread
+                .internal_messages
+                .iter()
+                .any(|msg| msg.content == "Still working"),
+            "post-retry assistant output should be appended onto the compacted transcript"
+        );
     }
 
     // ── Python ↔ Rust ActionCall round-trip ───────────────────────────────

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -652,8 +652,8 @@ async fn handle_llm_complete(
         Ok(output) => output,
         Err(EngineError::TokenLimitExceeded { used, limit }) => {
             let retry_messages = compact_thread_messages_for_retry(&messages);
-            let tokens_before = super::compaction::estimate_tokens(&messages);
-            let tokens_after = super::compaction::estimate_tokens(&retry_messages);
+            let tokens_before = estimate_retry_tokens(&messages);
+            let tokens_after = estimate_retry_tokens(&retry_messages);
             if !has_explicit_messages
                 || (retry_messages.len() >= messages.len() && tokens_after >= tokens_before)
             {
@@ -2406,6 +2406,21 @@ fn compact_thread_messages_for_retry(messages: &[ThreadMessage]) -> Vec<ThreadMe
     }
 
     compacted
+}
+
+/// Rough token estimate for retry-compaction decisions.
+///
+/// Mirrors `executor::compaction::estimate_tokens()` locally so the
+/// orchestrator retry path does not depend on that sibling module being
+/// available in every feature-gated build mode.
+fn estimate_retry_tokens(messages: &[ThreadMessage]) -> usize {
+    const CHARS_PER_TOKEN: usize = 4;
+
+    let total_chars: usize = messages
+        .iter()
+        .map(|m| m.content.len() + m.action_name.as_ref().map_or(0, |n| n.len()) + 4)
+        .sum();
+    total_chars.div_ceil(CHARS_PER_TOKEN)
 }
 
 /// Extract the last `n` characters from `s`.

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -652,8 +652,8 @@ async fn handle_llm_complete(
         Ok(output) => output,
         Err(EngineError::TokenLimitExceeded { used, limit }) => {
             let retry_messages = compact_thread_messages_for_retry(&messages);
-            let tokens_before = crate::executor::compaction::estimate_tokens(&messages);
-            let tokens_after = crate::executor::compaction::estimate_tokens(&retry_messages);
+            let tokens_before = super::compaction::estimate_tokens(&messages);
+            let tokens_after = super::compaction::estimate_tokens(&retry_messages);
             if !has_explicit_messages
                 || (retry_messages.len() >= messages.len() && tokens_after >= tokens_before)
             {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -1812,6 +1812,15 @@ fn handle_emit_event(
                 params_summary: None,
             }
         }
+        "message_added" => {
+            let role = extract_string_kwarg(kwargs, "role").unwrap_or_default();
+            let content_preview =
+                extract_string_kwarg(kwargs, "content_preview").unwrap_or_default();
+            EventKind::MessageAdded {
+                role,
+                content_preview,
+            }
+        }
         "skill_activated" => {
             let names_str = extract_string_kwarg(kwargs, "skill_names").unwrap_or_default();
             let skill_names: Vec<String> = names_str
@@ -3489,6 +3498,8 @@ mod tests {
 
     struct ContextOverflowRetryLlm {
         captured: tokio::sync::Mutex<Vec<Vec<ThreadMessage>>>,
+        overflow_used: u64,
+        overflow_limit: u64,
     }
 
     #[async_trait::async_trait]
@@ -3517,8 +3528,8 @@ mod tests {
                 })
             } else {
                 Err(EngineError::TokenLimitExceeded {
-                    used: 150_000,
-                    limit: 128_000,
+                    used: self.overflow_used,
+                    limit: self.overflow_limit,
                 })
             }
         }
@@ -3528,6 +3539,8 @@ mod tests {
     async fn llm_complete_retries_after_context_overflow_with_compacted_messages() {
         let concrete = Arc::new(ContextOverflowRetryLlm {
             captured: tokio::sync::Mutex::new(Vec::new()),
+            overflow_used: 150_000,
+            overflow_limit: 128_000,
         });
         let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
         let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
@@ -3616,6 +3629,8 @@ mod tests {
     async fn llm_complete_retries_after_context_overflow_when_using_thread_message_fallback() {
         let concrete = Arc::new(ContextOverflowRetryLlm {
             captured: tokio::sync::Mutex::new(Vec::new()),
+            overflow_used: 150_000,
+            overflow_limit: 128_000,
         });
         let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
         let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
@@ -3673,6 +3688,78 @@ mod tests {
                 .unwrap_or_default()
                 .contains(RETRY_COMPACTION_NOTE_SENTINEL)),
             "fallback retries should still compact the transcript"
+        );
+
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 2, "LLM should be retried exactly once");
+    }
+
+    #[tokio::test]
+    async fn llm_complete_retries_when_overflow_counts_are_unknown() {
+        let concrete = Arc::new(ContextOverflowRetryLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+            overflow_used: 0,
+            overflow_limit: 0,
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let messages = serde_json::json!([
+            {"role": "System", "content": "You are helpful."},
+            {"role": "User", "content": "First question"},
+            {"role": "Assistant", "content": "First answer"},
+            {"role": "User", "content": "Second question"},
+            {"role": "Assistant", "content": "Second answer"},
+            {"role": "User", "content": "Current request"}
+        ]);
+
+        let mut total_tokens = TokenUsage::default();
+        let result = handle_llm_complete(
+            &[
+                json_to_monty(&messages),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        let response = match result {
+            ExtFunctionResult::Return(obj) => monty_to_json(&obj),
+            other => panic!("expected successful retry result, got {other:?}"),
+        };
+
+        assert_eq!(response["type"], "text");
+        assert_eq!(response["content"], "FINAL(\"done\")");
+        assert!(
+            response["compacted_messages"]
+                .as_array()
+                .expect("compacted messages should be returned on retry")
+                .iter()
+                .any(|msg| msg["content"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .contains(RETRY_COMPACTION_NOTE_SENTINEL)),
+            "retry should still run when the provider cannot report used/limit counts"
         );
 
         let captured = concrete.captured.lock().await;
@@ -3950,6 +4037,16 @@ mod tests {
                 .iter()
                 .any(|msg| msg.content == "Still working"),
             "post-retry assistant output should be appended onto the compacted transcript"
+        );
+        assert!(
+            thread.events.iter().any(|event| matches!(
+                &event.kind,
+                EventKind::MessageAdded { role, content_preview }
+                    if role == "System"
+                        && content_preview
+                            .contains("overflow retry compacted working_messages")
+            )),
+            "retry compaction should be observable in the thread event log"
         );
     }
 

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -107,6 +107,10 @@ fn orchestrator_limits() -> ResourceLimits {
 /// Maximum consecutive failures before auto-rollback.
 const MAX_FAILURES_BEFORE_ROLLBACK: u64 = 3;
 
+/// Shared sentinel text for orchestrator retry-compaction notes.
+const RETRY_COMPACTION_NOTE_SENTINEL: &str =
+    "automatically compacted to fit within the context window";
+
 /// Well-known title for orchestrator failure tracking.
 const FAILURE_TRACKER_TITLE: &str = "orchestrator:failures";
 const LEASE_REFRESH_WARN_INTERVAL_SECS: u64 = 60;
@@ -654,9 +658,19 @@ async fn handle_llm_complete(
             let retry_messages = compact_thread_messages_for_retry(&messages);
             let tokens_before = estimate_retry_tokens(&messages);
             let tokens_after = estimate_retry_tokens(&retry_messages);
-            if !has_explicit_messages
-                || (retry_messages.len() >= messages.len() && tokens_after >= tokens_before)
-            {
+            let reduced_payload =
+                retry_messages.len() < messages.len() || tokens_after < tokens_before;
+            if !reduced_payload {
+                debug!(
+                    used,
+                    limit,
+                    tokens_before,
+                    tokens_after,
+                    messages_before = messages.len(),
+                    messages_after = retry_messages.len(),
+                    has_explicit_messages,
+                    "overflow retry skipped: compaction did not reduce the transcript"
+                );
                 return ExtFunctionResult::Error(monty::MontyException::new(
                     monty::ExcType::RuntimeError,
                     Some(format!(
@@ -666,13 +680,14 @@ async fn handle_llm_complete(
                 ));
             }
 
-            tracing::warn!(
+            debug!(
                 used,
                 limit,
                 tokens_before,
                 tokens_after,
                 messages_before = messages.len(),
                 messages_after = retry_messages.len(),
+                has_explicit_messages,
                 "orchestrator llm call exceeded context window, compacting and retrying"
             );
 
@@ -685,7 +700,7 @@ async fn handle_llm_complete(
                     return ExtFunctionResult::Error(monty::MontyException::new(
                         monty::ExcType::RuntimeError,
                         Some(format!(
-                            "LLM call failed after compaction retry: {retry_err}"
+                            "LLM call failed after compaction retry: original overflow used={used} limit={limit}; retry failed: {retry_err}"
                         )),
                     ));
                 }
@@ -2364,28 +2379,30 @@ fn thread_messages_to_python_json(messages: &[ThreadMessage]) -> Vec<serde_json:
 
 /// Compact thread messages for a single retry after a context-overflow error.
 ///
-/// Keeps all `System` messages that appeared before the last `User` message,
-/// inserts a short note, then preserves the last `User` message and everything
-/// after it (the current turn's assistant/action-result context).
+/// Keeps all `System` messages that appeared before the preserved suffix,
+/// inserts a short note, then preserves the most recent retry-worthy slice of
+/// the current turn. When the latest `User` message was injected mid tool
+/// sequence, the preserved slice expands backwards to keep the preceding
+/// `Assistant(action_calls)` and `ActionResult` messages so no surviving
+/// `action_call_id` references are orphaned on retry.
 fn compact_thread_messages_for_retry(messages: &[ThreadMessage]) -> Vec<ThreadMessage> {
     let mut compacted = Vec::new();
     let last_user_idx = messages.iter().rposition(|m| m.role == MessageRole::User);
 
     if let Some(idx) = last_user_idx {
-        for msg in &messages[..idx] {
+        let preserved_start = retry_preserved_start(messages, idx);
+
+        for msg in messages.iter().take(preserved_start) {
             if msg.role == MessageRole::System {
                 compacted.push(msg.clone());
             }
         }
 
-        if idx > 0 {
-            compacted.push(ThreadMessage::system(
-                "[Note: Earlier conversation history was automatically compacted \
-                 to fit within the context window. The most recent exchange is preserved below.]",
-            ));
+        if preserved_start > 0 {
+            compacted.push(ThreadMessage::system(retry_compaction_note(true)));
         }
 
-        compacted.extend_from_slice(&messages[idx..]);
+        compacted.extend_from_slice(&messages[preserved_start..]);
     } else {
         for msg in messages {
             if msg.role == MessageRole::System {
@@ -2393,10 +2410,7 @@ fn compact_thread_messages_for_retry(messages: &[ThreadMessage]) -> Vec<ThreadMe
             }
         }
         if compacted.len() < messages.len() {
-            compacted.push(ThreadMessage::system(
-                "[Note: Earlier conversation history was automatically compacted \
-                 to fit within the context window.]",
-            ));
+            compacted.push(ThreadMessage::system(retry_compaction_note(false)));
         }
         for msg in messages {
             if msg.role != MessageRole::System {
@@ -2406,6 +2420,29 @@ fn compact_thread_messages_for_retry(messages: &[ThreadMessage]) -> Vec<ThreadMe
     }
 
     compacted
+}
+
+fn retry_preserved_start(messages: &[ThreadMessage], last_user_idx: usize) -> usize {
+    let mut start = last_user_idx;
+    while start > 0
+        && matches!(
+            messages[start - 1].role,
+            MessageRole::Assistant | MessageRole::ActionResult
+        )
+    {
+        start -= 1;
+    }
+    start
+}
+
+fn retry_compaction_note(include_recent_exchange: bool) -> String {
+    if include_recent_exchange {
+        format!(
+            "[Note: Earlier conversation history was {RETRY_COMPACTION_NOTE_SENTINEL}. The most recent exchange is preserved below.]"
+        )
+    } else {
+        format!("[Note: Earlier conversation history was {RETRY_COMPACTION_NOTE_SENTINEL}.]")
+    }
 }
 
 /// Rough token estimate for retry-compaction decisions.
@@ -2418,7 +2455,9 @@ fn estimate_retry_tokens(messages: &[ThreadMessage]) -> usize {
 
     let total_chars: usize = messages
         .iter()
-        .map(|m| m.content.len() + m.action_name.as_ref().map_or(0, |n| n.len()) + 4)
+        .map(|m| {
+            m.content.chars().count() + m.action_name.as_ref().map_or(0, |n| n.chars().count()) + 4
+        })
         .sum();
     total_chars.div_ceil(CHARS_PER_TOKEN)
 }
@@ -3468,9 +3507,7 @@ mod tests {
 
             let compacted = messages.iter().any(|msg| {
                 msg.role == MessageRole::System
-                    && msg
-                        .content
-                        .contains("automatically compacted to fit within the context window")
+                    && msg.content.contains(RETRY_COMPACTION_NOTE_SENTINEL)
             });
 
             if compacted {
@@ -3553,7 +3590,7 @@ mod tests {
             compacted.iter().any(|msg| msg["content"]
                 .as_str()
                 .unwrap_or_default()
-                .contains("automatically compacted to fit within the context window")),
+                .contains(RETRY_COMPACTION_NOTE_SENTINEL)),
             "compaction note should be preserved for the retry"
         );
         assert_eq!(
@@ -3570,9 +3607,226 @@ mod tests {
         assert!(
             captured[1]
                 .iter()
-                .any(|msg| msg.content.contains("automatically compacted")),
+                .any(|msg| msg.content.contains(RETRY_COMPACTION_NOTE_SENTINEL)),
             "second call should receive the compacted retry transcript"
         );
+    }
+
+    #[tokio::test]
+    async fn llm_complete_retries_after_context_overflow_when_using_thread_message_fallback() {
+        let concrete = Arc::new(ContextOverflowRetryLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let llm: Arc<dyn LlmBackend> = Arc::clone(&concrete) as Arc<dyn LlmBackend>;
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+        thread.messages = vec![
+            ThreadMessage::system("You are helpful."),
+            ThreadMessage::user("First question"),
+            ThreadMessage::assistant("First answer"),
+            ThreadMessage::user("Second question"),
+            ThreadMessage::assistant("Second answer"),
+            ThreadMessage::user("Current request"),
+        ];
+
+        let mut total_tokens = TokenUsage::default();
+        let result = handle_llm_complete(
+            &[
+                json_to_monty(&serde_json::Value::Null),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        let response = match result {
+            ExtFunctionResult::Return(obj) => monty_to_json(&obj),
+            other => panic!("expected successful retry result, got {other:?}"),
+        };
+
+        assert_eq!(response["type"], "text");
+        let compacted = response["compacted_messages"]
+            .as_array()
+            .expect("compacted messages should be surfaced even on fallback retries");
+        assert!(
+            compacted.iter().any(|msg| msg["content"]
+                .as_str()
+                .unwrap_or_default()
+                .contains(RETRY_COMPACTION_NOTE_SENTINEL)),
+            "fallback retries should still compact the transcript"
+        );
+
+        let captured = concrete.captured.lock().await;
+        assert_eq!(captured.len(), 2, "LLM should be retried exactly once");
+    }
+
+    #[test]
+    fn compact_thread_messages_for_retry_keeps_inflight_tool_sequence_before_nested_user() {
+        let messages = vec![
+            ThreadMessage::system("You are helpful."),
+            ThreadMessage::user("Do the task"),
+            ThreadMessage::assistant_with_actions(
+                Some("Calling tools".to_string()),
+                vec![
+                    ActionCall {
+                        id: "call_a".to_string(),
+                        action_name: "tool_a".to_string(),
+                        parameters: serde_json::json!({"q": "one"}),
+                    },
+                    ActionCall {
+                        id: "call_b".to_string(),
+                        action_name: "tool_b".to_string(),
+                        parameters: serde_json::json!({"q": "two"}),
+                    },
+                ],
+            ),
+            ThreadMessage::action_result("call_a", "tool_a", "done a"),
+            ThreadMessage::user("Also include this detail"),
+            ThreadMessage::action_result("call_b", "tool_b", "done b"),
+            ThreadMessage::assistant("Finished"),
+        ];
+
+        let compacted = compact_thread_messages_for_retry(&messages);
+
+        let assistant_call_ids: std::collections::HashSet<String> = compacted
+            .iter()
+            .filter_map(|msg| msg.action_calls.as_ref())
+            .flatten()
+            .map(|call| call.id.clone())
+            .collect();
+        let result_call_ids: std::collections::HashSet<String> = compacted
+            .iter()
+            .filter(|msg| msg.role == MessageRole::ActionResult)
+            .filter_map(|msg| msg.action_call_id.clone())
+            .collect();
+
+        assert!(
+            assistant_call_ids.contains("call_b"),
+            "compaction should keep the assistant tool-call context for preserved action results"
+        );
+        assert!(
+            result_call_ids.is_subset(&assistant_call_ids),
+            "preserved action results should not be orphaned after compaction"
+        );
+        assert!(
+            compacted
+                .iter()
+                .any(|msg| msg.role == MessageRole::User
+                    && msg.content == "Also include this detail"),
+            "the nested user message should still be preserved"
+        );
+    }
+
+    #[test]
+    fn estimate_retry_tokens_counts_unicode_chars_not_utf8_bytes() {
+        let messages = vec![ThreadMessage::user("éééé")];
+        assert_eq!(estimate_retry_tokens(&messages), 2);
+    }
+
+    struct OverflowThenOtherErrorLlm {
+        calls: tokio::sync::Mutex<u32>,
+    }
+
+    #[async_trait::async_trait]
+    impl LlmBackend for OverflowThenOtherErrorLlm {
+        fn model_name(&self) -> &str {
+            "overflow-then-other-error"
+        }
+
+        async fn complete(
+            &self,
+            _messages: &[ThreadMessage],
+            _actions: &[crate::types::capability::ActionDef],
+            _config: &LlmCallConfig,
+        ) -> Result<crate::traits::llm::LlmOutput, EngineError> {
+            let mut calls = self.calls.lock().await;
+            *calls += 1;
+            if *calls == 1 {
+                Err(EngineError::TokenLimitExceeded {
+                    used: 150_000,
+                    limit: 128_000,
+                })
+            } else {
+                Err(EngineError::Llm {
+                    reason: "retry exploded".to_string(),
+                })
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn llm_complete_retry_failure_includes_original_overflow_context() {
+        let llm: Arc<dyn LlmBackend> = Arc::new(OverflowThenOtherErrorLlm {
+            calls: tokio::sync::Mutex::new(0),
+        });
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let store: Arc<dyn Store> = Arc::new(crate::tests::InMemoryStore::with_docs(vec![]));
+
+        let mut thread = Thread::new(
+            "goal",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let messages = serde_json::json!([
+            {"role": "System", "content": "You are helpful."},
+            {"role": "User", "content": "First question"},
+            {"role": "Assistant", "content": "First answer"},
+            {"role": "User", "content": "Second question"},
+            {"role": "Assistant", "content": "Second answer"},
+            {"role": "User", "content": "Current request"}
+        ]);
+
+        let mut total_tokens = TokenUsage::default();
+        let result = handle_llm_complete(
+            &[
+                json_to_monty(&messages),
+                json_to_monty(&serde_json::json!([])),
+                json_to_monty(&serde_json::json!({})),
+            ],
+            &[],
+            &mut thread,
+            LlmCompleteDeps {
+                llm: &llm,
+                effects: &effects,
+                leases: &leases,
+                store: Some(&store),
+            },
+            &mut total_tokens,
+        )
+        .await;
+
+        let error_message = match result {
+            ExtFunctionResult::Error(err) => err.message().unwrap_or_default().to_string(),
+            other => panic!("expected retry failure, got {other:?}"),
+        };
+
+        assert!(error_message.contains("used=150000"));
+        assert!(error_message.contains("limit=128000"));
+        assert!(error_message.contains("retry exploded"));
     }
 
     struct StatefulOverflowOrchestratorLlm {
@@ -3595,9 +3849,7 @@ mod tests {
 
             let has_compaction_note = messages.iter().any(|msg| {
                 msg.role == MessageRole::System
-                    && msg
-                        .content
-                        .contains("automatically compacted to fit within the context window")
+                    && msg.content.contains(RETRY_COMPACTION_NOTE_SENTINEL)
             });
             let has_progress_message = messages
                 .iter()

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -39,6 +39,20 @@ impl LlmBridgeAdapter {
     }
 }
 
+fn map_provider_error(error: crate::error::LlmError) -> EngineError {
+    match error {
+        crate::error::LlmError::ContextLengthExceeded { used, limit } => {
+            EngineError::TokenLimitExceeded {
+                used: used as u64,
+                limit: limit as u64,
+            }
+        }
+        other => EngineError::Llm {
+            reason: other.to_string(),
+        },
+    }
+}
+
 #[async_trait::async_trait]
 impl LlmBackend for LlmBridgeAdapter {
     async fn complete(
@@ -77,9 +91,7 @@ impl LlmBackend for LlmBridgeAdapter {
             let response = provider
                 .complete(request)
                 .await
-                .map_err(|e| EngineError::Llm {
-                    reason: e.to_string(),
-                })?;
+                .map_err(map_provider_error)?;
 
             // Check for code blocks in the response (CodeAct/RLM pattern)
             let llm_response = match extract_code_block(&response.content) {
@@ -113,13 +125,10 @@ impl LlmBackend for LlmBridgeAdapter {
         }
 
         // Call provider
-        let response =
-            provider
-                .complete_with_tools(request)
-                .await
-                .map_err(|e| EngineError::Llm {
-                    reason: e.to_string(),
-                })?;
+        let response = provider
+            .complete_with_tools(request)
+            .await
+            .map_err(map_provider_error)?;
 
         // Convert response — check for code blocks (CodeAct/RLM pattern)
         let llm_response = if !response.tool_calls.is_empty() {
@@ -1138,6 +1147,85 @@ And also check the token price:\n\
 
     /// Mock LLM provider that returns tool calls with template refs in
     /// their parameters, simulating Qwen-style parallel call behavior.
+    struct ContextOverflowProvider;
+
+    #[async_trait]
+    impl LlmProvider for ContextOverflowProvider {
+        fn model_name(&self) -> &str {
+            "context-overflow-mock"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: crate::llm::CompletionRequest,
+        ) -> Result<crate::llm::CompletionResponse, LlmError> {
+            Err(LlmError::ContextLengthExceeded {
+                used: 150_000,
+                limit: 128_000,
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            Err(LlmError::ContextLengthExceeded {
+                used: 150_000,
+                limit: 128_000,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_maps_context_overflow_to_engine_token_limit() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(ContextOverflowProvider);
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let err = adapter
+            .complete(
+                &[ThreadMessage::user("this overflows")],
+                &[],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .expect_err("context overflow should propagate as engine token limit");
+
+        assert!(matches!(
+            err,
+            EngineError::TokenLimitExceeded {
+                used: 150_000,
+                limit: 128_000
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_maps_context_overflow_to_engine_token_limit() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(ContextOverflowProvider);
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let err = adapter
+            .complete(
+                &[ThreadMessage::user("this overflows")],
+                &[test_action("search")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .expect_err("context overflow should propagate as engine token limit");
+
+        assert!(matches!(
+            err,
+            EngineError::TokenLimitExceeded {
+                used: 150_000,
+                limit: 128_000
+            }
+        ));
+    }
+
     struct TemplateRefProvider;
 
     #[async_trait]

--- a/src/llm/error.rs
+++ b/src/llm/error.rs
@@ -20,6 +20,8 @@ pub enum LlmError {
     #[error("Empty response from {provider}: no content returned")]
     EmptyResponse { provider: String },
 
+    // Providers surface this either natively or via provider-specific
+    // substring classification in `rig_adapter.rs` / `nearai_chat.rs`.
     #[error("Context length exceeded: {used} tokens used, {limit} allowed")]
     ContextLengthExceeded { used: usize, limit: usize },
 

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -308,8 +308,12 @@ impl NearAiChatProvider {
                 return Err(LlmError::ContextLengthExceeded { used, limit });
             }
 
-            // Some providers return 400 with "context_length_exceeded" in the body
-            // (e.g., OpenAI-compatible endpoints behind NEAR AI).
+            // Some providers return 400 with context-overflow text in the body
+            // (e.g., OpenAI-compatible endpoints behind NEAR AI). Some OpenAI-
+            // compatible backends also compute a negative remaining output budget
+            // when the prompt already exceeds the context window, surfacing that as
+            // "max_tokens must be at least 1, got -123" instead of the more common
+            // "context_length_exceeded" wording.
             if status_code == 400 {
                 let lower = response_text.to_ascii_lowercase();
                 const CONTEXT_PATTERNS: &[&str] = &[
@@ -317,6 +321,7 @@ impl NearAiChatProvider {
                     "maximum context length",
                     "too many tokens",
                     "payload too large",
+                    "max_tokens must be at least 1, got -",
                 ];
                 if CONTEXT_PATTERNS.iter().any(|p| lower.contains(p)) {
                     let (used, limit) = crate::llm::rig_adapter::parse_token_counts(&lower);
@@ -1167,6 +1172,11 @@ fn parse_usage(usage: Option<&ChatCompletionUsage>) -> (u32, u32) {
 mod tests {
     use super::*;
     use crate::llm::session::SessionConfig;
+    use axum::{
+        Router,
+        http::StatusCode,
+        routing::{get, post},
+    };
     use rust_decimal_macros::dec;
 
     fn test_nearai_config(base_url: &str) -> NearAiConfig {
@@ -1190,6 +1200,37 @@ mod tests {
 
     fn test_session() -> Arc<SessionManager> {
         Arc::new(SessionManager::new(SessionConfig::default()))
+    }
+
+    async fn spawn_nearai_test_server(
+        chat_status: StatusCode,
+        chat_body: &'static str,
+    ) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route(
+                "/v1/chat/completions",
+                post({
+                    let body = chat_body.to_string();
+                    move || {
+                        let body = body.clone();
+                        async move { (chat_status, body) }
+                    }
+                }),
+            )
+            .route(
+                "/v1/model/list",
+                get(|| async { (StatusCode::NOT_FOUND, "") }),
+            );
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("test server addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve test app");
+        });
+
+        (format!("http://{}", addr), handle)
     }
 
     #[test]
@@ -1903,6 +1944,29 @@ mod tests {
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
         }
+    }
+
+    #[tokio::test]
+    async fn test_send_request_maps_negative_max_tokens_400_to_context_length_exceeded() {
+        let (base_url, server) = spawn_nearai_test_server(
+            StatusCode::BAD_REQUEST,
+            r#"{"error":{"message":"max_tokens must be at least 1, got -139081"}}"#,
+        )
+        .await;
+        let provider = NearAiChatProvider::new(test_nearai_config(&base_url), test_session())
+            .expect("provider");
+
+        let err = provider
+            .send_request::<_, serde_json::Value>(&serde_json::json!({"ping": true}))
+            .await
+            .expect_err("negative max_tokens overflow should map to context-length error");
+
+        server.abort();
+
+        assert!(matches!(
+            err,
+            LlmError::ContextLengthExceeded { used: 0, limit: 0 }
+        ));
     }
 
     #[test]

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -313,7 +313,10 @@ impl NearAiChatProvider {
             // compatible backends also compute a negative remaining output budget
             // when the prompt already exceeds the context window, surfacing that as
             // "max_tokens must be at least 1, got -123" instead of the more common
-            // "context_length_exceeded" wording.
+            // "context_length_exceeded" wording. Keep this match intentionally
+            // narrow so unrelated 400s do not trigger overflow recovery; if token
+            // counts are absent, downstream retry heuristics still key off the
+            // structured `ContextLengthExceeded` signal rather than these numbers.
             if status_code == 400 {
                 let lower = response_text.to_ascii_lowercase();
                 const CONTEXT_PATTERNS: &[&str] = &[


### PR DESCRIPTION
## Summary
- classify NEAR AI / OpenAI-compatible negative `max_tokens` 400s as `ContextLengthExceeded` with intentionally narrow matching
- preserve structured overflow handling across the bridge and engine/orchestrator retry + compaction paths, including the `(0, 0)` token-count fallback case
- emit an orchestrator trace event when overflow retry compaction rewrites `working_messages`, with regression coverage for retry/state persistence behavior

## Testing
- `cargo fmt --all`
- `cargo clippy --all --benches --tests --examples --all-features`
- `cargo test -p ironclaw_engine llm_complete_retries_when_overflow_counts_are_unknown`
- `cargo test -p ironclaw_engine execute_orchestrator_persists_compacted_messages_after_retry`
- `cargo test -p ironclaw test_send_request_maps_negative_max_tokens_400_to_context_length_exceeded`
- `cargo test --lib` *(still fails locally on the pre-existing unrelated `pairing::approval::tests::propagate_approval_restores_runtime_state_when_on_start_fails` fixture issue)*
- `bash scripts/pre-commit-safety.sh`
