### PR TITLE
feat(engine): type message-added assistant events

### DIFF
--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -40,13 +40,13 @@ pub use types::capability::{
     PolicyEffect, PolicyRule,
 };
 pub use types::error::{CapabilityError, EngineError, StepError, ThreadError};
-pub use types::event::{EventId, EventKind, ThreadEvent};
+pub use types::event::{AssistantContentKind, EventId, EventKind, ThreadEvent};
 pub use types::memory::{DocId, DocType, MemoryDoc};
 pub use types::message::{MessageRole, ThreadMessage};
-pub use types::step::AssistantContent;
 pub use types::mission::{Mission, MissionCadence, MissionId, MissionStatus, ValidTimezone};
 pub use types::project::{Project, ProjectId, ProjectMetric};
 pub use types::provenance::Provenance;
+pub use types::step::AssistantContent;
 pub use types::step::{
     ActionCall, ActionResult, CodeExecutionFailure, ExecutionTier, LlmResponse, Step, StepId,
     StepStatus, TokenUsage,

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -70,7 +70,7 @@ fn truncate(s: &str, max: usize) -> String {
         format!("{}...", &s[..end]) // safety: end is validated by is_char_boundary loop above
     }
 }
-use crate::types::step::{StepId, TokenUsage};
+use crate::types::step::{AssistantContent, StepId, TokenUsage};
 use crate::types::thread::{ThreadId, ThreadState};
 
 /// Strongly-typed event identifier.
@@ -105,6 +105,36 @@ impl ThreadEvent {
             thread_id,
             timestamp: Utc::now(),
             kind,
+        }
+    }
+}
+
+/// Lightweight assistant-content semantic used on event previews.
+///
+/// `ThreadMessage.assistant_content` preserves the full typed model on the
+/// message itself. Events only need the visibility/meaning tag, not the full
+/// text payload, so history/replay consumers can avoid re-guessing from a raw
+/// preview string.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantContentKind {
+    Final,
+    UserVisibleNarrative,
+    InternalReasoning,
+}
+
+impl AssistantContentKind {
+    pub fn is_user_visible(self) -> bool {
+        matches!(self, Self::Final | Self::UserVisibleNarrative)
+    }
+}
+
+impl From<&AssistantContent> for AssistantContentKind {
+    fn from(value: &AssistantContent) -> Self {
+        match value {
+            AssistantContent::Final(_) => Self::Final,
+            AssistantContent::UserVisibleNarrative(_) => Self::UserVisibleNarrative,
+            AssistantContent::InternalReasoning(_) => Self::InternalReasoning,
         }
     }
 }
