### PR TITLE
docs(skills): clarify /search/issues returns issues and PRs

### DIFF
--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -141,7 +141,7 @@ GitHub has three search endpoints. Build queries with the [search syntax](https:
 http(method="GET", url="https://api.github.com/search/issues?q=repo:{owner}/{repo}+is:pr+is:open+label:bug")
 ```
 
-- The unified endpoint `/search/issues` returns BOTH issues and pull requests — there is no `/search/pulls` endpoint. Use `is:pr` or `is:issue` in the `q=` filter to narrow the results.
+- Note: There is no `/search/pulls` endpoint; `/search/issues` is the unified endpoint for both issues and PRs.
 
 **Search code:**
 ```

--- a/skills/github/SKILL.md
+++ b/skills/github/SKILL.md
@@ -141,6 +141,8 @@ GitHub has three search endpoints. Build queries with the [search syntax](https:
 http(method="GET", url="https://api.github.com/search/issues?q=repo:{owner}/{repo}+is:pr+is:open+label:bug")
 ```
 
+- The unified endpoint `/search/issues` returns BOTH issues and pull requests — there is no `/search/pulls` endpoint. Use `is:pr` or `is:issue` in the `q=` filter to narrow the results.
+
 **Search code:**
 ```
 http(method="GET", url="https://api.github.com/search/code?q=fn+main+language:rust+repo:{owner}/{repo}")


### PR DESCRIPTION
## Summary
- Add a clarifying bullet to `skills/github/SKILL.md` noting that the unified `/search/issues` endpoint returns BOTH issues and pull requests, and that there is no `/search/pulls` endpoint.
- Doc-only; functional behavior is already enforced by the `is:pr` / `is:issue` filters used throughout the existing examples.

## Test plan
- [ ] Render the updated SKILL.md and confirm the new bullet appears in the Search section
- [ ] No code changes — CI lint/test should pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)