### PR TITLE
feat(engine): default-flip plumbing — opt-out, canary, docs (#2800 PR-F)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- *(engine)* `IRONCLAW_LEGACY_ENGINE=true` hard opt-out forces v1 even when v2 is the default or explicitly enabled. Canary rollout mechanism `ENGINE_V2_CANARY_PCT=N` routes N% of users (by stable `user_id` hash) to engine v2 while others stay on v1. See `docs/engine-v2.md`. Refs #2800.
+- *(engine)* `create_job` / `cancel_job` are aliased to `mission_create` / `mission_complete` when running on engine v2. `build_software` remains v1-only. Refs #2800.
+- *(engine)* engine v2 now records per-action success rate and latency via `ReliabilityRecordingEffects`. Kill switch: `ENGINE_V2_RELIABILITY_HINTS=false`. Refs #2800.
+
 ### Changed
 
 - *(web)* gateway onboarding/auth SSE now uses the unified `onboarding_state` event; external SSE clients should migrate from the older auth/pairing event names. Legacy WebSocket `auth_token` and `auth_cancel` client messages remain accepted during the temporary web v1-auth compatibility window.
 - *(web)* extension setup/auth `ActionResponse` payloads no longer include the legacy `verification` field; clients should use `onboarding_state` / `onboarding` data instead of that deprecated wire field.
+- *(llm)* per-call USD cost formula extracted to a single shared helper (`src/llm/costs.rs::compute_call_cost_decimal`) so v1 and v2 bill identical numbers for the same LLM call. Refs #2800.
 ## [0.25.0](https://github.com/nearai/ironclaw/compare/ironclaw-v0.24.0...ironclaw-v0.25.0) - 2026-04-11
 
 ### Added

--- a/docs/engine-v2.md
+++ b/docs/engine-v2.md
@@ -1,0 +1,102 @@
+# IronClaw Engine v2
+
+Engine v2 is IronClaw's unified execution engine. It replaces ~10 separate v1
+abstractions (Session, Job, Routine, Channel, Tool, Skill, Hook, Observer,
+Extension, LoopDelegate) with 5 primitives: **Thread**, **Step**,
+**Capability**, **MemoryDoc**, **Project**. See the architecture plan at
+`docs/plans/2026-03-20-engine-v2-architecture.md` for the full design.
+
+## Current status
+
+Engine v2 is **opt-in**. The default flip is tracked in issue #2800. Until
+that lands:
+
+- `ENGINE_V2=true` turns engine v2 on.
+- Without it, IronClaw keeps using the legacy v1 agent loop.
+
+## How to opt in
+
+```bash
+# Start the CLI with v2
+ENGINE_V2=true ironclaw
+
+# Or during development
+ENGINE_V2=true cargo run
+```
+
+You can confirm which engine served a given request via the web gateway
+status endpoint — the `engine_v2_enabled` field in `/api/status` reflects
+the current routing decision.
+
+## How to opt out (once v2 becomes the default)
+
+When the default flips, set `IRONCLAW_LEGACY_ENGINE=true` to keep v1:
+
+```bash
+IRONCLAW_LEGACY_ENGINE=true ironclaw
+```
+
+This overrides any other engine flag — including `ENGINE_V2=true`. Use it
+if you hit a regression during the rollout and need to fall back. The
+opt-out will be removed one release after v2 is stable as the default.
+
+## Canary rollout
+
+During the staged rollout, operators can run a percentage-based canary:
+
+```bash
+# Route 10% of users (by user_id hash) to v2, keep the rest on v1
+ENGINE_V2_CANARY_PCT=10 ironclaw
+```
+
+Properties:
+
+- **Deterministic per user** — a given `user_id` always falls in the same
+  cohort across restarts. Users aren't shuffled between engines.
+- **Ignored without a user** — boot-time observations and aggregate status
+  endpoints report v1 until a user's request arrives.
+- **Beaten by explicit flags** — `ENGINE_V2=true` forces v2 on, and
+  `IRONCLAW_LEGACY_ENGINE=true` forces v1 off, regardless of the canary %.
+
+## What users will notice on v2
+
+- **`create_job` / `cancel_job`** — translated to the mission manager. New
+  `create_job` calls show up under `/missions`, not `/jobs`.
+- **`routine_create` / `routine_list` / `routine_fire` / `routine_pause` /
+  `routine_resume` / `routine_delete` / `routine_update` / `routine_history`** —
+  all aliased to the corresponding `mission_*` actions. The `/routine`
+  slash command still works via the shared manager.
+- **Cost reporting** — v1 and v2 now compute identical USD numbers for the
+  same LLM call (shared formula in `src/llm/costs.rs`).
+- **Reliability data** — v2 records per-action success rate and latency in
+  a tracker that will surface "recently unreliable" hints into the system
+  prompt once wired. Toggle with `ENGINE_V2_RELIABILITY_HINTS=false`.
+
+## What v1 does that v2 does not (yet)
+
+- **`build_software`** — remains v1-only; no mission equivalent exists.
+
+## Debugging
+
+```bash
+# Full engine v2 debug logs
+ENGINE_V2=true RUST_LOG=ironclaw_engine=debug cargo run
+
+# Trace recording (for E2E replay)
+ENGINE_V2=true IRONCLAW_RECORD_TRACE=1 cargo run
+```
+
+Traces live under `~/.ironclaw/traces/` by default (override with
+`IRONCLAW_TRACE_OUTPUT`).
+
+## Reporting v2-specific issues
+
+Tag issues with `engine-v2` and include:
+
+- the `ENGINE_V2` / `IRONCLAW_LEGACY_ENGINE` / `ENGINE_V2_CANARY_PCT`
+  values active at the time
+- whether v2 was selected for your request (see `/api/status`
+  `engine_v2_enabled` field)
+- a trace file from `IRONCLAW_RECORD_TRACE=1` if possible
+
+The umbrella tracker for the default flip is #2800.

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -57,6 +57,7 @@ pub use router::{
     // Initialization
     init_engine,
     is_engine_v2_enabled,
+    is_engine_v2_enabled_for_user,
     list_engine_missions,
     list_engine_projects,
     list_engine_thread_events,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -47,10 +47,164 @@ pub enum BridgeOutcome {
 use std::collections::HashSet;
 
 /// Check if the engine v2 is enabled via `ENGINE_V2=true` environment variable.
+/// Returns true when engine v2 should handle traffic.
+///
+/// Precedence (first match wins):
+/// 1. `IRONCLAW_LEGACY_ENGINE=true` → **false** (hard opt-out; keeps v1 even
+///    if v2 is the default or explicitly enabled).
+/// 2. `ENGINE_V2=true` / `ENGINE_V2=1` → **true** (explicit opt-in).
+/// 3. Default → **false** until issue #2800 PR-F merges the actual flip.
+///
+/// For per-user canary routing, see [`is_engine_v2_enabled_for_user`].
 pub fn is_engine_v2_enabled() -> bool {
-    std::env::var("ENGINE_V2")
-        .map(|v| v == "true" || v == "1")
+    decide_engine_v2(
+        std::env::var("IRONCLAW_LEGACY_ENGINE").ok().as_deref(),
+        std::env::var("ENGINE_V2").ok().as_deref(),
+        None, // canary ignored without a user_id
+        None,
+    )
+}
+
+/// Returns true when engine v2 should handle **this specific user's** traffic.
+///
+/// Same precedence as [`is_engine_v2_enabled`], with an additional step between
+/// explicit opt-in and the default: if `ENGINE_V2_CANARY_PCT=N` is set,
+/// `hash(user_id) % 100 < N` routes the user to v2. This lets staged rollouts
+/// pick a reproducible cohort from `user_id` alone, without any per-user state.
+pub fn is_engine_v2_enabled_for_user(user_id: &str) -> bool {
+    decide_engine_v2(
+        std::env::var("IRONCLAW_LEGACY_ENGINE").ok().as_deref(),
+        std::env::var("ENGINE_V2").ok().as_deref(),
+        std::env::var("ENGINE_V2_CANARY_PCT").ok().as_deref(),
+        Some(user_id),
+    )
+}
+
+/// Pure-function core of the gating decision. Separated from env reads so the
+/// precedence rules are exhaustively unit-testable without mutating process
+/// globals (env vars are process-wide and race across test threads).
+fn decide_engine_v2(
+    legacy_flag: Option<&str>,
+    v2_flag: Option<&str>,
+    canary_pct: Option<&str>,
+    user_id: Option<&str>,
+) -> bool {
+    // 1. Hard opt-out wins.
+    if legacy_flag
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "on"))
         .unwrap_or(false)
+    {
+        return false;
+    }
+    // 2. Explicit opt-in wins.
+    if v2_flag.map(|v| v == "true" || v == "1").unwrap_or(false) {
+        return true;
+    }
+    // 3. Canary, only when user_id is available and the pct parses.
+    if let (Some(pct_raw), Some(user_id)) = (canary_pct, user_id)
+        && let Ok(pct) = pct_raw.trim().parse::<u32>()
+    {
+        let pct = pct.min(100);
+        if pct == 0 {
+            return false;
+        }
+        if pct >= 100 {
+            return true;
+        }
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        user_id.hash(&mut hasher);
+        let bucket = (hasher.finish() % 100) as u32;
+        return bucket < pct;
+    }
+    false
+}
+
+#[cfg(test)]
+mod gating_tests {
+    use super::decide_engine_v2;
+
+    /// `IRONCLAW_LEGACY_ENGINE=true` must force v1 even when the explicit
+    /// opt-in is also set. Regression for the hard opt-out contract in #2800.
+    #[test]
+    fn legacy_opt_out_beats_explicit_opt_in() {
+        assert!(!decide_engine_v2(
+            Some("true"),
+            Some("true"),
+            Some("100"),
+            Some("u1")
+        ));
+        assert!(!decide_engine_v2(Some("1"), Some("1"), None, None));
+        assert!(!decide_engine_v2(Some("ON"), None, None, None));
+    }
+
+    #[test]
+    fn explicit_opt_in_turns_on_v2() {
+        assert!(decide_engine_v2(None, Some("true"), None, None));
+        assert!(decide_engine_v2(None, Some("1"), None, None));
+    }
+
+    #[test]
+    fn default_without_any_flags_is_v1() {
+        assert!(!decide_engine_v2(None, None, None, None));
+        // Random string in ENGINE_V2 that isn't "true"/"1" must not enable v2.
+        assert!(!decide_engine_v2(None, Some("yes"), None, None));
+    }
+
+    #[test]
+    fn canary_zero_pct_disables() {
+        assert!(!decide_engine_v2(None, None, Some("0"), Some("u1")));
+    }
+
+    #[test]
+    fn canary_hundred_pct_enables_all_users() {
+        assert!(decide_engine_v2(None, None, Some("100"), Some("u1")));
+        assert!(decide_engine_v2(None, None, Some("100"), Some("u2")));
+        // Values above 100 clamp to 100 rather than overflow-wrap.
+        assert!(decide_engine_v2(None, None, Some("250"), Some("u1")));
+    }
+
+    /// Canary must be deterministic for a given user_id. Two consecutive
+    /// calls must agree, so users aren't shuffled between engines turn-by-turn.
+    #[test]
+    fn canary_is_stable_for_user_id() {
+        let a = decide_engine_v2(None, None, Some("50"), Some("user-abc"));
+        let b = decide_engine_v2(None, None, Some("50"), Some("user-abc"));
+        assert_eq!(a, b);
+    }
+
+    /// A 50% canary across a representative cohort must produce roughly
+    /// 50% distribution — not 0% or 100% (which would indicate a broken hash).
+    #[test]
+    fn canary_50_pct_splits_cohort() {
+        let enabled = (0..200)
+            .filter(|i| decide_engine_v2(None, None, Some("50"), Some(&format!("user-{i}"))))
+            .count();
+        // Allow a generous band: 30-70% of 200 = 60-140.
+        assert!(
+            (60..=140).contains(&enabled),
+            "expected 60-140 users in v2 cohort, got {enabled}"
+        );
+    }
+
+    /// Canary is ignored when user_id is missing — unreachable from
+    /// `is_engine_v2_enabled()`, but the invariant is that env-only callers
+    /// never observe non-deterministic canary noise.
+    #[test]
+    fn canary_ignored_without_user_id() {
+        assert!(!decide_engine_v2(None, None, Some("100"), None));
+    }
+
+    /// Invalid canary string falls back to default (v1), does not panic.
+    #[test]
+    fn canary_invalid_string_falls_back_to_default() {
+        assert!(!decide_engine_v2(
+            None,
+            None,
+            Some("not-a-number"),
+            Some("u1")
+        ));
+    }
 }
 
 /// Shorthand for building an `Error` from an engine-related failure.


### PR DESCRIPTION
Part of #2800 (engine v2 default flip).

Adds the mechanisms needed before the engine v2 default can flip on. **Does NOT flip the default itself** — that's a separate one-line follow-up after user review of the full tracker stack.

## New env vars

| Var | Meaning |
|-----|---------|
| \`IRONCLAW_LEGACY_ENGINE=true\` | Hard opt-out. Forces v1 even when v2 is the default or \`ENGINE_V2=true\` is set. Use during rollout if you hit a regression. |
| \`ENGINE_V2_CANARY_PCT=N\` | Routes N% of users to v2 based on a stable hash of \`user_id\`. Deterministic per user (same cohort across restarts). Ignored without a user_id. Beaten by explicit flags. |

### Precedence (first match wins)

1. \`IRONCLAW_LEGACY_ENGINE=true\` → **v1**
2. \`ENGINE_V2=true\` → **v2**
3. \`ENGINE_V2_CANARY_PCT=N\` + user_id → hash-based
4. Default → **v1** (until the flip lands)

## New API

- \`pub fn is_engine_v2_enabled()\` — env-only, for boot-time and aggregate observations
- \`pub fn is_engine_v2_enabled_for_user(user_id)\` — consults canary
- \`fn decide_engine_v2(legacy, v2, canary_pct, user_id)\` — private pure function hosting all branch logic so unit tests cover every precedence rule without mutating process-global env vars

## Docs

- \`docs/engine-v2.md\` — user-facing one-pager: opt in now, opt out later, participate in canary, report issues
- \`CHANGELOG.md\` Unreleased — opt-out + canary + reliability + cost-formula entries

## Tests

9 new unit tests in \`bridge::router::gating_tests\`:
- \`legacy_opt_out_beats_explicit_opt_in\`
- \`explicit_opt_in_turns_on_v2\`
- \`default_without_any_flags_is_v1\`
- \`canary_zero_pct_disables\`
- \`canary_hundred_pct_enables_all_users\`
- \`canary_is_stable_for_user_id\`
- \`canary_50_pct_splits_cohort\` (200-user cohort, expects 60-140 in v2)
- \`canary_ignored_without_user_id\`
- \`canary_invalid_string_falls_back_to_default\`

## Why no default flip in this PR

The actual flip (\`parse_bool_env(\"ENGINE_V2\", false)\` → \`true\` in \`src/config/agent.rs\`) is a one-line change that becomes trivially reviewable once this plumbing lands. Keeping it as a separate, obvious follow-up gives the reviewer one spot to sign off on (or stage with \`ENGINE_V2_CANARY_PCT=10\` first, then raise to 50, then flip the default).

Recommended rollout order:
1. Merge this PR (plumbing only, default still v1)
2. Set \`ENGINE_V2_CANARY_PCT=10\` for a week, watch error rates
3. Raise to \`50\` for another week
4. Merge the one-line \"default = true\" PR
5. Remove \`IRONCLAW_LEGACY_ENGINE\` one release later

## Test plan

- [x] \`cargo test -p ironclaw --lib bridge::router::gating_tests\` — 9 pass
- [x] \`cargo clippy -p ironclaw --lib --tests -- -D warnings\` clean
- [ ] Manual: start with \`ENGINE_V2_CANARY_PCT=50\`, verify \`/api/status\` reports \`engine_v2_enabled\` depending on user
- [ ] Manual: \`IRONCLAW_LEGACY_ENGINE=true ENGINE_V2=true\` keeps v1

🤖 Generated with [Claude Code](https://claude.com/claude-code)