### PR TITLE
feat(engine): type code execution lifecycle events

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -860,6 +860,17 @@ async fn handle_execute_code_step(
 
     // Run user code in a nested Monty VM (same pattern as rlm_query)
     let code_start = std::time::Instant::now();
+    let started_event = ThreadEvent::new(
+        thread.id,
+        EventKind::CodeExecutionStarted {
+            step_id: exec_ctx.step_id,
+        },
+    );
+    if let Some(tx) = event_tx {
+        let _ = tx.send(started_event.clone());
+    }
+    thread.events.push(started_event);
+
     match Box::pin(execute_code(
         &code,
         thread,
@@ -936,6 +947,28 @@ async fn handle_execute_code_step(
                     let _ = tx.send(instrumentation_event.clone());
                 }
                 thread.events.push(instrumentation_event);
+            } else {
+                // Successful code execution: emit a structured Completed event
+                // so the router/SSE layer does not need to guess status from
+                // transcript preview strings like "[stdout]" or "[code ...".
+                let had_output = !result.stdout.is_empty()
+                    || result.return_value != serde_json::Value::Null
+                    || result.action_results.iter().any(|r| {
+                        let out = r.output.as_str().unwrap_or("");
+                        !out.is_empty()
+                    });
+                let completed_event = ThreadEvent::new(
+                    thread.id,
+                    EventKind::CodeExecutionCompleted {
+                        step_id: exec_ctx.step_id,
+                        had_output,
+                        duration_ms: code_start.elapsed().as_millis() as u64,
+                    },
+                );
+                if let Some(tx) = event_tx {
+                    let _ = tx.send(completed_event.clone());
+                }
+                thread.events.push(completed_event);
             }
             thread.updated_at = chrono::Utc::now();
 
@@ -3867,7 +3900,10 @@ mod tests {
             Some(AssistantContent::InternalReasoning(text))
                 if text == "I should inspect the page before answering."
         ));
-        let calls = assistant.action_calls.as_ref().expect("assistant action calls");
+        let calls = assistant
+            .action_calls
+            .as_ref()
+            .expect("assistant action calls");
         assert_eq!(calls.len(), 1);
         assert_eq!(
             calls[0].rationale.as_deref(),
@@ -4132,7 +4168,10 @@ mod tests {
             Some(AssistantContent::InternalReasoning(text))
                 if text == "I should inspect the page before answering."
         ));
-        let calls = assistant.action_calls.as_ref().expect("assistant action calls");
+        let calls = assistant
+            .action_calls
+            .as_ref()
+            .expect("assistant action calls");
         assert_eq!(calls.len(), 1);
         assert_eq!(
             calls[0].rationale.as_deref(),
@@ -4623,6 +4662,109 @@ FINAL(batch_error_count)
     // ── CodeExecutionFailed event emission (caller test) ────────
 
     #[tokio::test]
+    async fn execute_code_step_emits_started_and_completed_events_with_output_flag() {
+        let llm: Arc<dyn LlmBackend> = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+
+        let mut thread = Thread::new(
+            "test code execution success instrumentation",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let args = &[
+            json_to_monty(&serde_json::json!("print('hello from code')")),
+            json_to_monty(&serde_json::json!({})),
+        ];
+
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        let _result = handle_execute_code_step(
+            args,
+            &[],
+            &mut thread,
+            &llm,
+            &effects,
+            &leases,
+            &policy,
+            Some(&tx),
+        )
+        .await;
+
+        assert!(
+            thread
+                .events
+                .iter()
+                .any(|e| matches!(&e.kind, EventKind::CodeExecutionStarted { .. })),
+            "expected CodeExecutionStarted event"
+        );
+        assert!(
+            thread.events.iter().any(|e| matches!(
+                &e.kind,
+                EventKind::CodeExecutionCompleted {
+                    had_output: true,
+                    ..
+                }
+            )),
+            "expected CodeExecutionCompleted event with had_output=true"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_code_step_marks_completed_without_output() {
+        let llm: Arc<dyn LlmBackend> = Arc::new(ModelCapturingLlm {
+            captured: tokio::sync::Mutex::new(Vec::new()),
+        });
+        let effects: Arc<dyn EffectExecutor> = Arc::new(NoopEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+
+        let mut thread = Thread::new(
+            "test code execution no-output instrumentation",
+            crate::types::thread::ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            crate::types::thread::ThreadConfig::default(),
+        );
+        thread.transition_to(ThreadState::Running, None).unwrap();
+
+        let args = &[
+            json_to_monty(&serde_json::json!("x = 1")),
+            json_to_monty(&serde_json::json!({})),
+        ];
+
+        let (tx, _rx) = tokio::sync::broadcast::channel(16);
+        let _result = handle_execute_code_step(
+            args,
+            &[],
+            &mut thread,
+            &llm,
+            &effects,
+            &leases,
+            &policy,
+            Some(&tx),
+        )
+        .await;
+
+        assert!(
+            thread.events.iter().any(|e| matches!(
+                &e.kind,
+                EventKind::CodeExecutionCompleted {
+                    had_output: false,
+                    ..
+                }
+            )),
+            "expected CodeExecutionCompleted event with had_output=false"
+        );
+    }
+
+    #[tokio::test]
     async fn execute_code_step_emits_code_execution_failed_event() {
         let llm: Arc<dyn LlmBackend> = Arc::new(ModelCapturingLlm {
             captured: tokio::sync::Mutex::new(Vec::new()),
@@ -4658,6 +4800,14 @@ FINAL(batch_error_count)
             Some(&tx),
         )
         .await;
+
+        assert!(
+            thread
+                .events
+                .iter()
+                .any(|e| matches!(&e.kind, EventKind::CodeExecutionStarted { .. })),
+            "expected CodeExecutionStarted event"
+        );
 
         // Verify CodeExecutionFailed event was emitted on thread.events
         let code_failed_events: Vec<_> = thread

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -250,6 +250,20 @@ pub enum EventKind {
     },
 
     // ── Code execution instrumentation ────────────────────────
+    /// Emitted when a code (REPL) execution attempt starts.
+    CodeExecutionStarted {
+        step_id: StepId,
+    },
+    /// Emitted when a code (REPL) execution attempt completes successfully.
+    CodeExecutionCompleted {
+        step_id: StepId,
+        /// Whether execution produced user-visible output (stdout, return value,
+        /// or non-empty tool/action output summarized back into context).
+        had_output: bool,
+        /// Duration of the code execution attempt in milliseconds.
+        #[serde(default)]
+        duration_ms: u64,
+    },
     /// Emitted when a code (REPL) execution attempt fails. Enables aggregate
     /// analysis of code execution failure modes to determine whether the
     /// runtime (Monty), the LLM, or tool dispatch is the primary source of

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -3,8 +3,8 @@
 use std::sync::Arc;
 
 use ironclaw_engine::{
-    ActionDef, AssistantContent, EngineError, LlmBackend, LlmCallConfig, LlmOutput,
-    LlmResponse, ThreadMessage, TokenUsage,
+    ActionDef, AssistantContent, EngineError, LlmBackend, LlmCallConfig, LlmOutput, LlmResponse,
+    ThreadMessage, TokenUsage,
 };
 use rust_decimal::Decimal;
 use rust_decimal::prelude::ToPrimitive;
@@ -873,7 +873,9 @@ mod tests {
                     id: "call_fetch_1".to_string(),
                     name: "web_fetch".to_string(),
                     arguments: serde_json::json!({"url": "https://example.com"}),
-                    reasoning: Some("Need the page contents before I can summarize it.".to_string()),
+                    reasoning: Some(
+                        "Need the page contents before I can summarize it.".to_string(),
+                    ),
                 }],
                 input_tokens: 1,
                 output_tokens: 1,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4162,20 +4162,17 @@ fn format_action_display_name(action_name: &str, params_summary: &Option<String>
 
 /// Interpret a MessageAdded event into a human-readable status message.
 /// Returns `None` for events that don't need UI surfacing.
+///
+/// User-role code-execution result messages (`[stdout]…`, `[code …]`,
+/// `Traceback`) no longer drive UI status — that surface is owned by the
+/// typed `CodeExecutionStarted`/`CodeExecutionCompleted`/`CodeExecutionFailed`
+/// events emitted by the executor.
 fn interpret_message_event(
     role: &str,
     content_preview: &str,
     assistant_content_kind: Option<&ironclaw_engine::AssistantContentKind>,
 ) -> Option<String> {
-    if role == "User" && content_preview.starts_with("[stdout]") {
-        Some("Code executed".to_string())
-    } else if role == "User" && content_preview.starts_with("[code ") {
-        Some("Code executed (no output)".to_string())
-    } else if role == "User"
-        && (content_preview.contains("Error") || content_preview.starts_with("Traceback"))
-    {
-        Some("Code error — retrying...".to_string())
-    } else if role == "Assistant" {
+    if role == "Assistant" {
         match assistant_content_kind {
             Some(ironclaw_engine::AssistantContentKind::InternalReasoning) => None,
             Some(ironclaw_engine::AssistantContentKind::UserVisibleNarrative) => {
@@ -4191,6 +4188,15 @@ fn interpret_message_event(
         }
     } else {
         None
+    }
+}
+
+/// Human-readable status text for a `CodeExecutionCompleted` event.
+fn code_execution_completed_status(had_output: bool) -> &'static str {
+    if had_output {
+        "Code executed"
+    } else {
+        "Code executed (no output)"
     }
 }
 
@@ -4577,6 +4583,33 @@ async fn forward_event_to_channel(
                 )
                 .await;
         }
+        EventKind::CodeExecutionStarted { .. } => {
+            let _ = channels
+                .send_status(
+                    channel_name,
+                    StatusUpdate::Thinking("Executing code...".into()),
+                    metadata,
+                )
+                .await;
+        }
+        EventKind::CodeExecutionCompleted { had_output, .. } => {
+            let _ = channels
+                .send_status(
+                    channel_name,
+                    StatusUpdate::Thinking(code_execution_completed_status(*had_output).into()),
+                    metadata,
+                )
+                .await;
+        }
+        EventKind::CodeExecutionFailed { .. } => {
+            let _ = channels
+                .send_status(
+                    channel_name,
+                    StatusUpdate::Thinking("Code error — retrying...".into()),
+                    metadata,
+                )
+                .await;
+        }
         _ => {}
     }
 }
@@ -4684,6 +4717,18 @@ fn thread_event_to_app_events(
             skill_names: skill_names.clone(),
             thread_id: Some(thread_id.into()),
             feedback: Vec::new(),
+        }],
+        EventKind::CodeExecutionStarted { .. } => vec![AppEvent::Thinking {
+            message: "Executing code...".into(),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::CodeExecutionCompleted { had_output, .. } => vec![AppEvent::Thinking {
+            message: code_execution_completed_status(*had_output).into(),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::CodeExecutionFailed { .. } => vec![AppEvent::Thinking {
+            message: "Code error — retrying...".into(),
+            thread_id: Some(thread_id.into()),
         }],
         _ => vec![],
     }
@@ -7086,6 +7131,61 @@ mod tests {
         ));
     }
 
+    #[tokio::test]
+    async fn forward_event_to_channel_maps_code_execution_lifecycle_events() {
+        let statuses = Arc::new(TokioMutex::new(Vec::new()));
+        let manager = ChannelManager::new();
+        manager
+            .add(Box::new(RecordingStatusChannel {
+                name: "test".to_string(),
+                statuses: Arc::clone(&statuses),
+            }))
+            .await;
+        let manager = Arc::new(manager);
+        let thread_id = ironclaw_engine::ThreadId::new();
+        let step_id = ironclaw_engine::StepId::new();
+
+        let started = ironclaw_engine::ThreadEvent::new(
+            thread_id,
+            ironclaw_engine::EventKind::CodeExecutionStarted { step_id },
+        );
+        forward_event_to_channel(&started, &manager, "test", &serde_json::json!({})).await;
+
+        let completed = ironclaw_engine::ThreadEvent::new(
+            thread_id,
+            ironclaw_engine::EventKind::CodeExecutionCompleted {
+                step_id,
+                had_output: false,
+                duration_ms: 12,
+            },
+        );
+        forward_event_to_channel(&completed, &manager, "test", &serde_json::json!({})).await;
+
+        let failed = ironclaw_engine::ThreadEvent::new(
+            thread_id,
+            ironclaw_engine::EventKind::CodeExecutionFailed {
+                step_id,
+                category: ironclaw_engine::CodeExecutionFailure::RuntimeError,
+                error: "Traceback: boom".to_string(),
+                code_hash: Some("abc123".to_string()),
+                duration_ms: 19,
+            },
+        );
+        forward_event_to_channel(&failed, &manager, "test", &serde_json::json!({})).await;
+
+        let statuses = statuses.lock().await;
+        assert!(matches!(
+            statuses.as_slice(),
+            [
+                StatusUpdate::Thinking(started),
+                StatusUpdate::Thinking(completed),
+                StatusUpdate::Thinking(failed)
+            ] if started == "Executing code..."
+                && completed == "Code executed (no output)"
+                && failed == "Code error — retrying..."
+        ));
+    }
+
     #[test]
     fn thread_event_to_app_events_preserves_call_id_for_action_events() {
         let event = ironclaw_engine::ThreadEvent::new(
@@ -7128,6 +7228,70 @@ mod tests {
                 && !success
                 && duration_ms == &Some(17)
                 && thread_id.as_deref() == Some("thread-123")
+        ));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_map_code_execution_lifecycle_events() {
+        let thread_id = "thread-123";
+        let step_id = ironclaw_engine::StepId::new();
+
+        let started = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::CodeExecutionStarted { step_id },
+        );
+        assert!(matches!(
+            thread_event_to_app_events(&started, thread_id).as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Executing code..."
+                    && thread_id.as_deref() == Some("thread-123")
+        ));
+
+        let completed_with_output = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::CodeExecutionCompleted {
+                step_id,
+                had_output: true,
+                duration_ms: 25,
+            },
+        );
+        assert!(matches!(
+            thread_event_to_app_events(&completed_with_output, thread_id).as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Code executed"
+                    && thread_id.as_deref() == Some("thread-123")
+        ));
+
+        let completed_without_output = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::CodeExecutionCompleted {
+                step_id,
+                had_output: false,
+                duration_ms: 25,
+            },
+        );
+        assert!(matches!(
+            thread_event_to_app_events(&completed_without_output, thread_id).as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Code executed (no output)"
+                    && thread_id.as_deref() == Some("thread-123")
+        ));
+
+        let failed = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::CodeExecutionFailed {
+                step_id,
+                category: ironclaw_engine::CodeExecutionFailure::RuntimeError,
+                error: "Traceback: boom".to_string(),
+                code_hash: Some("abc123".to_string()),
+                duration_ms: 99,
+            },
+        );
+        assert!(matches!(
+            thread_event_to_app_events(&failed, thread_id).as_slice(),
+            [AppEvent::Thinking { message, thread_id }]
+                if message == "Code error — retrying..."
+                    && thread_id.as_deref() == Some("thread-123")
         ));
     }
 

--- a/src/channels/web/tests/reasoning_redaction.rs
+++ b/src/channels/web/tests/reasoning_redaction.rs
@@ -3,9 +3,9 @@
 //! lifecycle activity, not model planning or tool-selection rationale.
 
 use crate::channels::channel::Channel;
-use crate::channels::{StatusUpdate, ToolDecision};
 use crate::channels::web::GatewayChannel;
 use crate::channels::web::sse::DEFAULT_BROADCAST_BUFFER;
+use crate::channels::{StatusUpdate, ToolDecision};
 use crate::config::GatewayConfig;
 use futures::StreamExt;
 

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -415,7 +415,7 @@ FINAL(str(result))
     let llm = ScriptedLlm::new(vec![LlmOutput {
         response: LlmResponse::Code {
             code: python_code.to_string(),
-            content: None,
+            assistant_content: None,
         },
         usage: TokenUsage::default(),
     }]);
@@ -525,7 +525,7 @@ FINAL(str(result))
     let llm = ScriptedLlm::new(vec![LlmOutput {
         response: LlmResponse::Code {
             code: python_code.to_string(),
-            content: None,
+            assistant_content: None,
         },
         usage: TokenUsage::default(),
     }]);

--- a/tests/support/replay_outcome.rs
+++ b/tests/support/replay_outcome.rs
@@ -361,6 +361,8 @@ fn event_kind_name(kind: &ironclaw_engine::EventKind) -> &'static str {
         EventKind::SelfImprovementComplete { .. } => "SelfImprovementComplete",
         EventKind::SelfImprovementFailed { .. } => "SelfImprovementFailed",
         EventKind::SkillActivated { .. } => "SkillActivated",
+        EventKind::CodeExecutionStarted { .. } => "CodeExecutionStarted",
+        EventKind::CodeExecutionCompleted { .. } => "CodeExecutionCompleted",
         EventKind::CodeExecutionFailed { .. } => "CodeExecutionFailed",
         EventKind::OrchestratorRollback { .. } => "OrchestratorRollback",
         EventKind::Unknown => "Unknown",


### PR DESCRIPTION
Replace the remaining preview-string heuristics that drove code-execution UI status in the bridge/router with typed engine events emitted directly by the executor. Continues the semantic-typing work from #2581 / #2813 / #2822.

Stacked on **#2822** (typed MessageAdded events). Merge after that lands.

## What changed

**Engine**
- `EventKind::CodeExecutionStarted { step_id }` and `EventKind::CodeExecutionCompleted { step_id, had_output, duration_ms }` added alongside the existing `CodeExecutionFailed`.
- `handle_execute_code_step` now emits `CodeExecutionStarted` before the nested `execute_code()` call, and `CodeExecutionCompleted` on the success branch. `had_output` is derived from `!result.stdout.is_empty() || result.return_value != Null || any action result has non-empty output`, so the router can tell "Code executed" vs "Code executed (no output)" without parsing transcript previews.

**Bridge / router**
- `forward_event_to_channel` and `thread_event_to_app_events` now dispatch on the three typed lifecycle events:
  - `CodeExecutionStarted` -> `"Executing code..."`
  - `CodeExecutionCompleted { had_output: true }` -> `"Code executed"`
  - `CodeExecutionCompleted { had_output: false }` -> `"Code executed (no output)"`
  - `CodeExecutionFailed` -> `"Code error -- retrying..."`
- `interpret_message_event` no longer inspects User-role content previews — that surface is now owned by the typed events. Assistant-role mapping through `AssistantContentKind` is unchanged.

**Test plumbing**
- Exhaustive `event_kind_name` match in `tests/support/replay_outcome.rs` extended for the two new variants.

**Incidentally fixed pre-existing drift on the stacked chain**
- `tests/engine_v2_skill_codeact.rs`: `LlmResponse::Code { content: None }` -> `assistant_content: None` (the field was renamed in #2815; the test file wasn't updated).
- fmt drift in `src/bridge/llm_adapter.rs` and `src/channels/web/tests/reasoning_redaction.rs`.

## Why this matters

After #2822, the only preview-string heuristic left in the router was the code-execution status mapping. Making the executor emit typed events instead of the router reverse-engineering user-message content previews means:

- The SSE / REPL status layer no longer depends on brittle string patterns produced by the Python orchestrator.
- `CodeExecutionCompleted.duration_ms` is available to observers for free.
- `had_output` is computable at the source (where the `ActionResult` objects and `return_value` live) rather than inferred from a truncated preview string.

## Tests

TDD: tests landed red in the same commit, then the executor and router were updated.

- `ironclaw_engine::executor::orchestrator::tests::execute_code_step_emits_started_and_completed_events_with_output_flag`
- `ironclaw_engine::executor::orchestrator::tests::execute_code_step_marks_completed_without_output`
- `bridge::router::tests::forward_event_to_channel_maps_code_execution_lifecycle_events`
- `bridge::router::tests::thread_event_to_app_events_map_code_execution_lifecycle_events`

Local runs:
- `cargo test -p ironclaw_engine` — 466 passed
- `cargo test --lib -- bridge::router` — 74 passed
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all --tests --examples --all-features -- -D warnings` — clean

## Related

- Issue #2823 (follow-up to #2813)
- PR #2822 (typed MessageAdded events) — parent branch
- PR #2815 (typed assistant content model)
- PR #2581 (originating semantic-typing bug)
