### PR TITLE
feat(safety): projection-exempt lint for gateway event sources

### DIFF
--- a/.claude/rules/gateway-events.md
+++ b/.claude/rules/gateway-events.md
@@ -1,0 +1,97 @@
+---
+paths:
+  - "src/**"
+  - "crates/**"
+---
+# Gateway Events — Single Source of Truth
+
+Every `AppEvent` reaching the SSE/WS stream must come from a **typed
+source log**, or be on a small **transport-only allowlist**. Direct
+`sse.broadcast(...)` / `sse.broadcast_for_user(...)` calls from tools,
+handlers, or extension managers are the root cause of the UI state
+drift class tracked by #2792 — the stream and the replayable source
+end up telling different stories.
+
+This is the Phase 1 rule of the gateway state-convergence epic.
+
+## Why
+
+When `AppEvent` has producers outside the projection layer, those
+producers become a second source of truth. On SSE reconnect, replay
+from the engine event log can't reconstruct them (they were never
+logged). On tab focus, reconciliation against a GET endpoint can't
+confirm them (no persisted state backs them). Four recent bugs
+(#2654, #2534, #2731, #2079) share this shape: broadcast emitted,
+backend state unchanged, UI diverges.
+
+## Source logs
+
+Every `AppEvent` projects from exactly one of:
+
+| Source log | Projection function | Typical variants |
+|---|---|---|
+| `ironclaw_engine::EventKind` | `src/bridge/router.rs::thread_event_to_app_events` | Turn progression, tool execution, gates, leases, child threads, skills |
+| Sandbox `JobEvent` | `src/worker/job.rs` (currently inline; extract under #2792 Phase 1 PR 3) | `JobStarted`, `JobMessage`, `JobToolUse`, `JobToolResult`, `JobStatus`, `JobResult` |
+| Channel-lifecycle logs | `src/channels/web/features/oauth/`, `features/pairing/`, `features/extensions/`, `extensions/manager.rs` | `OnboardingState`, `ExtensionStatus` |
+
+## Transport-only allowlist
+
+A small number of `AppEvent` variants don't project from anything
+because they have no state backing them. These are documented
+exceptions, not a loophole for new state:
+
+- `Heartbeat` — SSE keepalive, no payload, no state
+- `StreamChunk` — LLM token streaming, pre-step-completion by design; formalizing into `EventKind` would pollute the durable log with token-level noise
+
+New `AppEvent` variants that claim "transport-only" status require
+review sign-off and an entry in this table.
+
+## The rule
+
+**No call to `SseManager::broadcast` / `SseManager::broadcast_for_user`
+is allowed outside:**
+
+1. The projection dispatcher loop that consumes one of the three source
+   logs above, **or**
+2. A line annotated with `// projection-exempt: <category>, <detail>`.
+
+## Annotation format
+
+```rust
+state.sse.broadcast_for_user(user_id, event); // projection-exempt: channel-lifecycle, extension activation
+```
+
+The `<category>` must name either:
+
+- A source log — `bridge dispatcher`, `sandbox JobEvent`, `channel-lifecycle` — plus a short detail.
+- A transport-only allowlist entry — `transport-only, heartbeat` or `transport-only, stream_chunk`.
+- A scheduled migration — `migrate in #NNNN` where the issue tracks moving the emit into a source log.
+
+An unnamed category (`// projection-exempt: legacy`) is not sufficient.
+Either the site is legitimately exempt and the category explains why,
+or it's a violation and should be migrated.
+
+## Enforcement
+
+Check #9 in `scripts/pre-commit-safety.sh` (label: `PROJECTION`) flags
+added lines that match `sse\.(broadcast|broadcast_for_user)\(` without
+a `// projection-exempt:` annotation on the same line. Lines in
+`#[cfg(test)] mod tests` blocks and under `tests/` are skipped via the
+shared `strip_test_mod_lines` filter.
+
+## Not covered by this rule
+
+- **`Channel::broadcast` on the `Channel` trait.** Different method,
+  different trait, different semantics (delivery to a specific channel
+  endpoint like Telegram, not to SSE subscribers). The `Channel` trait
+  has its own invariants in `src/channels/`.
+- **Non-SSE `broadcast` methods.** If you're broadcasting on a
+  `tokio::sync::broadcast::Sender` directly, you're below the
+  `AppEvent` abstraction; the rule doesn't apply.
+
+## References
+
+- Epic: #2792 — Gateway state convergence
+- Coverage: #2654 — Engine→AppEvent bridge gaps
+- Incidents: #2079 (SSE ordering), #2534 (stale approval), #2731 (Telegram thread split)
+- Rule cluster: `.claude/rules/types.md` for wire-stable enums; `.claude/rules/tools.md` for the parallel "everything goes through tools" rule this mirrors

--- a/.claude/rules/gateway-events.md
+++ b/.claude/rules/gateway-events.md
@@ -74,10 +74,23 @@ or it's a violation and should be migrated.
 ## Enforcement
 
 Check #9 in `scripts/pre-commit-safety.sh` (label: `PROJECTION`) flags
-added lines that match `sse\.(broadcast|broadcast_for_user)\(` without
-a `// projection-exempt:` annotation on the same line. Lines in
-`#[cfg(test)] mod tests` blocks and under `tests/` are skipped via the
-shared `strip_test_mod_lines` filter.
+added lines that call `SseManager::broadcast` or
+`SseManager::broadcast_for_user` without a `// projection-exempt:
+<category>, <detail>` annotation on the same line. The comma is
+required — the check rejects bare `// projection-exempt: legacy`. Lines
+in `#[cfg(test)] mod tests` blocks and under `tests/` are skipped via
+the shared `strip_test_mod_lines` filter.
+
+The matcher covers two call-site shapes:
+
+1. Same-line receiver + method — `sse.broadcast(...)` /
+   `state.sse.broadcast_for_user(...)`.
+2. Dangling method-chain — `.broadcast_for_user(...)` at the start of
+   a line, which is how `rustfmt` wraps long calls like
+   `state\n    .sse\n    .broadcast_for_user(...)`. Only
+   `broadcast_for_user` is matched in the dangling form, because a bare
+   `.broadcast(` at line start can legitimately be the
+   `Channel::broadcast` trait method, which is out of scope.
 
 ## Not covered by this rule
 

--- a/.claude/rules/gateway-events.md
+++ b/.claude/rules/gateway-events.md
@@ -83,14 +83,18 @@ the shared `strip_test_mod_lines` filter.
 
 The matcher covers two call-site shapes:
 
-1. Same-line receiver + method — `sse.broadcast(...)` /
-   `state.sse.broadcast_for_user(...)`.
-2. Dangling method-chain — `.broadcast_for_user(...)` at the start of
-   a line, which is how `rustfmt` wraps long calls like
-   `state\n    .sse\n    .broadcast_for_user(...)`. Only
-   `broadcast_for_user` is matched in the dangling form, because a bare
-   `.broadcast(` at line start can legitimately be the
-   `Channel::broadcast` trait method, which is out of scope.
+1. Any-receiver `.broadcast_for_user(...)` — the method is defined
+   only on `SseManager` (`src/channels/web/platform/sse.rs`), so
+   matching the method name alone catches same-line receivers
+   (`state.sse.broadcast_for_user(...)`), rustfmt wraps
+   (`state\n    .sse\n    .broadcast_for_user(...)`), and any other
+   receiver name (`manager.broadcast_for_user(...)`) without
+   false-positive risk.
+2. `<word-boundary>sse.broadcast(...)` — the single-name `broadcast`
+   is shared with the `Channel` trait, so this arm is deliberately
+   narrower and only fires when the receiver is literally named
+   `sse`. The boundary uses `(^|[^[:alnum:]_])` rather than `\b` so
+   the check is portable across GNU and BSD `grep -E`.
 
 ## Not covered by this rule
 

--- a/deny.toml
+++ b/deny.toml
@@ -9,9 +9,13 @@ ignore = [
     "RUSTSEC-2025-0111",
     # rustls-webpki advisories — 0.102.8 remains pinned by a libsql 0.6.0 transitive dep
     # (via rustls 0.22 → hyper-rustls 0.25); keep ignored until that pin is gone.
+    # RUSTSEC-2026-0104: panic on empty `onlySomeReasons` BIT STRING during CRL parsing.
+    # We do not use CRLs, and the advisory explicitly notes apps that don't parse CRLs
+    # are unaffected. Same transitive pin as 0049/0098/0099 — tracked with them.
     "RUSTSEC-2026-0049",
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -398,14 +398,20 @@ fi
 #    `// projection-exempt: legacy` does not suppress the check.
 #
 #    Two match patterns:
-#    1. `sse.broadcast[_for_user](...)` — same-line receiver + method.
-#    2. `.broadcast_for_user(...)` at start of line — rustfmt wraps long
-#       calls like `state\n    .sse\n    .broadcast_for_user(...)`.
-#       Only `broadcast_for_user` is SseManager-unique; the single-name
-#       `.broadcast(` on its own line can be the `Channel` trait method,
-#       which is intentionally out of scope.
+#    1. `*.broadcast_for_user(...)` on any receiver — `broadcast_for_user`
+#       is unique to `SseManager` (see `src/channels/web/platform/sse.rs`),
+#       so matching the method name alone catches both same-line
+#       receivers (`state.sse.broadcast_for_user(...)`) and rustfmt
+#       wraps (`state\n    .sse\n    .broadcast_for_user(...)`) without
+#       risk of false positives from other types.
+#    2. `<word-boundary>sse.broadcast(...)` — the single-name `.broadcast(`
+#       on its own line can be the `Channel` trait method, so this arm
+#       is deliberately narrower and anchors on an `sse` receiver.
+#       `(^|[^[:alnum:]_])sse\.` is a portable boundary; `grep -E`'s
+#       `\b` is a GNU extension and is not recognised by BSD grep, so
+#       we avoid it here.
 PROJECTION_HITS=$(echo "$DIFF_OUTPUT_NO_TESTS" | grep -nE '^\+' \
-    | grep -E '(\bsse\.(broadcast|broadcast_for_user)|^[^:]*:\+[[:space:]]*\.broadcast_for_user)\(' \
+    | grep -E '(\.broadcast_for_user|(^|[^[:alnum:]_])sse\.broadcast)[[:space:]]*\(' \
     | grep -vE '// projection-exempt: [^,]+,|// safety:|:\+\+\+ ' \
     | head -5 || true)
 if [ -n "$PROJECTION_HITS" ]; then

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -21,7 +21,7 @@
 # Suppress individual lines with an inline "// safety: <reason>" comment.
 # For check #7, use "// dispatch-exempt: <reason>" instead.
 # For check #8, use "// web-identity-exempt: <reason>" instead.
-# For check #9, use "// projection-exempt: <reason>" instead.
+# For check #9, use "// projection-exempt: <category>, <detail>" instead.
 
 set -euo pipefail
 
@@ -372,8 +372,11 @@ if [ -n "$WEB_IDENTITY_DIFF" ]; then
     # Strip lines inside `#[cfg(test)] mod tests` blocks using the same
     # precomputed boundaries used for other prod-only checks.
     WEB_IDENTITY_PROD=$(printf '%s\n' "$WEB_IDENTITY_DIFF" | strip_test_mod_lines)
+    # `(^|[^[:alnum:]_])CredentialName([^[:alnum:]_]|$)` is a portable
+    # word boundary; `grep -E`'s `\b` is a GNU extension and is not
+    # recognised by BSD grep.
     WEB_IDENTITY_HITS=$(echo "$WEB_IDENTITY_PROD" | grep -nE '^\+' \
-        | grep -E '\bCredentialName\b' \
+        | grep -E '(^|[^[:alnum:]_])CredentialName([^[:alnum:]_]|$)' \
         | grep -vE '// web-identity-exempt:|// safety:|:\+\+\+ ' \
         | head -5 || true)
     if [ -n "$WEB_IDENTITY_HITS" ]; then
@@ -410,9 +413,14 @@ fi
 #       `(^|[^[:alnum:]_])sse\.` is a portable boundary; `grep -E`'s
 #       `\b` is a GNU extension and is not recognised by BSD grep, so
 #       we avoid it here.
+#    Suppression regex requires a non-empty detail after the comma:
+#    `[^,]+,[[:space:]]*[^[:space:]]` — `// projection-exempt: foo,`
+#    (empty detail) does NOT exempt; `// projection-exempt: foo, bar`
+#    does. This matches the documented contract in
+#    `.claude/rules/gateway-events.md`.
 PROJECTION_HITS=$(echo "$DIFF_OUTPUT_NO_TESTS" | grep -nE '^\+' \
     | grep -E '(\.broadcast_for_user|(^|[^[:alnum:]_])sse\.broadcast)[[:space:]]*\(' \
-    | grep -vE '// projection-exempt: [^,]+,|// safety:|:\+\+\+ ' \
+    | grep -vE '// projection-exempt: [^,]+,[[:space:]]*[^[:space:]]|// safety:|:\+\+\+ ' \
     | head -5 || true)
 if [ -n "$PROJECTION_HITS" ]; then
     warn "PROJECTION" "Direct SSE broadcast outside the engine→AppEvent bridge. Route through \`thread_event_to_app_events\` in \`src/bridge/router.rs\` (project from a typed source log) or annotate with '// projection-exempt: <category>, <detail>'. See .claude/rules/gateway-events.md."

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -13,6 +13,7 @@
 #   6. .unwrap(), .expect(), assert!() in production code (panics)
 #   7. Gateway/CLI handlers bypassing ToolDispatcher (must go through tools)
 #   8. CredentialName referenced in web-layer code (wrong identity at boundary)
+#   9. SSE broadcast emitted outside the engine→AppEvent projection bridge
 #
 # Also runs check-i18n-parity.sh when crates/ironclaw_gateway/static/i18n/*.js
 # files are staged, to ensure every language pack has the same key set.
@@ -20,6 +21,7 @@
 # Suppress individual lines with an inline "// safety: <reason>" comment.
 # For check #7, use "// dispatch-exempt: <reason>" instead.
 # For check #8, use "// web-identity-exempt: <reason>" instead.
+# For check #9, use "// projection-exempt: <reason>" instead.
 
 set -euo pipefail
 
@@ -380,11 +382,34 @@ if [ -n "$WEB_IDENTITY_DIFF" ]; then
     fi
 fi
 
+# 9. SSE `AppEvent` broadcast outside the engine→AppEvent projection bridge.
+#    Every `AppEvent` that hits the SSE/WS stream should project from a typed
+#    source log (`ironclaw_engine::EventKind`, `JobEvent`, channel-lifecycle)
+#    or belong to the documented transport-only allowlist. Direct
+#    `sse.broadcast(...)` / `sse.broadcast_for_user(...)` calls from tools,
+#    handlers, or extension managers drift the UI stream out of alignment
+#    with the replayable source, which is the root cause of the state
+#    desync class tracked by #2792. See `.claude/rules/gateway-events.md`.
+#
+#    Annotation format: `// projection-exempt: <category>, <detail>` — the
+#    category names the source log (`bridge dispatcher`, `channel-lifecycle`,
+#    `sandbox JobEvent`, `legacy v1 auth`) or the transport-only allowlist
+#    (`transport-only, heartbeat`). Unannotated added lines fail the check.
+PROJECTION_HITS=$(echo "$DIFF_OUTPUT_NO_TESTS" | grep -nE '^\+' \
+    | grep -E '\bsse\.(broadcast|broadcast_for_user)\(' \
+    | grep -vE '// projection-exempt:|// safety:|^\+\+\+' \
+    | head -5 || true)
+if [ -n "$PROJECTION_HITS" ]; then
+    warn "PROJECTION" "Direct SSE broadcast outside the engine→AppEvent bridge. Route through \`bridge::thread_event_to_app_events\` (project from a typed source log) or annotate with '// projection-exempt: <reason>'. See .claude/rules/gateway-events.md."
+    echo "$PROJECTION_HITS" | sed 's/^/    /'
+fi
+
 if [ "$WARNINGS" -gt 0 ]; then
     echo ""
     echo "Found $WARNINGS potential issue(s). Fix them or add '// safety: <reason>' to suppress."
     echo "(For DISPATCH warnings, use '// dispatch-exempt: <reason>' instead.)"
     echo "(For CREDNAME warnings, use '// web-identity-exempt: <reason>' instead.)"
+    echo "(For PROJECTION warnings, use '// projection-exempt: <reason>' instead.)"
     echo ""
     exit 1
 fi

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -394,13 +394,22 @@ fi
 #    Annotation format: `// projection-exempt: <category>, <detail>` — the
 #    category names the source log (`bridge dispatcher`, `channel-lifecycle`,
 #    `sandbox JobEvent`, `legacy v1 auth`) or the transport-only allowlist
-#    (`transport-only, heartbeat`). Unannotated added lines fail the check.
+#    (`transport-only, heartbeat`). The comma is required — an unnamed
+#    `// projection-exempt: legacy` does not suppress the check.
+#
+#    Two match patterns:
+#    1. `sse.broadcast[_for_user](...)` — same-line receiver + method.
+#    2. `.broadcast_for_user(...)` at start of line — rustfmt wraps long
+#       calls like `state\n    .sse\n    .broadcast_for_user(...)`.
+#       Only `broadcast_for_user` is SseManager-unique; the single-name
+#       `.broadcast(` on its own line can be the `Channel` trait method,
+#       which is intentionally out of scope.
 PROJECTION_HITS=$(echo "$DIFF_OUTPUT_NO_TESTS" | grep -nE '^\+' \
-    | grep -E '\bsse\.(broadcast|broadcast_for_user)\(' \
-    | grep -vE '// projection-exempt:|// safety:|^\+\+\+' \
+    | grep -E '(\bsse\.(broadcast|broadcast_for_user)|^[^:]*:\+[[:space:]]*\.broadcast_for_user)\(' \
+    | grep -vE '// projection-exempt: [^,]+,|// safety:|^\+\+\+' \
     | head -5 || true)
 if [ -n "$PROJECTION_HITS" ]; then
-    warn "PROJECTION" "Direct SSE broadcast outside the engine→AppEvent bridge. Route through \`bridge::thread_event_to_app_events\` (project from a typed source log) or annotate with '// projection-exempt: <reason>'. See .claude/rules/gateway-events.md."
+    warn "PROJECTION" "Direct SSE broadcast outside the engine→AppEvent bridge. Route through \`thread_event_to_app_events\` in \`src/bridge/router.rs\` (project from a typed source log) or annotate with '// projection-exempt: <category>, <detail>'. See .claude/rules/gateway-events.md."
     echo "$PROJECTION_HITS" | sed 's/^/    /'
 fi
 
@@ -409,7 +418,7 @@ if [ "$WARNINGS" -gt 0 ]; then
     echo "Found $WARNINGS potential issue(s). Fix them or add '// safety: <reason>' to suppress."
     echo "(For DISPATCH warnings, use '// dispatch-exempt: <reason>' instead.)"
     echo "(For CREDNAME warnings, use '// web-identity-exempt: <reason>' instead.)"
-    echo "(For PROJECTION warnings, use '// projection-exempt: <reason>' instead.)"
+    echo "(For PROJECTION warnings, use '// projection-exempt: <category>, <detail>' instead.)"
     echo ""
     exit 1
 fi

--- a/scripts/pre-commit-safety.sh
+++ b/scripts/pre-commit-safety.sh
@@ -344,7 +344,7 @@ fi
 if [ -n "$DISPATCH_DIFF" ]; then
     DISPATCH_HITS=$(echo "$DISPATCH_DIFF" | grep -nE '^\+' \
         | grep -E 'state\.(store|workspace|workspace_pool|extension_manager|skill_registry|session_manager)\.' \
-        | grep -vE '// dispatch-exempt:|// safety:|^\+\+\+' \
+        | grep -vE '// dispatch-exempt:|// safety:|:\+\+\+ ' \
         | head -5 || true)
     if [ -n "$DISPATCH_HITS" ]; then
         warn "DISPATCH" "Handler directly touches state.{store,workspace,extension_manager,skill_registry,session_manager}. Route through ToolDispatcher::dispatch() instead. See .claude/rules/tools.md."
@@ -374,7 +374,7 @@ if [ -n "$WEB_IDENTITY_DIFF" ]; then
     WEB_IDENTITY_PROD=$(printf '%s\n' "$WEB_IDENTITY_DIFF" | strip_test_mod_lines)
     WEB_IDENTITY_HITS=$(echo "$WEB_IDENTITY_PROD" | grep -nE '^\+' \
         | grep -E '\bCredentialName\b' \
-        | grep -vE '// web-identity-exempt:|// safety:|^\+\+\+' \
+        | grep -vE '// web-identity-exempt:|// safety:|:\+\+\+ ' \
         | head -5 || true)
     if [ -n "$WEB_IDENTITY_HITS" ]; then
         warn "CREDNAME" "\`CredentialName\` referenced in src/channels/web/** — web code takes \`ExtensionName\`; credential identity stays backend-side. Push the mapping into bridge::auth_manager or annotate with '// web-identity-exempt: <reason>'."
@@ -406,7 +406,7 @@ fi
 #       which is intentionally out of scope.
 PROJECTION_HITS=$(echo "$DIFF_OUTPUT_NO_TESTS" | grep -nE '^\+' \
     | grep -E '(\bsse\.(broadcast|broadcast_for_user)|^[^:]*:\+[[:space:]]*\.broadcast_for_user)\(' \
-    | grep -vE '// projection-exempt: [^,]+,|// safety:|^\+\+\+' \
+    | grep -vE '// projection-exempt: [^,]+,|// safety:|:\+\+\+ ' \
     | head -5 || true)
 if [ -n "$PROJECTION_HITS" ]; then
     warn "PROJECTION" "Direct SSE broadcast outside the engine→AppEvent bridge. Route through \`thread_event_to_app_events\` in \`src/bridge/router.rs\` (project from a typed source log) or annotate with '// projection-exempt: <category>, <detail>'. See .claude/rules/gateway-events.md."

--- a/scripts/test-pre-commit-safety.sh
+++ b/scripts/test-pre-commit-safety.sh
@@ -58,7 +58,7 @@ assert_flagged() {
 # Exclusions: `// projection-exempt: <category>, <detail>`, `// safety:`,
 #             and diff-header lines (`+++ b/path`) via `:\+\+\+ `.
 PROJ_POS='(\.broadcast_for_user|(^|[^[:alnum:]_])sse\.broadcast)[[:space:]]*\('
-PROJ_NEG='// projection-exempt: [^,]+,|// safety:|:\+\+\+ '
+PROJ_NEG='// projection-exempt: [^,]+,[[:space:]]*[^[:space:]]|// safety:|:\+\+\+ '
 
 # Diff header lines must be filtered.
 assert_filtered "PROJECTION: diff header line is filtered" \
@@ -116,6 +116,19 @@ assert_flagged "PROJECTION: unnamed 'legacy' suppression still flagged" \
     "$PROJ_POS" \
     "$PROJ_NEG"
 
+# Empty detail after the comma (`// projection-exempt: foo,`) does NOT
+# exempt — the documented format requires a non-empty detail.
+assert_flagged "PROJECTION: empty detail after comma still flagged" \
+    "+    sse.broadcast_for_user(&user, event); // projection-exempt: foo," \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# Trailing whitespace after the comma without a detail also does NOT exempt.
+assert_flagged "PROJECTION: comma + whitespace-only detail still flagged" \
+    "+    sse.broadcast_for_user(&user, event); // projection-exempt: foo,   " \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
 # ── DISPATCH ──────────────────────────────────────────────────
 DISPATCH_POS='state\.(store|workspace|workspace_pool|extension_manager|skill_registry|session_manager)\.'
 DISPATCH_NEG='// dispatch-exempt:|// safety:|:\+\+\+ '
@@ -131,11 +144,19 @@ assert_flagged "DISPATCH: direct state.store touch is flagged" \
     "$DISPATCH_NEG"
 
 # ── CREDNAME ──────────────────────────────────────────────────
-CREDNAME_POS='\bCredentialName\b'
+# Portable word boundary: `(^|[^[:alnum:]_])` / `([^[:alnum:]_]|$)` —
+# `grep -E`'s `\b` is a GNU extension and not recognised by BSD grep.
+CREDNAME_POS='(^|[^[:alnum:]_])CredentialName([^[:alnum:]_]|$)'
 CREDNAME_NEG='// web-identity-exempt:|// safety:|:\+\+\+ '
 
 assert_filtered "CREDNAME: diff header line is filtered" \
     "+++ b/src/channels/web/features/settings.rs" \
+    "$CREDNAME_POS" \
+    "$CREDNAME_NEG"
+
+# A similarly-named but distinct identifier must not fire.
+assert_filtered "CREDNAME: CredentialNameExt (different type) is not flagged" \
+    "+    let ext: CredentialNameExt = ...;" \
     "$CREDNAME_POS" \
     "$CREDNAME_NEG"
 

--- a/scripts/test-pre-commit-safety.sh
+++ b/scripts/test-pre-commit-safety.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Regression tests for the grep pipelines in `pre-commit-safety.sh`.
+#
+# The PROJECTION / DISPATCH / CREDNAME checks all pipe through
+# `grep -nE '^\+' | grep -E <positive> | grep -vE <exclusions>`.
+# A previous version of the exclusion regex used `^\+\+\+` to filter
+# diff header lines (`+++ b/file.rs`), which silently never fired —
+# `grep -n` prepends a `N:` line-number prefix, so `^` no longer
+# anchors against the `+++` bytes. This test locks in the corrected
+# `:\+\+\+ ` shape.
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+PASS=0
+FAIL=0
+
+assert_filtered() {
+    local label="$1" input="$2" positive="$3" exclusions="$4"
+    # Emulate the production pipeline: `grep -n '^+'` adds the line-number
+    # prefix, then positive/negative filters run against that shape.
+    local result
+    if result=$(printf '%s\n' "$input" \
+        | grep -nE '^\+' \
+        | grep -E "$positive" \
+        | grep -vE "$exclusions" \
+        | head -5 || true); then :; fi
+    if [ -z "${result:-}" ]; then
+        echo "OK: $label (correctly filtered)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — line leaked past exclusions:"
+        echo "$result" | sed 's/^/    /'
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+assert_flagged() {
+    local label="$1" input="$2" positive="$3" exclusions="$4"
+    local result
+    if result=$(printf '%s\n' "$input" \
+        | grep -nE '^\+' \
+        | grep -E "$positive" \
+        | grep -vE "$exclusions" \
+        | head -5 || true); then :; fi
+    if [ -n "${result:-}" ]; then
+        echo "OK: $label (correctly flagged)"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label — line not flagged by positive pattern"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# ── PROJECTION ────────────────────────────────────────────────
+# Positive: direct sse.broadcast / .broadcast_for_user calls.
+# Exclusions: `// projection-exempt: <category>, <detail>`, `// safety:`,
+#             and diff-header lines (`+++ b/path`) via `:\+\+\+ `.
+PROJ_POS='(\bsse\.(broadcast|broadcast_for_user)|^[^:]*:\+[[:space:]]*\.broadcast_for_user)\('
+PROJ_NEG='// projection-exempt: [^,]+,|// safety:|:\+\+\+ '
+
+# Diff header lines must be filtered.
+assert_filtered "PROJECTION: diff header line is filtered" \
+    "+++ b/src/bridge/router.rs" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# A real broadcast call is flagged.
+assert_flagged "PROJECTION: bare sse.broadcast_for_user is flagged" \
+    "+    sse.broadcast_for_user(&user, event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# A rustfmt-wrapped call is flagged.
+assert_flagged "PROJECTION: rustfmt-wrapped .broadcast_for_user is flagged" \
+    "+    .broadcast_for_user(&user, event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# Correctly annotated call is exempted.
+assert_filtered "PROJECTION: annotated call with category+detail is exempt" \
+    "+    sse.broadcast_for_user(&user, event); // projection-exempt: bridge dispatcher, auth gate" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# Bare `// projection-exempt: legacy` (no comma, no detail) does NOT exempt.
+assert_flagged "PROJECTION: unnamed 'legacy' suppression still flagged" \
+    "+    sse.broadcast_for_user(&user, event); // projection-exempt: legacy" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# ── DISPATCH ──────────────────────────────────────────────────
+DISPATCH_POS='state\.(store|workspace|workspace_pool|extension_manager|skill_registry|session_manager)\.'
+DISPATCH_NEG='// dispatch-exempt:|// safety:|:\+\+\+ '
+
+assert_filtered "DISPATCH: diff header line is filtered" \
+    "+++ b/src/channels/web/handlers/foo.rs" \
+    "$DISPATCH_POS" \
+    "$DISPATCH_NEG"
+
+assert_flagged "DISPATCH: direct state.store touch is flagged" \
+    "+    state.store.create_project(...)" \
+    "$DISPATCH_POS" \
+    "$DISPATCH_NEG"
+
+# ── CREDNAME ──────────────────────────────────────────────────
+CREDNAME_POS='\bCredentialName\b'
+CREDNAME_NEG='// web-identity-exempt:|// safety:|:\+\+\+ '
+
+assert_filtered "CREDNAME: diff header line is filtered" \
+    "+++ b/src/channels/web/features/settings.rs" \
+    "$CREDNAME_POS" \
+    "$CREDNAME_NEG"
+
+assert_flagged "CREDNAME: bare CredentialName reference is flagged" \
+    "+    let name: CredentialName = ...;" \
+    "$CREDNAME_POS" \
+    "$CREDNAME_NEG"
+
+echo ""
+echo "Passed: $PASS, Failed: $FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/test-pre-commit-safety.sh
+++ b/scripts/test-pre-commit-safety.sh
@@ -53,10 +53,11 @@ assert_flagged() {
 }
 
 # ── PROJECTION ────────────────────────────────────────────────
-# Positive: direct sse.broadcast / .broadcast_for_user calls.
+# Positive: any `.broadcast_for_user(` (SseManager-unique method) or
+#           `sse.broadcast(` with a portable word boundary.
 # Exclusions: `// projection-exempt: <category>, <detail>`, `// safety:`,
 #             and diff-header lines (`+++ b/path`) via `:\+\+\+ `.
-PROJ_POS='(\bsse\.(broadcast|broadcast_for_user)|^[^:]*:\+[[:space:]]*\.broadcast_for_user)\('
+PROJ_POS='(\.broadcast_for_user|(^|[^[:alnum:]_])sse\.broadcast)[[:space:]]*\('
 PROJ_NEG='// projection-exempt: [^,]+,|// safety:|:\+\+\+ '
 
 # Diff header lines must be filtered.
@@ -71,9 +72,35 @@ assert_flagged "PROJECTION: bare sse.broadcast_for_user is flagged" \
     "$PROJ_POS" \
     "$PROJ_NEG"
 
+# Chained receiver (state.sse.broadcast_for_user) is flagged.
+assert_flagged "PROJECTION: chained state.sse.broadcast_for_user is flagged" \
+    "+    state.sse.broadcast_for_user(&user, event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
 # A rustfmt-wrapped call is flagged.
 assert_flagged "PROJECTION: rustfmt-wrapped .broadcast_for_user is flagged" \
     "+    .broadcast_for_user(&user, event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# Non-`sse` receiver must still fire — `broadcast_for_user` is unique to
+# SseManager, so the method name alone is authoritative.
+assert_flagged "PROJECTION: non-sse receiver .broadcast_for_user is flagged" \
+    "+    manager.broadcast_for_user(&user, event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# Plain sse.broadcast call is flagged via the portable word boundary.
+assert_flagged "PROJECTION: bare sse.broadcast is flagged" \
+    "+    sse.broadcast(event);" \
+    "$PROJ_POS" \
+    "$PROJ_NEG"
+
+# The portable boundary must not fire on a longer identifier that ends
+# in 'sse' (e.g. `usse.broadcast(...)` — not a real SseManager).
+assert_filtered "PROJECTION: identifier ending in sse is not flagged" \
+    "+    usse.broadcast(event);" \
     "$PROJ_POS" \
     "$PROJ_NEG"
 


### PR DESCRIPTION
## Summary

Phase 1 of the gateway state-convergence epic (#2792): establish the enforcement gate for the "every `AppEvent` projects from a typed source log" rule.

- `scripts/pre-commit-safety.sh` gains check #9 (`PROJECTION`): newly-added `sse.broadcast(` / `sse.broadcast_for_user(` calls must carry a `// projection-exempt: <category>, <detail>` annotation. Diff-based, same shape as checks #7 (`dispatch-exempt`) and #8 (`web-identity-exempt`).
- `.claude/rules/gateway-events.md` documents the invariant, the three source logs (`EventKind`, `JobEvent`, channel-lifecycle), the small transport-only allowlist (`Heartbeat`, `StreamChunk`), and the annotation format.

The rule forbids unnamed suppressions (`// projection-exempt: legacy`). Every exempt site has to name either a source log or a scheduled migration issue — the category is itself an audit trail.

## What this doesn't do

- **Does not baseline-annotate the ~20 existing emit sites.** The lint is diff-based; untouched existing code is grandfathered. Baselining is the next Phase 1 PR so this one stays reviewable.
- **Does not migrate any of the current direct-emit violations** (`tools/builtin/plan.rs:137`, the gate manager's direct `GateRequired` / `GateResolved` emits, reasoning/credential tool emits). Those are tracked under Phase 1 PR 3 of the epic and get their `migrate in #NNNN` annotations at baseline time.

## Testing

```
=== Fires on plain broadcast ===
+    sse.broadcast(event);

=== Suppressed with annotation ===
(no match — suppressed)

=== Fires on broadcast_for_user ===
+    state.sse.broadcast_for_user(uid, event);

=== Does not fire on Channel::broadcast ===
(no match — correctly ignored)
```

Full-script run against the PR diff: no warnings (self-consistent — the PR touches no `.rs` code).

End-to-end test: inserted a scratch `.rs` file with two broadcast calls (one plain, one annotated), ran the script — `PROJECTION` warning fires on the plain call, suppressed on the annotated one. Removed after verification.

## Refs

- Epic: #2792 — gateway state convergence
- Tracking: #2654 — engine→AppEvent coverage gaps
- Incident shape: #2079, #2534, #2731, #2654

## Test plan

- [x] Regex sanity: fires on `sse.broadcast(...)`, suppressed by annotation, ignores `Channel::broadcast`
- [x] `bash scripts/pre-commit-safety.sh` against this PR — no warnings
- [x] End-to-end: scratch file with violation triggers check; annotation suppresses it
- [ ] CI `Code Style` workflow picks up the new check on next PR that adds a broadcast call

🤖 Generated with [Claude Code](https://claude.com/claude-code)