### PR TITLE
Fix chat image picker attachment staging

### DIFF
--- a/crates/ironclaw_gateway/static/js/core/bootstrap.js
+++ b/crates/ironclaw_gateway/static/js/core/bootstrap.js
@@ -94,8 +94,7 @@ const JOB_EVENTS_CAP = 500;
 const JOB_EVENTS_MAX_JOBS = 50;
 const MAX_DOM_MESSAGES = 200;
 const MEMORY_SEARCH_QUERY_MAX_LENGTH = 100;
-let stagedImages = [];
-// Non-image attachments staged for the next /api/chat/send submission.
+// Attachments staged for the next /api/chat/send submission.
 // Shape matches SendMessageRequest::attachments: { mime_type, filename, data_base64 }.
 let stagedAttachments = [];
 // FileReader promises that have not yet resolved. sendMessage awaits this

--- a/crates/ironclaw_gateway/static/js/surfaces/chat.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/chat.js
@@ -305,24 +305,6 @@ function handleImageFiles(files) {
   });
 }
 
-document.getElementById('attach-btn').addEventListener('click', () => {
-  document.getElementById('image-file-input').click();
-});
-
-document.getElementById('image-file-input').addEventListener('change', (e) => {
-  handleImageFiles(e.target.files);
-  e.target.value = '';
-});
-
-document.getElementById('chat-input').addEventListener('paste', (e) => {
-  const items = (e.clipboardData || e.originalEvent.clipboardData).items;
-  for (let i = 0; i < items.length; i++) {
-    if (items[i].kind === 'file' && items[i].type.startsWith('image/')) {
-      const file = items[i].getAsFile();
-      if (file) handleImageFiles([file]);
-    }
-  }
-});
 
 const chatMessagesEl = document.getElementById('chat-messages');
 chatMessagesEl.addEventListener('copy', (e) => {
@@ -682,33 +664,40 @@ function handleAttachmentFiles(files) {
   });
 }
 
+// Canonical upload wiring for the chat composer.
+//
+// Use delegated listeners instead of binding directly to the initial
+// `#image-file-input` node. The chat surface can be re-rendered, and when the
+// hidden file input is replaced the paperclip button still finds the new node
+// via `getElementById(...)` and opens the picker, but any listener attached to
+// the old input is gone. Delegation keeps file selection working across DOM
+// replacement and avoids the silent "picker closes, nothing happens" failure.
 (function wireAttachmentUI() {
-  const attachBtn = document.getElementById('attach-btn');
-  if (attachBtn) {
-    attachBtn.addEventListener('click', () => {
-      const input = document.getElementById('image-file-input');
-      if (input) input.click();
-    });
-  }
-  const fileInput = document.getElementById('image-file-input');
-  if (fileInput) {
-    fileInput.addEventListener('change', (e) => {
-      handleAttachmentFiles(e.target.files);
-      e.target.value = '';
-    });
-  }
-  const chatInputEl = document.getElementById('chat-input');
-  if (chatInputEl) {
-    chatInputEl.addEventListener('paste', (e) => {
-      const items = (e.clipboardData || e.originalEvent.clipboardData).items;
-      for (let i = 0; i < items.length; i++) {
-        if (items[i].kind === 'file' && items[i].type.startsWith('image/')) {
-          const file = items[i].getAsFile();
-          if (file) handleAttachmentFiles([file]);
-        }
+  document.addEventListener('click', (e) => {
+    const attachBtn = e.target && e.target.closest ? e.target.closest('#attach-btn') : null;
+    if (!attachBtn) return;
+    const input = document.getElementById('image-file-input');
+    if (input && !input.disabled) input.click();
+  });
+
+  document.addEventListener('change', (e) => {
+    const fileInput = e.target;
+    if (!fileInput || fileInput.id !== 'image-file-input') return;
+    handleAttachmentFiles(fileInput.files);
+    fileInput.value = '';
+  });
+
+  document.addEventListener('paste', (e) => {
+    const chatInputEl = e.target;
+    if (!chatInputEl || chatInputEl.id !== 'chat-input') return;
+    const items = (e.clipboardData || e.originalEvent.clipboardData).items;
+    for (let i = 0; i < items.length; i++) {
+      if (items[i].kind === 'file' && items[i].type.startsWith('image/')) {
+        const file = items[i].getAsFile();
+        if (file) handleAttachmentFiles([file]);
       }
-    });
-  }
+    }
+  });
 })();
 
 // --- User message attachment parsing/rendering ---

--- a/crates/ironclaw_gateway/static/js/surfaces/chat.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/chat.js
@@ -81,7 +81,7 @@ async function sendMessage() {
   }
   if (_sendCooldown) return;
   const content = input.value.trim();
-  if (!content && stagedImages.length === 0 && stagedAttachments.length === 0) return;
+  if (!content && stagedAttachments.length === 0) return;
 
   // Intercept approval keywords when an unresolved approval card is pending.
   // Find the most recent unresolved card for the current thread (resolved cards
@@ -115,10 +115,8 @@ async function sendMessage() {
     }
   }
 
