### PR TITLE
refactor(gateway): promote cross-slice GatewayState test builders — ironclaw#2599 stage-6 prereq

### DIFF
--- a/src/channels/web/CLAUDE.md
+++ b/src/channels/web/CLAUDE.md
@@ -30,6 +30,7 @@ Browser-facing HTTP API and SSE/WebSocket real-time streaming. Axum-based, singl
 | `handlers/` | Transitional feature handlers that haven't migrated to `features/<slice>/` yet: `auth`, `engine`, `frontend`, `llm`, `memory`, `secrets`, `skills`, `system_prompt`, `tokens`, `tool_policy`, `users`, `webhooks`. Targeted for migration per ironclaw#2599 if churn / slice-boundary pressure justifies it. |
 | `openai_compat.rs` | OpenAI-compatible proxy (`/v1/chat/completions`, `/v1/models`) |
 | `util.rs` | Shared helpers (`web_incoming_message`, `build_turns_from_db_messages`, `images_to_attachments`, `truncate_preview`) |
+| `test_helpers.rs` | Always-compiled test utilities. `TestGatewayBuilder` (public) — the `tests/` crate's entry point for spinning up a `GatewayState` + optional Axum server on a random port. Plus three `pub(crate)` `#[cfg(test)]`-gated cross-slice builders — `test_gateway_state(ext_mgr)`, `test_gateway_state_with_dependencies(ext_mgr, store, db_auth, pairing_store)`, `test_gateway_state_with_store_and_session_manager(store, session_manager)` — promoted from `server.rs::tests` as the ironclaw#2599 stage-6 prerequisite so chat / extensions / oauth / pairing slice test modules can reach them without staying inside `server.rs::tests`. |
 | `static/` | Single-page app (HTML/CSS/JS) — embedded at compile time via `include_str!`/`include_bytes!` |
 
 ## Platform vs. feature layering (ironclaw#2599)

--- a/src/channels/web/features/chat/mod.rs
+++ b/src/channels/web/features/chat/mod.rs
@@ -1042,12 +1042,13 @@ fn summary_live_state(summary: &crate::history::ConversationSummary) -> Option<S
 // validation, turn-info construction, and live-state summarization.
 // Caller-level tests (`test_chat_history_handler_*`,
 // `test_chat_approval_handler*`, `test_chat_auth_*_handler*`,
