### PR TITLE
ci: prepare workflows for GitHub merge queue

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [labeled]
+    types: [opened, synchronize, ready_for_review]
 
 permissions:
   contents: read
@@ -17,7 +17,10 @@ concurrency:
 jobs:
   review:
     name: Claude Code Review
-    if: contains(github.event.pull_request.labels.*.name, 'staging-promotion')
+    if: >
+      !github.event.pull_request.draft &&
+      github.event.pull_request.user.login != 'release-plz[bot]' &&
+      github.event.pull_request.user.login != 'ironclaw-ci[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,8 +17,10 @@ concurrency:
 jobs:
   review:
     name: Claude Code Review
+    # Forked pull_request runs do not receive repository secrets.
     if: >
       !github.event.pull_request.draft &&
+      !github.event.pull_request.head.repo.fork &&
       github.event.pull_request.user.login != 'release-plz[bot]' &&
       github.event.pull_request.user.login != 'ironclaw-ci[bot]'
     runs-on: ubuntu-latest

--- a/.github/workflows/code_style.yml
+++ b/.github/workflows/code_style.yml
@@ -1,13 +1,13 @@
 name: Code Style
 on:
   pull_request:
-  # Pushes to main/staging refresh the rust-cache entries that PR jobs
-  # restore from. PR jobs themselves are restore-only (see `save-if`
-  # on the rust-cache steps below).
+  merge_group:
+  # Pushes to main refresh the rust-cache entries that PR and merge-queue
+  # jobs restore from. PR and merge-queue jobs themselves are restore-only
+  # (see `save-if` on the rust-cache steps below).
   push:
     branches:
       - main
-      - staging
 
 permissions:
   contents: read
@@ -49,7 +49,7 @@ jobs:
           fi
 
   # ── Dynamic matrix: SLIM (1 leg) for non-main PRs; FULL (3 legs) for PRs
-  # to main and pushes to long-lived branches.
+  # to main, merge_group runs, and pushes to main.
   clippy-matrix:
     name: Configure clippy matrix
     needs: changes
@@ -63,10 +63,10 @@ jobs:
           FULL='[{"name":"all-features","flags":"--all-features"},{"name":"default","flags":""},{"name":"libsql-only","flags":"--no-default-features --features libsql"}]'
           SLIM='[{"name":"all-features","flags":"--all-features"}]'
 
-          # Full matrix on push (cache-warming + verification across configs)
-          # and on PRs targeting main (final promotion gate). Other PRs use
-          # SLIM since lint findings are almost never feature-gated.
-          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.base_ref }}" = "main" ]; then
+          # Full matrix on pushes to main (cache-warming + verification),
+          # merge_group runs, and PRs targeting main. Other PRs use SLIM
+          # since lint findings are almost never feature-gated.
+          if [ "${{ github.event_name }}" = "push" ] || [ "${{ github.event_name }}" = "merge_group" ] || [ "${{ github.base_ref }}" = "main" ]; then
             echo "matrix=${FULL}" >> "$GITHUB_OUTPUT"
           else
             echo "matrix=${SLIM}" >> "$GITHUB_OUTPUT"
@@ -142,10 +142,10 @@ jobs:
         # Single shared slot across the clippy matrix. The all-features leg
         # builds a superset of the other configs; subset legs (push only)
         # restore from it. Only all-features writes the slot, and only on
-        # main/staging pushes — preventing a subset leg from winning the
+        # main pushes — preventing a subset leg from winning the
         # cache race and pinning the slot to a partial build.
         shared-key: clippy