-  // Snapshot attached images + attachments before the body block clears them,
-  // so the optimistic display, pending entry, and retry handler all see the
-  // same view the user pressed Enter on.
-  const attachedImageDataUrls = stagedImages.map(img => img.dataUrl);
+  // Snapshot attachments before the body block clears them, so the optimistic
+  // display and retry handler both see the same staged payload the user sent.
   const pendingAttachmentsForDisplay = stagedAttachments.map(att => ({
     kind: att.kind || (att.mime_type && att.mime_type.startsWith('image/') ? 'image' : 'document'),
     filename: att.filename || 'attachment',
@@ -127,14 +125,10 @@ async function sendMessage() {
     preview_url: att.preview_url || null,
     preview_text: '',
   }));
-  const displayContent = content
-    || (pendingAttachmentsForDisplay.length > 0 ? '(files attached)' : '(images attached)');
+  const displayContent = content || '(files attached)';
   const userMsg = addMessage('user', displayContent, {
     attachments: pendingAttachmentsForDisplay,
   });
-  if (attachedImageDataUrls.length > 0) {
-    appendImagesToMessage(userMsg, attachedImageDataUrls);
-  }
   pruneOldMessages();
   if (currentThreadId) {
     activeWorkStore.updateThread(currentThreadId, {
@@ -149,7 +143,7 @@ async function sendMessage() {
   let pendingId = null;
   const pendingThreadId = currentThreadId;
   if (currentThreadId) {
-    const displayContent = content || '(images attached)';
+    const displayContent = content || '(files attached)';
     if (!_pendingUserMessages.has(currentThreadId)) {
       _pendingUserMessages.set(currentThreadId, []);
     }
@@ -157,17 +151,11 @@ async function sendMessage() {
     _pendingUserMessages.get(currentThreadId).push({
       id: pendingId,
       content: displayContent,
-      images: attachedImageDataUrls,
       timestamp: Date.now(),
     });
   }
 
   const body = { content, thread_id: currentThreadId || undefined, timezone: Intl.DateTimeFormat().resolvedOptions().timeZone };
-  if (stagedImages.length > 0) {
-    body.images = stagedImages.map(img => ({ media_type: img.media_type, data: img.data }));
-    stagedImages = [];
-    renderImagePreviews();
-  }
   // Clone attachments so the retry handler can restore them if send fails
   // without getting mutated by subsequent stagedAttachments clears.
   const pendingAttachments = stagedAttachments.map(att => ({ ...att }));
@@ -222,8 +210,7 @@ async function sendMessage() {
         e.preventDefault();
         if (userMsg.parentNode) userMsg.parentNode.removeChild(userMsg);
         // Restore the attachments we just cleared so the retry carries the
-        // same payload the failed send attempted. `stagedImages` is kept
-        // separately by the existing preview machinery.
+        // same payload the failed send attempted.
         if (pendingAttachments.length > 0) {
           stagedAttachments = pendingAttachments.map(att => ({ ...att }));
           if (typeof renderAttachmentPreviews === 'function') {
@@ -248,63 +235,6 @@ function enableChatInput() {
   }
   if (btn) btn.disabled = false;
 }
-
-// --- Image Upload ---
-
-function renderImagePreviews() {
-  const strip = document.getElementById('image-preview-strip');
-  strip.innerHTML = '';
-  stagedImages.forEach((img, idx) => {
-    const container = document.createElement('div');
-    container.className = 'image-preview-container';
-
-    const preview = document.createElement('img');
-    preview.className = 'image-preview';
-    preview.src = img.dataUrl;
-    preview.alt = 'Attached image';
-
-    const removeBtn = document.createElement('button');
-    removeBtn.className = 'image-preview-remove';
-    removeBtn.textContent = '\u00d7';
-    removeBtn.addEventListener('click', () => {
-      stagedImages.splice(idx, 1);
-      renderImagePreviews();
-    });
-
-    container.appendChild(preview);
-    container.appendChild(removeBtn);
-    strip.appendChild(container);
-  });
-}
-
-const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024; // 5 MB per image
-const MAX_STAGED_IMAGES = 5;
-
-function handleImageFiles(files) {
-  Array.from(files).forEach(file => {
-    if (!file.type.startsWith('image/')) return;
-    if (file.size > MAX_IMAGE_SIZE_BYTES) {
-      alert(I18n.t('chat.imageTooBig', { name: file.name, size: (file.size / 1024 / 1024).toFixed(1) }));
-      return;
-    }
-    if (stagedImages.length >= MAX_STAGED_IMAGES) {
-      alert(I18n.t('chat.maxImages', { n: MAX_STAGED_IMAGES }));
-      return;
-    }
-    const reader = new FileReader();
-    reader.onload = function(e) {
-      const dataUrl = e.target.result;
-      const commaIdx = dataUrl.indexOf(',');
-      const meta = dataUrl.substring(0, commaIdx); // e.g. "data:image/png;base64"
-      const base64 = dataUrl.substring(commaIdx + 1);
-      const mediaType = meta.replace('data:', '').replace(';base64', '');
-      stagedImages.push({ media_type: mediaType, data: base64, dataUrl: dataUrl });
-      renderImagePreviews();
-    };
-    reader.readAsDataURL(file);
-  });
-}
-
 
 const chatMessagesEl = document.getElementById('chat-messages');
 chatMessagesEl.addEventListener('copy', (e) => {
@@ -674,7 +604,8 @@ function handleAttachmentFiles(files) {
 // replacement and avoids the silent "picker closes, nothing happens" failure.
 (function wireAttachmentUI() {
   document.addEventListener('click', (e) => {
-    const attachBtn = e.target && e.target.closest ? e.target.closest('#attach-btn') : null;
+    const eventTarget = e.target && e.target.nodeType === Node.TEXT_NODE ? e.target.parentElement : e.target;
+    const attachBtn = eventTarget && typeof eventTarget.closest === 'function' ? eventTarget.closest('#attach-btn') : null;
     if (!attachBtn) return;
     const input = document.getElementById('image-file-input');
     if (input && !input.disabled) input.click();

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -310,6 +310,49 @@ async def test_turn_cost_event_does_not_render_message_badge(page):
     assert "$1.6296" not in badge_count["text"]
 
 
+async def test_gateway_image_picker_selection_stages_attachment_preview(page):
+    """Selecting an image via the chat file input should stage a unified attachment preview immediately."""
+    attachment_input = page.locator(SEL["attachment_input"])
+
+    await page.wait_for_function(
+        "() => typeof currentThreadId !== 'undefined' && !!currentThreadId",
+        timeout=15000,
+    )
+
+    await attachment_input.set_input_files(
+        files=[
+            {
+                "name": "preview.png",
+                "mimeType": "image/png",
+                "buffer": ONE_BY_ONE_PNG,
+            }
+        ]
+    )
+
+    await page.wait_for_function(
+        """() => (
+          stagedAttachments.length === 1 &&
+          document.querySelectorAll('#image-preview-strip .attachment-preview-container').length === 1
+        )""",
+        timeout=10000,
+    )
+
+    preview_state = await page.evaluate(
+        """
+        () => ({
+          stagedAttachments: stagedAttachments.length,
+          stagedImages: stagedImages.length,
+          attachmentPreviews: document.querySelectorAll('#image-preview-strip .attachment-preview-container').length,
+          legacyImagePreviews: document.querySelectorAll('#image-preview-strip .image-preview-container').length,
+        })
+        """
+    )
+    assert preview_state["stagedAttachments"] == 1, preview_state
+    assert preview_state["attachmentPreviews"] == 1, preview_state
+    assert preview_state["stagedImages"] == 0, preview_state
+    assert preview_state["legacyImagePreviews"] == 0, preview_state
+
+
 async def test_gateway_attachment_flow_renders_thread_and_reaches_llm(page, ironclaw_server, mock_llm_server):
     """Upload image/PDF/text/slides, render them in-thread, and verify the LLM payload."""
     attachment_input = page.locator(SEL["attachment_input"])

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -311,15 +311,67 @@ async def test_turn_cost_event_does_not_render_message_badge(page):
 
 
 async def test_gateway_image_picker_selection_stages_attachment_preview(page):
-    """Selecting an image via the chat file input should stage a unified attachment preview immediately."""
-    attachment_input = page.locator(SEL["attachment_input"])
+    """The paperclip should survive input replacement, handle text-node clicks, and stage only unified attachments."""
+    attach_btn = page.locator(SEL["attach_btn"])
 
     await page.wait_for_function(
         "() => typeof currentThreadId !== 'undefined' && !!currentThreadId",
         timeout=15000,
     )
 
-    await attachment_input.set_input_files(
+    text_target_click = await page.evaluate(
+        """
+        () => {
+          const attachBtn = document.getElementById('attach-btn');
+          const input = document.getElementById('image-file-input');
+          if (!attachBtn || !input) {
+            return { ready: false };
+          }
+          attachBtn.textContent = '';
+          const textNode = document.createTextNode('Attach');
+          attachBtn.appendChild(textNode);
+          let clickCount = 0;
+          const originalClick = input.click.bind(input);
+          input.click = () => {
+            clickCount += 1;
+          };
+          let threw = false;
+          try {
+            textNode.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+          } catch (err) {
+            threw = true;
+          } finally {
+            input.click = originalClick;
+            attachBtn.textContent = '\uD83D\uDCCE';
+          }
+          return { ready: true, threw, clickCount };
+        }
+        """
+    )
+    assert text_target_click["ready"] is True, text_target_click
+    assert text_target_click["threw"] is False, text_target_click
+    assert text_target_click["clickCount"] == 1, text_target_click
+
+    await page.evaluate(
+        """
+        () => {
+          const oldInput = document.getElementById('image-file-input');
+          if (!oldInput) return false;
+          const replacement = oldInput.cloneNode(false);
+          replacement.id = oldInput.id;
+          replacement.accept = oldInput.accept;
+          replacement.multiple = oldInput.multiple;
+          replacement.style.display = oldInput.style.display;
+          oldInput.replaceWith(replacement);
+          return document.getElementById('image-file-input') === replacement;
+        }
+        """
+    )
+
+    async with page.expect_file_chooser() as chooser_info:
+        await attach_btn.click()
+    file_chooser = await chooser_info.value
+    await file_chooser.set_files(
         files=[
             {
                 "name": "preview.png",
@@ -341,7 +393,7 @@ async def test_gateway_image_picker_selection_stages_attachment_preview(page):
         """
         () => ({
           stagedAttachments: stagedAttachments.length,
-          stagedImages: stagedImages.length,
+          legacyStatePresent: typeof stagedImages !== 'undefined',
           attachmentPreviews: document.querySelectorAll('#image-preview-strip .attachment-preview-container').length,
           legacyImagePreviews: document.querySelectorAll('#image-preview-strip .image-preview-container').length,
         })
@@ -349,7 +401,7 @@ async def test_gateway_image_picker_selection_stages_attachment_preview(page):
     )
     assert preview_state["stagedAttachments"] == 1, preview_state
     assert preview_state["attachmentPreviews"] == 1, preview_state
-    assert preview_state["stagedImages"] == 0, preview_state
+    assert preview_state["legacyStatePresent"] is False, preview_state
     assert preview_state["legacyImagePreviews"] == 0, preview_state
 
 


### PR DESCRIPTION
## Summary

- Fix the chat composer paperclip flow so file selection still works after the chat surface re-renders
- Replace direct upload listener binding with delegated `click` / `change` / `paste` handlers on the document
- Add an e2e regression test that verifies selecting an image immediately stages the unified attachment preview
- Keep the existing attachment send-path coverage to ensure uploaded files still render in-thread and reach the LLM payload

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Fixes #2737.

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [x] Relevant tests pass: `pytest scenarios/test_chat.py -k 'image_picker_selection_stages_attachment_preview or gateway_attachment_flow_renders_thread_and_reaches_llm' -q`
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None.

## Database Impact

None.

## Blast Radius

Frontend chat attachment staging in `crates/ironclaw_gateway/static/js/surfaces/chat.js` and the matching e2e scenario coverage.

## Rollback Plan

Revert commit `196d55289b9377ebd5eb1f069a7573523eb925d8` to restore the previous attachment listener wiring.

## Review Follow-Through

None known.

---

**Review track**: B
