### PR TITLE
fix(gateway): address PR #2622 review feedback (follow-up)

### DIFF
--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1051,6 +1051,20 @@ async fn fail_waiting_thread(
     Ok(true)
 }
 
+/// Build the user-facing "<message>. Resuming..." status text for the
+/// auth-completed Ready arm.
+///
+/// `result.message` from `ExtensionManager::configure_token` already ends
+/// with a period (e.g. `"Configuration saved for 'telegram'."`), so a
+/// naive `format!("{}. Resuming...", msg)` produces `"...telegram'.. Resuming..."`
+/// — double period. Strip trailing periods and whitespace from the raw
+/// message before formatting. Other punctuation is intentionally left
+/// alone (no real-world backend message ends in `!`/`?`/etc.).
+fn format_auth_completed_resuming(raw: &str) -> String {
+    let trimmed = raw.trim_end_matches(|c: char| c == '.' || c.is_whitespace());
+    format!("{}. Resuming...", trimmed)
+}
+
 /// Outcome of `submit_pending_auth_credential` — distinguishes "a backend
 /// stored the credential" from "no backend is configured to store it." The
 /// caller maps the latter to either thread-fail (prod) or silent continue
@@ -2335,14 +2349,6 @@ pub async fn resolve_gate(
                             crate::channels::web::onboarding::ConfigureFlowOutcome::Ready
                         ) =>
                     {
-                        // `result.message` may already end with a period
-                        // (e.g. `ExtensionManager::configure_token` returns
-                        // "Configuration saved for 'telegram'."), so strip
-                        // trailing punctuation + whitespace before
-                        // concatenation to avoid "...foo.. Resuming...".
-                        let trimmed = result
-                            .message
-                            .trim_end_matches(|c: char| c == '.' || c.is_whitespace());
                         let _ = agent
                             .channels
                             .send_status(
@@ -2350,7 +2356,7 @@ pub async fn resolve_gate(
                                 StatusUpdate::AuthCompleted {
                                     extension_name: display_name.clone(),
                                     success: true,
-                                    message: format!("{}. Resuming...", trimmed),
+                                    message: format_auth_completed_resuming(&result.message),
                                 },
                                 &message.metadata,
                             )
@@ -7379,6 +7385,34 @@ mod tests {
         assert!(
             matches!(err, crate::extensions::ExtensionError::ValidationFailed(_)),
             "expected ValidationFailed, got: {err:?}"
+        );
+    }
+
+    /// `format_auth_completed_resuming` strips trailing periods and
+    /// whitespace from the upstream backend message before appending
+    /// ". Resuming...". Regression coverage for the double-period bug
+    /// flagged on PR #2622 — `ExtensionManager::configure_token` returns
+    /// "Configuration saved for 'X'." which used to render as
+    /// "...'X'.. Resuming...".
+    #[test]
+    fn format_auth_completed_resuming_strips_trailing_period() {
+        // The motivating case: extension-manager backend message.
+        assert_eq!(
+            format_auth_completed_resuming("Configuration saved for 'telegram'."),
+            "Configuration saved for 'telegram'. Resuming..."
+        );
+        // Multiple trailing periods + whitespace collapse cleanly.
+        assert_eq!(
+            format_auth_completed_resuming("done...  \n"),
+            "done. Resuming..."
+        );
+        // A message with no trailing punctuation gets exactly one period.
+        assert_eq!(format_auth_completed_resuming("ok"), "ok. Resuming...");
+        // Non-period punctuation is intentionally left intact (no backend
+        // currently produces these, but the spec is "trim periods only").
+        assert_eq!(
+            format_auth_completed_resuming("ready!"),
+            "ready!. Resuming..."
         );
     }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1042,12 +1042,12 @@ async fn fail_waiting_thread(
 
     thread
         .transition_to(ironclaw_engine::ThreadState::Failed, Some(reason.into()))
-        .map_err(|e| engine_err("reconcile waiting thread", e))?;
+        .map_err(|e| engine_err("fail waiting thread", e))?;
     state
         .store
         .save_thread(&thread)
         .await
-        .map_err(|e| engine_err("save reconciled thread", e))?;
+        .map_err(|e| engine_err("save failed thread", e))?;
     Ok(true)
 }
 
@@ -1064,17 +1064,50 @@ enum PendingAuthCredentialSubmission {
 /// Try to persist a user-supplied auth credential, falling back across the
 /// three backends in priority order:
 ///
-/// 1. `AuthManager::submit_auth_token` — the canonical path (runs the
-///    extension's `configure_token`, validates, and emits a
+/// 1. `AuthManager::submit_auth_token(submit_target, ...)` — the canonical
+///    path (runs the extension's `configure_token`, validates, and emits a
 ///    `ConfigureResult`). Requires a secrets-backed auth manager.
-/// 2. `ExtensionManager::configure_token` — used on hosted instances that
-///    run without `SECRETS_MASTER_KEY`, so no persistent auth manager
-///    exists but the extension manager's in-memory secrets store can still
-///    accept the credential. `NotInstalled` / `NotFound` fall through so
-///    non-extension credentials (plain secrets) are stored in step 3.
-/// 3. Plain `SecretsStore::create` — stores the credential verbatim for
-///    non-extension actions (HTTP tool, skill credentials) when no
-///    extension owns the action.
+/// 2. `ExtensionManager::configure_token(submit_target, ...)` — used on
+///    hosted instances that run without `SECRETS_MASTER_KEY`, so no
+///    persistent auth manager exists but the extension manager's in-memory
+///    secrets store can still accept the credential. `NotInstalled` /
+///    `NotFound` fall through so non-extension credentials (plain secrets)
+///    are stored in step 3.
+/// 3. Plain `SecretsStore::create(credential_name, ...)` — stores the
+///    credential verbatim for non-extension actions (HTTP tool, skill
+///    credentials) when no extension owns the action.
+///
+/// # Why two keys (`submit_target` + `credential_name`)
+///
+/// Steps 1–2 take the **extension** identity (`submit_target`, e.g.
+/// `"telegram"`). They resolve the actual secret key by walking the
+/// extension's capabilities file — that's the whole point of routing
+/// through `configure_token`, which validates the extension is installed
+/// and picks the correct required-secret slot.
+///
+/// Step 3 takes the **credential** identity (`credential_name`, e.g.
+/// `"telegram_bot_token"` or `"github_token"`) because the secrets store
+/// has no concept of extensions — it stores raw secrets keyed by name.
+/// For flows that reach step 3, there is no extension to resolve against
+/// (builtin HTTP tool, skill credentials), so the credential name *is*
+/// the storage key.
+///
+/// The asymmetry is intentional: the engine's `ResumeKind::Authentication`
+/// only carries `credential_name`, so the caller passes both identities
+/// through and each backend picks the one it operates on.
+///
+/// # Credential-name validation on the step-3 fallback
+///
+/// Steps 1–2 reject unknown credentials via their capabilities lookup
+/// (`auth_manager` through `get_credential_spec`; `extension_manager`
+/// through `determine_installed_kind`). Step 3 is the non-extension
+/// path, so the only validation is the upstream trust chain: the pending
+/// gate's `ResumeKind::Authentication.credential_name` is a typed
+/// `CredentialName` (newtype validated at construction), and the pending
+/// gate itself was inserted by the engine for a specific tool-call whose
+/// auth descriptor produced that credential. The caller here receives
+/// the value as `&str` because `CreateSecretParams` is string-typed at
+/// the boundary, but it originates from a validated newtype upstream.
 ///
 /// Returns `SkippedNoBackend` when none of the three is available (bare
 /// test harness with `resume_output` already staged).
@@ -1104,6 +1137,9 @@ async fn submit_pending_auth_credential(
     }
 
     if let Some(ss) = state.secrets_store.as_ref() {
+        // Non-extension path (builtin HTTP, skill credentials): store under
+        // the raw credential name. See function docs for why steps 1–2
+        // take `submit_target` but step 3 takes `credential_name`.
         let params = crate::secrets::CreateSecretParams::new(credential_name, token);
         ss.create(user_id, params).await.map_err(|e| {
             crate::extensions::ExtensionError::Other(format!("Failed to store credential: {e}"))
@@ -2299,6 +2335,14 @@ pub async fn resolve_gate(
                             crate::channels::web::onboarding::ConfigureFlowOutcome::Ready
                         ) =>
                     {
+                        // `result.message` may already end with a period
+                        // (e.g. `ExtensionManager::configure_token` returns
+                        // "Configuration saved for 'telegram'."), so strip
+                        // trailing punctuation + whitespace before
+                        // concatenation to avoid "...foo.. Resuming...".
+                        let trimmed = result
+                            .message
+                            .trim_end_matches(|c: char| c == '.' || c.is_whitespace());
                         let _ = agent
                             .channels
                             .send_status(
@@ -2306,7 +2350,7 @@ pub async fn resolve_gate(
                                 StatusUpdate::AuthCompleted {
                                     extension_name: display_name.clone(),
                                     success: true,
-                                    message: format!("{}. Resuming...", result.message),
+                                    message: format!("{}. Resuming...", trimmed),
                                 },
                                 &message.metadata,
                             )
@@ -2357,11 +2401,23 @@ pub async fn resolve_gate(
                     // Bare test-harness path: no backend exists, but the
                     // gate carries a staged `resume_output` (set when the
                     // gate was created with a synthetic output), so we can
-                    // proceed with the resume below. Production flows
-                    // always come through the auth-manager or extension-
-                    // manager branch above.
+                    // proceed with the resume below. The caller's token
+                    // is intentionally dropped here — the resume_output
+                    // already carries whatever the resumed action needs;
+                    // production flows always come through the
+                    // auth-manager or extension-manager branch above.
+                    // `debug!` (not `info!` — would corrupt the REPL/TUI)
+                    // so operators can still see the drop when tracing.
                     Ok(PendingAuthCredentialSubmission::SkippedNoBackend)
-                        if pending.resume_output.is_some() => {}
+                        if pending.resume_output.is_some() =>
+                    {
+                        tracing::debug!(
+                            user_id = %message.user_id,
+                            thread_id = %pending.thread_id,
+                            request_id = %pending.request_id,
+                            "auth gate resume: no backend, token dropped because resume_output is staged",
+                        );
+                    }
                     Ok(PendingAuthCredentialSubmission::SkippedNoBackend) => {
                         let msg =
                             "No auth manager, extension manager, or secrets store available to store credential.".to_string();


### PR DESCRIPTION
## Summary
Five small follow-ups to PR #2622 (already merged in 4ab8e434). Reviewer comments landed on the merged PR and are addressed here as a follow-up rather than reopening the original.

- **Trim trailing punctuation** in the auth-completed status message — fixes \"...telegram'.. Resuming...\" double-period when the extension-manager backend returns a message ending in \".\" (Copilot).
- **Rename error contexts** in \`fail_waiting_thread\` from \"reconcile waiting thread\" to \"fail waiting thread\" — the helper is now used by the no-auth-backend failure arm too, not just orphan reconciliation (Copilot).
- **Add \`debug!\` log** when an auth credential is intentionally dropped on the \`SkippedNoBackend\` + \`resume_output\` bare-test path, so the silent drop is observable (serrrfirat). Uses \`debug!\` (not \`info!\`) per the REPL/TUI logging rule in CLAUDE.md.
- **Document \`submit_target\` vs \`credential_name\` asymmetry** in \`submit_pending_auth_credential\`'s doc comment — steps 1-2 take the extension identity, step 3 takes the credential identity because the secrets store has no extension concept (serrrfirat).
- **Document the credential-name validation chain** on the step-3 \`secrets_store\` fallback — upstream typing (\`CredentialName\` newtype + pending-gate insertion by the engine) is the trust source (serrrfirat).

No behavior change beyond the punctuation trim and the \`debug!\` log. The five new tests added in #2622 still pass.

## Test plan
- [x] \`cargo fmt --all\`
- [x] \`cargo clippy --all --benches --tests --examples --all-features\` — zero warnings
- [x] \`cargo test --lib bridge::router::tests\` — 5 new tests pass

## Related
- #2622 (merged) — the original PR these comments were posted on

🤖 Generated with [Claude Code](https://claude.com/claude-code)