-        save-if: ${{ matrix.name == 'all-features' && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+        save-if: ${{ matrix.name == 'all-features' && github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     # `--benches` is intentionally omitted: lints rarely diverge in bench code,
     # and pulling in `criterion` adds ~30s+ of dependency compilation per run.
     # `bench-compile` in test.yml provides the type-check signal for benches.
@@ -155,12 +155,12 @@ jobs:
   clippy-windows:
     name: Clippy Windows (${{ matrix.name }})
     needs: [changes, clippy-matrix]
-    # PR-to-main runs the full Windows matrix; pushes to long-lived branches
-    # run it for cache warming. Other PRs skip Windows lint — windows-build
-    # in test.yml provides the Windows compile signal.
+    # PRs to main and merge_group runs execute the full Windows matrix;
+    # pushes to main run it for cache warming. Other PRs skip Windows lint —
+    # windows-build in test.yml provides the Windows compile signal.
     if: >
       needs.changes.outputs.has_code == 'true' &&
-      (github.event_name == 'push' || github.base_ref == 'main')
+      (github.event_name == 'push' || github.event_name == 'merge_group' || github.base_ref == 'main')
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -181,7 +181,7 @@ jobs:
         # job. windows-build runs on push (where save-if allows writes), so
         # clippy-windows restores from a warm cache on PRs.
         key: windows-${{ matrix.name }}
-        save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+        save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     # `--benches` omitted; see comment on the Linux clippy job above.
     - name: Check lints
       run: cargo clippy --all --tests --examples ${{ matrix.flags }} -- -D warnings
@@ -189,8 +189,9 @@ jobs:
   no-panics:
     name: No panics in production code
     needs: changes
-    # Diff is computed against the PR base SHA, which is unavailable on push.
-    # Gate to PRs only; the roll-up tolerates a skipped result on push.
+    # Diff is computed against the PR base SHA, which is unavailable on
+    # push and merge_group. Gate to PRs only; the roll-up tolerates a skipped
+    # result outside pull_request.
     if: github.event_name == 'pull_request' && needs.changes.outputs.has_code == 'true'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -15,6 +15,7 @@ on:
     paths:
       - "src/channels/web/**"
       - "tests/e2e/**"
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
   push:
     branches:
       - main
@@ -52,7 +53,7 @@ jobs:
             echo "No code changes detected — expensive jobs will be skipped"
           fi
 
-  # ── Dynamic matrix: PRs run only all-features; full matrix on staging/push ──
+  # ── Dynamic matrix: PRs run only all-features; full matrix on merge_group/push ──
   matrix-config:
     name: Configure matrix
     runs-on: ubuntu-latest
@@ -96,7 +97,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: ${{ matrix.name }}
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-component
         uses: ./.github/actions/install-cargo-component
       - name: Build WASM channels (for integration tests)
@@ -125,7 +126,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: heavy-integration
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Build Telegram WASM channel
         run: cargo build --manifest-path channels-src/telegram/Cargo.toml --target wasm32-wasip2 --release
       - name: Run thread scheduling integration tests
@@ -139,9 +140,6 @@ jobs:
 
   telegram-tests:
     name: Telegram Channel Tests
-    if: >
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -154,7 +152,7 @@ jobs:
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Run Telegram Channel Tests
         run: |
           timeout --signal=INT --kill-after=30s 10m \
@@ -163,9 +161,6 @@ jobs:
   windows-build:
     name: Windows Build (${{ matrix.name }})
     needs: matrix-config
-    if: >
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'staging'
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -182,15 +177,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: windows-${{ matrix.name }}
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Check compilation
         run: cargo check --all --benches --tests --examples ${{ matrix.flags }}
 
   wasm-wit-compat:
     name: WASM WIT Compatibility
-    if: >
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -206,7 +198,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: wasm-extensions
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Install cargo-component
         uses: ./.github/actions/install-cargo-component
       - name: Build all WASM extensions against current WIT
@@ -232,15 +224,12 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           key: bench
-          save-if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/staging') }}
+          save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
       - name: Compile benchmarks
         run: cargo bench --all-features --no-run
 
   docker-build:
     name: Docker Build
-    if: >
-      github.event_name != 'pull_request' ||
-      github.base_ref != 'staging'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- add `merge_group` support to the core CI workflows used by PR A
- remove staging-specific skips and cache-save conditions from `test.yml` and `code_style.yml`
- fire Claude review on active non-draft PRs instead of the old `staging-promotion` label

## Validation
- parsed the updated workflow YAML locally with PyYAML
- ran `git diff --check`
- did a focused workflow-semantics review on the final diff

## Not in this PR
- deleting staging promotion infrastructure
- changing `regression-test-check.yml` for `merge_group`
- docker / release-plz / staging branch cleanup

Part of #2719.
