### PR TITLE
feat:(cli) Add Engine V2 migrate CLI for OpenClaw and Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(cli)* add opt-in `ironclaw migrate openclaw|hermes` (behind `--features migrate`) for direct assistant migration into IronClaw Engine V2 state, legacy web history, settings, and encrypted secrets.
+
 ### Changed
 
 - *(web)* gateway onboarding/auth SSE now uses the unified `onboarding_state` event; external SSE clients should migrate from the older auth/pairing event names. Legacy WebSocket `auth_token` and `auth_cancel` client messages remain accepted during the temporary web v1-auth compatibility window.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -201,7 +201,7 @@ ed25519-dalek = { version = "2.2.0", features = ["std"] }
 bs58 = "0.5"
 hex = "0.4.3"
 
-# OpenClaw import (feature gated)
+# Migration readers (OpenClaw / Hermes)
 json5 = { version = "0.4", optional = true }
 
 # macOS keychain
@@ -253,7 +253,8 @@ replay = ["libsql"]
 html-to-markdown = ["dep:html-to-markdown-rs", "dep:readabilityrs"]
 bedrock = ["dep:aws-config", "dep:aws-sdk-bedrockruntime", "dep:aws-smithy-types"]
 tui = ["dep:ironclaw_tui"]
-import = ["dep:json5", "libsql"]
+# Opt-in migration/import CLI for external assistant homes.
+migrate = ["dep:json5", "libsql"]
 
 [[test]]
 name = "e2e_thread_scheduling"

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -167,6 +167,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 | `agents` | ✅ | ❌ | P3 | Multi-agent management |
 | `sessions` | ✅ | ❌ | P3 | Session listing (shows subagent models) |
 | `memory` | ✅ | ✅ | - | Memory search CLI |
+| `migrate` | ✅ | ✅ | P1 | `ironclaw migrate openclaw` and `ironclaw migrate hermes` import settings, secrets, workspace docs, Engine V2 threads/conversations, and legacy web history |
 | `skills` | ✅ | ✅ | - | CLI subcommands (list, search, info) + agent tools + web API endpoints |
 | `pairing` | ✅ | ✅ | - | list/approve, account selector |
 | `nodes` | ✅ | ❌ | P3 | Device management, remove/clear flows |

--- a/README.md
+++ b/README.md
@@ -292,6 +292,11 @@ Engine v2 is opt-in right now. If you want to run the new engine instead of the 
 # First-time setup (configures database, auth, etc.)
 ironclaw onboard
 
+# Migrate from OpenClaw or Hermes into IronClaw
+# (source builds: compile with the opt-in `migrate` feature)
+cargo run --features migrate -- migrate openclaw
+cargo run --features migrate -- migrate hermes --all-profiles
+
 # Start interactive REPL
 cargo run
 

--- a/README.md
+++ b/README.md
@@ -296,6 +296,8 @@ ironclaw onboard
 # (source builds: compile with the opt-in `migrate` feature)
 cargo run --features migrate -- migrate openclaw
 cargo run --features migrate -- migrate hermes --all-profiles
+# Hermes migrations preserve raw auth.json as an encrypted backup secret.
+# After verifying the import, rotate migrated credentials and remove the backup if you no longer need it.
 
 # Start interactive REPL
 cargo run

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -15,6 +15,7 @@ mod store_adapter;
 mod workspace_reader;
 
 pub use cost_guard_gate::CostGuardBudgetGate;
+pub use store_adapter::HybridStore;
 pub use workspace_reader::WorkspaceReaderAdapter;
 
 pub use effect_adapter::EffectBridgeAdapter;

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,162 +1,17 @@
-//! Import command for migrating data from other AI systems.
+//! Deprecated CLI alias for `ironclaw migrate`.
 
-use std::path::PathBuf;
-use std::sync::Arc;
+#[cfg(feature = "migrate")]
+pub type ImportCommand = crate::cli::migrate::MigrateCommand;
 
-use clap::Subcommand;
-
-#[cfg(feature = "import")]
-use crate::import::ImportOptions;
-#[cfg(feature = "import")]
-use crate::import::openclaw::OpenClawImporter;
-
-/// Import data from other AI systems.
-#[derive(Subcommand, Debug, Clone)]
-pub enum ImportCommand {
-    /// Import from OpenClaw (memory, history, settings, credentials)
-    #[cfg(feature = "import")]
-    Openclaw {
-        /// Path to OpenClaw directory (default: ~/.openclaw)
-        #[arg(long)]
-        path: Option<PathBuf>,
-
-        /// Dry-run mode: show what would be imported without writing
-        #[arg(long)]
-        dry_run: bool,
-
-        /// Re-embed memory if dimensions don't match target provider
-        #[arg(long)]
-        re_embed: bool,
-
-        /// User ID for imported data (default: 'default')
-        #[arg(long)]
-        user_id: Option<String>,
-    },
-}
-
-/// Run an import command.
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 pub async fn run_import_command(
     cmd: &ImportCommand,
     config: &crate::config::Config,
 ) -> anyhow::Result<()> {
-    match cmd {
-        ImportCommand::Openclaw {
-            path,
-            dry_run,
-            re_embed,
-            user_id,
-        } => run_import_openclaw(config, path.clone(), *dry_run, *re_embed, user_id.clone()).await,
-    }
+    crate::cli::run_migrate_command(cmd, config).await
 }
 
-/// Run the OpenClaw import.
-#[cfg(feature = "import")]
-async fn run_import_openclaw(
-    config: &crate::config::Config,
-    openclaw_path: Option<PathBuf>,
-    dry_run: bool,
-    re_embed: bool,
-    user_id: Option<String>,
-) -> anyhow::Result<()> {
-    use secrecy::SecretString;
-
-    // Determine OpenClaw path
-    let openclaw_path = if let Some(path) = openclaw_path {
-        path
-    } else if let Some(path) = OpenClawImporter::detect() {
-        path
-    } else {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
-        PathBuf::from(home).join(".openclaw")
-    };
-
-    let user_id = user_id.unwrap_or_else(|| "default".to_string());
-
-    println!("🔍 OpenClaw Import");
-    println!("  Path: {}", openclaw_path.display());
-    println!("  User: {}", user_id);
-    if dry_run {
-        println!("  Mode: DRY RUN (no data will be written)");
-    }
-    println!();
-
-    // Initialize database
-    let db = crate::db::connect_from_config(&config.database)
-        .await
-        .map_err(|e| anyhow::anyhow!("Failed to initialize database: {}", e))?;
-
-    // Initialize secrets store with master key from env or keychain
-    let secrets_crypto = if let Ok(master_key_hex) = std::env::var("SECRETS_MASTER_KEY") {
-        Arc::new(
-            crate::secrets::SecretsCrypto::new(SecretString::from(master_key_hex))
-                .map_err(|e| anyhow::anyhow!("Failed to initialize secrets: {}", e))?,
-        )
-    } else {
-        match crate::secrets::keychain::get_master_key().await {
-            Ok(key_bytes) => {
-                let key_hex: String = key_bytes.iter().map(|b| format!("{:02x}", b)).collect();
-                Arc::new(
-                    crate::secrets::SecretsCrypto::new(SecretString::from(key_hex))
-                        .map_err(|e| anyhow::anyhow!("Failed to initialize secrets: {}", e))?,
-                )
-            }
-            Err(_) => {
-                return Err(anyhow::anyhow!(
-                    "No secrets master key found. Set SECRETS_MASTER_KEY env var or run 'ironclaw onboard' first."
-                ));
-            }
-        }
-    };
-
-    let secrets: Arc<dyn crate::secrets::SecretsStore> = Arc::new(
-        crate::secrets::InMemorySecretsStore::new(secrets_crypto.clone()),
-    );
-
-    // Initialize workspace
-    let workspace = crate::workspace::Workspace::new_with_db(user_id.clone(), db.clone());
-
-    let opts = ImportOptions {
-        openclaw_path,
-        dry_run,
-        re_embed,
-        user_id,
-    };
-
-    let importer = OpenClawImporter::new(db, workspace, secrets, opts);
-    let stats = importer.import().await?;
-
-    // Print results
-    println!("Import Complete");
-    println!();
-    println!("Summary:");
-    println!("  Documents:    {}", stats.documents);
-    println!("  Chunks:       {}", stats.chunks);
-    println!("  Conversations: {}", stats.conversations);
-    println!("  Messages:     {}", stats.messages);
-    println!("  Settings:     {}", stats.settings);
-    println!("  Secrets:      {}", stats.secrets);
-    if stats.skipped > 0 {
-        println!("  Skipped:      {}", stats.skipped);
-    }
-    if stats.re_embed_queued > 0 {
-        println!("  Re-embed queued: {}", stats.re_embed_queued);
-    }
-    println!();
-    println!("Total imported: {}", stats.total_imported());
-
-    if dry_run {
-        println!();
-        println!("[DRY RUN] No data was written.");
-    }
-
-    Ok(())
-}
-
-#[cfg(not(feature = "import"))]
-pub async fn run_import_command(
-    _cmd: &ImportCommand,
-    _config: &crate::config::Config,
-) -> anyhow::Result<()> {
-    anyhow::bail!("Import feature not enabled. Compile with --features import")
+#[cfg(not(feature = "migrate"))]
+pub async fn run_import_command(_cmd: &(), _config: &crate::config::Config) -> anyhow::Result<()> {
+    anyhow::bail!("Migration feature not enabled. Compile with --features migrate")
 }

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -1,6 +1,8 @@
 //! Deprecated CLI alias for `ironclaw migrate`.
 
 #[cfg(feature = "migrate")]
+/// **Deprecated**: use [`MigrateCommand`](crate::cli::migrate::MigrateCommand) instead.
+/// This alias will be removed in a future release.
 pub type ImportCommand = crate::cli::migrate::MigrateCommand;
 
 #[cfg(feature = "migrate")]

--- a/src/cli/import.rs
+++ b/src/cli/import.rs
@@ -3,11 +3,12 @@
 #[cfg(feature = "migrate")]
 /// **Deprecated**: use [`MigrateCommand`](crate::cli::migrate::MigrateCommand) instead.
 /// This alias will be removed in a future release.
+#[deprecated(note = "use `ironclaw migrate` instead; removed in a future release")]
 pub type ImportCommand = crate::cli::migrate::MigrateCommand;
 
 #[cfg(feature = "migrate")]
 pub async fn run_import_command(
-    cmd: &ImportCommand,
+    cmd: &crate::cli::migrate::MigrateCommand,
     config: &crate::config::Config,
 ) -> anyhow::Result<()> {
     crate::cli::run_migrate_command(cmd, config).await

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -153,11 +153,23 @@ fn print_summary(cmd: &MigrateCommand, stats: &MigrationStats) {
         }
     }
 
-    if !stats.notes.is_empty() {
+    let (security_notes, general_notes): (Vec<_>, Vec<_>) = stats
+        .notes
+        .iter()
+        .partition(|note| note.contains("auth.json") || note.contains("credential"));
+    if !security_notes.is_empty() {
+        println!();
+        println!("SECURITY:");
+        for note in &security_notes {
+            println!("  !! {note}");
+        }
+        println!("  !! Consider rotating migrated credentials after verifying the import.");
+    }
+    if !general_notes.is_empty() {
         println!();
         println!("Notes:");
-        for note in &stats.notes {
-            println!("  - {}", note);
+        for note in &general_notes {
+            println!("  - {note}");
         }
     }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,163 @@
+//! CLI command for migrating from external assistants into IronClaw.
+
+use std::path::PathBuf;
+
+use clap::Subcommand;
+
+use crate::migrate::{MigrationServices, MigrationStats, hermes, openclaw};
+
+/// Migrate data from external assistants into IronClaw.
+#[derive(Subcommand, Debug, Clone)]
+pub enum MigrateCommand {
+    /// Migrate an OpenClaw home directory into IronClaw.
+    Openclaw {
+        /// Path to the OpenClaw home directory (defaults to ~/.openclaw).
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// Preview what would be imported without writing any state.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Target IronClaw user scope (defaults to config owner_id).
+        #[arg(long)]
+        user_id: Option<String>,
+    },
+
+    /// Migrate a Hermes Agent home/profile into IronClaw.
+    Hermes {
+        /// Path to the Hermes home directory (defaults to ~/.hermes).
+        #[arg(long)]
+        path: Option<PathBuf>,
+
+        /// One or more named Hermes profiles to import (repeatable).
+        #[arg(long = "profile")]
+        profiles: Vec<String>,
+
+        /// Import the default Hermes root plus every named profile under profiles/.
+        #[arg(long)]
+        all_profiles: bool,
+
+        /// Preview what would be imported without writing any state.
+        #[arg(long)]
+        dry_run: bool,
+
+        /// Target IronClaw user scope (defaults to config owner_id).
+        #[arg(long)]
+        user_id: Option<String>,
+    },
+}
+
+pub async fn run_migrate_command(
+    cmd: &MigrateCommand,
+    config: &crate::config::Config,
+) -> anyhow::Result<()> {
+    let user_id = migrate_user_id(cmd, config);
+    let services = MigrationServices::from_config(config, user_id).await?;
+    let stats = run_migrate_command_with_services(cmd, &services).await?;
+    print_summary(cmd, &stats);
+    Ok(())
+}
+
+#[doc(hidden)]
+pub async fn run_migrate_command_with_services(
+    cmd: &MigrateCommand,
+    services: &MigrationServices,
+) -> anyhow::Result<MigrationStats> {
+    let stats = match cmd {
+        MigrateCommand::Openclaw { path, dry_run, .. } => {
+            let path = path.clone().or_else(openclaw::detect).unwrap_or_else(|| {
+                std::env::var("HOME")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|_| PathBuf::from("."))
+                    .join(".openclaw")
+            });
+            openclaw::migrate(
+                services,
+                &openclaw::OpenClawMigrationOptions {
+                    path,
+                    dry_run: *dry_run,
+                },
+            )
+            .await?
+        }
+        MigrateCommand::Hermes {
+            path,
+            profiles,
+            all_profiles,
+            dry_run,
+            ..
+        } => {
+            let path = path.clone().or_else(hermes::detect).unwrap_or_else(|| {
+                std::env::var("HOME")
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|_| PathBuf::from("."))
+                    .join(".hermes")
+            });
+            hermes::migrate(
+                services,
+                &hermes::HermesMigrationOptions {
+                    path,
+                    dry_run: *dry_run,
+                    profiles: profiles.clone(),
+                    all_profiles: *all_profiles,
+                },
+            )
+            .await?
+        }
+    };
+
+    Ok(stats)
+}
+
+fn migrate_user_id(cmd: &MigrateCommand, config: &crate::config::Config) -> String {
+    match cmd {
+        MigrateCommand::Openclaw { user_id, .. } | MigrateCommand::Hermes { user_id, .. } => {
+            user_id.clone().unwrap_or_else(|| config.owner_id.clone())
+        }
+    }
+}
+
+fn print_summary(cmd: &MigrateCommand, stats: &MigrationStats) {
+    let source_name = match cmd {
+        MigrateCommand::Openclaw { .. } => "OpenClaw",
+        MigrateCommand::Hermes { .. } => "Hermes",
+    };
+
+    println!("Migration complete: {source_name}");
+    println!();
+    println!("Summary:");
+    println!("  Workspace docs:       {}", stats.workspace_documents);
+    println!("  Memory docs:          {}", stats.memory_docs);
+    println!("  Engine threads:       {}", stats.engine_threads);
+    println!("  Engine conversations: {}", stats.engine_conversations);
+    println!("  Legacy conversations: {}", stats.legacy_conversations);
+    println!("  Messages:             {}", stats.messages);
+    println!("  Settings:             {}", stats.settings);
+    println!("  Secrets:              {}", stats.secrets);
+    if stats.projects > 0 {
+        println!("  Projects created:     {}", stats.projects);
+    }
+    if stats.skipped > 0 {
+        println!("  Skipped:              {}", stats.skipped);
+    }
+    println!();
+    println!("Total migrated: {}", stats.total_imported());
+
+    match cmd {
+        MigrateCommand::Openclaw { dry_run, .. } | MigrateCommand::Hermes { dry_run, .. } => {
+            if *dry_run {
+                println!();
+                println!("[DRY RUN] No data was written.");
+            }
+        }
+    }
+
+    if !stats.notes.is_empty() {
+        println!();
+        println!("Notes:");
+        for note in &stats.notes {
+            println!("  - {}", note);
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -14,6 +14,7 @@
 //! - Active health diagnostics (`doctor`)
 //! - Viewing gateway logs (`logs`)
 //! - Checking system health (`status`)
+//! - Migrating from OpenClaw / Hermes (`migrate`)
 
 pub mod acp;
 mod channels;
@@ -22,11 +23,13 @@ mod config;
 mod doctor;
 pub mod fmt;
 mod hooks;
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 pub mod import;
 mod logs;
 mod mcp;
 pub mod memory;
+#[cfg(feature = "migrate")]
+pub mod migrate;
 mod models;
 mod pairing;
 mod profile;
@@ -43,12 +46,14 @@ pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
 pub use hooks::{HooksCommand, run_hooks_command};
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 pub use import::{ImportCommand, run_import_command};
 pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
 pub use memory::MemoryCommand;
 pub use memory::run_memory_command_with_db;
+#[cfg(feature = "migrate")]
+pub use migrate::{MigrateCommand, run_migrate_command, run_migrate_command_with_services};
 pub use models::{ModelsCommand, run_models_command};
 pub use pairing::{PairingCommand, run_pairing_command, run_pairing_command_with_store};
 pub use profile::{ProfileCommand, run_profile_command};
@@ -311,13 +316,18 @@ pub enum Command {
     )]
     Completion(Completion),
 
-    /// Import data from other AI systems
-    #[cfg(feature = "import")]
+    /// Migrate from external assistants into IronClaw
+    #[cfg(feature = "migrate")]
     #[command(
         subcommand,
-        about = "Import from other AI systems",
-        long_about = "Migrate data from other AI assistants like OpenClaw.\nExample: ironclaw import openclaw"
+        about = "Migrate from external assistants",
+        long_about = "Import data directly from external assistant homes into IronClaw Engine V2 + legacy history surfaces.\n\nExamples:\n  ironclaw migrate openclaw\n  ironclaw migrate hermes --all-profiles"
     )]
+    Migrate(MigrateCommand),
+
+    /// Deprecated alias for `ironclaw migrate`
+    #[cfg(feature = "migrate")]
+    #[command(subcommand, hide = true)]
     Import(ImportCommand),
 
     /// Authenticate with a provider (re-login)
@@ -479,7 +489,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "import")]
+    #[cfg(feature = "migrate")]
     fn test_help_output() {
         let mut cmd = Cli::command();
         let help = cmd.render_help().to_string();
@@ -487,7 +497,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "import"))]
+    #[cfg(not(feature = "migrate"))]
     fn test_help_output_without_import() {
         let mut cmd = Cli::command();
         let help = cmd.render_help().to_string();
@@ -495,7 +505,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(feature = "import")]
+    #[cfg(feature = "migrate")]
     fn test_long_help_output() {
         let mut cmd = Cli::command();
         let help = cmd.render_long_help().to_string();
@@ -503,7 +513,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(not(feature = "import"))]
+    #[cfg(not(feature = "migrate"))]
     fn test_long_help_output_without_import() {
         let mut cmd = Cli::command();
         let help = cmd.render_long_help().to_string();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -47,6 +47,7 @@ pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
 pub use hooks::{HooksCommand, run_hooks_command};
 #[cfg(feature = "migrate")]
+#[allow(deprecated)]
 pub use import::{ImportCommand, run_import_command};
 pub use logs::{LogsCommand, run_logs_command};
 pub use mcp::{McpCommand, run_mcp_command};
@@ -327,8 +328,13 @@ pub enum Command {
 
     /// Deprecated alias for `ironclaw migrate`
     #[cfg(feature = "migrate")]
-    #[command(subcommand, hide = true)]
-    Import(ImportCommand),
+    #[command(
+        subcommand,
+        hide = true,
+        about = "Deprecated alias for `ironclaw migrate`",
+        long_about = "Deprecated alias for `ironclaw migrate`.\n\nUse `ironclaw migrate ...` instead. This alias will be removed in a future release."
+    )]
+    Import(migrate::MigrateCommand),
 
     /// Authenticate with a provider (re-login)
     #[command(

