### PR TITLE
fix(web): stop exposing internal reasoning in browser chat

### DIFF
--- a/src/channels/web/features/chat/mod.rs
+++ b/src/channels/web/features/chat/mod.rs
@@ -1046,7 +1046,9 @@ fn turn_info_from_in_memory_turn(t: &crate::agent::session::Turn) -> TurnInfo {
                     result: tool_result_preview(tc.result.as_ref()),
                     result_preview: None,
                     error: tc.error.as_deref().map(tool_error_for_display),
-                    rationale: tc.rationale.clone(),
+                    // Hide internal tool-selection rationale from normal web
+                    // history responses.
+                    rationale: None,
                 }
             })
             .collect(),
@@ -1056,7 +1058,8 @@ fn turn_info_from_in_memory_turn(t: &crate::agent::session::Turn) -> TurnInfo {
                 .iter()
                 .map(|tc| (tc.tool_call_id.as_deref(), tc.result.as_ref())),
         ),
-        narrative: t.narrative.clone(),
+        // Hide internal tool-planning narrative from normal web history.
+        narrative: None,
     }
 }
 
@@ -1352,6 +1355,35 @@ mod tests {
         assert!(
             info.tool_calls[0].result_preview.is_none(),
             "in-memory path has no separate preview — leave `result_preview` empty to match DB semantics"
+        );
+    }
+
+    #[test]
+    fn test_in_memory_turn_info_hides_internal_reasoning() {
+        let mut thread = crate::agent::session::Thread::new(Uuid::new_v4(), Some("gateway"));
+        thread.start_turn("Summarize this page");
+        {
+            let turn = thread.turns.last_mut().expect("turn");
+            turn.narrative =
+                Some("I should fetch the page, inspect it, then summarize it.".to_string());
+            turn.record_tool_call_with_reasoning(
+                "web_fetch",
+                serde_json::json!({"url": "https://example.com"}),
+                Some("Need to inspect the page before answering.".to_string()),
+                Some("call_fetch_1".to_string()),
+            );
+        }
+
+        let info = turn_info_from_in_memory_turn(&thread.turns[0]);
+
+        assert!(
+            info.narrative.is_none(),
+            "web chat history should not expose internal reasoning narrative"
+        );
+        assert_eq!(info.tool_calls.len(), 1);
+        assert!(
+            info.tool_calls[0].rationale.is_none(),
+            "web chat history should not expose per-tool rationale"
         );
     }
 

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -829,20 +829,12 @@ impl Channel for GatewayChannel {
                 suggestions,
                 thread_id: thread_id.clone(),
             },
-            StatusUpdate::ReasoningUpdate {
-                narrative,
-                decisions,
-            } => AppEvent::ReasoningUpdate {
-                narrative,
-                decisions: decisions
-                    .into_iter()
-                    .map(|d| crate::channels::web::types::ToolDecisionDto {
-                        tool_name: d.tool_name,
-                        rationale: d.rationale,
-                    })
-                    .collect(),
-                thread_id,
-            },
+            StatusUpdate::ReasoningUpdate { .. } => {
+                // Internal planning/rationale must not be exposed to browser
+                // clients. The web UI should only show user-facing responses
+                // plus coarse tool lifecycle/status updates.
+                return Ok(());
+            }
             StatusUpdate::TurnCost {
                 input_tokens,
                 output_tokens,

--- a/src/channels/web/tests/mod.rs
+++ b/src/channels/web/tests/mod.rs
@@ -2,5 +2,6 @@
 
 mod multi_tenant;
 mod no_silent_drop;
+mod reasoning_redaction;
 mod rebuild_state_preserves_fields;
 mod tool_event_passthrough;

--- a/src/channels/web/tests/reasoning_redaction.rs
+++ b/src/channels/web/tests/reasoning_redaction.rs
@@ -1,0 +1,60 @@
+//! Regression: the browser-facing web gateway must not broadcast internal
+//! reasoning updates. Web users should only receive final responses and tool
+//! lifecycle activity, not model planning or tool-selection rationale.
+
+use crate::channels::channel::Channel;
+use crate::channels::{StatusUpdate, ToolDecision};
+use crate::channels::web::GatewayChannel;
+use crate::channels::web::sse::DEFAULT_BROADCAST_BUFFER;
+use crate::config::GatewayConfig;
+use futures::StreamExt;
+
+fn test_gateway() -> GatewayChannel {
+    GatewayChannel::new(
+        GatewayConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            auth_token: Some("test-token".to_string()),
+            max_connections: 100,
+            broadcast_buffer: DEFAULT_BROADCAST_BUFFER,
+            workspace_read_scopes: vec![],
+            memory_layers: vec![],
+            oidc: None,
+        },
+        "test-user".to_string(),
+    )
+}
+
+#[tokio::test]
+async fn gateway_send_status_does_not_broadcast_reasoning_updates() {
+    let gw = test_gateway();
+    let mut stream = gw
+        .state
+        .sse
+        .subscribe_raw(Some("test-user".to_string()), false)
+        .expect("subscribe should succeed");
+    let metadata = serde_json::json!({
+        "user_id": "test-user",
+        "thread_id": "thread-123"
+    });
+
+    gw.send_status(
+        StatusUpdate::ReasoningUpdate {
+            narrative: "I should call web_fetch, then inspect the page, then summarize it."
+                .to_string(),
+            decisions: vec![ToolDecision {
+                tool_name: "web_fetch".to_string(),
+                rationale: "Need to inspect the source before answering.".to_string(),
+            }],
+        },
+        &metadata,
+    )
+    .await
+    .expect("reasoning update should not error");
+
+    let next = tokio::time::timeout(std::time::Duration::from_millis(150), stream.next()).await;
+    assert!(
+        next.is_err(),
+        "web SSE should not expose reasoning_update events to browser clients"
+    );
+}

