### PR TITLE
[codex] fix v2 attachment persistence test path

### DIFF
--- a/tests/e2e_attachments.rs
+++ b/tests/e2e_attachments.rs
@@ -9,7 +9,10 @@ mod support;
 #[cfg(feature = "libsql")]
 mod attachment_tests {
     use std::path::PathBuf;
+    use std::sync::OnceLock;
     use std::time::Duration;
+
+    use tokio::sync::Mutex;
 
     use crate::support::test_rig::TestRigBuilder;
     use crate::support::trace_llm::LlmTrace;
@@ -22,6 +25,11 @@ mod attachment_tests {
         "/tests/fixtures/llm_traces/spot"
     );
     const TIMEOUT: Duration = Duration::from_secs(15);
+
+    fn engine_v2_attachment_root_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
 
     fn engine_v2_project_root() -> PathBuf {
         let base_dir = ironclaw::bootstrap::ironclaw_base_dir();
@@ -217,6 +225,7 @@ mod attachment_tests {
 
     #[tokio::test]
     async fn engine_v2_channel_attachments_persist_for_telegram_and_whatsapp() {
+        let _guard = engine_v2_attachment_root_lock().lock().await;
         let project_root = engine_v2_project_root();
 
         for channel in ["telegram", "whatsapp"] {

--- a/tests/e2e_attachments.rs
+++ b/tests/e2e_attachments.rs
@@ -8,8 +8,7 @@ mod support;
 
 #[cfg(feature = "libsql")]
 mod attachment_tests {
-    use std::path::{Path, PathBuf};
-    use std::sync::{Mutex, OnceLock};
+    use std::path::PathBuf;
     use std::time::Duration;
 
     use crate::support::test_rig::TestRigBuilder;
@@ -24,34 +23,9 @@ mod attachment_tests {
     );
     const TIMEOUT: Duration = Duration::from_secs(15);
 
-    fn cwd_lock() -> &'static Mutex<()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(()))
-    }
-
-    struct WorkingDirGuard {
-        original: PathBuf,
-        _guard: std::sync::MutexGuard<'static, ()>,
-    }
-
-    impl WorkingDirGuard {
-        fn enter(path: &Path) -> Self {
-            let guard = cwd_lock()
-                .lock()
-                .unwrap_or_else(|poison| poison.into_inner());
-            let original = std::env::current_dir().expect("current dir");
-            std::env::set_current_dir(path).expect("set current dir");
-            Self {
-                original,
-                _guard: guard,
-            }
-        }
-    }
-
-    impl Drop for WorkingDirGuard {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.original).expect("restore current dir");
-        }
+    fn engine_v2_project_root() -> PathBuf {
+        let base_dir = ironclaw::bootstrap::ironclaw_base_dir();
+        base_dir.parent().map(PathBuf::from).unwrap_or(base_dir)
     }
 
     fn make_attachment(kind: AttachmentKind) -> IncomingAttachment {
@@ -243,10 +217,9 @@ mod attachment_tests {
 
     #[tokio::test]
     async fn engine_v2_channel_attachments_persist_for_telegram_and_whatsapp() {
-        for channel in ["telegram", "whatsapp"] {
-            let cwd = tempfile::tempdir().expect("temp cwd");
-            let _cwd = WorkingDirGuard::enter(cwd.path());
+        let project_root = engine_v2_project_root();
 
+        for channel in ["telegram", "whatsapp"] {
             let rig = TestRigBuilder::new().with_engine_v2().build().await;
 
             let attachment_bytes = format!("Attachment from {channel}").into_bytes();
@@ -302,7 +275,7 @@ mod attachment_tests {
                 "unexpected persisted path for {channel}: {project_path}"
             );
 
-            let saved_path = cwd.path().join(project_path);
+            let saved_path = project_root.join(project_path);
             assert!(
                 saved_path.exists(),
                 "saved attachment missing: {}",


### PR DESCRIPTION
## Summary
This fixes a flaky `engine_v2` attachment persistence test in `tests/e2e_attachments.rs`.

The failing test was resolving the relative `project_path` against a temp current working directory, but the engine v2 router persists attachments under the runtime project root derived from `ironclaw_base_dir()`. In CI that mismatch caused the test to look for the saved file in the wrong absolute location.

## What changed
- replaced the cwd-based path assertion with a helper that resolves the same project root the v2 router uses
- kept the existing caller-level assertions around `project_path`, attachment suffixes, and persisted file contents
- removed the now-unused cwd guard scaffolding from the test module

## Validation
- `cargo test --features libsql --test e2e_attachments engine_v2_channel_attachments_persist_for_telegram_and_whatsapp -- --nocapture`
- `cargo test --features libsql --test e2e_attachments -- --nocapture`
- `cargo fmt --all`
- `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