--- a/src/import/mod.rs
+++ b/src/import/mod.rs
@@ -3,7 +3,7 @@
 //! Provides tools to migrate existing OpenClaw installations (memory, history,
 //! settings, and credentials) into IronClaw without data loss.
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 pub mod openclaw;
 
 use std::path::PathBuf;

--- a/src/import/openclaw/reader.rs
+++ b/src/import/openclaw/reader.rs
@@ -81,7 +81,7 @@ pub struct OpenClawMessage {
 }
 
 /// Open an OpenClaw SQLite database file via libsql for read-only access.
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 async fn open_sqlite(db_path: &Path) -> Result<libsql::Connection, ImportError> {
     let db = libsql::Builder::new_local(db_path)
         .build()
@@ -130,7 +130,7 @@ impl OpenClawReader {
 
         let content = std::fs::read_to_string(&config_path).map_err(ImportError::Io)?;
 
-        #[cfg(feature = "import")]
+        #[cfg(feature = "migrate")]
         {
             let config: serde_json::Value =
                 json5::from_str(&content).map_err(|e| ImportError::ConfigParse(e.to_string()))?;
@@ -194,10 +194,10 @@ impl OpenClawReader {
             })
         }
 
-        #[cfg(not(feature = "import"))]
+        #[cfg(not(feature = "migrate"))]
         {
             Err(ImportError::ConfigParse(
-                "Import feature not enabled (compile with --features import)".to_string(),
+                "Migration feature not enabled (compile with --features migrate)".to_string(),
             ))
         }
     }
@@ -235,7 +235,7 @@ impl OpenClawReader {
     }
 
     /// Read all memory chunks from an OpenClaw SQLite database.
