### PR TITLE
feat(engine): wire ReliabilityRecordingEffects + prompt formatter (#2800 PR-B)

### DIFF
--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -103,7 +103,7 @@ pub use memory::RetrievalEngine;
 
 // ── Re-exports: reliability ──────────────────────────────────
 
-pub use reliability::ReliabilityTracker;
+pub use reliability::{ActionMetrics, ReliabilityRecordingEffects, ReliabilityTracker};
 
 // ── Re-exports: workspace mounts ─────────────────────────────
 

--- a/crates/ironclaw_engine/src/reliability.rs
+++ b/crates/ironclaw_engine/src/reliability.rs
@@ -156,19 +156,15 @@ impl ReliabilityTracker {
             // Keep each entry short — never exceed ~120 chars — to bound the
             // system-prompt bloat. `last_error` is truncated to the first
             // line and 80 chars.
-            let err_hint = metrics
-                .last_error
-                .as_deref()
-                .map(|e| {
-                    let first_line = e.lines().next().unwrap_or("").trim();
-                    let truncated: String = first_line.chars().take(80).collect();
-                    if !truncated.is_empty() {
-                        format!(" (last error: {truncated})")
-                    } else {
-                        String::new()
-                    }
-                })
-                .unwrap_or_default();
+            let err_hint = metrics.last_error.as_deref().map_or_else(String::new, |e| {
+                let first_line = e.lines().next().unwrap_or("").trim();
+                let truncated: String = first_line.chars().take(80).collect();
+                if !truncated.is_empty() {
+                    format!(" (last error: {truncated})")
+                } else {
+                    String::new()
+                }
+            });
             lines.push(format!(
                 "- `{name}` — success rate {:.0}% over {} calls{}",
                 metrics.success_rate * 100.0,

--- a/crates/ironclaw_engine/src/reliability.rs
+++ b/crates/ironclaw_engine/src/reliability.rs
@@ -109,6 +109,141 @@ impl ReliabilityTracker {
             .filter(|(_, m)| m.success_rate < threshold)
             .collect()
     }
+
+    /// Get actions with reliability below a threshold, requiring at least
+    /// `min_calls` observations. Filters out cold-start noise where a single
+    /// failure of a brand-new action shouldn't poison its reputation.
+    ///
+    /// Recommended for system-prompt injection: `min_calls = 10` filters out
+    /// tools that haven't been exercised enough to establish a reliability
+    /// signal.
+    pub async fn unreliable_with_min_calls(
+        &self,
+        threshold: f64,
+        min_calls: u64,
+    ) -> Vec<(String, ActionMetrics)> {
+        let all = self.all_metrics().await;
+        all.into_iter()
+            .filter(|(_, m)| m.call_count >= min_calls && m.success_rate < threshold)
+            .collect()
+    }
+
+    /// Format the top-N unreliable actions as a system-prompt section. Returns
+    /// `None` if no actions meet the threshold or if the cap is zero.
+    ///
+    /// The returned string is intended to be appended to the CodeAct system
+    /// prompt so the model sees which tools have been flaky in recent history
+    /// and can pick alternatives.
+    ///
+    /// Default thresholds (tuned in #2800 PR-B): threshold=0.7, min_calls=10,
+    /// cap=5. These match the `EMA_ALPHA=0.3` smoothing — by the time the EMA
+    /// crosses 0.7 after 10 calls, we've seen a clear signal, not jitter.
+    pub async fn format_notes_section(
+        &self,
+        threshold: f64,
+        min_calls: u64,
+        cap: usize,
+    ) -> Option<String> {
+        if cap == 0 {
+            return None;
+        }
+        let unreliable = self.unreliable_with_min_calls(threshold, min_calls).await;
+        if unreliable.is_empty() {
+            return None;
+        }
+        let mut lines = vec!["## Action reliability notes".to_string()];
+        for (name, metrics) in unreliable.into_iter().take(cap) {
+            // Keep each entry short — never exceed ~120 chars — to bound the
+            // system-prompt bloat. `last_error` is truncated to the first
+            // line and 80 chars.
+            let err_hint = metrics
+                .last_error
+                .as_deref()
+                .map(|e| {
+                    let first_line = e.lines().next().unwrap_or("").trim();
+                    let truncated: String = first_line.chars().take(80).collect();
+                    if !truncated.is_empty() {
+                        format!(" (last error: {truncated})")
+                    } else {
+                        String::new()
+                    }
+                })
+                .unwrap_or_default();
+            lines.push(format!(
+                "- `{name}` — success rate {:.0}% over {} calls{}",
+                metrics.success_rate * 100.0,
+                metrics.call_count,
+                err_hint,
+            ));
+        }
+        Some(lines.join("\n"))
+    }
+}
+
+/// `EffectExecutor` decorator that records every action outcome in a
+/// `ReliabilityTracker`. Wrap your real effect executor with this at
+/// construction so success rate / latency data flows into the tracker
+/// automatically — the engine's execution loop doesn't need to know.
+///
+/// ```rust,ignore
+/// let tracker = Arc::new(ReliabilityTracker::new());
+/// let real_effects: Arc<dyn EffectExecutor> = Arc::new(MyEffects::new());
+/// let recorded: Arc<dyn EffectExecutor> = Arc::new(
+///     ReliabilityRecordingEffects::new(real_effects, tracker.clone())
+/// );
+/// // Pass `recorded` into the engine; `tracker` stays available for reads.
+/// ```
+pub struct ReliabilityRecordingEffects {
+    inner: Arc<dyn crate::traits::effect::EffectExecutor>,
+    tracker: Arc<ReliabilityTracker>,
+}
+
+impl ReliabilityRecordingEffects {
+    pub fn new(
+        inner: Arc<dyn crate::traits::effect::EffectExecutor>,
+        tracker: Arc<ReliabilityTracker>,
+    ) -> Self {
+        Self { inner, tracker }
+    }
+}
+
+#[async_trait::async_trait]
+impl crate::traits::effect::EffectExecutor for ReliabilityRecordingEffects {
+    async fn execute_action(
+        &self,
+        name: &str,
+        params: serde_json::Value,
+        lease: &crate::types::capability::CapabilityLease,
+        ctx: &crate::traits::effect::ThreadExecutionContext,
+    ) -> Result<crate::types::step::ActionResult, crate::types::error::EngineError> {
+        let start = std::time::Instant::now();
+        let result = self.inner.execute_action(name, params, lease, ctx).await;
+        let elapsed = start.elapsed();
+        match &result {
+            Ok(action_result) if !action_result.is_error => {
+                self.tracker.record_success(name, elapsed).await;
+            }
+            Ok(action_result) => {
+                // Treat a non-panicking but is_error=true ActionResult as a
+                // recorded failure. Include a short excerpt of the output for
+                // the last_error hint.
+                let err_summary = action_result.output.to_string();
+                let excerpt: String = err_summary.chars().take(120).collect();
+                self.tracker.record_failure(name, &excerpt).await;
+            }
+            Err(e) => {
+                self.tracker.record_failure(name, &e.to_string()).await;
+            }
+        }
+        result
+    }
+
+    async fn available_actions(
+        &self,
+        leases: &[crate::types::capability::CapabilityLease],
+    ) -> Result<Vec<crate::types::capability::ActionDef>, crate::types::error::EngineError> {
+        self.inner.available_actions(leases).await
+    }
 }
 
 impl Default for ReliabilityTracker {
@@ -190,5 +325,217 @@ mod tests {
     async fn unknown_action_returns_none() {
         let tracker = ReliabilityTracker::new();
         assert!(tracker.get_metrics("nonexistent").await.is_none());
+    }
+
+    /// `unreliable_with_min_calls` must filter out actions below the call
+    /// count floor so a single failure on a brand-new tool doesn't surface
+    /// in the system prompt. Regression for #2800 PR-B design: threshold
+    /// alone was not enough.
+    #[tokio::test]
+    async fn unreliable_with_min_calls_filters_cold_start() {
+        let tracker = ReliabilityTracker::new();
+        // Cold-start tool: one failure, below min_calls floor.
+        tracker.record_failure("new_tool", "boom").await;
+
+        // Established tool: ten failures, well below threshold.
+        for _ in 0..10 {
+            tracker.record_failure("old_tool", "fails").await;
+        }
+
+        let result = tracker.unreliable_with_min_calls(0.7, 10).await;
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].0, "old_tool");
+    }
+
+    #[tokio::test]
+    async fn format_notes_section_returns_none_when_empty() {
+        let tracker = ReliabilityTracker::new();
+        assert!(tracker.format_notes_section(0.7, 10, 5).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn format_notes_section_returns_none_when_cap_zero() {
+        let tracker = ReliabilityTracker::new();
+        for _ in 0..10 {
+            tracker.record_failure("bad", "err").await;
+        }
+        // Cap of 0 → no entries surfaced even though unreliable ones exist.
+        assert!(tracker.format_notes_section(0.7, 10, 0).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn format_notes_section_includes_name_rate_and_count() {
+        let tracker = ReliabilityTracker::new();
+        for _ in 0..10 {
+            tracker
+                .record_failure("flaky_tool", "network timeout")
+                .await;
+        }
+        let notes = tracker
+            .format_notes_section(0.7, 10, 5)
+            .await
+            .expect("notes section should be produced");
+        assert!(notes.contains("## Action reliability notes"));
+        assert!(notes.contains("`flaky_tool`"));
+        assert!(notes.contains("10 calls"));
+        assert!(notes.contains("network timeout"));
+    }
+
+    /// The decorator records successful calls in the underlying tracker.
+    /// Caller-level test per `.claude/rules/testing.md`: drives through the
+    /// trait impl, not `record_success` directly — if the decorator drops
+    /// an argument or mis-routes the success path, this catches it.
+    #[tokio::test]
+    async fn recording_decorator_records_successful_execute_action() {
+        use crate::traits::effect::{EffectExecutor, ThreadExecutionContext};
+        use crate::types::capability::{CapabilityLease, GrantedActions, LeaseId};
+        use crate::types::project::ProjectId;
+        use crate::types::step::ActionResult;
+        use crate::types::thread::ThreadId;
+
+        struct SuccessfulEffects;
+
+        #[async_trait::async_trait]
+        impl EffectExecutor for SuccessfulEffects {
+            async fn execute_action(
+                &self,
+                name: &str,
+                _params: serde_json::Value,
+                _lease: &CapabilityLease,
+                _ctx: &ThreadExecutionContext,
+            ) -> Result<ActionResult, crate::types::error::EngineError> {
+                Ok(ActionResult {
+                    call_id: String::new(),
+                    action_name: name.to_string(),
+                    output: serde_json::json!({"ok": true}),
+                    is_error: false,
+                    duration: Duration::from_millis(42),
+                })
+            }
+            async fn available_actions(
+                &self,
+                _leases: &[CapabilityLease],
+            ) -> Result<Vec<crate::types::capability::ActionDef>, crate::types::error::EngineError>
+            {
+                Ok(vec![])
+            }
+        }
+
+        let tracker = Arc::new(ReliabilityTracker::new());
+        let inner: Arc<dyn EffectExecutor> = Arc::new(SuccessfulEffects);
+        let decorated: Arc<dyn EffectExecutor> =
+            Arc::new(ReliabilityRecordingEffects::new(inner, tracker.clone()));
+
+        let lease = CapabilityLease {
+            id: LeaseId::new(),
+            thread_id: ThreadId::new(),
+            capability_name: "cap".into(),
+            granted_actions: GrantedActions::All,
+            granted_at: chrono::Utc::now(),
+            expires_at: None,
+            max_uses: None,
+            uses_remaining: None,
+            revoked: false,
+            revoked_reason: None,
+        };
+        let ctx = ThreadExecutionContext {
+            thread_id: ThreadId::new(),
+            thread_type: crate::types::thread::ThreadType::Foreground,
+            project_id: ProjectId::new(),
+            user_id: "u".into(),
+            step_id: crate::types::step::StepId::new(),
+            current_call_id: None,
+            source_channel: None,
+            user_timezone: None,
+            thread_goal: None,
+        };
+
+        decorated
+            .execute_action("ok_tool", serde_json::json!({}), &lease, &ctx)
+            .await
+            .expect("should succeed");
+
+        let m = tracker.get_metrics("ok_tool").await.unwrap();
+        assert_eq!(m.call_count, 1);
+        assert!((m.success_rate - 1.0).abs() < f64::EPSILON);
+    }
+
+    /// The decorator must record `is_error: true` ActionResults as failures,
+    /// not successes. A tool that returns `Ok(ActionResult { is_error: true,
+    /// .. })` is a semantic failure even though the Rust result is Ok.
+    #[tokio::test]
+    async fn recording_decorator_records_is_error_as_failure() {
+        use crate::traits::effect::{EffectExecutor, ThreadExecutionContext};
+        use crate::types::capability::{CapabilityLease, GrantedActions, LeaseId};
+        use crate::types::project::ProjectId;
+        use crate::types::step::ActionResult;
+        use crate::types::thread::ThreadId;
+
+        struct IsErrorEffects;
+
+        #[async_trait::async_trait]
+        impl EffectExecutor for IsErrorEffects {
+            async fn execute_action(
+                &self,
+                name: &str,
+                _params: serde_json::Value,
+                _lease: &CapabilityLease,
+                _ctx: &ThreadExecutionContext,
+            ) -> Result<ActionResult, crate::types::error::EngineError> {
+                Ok(ActionResult {
+                    call_id: String::new(),
+                    action_name: name.to_string(),
+                    output: serde_json::json!({"error": "bad request"}),
+                    is_error: true,
+                    duration: Duration::from_millis(5),
+                })
+            }
+            async fn available_actions(
+                &self,
+                _leases: &[CapabilityLease],
+            ) -> Result<Vec<crate::types::capability::ActionDef>, crate::types::error::EngineError>
+            {
+                Ok(vec![])
+            }
+        }
+
+        let tracker = Arc::new(ReliabilityTracker::new());
+        let inner: Arc<dyn EffectExecutor> = Arc::new(IsErrorEffects);
+        let decorated: Arc<dyn EffectExecutor> =
+            Arc::new(ReliabilityRecordingEffects::new(inner, tracker.clone()));
+
+        let lease = CapabilityLease {
+            id: LeaseId::new(),
+            thread_id: ThreadId::new(),
+            capability_name: "cap".into(),
+            granted_actions: GrantedActions::All,
+            granted_at: chrono::Utc::now(),
+            expires_at: None,
+            max_uses: None,
+            uses_remaining: None,
+            revoked: false,
+            revoked_reason: None,
+        };
+        let ctx = ThreadExecutionContext {
+            thread_id: ThreadId::new(),
+            thread_type: crate::types::thread::ThreadType::Foreground,
+            project_id: ProjectId::new(),
+            user_id: "u".into(),
+            step_id: crate::types::step::StepId::new(),
+            current_call_id: None,
+            source_channel: None,
+            user_timezone: None,
+            thread_goal: None,
+        };
+
+        decorated
+            .execute_action("bad_tool", serde_json::json!({}), &lease, &ctx)
+            .await
+            .expect("Ok(is_error=true) is still Ok");
+
+        let m = tracker.get_metrics("bad_tool").await.unwrap();
+        assert_eq!(m.call_count, 1);
+        assert_eq!(m.success_rate, 0.0);
+        assert!(m.last_error.is_some());
     }
 }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1202,6 +1202,12 @@ struct EngineState {
     extension_manager: Option<Arc<crate::extensions::ExtensionManager>>,
     /// Filesystem root for project-local attachment persistence.
     project_root: PathBuf,
+    /// Tracks per-action success rate / latency. Populated via the
+    /// `ReliabilityRecordingEffects` decorator wrapping the effect adapter.
+    /// Engine-side consumers (future: context builder) read
+    /// `unreliable_with_min_calls()` to generate prompt hints.
+    #[allow(dead_code)] // read-path wiring lands in #2800 PR-B follow-up
+    reliability_tracker: Arc<ironclaw_engine::ReliabilityTracker>,
 }
 
 /// Global engine state, initialized on first use.
@@ -1701,9 +1707,32 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         .set_capability_registry(Arc::clone(&capabilities))
         .await;
 
+    // #2800 PR-B: record per-action success rate and latency in a shared
+    // `ReliabilityTracker` so future context builders can inject "recently
+    // unreliable actions" hints into the system prompt. Wrapping here means
+    // the engine itself has no dependency on the host's recording policy —
+    // the decorator is transparent.
+    //
+    // Kill switch: `ENGINE_V2_RELIABILITY_HINTS=false` skips the decorator.
+    // Defaults to enabled. The tracker stays available either way; disabling
+    // just means the numbers are all zeros.
+    let reliability_tracker = Arc::new(ironclaw_engine::ReliabilityTracker::new());
+    let reliability_enabled = std::env::var("ENGINE_V2_RELIABILITY_HINTS")
+        .map(|v| !matches!(v.to_ascii_lowercase().as_str(), "false" | "0" | "off"))
+        .unwrap_or(true);
+    let effects_for_engine: Arc<dyn ironclaw_engine::traits::effect::EffectExecutor> =
+        if reliability_enabled {
+            Arc::new(ironclaw_engine::ReliabilityRecordingEffects::new(
+                effect_adapter.clone(),
+                Arc::clone(&reliability_tracker),
+            ))
+        } else {
+            effect_adapter.clone()
+        };
+
     let thread_manager = Arc::new(ThreadManager::new(
         llm_adapter,
-        effect_adapter.clone(),
+        effects_for_engine,
         store_dyn.clone(),
         capabilities,
         leases,
@@ -1968,6 +1997,7 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
         auth_manager,
         extension_manager: agent.deps.extension_manager.clone(),
         project_root: resolve_project_root(),
+        reliability_tracker,
     });
 
     Ok(())
@@ -5799,6 +5829,7 @@ pub(crate) mod test_support {
             auth_manager: None,
             extension_manager: None,
             project_root: super::resolve_project_root(),
+            reliability_tracker: Arc::new(ironclaw_engine::ReliabilityTracker::new()),
         };
 
         let lock = ENGINE_STATE.get_or_init(|| TokioRwLock::new(None));
@@ -7468,6 +7499,7 @@ mod tests {
             auth_manager: None,
             extension_manager: None,
             project_root: resolve_project_root(),
+            reliability_tracker: Arc::new(ironclaw_engine::ReliabilityTracker::new()),
         }
     }
 
@@ -7608,6 +7640,7 @@ mod tests {
             auth_manager: None,
             extension_manager: None,
             project_root: resolve_project_root(),
+            reliability_tracker: Arc::new(ironclaw_engine::ReliabilityTracker::new()),
         }
     }
 
@@ -8931,6 +8964,7 @@ mod tests {
             auth_manager: None,
             extension_manager: None,
             project_root: resolve_project_root(),
+            reliability_tracker: Arc::new(ironclaw_engine::ReliabilityTracker::new()),
         }
     }
 


### PR DESCRIPTION
Part of #2800 (engine v2 default flip).

Populates the engine's \`ReliabilityTracker\` so per-action success rate and latency flow into a shared registry, and adds a prompt-formatting helper. The read-side (system-prompt injection) lands in a focused follow-up.

## What this PR delivers

1. **\`ReliabilityRecordingEffects\` decorator** — wraps any \`Arc<dyn EffectExecutor>\` and records every outcome:
   - \`Ok(ActionResult { is_error: false })\` → \`record_success\` with latency
   - \`Ok(ActionResult { is_error: true })\` → \`record_failure\` with output excerpt
   - \`Err(EngineError)\` → \`record_failure\` with err.to_string
   
   The engine itself has no knowledge of reliability recording; it's a transparent decorator.

2. **Prompt-formatting helpers on \`ReliabilityTracker\`**
   - \`unreliable_with_min_calls(threshold, min_calls)\` — filters cold-start noise
   - \`format_notes_section(threshold, min_calls, cap)\` — emits the canonical \"## Action reliability notes\" section ready for system-prompt injection. Default tuning: threshold=0.7, min_calls=10, cap=5.

3. **Bridge wiring** (\`src/bridge/router.rs\`)
   - \`EngineState\` owns the \`Arc<ReliabilityTracker>\`
   - \`EffectBridgeAdapter\` is wrapped with \`ReliabilityRecordingEffects\` before being handed to \`ThreadManager\`
   - Kill switch: \`ENGINE_V2_RELIABILITY_HINTS=false\` skips the decorator (defaults to enabled)

## Scope deferred to follow-up

The read-side (prompt injection of \"recently unreliable actions\") is not yet wired. The tracker is populated and introspectable via \`get_metrics()\`; wiring it into the actual CodeAct system prompt requires:

- Parameter on \`build_codeact_system_prompt\` (or a new overload)
- Updates to ~5 call sites across executor/orchestrator
- \`TraceLlm\` update to ignore reliability-hint drift in replay parity

Isolated as a follow-up to keep this PR focused.

## Tests

6 new tests, all passing (plus 6 existing tests that still pass):
- \`unreliable_with_min_calls_filters_cold_start\`
- \`format_notes_section_returns_none_when_empty\`
- \`format_notes_section_returns_none_when_cap_zero\`
- \`format_notes_section_includes_name_rate_and_count\`
- \`recording_decorator_records_successful_execute_action\` (caller-level)
- \`recording_decorator_records_is_error_as_failure\` (caller-level, per \`.claude/rules/testing.md\`)

## Test plan

- [x] \`cargo test -p ironclaw_engine --lib\` — 460 pass
- [x] \`cargo test -p ironclaw --lib bridge::\` — 364 pass
- [x] \`cargo clippy -p ironclaw_engine --all-targets -- -D warnings\` clean
- [x] \`cargo clippy -p ironclaw --lib -- -D warnings\` clean
- [ ] Manual: run a session with ENGINE_V2=true, verify \`reliability_tracker.get_metrics(\"http\")\` reflects actual tool usage
- [ ] Manual: \`ENGINE_V2_RELIABILITY_HINTS=false\` skips decoration (tracker stays empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)