### PR TITLE
feat(skills): add CLAWHUB_ENABLED flag to disable ClawHub registry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -288,5 +288,11 @@ SAFETY_INJECTION_CHECK_ENABLED=true
 # GATEWAY_OIDC_ISSUER=https://your-idp.example.com
 # GATEWAY_OIDC_AUDIENCE=your-client-id
 
+# ─── Skills / ClawHub ─────────────────────────────────────────────────
+# CLAWHUB_ENABLED=true          # Set to false to disable remote ClawHub
+#                                # registry (catalog search + URL installs).
+#                                # Local skill management and inline content
+#                                # installs remain available.
+
 # Logging
 RUST_LOG=ironclaw=debug,tower_http=debug

--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -518,7 +518,7 @@
           </div>
           <div class="settings-subpanel" id="settings-skills">
             <div class="extensions-container">
-              <div class="extensions-section">
+              <div class="extensions-section skill-search-section">
                 <h3 data-i18n="skills.searchClawHub">Search ClawHub</h3>
                 <div class="skill-search-box">
                   <input type="text" id="skill-search-input" data-i18n-placeholder="skills.searchPlaceholder" placeholder="Search for skills...">

--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -532,7 +532,7 @@
                   <div class="empty-state" data-i18n="skills.loading">Loading skills...</div>
                 </div>
               </div>
-              <div class="extensions-section">
+              <div class="extensions-section skill-url-install-section">
                 <h3 data-i18n="skills.installByUrl">Install Skill by URL</h3>
                 <div class="ext-install-form">
                   <input type="text" id="skill-install-name" data-i18n-placeholder="skills.namePlaceholder" placeholder="Skill name or slug">

--- a/crates/ironclaw_gateway/static/js/core/gateway-tee.js
+++ b/crates/ironclaw_gateway/static/js/core/gateway-tee.js
@@ -45,6 +45,12 @@ function fetchGatewayStatus() {
       engineModeApplied = true;
     }
 
+    // Hide ClawHub search section when registry is disabled
+    var skillSearchSection = document.querySelector('.skill-search-section');
+    if (skillSearchSection) {
+      skillSearchSection.style.display = data.clawhub_enabled === false ? 'none' : '';
+    }
+
     var popover = document.getElementById('gateway-popover');
     var html = '';
 

--- a/crates/ironclaw_gateway/static/js/core/gateway-tee.js
+++ b/crates/ironclaw_gateway/static/js/core/gateway-tee.js
@@ -45,10 +45,15 @@ function fetchGatewayStatus() {
       engineModeApplied = true;
     }
 
-    // Hide ClawHub search section when registry is disabled
+    // Hide ClawHub-only skill install surfaces when registry is disabled.
+    var hideClawHubUi = data.clawhub_enabled === false;
     var skillSearchSection = document.querySelector('.skill-search-section');
     if (skillSearchSection) {
-      skillSearchSection.style.display = data.clawhub_enabled === false ? 'none' : '';
+      skillSearchSection.style.display = hideClawHubUi ? 'none' : '';
+    }
+    var skillUrlInstallSection = document.querySelector('.skill-url-install-section');
+    if (skillUrlInstallSection) {
+      skillUrlInstallSection.style.display = hideClawHubUi ? 'none' : '';
     }
 
     var popover = document.getElementById('gateway-popover');

