### PR TITLE
feat(bridge): project 3 dropped engine events to AppEvents

### DIFF
--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -468,6 +468,17 @@ pub enum AppEvent {
         goal: String,
     },
 
+    /// A child thread completed (terminal state reached).
+    ///
+    /// Symmetric to `ChildThreadSpawned`: the UI uses the pair to mark
+    /// child branches finished in tree views. Bridged from engine
+    /// `EventKind::ChildCompleted`.
+    #[serde(rename = "child_thread_completed")]
+    ChildThreadCompleted {
+        parent_thread_id: String,
+        child_thread_id: String,
+    },
+
     /// A mission spawned a new thread.
     #[serde(rename = "mission_thread_spawned")]
     MissionThreadSpawned {
@@ -494,6 +505,25 @@ pub enum AppEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         mission_id: Option<String>,
         /// Thread scope for SSE filtering.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
+    /// CodeAct (Python / Monty) execution failed.
+    ///
+    /// Bridged from engine `EventKind::CodeExecutionFailed`. `category`
+    /// is the snake_case `CodeExecutionFailure` display string
+    /// (`syntax_error`, `runtime_error`, `name_lookup`, `vm_panic`,
+    /// `resource_limit`, `tool_error`, `os_denied`) — the engine type is
+    /// not re-exported into `ironclaw_common`, so the wire form is a
+    /// string the frontend can match on.
+    #[serde(rename = "code_execution_failed")]
+    CodeExecutionFailed {
+        category: String,
+        error: String,
+        duration_ms: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        code_hash: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         thread_id: Option<String>,
     },
@@ -533,8 +563,10 @@ impl AppEvent {
             Self::TurnMetrics { .. } => "turn_metrics",
             Self::ThreadStateChanged { .. } => "thread_state_changed",
             Self::ChildThreadSpawned { .. } => "child_thread_spawned",
+            Self::ChildThreadCompleted { .. } => "child_thread_completed",
             Self::MissionThreadSpawned { .. } => "mission_thread_spawned",
             Self::PlanUpdate { .. } => "plan_update",
+            Self::CodeExecutionFailed { .. } => "code_execution_failed",
         }
     }
 
@@ -729,6 +761,17 @@ mod tests {
                 status: String::new(),
                 steps: vec![],
                 mission_id: None,
+                thread_id: None,
+            },
+            AppEvent::ChildThreadCompleted {
+                parent_thread_id: String::new(),
+                child_thread_id: String::new(),
+            },
+            AppEvent::CodeExecutionFailed {
+                category: String::new(),
+                error: String::new(),
+                duration_ms: 0,
+                code_hash: None,
                 thread_id: None,
             },
         ];