@@ -171,6 +201,8 @@ pub enum EventKind {
     MessageAdded {
         role: String,
         content_preview: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        assistant_content_kind: Option<AssistantContentKind>,
     },
 
     // ── Thread tree ─────────────────────────────────────────

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::types::capability::LeaseId;
 use crate::types::error::EngineError;
-use crate::types::event::{EventKind, ThreadEvent};
+use crate::types::event::{AssistantContentKind, EventKind, ThreadEvent};
 use crate::types::memory::DocId;
 use crate::types::message::ThreadMessage;
 use crate::types::project::ProjectId;
@@ -388,6 +388,10 @@ impl Thread {
         self.add_event(EventKind::MessageAdded {
             role: format!("{:?}", message.role),
             content_preview: preview,
+            assistant_content_kind: message
+                .assistant_content
+                .as_ref()
+                .map(AssistantContentKind::from),
         });
         self.messages.push(message);
     }
@@ -403,7 +407,9 @@ impl Thread {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::event::AssistantContentKind;
     use crate::types::memory::DocId;
+    use crate::types::step::AssistantContent;
 
     fn make_thread() -> Thread {
         Thread::new(
@@ -550,7 +556,38 @@ mod tests {
         assert_eq!(t.messages.len(), 1);
         assert_eq!(t.events.len(), 1);
         match &t.events[0].kind {
-            EventKind::MessageAdded { role, .. } => assert_eq!(role, "User"),
+            EventKind::MessageAdded {
+                role,
+                assistant_content_kind,
+                ..
+            } => {
+                assert_eq!(role, "User");
+                assert!(assistant_content_kind.is_none());
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn add_assistant_message_records_typed_content_kind() {
+        let mut t = make_thread();
+        t.add_message(ThreadMessage::assistant_with_typed_content(
+            AssistantContent::UserVisibleNarrative("Inspecting the page first...".to_string()),
+        ));
+
+        match &t.events[0].kind {
+            EventKind::MessageAdded {
+                role,
+                content_preview,
+                assistant_content_kind,
+            } => {
+                assert_eq!(role, "Assistant");
+                assert_eq!(content_preview, "Inspecting the page first...");
+                assert_eq!(
+                    *assistant_content_kind,
+                    Some(AssistantContentKind::UserVisibleNarrative)
+                );
+            }
             other => panic!("unexpected event: {other:?}"),
         }
     }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4162,17 +4162,33 @@ fn format_action_display_name(action_name: &str, params_summary: &Option<String>
 
 /// Interpret a MessageAdded event into a human-readable status message.
 /// Returns `None` for events that don't need UI surfacing.
-fn interpret_message_event(role: &str, content_preview: &str) -> Option<&'static str> {
+fn interpret_message_event(
+    role: &str,
+    content_preview: &str,
+    assistant_content_kind: Option<&ironclaw_engine::AssistantContentKind>,
+) -> Option<String> {
     if role == "User" && content_preview.starts_with("[stdout]") {
-        Some("Code executed")
+        Some("Code executed".to_string())
     } else if role == "User" && content_preview.starts_with("[code ") {
-        Some("Code executed (no output)")
+        Some("Code executed (no output)".to_string())
     } else if role == "User"
         && (content_preview.contains("Error") || content_preview.starts_with("Traceback"))
     {
-        Some("Code error — retrying...")
+        Some("Code error — retrying...".to_string())
     } else if role == "Assistant" {
-        Some("Executing code...")
+        match assistant_content_kind {
+            Some(ironclaw_engine::AssistantContentKind::InternalReasoning) => None,
+            Some(ironclaw_engine::AssistantContentKind::UserVisibleNarrative) => {
+                Some(content_preview.to_string())
+            }
+            Some(ironclaw_engine::AssistantContentKind::Final) => {
+                // Final assistant responses are surfaced through the main
+                // ThreadOutcome/AppEvent::Response path, so emitting a second
+                // preview-only status event here would be duplicate noise.
+                None
+            }
+            None => Some("Executing code...".to_string()),
+        }
     } else {
         None
     }
@@ -4534,10 +4550,13 @@ async fn forward_event_to_channel(
         EventKind::MessageAdded {
             role,
             content_preview,
+            assistant_content_kind,
         } => {
-            if let Some(text) = interpret_message_event(role, content_preview) {
+            if let Some(text) =
+                interpret_message_event(role, content_preview, assistant_content_kind.as_ref())
+            {
                 let _ = channels
-                    .send_status(channel_name, StatusUpdate::Thinking(text.into()), metadata)
+                    .send_status(channel_name, StatusUpdate::Thinking(text), metadata)
                     .await;
             }
         }
@@ -4640,9 +4659,10 @@ fn thread_event_to_app_events(
         EventKind::MessageAdded {
             role,
             content_preview,
-        } => interpret_message_event(role, content_preview)
+            assistant_content_kind,
+        } => interpret_message_event(role, content_preview, assistant_content_kind.as_ref())
             .map(|text| AppEvent::Thinking {
-                message: text.into(),
+                message: text,
                 thread_id: Some(thread_id.into()),
             })
             .into_iter()
@@ -7108,6 +7128,86 @@ mod tests {
                 && !success
                 && duration_ms == &Some(17)
                 && thread_id.as_deref() == Some("thread-123")
+        ));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_skips_internal_reasoning_message_added() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::MessageAdded {
+                role: "Assistant".to_string(),
+                content_preview: "I should inspect the page before answering.".to_string(),
+                assistant_content_kind: Some(
+                    ironclaw_engine::types::event::AssistantContentKind::InternalReasoning,
+                ),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-123");
+
+        assert!(app_events.is_empty());
+    }
+
+    #[test]
+    fn thread_event_to_app_events_surfaces_user_visible_narrative_preview() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::MessageAdded {
+                role: "Assistant".to_string(),
+                content_preview: "Inspecting the page first...".to_string(),
+                assistant_content_kind: Some(
+                    ironclaw_engine::types::event::AssistantContentKind::UserVisibleNarrative,
+                ),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-123");
+
+        assert!(matches!(
+            app_events.as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Inspecting the page first..."
+                    && thread_id.as_deref() == Some("thread-123")
+        ));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_final_assistant_message_relies_on_response_stream() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::MessageAdded {
+                role: "Assistant".to_string(),
+                content_preview: "Here is the answer".to_string(),
+                assistant_content_kind: Some(
+                    ironclaw_engine::types::event::AssistantContentKind::Final,
+                ),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-123");
+
+        assert!(app_events.is_empty());
+    }
+
+    #[test]
+    fn thread_event_to_app_events_legacy_assistant_message_keeps_execution_status() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::MessageAdded {
+                role: "Assistant".to_string(),
+                content_preview: "legacy assistant message".to_string(),
+                assistant_content_kind: None,
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-123");
+
+        assert!(matches!(
+            app_events.as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Executing code..."
+                    && thread_id.as_deref() == Some("thread-123")
         ));
     }
 


### PR DESCRIPTION
## Summary
- add a lightweight typed assistant-content kind to engine `MessageAdded` events
- emit that kind from `Thread::add_message` based on typed assistant message content
- stop the bridge/router SSE path from guessing assistant visibility from raw preview text alone
- suppress internal-reasoning message events while preserving legacy assistant fallback behavior

## Why
This is a stacked follow-up to #2815.

#2815 taught engine v2 messages and orchestrator interchange about typed assistant content, but `EventKind::MessageAdded` still only carried `role + content_preview`. That left the event/SSE layer guessing whether assistant preview text was user-visible or internal.

This PR threads a lightweight semantic tag through the event layer so the router can:
- hide `InternalReasoning`
- surface `UserVisibleNarrative`
- avoid duplicate preview events for `Final` assistant messages, which already flow through `AppEvent::Response`
- keep legacy assistant event behavior when no typed metadata exists

## Test plan
- [x] `cargo test -p ironclaw_engine types::thread::tests::add_`
- [x] `cargo test --lib bridge::router::tests::thread_event_to_app_events_`
