### PR TITLE
fix(gateway): Settings extension button label reflects auth state (#2235)

### DIFF
--- a/crates/ironclaw_gateway/static/js/surfaces/extensions.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/extensions.js
@@ -331,7 +331,7 @@ function renderExtensionCard(ext) {
       var fallbackStatus = ext.onboarding_state || ext.activation_status || 'installed';
       var inlineSetupCoversIt = fallbackStatus === 'setup_required' || fallbackStatus === 'installed';
       if (inlineSetupCoversIt) {
-        reconfigureBtn.textContent = I18n.t('extensions.reconfigure');
+        reconfigureBtn.textContent = I18n.t('ext.reconfigure');
       } else {
         reconfigureBtn.textContent = ext.authenticated ? I18n.t('ext.reconfigure') : I18n.t('ext.setup');
       }

--- a/crates/ironclaw_gateway/static/js/surfaces/extensions.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/extensions.js
@@ -322,9 +322,19 @@ function renderExtensionCard(ext) {
     } else if (status === 'failed') {
       actions.appendChild(createReconfigureButton(ext.name));
     } else {
+      // `setup_required` / `installed` keep the legacy label: the inline
+      // setup form below already renders a setup action, so re-labeling
+      // this button would duplicate it. Other fallback states have no
+      // inline form, so pick the label from `authenticated` — closes #2235.
       var reconfigureBtn = document.createElement('button');
       reconfigureBtn.className = 'btn-ext configure';
-      reconfigureBtn.textContent = I18n.t('extensions.reconfigure');
+      var fallbackStatus = ext.onboarding_state || ext.activation_status || 'installed';
+      var inlineSetupCoversIt = fallbackStatus === 'setup_required' || fallbackStatus === 'installed';
+      if (inlineSetupCoversIt) {
+        reconfigureBtn.textContent = I18n.t('extensions.reconfigure');
+      } else {
+        reconfigureBtn.textContent = ext.authenticated ? I18n.t('ext.reconfigure') : I18n.t('ext.setup');
+      }
       reconfigureBtn.addEventListener('click', function() { showConfigureModal(ext.name); });
       actions.appendChild(reconfigureBtn);
     }

--- a/crates/ironclaw_gateway/static/js/surfaces/extensions.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/extensions.js
@@ -322,14 +322,17 @@ function renderExtensionCard(ext) {
     } else if (status === 'failed') {
       actions.appendChild(createReconfigureButton(ext.name));
     } else {
-      // `setup_required` / `installed` keep the legacy label: the inline
-      // setup form below already renders a setup action, so re-labeling
-      // this button would duplicate it. Other fallback states have no
-      // inline form, so pick the label from `authenticated` — closes #2235.
+      // Only `setup_required` has an inline setup form below (see the
+      // `loadInlineChannelSetup` branch), so keep the legacy label there
+      // to avoid a duplicate setup action. Every other fallback state —
+      // including the default `installed` when no `onboarding_state` is
+      // set — renders no inline form, so pick the label from
+      // `authenticated`: "Setup" before credentials are on file,
+      // "Reconfigure" after. Closes #2235.
       var reconfigureBtn = document.createElement('button');
       reconfigureBtn.className = 'btn-ext configure';
       var fallbackStatus = ext.onboarding_state || ext.activation_status || 'installed';
-      var inlineSetupCoversIt = fallbackStatus === 'setup_required' || fallbackStatus === 'installed';
+      var inlineSetupCoversIt = fallbackStatus === 'setup_required';
       if (inlineSetupCoversIt) {
         reconfigureBtn.textContent = I18n.t('ext.reconfigure');
       } else {

--- a/crates/ironclaw_gateway/static/js/surfaces/extensions.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/extensions.js
@@ -331,9 +331,7 @@ function renderExtensionCard(ext) {
       // "Reconfigure" after. Closes #2235.
       var reconfigureBtn = document.createElement('button');
       reconfigureBtn.className = 'btn-ext configure';
-      var fallbackStatus = ext.onboarding_state || ext.activation_status || 'installed';
-      var inlineSetupCoversIt = fallbackStatus === 'setup_required';
-      if (inlineSetupCoversIt) {
+      if (status === 'setup_required') {
         reconfigureBtn.textContent = I18n.t('ext.reconfigure');
       } else {
         reconfigureBtn.textContent = ext.authenticated ? I18n.t('ext.reconfigure') : I18n.t('ext.setup');

--- a/src/channels/web/features/extensions/mod.rs
+++ b/src/channels/web/features/extensions/mod.rs
@@ -1394,16 +1394,15 @@ mod tests {
             .as_array()
             .and_then(|items| items.iter().find(|item| item["name"] == channel_name))
             .expect("telegram entry post-setup");
+        // A missing field indexes to `Value::Null` and trips this assertion
+        // too, so the single check covers both "field stripped from the wire"
+        // and "field present but wrong value".
         assert_eq!(
             telegram["authenticated"], true,
-            "post-setup: the `authenticated` flag must be true once the required \
-             secret is written — the Settings card's Setup/Reconfigure branch reads \
-             this field directly, and a regression here reopens #2235."
-        );
-        // The wire field must also still be present (not serialized away).
-        assert!(
-            telegram.get("authenticated").is_some(),
-            "`authenticated` must remain on the wire for the JS button-label branch"
+            "post-setup: the `authenticated` flag must be present and true once \
+             the required secret is written — the Settings card's \
+             Setup/Reconfigure branch reads this field directly, and a regression \
+             here reopens #2235."
         );
     }
 

--- a/src/channels/web/features/extensions/mod.rs
+++ b/src/channels/web/features/extensions/mod.rs
@@ -1261,6 +1261,152 @@ mod tests {
         assert_eq!(telegram["activation_status"], "installed");
     }
 
+    /// Caller-level wire-contract regression for nearai/ironclaw#2235.
+    ///
+    /// The Settings → Extensions UI picks the WASM-channel fallback button
+    /// label ("Setup" vs "Reconfigure") from `ExtensionInfo.authenticated`
+    /// on the `/api/extensions` response. A backend regression that left
+    /// `authenticated=false` after credentials were written — or dropped
+    /// the field off the wire entirely — would silently re-show the
+    /// credential popup on an already-configured install. The unit-level
+    /// classifier tests above cannot catch this because they do not
+    /// exercise the `configure()` → `list()` wire round-trip.
+    ///
+    /// This test drives the real pair of handlers — POST setup then GET
+    /// list — against a stub channel whose WASM binary intentionally
+    /// fails to activate (so `active=false`). The `authenticated` flag
+    /// must still flip to `true` once the required secret lands in the
+    /// secrets store.
+    #[tokio::test]
+    async fn test_extensions_list_reports_authenticated_after_setup_submit() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let secrets = test_secrets_store();
+        let (ext_mgr, _wasm_tools_dir, wasm_channels_dir) = test_ext_mgr(secrets);
+
+        let channel_name = "telegram";
+        std::fs::write(
+            wasm_channels_dir
+                .path()
+                .join(format!("{channel_name}.wasm")),
+            b"\0asm fake",
+        )
+        .expect("write fake wasm");
+        let caps = serde_json::json!({
+            "type": "channel",
+            "name": channel_name,
+            "setup": {
+                "required_secrets": [
+                    {"name": "BOT_TOKEN", "prompt": "Enter bot token"}
+                ]
+            }
+        });
+        std::fs::write(
+            wasm_channels_dir
+                .path()
+                .join(format!("{channel_name}.capabilities.json")),
+            serde_json::to_string(&caps).expect("serialize caps"),
+        )
+        .expect("write capabilities");
+
+        let state = test_gateway_state(Some(ext_mgr));
+        let app = Router::new()
+            .route("/api/extensions", get(extensions_list_handler))
+            .route(
+                "/api/extensions/{name}/setup",
+                post(extensions_setup_submit_handler),
+            )
+            .with_state(state);
+
+        // Pre-setup: authenticated must be false.
+        let mut req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app.clone(), req)
+            .await
+            .expect("pre-setup response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        let telegram = parsed["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == channel_name))
+            .expect("telegram entry pre-setup");
+        assert_eq!(
+            telegram["authenticated"], false,
+            "pre-setup: authenticated must start false (the JS Settings card shows \
+             'Setup' in this state — regressing it to true would flip the button to \
+             'Reconfigure' before credentials exist, re-introducing #2235)"
+        );
+
+        // Submit credentials via the real setup-submit handler.
+        let submit_body = serde_json::json!({
+            "secrets": {
+                "BOT_TOKEN": "dummy-token"
+            }
+        });
+        let mut req = axum::http::Request::builder()
+            .method("POST")
+            .uri(format!("/api/extensions/{channel_name}/setup"))
+            .header("content-type", "application/json")
+            .body(Body::from(submit_body.to_string()))
+            .expect("setup-submit request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app.clone(), req)
+            .await
+            .expect("setup-submit response");
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Post-setup: the wire contract the Settings UI depends on.
+        let mut req = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("request");
+        req.extensions_mut().insert(UserIdentity {
+            user_id: "test".to_string(),
+            role: "admin".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("post-setup response");
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), 1024 * 64)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("json");
+        let telegram = parsed["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == channel_name))
+            .expect("telegram entry post-setup");
+        assert_eq!(
+            telegram["authenticated"], true,
+            "post-setup: the `authenticated` flag must be true once the required \
+             secret is written — the Settings card's Setup/Reconfigure branch reads \
+             this field directly, and a regression here reopens #2235."
+        );
+        // The wire field must also still be present (not serialized away).
+        assert!(
+            telegram.get("authenticated").is_some(),
+            "`authenticated` must remain on the wire for the JS button-label branch"
+        );
+    }
+
     #[test]
     fn apply_extension_readiness_preserves_install_success_for_auth_followup() {
         let mut resp = ActionResponse::ok("Installed notion");

--- a/tests/e2e/scenarios/test_settings_extensions_labels.py
+++ b/tests/e2e/scenarios/test_settings_extensions_labels.py
@@ -1,0 +1,248 @@
+"""Scenario: Settings → Extensions fallback button label regression.
+
+Closes nearai/ironclaw#2235 — clicking the action button on an already-
+authenticated WASM channel previously re-prompted for credentials
+because the fallback branch labeled it "Reconfigure" unconditionally.
+The Settings UI now picks the label from `ext.authenticated`: "Setup"
+when no credentials are on file yet, "Reconfigure" once they are.
+
+The inline setup form already provides a setup action when
+`onboarding_state === 'setup_required'`, so we keep the legacy
+"Reconfigure" label in that one state to preserve the
+no-duplicate-setup-button invariant guarded by
+`test_wasm_channel_setup_states` in `test_extensions.py`. Those two
+invariants are both exercised here — the first (the #2235 fix) and the
+second (no regression) — so a future edit that re-introduces
+duplication or re-breaks the label will fail a named test rather than
+slip through.
+
+Every assertion runs against route-mocked `/api/extensions` responses
+so we exercise the production JS render path without needing a real
+WASM channel binary.
+"""
+
+import json
+
+from helpers import SEL
+
+
+_WASM_CHANNEL_BASE = {
+    "name": "test-channel-labels",
+    "display_name": "Label Channel",
+    "kind": "wasm_channel",
+    "description": "A WASM channel used to assert Settings card button labels.",
+    "url": None,
+    "tools": [],
+    "activation_error": None,
+    "has_auth": False,
+    "needs_setup": True,
+}
+
+
+async def _mock_and_go(page, *, installed):
+    """Mock /api/extensions with the given installed list and open the tab."""
+    ext_body = json.dumps({"extensions": installed})
+
+    async def handle_ext(route):
+        path = route.request.url.split("?")[0]
+        if path.endswith("/api/extensions"):
+            await route.fulfill(status=200, content_type="application/json", body=ext_body)
+        else:
+            await route.continue_()
+
+    await page.route("**/api/extensions*", handle_ext)
+
+    async def handle_registry(route):
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"entries": []}),
+        )
+
+    await page.route("**/api/extensions/registry", handle_registry)
+
+    # The setup-fetch fires from the inline setup form in `setup_required`
+    # state. Return a no-secrets payload so the form collapses and does not
+    # interfere with the action-area button assertions.
+    async def handle_setup_fetch(route):
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps(
+                {
+                    "name": _WASM_CHANNEL_BASE["name"],
+                    "kind": "wasm_channel",
+                    "secrets": [],
+                    "fields": [],
+                    "onboarding_state": None,
+                    "onboarding": None,
+                }
+            ),
+        )
+
+    await page.route(
+        f"**/api/extensions/{_WASM_CHANNEL_BASE['name']}/setup",
+        handle_setup_fetch,
+    )
+
+    await page.locator(SEL["tab_button"].format(tab="settings")).click()
+    await page.locator(SEL["settings_subtab"].format(subtab="channels")).click()
+    await page.locator(SEL["settings_subpanel"].format(subtab="channels")).wait_for(
+        state="visible", timeout=5000
+    )
+
+
+def _channel_with(**overrides):
+    return {**_WASM_CHANNEL_BASE, **overrides}
+
+
+async def test_fallback_button_says_setup_when_not_authenticated(page):
+    """Unauthenticated WASM channel in `configured` state shows Setup, not Reconfigure.
+
+    This is the core #2235 regression: the old build unconditionally said
+    "Reconfigure" here, leading users to click it expecting a configured
+    channel only to be shown a credential entry form.
+    """
+    await _mock_and_go(
+        page,
+        installed=[
+            _channel_with(
+                active=False,
+                authenticated=False,
+                activation_status="configured",
+                onboarding_state="activation_in_progress",
+                onboarding=None,
+            )
+        ],
+    )
+    card = page.locator(
+        SEL["channels_ext_card"], has_text=_WASM_CHANNEL_BASE["display_name"]
+    ).first
+    await card.wait_for(state="visible", timeout=5000)
+
+    setup_btn = card.locator(SEL["ext_configure_btn"], has_text="Setup")
+    reconfig_btn = card.locator(SEL["ext_configure_btn"], has_text="Reconfigure")
+    assert await setup_btn.count() == 1, (
+        "fallback button must say 'Setup' when no credentials are on file "
+        "(authenticated=false) — regresses #2235 if it says 'Reconfigure'"
+    )
+    assert await reconfig_btn.count() == 0, (
+        "fallback button must not say 'Reconfigure' for an unauthenticated channel"
+    )
+
+
+async def test_fallback_button_says_reconfigure_when_authenticated(page):
+    """Authenticated WASM channel in `configured` state shows Reconfigure."""
+    await _mock_and_go(
+        page,
+        installed=[
+            _channel_with(
+                active=False,
+                authenticated=True,
+                activation_status="configured",
+                onboarding_state="activation_in_progress",
+                onboarding=None,
+            )
+        ],
+    )
+    card = page.locator(
+        SEL["channels_ext_card"], has_text=_WASM_CHANNEL_BASE["display_name"]
+    ).first
+    await card.wait_for(state="visible", timeout=5000)
+
+    reconfig_btn = card.locator(SEL["ext_configure_btn"], has_text="Reconfigure")
+    setup_btn = card.locator(SEL["ext_configure_btn"], has_text="Setup")
+    assert await reconfig_btn.count() == 1, (
+        "fallback button must say 'Reconfigure' when credentials are on file "
+        "(authenticated=true)"
+    )
+    assert await setup_btn.count() == 0, (
+        "fallback button must not say 'Setup' once authenticated"
+    )
+
+
+async def test_fallback_button_preserves_no_duplicate_setup_invariant(page):
+    """`setup_required` + unauthenticated keeps the legacy label so the action
+    button does not duplicate the inline setup form's call-to-action.
+
+    The sibling invariant also asserted by `test_wasm_channel_setup_states`.
+    Kept here so a future refactor that inlines the Setup-label change into
+    this branch trips a named regression rather than quietly duplicating the
+    UI element.
+    """
+    await _mock_and_go(
+        page,
+        installed=[
+            _channel_with(
+                active=False,
+                authenticated=False,
+                activation_status="installed",
+                onboarding_state="setup_required",
+                onboarding=None,
+            )
+        ],
+    )
+    card = page.locator(
+        SEL["channels_ext_card"], has_text=_WASM_CHANNEL_BASE["display_name"]
+    ).first
+    await card.wait_for(state="visible", timeout=5000)
+
+    setup_btn = card.locator(SEL["ext_configure_btn"], has_text="Setup")
+    assert await setup_btn.count() == 0, (
+        "the action-area button must not say 'Setup' while the inline setup "
+        "form covers the same action (no-duplicate-setup-button invariant)"
+    )
+
+
+async def test_reconfigure_click_does_not_send_auth_event(page):
+    """Clicking Reconfigure on an already-authenticated channel must not
+    reissue a credential-prompt SSE event or trigger a reactivation request.
+
+    Covers the runtime half of the QA repro — clicking the button should
+    open the configure modal locally, not fire a handshake that the backend
+    would translate into a credential popup again.
+    """
+    await _mock_and_go(
+        page,
+        installed=[
+            _channel_with(
+                active=True,
+                authenticated=True,
+                activation_status="active",
+                onboarding_state="ready",
+                onboarding=None,
+            )
+        ],
+    )
+
+    activate_calls = {"count": 0}
+
+    async def handle_activate(route):
+        activate_calls["count"] += 1
+        await route.fulfill(
+            status=200,
+            content_type="application/json",
+            body=json.dumps({"success": True, "activated": True}),
+        )
+
+    await page.route(
+        f"**/api/extensions/{_WASM_CHANNEL_BASE['name']}/activate",
+        handle_activate,
+    )
+
+    card = page.locator(
+        SEL["channels_ext_card"], has_text=_WASM_CHANNEL_BASE["display_name"]
+    ).first
+    await card.wait_for(state="visible", timeout=5000)
+
+    reconfig_btn = card.locator(SEL["ext_configure_btn"], has_text="Reconfigure")
+    assert await reconfig_btn.count() == 1
+    await reconfig_btn.click()
+
+    # Modal should open locally.
+    await page.locator(SEL["configure_modal"]).wait_for(state="visible", timeout=3000)
+    assert activate_calls["count"] == 0, (
+        "Reconfigure must not call /activate — the button opens the configure "
+        "modal only. A non-zero call count means the click path regressed to "
+        "trigger activation (the shape of the #2235 repro)."
+    )

--- a/tests/e2e/scenarios/test_settings_extensions_labels.py
+++ b/tests/e2e/scenarios/test_settings_extensions_labels.py
@@ -39,8 +39,16 @@ _WASM_CHANNEL_BASE = {
 }
 
 
-async def _mock_and_go(page, *, installed):
-    """Mock /api/extensions with the given installed list and open the tab."""
+async def _mock_and_go(page, *, installed, setup_secrets=None):
+    """Mock /api/extensions with the given installed list and open the tab.
+
+    `setup_secrets` is the `secrets` array returned by
+    `/api/extensions/{name}/setup`. Defaults to empty — that makes
+    `showConfigureModal` short-circuit with a toast and skip rendering
+    the configure modal, which is fine for tests that only assert button
+    labels. Pass a non-empty list to exercise the full
+    `renderConfigureModal` path.
+    """
     ext_body = json.dumps({"extensions": installed})
 
     async def handle_ext(route):
@@ -61,9 +69,8 @@ async def _mock_and_go(page, *, installed):
 
     await page.route("**/api/extensions/registry", handle_registry)
 
-    # The setup-fetch fires from the inline setup form in `setup_required`
-    # state. Return a no-secrets payload so the form collapses and does not
-    # interfere with the action-area button assertions.
+    secrets_payload = setup_secrets if setup_secrets is not None else []
+
     async def handle_setup_fetch(route):
         await route.fulfill(
             status=200,
@@ -72,7 +79,7 @@ async def _mock_and_go(page, *, installed):
                 {
                     "name": _WASM_CHANNEL_BASE["name"],
                     "kind": "wasm_channel",
-                    "secrets": [],
+                    "secrets": secrets_payload,
                     "fields": [],
                     "onboarding_state": None,
                     "onboarding": None,
@@ -161,6 +168,51 @@ async def test_fallback_button_says_reconfigure_when_authenticated(page):
     )
 
 
+async def test_fallback_button_says_setup_on_production_installed_wire_shape(page):
+    """Exact #2235 production wire shape: `activation_status='installed'`,
+    `onboarding_state=null` — `derive_onboarding` only emits a non-null
+    onboarding state for the `Pairing` variant, so real clients never
+    receive `setup_required` alongside `activation_status='installed'`.
+
+    The inline setup form only renders when the effective status is
+    `setup_required`, so this card shows no inline form — the action-area
+    button is the ONLY setup affordance. Under the bug the label read
+    'Reconfigure' here, which is the precise shape Copilot flagged and
+    the precise shape the QA bug-bash repro hit.
+    """
+    await _mock_and_go(
+        page,
+        installed=[
+            _channel_with(
+                active=False,
+                authenticated=False,
+                activation_status="installed",
+                onboarding_state=None,
+                onboarding=None,
+            )
+        ],
+    )
+    card = page.locator(
+        SEL["channels_ext_card"], has_text=_WASM_CHANNEL_BASE["display_name"]
+    ).first
+    await card.wait_for(state="visible", timeout=5000)
+
+    assert await card.locator(SEL["ext_onboarding"]).count() == 0, (
+        "production `installed` wire shape must not render an inline setup "
+        "form — if this ever changes, revisit the `inlineSetupCoversIt` rule"
+    )
+    setup_btn = card.locator(SEL["ext_configure_btn"], has_text="Setup")
+    reconfig_btn = card.locator(SEL["ext_configure_btn"], has_text="Reconfigure")
+    assert await setup_btn.count() == 1, (
+        "fallback button must say 'Setup' for an unauthenticated channel in "
+        "the default `installed` state — this is the exact wire shape of #2235"
+    )
+    assert await reconfig_btn.count() == 0, (
+        "fallback button must not say 'Reconfigure' when credentials are not "
+        "yet on file and no inline setup form covers the action"
+    )
+
+
 async def test_fallback_button_preserves_no_duplicate_setup_invariant(page):
     """`setup_required` + unauthenticated keeps the legacy label so the action
     button does not duplicate the inline setup form's call-to-action.
@@ -202,6 +254,9 @@ async def test_reconfigure_click_does_not_send_auth_event(page):
     open the configure modal locally, not fire a handshake that the backend
     would translate into a credential popup again.
     """
+    # Pass a non-empty `secrets` so `showConfigureModal` actually renders
+    # `.configure-modal` — with an empty list it short-circuits with a
+    # "no config needed" toast and the modal selector never appears.
     await _mock_and_go(
         page,
         installed=[
@@ -212,6 +267,15 @@ async def test_reconfigure_click_does_not_send_auth_event(page):
                 onboarding_state="ready",
                 onboarding=None,
             )
+        ],
+        setup_secrets=[
+            {
+                "name": "BOT_TOKEN",
+                "prompt": "Bot token",
+                "provided": True,
+                "optional": False,
+                "auto_generate": False,
+            }
         ],
     )
 


### PR DESCRIPTION
## Summary

Extracts the UI activation fix from #2375 into a standalone PR, fixes the issues raised in review (stale `app.js` target, dropped `has_paired` axis, removed tests), and adds Playwright coverage.

Closes nearai/ironclaw#2235.

## Background

#2375 bundled two unrelated changes — a new `gws-bridge` MCP stdio server and a WASM-channel activation UX fix — and targeted `crates/ironclaw_gateway/static/app.js`, which was deleted when `assets.rs` switched to concatenating split modules under `static/js/`. Its backend change also dropped the `has_paired` axis from `classify_wasm_channel_activation` (regressing the #1921 truth-table tests that live in `features/extensions/mod.rs` and `src/extensions/manager.rs`).

This PR ports the UX intent to the live code paths without the regressions.

## What changes

**`crates/ironclaw_gateway/static/js/surfaces/extensions.js`** — the WASM-channel fallback branch now labels the button `Setup` when `!ext.authenticated` and `Reconfigure` when authenticated. `setup_required` / `installed` keep the legacy label because the inline setup form below already provides a setup action (no-duplicate-setup invariant, guarded by `test_wasm_channel_setup_states`).

**Does not touch** `classify_wasm_channel_activation` or `ExtensionInfo` — the `has_paired` axis and the existing wire contract stay intact.

## Tests

- `test_extensions_list_reports_authenticated_after_setup_submit` (caller-level, in `features/extensions/mod.rs`) drives POST `/api/extensions/{name}/setup` → GET `/api/extensions` and asserts `authenticated` flips on the wire — the field the JS branch now reads. If a future refactor stops surfacing this flag or mis-computes it, this test fails rather than the bug re-appearing silently.
- `tests/e2e/scenarios/test_settings_extensions_labels.py` (Playwright) covers:
  - unauthenticated channel in `configured` state → button says `Setup`
  - authenticated channel in `configured` state → button says `Reconfigure`
  - `setup_required` + unauthenticated → no duplicate `Setup` button (sibling invariant to `test_wasm_channel_setup_states`)
  - clicking `Reconfigure` on an authenticated channel does not fire `/activate`

All existing tests in `features::extensions::tests` and the #1921 regression in `src/extensions/manager.rs` still pass.

## Test plan

- [x] `cargo test -p ironclaw --lib channels::web::features::extensions::` — 16 passed
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib -p ironclaw --tests` — zero warnings
- [x] `bash scripts/pre-commit-safety.sh` — pass
- [ ] Playwright: `pytest tests/e2e/scenarios/test_settings_extensions_labels.py`
- [ ] Manual: install a WASM channel from chat, verify Settings card label

## References

- Supersedes the UI half of #2375 (gws-bridge half is out of scope)
- Co-authored with @G7CNF (original PR author)
- Related review: #2375 review comments noting the stale `app.js` target and the regression of the #1921 truth-table tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)