### PR TITLE
[codex] Fix gateway slash autocomplete and attachment rendering

### DIFF
--- a/crates/ironclaw_gateway/static/js/core/history.js
+++ b/crates/ironclaw_gateway/static/js/core/history.js
@@ -39,6 +39,22 @@ function loadHistory(before) {
 
   apiFetch(historyUrl).then((data) => {
     const container = document.getElementById('chat-messages');
+    const pending = !isPaginating ? _pendingUserMessages.get(currentThreadId) : null;
+    let freshPending = [];
+    let pendingByContent = null;
+
+    if (!isPaginating && pending && pending.length > 0) {
+      const now = Date.now();
+      freshPending = pending.filter(p => now - p.timestamp < PENDING_MSG_TTL_MS);
+      if (freshPending.length > 0) {
+        pendingByContent = new Map();
+        freshPending.forEach((p) => {
+          const key = p.content;
+          if (!pendingByContent.has(key)) pendingByContent.set(key, []);
+          pendingByContent.get(key).push(p);
+        });
+      }
+    }
 
     if (!isPaginating && currentThreadId && data.channel) {
       threadChannelHints.set(currentThreadId, data.channel);
@@ -49,7 +65,33 @@ function loadHistory(before) {
       container.innerHTML = '';
       for (const turn of data.turns) {
         if (turn.user_input) {
-          addMessage('user', turn.user_input);
+          let renderedPending = false;
+          const pendingQueue = pendingByContent && pendingByContent.get(turn.user_input);
+          const nextPending = pendingQueue && pendingQueue.length > 0 ? pendingQueue[0] : null;
+          if (nextPending) {
+            let persistedAttachments = [];
+            if (typeof parseUserMessageContent === 'function') {
+              persistedAttachments = parseUserMessageContent(turn.user_input).attachments;
+            }
+            const hasPendingVisuals = (
+              (Array.isArray(nextPending.attachments) && nextPending.attachments.length > 0)
+              || (Array.isArray(nextPending.images) && nextPending.images.length > 0)
+            );
+            if (hasPendingVisuals && persistedAttachments.length === 0) {
+              const div = addMessage('user', nextPending.content, {
+                attachments: Array.isArray(nextPending.attachments) ? nextPending.attachments : [],
+                copyText: nextPending.copyText || nextPending.content,
+              });
+              if (nextPending.images && nextPending.images.length > 0) {
+                appendImagesToMessage(div, nextPending.images);
+              }
+              renderedPending = true;
+            }
+            pendingQueue.shift();
+          }
+          if (!renderedPending) {
+            addMessage('user', turn.user_input);
+          }
         }
         if (turn.tool_calls && turn.tool_calls.length > 0) {
           addToolCallsSummary(turn.tool_calls);
@@ -75,54 +117,49 @@ function loadHistory(before) {
           addMessage('assistant', turn.response);
         }
       }
-      // Re-inject pending user messages not yet in DB (#2409)
-      const pending = _pendingUserMessages.get(currentThreadId);
-      let freshPending = [];
-      if (pending && pending.length > 0) {
-        const now = Date.now();
-        freshPending = pending.filter(p => now - p.timestamp < PENDING_MSG_TTL_MS);
-        if (freshPending.length > 0) {
-          const dbContentsCounts = new Map();
-          data.turns
-            .map(t => t.user_input)
-            .filter(Boolean)
-            .forEach(content => {
-              dbContentsCounts.set(content, (dbContentsCounts.get(content) || 0) + 1);
-            });
-          for (const p of freshPending) {
-            const count = dbContentsCounts.get(p.content) || 0;
-            if (count > 0) {
-              dbContentsCounts.set(p.content, count - 1);
-            } else {
-              const div = addMessage('user', p.content, {
-                attachments: Array.isArray(p.attachments) ? p.attachments : [],
-                copyText: p.copyText || p.content,
-              });
-              if (p.images && p.images.length > 0) {
-                appendImagesToMessage(div, p.images);
-              }
-            }
-          }
-          _pendingUserMessages.set(currentThreadId, freshPending);
-        } else {
-          _pendingUserMessages.delete(currentThreadId);
-        }
-      }
-      container.scrollTop = container.scrollHeight;
-      // Show welcome card when history is empty
-      if (data.turns.length === 0 && !data.in_progress && freshPending.length === 0) {
-        showWelcomeCard();
-      }
       // Show processing indicator if the last turn is still in-progress
       var lastTurn = data.turns.length > 0 ? data.turns[data.turns.length - 1] : null;
       if (data.in_progress) {
         const sameLastTurn = isSameInProgressTurn(lastTurn, data.in_progress);
         if (!sameLastTurn && data.in_progress.user_input) {
-          addMessage('user', data.in_progress.user_input);
+          const pendingQueue = pendingByContent && pendingByContent.get(data.in_progress.user_input);
+          const nextPending = pendingQueue && pendingQueue.length > 0 ? pendingQueue[0] : null;
+          const hasPendingVisuals = nextPending && (
+            (Array.isArray(nextPending.attachments) && nextPending.attachments.length > 0)
+            || (Array.isArray(nextPending.images) && nextPending.images.length > 0)
+          );
+          if (hasPendingVisuals) {
+            pendingQueue.shift();
+          } else {
+            addMessage('user', data.in_progress.user_input);
+          }
         }
         showActivityThinking(ActivityEntry.t('activity.processing', 'Processing...'));
       } else if (lastTurn && !lastTurn.response && lastTurn.state === 'Processing') {
         showActivityThinking(ActivityEntry.t('activity.processing', 'Processing...'));
+      }
+      // Re-inject pending user messages not yet in DB (#2409)
+      const remainingPending = freshPending.length > 0 && pendingByContent
+        ? Array.from(pendingByContent.values()).flat()
+        : freshPending;
+      if (remainingPending.length > 0) {
+        for (const p of remainingPending) {
+          const div = addMessage('user', p.content, {
+            attachments: Array.isArray(p.attachments) ? p.attachments : [],
+            copyText: p.copyText || p.content,
+          });
+          if (p.images && p.images.length > 0) {
+            appendImagesToMessage(div, p.images);
+          }
+        }
+        _pendingUserMessages.set(currentThreadId, freshPending);
+      } else {
+        _pendingUserMessages.delete(currentThreadId);
+      }
+      container.scrollTop = container.scrollHeight;
+      // Show welcome card when history is empty
+      if (data.turns.length === 0 && !data.in_progress && freshPending.length === 0) {
+        showWelcomeCard();
       }
       const hintedChannel = currentThreadId
         ? (data.channel || threadChannelHints.get(currentThreadId) || 'gateway')

--- a/crates/ironclaw_gateway/static/js/core/history.js
+++ b/crates/ironclaw_gateway/static/js/core/history.js
@@ -94,7 +94,10 @@ function loadHistory(before) {
             if (count > 0) {
               dbContentsCounts.set(p.content, count - 1);
             } else {
-              const div = addMessage('user', p.content);
+              const div = addMessage('user', p.content, {
+                attachments: Array.isArray(p.attachments) ? p.attachments : [],
+                copyText: p.copyText || p.content,
+              });
               if (p.images && p.images.length > 0) {
                 appendImagesToMessage(div, p.images);
               }
@@ -780,4 +783,3 @@ function updateTabIndicator() {
 window.addEventListener('resize', updateTabIndicator);
 
 // --- Memory (filesystem tree) ---
-

--- a/crates/ironclaw_gateway/static/js/core/history.js
+++ b/crates/ironclaw_gateway/static/js/core/history.js
@@ -129,6 +129,13 @@ function loadHistory(before) {
             || (Array.isArray(nextPending.images) && nextPending.images.length > 0)
           );
           if (hasPendingVisuals) {
+            const div = addMessage('user', nextPending.content, {
+              attachments: Array.isArray(nextPending.attachments) ? nextPending.attachments : [],
+              copyText: nextPending.copyText || nextPending.content,
+            });
+            if (nextPending.images && nextPending.images.length > 0) {
+              appendImagesToMessage(div, nextPending.images);
+            }
             pendingQueue.shift();
           } else {
             addMessage('user', data.in_progress.user_input);

--- a/crates/ironclaw_gateway/static/js/core/init-auth.js
+++ b/crates/ironclaw_gateway/static/js/core/init-auth.js
@@ -60,6 +60,7 @@ function initApp() {
     if (roleEl) roleEl.textContent = profile.role;
   }).catch(function() {});
   checkTeeStatus();
+  refreshSlashSkillEntries();
   loadThreads();
   loadMemoryTree();
   loadJobs();
@@ -412,4 +413,3 @@ function updateRestartButtonVisibility() {
 }
 
 // --- SSE ---
-

--- a/crates/ironclaw_gateway/static/js/surfaces/chat.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/chat.js
@@ -139,9 +139,10 @@ async function sendMessage() {
         : `[Attachment] ${att.filename || 'attachment'}`
     );
   });
+  const pendingCopyText = pendingCopyTextParts.join('\n');
   const userMsg = addMessage('user', displayContent, {
     attachments: pendingAttachmentsForDisplay,
-    copyText: pendingCopyTextParts.join('\n'),
+    copyText: pendingCopyText,
   });
   if (attachedImageDataUrls.length > 0) {
     appendImagesToMessage(userMsg, attachedImageDataUrls);
@@ -167,7 +168,7 @@ async function sendMessage() {
     _pendingUserMessages.get(currentThreadId).push({
       id: pendingId,
       content: displayContent,
-      copyText: pendingCopyTextParts.join('\n'),
+      copyText: pendingCopyText,
       attachments: pendingAttachmentsForDisplay.map((att) => ({ ...att })),
       images: attachedImageDataUrls,
       timestamp: Date.now(),
@@ -322,8 +323,8 @@ document.getElementById('attach-btn').addEventListener('click', () => {
 });
 
 document.getElementById('image-file-input').addEventListener('change', (e) => {
-  handleImageFiles(e.target.files);
-  e.target.value = '';
+  const files = Array.from(e.target.files || []);
+  handleImageFiles(files);
 });
 
 document.getElementById('chat-input').addEventListener('paste', (e) => {

--- a/crates/ironclaw_gateway/static/js/surfaces/chat.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/chat.js
@@ -129,8 +129,19 @@ async function sendMessage() {
   }));
   const displayContent = content
     || (pendingAttachmentsForDisplay.length > 0 ? '(files attached)' : '(images attached)');
+  const pendingCopyTextParts = [];
+  if (displayContent) pendingCopyTextParts.push(displayContent);
+  pendingAttachmentsForDisplay.forEach((att) => {
+    const suffix = [att.mime_type, att.size_label].filter(Boolean).join(' • ');
+    pendingCopyTextParts.push(
+      suffix
+        ? `[Attachment] ${att.filename || 'attachment'} (${suffix})`
+        : `[Attachment] ${att.filename || 'attachment'}`
+    );
+  });
   const userMsg = addMessage('user', displayContent, {
     attachments: pendingAttachmentsForDisplay,
+    copyText: pendingCopyTextParts.join('\n'),
   });
   if (attachedImageDataUrls.length > 0) {
     appendImagesToMessage(userMsg, attachedImageDataUrls);
@@ -149,7 +160,6 @@ async function sendMessage() {
   let pendingId = null;
   const pendingThreadId = currentThreadId;
   if (currentThreadId) {
-    const displayContent = content || '(images attached)';
     if (!_pendingUserMessages.has(currentThreadId)) {
       _pendingUserMessages.set(currentThreadId, []);
     }
@@ -157,6 +167,8 @@ async function sendMessage() {
     _pendingUserMessages.get(currentThreadId).push({
       id: pendingId,
       content: displayContent,
+      copyText: pendingCopyTextParts.join('\n'),
+      attachments: pendingAttachmentsForDisplay.map((att) => ({ ...att })),
       images: attachedImageDataUrls,
       timestamp: Date.now(),
     });
@@ -441,6 +453,8 @@ function resolveGeneratedImageForRender(threadId, image) {
 
 // --- Slash Autocomplete ---
 
+let _slashSkillEntries = [];
+
 function showSlashAutocomplete(matches) {
   const el = document.getElementById('slash-autocomplete');
   if (!el || matches.length === 0) { hideSlashAutocomplete(); return; }
@@ -466,6 +480,51 @@ function showSlashAutocomplete(matches) {
     el.appendChild(row);
   });
   el.style.display = 'block';
+}
+
+function setSlashSkillEntries(skills) {
+  if (!Array.isArray(skills)) {
+    _slashSkillEntries = [];
+    const input = document.getElementById('chat-input');
+    if (input && input.value.startsWith('/')) filterSlashCommands(input.value);
+    return;
+  }
+  _slashSkillEntries = skills
+    .filter((skill) => skill && typeof skill.name === 'string' && skill.name.trim() !== '')
+    .map((skill) => ({
+      cmd: '/' + skill.name.trim(),
+      desc: (skill.description || '').trim() || 'Skill',
+      kind: 'skill',
+    }))
+    .sort((a, b) => a.cmd.localeCompare(b.cmd));
+  const input = document.getElementById('chat-input');
+  if (input && input.value.startsWith('/')) filterSlashCommands(input.value);
+}
+
+function getSlashAutocompleteItems() {
+  const items = SLASH_COMMANDS.map((cmd) => ({
+    cmd: cmd.cmd,
+    desc: cmd.desc,
+    kind: 'command',
+  }));
+  const seen = new Set(items.map((item) => item.cmd.toLowerCase()));
+  _slashSkillEntries.forEach((item) => {
+    const key = item.cmd.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    items.push(item);
+  });
+  return items;
+}
+
+function refreshSlashSkillEntries() {
+  return apiFetch('/api/skills')
+    .then(function(data) {
+      setSlashSkillEntries((data && data.skills) || []);
+    })
+    .catch(function() {
+      // Preserve the last known skill list on transient fetch failures.
+    });
 }
 
 function hideSlashAutocomplete() {
@@ -495,8 +554,9 @@ function filterSlashCommands(value) {
   if (!value.startsWith('/')) { hideSlashAutocomplete(); return; }
   // Only show autocomplete when the input is just a slash command prefix (no spaces except /thread new)
   const lower = value.toLowerCase();
-  const matches = SLASH_COMMANDS.filter((c) => c.cmd.startsWith(lower));
-  if (matches.length === 0 || (matches.length === 1 && matches[0].cmd === lower.trimEnd())) {
+  const exactLower = lower.trimEnd();
+  const matches = getSlashAutocompleteItems().filter((c) => c.cmd.toLowerCase().startsWith(lower));
+  if (matches.length === 0 || (matches.length === 1 && matches[0].cmd.toLowerCase() === exactLower)) {
     hideSlashAutocomplete();
   } else {
     showSlashAutocomplete(matches);

--- a/crates/ironclaw_gateway/static/js/surfaces/skills.js
+++ b/crates/ironclaw_gateway/static/js/surfaces/skills.js
@@ -62,6 +62,7 @@ function loadSkills() {
   var skillsList = document.getElementById('skills-list');
   skillsList.innerHTML = renderCardsSkeleton(3);
   apiFetch('/api/skills').then(function(data) {
+    setSlashSkillEntries((data && data.skills) || []);
     if (!data.skills || data.skills.length === 0) {
       skillsList.innerHTML = '<div class="empty-state">' + I18n.t('skills.noInstalled') + '</div>';
       return;
@@ -390,4 +391,3 @@ document.getElementById('skill-search-input').addEventListener('keydown', functi
 });
 
 // --- Tool Permissions ---
-

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -63,6 +63,7 @@ fn web_attachment_ext(mime: &str) -> Option<&'static str> {
         "audio/aac" => Some("aac"),
         "audio/flac" => Some("flac"),
         "audio/webm" => Some("webm"),
+        "application/octet-stream" => Some("bin"),
         _ => None,
     };
 
@@ -108,6 +109,7 @@ fn is_allowed_attachment_mime(mime: &str) -> bool {
             | "application/pdf"
             | "application/json"
             | "application/xml"
+            | "application/octet-stream"
             | "application/rtf"
             | "text/rtf"
             | "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
@@ -1178,6 +1180,23 @@ mod tests {
 
         let err = web_attachments_to_incoming(&attachments).unwrap_err();
         assert!(err.contains("Unsupported file type"));
+    }
+
+    #[test]
+    fn web_upload_accepts_octet_stream_attachment() {
+        use base64::Engine;
+
+        let attachments = vec![AttachmentData {
+            mime_type: "application/octet-stream".to_string(),
+            filename: Some("mystery.bin".to_string()),
+            data_base64: base64::engine::general_purpose::STANDARD
+                .encode([0x00u8, 0x01, 0x02, 0x03]),
+        }];
+
+        let incoming = web_attachments_to_incoming(&attachments).expect("octet-stream should pass");
+        assert_eq!(incoming[0].mime_type, "application/octet-stream");
+        assert_eq!(incoming[0].filename.as_deref(), Some("mystery.bin"));
+        assert_eq!(incoming[0].kind, crate::channels::AttachmentKind::Document);
     }
 
     #[test]

--- a/tests/e2e/scenarios/test_pending_user_messages.py
+++ b/tests/e2e/scenarios/test_pending_user_messages.py
@@ -5,8 +5,12 @@ The frontend fix tracks optimistically-shown messages in a
 clears the DOM before the agent loop has persisted them.
 """
 
+import asyncio
+
 from helpers import (
+    AUTH_TOKEN,
     SEL,
+    api_get,
     send_chat_and_wait_for_terminal_message,
 )
 
@@ -24,6 +28,27 @@ async def _create_new_thread(page) -> str:
     await page.locator("#thread-new-btn").click()
     await page.wait_for_function("() => !!currentThreadId", timeout=10000)
     return await page.evaluate("() => currentThreadId")
+
+
+async def _reload_and_switch_to_thread(page, base_url: str, thread_id: str) -> None:
+    await page.goto(f"{base_url}/?token={AUTH_TOKEN}", timeout=15000)
+    await page.wait_for_selector(SEL["auth_screen"], state="hidden", timeout=10000)
+    await _wait_for_connected(page, timeout=10000)
+    await page.evaluate("(id) => switchThread(id)", thread_id)
+    await page.wait_for_function("(id) => currentThreadId === id", arg=thread_id, timeout=10000)
+
+
+async def _wait_for_in_progress_turn(base_url: str, thread_id: str, *, timeout: float = 15.0) -> dict:
+    last_payload = {}
+    for _ in range(int(timeout * 5)):
+        response = await api_get(base_url, f"/api/chat/history?thread_id={thread_id}", timeout=15)
+        response.raise_for_status()
+        payload = response.json()
+        last_payload = payload
+        if payload.get("in_progress"):
+            return payload
+        await asyncio.sleep(0.2)
+    raise AssertionError(f"Timed out waiting for in-progress turn: {last_payload}")
 
 
 async def test_user_message_visible_after_send(page):
@@ -126,6 +151,56 @@ async def test_pending_message_survives_sse_reconnect(page):
         await page.evaluate(
             "() => { if (window._testOrigApiFetch) { window.apiFetch = window._testOrigApiFetch; } }"
         )
+
+
+async def test_in_progress_attachment_turn_survives_reload(page, ironclaw_server):
+    """Reloading during a durable in-progress attachment turn keeps its file card."""
+    await _wait_for_connected(page, timeout=5000)
+
+    thread_id = await page.evaluate("() => currentThreadId")
+    assert thread_id, "expected an active thread before send"
+
+    attachment_input = page.locator(SEL["attachment_input"])
+    chat_input = page.locator(SEL["chat_input"])
+
+    await attachment_input.set_input_files(
+        files=[
+            {
+                "name": "pending-note.txt",
+                "mimeType": "text/plain",
+                "buffer": b"Attachment survives in-progress reload.",
+            }
+        ]
+    )
+
+    await chat_input.fill("issue 1780 loop forever")
+    await chat_input.press("Enter")
+
+    await page.wait_for_function(
+        """() => {
+            const pending = _pendingUserMessages.get(currentThreadId);
+            return pending && pending.some((p) =>
+                p.content === 'issue 1780 loop forever' &&
+                Array.isArray(p.attachments) &&
+                p.attachments.some((att) => att.filename === 'pending-note.txt')
+            );
+        }""",
+        timeout=5000,
+    )
+
+    await _wait_for_in_progress_turn(ironclaw_server, thread_id, timeout=15.0)
+    await _reload_and_switch_to_thread(page, ironclaw_server, thread_id)
+
+    await page.wait_for_function(
+        """() => {
+            const users = document.querySelectorAll('#chat-messages .message.user');
+            const lastUser = users.length ? users[users.length - 1] : null;
+            return !!lastUser
+              && lastUser.querySelectorAll('.message-attachment-file').length >= 1
+              && (lastUser.innerText || '').includes('pending-note.txt');
+        }""",
+        timeout=15000,
+    )
 
 
 async def test_pending_entry_cleared_when_send_fails(page):


### PR DESCRIPTION
## What changed
- restore slash autocomplete skill entries and merge them with built-in slash commands
- refresh the slash skill cache during gateway init and from the Skills surface without wiping the last known list on transient fetch failures
- preserve pending attachment cards and copy text when user messages are rehydrated from pending state
- keep slash skill matching case-insensitive so mixed-case skill names remain discoverable

## Why
The gateway frontend regressed in two visible ways:
- installed skills stopped appearing alongside built-in slash commands in autocomplete
- attachment-only user turns could lose their rendered file cards while the UI rehydrated pending history

The follow-up review also caught two correctness gaps in the first pass:
- mixed-case skill names were not surfaced by autocomplete even though backend slash resolution is case-insensitive
- a transient `/api/skills` error in the Skills tab could clear the cached slash skill entries for the rest of the session

## Impact
- slash autocomplete again shows both built-in commands and installed skills
- attachment uploads retain their in-thread file and image rendering during pending-history recovery
- autocomplete behavior now matches backend skill-name handling more closely

## Validation
- `cargo fmt --all --check`
- `cargo clippy --no-default-features --features libsql --all-targets -- -D warnings`

## Notes
- I previously attempted targeted gateway E2E coverage, but local pytest fixture setup was blocked by the Rust binary build timing out before the browser assertions ran.