### PR TITLE
chore(engine): bump Monty to v0.0.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4797,8 +4797,8 @@ dependencies = [
 
 [[package]]
 name = "monty"
-version = "0.0.11"
-source = "git+https://github.com/pydantic/monty.git?tag=v0.0.11#2e9df4b508e8a9ac80f3a6a26ed680242d1f460d"
+version = "0.0.16"
+source = "git+https://github.com/pydantic/monty.git?tag=v0.0.16#142807bbba3636a7525f017cea15b8d4f2bd5ed8"
 dependencies = [
  "ahash 0.8.12",
  "bytemuck",
@@ -4813,11 +4813,12 @@ dependencies = [
  "num-integer",
  "num-traits",
  "postcard",
- "pyo3-build-config",
  "ruff_python_ast",
  "ruff_python_parser",
+ "ruff_python_stdlib",
  "ruff_text_size",
  "serde",
+ "serde_json",
  "smallvec",
  "speedate",
  "strum 0.27.2",
@@ -6479,6 +6480,15 @@ dependencies = [
  "unicode-ident",
  "unicode-normalization",
  "unicode_names2",
+]
+
+[[package]]
+name = "ruff_python_stdlib"
+version = "0.0.0"
+source = "git+https://github.com/astral-sh/ruff.git?rev=6ded4bed1651e30b34dd04cdaa50c763036abb0d#6ded4bed1651e30b34dd04cdaa50c763036abb0d"
+dependencies = [
+ "bitflags 2.11.0",
+ "unicode-ident",
 ]
 
 [[package]]

--- a/crates/ironclaw_engine/Cargo.toml
+++ b/crates/ironclaw_engine/Cargo.toml
@@ -19,7 +19,7 @@ cron = "0.13"
 ironclaw_common = { path = "../ironclaw_common", version = "0.2.0" }
 ironclaw_skills = { path = "../ironclaw_skills", version = "0.1.0", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
-monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.11" }
+monty = { git = "https://github.com/pydantic/monty.git", tag = "v0.0.16" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/ironclaw_engine/MONTY.md
+++ b/crates/ironclaw_engine/MONTY.md
@@ -2,8 +2,8 @@
 
 Monty is the embedded Python interpreter used for Tier 1 (CodeAct) execution. It's a lightweight Rust-native Python implementation — not CPython — so it has a restricted feature set.
 
-**Source**: `git = "https://github.com/pydantic/monty.git", tag = "v0.0.11"`
-**Pinned at**: `v0.0.11` (2026-04-10)
+**Source**: `git = "https://github.com/pydantic/monty.git", tag = "v0.0.16"`
+**Pinned at**: `v0.0.16` (2026-04-19)
 
 ## Upgrade Process
 
@@ -14,7 +14,7 @@ Monty is the embedded Python interpreter used for Tier 1 (CodeAct) execution. It
 5. **Run tests**: `cargo test -p ironclaw_engine`
 6. **Watch traces**: After deploying, check traces for new `NotImplementedError` patterns (self-improvement mission catches these)
 
-## Current Limitations (as of pin `v0.0.11`)
+## Current Limitations (as of pin `v0.0.16`)
 
 These are documented in `prompts/codeact_preamble.md` so the LLM avoids them:
 
@@ -47,7 +47,7 @@ Available built-in modules:
 - `typing` — type hints (limited, for annotation only)
 
 ### Available builtins
-`abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`, `getattr`, `hash`, `hex`, `id`, `isinstance`, `len`, `map`, `min`, `max`, `next`, `oct`, `ord`, `pow`, `print`, `repr`, `reversed`, `round`, `sorted`, `sum`, `type`, `zip`
+`abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`, `getattr`, `hasattr`, `hash`, `hex`, `id`, `isinstance`, `len`, `map`, `min`, `max`, `next`, `oct`, `ord`, `pow`, `print`, `repr`, `reversed`, `round`, `sorted`, `sum`, `type`, `zip`
 
 ### Host-provided functions (always available)
 These are injected by the IronClaw executor, not by Monty:
@@ -62,6 +62,7 @@ These are injected by the IronClaw executor, not by Monty:
 
 | Date | Pin | Notable changes |
 |------|-----|-----------------|
+| 2026-04-19 | `v0.0.16` | Mixed `asyncio.gather()` future-resolution panic fix, `hasattr` builtin, and input-safety hardening. |
 | 2026-04-10 | `v0.0.11` | JSON perf improvements (~2x loads, ~1.6x dumps), filesystem mounting, Rust-side async API, mount edge case fixes. |
 | 2026-03-29 | `7a0d4b7` | Multi-module imports, `datetime` module, `json` module, nested subscript assignment, `str.expandtabs()`. |
 | 2026-03-20 | `6053820` | Initial integration. max() kwargs support. |

--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -72,7 +72,7 @@ The Python REPL runs in Monty, a lightweight embedded interpreter — not CPytho
 - **No `match` statements**: Use if/elif chains.
 - **No `del` statement**: Reassign to None instead.
 - **No `yield`/`yield from` statements**: Generator expressions (`x for x in ...`) work; use lists for the rest.
-- **Available builtins**: `abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`, `getattr`, `hash`, `hex`, `id`, `isinstance`, `len`, `map`, `min`, `max`, `next`, `oct`, `ord`, `pow`, `print`, `repr`, `reversed`, `round`, `sorted`, `sum`, `type`, `zip`.
+- **Available builtins**: `abs`, `all`, `any`, `bin`, `chr`, `divmod`, `enumerate`, `filter`, `getattr`, `hasattr`, `hash`, `hex`, `id`, `isinstance`, `len`, `map`, `min`, `max`, `next`, `oct`, `ord`, `pow`, `print`, `repr`, `reversed`, `round`, `sorted`, `sum`, `type`, `zip`.
 - **Available modules**: `asyncio`, `datetime`, `json`, `math`, `os.path` (path manipulation only), `re`, `sys`, `typing` (limited).
 - **String methods, list methods, dict methods**: All work normally.
 - For dates, use `import datetime`. `datetime.datetime.now()` and `datetime.date.today()` both work and return the current UTC instant; pass `tz=datetime.timezone.utc` for an aware datetime. For other timezones or ISO string output, the `time` tool is usually more convenient (e.g. `await time(operation="now", timezone=user_timezone)`).

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -372,7 +372,7 @@ pub async fn execute_orchestrator(
     let tracker = LimitedTracker::new(orchestrator_limits());
 
     let run_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        runner.start(input_values, tracker, PrintWriter::Collect(&mut stdout))
+        runner.start(input_values, tracker, PrintWriter::CollectString(&mut stdout))
     }));
 
     let mut progress = match run_result {
@@ -512,7 +512,7 @@ pub async fn execute_orchestrator(
 
                 // Resume the orchestrator VM
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    call.resume(ext_result, PrintWriter::Collect(&mut stdout))
+                    call.resume(ext_result, PrintWriter::CollectString(&mut stdout))
                 })) {
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
@@ -540,7 +540,7 @@ pub async fn execute_orchestrator(
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     lookup.resume(
                         NameLookupResult::Undefined,
-                        PrintWriter::Collect(&mut stdout),
+                        PrintWriter::CollectString(&mut stdout),
                     )
                 })) {
                     Ok(Ok(p)) => progress = p,
@@ -2610,7 +2610,7 @@ mod tests {
         let tracker = LimitedTracker::new(ResourceLimits::new().max_allocations(500_000));
 
         let mut progress = runner
-            .start(vec![], tracker, PrintWriter::Collect(&mut stdout))
+            .start(vec![], tracker, PrintWriter::CollectString(&mut stdout))
             .expect("Failed to start orchestrator test");
 
         loop {
@@ -2621,7 +2621,7 @@ mod tests {
                         let val = call.args.first().cloned().unwrap_or(MontyObject::None);
                         let _ = call.resume(
                             ExtFunctionResult::Return(MontyObject::None),
-                            PrintWriter::Collect(&mut stdout),
+                            PrintWriter::CollectString(&mut stdout),
                         );
                         return val;
                     }
@@ -2630,14 +2630,14 @@ mod tests {
                         _ => ExtFunctionResult::Return(MontyObject::None),
                     };
                     progress = call
-                        .resume(ext_result, PrintWriter::Collect(&mut stdout))
+                        .resume(ext_result, PrintWriter::CollectString(&mut stdout))
                         .expect("resume failed");
                 }
                 RunProgress::NameLookup(lookup) => {
                     progress = lookup
                         .resume(
                             NameLookupResult::Undefined,
-                            PrintWriter::Collect(&mut stdout),
+                            PrintWriter::CollectString(&mut stdout),
                         )
                         .expect("name lookup resume failed");
                 }

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -372,7 +372,11 @@ pub async fn execute_orchestrator(
     let tracker = LimitedTracker::new(orchestrator_limits());
 
     let run_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        runner.start(input_values, tracker, PrintWriter::CollectString(&mut stdout))
+        runner.start(
+            input_values,
+            tracker,
+            PrintWriter::CollectString(&mut stdout),
+        )
     }));
 
     let mut progress = match run_result {

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -481,7 +481,7 @@ pub async fn execute_code_with_skills(
     let tracker = LimitedTracker::new(default_limits());
 
     let run_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        runner.start(input_values, tracker, PrintWriter::Collect(&mut stdout))
+        runner.start(input_values, tracker, PrintWriter::CollectString(&mut stdout))
     }));
 
     let mut progress = match run_result {
@@ -624,7 +624,7 @@ pub async fn execute_code_with_skills(
                 if let Some(ext_result) = sync_result {
                     // Sync resume for builtins
                     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        call.resume(ext_result, PrintWriter::Collect(&mut stdout))
+                        call.resume(ext_result, PrintWriter::CollectString(&mut stdout))
                     })) {
                         Ok(Ok(p)) => progress = p,
                         Ok(Err(e)) => {
@@ -662,7 +662,7 @@ pub async fn execute_code_with_skills(
                 // resume_pending and continue — no preflight needed.
                 if pending_futures.contains_key(&monty_call_id) {
                     match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                        call.resume_pending(PrintWriter::Collect(&mut stdout))
+                        call.resume_pending(PrintWriter::CollectString(&mut stdout))
                     })) {
                         Ok(Ok(p)) => progress = p,
                         Ok(Err(e)) => {
@@ -748,7 +748,7 @@ pub async fn execute_code_with_skills(
 
                         // Resume with pending future — Python gets ExternalFuture
                         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            call.resume_pending(PrintWriter::Collect(&mut stdout))
+                            call.resume_pending(PrintWriter::CollectString(&mut stdout))
                         })) {
                             Ok(Ok(p)) => progress = p,
                             Ok(Err(e)) => {
@@ -783,7 +783,7 @@ pub async fn execute_code_with_skills(
                     PreflightResult::Denied(ext_result) => {
                         // Resume with error — Python sees an exception
                         match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                            call.resume(ext_result, PrintWriter::Collect(&mut stdout))
+                            call.resume(ext_result, PrintWriter::CollectString(&mut stdout))
                         })) {
                             Ok(Ok(p)) => progress = p,
                             Ok(Err(e)) => {
@@ -881,7 +881,7 @@ pub async fn execute_code_with_skills(
                 }
 
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    resolve.resume(results, PrintWriter::Collect(&mut stdout))
+                    resolve.resume(results, PrintWriter::CollectString(&mut stdout))
                 })) {
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
@@ -934,7 +934,7 @@ pub async fn execute_code_with_skills(
                 };
 
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    lookup.resume(result, PrintWriter::Collect(&mut stdout))
+                    lookup.resume(result, PrintWriter::CollectString(&mut stdout))
                 })) {
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {
@@ -989,7 +989,7 @@ pub async fn execute_code_with_skills(
                     ))
                 });
                 match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                    os_call.resume(reply, PrintWriter::Collect(&mut stdout))
+                    os_call.resume(reply, PrintWriter::CollectString(&mut stdout))
                 })) {
                     Ok(Ok(p)) => progress = p,
                     Ok(Err(e)) => {

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -481,7 +481,11 @@ pub async fn execute_code_with_skills(
     let tracker = LimitedTracker::new(default_limits());
 
     let run_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-        runner.start(input_values, tracker, PrintWriter::CollectString(&mut stdout))
+        runner.start(
+            input_values,
+            tracker,
+            PrintWriter::CollectString(&mut stdout),
+        )
     }));
 
     let mut progress = match run_result {


### PR DESCRIPTION
## Summary
- bump `crates/ironclaw_engine` from Monty `v0.0.11` to `v0.0.16`
- update the engine Monty integration notes to reflect the new pin and notable release changes
- expose the newly available `hasattr` builtin in the CodeAct preamble and Monty docs

## Validation
- `cargo update -p monty`
- `cargo metadata --format-version 1 --no-deps`
- `cargo tree -p monty`
- attempted `cargo test -p ironclaw_engine -j 1`, but the host environment hit `Too many open files in system (os error 23)` while compiling dependencies (e.g. `zerocopy` / linker inputs), so full test execution could not complete in this session