--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -511,15 +511,16 @@ pub enum AppEvent {
 
     /// CodeAct (Python / Monty) execution failed.
     ///
-    /// Bridged from engine `EventKind::CodeExecutionFailed`. `category`
-    /// is the snake_case `CodeExecutionFailure` display string
-    /// (`syntax_error`, `runtime_error`, `name_lookup`, `vm_panic`,
-    /// `resource_limit`, `tool_error`, `os_denied`) — the engine type is
-    /// not re-exported into `ironclaw_common`, so the wire form is a
-    /// string the frontend can match on.
+    /// Bridged from engine `EventKind::CodeExecutionFailed`. The engine's
+    /// `CodeExecutionFailure` enum isn't re-exported into this crate
+    /// (dependency direction: `ironclaw_engine` depends on
+    /// `ironclaw_common`, not vice versa), so the wire type is a
+    /// dedicated parallel enum with matching snake_case serialization —
+    /// per `.claude/rules/types.md` "Wire-stable enums", not a stringly
+    /// typed field.
     #[serde(rename = "code_execution_failed")]
     CodeExecutionFailed {
-        category: String,
+        category: CodeExecutionFailureCategory,
         error: String,
         duration_ms: u64,
         #[serde(skip_serializing_if = "Option::is_none")]
@@ -527,6 +528,31 @@ pub enum AppEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         thread_id: Option<String>,
     },
+}
+
+/// Wire-side mirror of `ironclaw_engine::CodeExecutionFailure`.
+///
+/// Must be kept in variant-for-variant lock with the engine enum.  Both
+/// types serialize to the same snake_case strings so that a single
+/// frontend matcher handles any direct-engine telemetry path that may
+/// later emerge alongside the bridge projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CodeExecutionFailureCategory {
+    /// Python parse error — LLM generated invalid syntax.
+    SyntaxError,
+    /// Python runtime error (NameError, TypeError, ValueError, etc.).
+    RuntimeError,
+    /// Name lookup failed — function/variable not in scope and not a known tool.
+    NameLookup,
+    /// Monty VM panicked (caught by `catch_unwind`).
+    VmPanic,
+    /// Resource limit hit (timeout, memory, allocation cap).
+    ResourceLimit,
+    /// A tool call inside code returned an error.
+    ToolError,
+    /// OS operation attempted (blocked by sandbox).
+    OsDenied,
 }
 
 impl AppEvent {
@@ -768,7 +794,7 @@ mod tests {
                 child_thread_id: String::new(),
             },
             AppEvent::CodeExecutionFailed {
-                category: String::new(),
+                category: CodeExecutionFailureCategory::SyntaxError,
                 error: String::new(),
                 duration_ms: 0,
                 code_hash: None,

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -6,8 +6,8 @@ mod timezone;
 mod util;
 
 pub use event::{
-    AppEvent, JobResultStatus, JobResultStatusParseError, OnboardingStateDto, PlanStepDto,
-    ToolDecisionDto,
+    AppEvent, CodeExecutionFailureCategory, JobResultStatus, JobResultStatusParseError,
+    OnboardingStateDto, PlanStepDto, ToolDecisionDto,
 };
 pub use identity::{
     CredentialName, ExtensionName, ExternalThreadId, ExternalThreadIdError, IdentityError,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4484,6 +4484,31 @@ async fn forward_event_to_channel(
 ///
 /// Returns multiple events when needed (e.g., ToolStarted + ToolCompleted
 /// so the frontend creates the card then resolves it).
+/// Bridge engine-side `CodeExecutionFailure` to its wire mirror
+/// `CodeExecutionFailureCategory` in `ironclaw_common`.
+///
+/// Exhaustive on purpose: if the engine enum gains a variant, this must
+/// fail to compile so both enums stay in lockstep. Per
+/// `.claude/rules/types.md` "Wire-stable enums" — do not reach for
+/// `format!("{:?}", ...)` or `.to_string()` here; the serde rename rules
+/// on the two enums independently produce snake_case, and a `Debug`
+/// detour would silently drift.
+fn code_execution_category_to_wire(
+    category: &ironclaw_engine::CodeExecutionFailure,
+) -> ironclaw_common::CodeExecutionFailureCategory {
+    use ironclaw_common::CodeExecutionFailureCategory as Wire;
+    use ironclaw_engine::CodeExecutionFailure as Src;
+    match category {
+        Src::SyntaxError => Wire::SyntaxError,
+        Src::RuntimeError => Wire::RuntimeError,
+        Src::NameLookup => Wire::NameLookup,
+        Src::VmPanic => Wire::VmPanic,
+        Src::ResourceLimit => Wire::ResourceLimit,
+        Src::ToolError => Wire::ToolError,
+        Src::OsDenied => Wire::OsDenied,
+    }
+}
+
 fn thread_event_to_app_events(
     event: &ironclaw_engine::ThreadEvent,
     thread_id: &str,
@@ -4593,7 +4618,7 @@ fn thread_event_to_app_events(
             duration_ms,
             ..
         } => vec![AppEvent::CodeExecutionFailed {
-            category: category.to_string(),
+            category: code_execution_category_to_wire(category),
             error: error.clone(),
             duration_ms: *duration_ms,
             code_hash: code_hash.clone(),
@@ -7065,7 +7090,10 @@ mod tests {
                 app_events[0]
             );
         };
-        assert_eq!(category, "runtime_error");
+        assert_eq!(
+            *category,
+            ironclaw_common::CodeExecutionFailureCategory::RuntimeError
+        );
         assert_eq!(error, "NameError: 'foo' is not defined");
         assert_eq!(*duration_ms, 42);
         assert_eq!(code_hash.as_deref(), Some("abc123"));

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4578,6 +4578,27 @@ fn thread_event_to_app_events(
             child_thread_id: child_id.to_string(),
             goal: goal.clone(),
         }],
+        EventKind::ChildCompleted { child_id } => vec![AppEvent::ChildThreadCompleted {
+            parent_thread_id: thread_id.into(),
+            child_thread_id: child_id.to_string(),
+        }],
+        EventKind::StepFailed { error, .. } => vec![AppEvent::Error {
+            message: format!("Step failed: {error}"),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::CodeExecutionFailed {
+            category,
+            error,
+            code_hash,
+            duration_ms,
+            ..
+        } => vec![AppEvent::CodeExecutionFailed {
+            category: category.to_string(),
+            error: error.clone(),
+            duration_ms: *duration_ms,
+            code_hash: code_hash.clone(),
+            thread_id: Some(thread_id.into()),
+        }],
         EventKind::SkillActivated { skill_names } => vec![AppEvent::SkillActivated {
             skill_names: skill_names.clone(),
             thread_id: Some(thread_id.into()),
@@ -6965,6 +6986,90 @@ mod tests {
                 && duration_ms == &Some(17)
                 && thread_id.as_deref() == Some("thread-123")
         ));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_step_failed_to_error() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::StepFailed {
+                step_id: ironclaw_engine::StepId::new(),
+                error: "llm provider returned 502".to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-step-fail");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::Error { message, thread_id } = &app_events[0] else {
+            panic!("expected AppEvent::Error, got {:?}", app_events[0]);
+        };
+        assert!(
+            message.contains("llm provider returned 502"),
+            "error message should carry the engine error text, got {message:?}"
+        );
+        assert_eq!(thread_id.as_deref(), Some("thread-step-fail"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_child_completed() {
+        let child = ironclaw_engine::ThreadId::new();
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::ChildCompleted { child_id: child },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-parent");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::ChildThreadCompleted {
+            parent_thread_id,
+            child_thread_id,
+        } = &app_events[0]
+        else {
+            panic!(
+                "expected AppEvent::ChildThreadCompleted, got {:?}",
+                app_events[0]
+            );
+        };
+        assert_eq!(parent_thread_id, "thread-parent");
+        assert_eq!(child_thread_id, &child.to_string());
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_code_execution_failed() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::CodeExecutionFailed {
+                step_id: ironclaw_engine::StepId::new(),
+                category: ironclaw_engine::CodeExecutionFailure::RuntimeError,
+                error: "NameError: 'foo' is not defined".to_string(),
+                code_hash: Some("abc123".to_string()),
+                duration_ms: 42,
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-codeact");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::CodeExecutionFailed {
+            category,
+            error,
+            duration_ms,
+            code_hash,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!(
+                "expected AppEvent::CodeExecutionFailed, got {:?}",
+                app_events[0]
+            );
+        };
+        assert_eq!(category, "runtime_error");
+        assert_eq!(error, "NameError: 'foo' is not defined");
+        assert_eq!(*duration_ms, 42);
+        assert_eq!(code_hash.as_deref(), Some("abc123"));
+        assert_eq!(thread_id.as_deref(), Some("thread-codeact"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes 3 of ~9 coverage gaps in `thread_event_to_app_events` at `src/bridge/router.rs` — first slice of Phase 1 under the state-convergence epic.

| `EventKind` | `AppEvent` | UX gap before |
|---|---|---|
| `StepFailed` | existing `Error` | LLM / step failures silently dropped; "Processing..." with no explanation |
| `ChildCompleted` | new `ChildThreadCompleted` | Symmetric pair to `ChildThreadSpawned` was missing; tree views couldn't mark child branches finished |
| `CodeExecutionFailed` | new `CodeExecutionFailed` | CodeAct / Monty runtime failures never surfaced |

## Scope

Intentionally narrow. `ApprovalRequested` / `ApprovalReceived` are deferred to the next PR because the gate manager emits `GateRequired` / `GateResolved` directly today — bridging the engine variants now would create duplicate SSE emits until that path is migrated. That audit naturally pairs with the `projection-exempt` lint in Phase 1 PR 2.

`category` on `AppEvent::CodeExecutionFailed` is a snake_case string (`syntax_error`, `runtime_error`, `name_lookup`, `vm_panic`, `resource_limit`, `tool_error`, `os_denied`) derived via the existing `CodeExecutionFailure` Display impl — the engine type isn't re-exported into `ironclaw_common`.

## Refs

- Epic: #2792 (gateway state convergence)
- Tracking: #2654 (engine→AppEvent coverage gaps)

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] `cargo test --lib bridge::router::tests::thread_event_to_app_events` — 4 passed (1 pre-existing + 3 new)
- [x] `cargo test -p ironclaw_common event_type_matches_serde_type_field` — passes with 2 new variants in the drift-catch list
- [ ] Manual verification on staging: trigger a failing `shell` step → `Error` event renders; spawn + finish a child thread → both events visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)