--- a/src/agent/commands.rs
+++ b/src/agent/commands.rs
@@ -690,51 +690,61 @@ impl Agent {
         tenant: &crate::tenant::TenantCtx,
     ) -> Result<SubmissionResult, Error> {
         match command {
-            "help" => Ok(SubmissionResult::response(concat!(
-                "System:\n",
-                "  /help             Show this help\n",
-                "  /model [name]     Show or switch the active model\n",
-                "  /version          Show version info\n",
-                "  /tools            List available tools\n",
-                "  /debug            Toggle debug mode\n",
-                "  /reasoning [N|all] Show agent reasoning for turns\n",
-                "  /ping             Connectivity check\n",
-                "\n",
-                "Jobs:\n",
-                "  /job <desc>       Create a new job\n",
-                "  /status [id]      Check job status\n",
-                "  /cancel <id>      Cancel a job\n",
-                "  /list             List all jobs\n",
-                "\n",
-                "Plans:\n",
-                "  /plan <desc>      Create an execution plan\n",
-                "  /plan approve [ref] Approve and start execution\n",
-                "  /plan status [ref]  Check plan progress\n",
-                "  /plan revise [ref]  Revise with feedback\n",
-                "  /plan list        List all plans\n",
-                "\n",
-                "Session:\n",
-                "  /undo             Undo last turn\n",
-                "  /redo             Redo undone turn\n",
-                "  /compact          Compress context window\n",
-                "  /clear            Clear current thread\n",
-                "  /interrupt        Stop current operation\n",
-                "  /new              New conversation thread\n",
-                "  /thread <id>      Switch to thread\n",
-                "  /resume           Resume a previous conversation\n",
-                "\n",
-                "Skills:\n",
-                "  /skills             List installed skills\n",
-                "  /skills search <q>  Search ClawHub registry\n",
-                "\n",
-                "Agent:\n",
-                "  /heartbeat        Run heartbeat check\n",
-                "  /summarize        Summarize current thread\n",
-                "  /suggest          Suggest next steps\n",
-                "  /restart          Gracefully restart the process\n",
-                "\n",
-                "  /quit             Exit",
-            ))),
+            "help" => {
+                let search_line = if self.skill_catalog().is_some() {
+                    "  /skills search <q>  Search ClawHub registry\n"
+                } else {
+                    ""
+                };
+                Ok(SubmissionResult::response(format!(
+                    concat!(
+                        "System:\n",
+                        "  /help             Show this help\n",
+                        "  /model [name]     Show or switch the active model\n",
+                        "  /version          Show version info\n",
+                        "  /tools            List available tools\n",
+                        "  /debug            Toggle debug mode\n",
+                        "  /reasoning [N|all] Show agent reasoning for turns\n",
+                        "  /ping             Connectivity check\n",
+                        "\n",
+                        "Jobs:\n",
+                        "  /job <desc>       Create a new job\n",
+                        "  /status [id]      Check job status\n",
+                        "  /cancel <id>      Cancel a job\n",
+                        "  /list             List all jobs\n",
+                        "\n",
+                        "Plans:\n",
+                        "  /plan <desc>      Create an execution plan\n",
+                        "  /plan approve [ref] Approve and start execution\n",
+                        "  /plan status [ref]  Check plan progress\n",
+                        "  /plan revise [ref]  Revise with feedback\n",
+                        "  /plan list        List all plans\n",
+                        "\n",
+                        "Session:\n",
+                        "  /undo             Undo last turn\n",
+                        "  /redo             Redo undone turn\n",
+                        "  /compact          Compress context window\n",
+                        "  /clear            Clear current thread\n",
+                        "  /interrupt        Stop current operation\n",
+                        "  /new              New conversation thread\n",
+                        "  /thread <id>      Switch to thread\n",
+                        "  /resume           Resume a previous conversation\n",
+                        "\n",
+                        "Skills:\n",
+                        "  /skills             List installed skills\n",
+                        "{}",
+                        "\n",
+                        "Agent:\n",
+                        "  /heartbeat        Run heartbeat check\n",
+                        "  /summarize        Summarize current thread\n",
+                        "  /suggest          Suggest next steps\n",
+                        "  /restart          Gracefully restart the process\n",
+                        "\n",
+                        "  /quit             Exit",
+                    ),
+                    search_line,
+                )))
+            }
 
             "ping" => Ok(SubmissionResult::response("pong!")),
 
@@ -824,6 +834,12 @@ impl Agent {
 
             "skills" => {
                 if args.first().map(|s| s.as_str()) == Some("search") {
+                    if self.skill_catalog().is_none() {
+                        return Ok(SubmissionResult::error(
+                            "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
+                             Catalog search is not available.",
+                        ));
+                    }
                     let query = args[1..].join(" ");
                     if query.is_empty() {
                         return Ok(SubmissionResult::error("Usage: /skills search <query>"));
@@ -832,9 +848,12 @@ impl Agent {
                 } else if args.is_empty() {
                     self.handle_skills_list().await
                 } else {
-                    Ok(SubmissionResult::error(
-                        "Usage: /skills or /skills search <query>",
-                    ))
+                    let hint = if self.skill_catalog().is_some() {
+                        "Usage: /skills or /skills search <query>"
+                    } else {
+                        "Usage: /skills"
+                    };
+                    Ok(SubmissionResult::error(hint))
                 }
             }
 
@@ -942,10 +961,19 @@ impl Agent {
         };
 
         let skills = guard.skills();
+        let clawhub_hint = if self.skill_catalog().is_some() {
+            "\nUse /skills search <query> to find more on ClawHub."
+        } else {
+            ""
+        };
+
         if skills.is_empty() {
-            return Ok(SubmissionResult::response(
-                "No skills installed.\n\nUse /skills search <query> to find skills on ClawHub.",
-            ));
+            let msg = if self.skill_catalog().is_some() {
+                "No skills installed.\n\nUse /skills search <query> to find skills on ClawHub."
+            } else {
+                "No skills installed."
+            };
+            return Ok(SubmissionResult::response(msg));
         }
 
         let mut out = String::from("Installed skills:\n\n");
@@ -961,7 +989,7 @@ impl Agent {
                 s.manifest.name, s.manifest.version, s.trust, desc,
             ));
         }
-        out.push_str("\nUse /skills search <query> to find more on ClawHub.");
+        out.push_str(clawhub_hint);
 
         Ok(SubmissionResult::response(out))
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1149,9 +1149,14 @@ impl AppBuilder {
             }
 
             let registry = Arc::new(std::sync::RwLock::new(registry));
-            let catalog = ironclaw_skills::catalog::shared_catalog();
-            tools.register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
-            (Some(registry), Some(catalog))
+            let catalog = if self.config.skills.clawhub_enabled {
+                Some(ironclaw_skills::catalog::shared_catalog())
+            } else {
+                tracing::debug!("ClawHub registry disabled (CLAWHUB_ENABLED=false)");
+                None
+            };
+            tools.register_skill_tools(Arc::clone(&registry), catalog.clone());
+            (Some(registry), catalog)
         } else {
             (None, None)
         };

--- a/src/channels/web/features/status/mod.rs
+++ b/src/channels/web/features/status/mod.rs
@@ -44,6 +44,7 @@ pub(crate) struct GatewayStatusResponse {
     llm_model: String,
     enabled_channels: Vec<String>,
     engine_v2_enabled: bool,
+    clawhub_enabled: bool,
 }
 
 /// `GET /api/gateway/status` — runtime snapshot for the admin dashboard.
@@ -114,5 +115,6 @@ pub(crate) async fn gateway_status_handler(
         llm_model: active_config.llm_model,
         enabled_channels: active_config.enabled_channels,
         engine_v2_enabled: crate::bridge::is_engine_v2_enabled(),
+        clawhub_enabled: state.skill_catalog.is_some(),
     })
 }

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -123,7 +123,7 @@ pub async fn skills_search_handler(
 
     let catalog = Arc::clone(state.skill_catalog.as_ref().ok_or((
         StatusCode::NOT_IMPLEMENTED,
-        "Skill catalog not available".to_string(),
+        "ClawHub registry is not enabled (CLAWHUB_ENABLED=false)".to_string(),
     ))?);
 
     // Search ClawHub catalog
@@ -213,7 +213,8 @@ pub async fn skills_install_handler(
         ));
     }
 