--- a/src/channels/web/util.rs
+++ b/src/channels/web/util.rs
@@ -446,7 +446,9 @@ fn parse_tool_call_infos(calls: &[serde_json::Value]) -> Vec<ToolCallInfo> {
                 result,
                 result_preview,
                 error: c["error"].as_str().map(tool_error_for_display),
-                rationale: c["rationale"].as_str().map(String::from),
+                // Hide internal tool-selection rationale from normal web
+                // history responses.
+                rationale: None,
             }
         })
         .collect()
@@ -553,11 +555,9 @@ pub fn build_turns_from_db_messages(
                         );
                     }
                     Ok(serde_json::Value::Object(obj)) => {
-                        // New wrapped format with narrative
-                        turn.narrative = obj
-                            .get("narrative")
-                            .and_then(|v| v.as_str())
-                            .map(String::from);
+                        // Wrapped format may carry internal reasoning
+                        // narrative, but normal web history intentionally
+                        // suppresses it.
                         if let Some(serde_json::Value::Array(calls)) = obj.get("calls") {
                             turn.tool_calls = parse_tool_call_infos(calls);
                             turn.generated_images = collect_generated_images_from_tool_results(
@@ -912,15 +912,15 @@ mod tests {
         ];
         let turns = build_turns_from_db_messages(&messages);
         assert_eq!(turns.len(), 1);
-        assert_eq!(
-            turns[0].narrative.as_deref(),
-            Some("Searching memory for context before proceeding.")
+        assert!(
+            turns[0].narrative.is_none(),
+            "web history should not expose internal reasoning narrative"
         );
         assert_eq!(turns[0].tool_calls.len(), 2);
         assert_eq!(turns[0].tool_calls[0].name, "memory_search");
-        assert_eq!(
-            turns[0].tool_calls[0].rationale.as_deref(),
-            Some("consult prior context")
+        assert!(
+            turns[0].tool_calls[0].rationale.is_none(),
+            "web history should not expose per-tool rationale"
         );
         assert!(turns[0].tool_calls[0].has_result);
         assert_eq!(turns[0].tool_calls[1].name, "shell");


### PR DESCRIPTION
## Summary
- stop broadcasting `ReasoningUpdate` events to browser SSE clients
- hide persisted and in-memory tool-call `narrative` / `rationale` from normal web chat history
- add regression coverage for the browser-facing reasoning leak

## Problem
Issue #2581 reports that the web UI can show the agent's internal reasoning / chain-of-thought during tool-use turns instead of only the final user-facing answer.

The immediate leak surface was browser-specific:
- live SSE `ReasoningUpdate` events
- persisted web history `narrative`
- persisted / in-memory per-tool `rationale`

This PR applies a focused browser-side fix so the web UI still shows:
- final assistant responses
- coarse thinking/status updates
- tool lifecycle activity

…but not the agent's internal planning text.

## Test plan
- [x] `cargo test --lib gateway_send_status_does_not_broadcast_reasoning_updates`
- [x] `cargo test --lib test_build_turns_with_wrapped_tool_calls_format`
- [x] `cargo test --lib test_in_memory_turn_info_hides_internal_reasoning`