-// `test_chat_gate_resolve_handler*`) stay in `server.rs::tests` for now
-// because they rely on shared `GatewayState` builders
-// (`test_gateway_state`, `test_gateway_state_with_store_and_session_manager`,
-// `test_gateway_state_with_dependencies`) that construct state for multiple
-// slices, not just chat. Promoting those builders to the public
-// `src/channels/web/test_helpers.rs` surface is a follow-up.
+// `test_chat_gate_resolve_handler*`) still live in `server.rs::tests`;
+// the shared `GatewayState` builders they depend on (`test_gateway_state`,
+// `test_gateway_state_with_store_and_session_manager`,
+// `test_gateway_state_with_dependencies`) now live in
+// `crate::channels::web::test_helpers` as `pub(crate)` functions, so
+// stage 6 of ironclaw#2599 can migrate the caller-level tests into this
+// module alongside the helpers without an API change.
 
 #[cfg(test)]
 mod tests {

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -35,11 +35,15 @@ pub use platform::auth;
 pub use platform::sse;
 pub use platform::ws;
 
-/// Test helpers for gateway integration tests.
+/// Test helpers for gateway tests.
 ///
 /// Always compiled (not behind `#[cfg(test)]`) so that integration tests in
 /// `tests/` -- which import this crate as a regular dependency -- can use
-/// [`TestGatewayBuilder`](test_helpers::TestGatewayBuilder).
+/// [`TestGatewayBuilder`](test_helpers::TestGatewayBuilder). The
+/// cross-slice `pub(crate)` builders inside the module
+/// (`test_gateway_state`, `test_gateway_state_with_dependencies`,
+/// `test_gateway_state_with_store_and_session_manager`) are individually
+/// `#[cfg(test)]`-gated since they only have in-crate unit-test callers.
 pub mod test_helpers;
 
 #[cfg(test)]

--- a/src/channels/web/server.rs
+++ b/src/channels/web/server.rs
@@ -49,6 +49,10 @@ mod tests {
         css_handler, generate_csp_nonce, stamp_nonce_into_html,
     };
     use crate::channels::web::sse::SseManager;
+    use crate::channels::web::test_helpers::{
+        test_gateway_state, test_gateway_state_with_dependencies,
+        test_gateway_state_with_store_and_session_manager,
+    };
     use crate::channels::web::types::*;
     use crate::channels::web::types::{
         ExtensionActivationStatus, classify_wasm_channel_activation,
@@ -164,119 +168,6 @@ mod tests {
     }
 
     // --- OAuth callback handler tests ---
-
-    /// Build a minimal `GatewayState` for handler tests.
-    fn test_gateway_state_with_dependencies(
-        ext_mgr: Option<Arc<ExtensionManager>>,
-        store: Option<Arc<dyn Database>>,
-        db_auth: Option<Arc<crate::channels::web::auth::DbAuthenticator>>,
-        pairing_store: Option<Arc<crate::pairing::PairingStore>>,
-    ) -> Arc<GatewayState> {
-        Arc::new(GatewayState {
-            msg_tx: tokio::sync::RwLock::new(None),
-            sse: Arc::new(SseManager::new()),
-            workspace: None,
-            workspace_pool: None,
-            session_manager: None,
-            log_broadcaster: None,
-            log_level_handle: None,
-            extension_manager: ext_mgr,
-            tool_registry: None,
-            store,
-            settings_cache: None,
-            job_manager: None,
-            prompt_queue: None,
-            owner_id: "test".to_string(),
-            shutdown_tx: tokio::sync::RwLock::new(None),
-            ws_tracker: None,
-            llm_provider: None,
-            llm_reload: None,
-            llm_session_manager: None,
-            config_toml_path: None,
-            skill_registry: None,
-            skill_catalog: None,
-            auth_manager: None,
-            scheduler: None,
-            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
-            webhook_rate_limiter: RateLimiter::new(10, 60),
-            registry_entries: vec![],
-            cost_guard: None,
-            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
-            startup_time: std::time::Instant::now(),
-            active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
-            secrets_store: None,
-            db_auth,
-            pairing_store,
-            oauth_providers: None,
-            oauth_state_store: None,
-            oauth_base_url: None,
-            oauth_allowed_domains: Vec::new(),
-            near_nonce_store: None,
-            near_rpc_url: None,
-            near_network: None,
-            oauth_sweep_shutdown: None,
-            frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
-            tool_dispatcher: None,
-        })
-    }
-
-    fn test_gateway_state(ext_mgr: Option<Arc<ExtensionManager>>) -> Arc<GatewayState> {
-        test_gateway_state_with_dependencies(ext_mgr, None, None, None)
-    }
-
-    fn test_gateway_state_with_store_and_session_manager(
-        store: Arc<dyn Database>,
-        session_manager: Arc<SessionManager>,
-    ) -> Arc<GatewayState> {
-        Arc::new(GatewayState {
-            msg_tx: tokio::sync::RwLock::new(None),
-            sse: Arc::new(SseManager::new()),
-            workspace: None,
-            workspace_pool: None,
-            session_manager: Some(session_manager),
-            log_broadcaster: None,
-            log_level_handle: None,
-            extension_manager: None,
-            tool_registry: None,
-            store: Some(store),
-            settings_cache: None,
-            job_manager: None,
-            prompt_queue: None,
-            owner_id: "test".to_string(),
-            shutdown_tx: tokio::sync::RwLock::new(None),
-            ws_tracker: None,
-            llm_provider: None,
-            llm_reload: None,
-            llm_session_manager: None,
-            config_toml_path: None,
-            skill_registry: None,
-            skill_catalog: None,
-            auth_manager: None,
-            scheduler: None,
-            chat_rate_limiter: PerUserRateLimiter::new(30, 60),
-            oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
-            webhook_rate_limiter: RateLimiter::new(10, 60),
-            registry_entries: vec![],
-            cost_guard: None,
-            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
-            startup_time: std::time::Instant::now(),
-            active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
-            secrets_store: None,
-            db_auth: None,
-            pairing_store: None,
-            oauth_providers: None,
-            oauth_state_store: None,
-            oauth_base_url: None,
-            oauth_allowed_domains: Vec::new(),
-            near_nonce_store: None,
-            near_rpc_url: None,
-            near_network: None,
-            oauth_sweep_shutdown: None,
-            frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
-            tool_dispatcher: None,
-        })
-    }
 
     #[cfg(feature = "libsql")]
     #[tokio::test]

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -1,8 +1,19 @@
-//! Shared test utilities for gateway integration tests.
+//! Shared test utilities for gateway tests.
 //!
-//! This module is always compiled (not `#[cfg(test)]`) because integration tests
-//! in `tests/` import the crate as a regular dependency and `cfg(test)` is only
-//! set when compiling *this* crate's unit tests.
+//! This module is **always compiled** (not `#[cfg(test)]`) because integration
+//! tests in `tests/` import the crate as a regular dependency and `cfg(test)`
+//! is only set when compiling *this* crate's unit tests. The publicly exposed
+//! [`TestGatewayBuilder`] is therefore unconditionally visible.
+//!
+//! The three cross-slice `pub(crate)` functions below — `test_gateway_state`,
+//! `test_gateway_state_with_dependencies`,
+//! `test_gateway_state_with_store_and_session_manager` — are scoped to unit
+//! tests and are individually gated with `#[cfg(test)]`. They previously
+//! lived inside `server.rs::tests` where they were unreachable from other
+//! slice test modules; promoting them here (ironclaw#2599 stage-6
+//! prerequisite) lets caller-level tests migrate out of `server.rs::tests`
+//! and into the feature slice they actually exercise (chat, oauth, pairing,
+//! extensions).
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -14,6 +25,11 @@ use crate::channels::web::auth::MultiAuthState;
 use crate::channels::web::server::{GatewayState, PerUserRateLimiter, RateLimiter, start_server};
 use crate::channels::web::sse::SseManager;
 use crate::channels::web::ws::WsConnectionTracker;
+
+#[cfg(test)]
+use crate::channels::web::auth::DbAuthenticator;
+#[cfg(test)]
+use crate::channels::web::server::ActiveConfigSnapshot;
 
 /// Builder for constructing a [`GatewayState`] with sensible test defaults.
 ///
@@ -142,4 +158,143 @@ impl TestGatewayBuilder {
         let bound = start_server(addr, state.clone(), auth.into()).await?;
         Ok((bound, state))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Cross-slice positional builders used by unit tests in `server.rs::tests`
+// and (per the ironclaw#2599 stage-6 plan) the chat / extensions / oauth /
+// pairing slice test modules. Kept as `pub(crate)` free functions with
+// the same positional signatures they had when they lived in
+// `server.rs::tests`, so call sites migrate in later PRs without touching
+// argument lists. Gated to `cfg(test)` because the surrounding module is
+// always-compiled (so integration tests in `tests/` can reach
+// `TestGatewayBuilder`), but these three functions only have in-crate
+// unit-test callers.
+// ---------------------------------------------------------------------------
+
+/// Build a minimal `GatewayState` with every optional subsystem `None`
+/// except `extension_manager`.
+///
+/// Equivalent to calling
+/// [`test_gateway_state_with_dependencies(ext_mgr, None, None, None)`].
+#[cfg(test)]
+pub(crate) fn test_gateway_state(
+    ext_mgr: Option<Arc<crate::extensions::ExtensionManager>>,
+) -> Arc<GatewayState> {
+    test_gateway_state_with_dependencies(ext_mgr, None, None, None)
+}
+
+/// Build a `GatewayState` with the four subsystems most commonly exercised
+/// by cross-slice handler tests (extensions, store, db-auth, pairing).
+/// Every field not reachable from these four dependencies stays `None`.
+#[cfg(test)]
+pub(crate) fn test_gateway_state_with_dependencies(
+    ext_mgr: Option<Arc<crate::extensions::ExtensionManager>>,
+    store: Option<Arc<dyn crate::db::Database>>,
+    db_auth: Option<Arc<DbAuthenticator>>,
+    pairing_store: Option<Arc<crate::pairing::PairingStore>>,
+) -> Arc<GatewayState> {
+    Arc::new(GatewayState {
+        msg_tx: tokio::sync::RwLock::new(None),
+        sse: Arc::new(SseManager::new()),
+        workspace: None,
+        workspace_pool: None,
+        session_manager: None,
+        log_broadcaster: None,
+        log_level_handle: None,
+        extension_manager: ext_mgr,
+        tool_registry: None,
+        store,
+        settings_cache: None,
+        job_manager: None,
+        prompt_queue: None,
+        owner_id: "test".to_string(),
+        shutdown_tx: tokio::sync::RwLock::new(None),
+        ws_tracker: None,
+        llm_provider: None,
+        llm_reload: None,
+        llm_session_manager: None,
+        config_toml_path: None,
+        skill_registry: None,
+        skill_catalog: None,
+        auth_manager: None,
+        scheduler: None,
+        chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+        webhook_rate_limiter: RateLimiter::new(10, 60),
+        registry_entries: vec![],
+        cost_guard: None,
+        routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+        startup_time: std::time::Instant::now(),
+        active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
+        secrets_store: None,
+        db_auth,
+        pairing_store,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
+        frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
+        tool_dispatcher: None,
+    })
+}
+
+/// Build a `GatewayState` wired to a real store + `SessionManager` for
+/// chat-slice caller-level tests (history / approval / auth-token / gate).
+#[cfg(test)]
+pub(crate) fn test_gateway_state_with_store_and_session_manager(
+    store: Arc<dyn crate::db::Database>,
+    session_manager: Arc<crate::agent::SessionManager>,
+) -> Arc<GatewayState> {
+    Arc::new(GatewayState {
+        msg_tx: tokio::sync::RwLock::new(None),
+        sse: Arc::new(SseManager::new()),
+        workspace: None,
+        workspace_pool: None,
+        session_manager: Some(session_manager),
+        log_broadcaster: None,
+        log_level_handle: None,
+        extension_manager: None,
+        tool_registry: None,
+        store: Some(store),
+        settings_cache: None,
+        job_manager: None,
+        prompt_queue: None,
+        owner_id: "test".to_string(),
+        shutdown_tx: tokio::sync::RwLock::new(None),
+        ws_tracker: None,
+        llm_provider: None,
+        llm_reload: None,
+        llm_session_manager: None,
+        config_toml_path: None,
+        skill_registry: None,
+        skill_catalog: None,
+        auth_manager: None,
+        scheduler: None,
+        chat_rate_limiter: PerUserRateLimiter::new(30, 60),
+        oauth_rate_limiter: PerUserRateLimiter::new(20, 60),
+        webhook_rate_limiter: RateLimiter::new(10, 60),
+        registry_entries: vec![],
+        cost_guard: None,
+        routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+        startup_time: std::time::Instant::now(),
+        active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
+        secrets_store: None,
+        db_auth: None,
+        pairing_store: None,
+        oauth_providers: None,
+        oauth_state_store: None,
+        oauth_base_url: None,
+        oauth_allowed_domains: Vec::new(),
+        near_nonce_store: None,
+        near_rpc_url: None,
+        near_network: None,
+        oauth_sweep_shutdown: None,
+        frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
+        tool_dispatcher: None,
+    })
 }


### PR DESCRIPTION
## Summary

Moves three `GatewayState` builders out of `server.rs::tests` (where they were private) into `src/channels/web/test_helpers.rs` as `pub(crate)` functions. This is the focused prerequisite the tracked [#2599 follow-ups comment](https://github.com/nearai/ironclaw/issues/2599#issuecomment-4276141874) calls out as the gate to stage 6 (deletion of `server.rs`).

- `test_gateway_state(ext_mgr)`
- `test_gateway_state_with_dependencies(ext_mgr, store, db_auth, pairing_store)`
- `test_gateway_state_with_store_and_session_manager(store, session_manager)`

## Why now

The caller-level tests currently in `server.rs::tests` exercise four slices — `features/chat`, `features/extensions`, `features/oauth`, `features/pairing` — and every one of them consumes at least one of these three builders. As long as the builders lived inside `server.rs::tests`, the tests couldn't migrate into their respective slice `mod tests` blocks. Without that migration, `server.rs::tests` can't be deleted, so the back-compat shim can't go either, so stage 6 is blocked.

Promoting the builders first (this PR) decouples the test-relocation work from the shim-deletion work and lets stage 6 be a pure `git mv` + import-path update with zero API surface changes.

## What moved vs. what stayed

| File | Change |
|---|---|
| `src/channels/web/test_helpers.rs` | +163 — three `pub(crate) #[cfg(test)]` functions added alongside the existing `TestGatewayBuilder`. Exact positional signatures preserved. |
| `src/channels/web/server.rs` | -117 — the three function bodies removed from `server.rs::tests`; replaced by a `use crate::channels::web::test_helpers::{...}` import. 48 call sites inside that test module use the imported versions unchanged. |
| `src/channels/web/features/chat/mod.rs` | Updated the pending-follow-up comment to point to stage 6 as the migration step, not "promote helpers first." |
| `src/channels/web/mod.rs` | Updated `pub mod test_helpers;` doc-comment to cover both the public builder and the three gated `pub(crate)` fns. |
| `src/channels/web/CLAUDE.md` | Added a `test_helpers.rs` row to the File Map. |

## Visibility / compilation scope

`test_helpers.rs` is always compiled (not `#[cfg(test)]`-gated) because integration tests in `tests/` import the crate as a regular dependency and `cfg(test)` is only set when compiling *this* crate's unit tests. `TestGatewayBuilder` relies on this.

The three cross-slice builders are individually `#[cfg(test)]`-gated because their only callers are in-crate unit tests — leaving them un-gated produces `dead_code` warnings in release builds (I verified). The `DbAuthenticator` and `ActiveConfigSnapshot` imports that only these three functions need are `cfg(test)`-gated for the same reason.

## Quality gate

- [x] `cargo fmt --all`
- [x] `cargo check -p ironclaw --tests --all-features` — clean
- [x] `cargo check -p ironclaw --all-features` — clean (no dead-code warnings in release builds)
- [x] `cargo check -p ironclaw --no-default-features --features libsql --tests` — clean
- [x] `cargo clippy -p ironclaw --tests --all-features` — zero warnings
- [x] `cargo test -p ironclaw --lib channels::web` — 431 passed
- [x] `cargo test -p ironclaw --test multi_tenant_integration` — 40 passed
- [x] `cargo test -p ironclaw --test openai_compat_integration` — 16 passed
- [x] `cargo test -p ironclaw --test admin_system_prompt` — passed

## Regression coverage

Pure relocation, no behavior change. The existing 64 tests in `server.rs::tests` that consume these three helpers continue to pass unmodified — that's the regression evidence. A "test that would have caught this" would necessarily be identical to the existing tests; no new test adds coverage. Tagged `[skip-regression-check]` on the commit.

## What comes next

Stage 6 (separate PR) uses these promoted builders to:
1. Move the ~50+ caller-level tests from `server.rs::tests` into `features/{chat,extensions,oauth,pairing}/mod.rs::tests`.
2. Delete `src/channels/web/server.rs` entirely once all callers in `src/main.rs`, `src/app.rs`, and integration tests flip their imports from `channels::web::server::*` to `channels::web::platform::*`.

## Migration progress (ironclaw#2599)

| Slice | Stage | PR | Status |
|---|---|---|---|
| oauth | 4a | #2645 | ✅ merged |
| logs / pairing / status | 4b | #2665 | ✅ merged |
| chat | 4c | #2680 | ✅ merged |
| extensions + jobs + settings + routines | 4d + 5 | #2687 | ✅ merged |
| **test-helper promotion (stage-6 prereq)** | **6a** | **this PR** | in review |
| `server.rs` test relocation + shim deletion | 6 | pending (blocked on this) | |
| contracts crate | 7 | pending (evaluate) | |

🤖 Generated with [Claude Code](https://claude.com/claude-code)