### PR TITLE
ci: release ironclaw docker image with version tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,11 @@ on:
   # Called by release.yml or other workflows
   workflow_call:
     inputs:
+      release:
+        description: "Set true when called from release.yml to publish version/latest tags"
+        required: false
+        type: boolean
+        default: false
       tag:
         description: "Image tag override (leave empty for auto-detect)"
         required: false
@@ -12,6 +17,11 @@ on:
   # On-demand builds
   workflow_dispatch:
     inputs:
+      release:
+        description: "Set true to force release-style tags (:version, :latest, :sha-xxx)"
+        required: false
+        type: boolean
+        default: false
       tag:
         description: "Image tag override (leave empty for auto-detect)"
         required: false
@@ -63,6 +73,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
           EVENT_NAME: ${{ github.event_name }}
+          IS_RELEASE_BUILD: ${{ inputs.release && 'true' || 'false' }}
           INPUT_TAG: ${{ inputs.tag }}
           SOURCE_SHA: ${{ steps.source_sha.outputs.sha }}
         run: |
@@ -74,7 +85,7 @@ jobs:
           SHA="sha-${SOURCE_SHA::7}"
           echo "sha_tag=${SHA}" >> "$GITHUB_OUTPUT"
 
-          if [[ "${EVENT_NAME}" == "workflow_call" ]]; then
+          if [[ "${IS_RELEASE_BUILD}" == "true" ]]; then
             # Release: :version + :latest + :sha-xxx
             TAGS="${IMAGE_NAME}:${VERSION}"
             TAGS="${TAGS},${IMAGE_NAME}:latest"
@@ -192,10 +203,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           EVENT_NAME: ${{ github.event_name }}
+          IS_RELEASE_BUILD: ${{ inputs.release && 'true' || 'false' }}
           INPUT_TAG: ${{ inputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if [[ "${EVENT_NAME}" == "workflow_call" && -n "${VERSION}" ]]; then
+          if [[ "${IS_RELEASE_BUILD}" == "true" && -n "${VERSION}" ]]; then
             gh api repos/nearai/ironclaw-dind/dispatches \
               --method POST \
               -f event_type="ironclaw_image_published" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,6 +479,8 @@ jobs:
       packages: read
       actions: write
     uses: ./.github/workflows/docker.yml
+    with:
+      release: true
     secrets: inherit
 
   # Commit patched manifest SHA256 checksums back to main so the repo


### PR DESCRIPTION
## Summary

- Fixes Docker tagging mode detection in `ironclaw/.github/workflows/docker.yml` by replacing implicit event-based logic with an explicit reusable-workflow input (`release`).
- Updates `ironclaw/.github/workflows/release.yml` to call `docker.yml` with `release: true`, so release flows always publish `:version`, `:latest`, and `:sha-*` tags as intended.
- Keeps non-release behavior unchanged: scheduled runs still publish `:staging` + `:sha-*`, and manual runs default to `:sha-*` (plus optional override tag).
- Applies the same `release` gating to the `ironclaw-dind` repository dispatch so downstream release notifications align with actual release-tag publication.
- This fixes the root issue because `github.event_name` in reusable workflows may be `push` (from caller context), so checking for `workflow_call` was unreliable and caused release runs to skip version/latest tags.

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: N/A (workflow-only changes)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Verified workflow logic paths in `docker.yml` and `release.yml`; ran editor lint/diagnostics for modified YAML files (no lints reported)
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches only GitHub Actions workflow behavior for Docker image tagging and downstream release dispatch. Potential risk is incorrect tagging mode if callers forget to pass `release: true` for release paths.

## Rollback Plan

Revert the two workflow files to prior versions:
- `ironclaw/.github/workflows/docker.yml`
- `ironclaw/.github/workflows/release.yml`

Then re-run the release workflow. This restores the previous event-derived behavior.

## Review Follow-Through

- Confirm no other workflows call `docker.yml` expecting implicit release behavior.
- Reviewer check: whether manual `workflow_dispatch` should expose/allow `release: true` in policy terms.

---

**Review track**: C
## Summary

- Update Docker image CI schedule to run hourly for staging builds.
- Add a staging commit guard so scheduled/staging-target builds are skipped only if the current source commit is already published for **both** `nearaidev/ironclaw:staging` and `nearaidev/ironclaw-worker:staging` (prevents partial-failure drift).
- Record source commit provenance on built images via `ironclaw.git.sha` label and use the checked-out commit SHA for `sha-*` tags to avoid schedule/ref mismatch.
- Ensure downstream steps (app token creation, `ironclaw-dind` dispatch, and summaries) are skipped when a build is skipped.

## Change Type

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [x] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

None

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: N/A (workflow-only change; no Rust test suite run in this session).
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: Reviewed workflow logic and verified conditions/outputs locally in file checks (schedule cron, staging-target guard, label/tag source SHA usage, and skip-gated downstream steps).
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None

## Database Impact

None

## Blast Radius

Touches `ironclaw` CI only (`.github/workflows/docker.yml`). Risk is limited to Docker image build/publish cadence and skip behavior for staging-target builds, plus downstream dispatch timing to `ironclaw-dind`.

## Rollback Plan

Revert workflow changes in `.github/workflows/docker.yml` to restore previous schedule and unconditional staging build behavior.

## Review Follow-Through

Reviewer focus requested on:
- Whether skipping based on `nearaidev/ironclaw:staging` label `ironclaw.git.sha` matches release expectations for all staging build paths.
- Whether any additional observability is desired when a build is skipped (for example explicit metric/log hooks beyond step summary).

---

**Review track**: C
