### PR TITLE
[codex] Fix Windows clippy gating and bump channel registry versions

### DIFF
--- a/crates/ironclaw_engine/src/workspace/filesystem.rs
+++ b/crates/ironclaw_engine/src/workspace/filesystem.rs
@@ -331,6 +331,7 @@ mod tests {
         assert!(matches!(err, MountError::InvalidPath { .. }));
     }
 
+    #[cfg(unix)]
     #[tokio::test]
     async fn rejects_symlink_escapes() {
         // Set up: backend root is a tempdir; create a symlink inside that
@@ -340,20 +341,13 @@ mod tests {
         let outside = tempfile::tempdir().unwrap();
         std::fs::write(outside.path().join("secret"), b"oops").unwrap();
         // best effort — symlink may not work on all platforms; skip if it fails
-        #[cfg(unix)]
-        {
-            let link = dir.path().join("escape");
-            std::os::unix::fs::symlink(outside.path(), &link).unwrap();
-            let err = backend
-                .read(Path::new("escape/secret"))
-                .await
-                .expect_err("symlink escape must be rejected");
-            assert!(matches!(err, MountError::InvalidPath { .. }));
-        }
-        #[cfg(not(unix))]
-        {
-            let _ = dir; // unused on non-unix
-        }
+        let link = dir.path().join("escape");
+        std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+        let err = backend
+            .read(Path::new("escape/secret"))
+            .await
+            .expect_err("symlink escape must be rejected");
+        assert!(matches!(err, MountError::InvalidPath { .. }));
     }
 
     #[tokio::test]

--- a/registry/channels/feishu.json
+++ b/registry/channels/feishu.json
@@ -2,7 +2,7 @@
   "name": "feishu",
   "display_name": "Feishu / Lark Channel",
   "kind": "channel",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "wit_version": "0.3.0",
   "description": "Talk to your agent through a Feishu or Lark bot",
   "keywords": [

--- a/registry/channels/slack.json
+++ b/registry/channels/slack.json
@@ -2,7 +2,7 @@
   "name": "slack",
   "display_name": "Slack Channel",
   "kind": "channel",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "wit_version": "0.3.0",
   "description": "Talk to your agent in Slack",
   "keywords": [


### PR DESCRIPTION
## Summary
- gate the Unix-only symlink escape test so `ironclaw_engine` test builds stay clean under Windows `-D warnings`
- bump `registry/channels/feishu.json` from `0.2.1` to `0.2.2`
- bump `registry/channels/slack.json` from `0.3.0` to `0.3.1`

## Why
This branch fixes a Windows clippy failure caused by a Unix-only test binding becoming unused on non-Unix targets. It also addresses the channel registry validation failure that requires registry versions to be bumped when `channels-src/feishu/` and `channels-src/slack/` change.

## Impact
- Windows test/clippy builds no longer fail on the unused `backend` binding in `workspace::filesystem` tests
- channel registry validation will see the required version bumps for Feishu and Slack

## Validation
- `cargo test -p ironclaw_engine rejects_symlink_escapes`
- `cargo clippy -p ironclaw_engine --tests -- -D warnings`
