### PR TITLE
fix(engine-v2): recover flattened tool calls

### DIFF
--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -11,7 +11,7 @@ use rust_decimal::prelude::ToPrimitive;
 
 use crate::llm::{
     ChatMessage, LlmProvider, Role, ToolCall, ToolCompletionRequest, ToolDefinition,
-    sanitize_tool_messages,
+    clean_response, recover_tool_calls_from_content, sanitize_tool_messages,
 };
 
 /// Compute the USD cost of a single completion response, honoring the
@@ -161,7 +161,7 @@ impl LlmBackend for LlmBridgeAdapter {
         }
 
         // With tools: use tool completion (matches existing tools path)
-        let mut request = ToolCompletionRequest::new(chat_messages, tools)
+        let mut request = ToolCompletionRequest::new(chat_messages, tools.clone())
             .with_max_tokens(max_tokens)
             .with_temperature(temperature)
             .with_tool_choice("auto");
@@ -211,14 +211,35 @@ impl LlmBackend for LlmBridgeAdapter {
                 content: response.content.clone(),
             }
         } else {
-            let text = response.content.unwrap_or_default();
-            // Detect ```repl or ```python fenced code blocks
-            match extract_code_block(&text) {
-                Some(code) => LlmResponse::Code {
-                    code,
-                    content: Some(text),
-                },
-                None => LlmResponse::Text(text),
+            let raw_text = response.content.unwrap_or_default();
+            let cleaned_text = clean_response(&raw_text);
+            let recovered_calls = recover_tool_calls_from_content(&raw_text, &tools);
+
+            if !recovered_calls.is_empty() {
+                let calls: Vec<ironclaw_engine::ActionCall> = recovered_calls
+                    .iter()
+                    .map(|tc| ironclaw_engine::ActionCall {
+                        id: tc.id.clone(),
+                        action_name: tc.name.clone(),
+                        parameters: tc.arguments.clone(),
+                    })
+                    .collect();
+                let content = if cleaned_text.trim().is_empty() {
+                    None
+                } else {
+                    Some(cleaned_text)
+                };
+                LlmResponse::ActionCalls { calls, content }
+            } else {
+                // Detect ```repl or ```python fenced code blocks after stripping
+                // provider-flattened tool markers from visible text.
+                match extract_code_block(&cleaned_text) {
+                    Some(code) => LlmResponse::Code {
+                        code,
+                        content: Some(cleaned_text),
+                    },
+                    None => LlmResponse::Text(cleaned_text),
+                }
             }
         };
 
@@ -763,6 +784,97 @@ mod tests {
         assert_eq!(sent[2].content, "result payload");
         assert_eq!(sent[2].tool_call_id.as_deref(), Some("call_1"));
         assert_eq!(sent[2].name.as_deref(), Some("search"));
+    }
+
+    struct FlattenedToolCallProvider {
+        content: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FlattenedToolCallProvider {
+        fn model_name(&self) -> &str {
+            "flattened-tool-call-provider"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: crate::llm::CompletionRequest,
+        ) -> Result<crate::llm::CompletionResponse, LlmError> {
+            unreachable!("test only uses complete_with_tools")
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            Ok(ToolCompletionResponse {
+                content: Some(self.content.clone()),
+                tool_calls: Vec::new(),
+                input_tokens: 1,
+                output_tokens: 1,
+                finish_reason: crate::llm::FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_recovers_flattened_bracket_tool_calls() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
+            content: "Now let me list your installed extensions and start Pi:\n\n[Called tool `shell` with arguments: {\"command\":\"pi list 2>&1\",\"timeout\":10,\"workdir\":\".\"}]".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("do it")],
+                &[test_action("shell")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::ActionCalls { calls, content } => {
+                assert_eq!(calls.len(), 1);
+                assert_eq!(calls[0].action_name, "shell");
+                assert_eq!(calls[0].parameters["command"], "pi list 2>&1");
+                assert_eq!(
+                    content.as_deref(),
+                    Some("Now let me list your installed extensions and start Pi:")
+                );
+            }
+            other => panic!("expected recovered action call, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_strips_flattened_bracket_markers_from_text() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
+            content: "Let me check.\n[Called tool `unknown_tool` with arguments: {}]".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("do it")],
+                &[test_action("shell")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => {
+                assert_eq!(text, "Let me check.");
+            }
+            other => panic!("expected sanitized text response, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -14,6 +14,8 @@ use crate::llm::{
     clean_response, recover_tool_calls_from_content, sanitize_tool_messages,
 };
 
+const EMPTY_CLEANED_RESPONSE_FALLBACK: &str = "I'm not sure how to respond to that.";
+
 /// Compute the USD cost of a single completion response, honoring the
 /// provider's prompt-caching pricing. Mirrors the formula in
 /// `src/agent/cost_guard.rs::CostGuard::record_llm_call` so engine v2's
@@ -137,13 +139,7 @@ impl LlmBackend for LlmBridgeAdapter {
 
             // Check for code blocks in the response (CodeAct/RLM pattern)
             // after stripping provider-flattened internal markers from visible text.
-            let llm_response = match extract_code_block(&cleaned_text) {
-                Some(code) => LlmResponse::Code {
-                    code,
-                    content: Some(cleaned_text),
-                },
-                None => LlmResponse::Text(cleaned_text),
-            };
+            let llm_response = text_response_from_cleaned_text(cleaned_text);
 
             return Ok(LlmOutput {
                 response: llm_response,
@@ -236,13 +232,7 @@ impl LlmBackend for LlmBridgeAdapter {
             } else {
                 // Detect ```repl or ```python fenced code blocks after stripping
                 // provider-flattened tool markers from visible text.
-                match extract_code_block(&cleaned_text) {
-                    Some(code) => LlmResponse::Code {
-                        code,
-                        content: Some(cleaned_text),
-                    },
-                    None => LlmResponse::Text(cleaned_text),
-                }
+                text_response_from_cleaned_text(cleaned_text)
             }
         };
 
@@ -502,6 +492,19 @@ fn extract_code_block(text: &str) -> Option<String> {
     }
 
     Some(all_code.join("\n\n"))
+}
+
+fn text_response_from_cleaned_text(cleaned_text: String) -> LlmResponse {
+    match extract_code_block(&cleaned_text) {
+        Some(code) => LlmResponse::Code {
+            code,
+            content: Some(cleaned_text),
+        },
+        None if cleaned_text.trim().is_empty() => {
+            LlmResponse::Text(EMPTY_CLEANED_RESPONSE_FALLBACK.to_string())
+        }
+        None => LlmResponse::Text(cleaned_text),
+    }
 }
 
 /// Heuristic check that a bare ``` block contains Python rather than
@@ -937,6 +940,54 @@ mod tests {
                 assert_eq!(text, "Let me check.");
             }
             other => panic!("expected sanitized text response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_falls_back_when_cleaned_text_is_empty() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedToolCallProvider {
+            content: "[Called tool `unknown_tool` with arguments: {}]".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("do it")],
+                &[test_action("shell")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => {
+                assert_eq!(text, EMPTY_CLEANED_RESPONSE_FALLBACK);
+            }
+            other => panic!("expected fallback text response, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_without_tools_falls_back_when_cleaned_text_is_empty() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedPlainTextProvider {
+            content: "[Called tool `shell` with arguments: {}]".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("do it")],
+                &[],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => {
+                assert_eq!(text, EMPTY_CLEANED_RESPONSE_FALLBACK);
+            }
+            other => panic!("expected fallback text response, got {other:?}"),
         }
     }
 

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -133,13 +133,16 @@ impl LlmBackend for LlmBridgeAdapter {
                     reason: e.to_string(),
                 })?;
 
+            let cleaned_text = clean_response(&response.content);
+
             // Check for code blocks in the response (CodeAct/RLM pattern)
-            let llm_response = match extract_code_block(&response.content) {
+            // after stripping provider-flattened internal markers from visible text.
+            let llm_response = match extract_code_block(&cleaned_text) {
                 Some(code) => LlmResponse::Code {
                     code,
-                    content: Some(response.content),
+                    content: Some(cleaned_text),
                 },
-                None => LlmResponse::Text(response.content),
+                None => LlmResponse::Text(cleaned_text),
             };
 
             return Ok(LlmOutput {
@@ -864,6 +867,66 @@ mod tests {
             .complete(
                 &[ThreadMessage::user("do it")],
                 &[test_action("shell")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => {
+                assert_eq!(text, "Let me check.");
+            }
+            other => panic!("expected sanitized text response, got {other:?}"),
+        }
+    }
+
+    struct FlattenedPlainTextProvider {
+        content: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FlattenedPlainTextProvider {
+        fn model_name(&self) -> &str {
+            "flattened-plain-text-provider"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: crate::llm::CompletionRequest,
+        ) -> Result<crate::llm::CompletionResponse, LlmError> {
+            Ok(crate::llm::CompletionResponse {
+                content: self.content.clone(),
+                input_tokens: 1,
+                output_tokens: 1,
+                finish_reason: crate::llm::FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            unreachable!("test only uses plain completion")
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_without_tools_strips_flattened_bracket_markers_from_text() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FlattenedPlainTextProvider {
+            content: "Let me check.\n[Called tool `shell` with arguments: {}]".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("do it")],
+                &[],
                 &LlmCallConfig::default(),
             )
             .await

--- a/src/llm/mod.rs
+++ b/src/llm/mod.rs
@@ -69,6 +69,7 @@ pub use reasoning::{
     TokenUsage, ToolSelection, is_silent_reply, llm_signals_tool_intent,
     user_signals_execution_intent,
 };
+pub(crate) use reasoning::{clean_response, recover_tool_calls_from_content};
 pub use recording::RecordingLlm;
 pub use registry::{ProviderDefinition, ProviderProtocol, ProviderRegistry};
 pub use response_cache::{CachedProvider, ResponseCacheConfig};

--- a/src/llm/reasoning.rs
+++ b/src/llm/reasoning.rs
@@ -1586,7 +1586,7 @@ fn is_recoverable_tool_call_segment(
 /// - `<function_call>...</function_call>` (function_call variant)
 ///
 /// Only returns calls whose name matches an available tool.
-fn recover_tool_calls_from_content(
+pub(crate) fn recover_tool_calls_from_content(
     content: &str,
     available_tools: &[ToolDefinition],
 ) -> Vec<ToolCall> {
@@ -1726,7 +1726,7 @@ fn recover_tool_calls_from_content(
 /// 5. Strip pipe-delimited reasoning tags (code-aware)
 /// 6. Strip tool tags (string matching — no code-awareness needed)
 /// 7. Collapse triple+ newlines, trim
-fn clean_response(text: &str) -> String {
+pub(crate) fn clean_response(text: &str) -> String {
     // 1. Quick-check
     let mut result = if !QUICK_TAG_RE.is_match(text) {
         text.to_string()


### PR DESCRIPTION
## Summary
- recover provider-flattened bracket tool calls in the Engine V2 LLM bridge
- strip leaked internal `[Called tool ...]` markers from visible text responses
- add focused regression tests covering recovery and sanitization behavior

## Problem
In Engine V2, provider responses that flattened tool calls into assistant text like:

- `[Called tool \`shell\` with arguments: {...}]`

could be treated as final assistant text instead of structured tool calls. That caused two user-visible failures:

- internal tool-call markers leaked into the Web UI/history
- the engine could prematurely complete a turn instead of actually executing the intended tool

This is not specific to one provider in principle: it can affect any provider or response path that flattens tool calls into assistant content instead of returning structured tool calls. The concrete reproduction for this bug came from the NEAR AI provider path.

Legacy/v1 paths already handled this cleanup/recovery, but the Engine V2 bridge path did not.

## Fix
- reuse `clean_response()` to sanitize visible assistant text
- reuse `recover_tool_calls_from_content()` to reconstruct structured tool calls from flattened content
- return `LlmResponse::ActionCalls` when recovery succeeds, preserving any cleaned visible preamble text

## Tests
- `cargo fmt --all --check`
- `cargo test --lib --features libsql complete_with_tools_recovers_flattened_bracket_tool_calls -- --nocapture`
- `cargo test --lib --features libsql complete_with_tools_strips_flattened_bracket_markers_from_text -- --nocapture`

## Notes
- This PR branch is based directly on `staging` with only this fix cherry-picked on top.
- Full end-to-end manual revalidation in the clean Web UI instance is still pending.