-    #[cfg(feature = "import")]
+    #[cfg(feature = "migrate")]
     pub async fn read_memory_chunks(
         &self,
         db_path: &Path,
@@ -288,7 +288,7 @@ impl OpenClawReader {
     }
 
     /// Read all conversations from an OpenClaw SQLite database.
-    #[cfg(feature = "import")]
+    #[cfg(feature = "migrate")]
     pub async fn read_conversations(
         &self,
         db_path: &Path,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,11 @@ pub(crate) mod generated_images;
 pub mod history;
 pub mod hooks;
 pub mod http_intercept;
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 pub mod import;
 pub mod llm;
+#[cfg(feature = "migrate")]
+pub mod migrate;
 pub mod observability;
 pub mod orchestrator;
 pub mod ownership;

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,7 +220,13 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return completion.run();
         }
-        #[cfg(feature = "import")]
+        #[cfg(feature = "migrate")]
+        Some(Command::Migrate(migrate_cmd)) => {
+            init_cli_tracing();
+            let config = ironclaw::config::Config::from_env().await?;
+            return ironclaw::cli::run_migrate_command(migrate_cmd, &config).await;
+        }
+        #[cfg(feature = "migrate")]
         Some(Command::Import(import_cmd)) => {
             init_cli_tracing();
             let config = ironclaw::config::Config::from_env().await?;

--- a/src/migrate/hermes.rs
+++ b/src/migrate/hermes.rs
@@ -1,0 +1,949 @@
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+
+use secrecy::SecretString;
+use serde_json::{Value, json};
+
+use crate::settings::{
+    CustomLlmProviderSettings, LlmBuiltinOverride, builtin_secret_name, custom_secret_name,
+};
+
+use super::{
+    ImportedConversation, ImportedDocument, ImportedMessage, ImportedMessageRole, ImportedSecret,
+    MigrationError, MigrationServices, MigrationStats, collect_markdown_files,
+    normalize_relative_path, parse_timestamp_str, slugify,
+};
+
+#[derive(Debug, Clone)]
+pub struct HermesMigrationOptions {
+    pub path: PathBuf,
+    pub dry_run: bool,
+    pub profiles: Vec<String>,
+    pub all_profiles: bool,
+}
+
+#[derive(Debug, Clone)]
+struct HermesProviderEntry {
+    id: String,
+    name: String,
+    base_url: Option<String>,
+    key_env: Option<String>,
+    transport: Option<String>,
+    model: Option<String>,
+    api_key: Option<SecretString>,
+}
+
+#[derive(Debug, Clone, Default)]
+struct HermesConfigData {
+    model_provider: Option<String>,
+    default_model: Option<String>,
+    model_base_url: Option<String>,
+    providers: Vec<HermesProviderEntry>,
+}
+
+#[derive(Debug, Clone)]
+struct HermesMessage {
+    role: String,
+    content: String,
+    timestamp: Option<chrono::DateTime<chrono::Utc>>,
+    tool_name: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct HermesSession {
+    id: String,
+    source: Option<String>,
+    user_id: Option<String>,
+    model: Option<String>,
+    title: Option<String>,
+    started_at: Option<chrono::DateTime<chrono::Utc>>,
+    messages: Vec<HermesMessage>,
+}
+
+#[derive(Debug, Clone)]
+struct HermesScope {
+    name: String,
+    root: PathBuf,
+}
+
+pub fn detect() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(PathBuf::from)
+        .map(|home| home.join(".hermes"))
+        .filter(|path| path.join("config.yaml").exists() || path.join("state.db").exists())
+}
+
+pub async fn migrate(
+    services: &MigrationServices,
+    options: &HermesMigrationOptions,
+) -> Result<MigrationStats, MigrationError> {
+    let scopes = resolve_scopes(&options.path, &options.profiles, options.all_profiles)?;
+    let mut stats = MigrationStats::default();
+
+    if scopes.len() > 1 {
+        stats.push_note(format!(
+            "Importing {} Hermes scopes. Runtime settings/secrets will be taken from the primary scope '{}'; conversations and markdown memory will be imported from all selected scopes.",
+            scopes.len(),
+            scopes.first().map(|scope| scope.name.as_str()).unwrap_or("default")
+        ));
+    }
+
+    if let Some(primary) = scopes.first() {
+        let config = read_config(&primary.root)?;
+        let env = read_env_file(&primary.root.join(".env"))?;
+        let auth = read_optional_json(&primary.root.join("auth.json"))?;
+        let (settings_patch, secrets, notes) =
+            map_primary_scope(&primary.name, &config, &env, auth.as_ref());
+        for note in notes {
+            stats.push_note(note);
+        }
+
+        if options.dry_run {
+            stats.settings += settings_patch.len();
+            stats.secrets += secrets.len();
+        } else {
+            services
+                .apply_settings_patch(settings_patch, &mut stats)
+                .await?;
+            for secret in secrets {
+                services.store_secret(secret, &mut stats).await?;
+            }
+        }
+    }
+
+    for scope in scopes {
+        import_scope_markdown(services, options, &scope, &mut stats).await?;
+        import_scope_sessions(services, options, &scope, &mut stats).await?;
+    }
+
+    Ok(stats)
+}
+
+fn resolve_scopes(
+    root: &Path,
+    profiles: &[String],
+    all_profiles: bool,
+) -> Result<Vec<HermesScope>, MigrationError> {
+    if !root.exists() {
+        return Err(MigrationError::NotFound {
+            path: root.to_path_buf(),
+            reason: "directory does not exist".to_string(),
+        });
+    }
+
+    let mut scopes = Vec::new();
+    if all_profiles {
+        scopes.push(HermesScope {
+            name: "default".to_string(),
+            root: root.to_path_buf(),
+        });
+        let profiles_dir = root.join("profiles");
+        if profiles_dir.exists() {
+            let mut names = std::fs::read_dir(&profiles_dir)?
+                .flatten()
+                .filter(|entry| entry.path().is_dir())
+                .filter_map(|entry| entry.file_name().to_str().map(|value| value.to_string()))
+                .collect::<Vec<_>>();
+            names.sort();
+            for name in names {
+                scopes.push(HermesScope {
+                    name: name.clone(),
+                    root: profiles_dir.join(name),
+                });
+            }
+        }
+        return Ok(scopes);
+    }
+
+    if profiles.is_empty() {
+        scopes.push(HermesScope {
+            name: "default".to_string(),
+            root: root.to_path_buf(),
+        });
+        return Ok(scopes);
+    }
+
+    for profile in profiles {
+        if profile == "default" {
+            scopes.push(HermesScope {
+                name: "default".to_string(),
+                root: root.to_path_buf(),
+            });
+            continue;
+        }
+        let path = root.join("profiles").join(profile);
+        if !path.exists() {
+            return Err(MigrationError::NotFound {
+                path,
+                reason: format!("Hermes profile '{}' not found", profile),
+            });
+        }
+        scopes.push(HermesScope {
+            name: profile.clone(),
+            root: root.join("profiles").join(profile),
+        });
+    }
+
+    Ok(scopes)
+}
+
+fn read_config(root: &Path) -> Result<HermesConfigData, MigrationError> {
+    let config_path = root.join("config.yaml");
+    if !config_path.exists() {
+        return Ok(HermesConfigData::default());
+    }
+
+    let content = std::fs::read_to_string(&config_path)?;
+    let yaml: Value =
+        serde_yml::from_str(&content).map_err(|e| MigrationError::ConfigParse(e.to_string()))?;
+
+    let model_obj = yaml.get("model").and_then(Value::as_object);
+    let model_provider = model_obj
+        .and_then(|value| value.get("provider"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            yaml.get("provider")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        });
+    let default_model = model_obj
+        .and_then(|value| value.get("default"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            yaml.get("model")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        });
+    let model_base_url = model_obj
+        .and_then(|value| value.get("base_url"))
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .or_else(|| {
+            yaml.get("base_url")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        });
+
+    let mut providers = Vec::new();
+    if let Some(map) = yaml.get("providers").and_then(Value::as_object) {
+        for (provider_id, value) in map {
+            let Some(entry) = value.as_object() else {
+                continue;
+            };
+            let base_url = ["api", "url", "base_url"]
+                .iter()
+                .find_map(|key| entry.get(*key).and_then(Value::as_str))
+                .map(ToString::to_string);
+            let key_env = entry
+                .get("key_env")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            let transport = entry
+                .get("transport")
+                .or_else(|| entry.get("api_mode"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            let model = entry
+                .get("model")
+                .or_else(|| entry.get("default_model"))
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            let api_key = entry
+                .get("api_key")
+                .and_then(Value::as_str)
+                .map(|value| SecretString::new(value.to_string().into_boxed_str()));
+            providers.push(HermesProviderEntry {
+                id: slugify(provider_id),
+                name: entry
+                    .get("name")
+                    .and_then(Value::as_str)
+                    .unwrap_or(provider_id)
+                    .to_string(),
+                base_url,
+                key_env,
+                transport,
+                model,
+                api_key,
+            });
+        }
+        providers.sort_by(|a, b| a.id.cmp(&b.id));
+    }
+
+    Ok(HermesConfigData {
+        model_provider,
+        default_model,
+        model_base_url,
+        providers,
+    })
+}
+
+fn read_env_file(path: &Path) -> Result<HashMap<String, SecretString>, MigrationError> {
+    let mut values = HashMap::new();
+    if !path.exists() {
+        return Ok(values);
+    }
+    for item in
+        dotenvy::from_path_iter(path).map_err(|e| MigrationError::ConfigParse(e.to_string()))?
+    {
+        let (key, value) = item.map_err(|e| MigrationError::ConfigParse(e.to_string()))?;
+        values.insert(key, SecretString::new(value.into_boxed_str()));
+    }
+    Ok(values)
+}
+
+fn read_optional_json(path: &Path) -> Result<Option<Value>, MigrationError> {
+    if !path.exists() {
+        return Ok(None);
+    }
+    let content = std::fs::read_to_string(path)?;
+    let value =
+        serde_json::from_str(&content).map_err(|e| MigrationError::ConfigParse(e.to_string()))?;
+    Ok(Some(value))
+}
+
+fn map_primary_scope(
+    scope_name: &str,
+    config: &HermesConfigData,
+    env: &HashMap<String, SecretString>,
+    auth: Option<&Value>,
+) -> (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>) {
+    let mut patch = HashMap::new();
+    let mut secrets = Vec::new();
+    let mut notes = Vec::new();
+
+    let active_provider = config.model_provider.clone().or_else(|| {
+        auth.and_then(|value| value.get("active_provider"))
+            .and_then(Value::as_str)
+            .map(ToString::to_string)
+    });
+    if config.model_provider.is_none() {
+        if let Some(provider) = active_provider.as_ref() {
+            notes.push(format!(
+                "Hermes config had no active model.provider; used auth.json active_provider='{}'.",
+                provider
+            ));
+        }
+    }
+
+    let mut custom_providers = Vec::new();
+    let mut builtin_overrides: HashMap<String, LlmBuiltinOverride> = HashMap::new();
+
+    for provider in &config.providers {
+        if let Some(builtin) = normalize_builtin_provider(&provider.name)
+            .or_else(|| normalize_builtin_provider(&provider.id))
+        {
+            if let Some(base_url) = provider.base_url.as_ref()
+                && builtin != "openai_compatible"
+                && builtin != "ollama"
+            {
+                builtin_overrides.insert(
+                    builtin.clone(),
+                    LlmBuiltinOverride {
+                        api_key: None,
+                        model: provider.model.clone(),
+                        base_url: Some(base_url.clone()),
+                    },
+                );
+            }
+        } else if let Some(base_url) = provider.base_url.as_ref() {
+            custom_providers.push(CustomLlmProviderSettings {
+                id: provider.id.clone(),
+                name: provider.name.clone(),
+                adapter: provider_adapter(provider),
+                base_url: Some(base_url.clone()),
+                default_model: provider.model.clone(),
+                api_key: None,
+                builtin: false,
+            });
+        }
+
+        if let Some(secret) = provider_secret(provider, env) {
+            secrets.push(secret);
+        }
+    }
+
+    if let Some(provider) = active_provider.as_deref() {
+        if let Some(builtin) = normalize_builtin_provider(provider) {
+            patch.insert("llm_backend".to_string(), Value::String(builtin.clone()));
+            match builtin.as_str() {
+                "ollama" => {
+                    if let Some(url) = config
+                        .model_base_url
+                        .clone()
+                        .or_else(|| provider_base_url(config, provider))
+                    {
+                        patch.insert("ollama_base_url".to_string(), Value::String(url));
+                    }
+                }
+                "openai_compatible" => {
+                    if let Some(url) = config
+                        .model_base_url
+                        .clone()
+                        .or_else(|| provider_base_url(config, provider))
+                    {
+                        patch.insert("openai_compatible_base_url".to_string(), Value::String(url));
+                    }
+                }
+                _ => {
+                    if let Some(url) = config.model_base_url.clone() {
+                        builtin_overrides.insert(
+                            builtin,
+                            LlmBuiltinOverride {
+                                api_key: None,
+                                model: config.default_model.clone(),
+                                base_url: Some(url),
+                            },
+                        );
+                    }
+                }
+            }
+        } else if let Some(custom) = resolve_custom_provider(provider, &custom_providers) {
+            patch.insert("llm_backend".to_string(), Value::String(custom.id.clone()));
+        } else if provider.eq_ignore_ascii_case("custom") && custom_providers.len() == 1 {
+            patch.insert(
+                "llm_backend".to_string(),
+                Value::String(custom_providers[0].id.clone()),
+            );
+        } else if let Some(url) = config.model_base_url.as_ref() {
+            patch.insert(
+                "llm_backend".to_string(),
+                Value::String("openai_compatible".to_string()),
+            );
+            patch.insert(
+                "openai_compatible_base_url".to_string(),
+                Value::String(url.clone()),
+            );
+            notes.push(format!(
+                "Hermes provider '{}' was treated as openai_compatible because it supplied only a base URL.",
+                provider
+            ));
+        } else {
+            notes.push(format!(
+                "Hermes active provider '{}' could not be mapped onto a runnable IronClaw provider.",
+                provider
+            ));
+        }
+    }
+
+    if let Some(model) = config.default_model.as_ref() {
+        patch.insert("selected_model".to_string(), Value::String(model.clone()));
+    }
+
+    if !custom_providers.is_empty() {
+        patch.insert(
+            "llm_custom_providers".to_string(),
+            serde_json::to_value(custom_providers).unwrap_or(Value::Null),
+        );
+    }
+    if !builtin_overrides.is_empty() {
+        patch.insert(
+            "llm_builtin_overrides".to_string(),
+            serde_json::to_value(builtin_overrides).unwrap_or(Value::Null),
+        );
+    }
+
+    for (env_key, provider_id) in builtin_env_secret_mappings() {
+        if let Some(value) = env.get(*env_key) {
+            secrets.push(
+                ImportedSecret::new(builtin_secret_name(provider_id), value.clone())
+                    .with_provider(*provider_id),
+            );
+        }
+    }
+
+    if let Some(auth) = auth {
+        secrets.push(
+            ImportedSecret::new(
+                format!("migrate_hermes_{}_auth_json", slugify(scope_name)),
+                SecretString::new(auth.to_string().into_boxed_str()),
+            )
+            .with_provider("hermes"),
+        );
+        notes.push(
+            "Stored raw Hermes auth.json as an encrypted backup secret. It is preserved for manual recovery but not auto-wired into an IronClaw provider."
+                .to_string(),
+        );
+    }
+
+    (patch, dedupe_secrets(secrets), notes)
+}
+
+fn provider_base_url(config: &HermesConfigData, provider: &str) -> Option<String> {
+    let provider_slug = slugify(provider);
+    config
+        .providers
+        .iter()
+        .find(|entry| entry.id == provider_slug || entry.name.eq_ignore_ascii_case(provider))
+        .and_then(|entry| entry.base_url.clone())
+}
+
+fn resolve_custom_provider<'a>(
+    provider: &str,
+    custom_providers: &'a [CustomLlmProviderSettings],
+) -> Option<&'a CustomLlmProviderSettings> {
+    let provider_slug = slugify(provider);
+    custom_providers
+        .iter()
+        .find(|entry| entry.id == provider_slug || entry.name.eq_ignore_ascii_case(provider))
+}
+
+fn provider_adapter(provider: &HermesProviderEntry) -> String {
+    let transport = provider
+        .transport
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if transport.contains("anthropic") || provider.name.to_ascii_lowercase().contains("anthropic") {
+        "anthropic".to_string()
+    } else if transport.contains("ollama") || provider.name.to_ascii_lowercase().contains("ollama")
+    {
+        "ollama".to_string()
+    } else {
+        "open_ai_completions".to_string()
+    }
+}
+
+fn provider_secret(
+    provider: &HermesProviderEntry,
+    env: &HashMap<String, SecretString>,
+) -> Option<ImportedSecret> {
+    let value = provider
+        .key_env
+        .as_ref()
+        .and_then(|key| env.get(key).cloned())
+        .or_else(|| provider.api_key.clone())?;
+
+    if let Some(builtin) = normalize_builtin_provider(&provider.name)
+        .or_else(|| normalize_builtin_provider(&provider.id))
+    {
+        if builtin == "ollama" || builtin == "bedrock" {
+            return None;
+        }
+        return Some(
+            ImportedSecret::new(builtin_secret_name(&builtin), value).with_provider(builtin),
+        );
+    }
+
+    Some(
+        ImportedSecret::new(custom_secret_name(&provider.id), value)
+            .with_provider(provider.id.clone()),
+    )
+}
+
+fn dedupe_secrets(secrets: Vec<ImportedSecret>) -> Vec<ImportedSecret> {
+    let mut by_name = HashMap::new();
+    for secret in secrets {
+        by_name.insert(secret.name.clone(), secret);
+    }
+    let mut deduped: Vec<_> = by_name.into_values().collect();
+    deduped.sort_by(|a, b| a.name.cmp(&b.name));
+    deduped
+}
+
+fn builtin_env_secret_mappings() -> &'static [(&'static str, &'static str)] {
+    &[
+        ("OPENAI_API_KEY", "openai"),
+        ("ANTHROPIC_API_KEY", "anthropic"),
+        ("NEARAI_API_KEY", "nearai"),
+        ("TINFOIL_API_KEY", "tinfoil"),
+        ("OPENAI_COMPATIBLE_API_KEY", "openai_compatible"),
+    ]
+}
+
+fn normalize_builtin_provider(provider: &str) -> Option<String> {
+    let normalized = provider.trim().to_ascii_lowercase().replace('-', "_");
+    let mapped = match normalized.as_str() {
+        "claude" => "anthropic",
+        "copilot" => "github_copilot",
+        "openai_compatible" | "openrouter" | "vllm" | "lmstudio" | "lm_studio" => {
+            "openai_compatible"
+        }
+        "openai" | "anthropic" | "nearai" | "github_copilot" | "ollama" | "tinfoil" | "bedrock" => {
+            normalized.as_str()
+        }
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+async fn import_scope_markdown(
+    services: &MigrationServices,
+    options: &HermesMigrationOptions,
+    scope: &HermesScope,
+    stats: &mut MigrationStats,
+) -> Result<(), MigrationError> {
+    let file_sets = [
+        scope.root.join("SOUL.md"),
+        scope.root.join("memories"),
+        scope.root.join("skills"),
+        scope.root.join("workspace"),
+        scope.root.join("plans"),
+        scope.root.join("home"),
+        scope.root.join("cron"),
+    ];
+
+    let mut seen = HashSet::new();
+    for path in file_sets {
+        if path.is_file() {
+            let rel = normalize_relative_path(
+                &path
+                    .strip_prefix(&scope.root)
+                    .unwrap_or(&path)
+                    .to_string_lossy(),
+            );
+            if seen.insert(rel.clone()) {
+                let content = std::fs::read_to_string(&path)?;
+                let imported = ImportedDocument {
+                    source: "hermes",
+                    namespace: scope.name.clone(),
+                    external_id: rel.clone(),
+                    workspace_path: format!("imports/hermes/{}/{}", slugify(&scope.name), rel),
+                    title: format!("Hermes {}: {}", scope.name, rel),
+                    content,
+                    tags: vec![
+                        "migration".to_string(),
+                        "hermes".to_string(),
+                        scope.name.clone(),
+                    ],
+                    doc_type: ironclaw_engine::DocType::Note,
+                    created_at: None,
+                    metadata: json!({"scope": scope.name.clone(), "source_path": rel}),
+                };
+                if options.dry_run {
+                    stats.workspace_documents += 1;
+                    stats.memory_docs += 1;
+                } else {
+                    services.upsert_document(imported, stats).await?;
+                }
+            }
+            continue;
+        }
+
+        for (rel, content) in collect_markdown_files(&path)? {
+            let full_rel = if let Ok(stripped) = path.strip_prefix(&scope.root) {
+                let base = normalize_relative_path(&stripped.to_string_lossy());
+                if base.is_empty() {
+                    rel.clone()
+                } else {
+                    format!("{base}/{rel}")
+                }
+            } else {
+                rel.clone()
+            };
+            if !seen.insert(full_rel.clone()) {
+                continue;
+            }
+            let imported = ImportedDocument {
+                source: "hermes",
+                namespace: scope.name.clone(),
+                external_id: full_rel.clone(),
+                workspace_path: format!("imports/hermes/{}/{}", slugify(&scope.name), full_rel),
+                title: format!("Hermes {}: {}", scope.name, full_rel),
+                content,
+                tags: vec![
+                    "migration".to_string(),
+                    "hermes".to_string(),
+                    scope.name.clone(),
+                ],
+                doc_type: ironclaw_engine::DocType::Note,
+                created_at: None,
+                metadata: json!({"scope": scope.name.clone(), "source_path": full_rel}),
+            };
+            if options.dry_run {
+                stats.workspace_documents += 1;
+                stats.memory_docs += 1;
+            } else {
+                services.upsert_document(imported, stats).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn import_scope_sessions(
+    services: &MigrationServices,
+    options: &HermesMigrationOptions,
+    scope: &HermesScope,
+    stats: &mut MigrationStats,
+) -> Result<(), MigrationError> {
+    let state_db = scope.root.join("state.db");
+    if !state_db.exists() {
+        stats.push_note(format!(
+            "Hermes scope '{}' has no state.db; skipped session history import.",
+            scope.name
+        ));
+        return Ok(());
+    }
+
+    let sessions = read_sessions(&state_db).await?;
+    for session in sessions {
+        let title = session
+            .title
+            .clone()
+            .unwrap_or_else(|| session_title(&session));
+        let messages = session
+            .messages
+            .iter()
+            .map(|message| ImportedMessage {
+                role: hermes_message_role(message),
+                content: hermes_message_content(message),
+                timestamp: message.timestamp,
+            })
+            .collect::<Vec<_>>();
+
+        let imported = ImportedConversation {
+            source: "hermes",
+            namespace: scope.name.clone(),
+            external_id: session.id.clone(),
+            source_channel: session
+                .source
+                .clone()
+                .unwrap_or_else(|| format!("hermes:{}", scope.name)),
+            title,
+            created_at: session.started_at,
+            messages,
+            metadata: json!({
+                "scope": scope.name.clone(),
+                "hermes_user_id": session.user_id,
+                "model": session.model,
+                "source": session.source,
+            }),
+        };
+
+        if options.dry_run {
+            stats.engine_threads += 1;
+            stats.engine_conversations += 1;
+            stats.legacy_conversations += 1;
+            stats.messages += imported.messages.len();
+        } else {
+            services.upsert_conversation(imported, stats).await?;
+        }
+    }
+
+    Ok(())
+}
+
+fn session_title(session: &HermesSession) -> String {
+    if let Some(first_user) = session
+        .messages
+        .iter()
+        .find(|message| message.role.eq_ignore_ascii_case("user"))
+    {
+        let mut title: String = first_user.content.chars().take(80).collect();
+        if first_user.content.chars().count() > 80 {
+            title.push('…');
+        }
+        return title;
+    }
+    format!("Hermes session {}", session.id)
+}
+
+fn hermes_message_role(message: &HermesMessage) -> ImportedMessageRole {
+    match message.role.to_ascii_lowercase().as_str() {
+        "user" => ImportedMessageRole::User,
+        "assistant" => ImportedMessageRole::Assistant,
+        "system" => ImportedMessageRole::System,
+        _ => ImportedMessageRole::Tool {
+            name: message
+                .tool_name
+                .clone()
+                .or_else(|| Some(message.role.clone())),
+        },
+    }
+}
+
+fn hermes_message_content(message: &HermesMessage) -> String {
+    if message.content.is_empty() {
+        if let Some(tool) = message.tool_name.as_ref() {
+            return format!("[{tool}] (empty output)");
+        }
+    }
+    message.content.clone()
+}
+
+async fn read_sessions(db_path: &Path) -> Result<Vec<HermesSession>, MigrationError> {
+    let db = libsql::Builder::new_local(db_path)
+        .build()
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+    let conn = db
+        .connect()
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+
+    let session_columns = table_columns(&conn, "sessions").await?;
+    if session_columns.is_empty() {
+        return Ok(Vec::new());
+    }
+    let message_columns = table_columns(&conn, "messages").await?;
+
+    let order_expr = if session_columns.contains("started_at") {
+        "CAST(started_at AS TEXT)"
+    } else if session_columns.contains("created_at") {
+        "CAST(created_at AS TEXT)"
+    } else {
+        "CAST(id AS TEXT)"
+    };
+
+    let query = format!(
+        "SELECT \
+            {} , {} , {} , {} , {} , {} \
+         FROM sessions ORDER BY {}",
+        select_text_expr(&session_columns, &["id"], "id"),
+        select_text_expr(&session_columns, &["source"], "source"),
+        select_text_expr(&session_columns, &["user_id"], "user_id"),
+        select_text_expr(&session_columns, &["model"], "model"),
+        select_text_expr(&session_columns, &["title"], "title"),
+        select_text_expr(
+            &session_columns,
+            &["started_at", "created_at"],
+            "started_at"
+        ),
+        order_expr,
+    );
+
+    let mut rows = conn
+        .query(&query, ())
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+
+    let mut sessions = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?
+    {
+        let id: Option<String> = row
+            .get(0)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let Some(id) = id else { continue };
+        let source: Option<String> = row
+            .get(1)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let user_id: Option<String> = row
+            .get(2)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let model: Option<String> = row
+            .get(3)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let title: Option<String> = row
+            .get(4)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let started_at: Option<String> = row
+            .get(5)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+
+        let messages = read_messages(&conn, &message_columns, &id).await?;
+        sessions.push(HermesSession {
+            id,
+            source,
+            user_id,
+            model,
+            title,
+            started_at: started_at.as_deref().and_then(parse_timestamp_str),
+            messages,
+        });
+    }
+
+    Ok(sessions)
+}
+
+async fn read_messages(
+    conn: &libsql::Connection,
+    message_columns: &HashSet<String>,
+    session_id: &str,
+) -> Result<Vec<HermesMessage>, MigrationError> {
+    if message_columns.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let query = format!(
+        "SELECT \
+            {} , {} , {} , {} \
+         FROM messages WHERE session_id = ?1 ORDER BY {}",
+        select_text_expr(message_columns, &["role"], "role"),
+        select_text_expr(message_columns, &["content"], "content"),
+        select_text_expr(message_columns, &["timestamp", "created_at"], "timestamp"),
+        select_text_expr(message_columns, &["tool_name"], "tool_name"),
+        if message_columns.contains("timestamp") {
+            "CAST(timestamp AS TEXT)"
+        } else if message_columns.contains("created_at") {
+            "CAST(created_at AS TEXT)"
+        } else {
+            "rowid"
+        }
+    );
+
+    let mut rows = conn
+        .query(&query, libsql::params![session_id])
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+
+    let mut messages = Vec::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?
+    {
+        let role: Option<String> = row
+            .get(0)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let content: Option<String> = row
+            .get(1)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let timestamp: Option<String> = row
+            .get(2)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        let tool_name: Option<String> = row
+            .get(3)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        messages.push(HermesMessage {
+            role: role.unwrap_or_else(|| "assistant".to_string()),
+            content: content.unwrap_or_default(),
+            timestamp: timestamp.as_deref().and_then(parse_timestamp_str),
+            tool_name,
+        });
+    }
+
+    Ok(messages)
+}
+
+async fn table_columns(
+    conn: &libsql::Connection,
+    table: &str,
+) -> Result<HashSet<String>, MigrationError> {
+    let mut rows = conn
+        .query(&format!("PRAGMA table_info({table})"), ())
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+    let mut columns = HashSet::new();
+    while let Some(row) = rows
+        .next()
+        .await
+        .map_err(|e| MigrationError::Sqlite(e.to_string()))?
+    {
+        let name: String = row
+            .get(1)
+            .map_err(|e| MigrationError::Sqlite(e.to_string()))?;
+        columns.insert(name);
+    }
+    Ok(columns)
+}
+
+fn select_text_expr(columns: &HashSet<String>, candidates: &[&str], alias: &str) -> String {
+    let available = candidates
+        .iter()
+        .filter(|candidate| columns.contains(**candidate))
+        .map(|candidate| format!("CAST({candidate} AS TEXT)"))
+        .collect::<Vec<_>>();
+    if available.is_empty() {
+        format!("NULL AS {alias}")
+    } else if available.len() == 1 {
+        format!("{} AS {alias}", available[0])
+    } else {
+        format!("COALESCE({}) AS {alias}", available.join(", "))
+    }
+}

--- a/src/migrate/hermes.rs
+++ b/src/migrate/hermes.rs
@@ -60,6 +60,8 @@ struct HermesSession {
     messages: Vec<HermesMessage>,
 }
 
+type ScopeResult = (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>);
+
 #[derive(Debug, Clone)]
 struct HermesScope {
     name: String,
@@ -94,7 +96,7 @@ pub async fn migrate(
         let env = read_env_file(&primary.root.join(".env"))?;
         let auth = read_optional_json(&primary.root.join("auth.json"))?;
         let (settings_patch, secrets, notes) =
-            map_primary_scope(&primary.name, &config, &env, auth.as_ref());
+            map_primary_scope(&primary.name, &config, &env, auth.as_ref())?;
         for note in notes {
             stats.push_note(note);
         }
@@ -309,7 +311,7 @@ fn map_primary_scope(
     config: &HermesConfigData,
     env: &HashMap<String, SecretString>,
     auth: Option<&Value>,
-) -> (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>) {
+) -> Result<ScopeResult, MigrationError> {
     let mut patch = HashMap::new();
     let mut secrets = Vec::new();
     let mut notes = Vec::new();
@@ -319,13 +321,13 @@ fn map_primary_scope(
             .and_then(Value::as_str)
             .map(ToString::to_string)
     });
-    if config.model_provider.is_none() {
-        if let Some(provider) = active_provider.as_ref() {
-            notes.push(format!(
-                "Hermes config had no active model.provider; used auth.json active_provider='{}'.",
-                provider
-            ));
-        }
+    if config.model_provider.is_none()
+        && let Some(provider) = active_provider.as_ref()
+    {
+        notes.push(format!(
+            "Hermes config had no active model.provider; used auth.json active_provider='{}'.",
+            provider
+        ));
     }
 
     let mut custom_providers = Vec::new();
@@ -435,13 +437,15 @@ fn map_primary_scope(
     if !custom_providers.is_empty() {
         patch.insert(
             "llm_custom_providers".to_string(),
-            serde_json::to_value(custom_providers).unwrap_or(Value::Null),
+            serde_json::to_value(custom_providers)
+                .map_err(|e| MigrationError::Serialization(e.to_string()))?,
         );
     }
     if !builtin_overrides.is_empty() {
         patch.insert(
             "llm_builtin_overrides".to_string(),
-            serde_json::to_value(builtin_overrides).unwrap_or(Value::Null),
+            serde_json::to_value(builtin_overrides)
+                .map_err(|e| MigrationError::Serialization(e.to_string()))?,
         );
     }
 
@@ -468,7 +472,7 @@ fn map_primary_scope(
         );
     }
 
-    (patch, dedupe_secrets(secrets), notes)
+    Ok((patch, dedupe_secrets(secrets), notes))
 }
 
 fn provider_base_url(config: &HermesConfigData, provider: &str) -> Option<String> {
@@ -757,10 +761,10 @@ fn hermes_message_role(message: &HermesMessage) -> ImportedMessageRole {
 }
 
 fn hermes_message_content(message: &HermesMessage) -> String {
-    if message.content.is_empty() {
-        if let Some(tool) = message.tool_name.as_ref() {
-            return format!("[{tool}] (empty output)");
-        }
+    if message.content.is_empty()
+        && let Some(tool) = message.tool_name.as_ref()
+    {
+        return format!("[{tool}] (empty output)");
     }
     message.content.clone()
 }

--- a/src/migrate/hermes.rs
+++ b/src/migrate/hermes.rs
@@ -10,8 +10,8 @@ use crate::settings::{
 
 use super::{
     ImportedConversation, ImportedDocument, ImportedMessage, ImportedMessageRole, ImportedSecret,
-    MigrationError, MigrationServices, MigrationStats, collect_markdown_files,
-    normalize_relative_path, parse_timestamp_str, slugify,
+    MigrationError, MigrationServices, MigrationStats, collect_markdown_files, dedupe_secrets,
+    normalize_builtin_provider, normalize_relative_path, parse_timestamp_str, slugify,
 };
 
 #[derive(Debug, Clone)]
@@ -537,16 +537,6 @@ fn provider_secret(
     )
 }
 
-fn dedupe_secrets(secrets: Vec<ImportedSecret>) -> Vec<ImportedSecret> {
-    let mut by_name = HashMap::new();
-    for secret in secrets {
-        by_name.insert(secret.name.clone(), secret);
-    }
-    let mut deduped: Vec<_> = by_name.into_values().collect();
-    deduped.sort_by(|a, b| a.name.cmp(&b.name));
-    deduped
-}
-
 fn builtin_env_secret_mappings() -> &'static [(&'static str, &'static str)] {
     &[
         ("OPENAI_API_KEY", "openai"),
@@ -555,22 +545,6 @@ fn builtin_env_secret_mappings() -> &'static [(&'static str, &'static str)] {
         ("TINFOIL_API_KEY", "tinfoil"),
         ("OPENAI_COMPATIBLE_API_KEY", "openai_compatible"),
     ]
-}
-
-fn normalize_builtin_provider(provider: &str) -> Option<String> {
-    let normalized = provider.trim().to_ascii_lowercase().replace('-', "_");
-    let mapped = match normalized.as_str() {
-        "claude" => "anthropic",
-        "copilot" => "github_copilot",
-        "openai_compatible" | "openrouter" | "vllm" | "lmstudio" | "lm_studio" => {
-            "openai_compatible"
-        }
-        "openai" | "anthropic" | "nearai" | "github_copilot" | "ollama" | "tinfoil" | "bedrock" => {
-            normalized.as_str()
-        }
-        _ => return None,
-    };
-    Some(mapped.to_string())
 }
 
 async fn import_scope_markdown(

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -1,0 +1,893 @@
+//! Migration helpers for importing external assistant state into IronClaw.
+//!
+//! The CLI entrypoint lives in `src/cli/migrate.rs`. This module owns the
+//! source-specific readers plus the common write path into:
+//! - Engine V2 workspace-backed state (`HybridStore`)
+//! - Legacy DB conversation history (for current web/thread list views)
+//! - Workspace documents
+//! - Settings + encrypted secrets
+
+pub mod hermes;
+pub mod openclaw;
+
+use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use ironclaw_engine::types::conversation::EntryId;
+use ironclaw_engine::{
+    ConversationEntry, ConversationId, ConversationSurface, DocId, DocType, EntrySender, MemoryDoc,
+    MessageRole, Project, ProjectId, Provenance, Store, Thread, ThreadConfig, ThreadId,
+    ThreadMessage, ThreadState, ThreadType,
+};
+use secrecy::{ExposeSecret, SecretString};
+use serde_json::{Map, Value, json};
+use uuid::Uuid;
+
+use crate::bridge::HybridStore;
+use crate::config::Config;
+use crate::db::{Database, SettingsStore};
+use crate::secrets::{CreateSecretParams, SecretsStore};
+use crate::settings::{CustomLlmProviderSettings, LlmBuiltinOverride, Settings};
+use crate::workspace::{Workspace, WorkspaceSettingsAdapter};
+
+#[derive(Debug, Clone, Default)]
+pub struct MigrationStats {
+    pub workspace_documents: usize,
+    pub memory_docs: usize,
+    pub engine_threads: usize,
+    pub engine_conversations: usize,
+    pub legacy_conversations: usize,
+    pub messages: usize,
+    pub settings: usize,
+    pub secrets: usize,
+    pub projects: usize,
+    pub skipped: usize,
+    pub notes: Vec<String>,
+}
+
+impl MigrationStats {
+    pub fn total_imported(&self) -> usize {
+        self.workspace_documents
+            + self.memory_docs
+            + self.engine_threads
+            + self.engine_conversations
+            + self.legacy_conversations
+            + self.messages
+            + self.settings
+            + self.secrets
+            + self.projects
+    }
+
+    pub fn push_note(&mut self, note: impl Into<String>) {
+        self.notes.push(note.into());
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MigrationError {
+    #[error("Migration source not found at {path}: {reason}")]
+    NotFound { path: PathBuf, reason: String },
+
+    #[error("Config parse error: {0}")]
+    ConfigParse(String),
+
+    #[error("SQLite error: {0}")]
+    Sqlite(String),
+
+    #[error("Database error: {0}")]
+    Database(String),
+
+    #[error("Workspace error: {0}")]
+    Workspace(String),
+
+    #[error("Secrets error: {0}")]
+    Secret(String),
+
+    #[error("Engine error: {0}")]
+    Engine(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+impl From<crate::import::ImportError> for MigrationError {
+    fn from(value: crate::import::ImportError) -> Self {
+        match value {
+            crate::import::ImportError::NotFound { path, reason } => {
+                Self::NotFound { path, reason }
+            }
+            crate::import::ImportError::ConfigParse(reason) => Self::ConfigParse(reason),
+            crate::import::ImportError::Sqlite(reason) => Self::Sqlite(reason),
+            crate::import::ImportError::Database(reason) => Self::Database(reason),
+            crate::import::ImportError::Workspace(reason) => Self::Workspace(reason),
+            crate::import::ImportError::Secret(reason) => Self::Secret(reason),
+            crate::import::ImportError::Io(err) => Self::Io(err),
+            crate::import::ImportError::InvalidUtf8(reason) => Self::ConfigParse(reason),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportedSecret {
+    pub name: String,
+    pub value: SecretString,
+    pub provider: Option<String>,
+}
+
+impl ImportedSecret {
+    pub fn new(name: impl Into<String>, value: SecretString) -> Self {
+        Self {
+            name: name.into(),
+            value,
+            provider: None,
+        }
+    }
+
+    pub fn with_provider(mut self, provider: impl Into<String>) -> Self {
+        self.provider = Some(provider.into());
+        self
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportedDocument {
+    pub source: &'static str,
+    pub namespace: String,
+    pub external_id: String,
+    pub workspace_path: String,
+    pub title: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub doc_type: DocType,
+    pub created_at: Option<DateTime<Utc>>,
+    pub metadata: Value,
+}
+
+#[derive(Debug, Clone)]
+pub enum ImportedMessageRole {
+    User,
+    Assistant,
+    System,
+    Tool { name: Option<String> },
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportedMessage {
+    pub role: ImportedMessageRole,
+    pub content: String,
+    pub timestamp: Option<DateTime<Utc>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ImportedConversation {
+    pub source: &'static str,
+    pub namespace: String,
+    pub external_id: String,
+    pub source_channel: String,
+    pub title: String,
+    pub created_at: Option<DateTime<Utc>>,
+    pub messages: Vec<ImportedMessage>,
+    pub metadata: Value,
+}
+
+pub struct MigrationServices {
+    pub user_id: String,
+    pub db: Arc<dyn Database>,
+    pub workspace: Arc<Workspace>,
+    pub settings_store: Arc<dyn SettingsStore + Send + Sync>,
+    pub secrets_store: Arc<dyn SecretsStore + Send + Sync>,
+    pub engine_store: Arc<HybridStore>,
+    pub project_id: ProjectId,
+}
+
+impl MigrationServices {
+    pub async fn from_config(config: &Config, user_id: String) -> Result<Self, MigrationError> {
+        let db = crate::db::connect_from_config(&config.database)
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+
+        let master_key = config.secrets.master_key().ok_or_else(|| {
+            MigrationError::Secret(
+                "SECRETS_MASTER_KEY not set. Run 'ironclaw onboard' first or set it in .env"
+                    .to_string(),
+            )
+        })?;
+        let crypto = Arc::new(
+            crate::secrets::SecretsCrypto::new(master_key.clone())
+                .map_err(|e| MigrationError::Secret(e.to_string()))?,
+        );
+        let secrets_store = crate::db::create_secrets_store(&config.database, crypto)
+            .await
+            .map_err(|e| MigrationError::Secret(e.to_string()))?;
+
+        let workspace = Arc::new(Workspace::new_with_db(user_id.clone(), Arc::clone(&db)));
+        let adapter = Arc::new(WorkspaceSettingsAdapter::new(
+            Arc::clone(&workspace),
+            Arc::clone(&db),
+        ));
+        adapter
+            .ensure_system_config()
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+        let settings_store: Arc<dyn SettingsStore + Send + Sync> = adapter;
+
+        let engine_store = Arc::new(HybridStore::new(Some(Arc::clone(&workspace))));
+        engine_store.load_state_from_workspace().await;
+        let store_dyn: Arc<dyn Store> = engine_store.clone();
+        let (project_id, _created_project) = resolve_default_project(&store_dyn, &user_id).await?;
+
+        Ok(Self {
+            user_id,
+            db,
+            workspace,
+            settings_store,
+            secrets_store,
+            engine_store,
+            project_id,
+        })
+    }
+
+    pub async fn apply_settings_patch(
+        &self,
+        patch: HashMap<String, Value>,
+        stats: &mut MigrationStats,
+    ) -> Result<(), MigrationError> {
+        if patch.is_empty() {
+            return Ok(());
+        }
+
+        let existing_map = self
+            .settings_store
+            .get_all_settings(&self.user_id)
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+        let existing_settings = Settings::from_db_map(&existing_map);
+
+        let mut merged_patch = patch;
+
+        if let Some(value) = merged_patch.remove("llm_custom_providers") {
+            let incoming: Vec<CustomLlmProviderSettings> = serde_json::from_value(value)
+                .map_err(|e| MigrationError::Serialization(e.to_string()))?;
+            let mut providers = existing_settings.llm_custom_providers;
+            for provider in incoming {
+                if let Some(existing) = providers.iter_mut().find(|item| item.id == provider.id) {
+                    *existing = provider;
+                } else {
+                    providers.push(provider);
+                }
+            }
+            providers.sort_by(|a, b| a.id.cmp(&b.id));
+            merged_patch.insert(
+                "llm_custom_providers".to_string(),
+                serde_json::to_value(providers)
+                    .map_err(|e| MigrationError::Serialization(e.to_string()))?,
+            );
+        }
+
+        if let Some(value) = merged_patch.remove("llm_builtin_overrides") {
+            let incoming: HashMap<String, LlmBuiltinOverride> = serde_json::from_value(value)
+                .map_err(|e| MigrationError::Serialization(e.to_string()))?;
+            let mut overrides = existing_settings.llm_builtin_overrides;
+            for (provider_id, override_value) in incoming {
+                overrides.insert(provider_id, override_value);
+            }
+            merged_patch.insert(
+                "llm_builtin_overrides".to_string(),
+                serde_json::to_value(overrides)
+                    .map_err(|e| MigrationError::Serialization(e.to_string()))?,
+            );
+        }
+
+        self.settings_store
+            .set_all_settings(&self.user_id, &merged_patch)
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+        stats.settings += merged_patch.len();
+        Ok(())
+    }
+
+    pub async fn store_secret(
+        &self,
+        secret: ImportedSecret,
+        stats: &mut MigrationStats,
+    ) -> Result<(), MigrationError> {
+        let mut params = CreateSecretParams::new(secret.name, secret.value.expose_secret());
+        if let Some(provider) = secret.provider {
+            params = params.with_provider(provider);
+        }
+        self.secrets_store
+            .create(&self.user_id, params)
+            .await
+            .map_err(|e| MigrationError::Secret(e.to_string()))?;
+        stats.secrets += 1;
+        Ok(())
+    }
+
+    pub async fn upsert_document(
+        &self,
+        doc: ImportedDocument,
+        stats: &mut MigrationStats,
+    ) -> Result<(), MigrationError> {
+        let marker = migration_marker(doc.source, "document", &doc.namespace, &doc.external_id);
+        let metadata = merge_metadata(
+            &json!({
+                "migration": marker,
+                "workspace_path": doc.workspace_path,
+                "tags": doc.tags,
+            }),
+            &doc.metadata,
+        );
+
+        let doc_id = DocId(deterministic_uuid(
+            "memory-doc",
+            doc.source,
+            &doc.namespace,
+            &doc.external_id,
+        ));
+        let existing_doc = Store::load_memory_doc(self.engine_store.as_ref(), doc_id)
+            .await
+            .map_err(|e| MigrationError::Engine(e.to_string()))?;
+        let existing_workspace = self.workspace.read(&doc.workspace_path).await.ok();
+
+        let now = Utc::now();
+        let mut memory_doc = MemoryDoc::new(
+            self.project_id,
+            self.user_id.clone(),
+            doc.doc_type,
+            doc.title,
+            doc.content.clone(),
+        );
+        memory_doc.id = doc_id;
+        memory_doc.tags = doc.tags;
+        memory_doc.metadata = metadata.clone();
+        memory_doc.created_at = doc.created_at.unwrap_or(now);
+        memory_doc.updated_at = now;
+        if let Some(existing) = existing_doc.as_ref() {
+            memory_doc.created_at = existing.created_at;
+        }
+
+        let existing_doc_json = existing_doc
+            .as_ref()
+            .and_then(|value| serde_json::to_value(value).ok());
+        let new_doc_json = serde_json::to_value(&memory_doc).ok();
+        let workspace_unchanged = existing_workspace
+            .as_ref()
+            .is_some_and(|value| value.content == doc.content && value.metadata == metadata);
+        let doc_unchanged = existing_doc_json == new_doc_json;
+
+        if workspace_unchanged && doc_unchanged {
+            stats.skipped += 1;
+            return Ok(());
+        }
+
+        let workspace_doc = self
+            .workspace
+            .write(&doc.workspace_path, &doc.content)
+            .await
+            .map_err(|e| MigrationError::Workspace(e.to_string()))?;
+        self.workspace
+            .update_metadata(workspace_doc.id, &metadata)
+            .await
+            .map_err(|e| MigrationError::Workspace(e.to_string()))?;
+        Store::save_memory_doc(self.engine_store.as_ref(), &memory_doc)
+            .await
+            .map_err(|e| MigrationError::Engine(e.to_string()))?;
+
+        stats.workspace_documents += 1;
+        stats.memory_docs += 1;
+        Ok(())
+    }
+
+    pub async fn upsert_conversation(
+        &self,
+        conversation: ImportedConversation,
+        stats: &mut MigrationStats,
+    ) -> Result<(), MigrationError> {
+        let namespace = if conversation.namespace.is_empty() {
+            "default".to_string()
+        } else {
+            conversation.namespace.clone()
+        };
+        let base_ts = conversation
+            .created_at
+            .or_else(|| {
+                conversation
+                    .messages
+                    .iter()
+                    .find_map(|message| message.timestamp)
+            })
+            .unwrap_or_else(Utc::now);
+        let last_ts = conversation
+            .messages
+            .iter()
+            .filter_map(|message| message.timestamp)
+            .max()
+            .unwrap_or(base_ts);
+
+        let thread_id = ThreadId(deterministic_uuid(
+            "thread",
+            conversation.source,
+            &namespace,
+            &conversation.external_id,
+        ));
+        let engine_conv_id = ConversationId(deterministic_uuid(
+            "conversation",
+            conversation.source,
+            &namespace,
+            &conversation.external_id,
+        ));
+        let legacy_conv_id = deterministic_uuid(
+            "legacy-conversation",
+            conversation.source,
+            &namespace,
+            &conversation.external_id,
+        );
+        let synthetic_channel = format!(
+            "migrate/{}/{}/{}",
+            slugify(conversation.source),
+            slugify(&namespace),
+            deterministic_uuid(
+                "channel",
+                conversation.source,
+                &namespace,
+                &conversation.external_id,
+            )
+        );
+
+        let marker = migration_marker(
+            conversation.source,
+            "conversation",
+            &namespace,
+            &conversation.external_id,
+        );
+        let metadata = merge_metadata(
+            &json!({
+                "migration": marker,
+                "source_channel": conversation.source_channel,
+                "source_title": conversation.title,
+                "thread_type": "migration",
+            }),
+            &conversation.metadata,
+        );
+
+        let mut thread = Thread::new(
+            conversation.title.clone(),
+            ThreadType::Foreground,
+            self.project_id,
+            self.user_id.clone(),
+            ThreadConfig::default(),
+        );
+        thread.id = thread_id;
+        thread.state = ThreadState::Done;
+        thread.created_at = base_ts;
+        thread.updated_at = last_ts;
+        thread.completed_at = Some(last_ts);
+        thread.metadata = metadata.clone();
+        thread.messages = conversation
+            .messages
+            .iter()
+            .map(|message| imported_message_to_thread_message(message))
+            .collect();
+
+        let mut surface = ConversationSurface::new(synthetic_channel.clone(), self.user_id.clone());
+        surface.id = engine_conv_id;
+        surface.metadata = metadata.clone();
+        surface.created_at = base_ts;
+        surface.updated_at = last_ts;
+        surface.entries = conversation
+            .messages
+            .iter()
+            .enumerate()
+            .map(|(index, message)| {
+                imported_message_to_entry(
+                    thread_id,
+                    message,
+                    conversation.source,
+                    &namespace,
+                    &conversation.external_id,
+                    index,
+                )
+            })
+            .collect();
+        surface.active_threads.clear();
+
+        let existing_thread = Store::load_thread(self.engine_store.as_ref(), thread_id)
+            .await
+            .map_err(|e| MigrationError::Engine(e.to_string()))?;
+        let existing_surface = Store::load_conversation(self.engine_store.as_ref(), engine_conv_id)
+            .await
+            .map_err(|e| MigrationError::Engine(e.to_string()))?;
+
+        let thread_same = existing_thread
+            .as_ref()
+            .and_then(|value| serde_json::to_value(value).ok())
+            == serde_json::to_value(&thread).ok();
+        let surface_same = existing_surface
+            .as_ref()
+            .and_then(|value| serde_json::to_value(value).ok())
+            == serde_json::to_value(&surface).ok();
+
+        if !thread_same {
+            Store::save_thread(self.engine_store.as_ref(), &thread)
+                .await
+                .map_err(|e| MigrationError::Engine(e.to_string()))?;
+            stats.engine_threads += 1;
+        }
+        if !surface_same {
+            Store::save_conversation(self.engine_store.as_ref(), &surface)
+                .await
+                .map_err(|e| MigrationError::Engine(e.to_string()))?;
+            stats.engine_conversations += 1;
+        }
+
+        let thread_id_text = thread_id.0.to_string();
+        let ensured = self
+            .db
+            .ensure_conversation(
+                legacy_conv_id,
+                &synthetic_channel,
+                &self.user_id,
+                Some(&thread_id_text),
+                Some(&conversation.source_channel),
+            )
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+        if !ensured {
+            return Err(MigrationError::Database(format!(
+                "legacy conversation id collision for {legacy_conv_id}"
+            )));
+        }
+
+        if let Some(metadata_obj) = metadata.as_object() {
+            for (key, value) in metadata_obj {
+                self.db
+                    .update_conversation_metadata_field(legacy_conv_id, key, value)
+                    .await
+                    .map_err(|e| MigrationError::Database(e.to_string()))?;
+            }
+        }
+
+        let expected_len = conversation.messages.len() as i64 + 1;
+        let (existing_messages, has_more) = self
+            .db
+            .list_conversation_messages_paginated(legacy_conv_id, None, expected_len)
+            .await
+            .map_err(|e| MigrationError::Database(e.to_string()))?;
+
+        if existing_messages.is_empty() {
+            for message in &conversation.messages {
+                let (role, content) = imported_message_to_legacy_pair(message);
+                self.db
+                    .add_conversation_message(legacy_conv_id, &role, &content)
+                    .await
+                    .map_err(|e| MigrationError::Database(e.to_string()))?;
+            }
+            stats.legacy_conversations += 1;
+            stats.messages += conversation.messages.len();
+        } else if existing_messages.len() == conversation.messages.len() && !has_more {
+            if thread_same && surface_same {
+                stats.skipped += 1;
+            }
+        } else {
+            stats.push_note(format!(
+                "Legacy conversation {legacy_conv_id} already existed with {} messages; expected {}. Engine V2 state was refreshed, but legacy DB history was left unchanged.",
+                existing_messages.len(),
+                conversation.messages.len()
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+async fn resolve_default_project(
+    store: &Arc<dyn Store>,
+    user_id: &str,
+) -> Result<(ProjectId, bool), MigrationError> {
+    let projects = store
+        .list_projects(user_id)
+        .await
+        .map_err(|e| MigrationError::Engine(e.to_string()))?;
+
+    if let Some(project) = projects.iter().find(|project| project.name == "default") {
+        return Ok((project.id, false));
+    }
+
+    let project = Project::new(user_id, "default", "Default project for migrated data");
+    let project_id = project.id;
+    store
+        .save_project(&project)
+        .await
+        .map_err(|e| MigrationError::Engine(e.to_string()))?;
+    Ok((project_id, true))
+}
+
+pub(crate) fn deterministic_uuid(
+    kind: &str,
+    source: &str,
+    namespace: &str,
+    external_id: &str,
+) -> Uuid {
+    let seed = format!("ironclaw-migrate::{kind}::{source}::{namespace}::{external_id}");
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, seed.as_bytes())
+}
+
+pub(crate) fn normalize_relative_path(path: &str) -> String {
+    let mut parts = Vec::new();
+    for component in Path::new(path).components() {
+        match component {
+            Component::Normal(value) => parts.push(value.to_string_lossy().to_string()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if !parts.is_empty() {
+                    parts.pop();
+                }
+            }
+            Component::RootDir | Component::Prefix(_) => {}
+        }
+    }
+    parts.join("/")
+}
+
+pub(crate) fn slugify(value: &str) -> String {
+    let mut out = String::new();
+    let mut last_dash = false;
+    for ch in value.chars() {
+        let ch = ch.to_ascii_lowercase();
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch);
+            last_dash = false;
+        } else if matches!(ch, '-' | '_' | '/' | ' ' | '.') {
+            if !last_dash && !out.is_empty() {
+                out.push('-');
+                last_dash = true;
+            }
+        }
+    }
+    let out = out.trim_matches('-').to_string();
+    if out.is_empty() {
+        "default".to_string()
+    } else {
+        out
+    }
+}
+
+pub(crate) fn migration_marker(
+    source: &str,
+    kind: &str,
+    namespace: &str,
+    external_id: &str,
+) -> Value {
+    json!({
+        "source": source,
+        "kind": kind,
+        "namespace": namespace,
+        "external_id": external_id,
+    })
+}
+
+pub(crate) fn merge_metadata(base: &Value, overlay: &Value) -> Value {
+    match (base, overlay) {
+        (Value::Object(base_obj), Value::Object(overlay_obj)) => {
+            let mut merged: Map<String, Value> = base_obj.clone();
+            for (key, value) in overlay_obj {
+                let next = merged
+                    .get(key)
+                    .map(|existing| merge_metadata(existing, value))
+                    .unwrap_or_else(|| value.clone());
+                merged.insert(key.clone(), next);
+            }
+            Value::Object(merged)
+        }
+        (_, overlay_value) if !overlay_value.is_null() => overlay_value.clone(),
+        (base_value, _) => base_value.clone(),
+    }
+}
+
+pub(crate) fn imported_message_to_thread_message(message: &ImportedMessage) -> ThreadMessage {
+    let timestamp = message.timestamp.unwrap_or_else(Utc::now);
+    match &message.role {
+        ImportedMessageRole::User => ThreadMessage {
+            role: MessageRole::User,
+            content: message.content.clone(),
+            provenance: Provenance::User,
+            action_call_id: None,
+            action_name: None,
+            action_calls: None,
+            timestamp,
+        },
+        ImportedMessageRole::Assistant => ThreadMessage {
+            role: MessageRole::Assistant,
+            content: message.content.clone(),
+            provenance: Provenance::LlmGenerated,
+            action_call_id: None,
+            action_name: None,
+            action_calls: None,
+            timestamp,
+        },
+        ImportedMessageRole::System => ThreadMessage {
+            role: MessageRole::System,
+            content: message.content.clone(),
+            provenance: Provenance::System,
+            action_call_id: None,
+            action_name: None,
+            action_calls: None,
+            timestamp,
+        },
+        ImportedMessageRole::Tool { name } => ThreadMessage {
+            role: MessageRole::ActionResult,
+            content: message.content.clone(),
+            provenance: Provenance::ToolOutput {
+                action_name: name.clone().unwrap_or_else(|| "imported_tool".to_string()),
+            },
+            action_call_id: None,
+            action_name: name.clone(),
+            action_calls: None,
+            timestamp,
+        },
+    }
+}
+
+pub(crate) fn imported_message_to_entry(
+    thread_id: ThreadId,
+    message: &ImportedMessage,
+    source: &str,
+    namespace: &str,
+    external_id: &str,
+    index: usize,
+) -> ConversationEntry {
+    let timestamp = message.timestamp.unwrap_or_else(Utc::now);
+    let entry_id = EntryId(deterministic_uuid(
+        "entry",
+        source,
+        namespace,
+        &format!("{external_id}:{index}"),
+    ));
+    match &message.role {
+        ImportedMessageRole::User => ConversationEntry {
+            id: entry_id,
+            sender: EntrySender::User,
+            content: message.content.clone(),
+            origin_thread_id: None,
+            timestamp,
+            metadata: Value::Null,
+        },
+        ImportedMessageRole::Assistant => ConversationEntry {
+            id: entry_id,
+            sender: EntrySender::Agent { thread_id },
+            content: message.content.clone(),
+            origin_thread_id: Some(thread_id),
+            timestamp,
+            metadata: Value::Null,
+        },
+        ImportedMessageRole::System => ConversationEntry {
+            id: entry_id,
+            sender: EntrySender::System,
+            content: message.content.clone(),
+            origin_thread_id: Some(thread_id),
+            timestamp,
+            metadata: Value::Null,
+        },
+        ImportedMessageRole::Tool { name } => ConversationEntry {
+            id: entry_id,
+            sender: EntrySender::System,
+            content: match name {
+                Some(name) if !name.is_empty() => format!("[tool:{name}] {}", message.content),
+                _ => format!("[tool] {}", message.content),
+            },
+            origin_thread_id: Some(thread_id),
+            timestamp,
+            metadata: Value::Null,
+        },
+    }
+}
+
+pub(crate) fn imported_message_to_legacy_pair(message: &ImportedMessage) -> (String, String) {
+    match &message.role {
+        ImportedMessageRole::User => ("user".to_string(), message.content.clone()),
+        ImportedMessageRole::Assistant => ("assistant".to_string(), message.content.clone()),
+        ImportedMessageRole::System => ("system".to_string(), message.content.clone()),
+        ImportedMessageRole::Tool { name } => (
+            "assistant".to_string(),
+            match name {
+                Some(name) if !name.is_empty() => format!("[tool:{name}] {}", message.content),
+                _ => format!("[tool] {}", message.content),
+            },
+        ),
+    }
+}
+
+pub(crate) fn collect_markdown_files(root: &Path) -> Result<Vec<(String, String)>, MigrationError> {
+    let mut results = Vec::new();
+    if !root.exists() {
+        return Ok(results);
+    }
+    collect_markdown_files_recursive(root, root, &mut results)?;
+    results.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(results)
+}
+
+fn collect_markdown_files_recursive(
+    root: &Path,
+    current: &Path,
+    results: &mut Vec<(String, String)>,
+) -> Result<(), MigrationError> {
+    for entry in std::fs::read_dir(current)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_markdown_files_recursive(root, &path, results)?;
+            continue;
+        }
+
+        let is_markdown = path
+            .extension()
+            .and_then(|value| value.to_str())
+            .is_some_and(|value| value.eq_ignore_ascii_case("md"));
+        if !is_markdown {
+            continue;
+        }
+
+        let rel = path
+            .strip_prefix(root)
+            .map_err(|e| MigrationError::Workspace(e.to_string()))?;
+        let rel = normalize_relative_path(&rel.to_string_lossy());
+        let content = std::fs::read_to_string(&path)?;
+        results.push((rel, content));
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_timestamp_str(raw: &str) -> Option<DateTime<Utc>> {
+    if raw.trim().is_empty() {
+        return None;
+    }
+
+    if let Ok(parsed) = DateTime::parse_from_rfc3339(raw) {
+        return Some(parsed.with_timezone(&Utc));
+    }
+    if let Ok(parsed) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S%.f") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(parsed, Utc));
+    }
+    if let Ok(parsed) = chrono::NaiveDateTime::parse_from_str(raw, "%Y-%m-%d %H:%M:%S") {
+        return Some(DateTime::<Utc>::from_naive_utc_and_offset(parsed, Utc));
+    }
+    if let Ok(epoch) = raw.parse::<i64>() {
+        return DateTime::<Utc>::from_timestamp(epoch, 0);
+    }
+    None
+}
+
+pub(crate) fn compatible_scalar_settings_patch(
+    candidates: &HashMap<String, Value>,
+) -> (HashMap<String, Value>, Vec<String>) {
+    let mut accepted = HashMap::new();
+    let mut ignored = Vec::new();
+
+    for (key, value) in candidates {
+        let value_str = match value {
+            Value::String(value) => value.clone(),
+            Value::Bool(value) => value.to_string(),
+            Value::Number(value) => value.to_string(),
+            Value::Array(_) | Value::Object(_) => {
+                ignored.push(key.clone());
+                continue;
+            }
+            Value::Null => continue,
+        };
+
+        let mut probe = Settings::default();
+        if probe.set(key, &value_str).is_ok() {
+            accepted.insert(key.clone(), value.clone());
+        } else {
+            ignored.push(key.clone());
+        }
+    }
+
+    (accepted, ignored)
+}

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -351,14 +351,15 @@ impl MigrationServices {
             memory_doc.created_at = existing.created_at;
         }
 
-        let existing_doc_json = existing_doc
-            .as_ref()
-            .and_then(|value| serde_json::to_value(value).ok());
-        let new_doc_json = serde_json::to_value(&memory_doc).ok();
         let workspace_unchanged = existing_workspace
             .as_ref()
             .is_some_and(|value| value.content == doc.content && value.metadata == metadata);
-        let doc_unchanged = existing_doc_json == new_doc_json;
+        let doc_unchanged = existing_doc.as_ref().is_some_and(|ed| {
+            ed.content == memory_doc.content
+                && ed.metadata == memory_doc.metadata
+                && ed.title == memory_doc.title
+                && ed.tags == memory_doc.tags
+        });
 
         if workspace_unchanged && doc_unchanged {
             stats.skipped += 1;
@@ -471,7 +472,7 @@ impl MigrationServices {
         thread.messages = conversation
             .messages
             .iter()
-            .map(|message| imported_message_to_thread_message(message))
+            .map(imported_message_to_thread_message)
             .collect();
 
         let mut surface = ConversationSurface::new(synthetic_channel.clone(), self.user_id.clone());
@@ -526,8 +527,7 @@ impl MigrationServices {
         }
 
         let thread_id_text = thread_id.0.to_string();
-        let ensured = self
-            .db
+        self.db
             .ensure_conversation(
                 legacy_conv_id,
                 &synthetic_channel,
@@ -537,11 +537,6 @@ impl MigrationServices {
             )
             .await
             .map_err(|e| MigrationError::Database(e.to_string()))?;
-        if !ensured {
-            return Err(MigrationError::Database(format!(
-                "legacy conversation id collision for {legacy_conv_id}"
-            )));
-        }
 
         if let Some(metadata_obj) = metadata.as_object() {
             for (key, value) in metadata_obj {
@@ -642,11 +637,9 @@ pub(crate) fn slugify(value: &str) -> String {
         if ch.is_ascii_alphanumeric() {
             out.push(ch);
             last_dash = false;
-        } else if matches!(ch, '-' | '_' | '/' | ' ' | '.') {
-            if !last_dash && !out.is_empty() {
-                out.push('-');
-                last_dash = true;
-            }
+        } else if matches!(ch, '-' | '_' | '/' | ' ' | '.') && !last_dash && !out.is_empty() {
+            out.push('-');
+            last_dash = true;
         }
     }
     let out = out.trim_matches('-').to_string();

--- a/src/migrate/mod.rs
+++ b/src/migrate/mod.rs
@@ -856,6 +856,32 @@ pub(crate) fn parse_timestamp_str(raw: &str) -> Option<DateTime<Utc>> {
     None
 }
 
+pub(crate) fn normalize_builtin_provider(provider: &str) -> Option<String> {
+    let normalized = provider.trim().to_ascii_lowercase().replace('-', "_");
+    let mapped = match normalized.as_str() {
+        "claude" => "anthropic",
+        "copilot" => "github_copilot",
+        "openai_compatible" | "openrouter" | "vllm" | "lmstudio" | "lm_studio" => {
+            "openai_compatible"
+        }
+        "openai" | "anthropic" | "nearai" | "github_copilot" | "ollama" | "tinfoil" | "bedrock" => {
+            normalized.as_str()
+        }
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}
+
+pub(crate) fn dedupe_secrets(secrets: Vec<ImportedSecret>) -> Vec<ImportedSecret> {
+    let mut by_name = HashMap::new();
+    for secret in secrets {
+        by_name.insert(secret.name.clone(), secret);
+    }
+    let mut deduped: Vec<_> = by_name.into_values().collect();
+    deduped.sort_by(|a, b| a.name.cmp(&b.name));
+    deduped
+}
+
 pub(crate) fn compatible_scalar_settings_patch(
     candidates: &HashMap<String, Value>,
 ) -> (HashMap<String, Value>, Vec<String>) {

--- a/src/migrate/openclaw.rs
+++ b/src/migrate/openclaw.rs
@@ -1,0 +1,473 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde_json::{Value, json};
+
+use crate::import::openclaw::reader::{
+    OpenClawConfig, OpenClawConversation, OpenClawLlmConfig, OpenClawMemoryChunk, OpenClawReader,
+};
+use crate::settings::{
+    CustomLlmProviderSettings, LlmBuiltinOverride, builtin_secret_name, custom_secret_name,
+};
+
+use super::{
+    ImportedConversation, ImportedDocument, ImportedMessage, ImportedMessageRole, ImportedSecret,
+    MigrationError, MigrationServices, MigrationStats, collect_markdown_files,
+    compatible_scalar_settings_patch, normalize_relative_path, slugify,
+};
+
+#[derive(Debug, Clone)]
+pub struct OpenClawMigrationOptions {
+    pub path: PathBuf,
+    pub dry_run: bool,
+}
+
+pub fn detect() -> Option<PathBuf> {
+    std::env::var("HOME")
+        .ok()
+        .map(PathBuf::from)
+        .map(|home| home.join(".openclaw"))
+        .filter(|path| path.join("openclaw.json").exists())
+}
+
+pub async fn migrate(
+    services: &MigrationServices,
+    options: &OpenClawMigrationOptions,
+) -> Result<MigrationStats, MigrationError> {
+    let reader = OpenClawReader::new(&options.path)?;
+    let config = reader.read_config()?;
+    let mut stats = MigrationStats::default();
+
+    let (settings_patch, secrets, config_notes) = map_openclaw_config(&config);
+    for note in config_notes {
+        stats.push_note(note);
+    }
+
+    if options.dry_run {
+        stats.settings += settings_patch.len();
+        stats.secrets += secrets.len();
+    } else {
+        services
+            .apply_settings_patch(settings_patch, &mut stats)
+            .await?;
+        for secret in secrets {
+            services.store_secret(secret, &mut stats).await?;
+        }
+    }
+
+    let workspace_root = options.path.join("workspace");
+    for (relative_path, content) in collect_markdown_files(&workspace_root)? {
+        let imported = ImportedDocument {
+            source: "openclaw",
+            namespace: "root".to_string(),
+            external_id: relative_path.clone(),
+            workspace_path: format!("imports/openclaw/root/workspace/{relative_path}"),
+            title: format!("OpenClaw workspace: {relative_path}"),
+            content,
+            tags: vec![
+                "migration".to_string(),
+                "openclaw".to_string(),
+                "workspace".to_string(),
+            ],
+            doc_type: ironclaw_engine::DocType::Note,
+            created_at: None,
+            metadata: json!({"source_path": relative_path}),
+        };
+        if options.dry_run {
+            stats.workspace_documents += 1;
+            stats.memory_docs += 1;
+        } else {
+            services.upsert_document(imported, &mut stats).await?;
+        }
+    }
+
+    let agent_dbs = reader.list_agent_dbs()?;
+    for (agent_name, db_path) in agent_dbs {
+        let namespace = slugify(&agent_name);
+        let chunks = reader.read_memory_chunks(&db_path).await?;
+        let grouped_chunks = group_chunks_by_path(chunks);
+        for (path, content) in grouped_chunks {
+            let normalized = normalized_memory_path(&path);
+            let imported = ImportedDocument {
+                source: "openclaw",
+                namespace: namespace.clone(),
+                external_id: path.clone(),
+                workspace_path: format!("imports/openclaw/agents/{namespace}/memory/{normalized}"),
+                title: format!("OpenClaw memory ({agent_name}): {path}"),
+                content,
+                tags: vec![
+                    "migration".to_string(),
+                    "openclaw".to_string(),
+                    "memory".to_string(),
+                    agent_name.clone(),
+                ],
+                doc_type: ironclaw_engine::DocType::Note,
+                created_at: None,
+                metadata: json!({"agent": agent_name, "source_path": path}),
+            };
+            if options.dry_run {
+                stats.workspace_documents += 1;
+                stats.memory_docs += 1;
+            } else {
+                services.upsert_document(imported, &mut stats).await?;
+            }
+        }
+
+        let conversations = reader.read_conversations(&db_path).await?;
+        for conversation in conversations {
+            let imported = imported_conversation(&agent_name, &namespace, conversation);
+            if options.dry_run {
+                stats.engine_threads += 1;
+                stats.engine_conversations += 1;
+                stats.legacy_conversations += 1;
+                stats.messages += imported.messages.len();
+            } else {
+                services.upsert_conversation(imported, &mut stats).await?;
+            }
+        }
+    }
+
+    Ok(stats)
+}
+
+fn group_chunks_by_path(chunks: Vec<OpenClawMemoryChunk>) -> Vec<(String, String)> {
+    let mut grouped: HashMap<String, Vec<OpenClawMemoryChunk>> = HashMap::new();
+    for chunk in chunks {
+        grouped.entry(chunk.path.clone()).or_default().push(chunk);
+    }
+
+    let mut docs: Vec<(String, String)> = grouped
+        .into_iter()
+        .map(|(path, mut parts)| {
+            parts.sort_by_key(|chunk| chunk.chunk_index);
+            let content = parts
+                .into_iter()
+                .map(|chunk| chunk.content)
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            (path, content)
+        })
+        .collect();
+    docs.sort_by(|a, b| a.0.cmp(&b.0));
+    docs
+}
+
+fn imported_conversation(
+    agent_name: &str,
+    namespace: &str,
+    conversation: OpenClawConversation,
+) -> ImportedConversation {
+    let title = conversation_title(&conversation);
+    let created_at = conversation.created_at;
+    ImportedConversation {
+        source: "openclaw",
+        namespace: namespace.to_string(),
+        external_id: conversation.id.clone(),
+        source_channel: conversation.channel.clone(),
+        title,
+        created_at,
+        messages: conversation
+            .messages
+            .into_iter()
+            .map(|message| ImportedMessage {
+                role: match message.role.to_ascii_lowercase().as_str() {
+                    "user" | "human" => ImportedMessageRole::User,
+                    "assistant" | "ai" => ImportedMessageRole::Assistant,
+                    "system" => ImportedMessageRole::System,
+                    other => ImportedMessageRole::Tool {
+                        name: Some(other.to_string()),
+                    },
+                },
+                content: message.content,
+                timestamp: message.created_at,
+            })
+            .collect(),
+        metadata: json!({
+            "agent": agent_name,
+            "source_id": conversation.id,
+            "source_created_at": created_at.map(|value| value.to_rfc3339()),
+        }),
+    }
+}
+
+fn conversation_title(conversation: &OpenClawConversation) -> String {
+    if let Some(first_user) = conversation
+        .messages
+        .iter()
+        .find(|message| matches!(message.role.to_ascii_lowercase().as_str(), "user" | "human"))
+    {
+        let mut title: String = first_user.content.chars().take(80).collect();
+        if first_user.content.chars().count() > 80 {
+            title.push('…');
+        }
+        return title;
+    }
+    format!(
+        "OpenClaw {} conversation {}",
+        conversation.channel, conversation.id
+    )
+}
+
+fn normalized_memory_path(path: &str) -> String {
+    let normalized = normalize_relative_path(path);
+    if normalized.is_empty() {
+        "memory.md".to_string()
+    } else {
+        normalized
+    }
+}
+
+struct ProviderResolution {
+    backend: Option<String>,
+    custom_provider: Option<CustomLlmProviderSettings>,
+    builtin_override: Option<(String, LlmBuiltinOverride)>,
+    secret_name: Option<String>,
+    notes: Vec<String>,
+}
+
+fn map_openclaw_config(
+    config: &OpenClawConfig,
+) -> (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>) {
+    let mut patch = HashMap::new();
+    let mut secrets = Vec::new();
+    let mut notes = Vec::new();
+
+    if let Some(OpenClawLlmConfig {
+        provider,
+        model,
+        api_key,
+        base_url,
+    }) = config.llm.as_ref()
+    {
+        let resolution = resolve_provider(
+            provider.as_deref(),
+            base_url.as_deref(),
+            model.as_deref(),
+            provider.as_deref().unwrap_or("openclaw"),
+        );
+        if let Some(backend) = resolution.backend.clone() {
+            patch.insert("llm_backend".to_string(), Value::String(backend));
+        }
+        if let Some(model) = model {
+            patch.insert("selected_model".to_string(), Value::String(model.clone()));
+        }
+        if let Some(custom_provider) = resolution.custom_provider {
+            patch.insert(
+                "llm_custom_providers".to_string(),
+                serde_json::to_value(vec![custom_provider]).unwrap_or(Value::Null),
+            );
+        }
+        if let Some(base_url) = base_url.as_ref() {
+            match resolution.backend.as_deref() {
+                Some("openai_compatible") => {
+                    patch.insert(
+                        "openai_compatible_base_url".to_string(),
+                        Value::String(base_url.clone()),
+                    );
+                }
+                Some("ollama") => {
+                    patch.insert(
+                        "ollama_base_url".to_string(),
+                        Value::String(base_url.clone()),
+                    );
+                }
+                _ => {}
+            }
+        }
+        if let Some((provider_id, override_value)) = resolution.builtin_override {
+            let mut overrides = HashMap::new();
+            overrides.insert(provider_id, override_value);
+            patch.insert(
+                "llm_builtin_overrides".to_string(),
+                serde_json::to_value(overrides).unwrap_or(Value::Null),
+            );
+        }
+        if let (Some(secret_name), Some(api_key)) = (resolution.secret_name, api_key.clone()) {
+            let provider_hint = provider.clone().map(|value| value.to_ascii_lowercase());
+            secrets.push(
+                ImportedSecret::new(secret_name, api_key)
+                    .with_provider(provider_hint.unwrap_or_else(|| "openclaw".to_string())),
+            );
+        }
+        notes.extend(resolution.notes);
+    }
+
+    if let Some(embeddings) = &config.embeddings {
+        if let Some(provider) = embeddings.provider.as_ref() {
+            let normalized = normalize_builtin_provider(provider);
+            if matches!(
+                normalized.as_deref(),
+                Some("openai" | "nearai" | "ollama" | "bedrock")
+            ) {
+                patch.insert("embeddings.enabled".to_string(), Value::Bool(true));
+                patch.insert(
+                    "embeddings.provider".to_string(),
+                    Value::String(normalized.unwrap_or_else(|| provider.to_ascii_lowercase())),
+                );
+            } else {
+                notes.push(format!(
+                    "OpenClaw embeddings provider '{}' could not be mapped cleanly; skipped embeddings.provider.",
+                    provider
+                ));
+            }
+        }
+        if let Some(model) = embeddings.model.as_ref() {
+            patch.insert("embeddings.enabled".to_string(), Value::Bool(true));
+            patch.insert("embeddings.model".to_string(), Value::String(model.clone()));
+        }
+        if let (Some(api_key), Some(provider)) =
+            (embeddings.api_key.clone(), embeddings.provider.as_deref())
+        {
+            if normalize_builtin_provider(provider).as_deref() == Some("openai") {
+                secrets.push(
+                    ImportedSecret::new(builtin_secret_name("openai"), api_key)
+                        .with_provider("openai"),
+                );
+            }
+        }
+    }
+
+    let (compatible, ignored) = compatible_scalar_settings_patch(&config.other_settings);
+    patch.extend(compatible);
+    if !ignored.is_empty() {
+        notes.push(format!(
+            "Ignored {} OpenClaw config keys that do not map cleanly onto current IronClaw settings: {}",
+            ignored.len(),
+            ignored.join(", ")
+        ));
+    }
+
+    (patch, dedupe_secrets(secrets), notes)
+}
+
+fn dedupe_secrets(secrets: Vec<ImportedSecret>) -> Vec<ImportedSecret> {
+    let mut by_name = HashMap::new();
+    for secret in secrets {
+        by_name.insert(secret.name.clone(), secret);
+    }
+    let mut deduped: Vec<_> = by_name.into_values().collect();
+    deduped.sort_by(|a, b| a.name.cmp(&b.name));
+    deduped
+}
+
+fn resolve_provider(
+    provider: Option<&str>,
+    base_url: Option<&str>,
+    model: Option<&str>,
+    custom_hint: &str,
+) -> ProviderResolution {
+    let mut notes = Vec::new();
+    let normalized = provider.and_then(normalize_builtin_provider);
+
+    match normalized.as_deref() {
+        Some("openai")
+        | Some("anthropic")
+        | Some("nearai")
+        | Some("github_copilot")
+        | Some("tinfoil") => {
+            let provider_id = normalized.unwrap_or_else(|| "openai".to_string());
+            let builtin_override = base_url.map(|url| {
+                (
+                    provider_id.clone(),
+                    LlmBuiltinOverride {
+                        api_key: None,
+                        model: model.map(|value| value.to_string()),
+                        base_url: Some(url.to_string()),
+                    },
+                )
+            });
+            ProviderResolution {
+                backend: Some(provider_id.clone()),
+                custom_provider: None,
+                builtin_override,
+                secret_name: Some(builtin_secret_name(&provider_id)),
+                notes,
+            }
+        }
+        Some("openai_compatible") => ProviderResolution {
+            backend: Some("openai_compatible".to_string()),
+            custom_provider: None,
+            builtin_override: None,
+            secret_name: Some(builtin_secret_name("openai_compatible")),
+            notes,
+        },
+        Some("ollama") => ProviderResolution {
+            backend: Some("ollama".to_string()),
+            custom_provider: None,
+            builtin_override: None,
+            secret_name: None,
+            notes,
+        },
+        Some("bedrock") => ProviderResolution {
+            backend: Some("bedrock".to_string()),
+            custom_provider: None,
+            builtin_override: None,
+            secret_name: None,
+            notes,
+        },
+        _ => {
+            let Some(base_url) = base_url else {
+                notes.push(format!(
+                    "OpenClaw provider '{}' has no base_url; skipping active provider migration.",
+                    provider.unwrap_or("unknown")
+                ));
+                return ProviderResolution {
+                    backend: None,
+                    custom_provider: None,
+                    builtin_override: None,
+                    secret_name: None,
+                    notes,
+                };
+            };
+
+            let provider_id = slugify(custom_hint);
+            let adapter = if provider
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .contains("anthropic")
+            {
+                "anthropic"
+            } else if provider
+                .unwrap_or_default()
+                .to_ascii_lowercase()
+                .contains("ollama")
+            {
+                "ollama"
+            } else {
+                "open_ai_completions"
+            };
+
+            ProviderResolution {
+                backend: Some(provider_id.clone()),
+                custom_provider: Some(CustomLlmProviderSettings {
+                    id: provider_id.clone(),
+                    name: provider.unwrap_or(custom_hint).to_string(),
+                    adapter: adapter.to_string(),
+                    base_url: Some(base_url.to_string()),
+                    default_model: model.map(|value| value.to_string()),
+                    api_key: None,
+                    builtin: false,
+                }),
+                builtin_override: None,
+                secret_name: Some(custom_secret_name(&provider_id)),
+                notes,
+            }
+        }
+    }
+}
+
+fn normalize_builtin_provider(provider: &str) -> Option<String> {
+    let normalized = provider.trim().to_ascii_lowercase().replace('-', "_");
+    let mapped = match normalized.as_str() {
+        "claude" => "anthropic",
+        "copilot" => "github_copilot",
+        "openai_compatible" | "openrouter" | "vllm" | "lmstudio" | "lm_studio" => {
+            "openai_compatible"
+        }
+        "openai" | "anthropic" | "nearai" | "github_copilot" | "ollama" | "tinfoil" | "bedrock" => {
+            normalized.as_str()
+        }
+        _ => return None,
+    };
+    Some(mapped.to_string())
+}

--- a/src/migrate/openclaw.rs
+++ b/src/migrate/openclaw.rs
@@ -317,13 +317,11 @@ fn map_openclaw_config(
         }
         if let (Some(api_key), Some(provider)) =
             (embeddings.api_key.clone(), embeddings.provider.as_deref())
+            && normalize_builtin_provider(provider).as_deref() == Some("openai")
         {
-            if normalize_builtin_provider(provider).as_deref() == Some("openai") {
-                secrets.push(
-                    ImportedSecret::new(builtin_secret_name("openai"), api_key)
-                        .with_provider("openai"),
-                );
-            }
+            secrets.push(
+                ImportedSecret::new(builtin_secret_name("openai"), api_key).with_provider("openai"),
+            );
         }
     }
 

--- a/src/migrate/openclaw.rs
+++ b/src/migrate/openclaw.rs
@@ -13,8 +13,11 @@ use crate::settings::{
 use super::{
     ImportedConversation, ImportedDocument, ImportedMessage, ImportedMessageRole, ImportedSecret,
     MigrationError, MigrationServices, MigrationStats, collect_markdown_files,
-    compatible_scalar_settings_patch, normalize_relative_path, slugify,
+    compatible_scalar_settings_patch, dedupe_secrets, normalize_builtin_provider,
+    normalize_relative_path, slugify,
 };
+
+type ConfigResult = (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>);
 
 #[derive(Debug, Clone)]
 pub struct OpenClawMigrationOptions {
@@ -38,7 +41,7 @@ pub async fn migrate(
     let config = reader.read_config()?;
     let mut stats = MigrationStats::default();
 
-    let (settings_patch, secrets, config_notes) = map_openclaw_config(&config);
+    let (settings_patch, secrets, config_notes) = map_openclaw_config(&config)?;
     for note in config_notes {
         stats.push_note(note);
     }
@@ -225,9 +228,7 @@ struct ProviderResolution {
     notes: Vec<String>,
 }
 
-fn map_openclaw_config(
-    config: &OpenClawConfig,
-) -> (HashMap<String, Value>, Vec<ImportedSecret>, Vec<String>) {
+fn map_openclaw_config(config: &OpenClawConfig) -> Result<ConfigResult, MigrationError> {
     let mut patch = HashMap::new();
     let mut secrets = Vec::new();
     let mut notes = Vec::new();
@@ -254,7 +255,8 @@ fn map_openclaw_config(
         if let Some(custom_provider) = resolution.custom_provider {
             patch.insert(
                 "llm_custom_providers".to_string(),
-                serde_json::to_value(vec![custom_provider]).unwrap_or(Value::Null),
+                serde_json::to_value(vec![custom_provider])
+                    .map_err(|e| MigrationError::Serialization(e.to_string()))?,
             );
         }
         if let Some(base_url) = base_url.as_ref() {
@@ -279,7 +281,8 @@ fn map_openclaw_config(
             overrides.insert(provider_id, override_value);
             patch.insert(
                 "llm_builtin_overrides".to_string(),
-                serde_json::to_value(overrides).unwrap_or(Value::Null),
+                serde_json::to_value(overrides)
+                    .map_err(|e| MigrationError::Serialization(e.to_string()))?,
             );
         }
         if let (Some(secret_name), Some(api_key)) = (resolution.secret_name, api_key.clone()) {
@@ -335,17 +338,7 @@ fn map_openclaw_config(
         ));
     }
 
-    (patch, dedupe_secrets(secrets), notes)
-}
-
-fn dedupe_secrets(secrets: Vec<ImportedSecret>) -> Vec<ImportedSecret> {
-    let mut by_name = HashMap::new();
-    for secret in secrets {
-        by_name.insert(secret.name.clone(), secret);
-    }
-    let mut deduped: Vec<_> = by_name.into_values().collect();
-    deduped.sort_by(|a, b| a.name.cmp(&b.name));
-    deduped
+    Ok((patch, dedupe_secrets(secrets), notes))
 }
 
 fn resolve_provider(
@@ -452,20 +445,4 @@ fn resolve_provider(
             }
         }
     }
-}
-
-fn normalize_builtin_provider(provider: &str) -> Option<String> {
-    let normalized = provider.trim().to_ascii_lowercase().replace('-', "_");
-    let mapped = match normalized.as_str() {
-        "claude" => "anthropic",
-        "copilot" => "github_copilot",
-        "openai_compatible" | "openrouter" | "vllm" | "lmstudio" | "lm_studio" => {
-            "openai_compatible"
-        }
-        "openai" | "anthropic" | "nearai" | "github_copilot" | "ollama" | "tinfoil" | "bedrock" => {
-            normalized.as_str()
-        }
-        _ => return None,
-    };
-    Some(mapped.to_string())
 }

--- a/tests/import_openclaw.rs
+++ b/tests/import_openclaw.rs
@@ -1,8 +1,8 @@
 //! Integration tests for OpenClaw import functionality.
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod import_tests {
     use ironclaw::import::openclaw::reader::{OpenClawConfig, OpenClawMemoryChunk};
     use ironclaw::import::{ImportError, ImportStats};

--- a/tests/import_openclaw_comprehensive.rs
+++ b/tests/import_openclaw_comprehensive.rs
@@ -1,8 +1,8 @@
 //! Comprehensive end-to-end tests for OpenClaw import with synthetic test data.
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod comprehensive_import_tests {
     use std::path::{Path, PathBuf};
     use tempfile::TempDir;

--- a/tests/import_openclaw_e2e.rs
+++ b/tests/import_openclaw_e2e.rs
@@ -3,9 +3,9 @@
 //! These tests verify the complete import pipeline: configuration, settings,
 //! credentials, memory chunks, workspace documents, and conversations.
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod e2e_import_tests {
     use std::path::PathBuf;
     use tempfile::TempDir;

--- a/tests/import_openclaw_errors.rs
+++ b/tests/import_openclaw_errors.rs
@@ -7,9 +7,9 @@
 //! - Permission issues
 //! - Edge cases in data
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod error_handling_tests {
     use std::path::PathBuf;
     use tempfile::TempDir;

--- a/tests/import_openclaw_idempotency.rs
+++ b/tests/import_openclaw_idempotency.rs
@@ -5,9 +5,9 @@
 //! 2. Dry-run mode doesn't modify any state
 //! 3. Re-running import doesn't create duplicates
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod idempotency_tests {
     use std::path::PathBuf;
     use tempfile::TempDir;

--- a/tests/import_openclaw_integration.rs
+++ b/tests/import_openclaw_integration.rs
@@ -4,9 +4,9 @@
 //! verifying that data is correctly stored, idempotent, and that dry-run mode
 //! prevents modifications.
 
-#![cfg(feature = "import")]
+#![cfg(feature = "migrate")]
 
-#[cfg(feature = "import")]
+#[cfg(feature = "migrate")]
 mod import_integration_tests {
     use ironclaw::db::Database;
     use ironclaw::db::libsql::LibSqlBackend;

--- a/tests/migrate_cli_integration.rs
+++ b/tests/migrate_cli_integration.rs
@@ -1,0 +1,341 @@
+#![cfg(all(feature = "migrate", feature = "libsql"))]
+
+use std::path::Path;
+use std::sync::Arc;
+
+use ironclaw::bridge::HybridStore;
+use ironclaw::cli::{MigrateCommand, run_migrate_command_with_services};
+use ironclaw::db::Database;
+use ironclaw::db::SettingsStore;
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::migrate::MigrationServices;
+use ironclaw::secrets::{LibSqlSecretsStore, SecretsCrypto, SecretsStore};
+use ironclaw::workspace::{Workspace, WorkspaceSettingsAdapter};
+use ironclaw_engine::{Project, Store};
+use secrecy::SecretString;
+use tempfile::TempDir;
+use uuid::Uuid;
+
+async fn make_services() -> (MigrationServices, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("target.db");
+    let backend = Arc::new(LibSqlBackend::new_local(&db_path).await.expect("new_local"));
+    backend.run_migrations().await.expect("migrations");
+
+    let db: Arc<dyn Database> = backend.clone();
+    let workspace = Arc::new(Workspace::new_with_db("alice", Arc::clone(&db)));
+    let settings_adapter = Arc::new(WorkspaceSettingsAdapter::new(
+        Arc::clone(&workspace),
+        Arc::clone(&db),
+    ));
+    settings_adapter
+        .ensure_system_config()
+        .await
+        .expect("seed system config");
+    let settings_store: Arc<dyn SettingsStore + Send + Sync> = settings_adapter;
+
+    let crypto = Arc::new(
+        SecretsCrypto::new(SecretString::from(
+            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+        ))
+        .expect("crypto"),
+    );
+    let secrets_store: Arc<dyn SecretsStore + Send + Sync> =
+        Arc::new(LibSqlSecretsStore::new(backend.shared_db(), crypto));
+
+    let engine_store = Arc::new(HybridStore::new(Some(Arc::clone(&workspace))));
+    engine_store.load_state_from_workspace().await;
+    let project = Project::new("alice", "default", "test project");
+    let project_id = project.id;
+    Store::save_project(engine_store.as_ref(), &project)
+        .await
+        .expect("save project");
+
+    (
+        MigrationServices {
+            user_id: "alice".to_string(),
+            db,
+            workspace,
+            settings_store,
+            secrets_store,
+            engine_store,
+            project_id,
+        },
+        dir,
+    )
+}
+
+async fn create_openclaw_source(root: &Path) {
+    std::fs::write(
+        root.join("openclaw.json"),
+        r#"{
+            llm: {
+                provider: "openai",
+                model: "gpt-4o",
+                api_key: "sk-openclaw-test"
+            },
+            embeddings: {
+                provider: "openai",
+                model: "text-embedding-3-small",
+                api_key: "sk-openclaw-embed"
+            }
+        }"#,
+    )
+    .expect("write config");
+
+    let workspace_dir = root.join("workspace");
+    std::fs::create_dir_all(&workspace_dir).expect("workspace dir");
+    std::fs::write(
+        workspace_dir.join("notes.md"),
+        "# Imported\n\nOpenClaw workspace doc",
+    )
+    .expect("workspace doc");
+
+    let agents_dir = root.join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("agents dir");
+    let db_path = agents_dir.join("assistant.sqlite");
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("source db");
+    let conn = db.connect().expect("source conn");
+    conn.execute_batch(
+        "CREATE TABLE chunks (
+            id TEXT PRIMARY KEY,
+            path TEXT NOT NULL,
+            content TEXT NOT NULL,
+            embedding BLOB,
+            chunk_index INTEGER NOT NULL
+        );
+        CREATE TABLE conversations (
+            id TEXT PRIMARY KEY,
+            channel TEXT,
+            created_at TEXT
+        );
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            created_at TEXT
+        );",
+    )
+    .await
+    .expect("schema");
+
+    let conversation_id = "openclaw-conv-1";
+    conn.execute(
+        "INSERT INTO chunks (id, path, content, embedding, chunk_index) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params!["chunk-1", "memory/topic.md", "Remember the migration plan", libsql::Value::Null, 0i64],
+    )
+    .await
+    .expect("chunk");
+    conn.execute(
+        "INSERT INTO conversations (id, channel, created_at) VALUES (?1, ?2, ?3)",
+        libsql::params![conversation_id, "slack", "2026-01-01T10:00:00Z"],
+    )
+    .await
+    .expect("conversation");
+    conn.execute(
+        "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params!["msg-1", conversation_id, "user", "hello from openclaw", "2026-01-01T10:00:00Z"],
+    )
+    .await
+    .expect("message1");
+    conn.execute(
+        "INSERT INTO messages (id, conversation_id, role, content, created_at) VALUES (?1, ?2, ?3, ?4, ?5)",
+        libsql::params!["msg-2", conversation_id, "assistant", "hi from ironclaw migration", "2026-01-01T10:00:05Z"],
+    )
+    .await
+    .expect("message2");
+}
+
+async fn create_hermes_source(root: &Path) {
+    std::fs::write(
+        root.join("config.yaml"),
+        "model:\n  provider: local\n  default: hermes-model\n  base_url: http://localhost:1234/v1\nproviders:\n  local:\n    name: Local Provider\n    base_url: http://localhost:1234/v1\n    key_env: LOCAL_MODEL_API_KEY\n    transport: openai_chat\n    model: hermes-model\n",
+    )
+    .expect("config.yaml");
+    std::fs::write(root.join(".env"), "LOCAL_MODEL_API_KEY=sk-hermes-local\n").expect("env");
+    std::fs::write(root.join("auth.json"), "{\"active_provider\":\"local\"}").expect("auth");
+    std::fs::write(root.join("SOUL.md"), "# Soul\n\nHermes remembers this.").expect("soul");
+
+    let db_path = root.join("state.db");
+    let db = libsql::Builder::new_local(&db_path)
+        .build()
+        .await
+        .expect("state db");
+    let conn = db.connect().expect("state conn");
+    conn.execute_batch(
+        "CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            user_id TEXT,
+            model TEXT,
+            title TEXT,
+            started_at TEXT
+        );
+        CREATE TABLE messages (
+            id TEXT PRIMARY KEY,
+            session_id TEXT NOT NULL,
+            role TEXT NOT NULL,
+            content TEXT NOT NULL,
+            timestamp TEXT,
+            tool_name TEXT
+        );",
+    )
+    .await
+    .expect("schema");
+    conn.execute(
+        "INSERT INTO sessions (id, source, user_id, model, title, started_at) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params!["session-1", "cli", "hermes-user", "hermes-model", "Hermes Session", "2026-02-02T12:00:00Z"],
+    )
+    .await
+    .expect("session");
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, content, timestamp, tool_name) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params!["hermes-msg-1", "session-1", "user", "hello from hermes", "2026-02-02T12:00:00Z", libsql::Value::Null],
+    )
+    .await
+    .expect("message1");
+    conn.execute(
+        "INSERT INTO messages (id, session_id, role, content, timestamp, tool_name) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        libsql::params!["hermes-msg-2", "session-1", "assistant", "Hermes answer", "2026-02-02T12:00:10Z", libsql::Value::Null],
+    )
+    .await
+    .expect("message2");
+}
+
+fn migration_uuid(kind: &str, source: &str, namespace: &str, external_id: &str) -> Uuid {
+    let seed = format!("ironclaw-migrate::{kind}::{source}::{namespace}::{external_id}");
+    Uuid::new_v5(&Uuid::NAMESPACE_URL, seed.as_bytes())
+}
+
+#[tokio::test]
+async fn openclaw_command_migrates_into_engine_and_legacy_history() {
+    let (services, _tmp) = make_services().await;
+    let source = TempDir::new().expect("source tempdir");
+    create_openclaw_source(source.path()).await;
+
+    let cmd = MigrateCommand::Openclaw {
+        path: Some(source.path().to_path_buf()),
+        dry_run: false,
+        user_id: None,
+    };
+    let stats = run_migrate_command_with_services(&cmd, &services)
+        .await
+        .expect("migrate openclaw");
+
+    assert!(
+        stats.workspace_documents >= 2,
+        "workspace + chunk docs should be written"
+    );
+    assert_eq!(stats.engine_threads, 1);
+    assert_eq!(stats.engine_conversations, 1);
+    assert_eq!(stats.legacy_conversations, 1);
+    assert_eq!(stats.messages, 2);
+    assert!(
+        stats.settings >= 4,
+        "llm + embeddings settings should be persisted"
+    );
+    assert!(
+        services
+            .secrets_store
+            .exists("alice", "llm_builtin_openai_api_key")
+            .await
+            .expect("secret exists"),
+        "OpenAI key should be migrated into persistent secrets"
+    );
+
+    let threads = Store::list_threads(services.engine_store.as_ref(), services.project_id, "alice")
+        .await
+        .expect("list threads");
+    assert_eq!(
+        threads.len(),
+        1,
+        "imported engine thread should be visible in default project"
+    );
+
+    let imported_doc = services
+        .workspace
+        .read("imports/openclaw/root/workspace/notes.md")
+        .await
+        .expect("imported workspace doc");
+    assert!(imported_doc.content.contains("OpenClaw workspace doc"));
+
+    let legacy_id = migration_uuid(
+        "legacy-conversation",
+        "openclaw",
+        "assistant",
+        "openclaw-conv-1",
+    );
+    let metadata = services
+        .db
+        .get_conversation_metadata(legacy_id)
+        .await
+        .expect("metadata lookup")
+        .expect("metadata present");
+    assert_eq!(
+        metadata.get("thread_type").and_then(|v| v.as_str()),
+        Some("migration")
+    );
+}
+
+#[tokio::test]
+async fn hermes_command_migrates_custom_provider_and_session_history() {
+    let (services, _tmp) = make_services().await;
+    let source = TempDir::new().expect("source tempdir");
+    create_hermes_source(source.path()).await;
+
+    let cmd = MigrateCommand::Hermes {
+        path: Some(source.path().to_path_buf()),
+        profiles: Vec::new(),
+        all_profiles: false,
+        dry_run: false,
+        user_id: None,
+    };
+    let stats = run_migrate_command_with_services(&cmd, &services)
+        .await
+        .expect("migrate hermes");
+
+    assert_eq!(stats.engine_threads, 1);
+    assert_eq!(stats.engine_conversations, 1);
+    assert_eq!(stats.legacy_conversations, 1);
+    assert_eq!(stats.messages, 2);
+    assert!(stats.settings >= 2, "Hermes settings should be written");
+    assert!(
+        services
+            .secrets_store
+            .exists("alice", "llm_custom_local_api_key")
+            .await
+            .expect("custom provider secret"),
+        "Hermes custom provider secret should be migrated"
+    );
+    assert!(
+        services
+            .secrets_store
+            .exists("alice", "migrate_hermes_default_auth_json")
+            .await
+            .expect("auth backup secret"),
+        "auth.json should be preserved as encrypted backup"
+    );
+
+    let settings = ironclaw::settings::Settings::from_db_map(
+        &services
+            .settings_store
+            .get_all_settings("alice")
+            .await
+            .expect("all settings"),
+    );
+    assert_eq!(settings.llm_backend.as_deref(), Some("local"));
+    assert_eq!(settings.selected_model.as_deref(), Some("hermes-model"));
+    assert_eq!(settings.llm_custom_providers.len(), 1);
+    assert_eq!(settings.llm_custom_providers[0].id, "local");
+
+    let imported_doc = services
+        .workspace
+        .read("imports/hermes/default/SOUL.md")
+        .await
+        .expect("soul doc");
+    assert!(imported_doc.content.contains("Hermes remembers this"));
+}

--- a/tests/migrate_cli_integration.rs
+++ b/tests/migrate_cli_integration.rs
@@ -339,3 +339,34 @@ async fn hermes_command_migrates_custom_provider_and_session_history() {
         .expect("soul doc");
     assert!(imported_doc.content.contains("Hermes remembers this"));
 }
+
+#[tokio::test]
+async fn rerun_migration_is_idempotent() {
+    let (services, _tmp) = make_services().await;
+    let source = TempDir::new().expect("source tempdir");
+    create_openclaw_source(source.path()).await;
+
+    let cmd = MigrateCommand::Openclaw {
+        path: Some(source.path().to_path_buf()),
+        dry_run: false,
+        user_id: None,
+    };
+
+    // First run
+    let stats1 = run_migrate_command_with_services(&cmd, &services)
+        .await
+        .expect("first migration");
+    assert!(stats1.engine_threads >= 1);
+    assert!(stats1.legacy_conversations >= 1);
+
+    // Second run — must not error (idempotency)
+    let stats2 = run_migrate_command_with_services(&cmd, &services)
+        .await
+        .expect("re-run migration should succeed");
+
+    // On re-run, unchanged documents should be skipped
+    assert!(
+        stats2.skipped > 0 || stats2.workspace_documents == 0,
+        "re-run should skip unchanged documents or write zero new ones"
+    );
+}

--- a/tests/migrate_cli_integration.rs
+++ b/tests/migrate_cli_integration.rs
@@ -1,6 +1,7 @@
 #![cfg(all(feature = "migrate", feature = "libsql"))]
 
 use std::path::Path;
+use std::process::Command;
 use std::sync::Arc;
 
 use ironclaw::bridge::HybridStore;
@@ -12,18 +13,22 @@ use ironclaw::migrate::MigrationServices;
 use ironclaw::secrets::{LibSqlSecretsStore, SecretsCrypto, SecretsStore};
 use ironclaw::workspace::{Workspace, WorkspaceSettingsAdapter};
 use ironclaw_engine::{Project, Store};
-use secrecy::SecretString;
+use secrecy::{ExposeSecret, SecretString};
 use tempfile::TempDir;
 use uuid::Uuid;
 
-async fn make_services() -> (MigrationServices, TempDir) {
-    let dir = TempDir::new().expect("tempdir");
-    let db_path = dir.path().join("target.db");
-    let backend = Arc::new(LibSqlBackend::new_local(&db_path).await.expect("new_local"));
+fn test_master_key() -> SecretString {
+    SecretString::from(
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
+    )
+}
+
+async fn make_services_for_db_path(db_path: &Path, user_id: &str) -> MigrationServices {
+    let backend = Arc::new(LibSqlBackend::new_local(db_path).await.expect("new_local"));
     backend.run_migrations().await.expect("migrations");
 
     let db: Arc<dyn Database> = backend.clone();
-    let workspace = Arc::new(Workspace::new_with_db("alice", Arc::clone(&db)));
+    let workspace = Arc::new(Workspace::new_with_db(user_id.to_string(), Arc::clone(&db)));
     let settings_adapter = Arc::new(WorkspaceSettingsAdapter::new(
         Arc::clone(&workspace),
         Arc::clone(&db),
@@ -34,35 +39,51 @@ async fn make_services() -> (MigrationServices, TempDir) {
         .expect("seed system config");
     let settings_store: Arc<dyn SettingsStore + Send + Sync> = settings_adapter;
 
-    let crypto = Arc::new(
-        SecretsCrypto::new(SecretString::from(
-            "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef".to_string(),
-        ))
-        .expect("crypto"),
-    );
+    let crypto = Arc::new(SecretsCrypto::new(test_master_key()).expect("crypto"));
     let secrets_store: Arc<dyn SecretsStore + Send + Sync> =
         Arc::new(LibSqlSecretsStore::new(backend.shared_db(), crypto));
 
     let engine_store = Arc::new(HybridStore::new(Some(Arc::clone(&workspace))));
     engine_store.load_state_from_workspace().await;
-    let project = Project::new("alice", "default", "test project");
+    let project = Project::new(user_id, "default", "test project");
     let project_id = project.id;
     Store::save_project(engine_store.as_ref(), &project)
         .await
         .expect("save project");
 
-    (
-        MigrationServices {
-            user_id: "alice".to_string(),
-            db,
-            workspace,
-            settings_store,
-            secrets_store,
-            engine_store,
-            project_id,
-        },
-        dir,
-    )
+    MigrationServices {
+        user_id: user_id.to_string(),
+        db,
+        workspace,
+        settings_store,
+        secrets_store,
+        engine_store,
+        project_id,
+    }
+}
+
+async fn make_services() -> (MigrationServices, TempDir) {
+    let dir = TempDir::new().expect("tempdir");
+    let db_path = dir.path().join("target.db");
+    let services = make_services_for_db_path(&db_path, "alice").await;
+    (services, dir)
+}
+
+async fn load_services_from_config(
+    db_path: &Path,
+    base_dir: &Path,
+    user_id: &str,
+) -> MigrationServices {
+    let mut config = ironclaw::config::Config::for_testing(
+        db_path.to_path_buf(),
+        base_dir.join("skills"),
+        base_dir.join("installed-skills"),
+    );
+    config.owner_id = user_id.to_string();
+    config.secrets.master_key = Some(test_master_key());
+    MigrationServices::from_config(&config, user_id.to_string())
+        .await
+        .expect("load services from config")
 }
 
 async fn create_openclaw_source(root: &Path) {
@@ -368,5 +389,91 @@ async fn rerun_migration_is_idempotent() {
     assert!(
         stats2.skipped > 0 || stats2.workspace_documents == 0,
         "re-run should skip unchanged documents or write zero new ones"
+    );
+}
+
+#[test]
+fn migrate_binary_dispatches_through_main() {
+    let runtime = tokio::runtime::Runtime::new().expect("runtime");
+    let base_dir = TempDir::new().expect("base tempdir");
+    let source = TempDir::new().expect("source tempdir");
+    runtime.block_on(create_openclaw_source(source.path()));
+
+    let db_path = base_dir.path().join("binary-migrate.db");
+    let output = Command::new(env!("CARGO_BIN_EXE_ironclaw"))
+        .args(["migrate", "openclaw", "--path"])
+        .arg(source.path())
+        .args(["--user-id", "alice"])
+        .env("IRONCLAW_BASE_DIR", base_dir.path())
+        .env("DATABASE_BACKEND", "libsql")
+        .env("DATABASE_URL", "unused://libsql")
+        .env("LIBSQL_PATH", &db_path)
+        .env("SECRETS_MASTER_KEY", test_master_key().expose_secret())
+        .current_dir(base_dir.path())
+        .output()
+        .expect("run ironclaw migrate");
+
+    assert!(
+        output.status.success(),
+        "migrate command failed:\nstdout:\n{}\n\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Migration complete: OpenClaw"),
+        "migrate output did not print the CLI summary:\n{stdout}"
+    );
+
+    let services = runtime.block_on(load_services_from_config(
+        &db_path,
+        base_dir.path(),
+        "alice",
+    ));
+    let threads = runtime
+        .block_on(Store::list_threads(
+            services.engine_store.as_ref(),
+            services.project_id,
+            "alice",
+        ))
+        .expect("list threads");
+    assert_eq!(
+        threads.len(),
+        1,
+        "binary migrate should persist imported thread"
+    );
+
+    let imported_doc = runtime
+        .block_on(
+            services
+                .workspace
+                .read("imports/openclaw/root/workspace/notes.md"),
+        )
+        .expect("imported workspace doc");
+    assert!(imported_doc.content.contains("OpenClaw workspace doc"));
+}
+
+#[test]
+fn import_help_mentions_deprecation() {
+    let base_dir = TempDir::new().expect("base tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_ironclaw"))
+        .args(["import", "--help"])
+        .env("IRONCLAW_BASE_DIR", base_dir.path())
+        .current_dir(base_dir.path())
+        .output()
+        .expect("run ironclaw import --help");
+
+    assert!(
+        output.status.success(),
+        "import --help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("Deprecated alias for `ironclaw migrate`")
+            && stdout.contains("will be removed in a future release"),
+        "import help did not mention deprecation:\n{stdout}"
     );
 }


### PR DESCRIPTION
## Summary

- add a first-class `ironclaw migrate` CLI with `openclaw` and `hermes` source adapters
- gate the migration/import CLI behind an opt-in `migrate` Cargo feature instead of shipping it in default features
- remove the temporary `import` Cargo feature alias entirely so `migrate` is the only feature gate
- write migrated data into Engine V2-visible state via `HybridStore`, workspace docs, legacy conversation history, settings, and encrypted secrets
- keep `ironclaw import` as a compatibility CLI alias that delegates to the new migrate flow when the feature is enabled
- add targeted migration integration tests plus README / parity / changelog updates

## Change Type

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [x] Relevant tests pass: `cargo test --features migrate --test migrate_cli_integration`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed (not run locally; targeted `cargo test --features migrate --test migrate_cli_integration` covers the migration path, including binary CLI dispatch)
- [x] Manual testing: `cargo check`, `cargo check --tests --features migrate`, `cargo run --features migrate --bin ironclaw -- migrate --help`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

Touches migration-time secrets handling by importing provider credentials and Hermes auth material into the encrypted secrets store. Does not weaken existing runtime auth flows.

## Database Impact

No schema changes. Migration writes existing settings/history/workspace/secrets data through current abstractions and currently validates against the libSQL-backed path used by the feature.

## Blast Radius

CLI command surface, migration/import pipeline, Engine V2 store adapter usage, workspace/settings/secrets persistence, feature gating, and migration docs/tests.

## Rollback Plan

Revert this PR to remove the `migrate` command and restore the prior `import`-only behavior.

## Review Follow-Through

This branch was rebased to drop unrelated cheap-model/settings UI work so the PR now contains only the migration feature changes. The migration CLI is opt-in behind `--features migrate`, is no longer part of the default feature set, and no longer exposes an `import` Cargo feature alias.

---

**Review track**: C

