### PR TITLE
build(cargo): slim default local feature profile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,9 +7,10 @@
 ```bash
 cargo fmt                                                    # format
 cargo clippy --all --benches --tests --examples --all-features  # lint (zero warnings)
-cargo test                                                   # unit tests
-cargo test --features integration                            # + PostgreSQL tests
-RUST_LOG=ironclaw=debug cargo run                            # run with logging
+cargo test                                                   # default libsql-backed test suite
+cargo test --features postgres,integration                   # PostgreSQL-backed integration tests
+RUST_LOG=ironclaw=debug cargo run                            # run with logging (default local profile)
+RUST_LOG=ironclaw=debug cargo run --features local-tui       # local profile + TUI
 ```
 
 E2E tests: see `tests/e2e/CLAUDE.md`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -229,7 +229,14 @@ tempfile = "3"
 insta = { version = "1.46.3", features = ["yaml"] }
 
 [features]
-default = ["postgres", "libsql", "html-to-markdown", "tui"]
+# Minimal local-dev profile: channels + web UI + Monty + libSQL.
+local = ["libsql"]
+# `cargo build` / `cargo run` default to the local-dev profile.
+default = ["local"]
+# Local-dev profile with the optional terminal UI enabled.
+local-tui = ["local", "tui"]
+# Full feature set used for release-style builds and broad manual testing.
+full = ["local-tui", "postgres", "html-to-markdown"]
 postgres = [
     "dep:deadpool-postgres",
     "dep:tokio-postgres",
@@ -305,6 +312,10 @@ install-path = "CARGO_HOME"
 install-updater = true
 # Cache intermediate build artifacts to speed up the release pipelines
 cache-builds = true
+# Release/distribution artifacts should continue to include the full feature set
+# even though local development defaults are intentionally slimmed down.
+default-features = false
+features = ["full"]
 
 [workspace.metadata.dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ COPY wit/ wit/
 COPY providers.json providers.json
 COPY profiles/ profiles/
 
-RUN cargo build --profile dist --bin ironclaw
+RUN cargo build --profile dist --bin ironclaw --no-default-features --features full
 
 # Stage 4b: Build all WASM extensions from source (only used by runtime-staging)
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ENV CARGO_PROFILE_DIST_PANIC=abort \
     CARGO_PROFILE_DIST_CODEGEN_UNITS=1
 
 COPY --from=planner /app/recipe.json recipe.json
-RUN cargo chef cook --profile dist --recipe-path recipe.json
+RUN cargo chef cook --profile dist --recipe-path recipe.json --no-default-features --features full
 
 # Stage 4: Build the actual binary (only recompiles ironclaw source)
 FROM deps AS builder

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -14,8 +14,8 @@ FROM rust:1.92-bookworm AS builder
 WORKDIR /build
 COPY . .
 
-# Build only the ironclaw binary (release mode)
-RUN cargo build --release --bin ironclaw
+# Build the ironclaw binary with the full release feature set.
+RUN cargo build --release --bin ironclaw --no-default-features --features full
 
 # ---
 

--- a/README.md
+++ b/README.md
@@ -135,8 +135,11 @@ Install it with `cargo`, just make sure you have [Rust](https://rustup.rs) insta
 git clone https://github.com/nearai/ironclaw.git
 cd ironclaw
 
-# Build
-cargo build --release
+# Build the default local profile (channels + web UI + Monty + libsql)
+cargo build
+
+# Build the full release profile
+cargo build --release --no-default-features --features full
 
 # Run tests
 cargo test
@@ -290,8 +293,11 @@ External content passes through multiple security layers:
 # First-time setup (configures database, auth, etc.)
 ironclaw onboard
 
-# Start interactive REPL
+# Start interactive REPL (default local profile)
 cargo run
+
+# Start interactive REPL with the optional TUI enabled
+cargo run --features local-tui
 
 # With debug logging
 RUST_LOG=ironclaw=debug cargo run
@@ -306,9 +312,11 @@ cargo fmt
 # Lint
 cargo clippy --all --benches --tests --examples --all-features
 
-# Run tests
-createdb ironclaw_test
+# Run tests (default suite uses libsql temp DB)
 cargo test
+
+# Run PostgreSQL-backed integration tests when needed
+cargo test --features postgres,integration
 
 # Run specific test
 cargo test test_name
@@ -316,6 +324,7 @@ cargo test test_name
 
 - **Channels**: See [docs/channels/overview.mdx](docs/channels/overview.mdx) for setup of Telegram, Discord, and other channels.
 - **Changing channel sources**: Run `./channels-src/telegram/build.sh` before `cargo build` so the updated WASM is bundled.
+- **Feature profiles**: `cargo run` uses the slim local profile by default; use `--features local-tui` for the TUI or `--no-default-features --features full` for release-style builds.
 
 ## OpenClaw Heritage
 

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -14,8 +14,8 @@ if [ -d "channels-src/telegram" ]; then
 fi
 
 echo ""
-echo "Building IronClaw..."
-cargo build --release
+echo "Building IronClaw (full feature set)..."
+cargo build --release --no-default-features --features full
 
 echo ""
 echo "Done. Binary: target/release/ironclaw"

--- a/scripts/dev-setup.sh
+++ b/scripts/dev-setup.sh
@@ -8,9 +8,10 @@
 #   ./scripts/dev-setup.sh
 #
 # After running, you can:
-#   cargo check           # default features (postgres + libsql)
-#   cargo test            # default test suite (uses libsql temp DB)
-#   cargo test --all-features         # full test suite
+#   cargo check                              # default local profile (libsql)
+#   cargo test                               # default test suite (uses libsql temp DB)
+#   cargo test --all-features                # full test suite
+#   cargo run --features local-tui           # local profile + TUI
 
 set -euo pipefail
 
@@ -67,7 +68,8 @@ echo ""
 echo "=== Setup complete ==="
 echo ""
 echo "Quick start:"
-echo "  cargo run                            # Run with default features"
+echo "  cargo run                            # Run with the default local profile (libsql)"
+echo "  cargo run --features local-tui       # Add the optional TUI"
 echo "  cargo test                           # Test suite (libsql temp DB)"
 echo "  cargo test --all-features            # Full test suite"
 echo "  cargo clippy --all-features          # Lint all code"


### PR DESCRIPTION
## Summary

This PR shrinks IronClaw's default Cargo feature set to match the common local development workflow.

### New default
`cargo build` / `cargo run` now use:

- channels
- web UI
- Monty / engine-v2 core
- libsql

TUI is now opt-in via `--features local-tui`.

### New feature profiles

- `local = ["libsql"]`
- `default = ["local"]`
- `local-tui = ["local", "tui"]`
- `full = ["local-tui", "postgres", "html-to-markdown"]`

Release/distribution builds continue to use the full feature set via explicit config:
- `workspace.metadata.dist.default-features = false`
- `workspace.metadata.dist.features = ["full"]`

Dockerfiles and release build scripts were also updated to build with `--no-default-features --features full`.

---

## Why

The old default feature set pulled in:

- `postgres`
- `libsql`
- `html-to-markdown`
- `tui`

That was broader than what most local contributors need day-to-day.

The intended local default is:

- channels
- web UI
- Monty
- libsql

with TUI as an add-on, not part of the baseline compile path.

---

## Measured compile-time impact

Benchmarks were run with:
- isolated `CARGO_TARGET_DIR`
- `CARGO_INCREMENTAL=0`
- clean builds/checks

### Dependency graph size
- old default: **906** unique packages
- new default (`libsql`): **762** unique packages
- new default + TUI (`libsql,tui`): **819** unique packages

### Clean `cargo check`
- old default: **149.9s**
- new default (`libsql`): **100.0s**
- new default + TUI: **116.7s**

### Clean debug `cargo build`
- old default: **213.8s**
- new default (`libsql`): **178.3s**
- new default + TUI: **182.6s**

### Net win
Default local profile improvements:
- `cargo check`: **~33% faster** (`149.9s -> 100.0s`)
- `cargo build`: **~17% faster** (`213.8s -> 178.3s`)

---

## Scope note

This is intentionally only **Phase 1**.

It does **not** yet feature-gate always-compiled heavyweight subsystems like:
- Docker / `bollard`
- document extraction / `pdf-extract`
- Wasmtime / WASI

So there is still more compile-time headroom after this change.

---

## Docs / scripts updated

- `README.md`
- `CLAUDE.md`
- `scripts/dev-setup.sh`
- `scripts/build-all.sh`
- `Dockerfile`
- `Dockerfile.worker`

These now reflect:
- slim local default
- optional TUI
- explicit `full` release builds

---

## Validation

Ran:
- `cargo check --quiet`
- `cargo check --quiet --no-default-features --features full`
