### PR TITLE
test: scaffold v2 acceptance + regression ports + differential suites (#2800 PR-D/E/diff)

### DIFF
--- a/tests/v2_acceptance_coverage.rs
+++ b/tests/v2_acceptance_coverage.rs
@@ -1,0 +1,268 @@
+//! Engine v2 acceptance test coverage scaffold (#2800 PR-D).
+//!
+//! The #2800 tracker lists six coverage gaps that must be closed before
+//! engine v2 can become the default:
+//!
+//! 1. gate pause/resume
+//! 2. auth flow round-trip
+//! 3. mission lifecycle end-to-end
+//! 4. retrieval/learning flows (project-scoped docs in context)
+//! 5. orchestrator-driven compaction
+//! 6. broader replay parity with recorded traces
+//!
+//! Each is represented here as `#[ignore]` stubs with detailed TODOs
+//! pointing at the harness + assertions required. As each is implemented:
+//! - remove `#[ignore]`, delete the TODO
+//! - check off the corresponding line in issue #2800
+//!
+//! These stubs keep the surface tracked — `cargo test -- --ignored` shows
+//! exactly what's still pending, instead of a blank directory where the
+//! gap used to live.
+
+#![allow(dead_code)]
+
+// ── 1. Gate pause / resume ────────────────────────────────────────────
+
+/// Covers #2800 PR-D item 1: `WriteExternal` / `Financial` effects must
+/// pause the thread via `ThreadOutcome::GatePaused` and resume cleanly
+/// through the unified gate resolver.
+///
+/// TODO(#2800 PR-D item 1):
+/// 1. Use `TestRig` + `TraceLlm` to drive a Thread through an action
+///    with `EffectType::WriteExternal`.
+/// 2. Assert `ThreadOutcome::GatePaused` is produced.
+/// 3. Resolve via `POST /api/chat/gate/resolve` with approved=true.
+/// 4. Assert the thread resumes and completes normally.
+/// 5. Negative variant: approved=false → thread fails cleanly with a
+///    recognizable reason string.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D gate pause/resume"]
+async fn v2_write_external_gate_pauses_and_resumes() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── 2. Auth flow round-trip ───────────────────────────────────────────
+
+/// Covers #2800 PR-D item 2: a tool requiring a missing credential must
+/// surface an auth gate, complete through the OAuth/token store flow,
+/// and the paused thread must resume with the credential now available.
+///
+/// TODO(#2800 PR-D item 2):
+/// 1. Seed no credential for user A.
+/// 2. Drive a Thread through an action requiring `credential_name`.
+/// 3. Assert GatePaused with a credential-auth shape.
+/// 4. Simulate the auth callback via
+///    `handle_engine_auth_callback(state, ...)`.
+/// 5. Assert the Thread resumes, makes the same action call again, and
+///    this time the credential is present.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D auth flow round-trip"]
+async fn v2_auth_gate_completes_round_trip_to_resume() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── 3. Mission lifecycle end-to-end ────────────────────────────────────
+
+/// Covers #2800 PR-D item 3: full Mission lifecycle (create → list →
+/// fire → complete) must work end-to-end.
+///
+/// TODO(#2800 PR-D item 3):
+/// 1. Create a Mission via `mission_create` action.
+/// 2. List missions, assert the new one is present.
+/// 3. Fire it manually via `mission_fire`.
+/// 4. Assert a child Thread is spawned and runs to completion.
+/// 5. Complete via `mission_complete`.
+/// 6. Assert the mission is marked Completed and further fires no-op.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D mission lifecycle"]
+async fn v2_mission_lifecycle_end_to_end() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── 4. Retrieval / learning (project docs in context) ──────────────────
+
+/// Covers #2800 PR-D item 4: memory docs in a project must surface in
+/// the system prompt during thread execution via `build_step_context`.
+///
+/// TODO(#2800 PR-D item 4):
+/// 1. Pre-seed a `DocType::Lesson` MemoryDoc in a project.
+/// 2. Spawn a Thread in that project with a goal keyword-matching the doc.
+/// 3. Use a `TraceLlm` that captures the system prompt passed on each call.
+/// 4. Assert the "## Prior Knowledge" section is present in the first
+///    LLM call's system prompt and contains the seeded doc's title.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D retrieval injection"]
+async fn v2_memory_docs_surface_in_system_prompt() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── 5. Orchestrator-driven compaction ──────────────────────────────────
+
+/// Covers #2800 PR-D item 5: the Python orchestrator at
+/// `crates/ironclaw_engine/orchestrator/default.py:240-310` must compact
+/// working messages when token count crosses 85% of the model limit.
+///
+/// TODO(#2800 PR-D item 5):
+/// 1. Stub the context estimator so 85% fires on a small message count.
+/// 2. Configure a Thread to use CodeAct / scripting tier.
+/// 3. Pump enough messages to cross the threshold.
+/// 4. Assert the orchestrator state's `working_messages` got replaced by
+///    `[system, summary_msg, continuation_prompt]`.
+/// 5. Assert the snapshot ends up in state history for audit.
+/// 6. Assert FINAL() still resolves correctly after compaction.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D orchestrator compaction"]
+async fn v2_orchestrator_compaction_preserves_intermediate_results() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── 6. Replay parity ───────────────────────────────────────────────────
+
+/// Covers #2800 PR-D item 6: recorded traces under
+/// `tests/fixtures/llm_traces/` must replay identically on v2.
+///
+/// TODO(#2800 PR-D item 6):
+/// 1. For each trace in `tests/fixtures/llm_traces/`, replay through
+///    `TraceLlm` + `TestRig.with_engine_v2()`.
+/// 2. Assert the same final outcome (text, tool calls, error-free) as v1.
+/// 3. When `ENGINE_V2_RELIABILITY_HINTS=true`, `TraceLlm` must tolerate
+///    drift in the "## Action reliability notes" system-prompt block —
+///    that section is non-deterministic across runs and must not fail
+///    replay parity.
+#[tokio::test]
+#[ignore = "acceptance coverage — #2800 PR-D replay parity"]
+async fn v2_replays_recorded_traces_with_identical_outcome() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── PR-differential: v2 is strictly better than v1 ─────────────────────
+//
+// Each test below runs the same input through v1 and v2, asserting v2
+// is at least as good on a measurable axis and strictly better on at
+// least: success rate, token cost, turn count, one security property.
+//
+// Differential scope was agreed in #2800. These tests gate the final
+// default-flip merge (see the "Rollout gates" section in the tracker).
+
+/// Differential: task success rate on multi-tool-call fixtures.
+/// Expect v2 ≥ v1 (v2's CodeAct can compose; v1 does one tool per turn).
+#[tokio::test]
+#[ignore = "differential — #2800 task success rate"]
+async fn differential_v2_success_rate_at_least_v1() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: token cost on retrieval-heavy tasks.
+/// Expect v2 ≤ v1 (project-scoped memory docs vs full history replay).
+#[tokio::test]
+#[ignore = "differential — #2800 token cost"]
+async fn differential_v2_token_cost_at_most_v1() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: turn count on multi-step workflows.
+/// Expect v2 < v1 on fixtures needing 5+ tool calls (CodeAct batches).
+#[tokio::test]
+#[ignore = "differential — #2800 turn count"]
+async fn differential_v2_turn_count_lower_on_multi_step() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: recursive sub-agent capability (v2-only).
+/// A task decomposable into parallel independent sub-queries: v2 solves
+/// it in one step via `llm_query_batched`; v1 either sequentializes or
+/// fails. This is a "v1 cannot cross the bar" test.
+#[tokio::test]
+#[ignore = "differential — #2800 recursive sub-agent"]
+async fn differential_v2_only_recursive_sub_agent_capability() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: learning across threads.
+/// Run the same task twice. v2 produces a `DocType::Lesson` between runs
+/// and completes the second run in fewer turns. v1 has no learning loop
+/// — identical turn count run-to-run. Assert v2 improves.
+#[tokio::test]
+#[ignore = "differential — #2800 learning across threads"]
+async fn differential_v2_improves_run_over_run_via_lessons() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: capability lease expiry is a v2-only security property.
+/// A time-limited lease (5s) blocks the action after expiry; v1's static
+/// `ApprovalRequirement` has no equivalent — asserting it "blocks" is
+/// meaningless. This test documents v2's strictly-better safety stance.
+#[tokio::test]
+#[ignore = "differential — #2800 lease expiry"]
+async fn differential_v2_capability_lease_blocks_after_expiry() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: provenance taint on `Financial` effects from LLM output.
+/// v2 `PolicyEngine::evaluate_with_provenance` forces `RequireApproval`;
+/// v1 allows by default. Strictly-better safety.
+#[tokio::test]
+#[ignore = "differential — #2800 provenance taint"]
+async fn differential_v2_taints_llm_generated_financial_effects() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: event-sourced determinism.
+/// Same trace + same seed produces identical `ThreadEvent` sequences in
+/// v2. v1 has no event sourcing → test that v1 can't pass, documenting
+/// the v2-only capability.
+#[tokio::test]
+#[ignore = "differential — #2800 event sourcing determinism"]
+async fn differential_v2_replay_is_deterministic_per_event_log() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: long-context graceful degradation.
+/// Feed > 85% of context window. v2 compacts via orchestrator; v1 either
+/// errors or silently truncates. Assert v2 completes the task, v1 fails
+/// or loses information.
+#[tokio::test]
+#[ignore = "differential — #2800 long-context compaction"]
+async fn differential_v2_compacts_long_context_v1_fails() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: reliability-driven tool avoidance (after PR-B wiring).
+/// Pre-warm tracker with 10 failures of tool X. Submit a task where X is
+/// one of several valid choices. Assert v2 prefers an alternative; v1
+/// has no such mechanism.
+#[tokio::test]
+#[ignore = "differential — #2800 reliability avoidance"]
+async fn differential_v2_avoids_known_unreliable_tools() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: parallel thread isolation within a project.
+/// Spawn two threads in the same project with overlapping leases. Assert
+/// both complete and memory writes are project-scoped and don't
+/// interfere. v1's session model doesn't express this shape.
+#[tokio::test]
+#[ignore = "differential — #2800 parallel thread isolation"]
+async fn differential_v2_parallel_threads_isolated_within_project() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: CodeAct error self-correction.
+/// A script raises `NameError`, then self-corrects on the next iteration.
+/// Assert v2 reaches FINAL(). v1 treats tool errors as terminal at the
+/// same position. Measures recovery rate on synthetic broken-code fixtures.
+#[tokio::test]
+#[ignore = "differential — #2800 CodeAct self-correction"]
+async fn differential_v2_codeact_recovers_from_python_errors() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// Differential: cost-budget pre-call enforcement.
+/// Thread with `max_budget_usd = 0.05`. v2 terminates cleanly via
+/// `cost_guard_gate` before spending more. v1 has no pre-call gate (only
+/// post-fact accounting). Strictly-better safety.
+#[tokio::test]
+#[ignore = "differential — #2800 cost budget enforcement"]
+async fn differential_v2_pre_call_cost_budget_enforcement() {
+    unimplemented!("see TODO in test comment");
+}

--- a/tests/v2_regression_ports.rs
+++ b/tests/v2_regression_ports.rs
@@ -1,0 +1,284 @@
+//! V1 → V2 regression test port scaffold (#2800 PR-E).
+//!
+//! For every v1 regression test that protects an invariant still present
+//! in v2, this file holds a v2-side equivalent. The goal: before engine
+//! v2 becomes the default, every bug the v1 suite caught also has a v2
+//! version of the same assertion, so we don't re-ship a fix that only
+//! covers half the codebase.
+//!
+//! ## Scope
+//!
+//! The scoping pass in #2800 found:
+//! - ~26 explicit v1 regression tests with issue-number comments
+//! - Categorised into A (already covered in v2), B (shared-path, no v2
+//!   duplication needed), C (needs v2 port), D (obsolete in v2)
+//! - **13 Category-C tests** — listed below — require v2 equivalents
+//!
+//! ## Format
+//!
+//! Each test is currently `#[ignore]` with a TODO pointing at the v1
+//! original and the invariant to preserve. As each is implemented:
+//! 1. Remove `#[ignore]`
+//! 2. Delete the TODO block
+//! 3. Check off the entry in the umbrella tracker #2800
+//!
+//! The `#[ignore]` tests still run under `cargo test -- --ignored` so CI
+//! can report "port not yet done" visibly instead of silently passing.
+
+#![allow(dead_code)]
+
+// ── Thread approval (replaces v1 TOCTOU + missing-thread invariants) ─────
+
+/// #2800 PR-E port of v1's `src/agent/thread_ops.rs:3867` regression
+/// for #1486 (TOCTOU race in `process_approval`).
+///
+/// V1 invariant: two concurrent calls to `process_approval` for the same
+/// thread id must not both proceed — exactly one wins, the other sees the
+/// already-approved state.
+///
+/// V2 equivalent: two concurrent `resolve_gate` calls against the same
+/// `PendingGate` must produce exactly one resume, not two. The pending-gate
+/// store's atomic take-or-fail semantics are what guards this in v2.
+///
+/// TODO(#2800 PR-E): drive through
+/// `bridge::router::resolve_gate(&state, ...)` from two tokio tasks
+/// spawned on the same thread's pending gate. Assert: one returns
+/// Resolved, the other returns AlreadyResolved (or Ambiguous).
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E TOCTOU gate resolve"]
+async fn v2_gate_resolve_is_toctou_safe_for_concurrent_callers() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/thread_ops.rs:3946` for #1487
+/// (approving a nonexistent thread must error cleanly, not panic).
+///
+/// V2 equivalent: `resolve_gate` for a thread id that has no pending
+/// entry must return a clean error, not panic or hang.
+///
+/// TODO(#2800 PR-E): call `resolve_gate` with a random ThreadId that has
+/// no PendingGate. Assert: `Ok(PendingGateResolution::None)` or a typed
+/// NotFound error, no panic.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E missing-thread gate resolve"]
+async fn v2_gate_resolve_for_missing_thread_is_clean_error() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── Routine / mission triggers (replaces v1 channel case + user isolation) ─
+
+/// #2800 PR-E port of v1's `src/agent/routine_engine.rs:2481` for #1051
+/// pt1 (channel case insensitivity).
+///
+/// V1 invariant: a routine with channel filter "telegram" must fire on an
+/// event with channel "Telegram" (case-insensitive match).
+///
+/// V2 equivalent: a Mission with `MissionCadence::OnEvent { channel:
+/// Some("telegram"), .. }` must fire when an event arrives with channel
+/// "Telegram". `MissionManager::allow_mission_fire` is the gate.
+///
+/// TODO(#2800 PR-E): create a Mission with an OnEvent cadence filtered
+/// to a given channel casing. Post an event with a different casing.
+/// Assert fire was allowed.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E channel case match"]
+async fn v2_mission_on_event_matches_channel_case_insensitive() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/routine_engine.rs:2507` for #1051
+/// pt2 (user isolation).
+///
+/// V1 invariant: user A's routine must not fire on a message from user B,
+/// even if the channel/pattern would otherwise match.
+///
+/// V2 equivalent: a Mission owned by user_id "alice" must not fire on an
+/// event whose originating user_id is "bob".
+///
+/// TODO(#2800 PR-E): create Missions for two user_ids. Post an event from
+/// one user. Assert only that user's Mission fires.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E mission user isolation"]
+async fn v2_mission_on_event_respects_user_isolation() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/routine_engine.rs:2711` for #1317
+/// (full job watcher terminal states).
+///
+/// V1 invariant: routine-spawned jobs transition Stuck→Complete and
+/// Error→InProgress correctly when watched by the routine engine.
+///
+/// V2 equivalent: Mission-spawned threads transition through the engine
+/// Thread state machine (Running → Completed / Failed) and the mission
+/// manager observes the outcome correctly.
+///
+/// TODO(#2800 PR-E): spawn a Mission thread that completes/fails. Assert
+/// `MissionManager.history` records the correct outcome.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E mission watcher terminal states"]
+async fn v2_mission_watcher_records_terminal_state_transitions() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/routine_engine.rs:2793` for #1320
+/// (lightweight routine transient retry).
+///
+/// V1 invariant: transient errors in lightweight routine execution trigger
+/// automatic retry, they don't fail the routine outright.
+///
+/// V2 equivalent: transient engine errors during mission fire retry per
+/// `FireRateLimit` policy rather than marking the mission Failed.
+///
+/// TODO(#2800 PR-E): simulate a transient EffectExecutor error on first
+/// fire attempt. Assert the mission retries and eventually succeeds.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E mission transient retry"]
+async fn v2_mission_retries_transient_errors_before_marking_failed() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── Session hydration (replaces v1 tool call survival) ────────────────────
+
+/// #2800 PR-E port of v1's `src/agent/session.rs:1457` for #568 (tool
+/// call history survival across hydration).
+///
+/// V1 invariant: tool calls reloaded from DB retain their id and result.
+///
+/// V2 equivalent: when Thread/Step rows are reloaded from the Store (e.g.
+/// after restart), the ActionCalls and ActionResults in each Step retain
+/// their call_ids and output values.
+///
+/// TODO(#2800 PR-E): save a Thread with Steps containing ActionCalls and
+/// ActionResults. Drop in-memory state. Reload via Store::load_thread +
+/// Store::load_steps. Assert call_ids and outputs match.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E thread/step hydration fidelity"]
+async fn v2_thread_hydration_preserves_action_call_and_result_metadata() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── Job monitor (replaces v1 container output spoofing) ────────────────────
+
+/// #2800 PR-E port of v1's `src/agent/job_monitor.rs:379` (external
+/// channel spoofing prevention).
+///
+/// V1 invariant: only official container events should update job state;
+/// a user-crafted message matching the container event format must not.
+///
+/// V2 equivalent: ThreadEvents consumed by engine v2 must only accept
+/// events emitted by the engine's own ThreadManager, not arbitrary user
+/// input posing as an event. (The shape of this defense differs between
+/// engines — v2's event bus is internal-only, so the test shape is
+/// "external message cannot inject a ThreadEvent of kind ToolCompleted".)
+///
+/// TODO(#2800 PR-E): attempt to push a ThreadEvent through whatever
+/// ingress path exists. Assert rejection at the bridge boundary.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E event spoofing prevention"]
+async fn v2_external_messages_cannot_spoof_thread_events() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── Dispatcher isolation (replaces v1 allow_always + session + loop guards) ─
+
+/// #2800 PR-E port of v1's `src/agent/dispatcher.rs:2174`
+/// (`allow_always` mutual exclusivity).
+///
+/// V1 invariant: approval state must not slip to true when it should
+/// remain false — auto-approval is scoped to the calling thread.
+///
+/// V2 equivalent: a lease's `GrantedActions::All` + `max_uses: Some(N)`
+/// does not leak beyond its thread_id. A second thread cannot consume
+/// another thread's lease.
+///
+/// TODO(#2800 PR-E): grant a lease to ThreadId A. From ThreadId B, try
+/// to consume it via EffectBridgeAdapter::execute_action. Assert denial.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E lease scope isolation"]
+async fn v2_capability_lease_does_not_leak_across_threads() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/dispatcher.rs:2262` (session
+/// approval override isolation).
+///
+/// V1 invariant: tool auto-approval granted in one session must not
+/// leak to another session.
+///
+/// V2 equivalent: lease-granted auto-approval via
+/// `ActionDef { requires_approval: false, .. }` in one thread's lease
+/// must not affect another thread's policy evaluation.
+///
+/// TODO(#2800 PR-E): two threads, same capability, different lease
+/// policies. Execute same action. Assert each thread sees its own policy
+/// decision, not the other's.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E per-thread policy isolation"]
+async fn v2_policy_decisions_are_scoped_to_thread_lease() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/agent/dispatcher.rs:3427` (infinite loop
+/// prevention, PR #252).
+///
+/// V1 invariant: a `continue` in the agentic loop must not skip the
+/// iteration counter or depth checks.
+///
+/// V2 equivalent: the engine v2 ExecutionLoop respects
+/// `ThreadConfig::max_steps` regardless of how a step terminates. A
+/// pathological LLM that emits nothing but "Text — think more" must
+/// hit the step limit and terminate, not loop forever.
+///
+/// TODO(#2800 PR-E): build an LlmBackend that always returns
+/// `LlmResponse::Text("...")`. Run a Thread with `max_steps = 10`.
+/// Assert the loop halts and the thread terminates with `StepLimitExceeded`.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E step-limit termination"]
+async fn v2_execution_loop_respects_max_steps_under_infinite_text_responses() {
+    unimplemented!("see TODO in test comment");
+}
+
+// ── Orchestrator credential scoping (replaces v1 per-job creds + leak tests) ─
+
+/// #2800 PR-E port of v1's `src/orchestrator/api.rs:880` for #2068 pt1
+/// (credentials handler uses job creator's user_id, not global owner).
+///
+/// V1 invariant: credentials injected into a sandboxed job belong to the
+/// job's creator, not the system/global owner.
+///
+/// V2 equivalent: credentials injected into engine v2 tool calls honor
+/// the thread's `user_id` field, not the global agent owner. This is
+/// enforced at `EffectBridgeAdapter::execute_action`, which looks up the
+/// credential for the `ThreadExecutionContext::user_id`.
+///
+/// TODO(#2800 PR-E): two user_ids, same credential name, different stored
+/// values. Spawn a Thread for user A that calls a tool requiring the
+/// credential. Assert the A-valued credential is used, not B's.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E creds scoped to thread user_id"]
+async fn v2_credentials_are_scoped_to_thread_user_id() {
+    unimplemented!("see TODO in test comment");
+}
+
+/// #2800 PR-E port of v1's `src/orchestrator/api.rs:941` for #2068 pt2
+/// (cross-tenant credential leakage prevention).
+///
+/// V1 invariant: a sandbox job for user A cannot read credentials owned
+/// by user B, even if the credential names match.
+///
+/// V2 equivalent: `EffectBridgeAdapter::execute_action` from a Thread
+/// owned by user A must fail-closed when the invoked tool requires a
+/// credential only user B has stored. The failure mode is
+/// `authentication_required` with no data leak — not a fallback to
+/// another user's credential.
+///
+/// TODO(#2800 PR-E): user B has credential X stored; user A has nothing.
+/// Spawn a Thread for A that calls a tool requiring X. Assert the call
+/// fails with `authentication_required`, not a silent success using B's
+/// credential.
+#[tokio::test]
+#[ignore = "v1 regression port — #2800 PR-E cross-user credential isolation"]
+async fn v2_cross_user_credentials_fail_closed_not_leaked() {
+    unimplemented!("see TODO in test comment");
+}


### PR DESCRIPTION
Part of #2800 (engine v2 default flip). Covers **PR-D**, **PR-E**, and **PR-differential** as visible \`#[ignore]\` stubs so the work items are tracked in CI rather than hidden in prose.

## Why scaffolds, not full implementations

Each of these tests needs the full \`TestRig\` / \`TraceLlm\` harness plus per-item fixtures:
- 13 PR-E regression ports require walking through v1 test bodies one-by-one and finding the v2 observation surface (\`ThreadEvent\` instead of \`SessionEvent\`, \`PendingGate\` instead of \`ApprovalContext\`, etc.)
- 6 PR-D acceptance tests need curated fixtures + multi-turn choreography (gate resume, auth round-trip, mission firing, compaction thresholds)
- 13 PR-differential tests need paired v1-vs-v2 runners + success-axis assertions

Landing them as \`unimplemented!()\` stubs with \`#[ignore]\` reasons gives:
- a visible checklist in CI (\`cargo test -- --ignored\` lists every pending item)
- a stable structure to paste real implementations into
- no silently-passing empty test suite that looks healthy but isn't

## What's in each file

### \`tests/v2_regression_ports.rs\` — 13 stubs for PR-E

Each stub cites the v1 file:line and the invariant to preserve, then describes the v2 observation surface:

| v1 bug | v1 location | v2 test | Invariant |
|--------|-------------|---------|-----------|
| #1486 | \`thread_ops.rs:3867\` | \`v2_gate_resolve_is_toctou_safe...\` | concurrent resolves → exactly one wins |
| #1487 | \`thread_ops.rs:3946\` | \`v2_gate_resolve_for_missing_thread_is_clean_error\` | no panic on missing id |
| #1051 pt1 | \`routine_engine.rs:2481\` | \`v2_mission_on_event_matches_channel_case...\` | case-insensitive channel match |
| #1051 pt2 | \`routine_engine.rs:2507\` | \`v2_mission_on_event_respects_user_isolation\` | user A's mission doesn't fire on user B |
| #1317 | \`routine_engine.rs:2711\` | \`v2_mission_watcher_records_terminal_state...\` | state transitions observed |
| #1320 | \`routine_engine.rs:2793\` | \`v2_mission_retries_transient_errors...\` | transient errors retry |
| #568 | \`session.rs:1457\` | \`v2_thread_hydration_preserves_action_call...\` | reload preserves call_id + result |
| spoofing | \`job_monitor.rs:379\` | \`v2_external_messages_cannot_spoof_thread_events\` | external messages can't forge events |
| \`allow_always\` | \`dispatcher.rs:2174\` | \`v2_capability_lease_does_not_leak_across_threads\` | lease scope isolation |
| approval leak | \`dispatcher.rs:2262\` | \`v2_policy_decisions_are_scoped_to_thread_lease\` | policy isolation per lease |
| #252 | \`dispatcher.rs:3427\` | \`v2_execution_loop_respects_max_steps...\` | infinite-loop guard |
| #2068 pt1 | \`orchestrator/api.rs:880\` | \`v2_credentials_are_scoped_to_thread_user_id\` | creds scoped to creator |
| #2068 pt2 | \`orchestrator/api.rs:941\` | \`v2_cross_user_credentials_fail_closed...\` | no cross-user leak |

### \`tests/v2_acceptance_coverage.rs\` — 6 PR-D + 13 PR-differential stubs

PR-D (6): gate pause/resume, auth round-trip, mission lifecycle, retrieval injection, compaction, replay parity.

PR-differential (13): task success rate, token cost, turn count, recursive sub-agent, learning, lease expiry, provenance taint, event-sourced determinism, long-context compaction, reliability avoidance, parallel threads, CodeAct self-correction, cost-budget enforcement.

## Test plan

- [x] \`cargo test --test v2_regression_ports\` — 13 ignored, 0 failed
- [x] \`cargo test --test v2_acceptance_coverage\` — 19 ignored, 0 failed
- [x] \`cargo test --test v2_regression_ports -- --ignored\` prints the full TODO list with reasons
- [ ] Implement each stub in follow-up PRs, landing them incrementally

## How to port a stub

1. Remove \`#[ignore = \"...\"]\`
2. Delete the TODO block in the doc comment
3. Implement the body using \`TestRig\` / \`TraceLlm\`
4. Check off the corresponding line in issue #2800

🤖 Generated with [Claude Code](https://claude.com/claude-code)