-    tracing::info!(user_id = %user.user_id, skill = %req.name, "skill install requested");
+    let name = req.name.as_deref().unwrap_or("");
+    tracing::info!(user_id = %user.user_id, skill = %name, "skill install requested");
 
     let registry = state.skill_registry.as_ref().ok_or((
         StatusCode::NOT_IMPLEMENTED,
@@ -227,6 +228,14 @@ pub async fn skills_install_handler(
             ..crate::tools::builtin::skill_tools::SkillInstallPayload::default()
         }
     } else if let Some(ref url) = req.url {
+        // URL installs require ClawHub to be enabled
+        if state.skill_catalog.is_none() {
+            return Err((
+                StatusCode::FORBIDDEN,
+                "URL-based skill installs are disabled (ClawHub registry is not enabled)"
+                    .to_string(),
+            ));
+        }
         // Fetch from explicit URL (with SSRF protection)
         crate::tools::builtin::skill_tools::fetch_skill_payload(url)
             .await
@@ -234,14 +243,11 @@ pub async fn skills_install_handler(
     } else if let Some(ref catalog) = state.skill_catalog {
         let download_key = if let Some(slug) = req.slug.as_deref().filter(|s| !s.is_empty()) {
             slug.to_string()
-        } else if req.name.contains('/') {
-            req.name.clone()
+        } else if name.contains('/') {
+            name.to_string()
         } else {
-            let outcome = catalog.search(&req.name).await;
-            match ironclaw_skills::catalog::resolve_catalog_slug_for_name(
-                &req.name,
-                &outcome.results,
-            ) {
+            let outcome = catalog.search(name).await;
+            match ironclaw_skills::catalog::resolve_catalog_slug_for_name(name, &outcome.results) {
                 Ok(Some(resolved)) => resolved,
                 Ok(None) => {
                     let reason = outcome
@@ -251,7 +257,7 @@ pub async fn skills_install_handler(
                         StatusCode::BAD_REQUEST,
                         format!(
                             "Could not resolve skill name '{}' to a catalog slug: {}",
-                            req.name, reason
+                            name, reason
                         ),
                     ));
                 }
@@ -266,16 +272,13 @@ pub async fn skills_install_handler(
             .map_err(|e| (StatusCode::BAD_GATEWAY, e.to_string()))?
     } else {
         return Ok(Json(ActionResponse::fail(
-            "Provide 'content' or 'url' to install a skill".to_string(),
+            "Provide 'content' to install a skill (ClawHub registry is not enabled)".to_string(),
         )));
     };
 
     let normalized = ironclaw_skills::normalize_line_endings(&install_payload.skill_md);
-    let requested_identifier = install_requested_identifier(
-        &req.name,
-        req.slug.as_deref(),
-        resolved_download_key.as_deref(),
-    );
+    let requested_identifier =
+        install_requested_identifier(name, req.slug.as_deref(), resolved_download_key.as_deref());
 
     // Parse, check duplicates, and get install_dir under a brief read lock.
     let (user_dir, skill_name_from_parse, install_content) = {

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -14,14 +14,14 @@ use crate::channels::web::platform::state::GatewayState;
 use crate::channels::web::types::*;
 
 fn install_requested_identifier<'a>(
-    name: &'a str,
+    name: Option<&'a str>,
     explicit_slug: Option<&'a str>,
     resolved_download_key: Option<&'a str>,
-) -> &'a str {
+) -> Option<&'a str> {
     explicit_slug
         .filter(|s| !s.is_empty())
         .or(resolved_download_key.filter(|s| !s.is_empty()))
-        .unwrap_or(name)
+        .or(name.filter(|s| !s.is_empty()))
 }
 
 fn skill_setup_hint(skill: &ironclaw_skills::types::LoadedSkill) -> Option<String> {
@@ -277,8 +277,11 @@ pub async fn skills_install_handler(
     };
 
     let normalized = ironclaw_skills::normalize_line_endings(&install_payload.skill_md);
-    let requested_identifier =
-        install_requested_identifier(name, req.slug.as_deref(), resolved_download_key.as_deref());
+    let requested_identifier = install_requested_identifier(
+        req.name.as_deref(),
+        req.slug.as_deref(),
+        resolved_download_key.as_deref(),
+    );
 
     // Parse, check duplicates, and get install_dir under a brief read lock.
     let (user_dir, skill_name_from_parse, install_content) = {
@@ -292,7 +295,7 @@ pub async fn skills_install_handler(
         let (skill_name, install_content) =
             ironclaw_skills::registry::SkillRegistry::resolve_install_content(
                 &normalized,
-                Some(requested_identifier),
+                requested_identifier,
             )
             .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
 
@@ -401,7 +404,16 @@ pub async fn skills_remove_handler(
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use super::*;
+    use std::{path::Path, sync::Arc};
+
+    use axum::{Json, extract::State, http::HeaderMap};
+
+    use crate::channels::web::{
+        auth::{AuthenticatedUser, UserIdentity},
+        platform::{state::ActiveConfigSnapshot, ws::WsConnectionTracker},
+        sse::SseManager,
+    };
 
     #[test]
     fn catalog_entry_matches_installed_slug_suffix() {
@@ -451,11 +463,114 @@ mod tests {
     fn install_requested_identifier_prefers_resolved_slug_for_manual_name_installs() {
         assert_eq!(
             super::install_requested_identifier(
-                "Mortgage Calculator",
+                Some("Mortgage Calculator"),
                 None,
                 Some("finance/mortgage-calculator"),
             ),
-            "finance/mortgage-calculator"
+            Some("finance/mortgage-calculator")
+        );
+    }
+
+    #[test]
+    fn install_requested_identifier_omits_empty_name_hints() {
+        assert_eq!(super::install_requested_identifier(None, None, None), None);
+        assert_eq!(
+            super::install_requested_identifier(Some(""), None, None),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn skills_install_handler_uses_manifest_name_when_request_name_is_absent() {
+        let install_dir = tempfile::tempdir().expect("tempdir");
+        let state = Arc::new(GatewayState {
+            msg_tx: tokio::sync::RwLock::new(None),
+            sse: Arc::new(SseManager::new()),
+            workspace: None,
+            workspace_pool: None,
+            session_manager: None,
+            log_broadcaster: None,
+            log_level_handle: None,
+            extension_manager: None,
+            tool_registry: None,
+            store: None,
+            settings_cache: None,
+            job_manager: None,
+            prompt_queue: None,
+            owner_id: "test-user".to_string(),
+            shutdown_tx: tokio::sync::RwLock::new(None),
+            ws_tracker: Some(Arc::new(WsConnectionTracker::new())),
+            llm_provider: None,
+            llm_reload: None,
+            llm_session_manager: None,
+            config_toml_path: None,
+            skill_registry: Some(Arc::new(std::sync::RwLock::new(
+                ironclaw_skills::SkillRegistry::new(install_dir.path().to_path_buf()),
+            ))),
+            skill_catalog: None,
+            auth_manager: None,
+            scheduler: None,
+            chat_rate_limiter: crate::channels::web::platform::state::PerUserRateLimiter::new(
+                30, 60,
+            ),
+            oauth_rate_limiter: crate::channels::web::platform::state::PerUserRateLimiter::new(
+                20, 60,
+            ),
+            webhook_rate_limiter: crate::channels::web::platform::state::RateLimiter::new(10, 60),
+            registry_entries: Vec::new(),
+            cost_guard: None,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            startup_time: std::time::Instant::now(),
+            active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
+            secrets_store: None,
+            db_auth: None,
+            pairing_store: None,
+            oauth_providers: None,
+            oauth_state_store: None,
+            oauth_base_url: None,
+            oauth_allowed_domains: Vec::new(),
+            near_nonce_store: None,
+            near_rpc_url: None,
+            near_network: None,
+            oauth_sweep_shutdown: None,
+            frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
+            tool_dispatcher: None,
+        });
+        let mut headers = HeaderMap::new();
+        headers.insert("x-confirm-action", "true".parse().expect("static header"));
+
+        let response = super::skills_install_handler(
+            State(Arc::clone(&state)),
+            AuthenticatedUser(UserIdentity {
+                user_id: "test-user".to_string(),
+                role: "owner".to_string(),
+                workspace_read_scopes: Vec::new(),
+            }),
+            headers,
+            Json(SkillInstallRequest {
+                name: None,
+                slug: None,
+                url: None,
+                content: Some(
+                    "---\nname: manifest-only-skill\ndescription: demo\nactivation:\n  keywords: [demo]\n---\n\n# Demo\n"
+                        .to_string(),
+                ),
+            }),
+        )
+        .await
+        .expect("handler should accept inline content without name");
+
+        assert!(response.0.success);
+        assert_eq!(response.0.message, "Skill 'manifest-only-skill' installed");
+        assert!(
+            state
+                .skill_registry
+                .as_ref()
+                .expect("registry")
+                .read()
+                .expect("lock")
+                .has("manifest-only-skill"),
+            "manifest name should be preserved when request omits name"
         );
     }
 

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -411,8 +411,7 @@ mod tests {
 
     use crate::channels::web::{
         auth::{AuthenticatedUser, UserIdentity},
-        platform::{state::ActiveConfigSnapshot, ws::WsConnectionTracker},
-        sse::SseManager,
+        test_helpers::TestGatewayBuilder,
     };
 
     #[test]
@@ -483,59 +482,12 @@ mod tests {
     #[tokio::test]
     async fn skills_install_handler_uses_manifest_name_when_request_name_is_absent() {
         let install_dir = tempfile::tempdir().expect("tempdir");
-        let state = Arc::new(GatewayState {
-            msg_tx: tokio::sync::RwLock::new(None),
-            sse: Arc::new(SseManager::new()),
-            workspace: None,
-            workspace_pool: None,
-            session_manager: None,
-            log_broadcaster: None,
-            log_level_handle: None,
-            extension_manager: None,
-            tool_registry: None,
-            store: None,
-            settings_cache: None,
-            job_manager: None,
-            prompt_queue: None,
-            owner_id: "test-user".to_string(),
-            shutdown_tx: tokio::sync::RwLock::new(None),
-            ws_tracker: Some(Arc::new(WsConnectionTracker::new())),
-            llm_provider: None,
-            llm_reload: None,
-            llm_session_manager: None,
-            config_toml_path: None,
-            skill_registry: Some(Arc::new(std::sync::RwLock::new(
-                ironclaw_skills::SkillRegistry::new(install_dir.path().to_path_buf()),
-            ))),
-            skill_catalog: None,
-            auth_manager: None,
-            scheduler: None,
-            chat_rate_limiter: crate::channels::web::platform::state::PerUserRateLimiter::new(
-                30, 60,
-            ),
-            oauth_rate_limiter: crate::channels::web::platform::state::PerUserRateLimiter::new(
-                20, 60,
-            ),
-            webhook_rate_limiter: crate::channels::web::platform::state::RateLimiter::new(10, 60),
-            registry_entries: Vec::new(),
-            cost_guard: None,
-            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
-            startup_time: std::time::Instant::now(),
-            active_config: Arc::new(tokio::sync::RwLock::new(ActiveConfigSnapshot::default())),
-            secrets_store: None,
-            db_auth: None,
-            pairing_store: None,
-            oauth_providers: None,
-            oauth_state_store: None,
-            oauth_base_url: None,
-            oauth_allowed_domains: Vec::new(),
-            near_nonce_store: None,
-            near_rpc_url: None,
-            near_network: None,
-            oauth_sweep_shutdown: None,
-            frontend_html_cache: Arc::new(tokio::sync::RwLock::new(None)),
-            tool_dispatcher: None,
-        });
+        let mut state = TestGatewayBuilder::new().build();
+        Arc::get_mut(&mut state)
+            .expect("state should be uniquely owned in test")
+            .skill_registry = Some(Arc::new(std::sync::RwLock::new(
+            ironclaw_skills::SkillRegistry::new(install_dir.path().to_path_buf()),
+        )));
         let mut headers = HeaderMap::new();
         headers.insert("x-confirm-action", "true".parse().expect("static header"));
 

--- a/src/channels/web/types.rs
+++ b/src/channels/web/types.rs
@@ -840,7 +840,7 @@ pub struct SkillSearchResponse {
 
 #[derive(Debug, Deserialize)]
 pub struct SkillInstallRequest {
-    pub name: String,
+    pub name: Option<String>,
     /// Registry slug (e.g. "owner/skill-name"). Preferred over `name` for
     /// constructing the download URL when fetching from ClawHub.
     pub slug: Option<String>,

--- a/src/cli/skills.rs
+++ b/src/cli/skills.rs
@@ -61,7 +61,15 @@ pub async fn run_skills_command(
 
     match cmd {
         SkillsCommand::List { verbose, json } => cmd_list(&config, verbose, json).await,
-        SkillsCommand::Search { query, json } => cmd_search(&query, json).await,
+        SkillsCommand::Search { query, json } => {
+            if !config.clawhub_enabled {
+                anyhow::bail!(
+                    "ClawHub registry is disabled (CLAWHUB_ENABLED=false). \
+                     Catalog search is not available."
+                );
+            }
+            cmd_search(&query, json).await
+        }
         SkillsCommand::Info { name, json } => cmd_info(&config, &name, json).await,
     }
 }
@@ -122,8 +130,10 @@ async fn cmd_list(config: &SkillsConfig, verbose: bool, json: bool) -> anyhow::R
         println!("Skills directories:");
         println!("  User:      {}", config.local_dir.display());
         println!("  Installed: {}", config.installed_dir.display());
-        println!();
-        println!("Use 'ironclaw skills search <query>' to find skills on ClawHub.");
+        if config.clawhub_enabled {
+            println!();
+            println!("Use 'ironclaw skills search <query>' to find skills on ClawHub.");
+        }
         return Ok(());
     }
 

--- a/src/config/skills.rs
+++ b/src/config/skills.rs
@@ -12,6 +12,10 @@ use crate::settings::Settings;
 pub struct SkillsConfig {
     /// Whether the skills system is enabled.
     pub enabled: bool,
+    /// Whether the ClawHub public registry is enabled.
+    /// When `false`, catalog search and URL-based installs are disabled;
+    /// local skill management and inline content installs still work.
+    pub clawhub_enabled: bool,
     /// Directory containing user-placed skills (default: ~/.ironclaw/skills/).
     /// Skills here are loaded with `Trusted` trust level.
     pub local_dir: PathBuf,
@@ -31,6 +35,7 @@ impl Default for SkillsConfig {
     fn default() -> Self {
         Self {
             enabled: true,
+            clawhub_enabled: true,
             local_dir: default_skills_dir(),
             installed_dir: default_installed_skills_dir(),
             max_active_skills: 3,
@@ -65,6 +70,11 @@ impl SkillsConfig {
 
         Ok(Self {
             enabled: db_first_bool(ss.enabled, defaults.enabled, "SKILLS_ENABLED")?,
+            clawhub_enabled: db_first_bool(
+                ss.clawhub_enabled,
+                defaults.clawhub_enabled,
+                "CLAWHUB_ENABLED",
+            )?,
             // local_dir and installed_dir are env-only (filesystem paths, no settings counterpart)
             local_dir: optional_env("SKILLS_DIR")?
                 .map(PathBuf::from)
@@ -84,5 +94,42 @@ impl SkillsConfig {
             )?,
             max_scan_depth: parse_optional_env("SKILLS_MAX_SCAN_DEPTH", 3)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::helpers::lock_env;
+    use crate::settings::Settings;
+
+    #[test]
+    fn clawhub_enabled_defaults_true() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+        let cfg = SkillsConfig::resolve(&settings).expect("resolve");
+        assert!(cfg.clawhub_enabled);
+    }
+
+    #[test]
+    fn clawhub_enabled_env_false() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("CLAWHUB_ENABLED", "false") };
+        let cfg = SkillsConfig::resolve(&settings).expect("resolve");
+        unsafe { std::env::remove_var("CLAWHUB_ENABLED") };
+        assert!(!cfg.clawhub_enabled);
+    }
+
+    #[test]
+    fn clawhub_enabled_rejects_invalid() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+        // SAFETY: Under ENV_MUTEX, no concurrent env access.
+        unsafe { std::env::set_var("CLAWHUB_ENABLED", "not_a_bool") };
+        let result = SkillsConfig::resolve(&settings);
+        unsafe { std::env::remove_var("CLAWHUB_ENABLED") };
+        assert!(result.is_err());
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -911,6 +911,10 @@ pub struct SkillsSettings {
     #[serde(default = "default_true")]
     pub enabled: bool,
 
+    /// Whether the ClawHub public registry is enabled.
+    #[serde(default = "default_true")]
+    pub clawhub_enabled: bool,
+
     /// Maximum number of skills that can be active simultaneously.
     #[serde(default = "default_skills_max_active")]
     pub max_active_skills: usize,
@@ -932,6 +936,7 @@ impl Default for SkillsSettings {
     fn default() -> Self {
         Self {
             enabled: true,
+            clawhub_enabled: true,
             max_active_skills: default_skills_max_active(),
             max_context_tokens: default_skills_max_context_tokens(),
         }

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -697,13 +697,13 @@ impl Tool for SkillSearchTool {
 
 pub struct SkillInstallTool {
     registry: Arc<std::sync::RwLock<SkillRegistry>>,
-    catalog: Arc<SkillCatalog>,
+    catalog: Option<Arc<SkillCatalog>>,
 }
 
 impl SkillInstallTool {
     pub fn new(
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
-        catalog: Arc<SkillCatalog>,
+        catalog: Option<Arc<SkillCatalog>>,
     ) -> Self {
         Self { registry, catalog }
     }
@@ -745,37 +745,58 @@ impl Tool for SkillInstallTool {
     }
 
     fn description(&self) -> &str {
-        "Install a skill from SKILL.md content, a URL, or by name from the ClawHub catalog."
+        if self.catalog.is_some() {
+            "Install a skill from SKILL.md content, a URL, or by name from the ClawHub catalog."
+        } else {
+            "Install a skill from inline SKILL.md content."
+        }
     }
 
     fn parameters_schema(&self) -> serde_json::Value {
-        serde_json::json!({
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "Skill name or slug (from search results)"
+        if self.catalog.is_some() {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Skill name or slug (from search results)"
+                    },
+                    "slug": {
+                        "type": "string",
+                        "description": "Registry slug from catalog search results; preferred when installing from ClawHub"
+                    },
+                    "url": {
+                        "type": "string",
+                        "description": "Direct URL to a SKILL.md file"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Raw SKILL.md content to install directly"
+                    },
+                    "install_dependencies": {
+                        "type": "boolean",
+                        "description": "When true, also install companion skills declared in requires.skills. Defaults to false so dependency installs stay explicit in the approved tool call.",
+                        "default": false
+                    }
                 },
-                "slug": {
-                    "type": "string",
-                    "description": "Registry slug from catalog search results; preferred when installing from ClawHub"
+                "required": ["name"]
+            })
+        } else {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Skill name for the installed content"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "Raw SKILL.md content to install directly"
+                    }
                 },
-                "url": {
-                    "type": "string",
-                    "description": "Direct URL to a SKILL.md file"
-                },
-                "content": {
-                    "type": "string",
-                    "description": "Raw SKILL.md content to install directly"
-                },
-                "install_dependencies": {
-                    "type": "boolean",
-                    "description": "When true, also install companion skills declared in requires.skills. Defaults to false so dependency installs stay explicit in the approved tool call.",
-                    "default": false
-                }
-            },
-            "required": ["name"]
-        })
+                "required": ["content"]
+            })
+        }
     }
 
     async fn execute(
@@ -784,7 +805,10 @@ impl Tool for SkillInstallTool {
         _ctx: &JobContext,
     ) -> Result<ToolOutput, ToolError> {
         let start = std::time::Instant::now();
-        let name = require_str(&params, "name")?;
+        let name = params
+            .get("name")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty());
         let install_dependencies = params
             .get("install_dependencies")
             .and_then(|v| v.as_bool())
@@ -800,7 +824,7 @@ impl Tool for SkillInstallTool {
         // reinstalling the top-level skill. Dependency installs are not a
         // no-op: when explicitly requested, walk the loaded skill's companion
         // list instead of returning early.
-        let loaded_required_skills = {
+        let loaded_required_skills = if let Some(name) = name {
             let guard = self
                 .registry
                 .read()
@@ -819,19 +843,35 @@ impl Tool for SkillInstallTool {
             } else {
                 None
             }
+        } else {
+            None
         };
 
         if let Some(required_skills) = loaded_required_skills {
-            let chain_report = install_missing_skill_dependencies(
-                &self.registry,
-                self.catalog.registry_url(),
-                required_skills,
-                |url| async move { fetch_skill_payload(&url).await },
-            )
-            .await?;
+            let chain_report = if let Some(ref catalog) = self.catalog {
+                install_missing_skill_dependencies(
+                    &self.registry,
+                    catalog.registry_url(),
+                    required_skills.clone(),
+                    |url| async move { fetch_skill_payload(&url).await },
+                )
+                .await?
+            } else {
+                let missing = {
+                    let guard = registry_read(&self.registry);
+                    required_skills
+                        .into_iter()
+                        .filter(|s| !guard.has(s))
+                        .collect::<Vec<_>>()
+                };
+                ChainInstallReport {
+                    pending_explicit_install: missing,
+                    ..Default::default()
+                }
+            };
 
             return Ok(ToolOutput::success(
-                build_already_installed_output(name, &chain_report),
+                build_already_installed_output(name.unwrap_or("unknown"), &chain_report),
                 start.elapsed(),
             ));
         }
@@ -847,21 +887,34 @@ impl Tool for SkillInstallTool {
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
         {
+            // URL installs require ClawHub to be enabled
+            if self.catalog.is_none() {
+                return Err(ToolError::ExecutionFailed(
+                    "URL-based skill installs are disabled (ClawHub registry is not enabled). \
+                     Use the 'content' parameter to install from inline SKILL.md content."
+                        .to_string(),
+                ));
+            }
             // Fetch from explicit URL
             fetch_skill_payload(url).await.map_err(ToolError::from)?
         } else {
-            // Look up in catalog and fetch
+            // Catalog lookup requires ClawHub
+            let catalog = self.catalog.as_ref().ok_or_else(|| {
+                ToolError::ExecutionFailed(
+                    "Catalog-based skill installs are disabled (ClawHub registry is not enabled). \
+                     Use the 'content' parameter to install from inline SKILL.md content."
+                        .to_string(),
+                )
+            })?;
             let download_key = resolve_catalog_download_key(
-                self.catalog.as_ref(),
-                name,
+                catalog.as_ref(),
+                name.unwrap_or(""),
                 requested_identifier.as_deref(),
             )
             .await?;
             requested_identifier = Some(download_key.clone());
-            let download_url = ironclaw_skills::catalog::skill_download_url(
-                self.catalog.registry_url(),
-                &download_key,
-            );
+            let download_url =
+                ironclaw_skills::catalog::skill_download_url(catalog.registry_url(), &download_key);
             fetch_skill_payload(&download_url)
                 .await
                 .map_err(ToolError::from)?
@@ -966,10 +1019,7 @@ impl Tool for SkillInstallTool {
             ChainInstallReport::default()
         } else if !install_dependencies {
             let missing_required_skills = {
-                let guard = self
-                    .registry
-                    .read()
-                    .map_err(|e| ToolError::ExecutionFailed(format!("Lock poisoned: {}", e)))?;
+                let guard = registry_read(&self.registry);
                 required_skills
                     .into_iter()
                     .filter(|skill| !guard.has(skill))
@@ -980,14 +1030,26 @@ impl Tool for SkillInstallTool {
                 pending_explicit_install: missing_required_skills,
                 ..Default::default()
             }
-        } else {
+        } else if let Some(ref catalog) = self.catalog {
             install_missing_skill_dependencies(
                 &self.registry,
-                self.catalog.registry_url(),
+                catalog.registry_url(),
                 required_skills,
                 |url| async move { fetch_skill_payload(&url).await },
             )
             .await?
+        } else {
+            let missing = {
+                let guard = registry_read(&self.registry);
+                required_skills
+                    .into_iter()
+                    .filter(|s| !guard.has(s))
+                    .collect::<Vec<_>>()
+            };
+            ChainInstallReport {
+                pending_explicit_install: missing,
+                ..Default::default()
+            }
         };
 
         let output = build_skill_install_output(&installed_name, &chain_report);
@@ -1948,7 +2010,7 @@ mod tests {
     #[test]
     fn test_skill_install_schema() {
         use crate::tools::tool::ApprovalRequirement;
-        let tool = SkillInstallTool::new(test_registry(), test_catalog());
+        let tool = SkillInstallTool::new(test_registry(), Some(test_catalog()));
         assert_eq!(tool.name(), "skill_install");
         assert_eq!(
             tool.requires_approval(&serde_json::json!({})),
@@ -1959,6 +2021,74 @@ mod tests {
         assert!(schema["properties"].get("slug").is_some());
         assert!(schema["properties"].get("url").is_some());
         assert!(schema["properties"].get("content").is_some());
+    }
+
+    #[test]
+    fn test_skill_install_schema_without_catalog() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let schema = tool.parameters_schema();
+        assert!(schema["properties"].get("content").is_some());
+        assert!(schema["properties"].get("url").is_none());
+        assert!(schema["properties"].get("slug").is_none());
+        assert!(
+            tool.description().contains("inline"),
+            "description should mention inline when catalog is disabled"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_install_blocks_url_without_catalog() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let ctx = crate::context::JobContext::default();
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "name": "some-skill",
+                    "url": "https://example.com/SKILL.md"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("ClawHub"),
+            "error should mention ClawHub: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_install_blocks_catalog_lookup_without_catalog() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let ctx = crate::context::JobContext::default();
+        let result = tool
+            .execute(serde_json::json!({"name": "some-skill"}), &ctx)
+            .await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("ClawHub"),
+            "error should mention ClawHub: {err_msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_install_content_succeeds_without_catalog() {
+        let tool = SkillInstallTool::new(test_registry(), None);
+        let ctx = crate::context::JobContext::default();
+        let result = tool
+            .execute(
+                serde_json::json!({
+                    "content": "---\nname: test-inline\ndescription: a test\nactivation:\n  keywords: [test]\n---\nHello"
+                }),
+                &ctx,
+            )
+            .await;
+        assert!(
+            result.is_ok(),
+            "content install should succeed: {:?}",
+            result
+        );
     }
 
     /// Regression: when a persona bundle is already loaded (via bundled
@@ -1987,7 +2117,7 @@ mod tests {
             .unwrap()
             .commit_install(&name, loaded)
             .expect("commit should succeed");
-        let tool = SkillInstallTool::new(Arc::clone(&registry), test_catalog());
+        let tool = SkillInstallTool::new(Arc::clone(&registry), Some(test_catalog()));
 
         assert_eq!(
             tool.requires_approval(&serde_json::json!({"name": "ceo-setup"})),
@@ -2031,7 +2161,7 @@ mod tests {
             .unwrap()
             .commit_install(&name, loaded)
             .expect("commit should succeed");
-        let tool = SkillInstallTool::new(Arc::clone(&registry), test_catalog());
+        let tool = SkillInstallTool::new(Arc::clone(&registry), Some(test_catalog()));
 
         let output = tool
             .execute(

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -748,7 +748,7 @@ impl Tool for SkillInstallTool {
         if self.catalog.is_some() {
             "Install a skill from SKILL.md content, a URL, or by name from the ClawHub catalog."
         } else {
-            "Install a skill from inline SKILL.md content."
+            "Install a skill from inline SKILL.md content, or reference an already-loaded skill by name."
         }
     }
 
@@ -787,14 +787,14 @@ impl Tool for SkillInstallTool {
                 "properties": {
                     "name": {
                         "type": "string",
-                        "description": "Skill name for the installed content"
+                        "description": "Already-loaded skill name for idempotency or companion dependency reporting when ClawHub is disabled"
                     },
                     "content": {
                         "type": "string",
                         "description": "Raw SKILL.md content to install directly"
                     }
                 },
-                "required": ["content"]
+                "minProperties": 1
             })
         }
     }
@@ -2027,12 +2027,14 @@ mod tests {
     fn test_skill_install_schema_without_catalog() {
         let tool = SkillInstallTool::new(test_registry(), None);
         let schema = tool.parameters_schema();
+        assert!(schema["properties"].get("name").is_some());
         assert!(schema["properties"].get("content").is_some());
         assert!(schema["properties"].get("url").is_none());
         assert!(schema["properties"].get("slug").is_none());
+        assert_eq!(schema["minProperties"], 1);
         assert!(
-            tool.description().contains("inline"),
-            "description should mention inline when catalog is disabled"
+            tool.description().contains("already-loaded skill"),
+            "description should mention the no-op name path when catalog is disabled"
         );
     }
 
@@ -2088,6 +2090,44 @@ mod tests {
             result.is_ok(),
             "content install should succeed: {:?}",
             result
+        );
+    }
+
+    #[tokio::test]
+    async fn skill_install_already_loaded_succeeds_without_catalog() {
+        let registry = test_registry();
+        let (name, loaded) = {
+            let dir = registry.read().unwrap().install_target_dir().to_path_buf();
+            SkillRegistry::prepare_install_to_disk(
+                &dir,
+                "ceo-setup",
+                &skill_content("ceo-setup", &["dep-a"]),
+            )
+            .await
+            .expect("prepare should succeed")
+        };
+        registry
+            .write()
+            .unwrap()
+            .commit_install(&name, loaded)
+            .expect("commit should succeed");
+
+        let tool = SkillInstallTool::new(Arc::clone(&registry), None);
+        let output = tool
+            .execute(
+                serde_json::json!({
+                    "name": "ceo-setup",
+                    "install_dependencies": true,
+                }),
+                &JobContext::default(),
+            )
+            .await
+            .expect("already-loaded skill should support dependency reporting without catalog");
+
+        assert_eq!(output.result["status"], "already_installed_with_warnings");
+        assert_eq!(
+            output.result["pending_dependency_install"],
+            serde_json::json!(["dep-a"])
         );
     }
 

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -752,23 +752,28 @@ impl ToolRegistry {
 
     /// Register skill management tools (list, search, install, remove).
     ///
-    /// These allow the LLM to manage prompt-level skills through conversation.
+    /// When `catalog` is `None` (ClawHub disabled), `skill_search` is not
+    /// registered and `skill_install` only accepts inline content.
     pub fn register_skill_tools(
         &self,
         registry: Arc<std::sync::RwLock<SkillRegistry>>,
-        catalog: Arc<SkillCatalog>,
+        catalog: Option<Arc<SkillCatalog>>,
     ) {
+        let has_catalog = catalog.is_some();
         self.register_sync(Arc::new(SkillListTool::new(Arc::clone(&registry))));
-        self.register_sync(Arc::new(SkillSearchTool::new(
-            Arc::clone(&registry),
-            Arc::clone(&catalog),
-        )));
+        if let Some(ref cat) = catalog {
+            self.register_sync(Arc::new(SkillSearchTool::new(
+                Arc::clone(&registry),
+                Arc::clone(cat),
+            )));
+        }
         self.register_sync(Arc::new(SkillInstallTool::new(
             Arc::clone(&registry),
-            Arc::clone(&catalog),
+            catalog,
         )));
         self.register_sync(Arc::new(SkillRemoveTool::new(registry)));
-        tracing::debug!("Registered 4 skill management tools");
+        let tool_count = if has_catalog { 4 } else { 3 };
+        tracing::debug!("Registered {} skill management tools", tool_count);
     }
 
     /// Register routine management tools.

--- a/src/tools/schema_validator.rs
+++ b/src/tools/schema_validator.rs
@@ -522,7 +522,7 @@ mod tests {
             )),
             Box::new(SkillInstallTool::new(
                 Arc::clone(&registry),
-                Arc::clone(&catalog),
+                Some(Arc::clone(&catalog)),
             )),
             Box::new(SkillRemoveTool::new(Arc::clone(&registry))),
         ];

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -665,6 +665,7 @@ pub struct TestRigBuilder {
     injection_check: bool,
     auto_approve_tools: Option<bool>,
     enable_skills: bool,
+    clawhub_disabled: bool,
     skills_dir: Option<std::path::PathBuf>,
     enable_routines: bool,
     http_exchanges: Vec<HttpExchange>,
@@ -693,6 +694,7 @@ impl TestRigBuilder {
             injection_check: false,
             auto_approve_tools: Some(true),
             enable_skills: false,
+            clawhub_disabled: false,
             skills_dir: None,
             enable_routines: false,
             http_exchanges: Vec::new(),
@@ -844,6 +846,14 @@ impl TestRigBuilder {
         self
     }
 
+    /// Disable ClawHub registry (catalog search + URL installs).
+    /// Implies `with_skills()`.
+    pub fn with_clawhub_disabled(mut self) -> Self {
+        self.enable_skills = true;
+        self.clawhub_disabled = true;
+        self
+    }
+
     /// Set a custom skills directory so the test rig loads skill files
     /// from a real path (e.g. the repo's `skills/` directory) instead of
     /// an empty temp directory. Implies `with_skills()`.
@@ -913,6 +923,7 @@ impl TestRigBuilder {
             injection_check,
             auto_approve_tools,
             enable_skills,
+            clawhub_disabled,
             skills_dir,
             enable_routines,
             http_exchanges: explicit_http_exchanges,
@@ -1179,12 +1190,16 @@ impl TestRigBuilder {
                     .with_installed_dir(installed_skills_dir.clone());
                 let _loaded = registry.discover_all().await;
                 let registry = Arc::new(std::sync::RwLock::new(registry));
-                let catalog = ironclaw_skills::catalog::shared_catalog();
+                let catalog = if clawhub_disabled {
+                    None
+                } else {
+                    Some(ironclaw_skills::catalog::shared_catalog())
+                };
                 components
                     .tools
-                    .register_skill_tools(Arc::clone(&registry), Arc::clone(&catalog));
+                    .register_skill_tools(Arc::clone(&registry), catalog.clone());
                 components.skill_registry = Some(registry);
-                components.skill_catalog = Some(catalog);
+                components.skill_catalog = catalog;
             }
 
             // Register any extra test-specific tools.


### PR DESCRIPTION
## Summary

- Adds `CLAWHUB_ENABLED` env var (default `true`) to control access to the public ClawHub skill registry
- When `false`, disables catalog search and URL-based installs while preserving local skill management and inline content installs
- Supersedes stale PR #1594 (created March 23, merge state CONFLICTING due to gateway migration)

## Changes

**Config layer**: `clawhub_enabled` field on `SkillsConfig` + `SkillsSettings`, resolved via `db_first_bool` with `CLAWHUB_ENABLED` env override

**Core**: `skill_catalog` is now `Option<Arc<SkillCatalog>>` throughout — `app.rs`, `registry.rs`, `skill_tools.rs`, `test_rig.rs`

**Tool behavior when disabled**:
- `skill_search` tool is not registered
- `skill_install` only accepts `content` param; URL/catalog lookups return clear error messages
- Dependency chain install degrades gracefully (reports missing deps without fetching)

**Web API**:
- `GET /api/skills/search` returns 501 when disabled
- `POST /api/skills/install` with URL returns 403 when disabled
- `GET /api/gateway/status` includes `clawhub_enabled` field
- Frontend hides ClawHub search section via `.skill-search-section`

**CLI/Agent**: `/skills search` gated in help text, agent commands, and CLI subcommand

## Test plan

- [ ] `cargo fmt && cargo clippy --all --all-features` — zero warnings
- [ ] `cargo test --lib` — unit tests pass (3 new config tests + 4 new skill_tools tests)
- [ ] `CLAWHUB_ENABLED=false cargo run` — verify `/api/gateway/status` shows `clawhub_enabled: false`, search returns 501
- [ ] Verify default behavior unchanged (ClawHub enabled by default)

Refs #1570

🤖 Generated with [Claude Code](https://claude.com/claude-code)