### PR TITLE
fix(release): include sandbox_daemon in MSI

### DIFF
--- a/wix/main.wxs
+++ b/wix/main.wxs
@@ -128,6 +128,14 @@
                                 Source='$(var.CargoTargetBinDir)\ironclaw.exe'
                                 KeyPath='yes'/>
                         </Component>
+                        <Component Id='binary1' Guid='*'>
+                            <File
+                                Id='exe1'
+                                Name='sandbox_daemon.exe'
+                                DiskId='1'
+                                Source='$(var.CargoTargetBinDir)\sandbox_daemon.exe'
+                                KeyPath='yes'/>
+                        </Component>
                     </Directory>
                 </Directory>
             </Directory>
@@ -150,6 +158,7 @@
             <!--<ComponentRef Id='License'/>-->
 
             <ComponentRef Id='binary0'/>
+            <ComponentRef Id='binary1'/>
 
             <Feature
                 Id='Environment'


### PR DESCRIPTION
Fixes the failed `Release` workflow for `ironclaw-v0.26.0` by updating `wix/main.wxs` to include `sandbox_daemon.exe` in the Windows MSI template.

Context:
- failed run: https://github.com/nearai/ironclaw/actions/runs/24705020263
- root cause: `cargo dist` detected `sandbox_daemon.exe` but the checked-in WiX template only referenced `ironclaw.exe`

Verification:
- matched the exact `cargo dist` diff from the failed run log
- `git diff --check -- wix/main.wxs` passes

This is a release-template fix only; no Rust code changes.