### PR TITLE
feat: multi-tenant channel instances control plane (phase 1)

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,7 +69,9 @@ jobs:
           - group: features
             files: "tests/e2e/scenarios/test_skills.py tests/e2e/scenarios/test_tool_approval.py tests/e2e/scenarios/test_webhook.py"
           - group: extensions
-            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
+            files: "tests/e2e/scenarios/test_extensions.py tests/e2e/scenarios/test_extension_oauth.py tests/e2e/scenarios/test_oauth_url_parameters.py tests/e2e/scenarios/test_wasm_lifecycle.py tests/e2e/scenarios/test_tool_execution.py tests/e2e/scenarios/test_agent_loop_recovery.py tests/e2e/scenarios/test_pairing.py tests/e2e/scenarios/test_mcp_auth_flow.py tests/e2e/scenarios/test_oauth_credential_fallback.py tests/e2e/scenarios/test_routine_oauth_credential_injection.py"
+          - group: telegram
+            files: "tests/e2e/scenarios/test_telegram_token_validation.py tests/e2e/scenarios/test_telegram_hot_activation.py tests/e2e/scenarios/test_telegram_e2e.py tests/e2e/scenarios/test_multi_tenant_channels.py"
           - group: routines
             files: "tests/e2e/scenarios/test_owner_scope.py tests/e2e/scenarios/test_routine_event_batch.py"
     steps:

--- a/migrations/V25__channel_instances.sql
+++ b/migrations/V25__channel_instances.sql
@@ -1,0 +1,25 @@
+CREATE TABLE channel_instances (
+    id UUID PRIMARY KEY,
+    user_id TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_kind TEXT NOT NULL CHECK (channel_kind = lower(channel_kind)),
+    instance_key TEXT NOT NULL UNIQUE,
+    display_name TEXT NOT NULL,
+    is_primary BOOLEAN NOT NULL DEFAULT TRUE,
+    enabled BOOLEAN NOT NULL DEFAULT TRUE,
+    config JSONB NOT NULL DEFAULT '{}'::jsonb,
+    metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_channel_instances_user_kind
+    ON channel_instances (user_id, channel_kind);
+
+CREATE INDEX idx_channel_instances_enabled
+    ON channel_instances (enabled)
+    WHERE enabled = TRUE;
+
+CREATE UNIQUE INDEX idx_channel_instances_primary_per_kind
+    ON channel_instances (user_id, channel_kind)
+    WHERE is_primary = TRUE;

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -37,3 +37,4 @@ V21__backfill_conversation_source_channel = 4041142068103384561
 V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
+V25__channel_instances = 11575638364465791573

--- a/src/agent/agent_loop.rs
+++ b/src/agent/agent_loop.rs
@@ -159,6 +159,16 @@ async fn resolve_channel_notification_user(
     }
 
     if let Some(channel_name) = trimmed_option(channel)
+        && let Some(owner_user) = trimmed_option(owner_fallback)
+        && let Some(extension_manager) = extension_manager
+        && let Some(target) = extension_manager
+            .notification_target_for_channel_for_user(&channel_name, owner_user.as_str())
+            .await
+    {
+        return Some(target);
+    }
+
+    if let Some(channel_name) = trimmed_option(channel)
         && let Some(extension_manager) = extension_manager
         && let Some(target) = extension_manager
             .notification_target_for_channel(&channel_name)
@@ -168,6 +178,24 @@ async fn resolve_channel_notification_user(
     }
 
     resolve_owner_scope_notification_user(explicit_user, owner_fallback)
+}
+
+async fn resolve_channel_notification_dispatch_key(
+    extension_manager: Option<&Arc<ExtensionManager>>,
+    channel: Option<&str>,
+    owner_fallback: Option<&str>,
+) -> Option<String> {
+    let channel_name = trimmed_option(channel)?;
+    if let Some(owner_user) = trimmed_option(owner_fallback)
+        && let Some(extension_manager) = extension_manager
+    {
+        return Some(
+            extension_manager
+                .notification_channel_dispatch_key_for_user(&channel_name, owner_user.as_str())
+                .await,
+        );
+    }
+    Some(channel_name)
 }
 
 async fn resolve_routine_notification_target(
@@ -911,31 +939,50 @@ impl Agent {
                     .await;
                     let notify_user = heartbeat_notify_user;
                     let channels = self.channels.clone();
+                    let extension_manager = self.deps.extension_manager.clone();
+                    let owner_user_id = self.owner_id().to_string();
+                    let configured_notify_user = hb_config.notify_user.clone();
                     let is_multi_tenant = hb_config.multi_tenant;
                     tokio::spawn(async move {
                         while let Some(response) = notify_rx.recv().await {
-                            // In multi-tenant mode, extract the owning user_id from
-                            // the response metadata so notifications reach the
-                            // correct user rather than the agent's owner.
-                            // This intentionally overrides the configured notify_target
-                            // because each user's heartbeat should notify that user.
-                            let effective_user = if is_multi_tenant {
+                            let effective_owner_user = if is_multi_tenant {
                                 response
                                     .metadata
                                     .get("owner_id")
                                     .and_then(|v| v.as_str())
                                     .map(String::from)
                             } else {
-                                None
+                                Some(owner_user_id.clone())
+                            };
+
+                            let effective_target = if let Some(ref channel) = notify_channel {
+                                resolve_channel_notification_user(
+                                    extension_manager.as_ref(),
+                                    Some(channel),
+                                    configured_notify_user.as_deref(),
+                                    effective_owner_user.as_deref(),
+                                )
+                                .await
+                                .or_else(|| notify_target.clone())
+                            } else {
+                                effective_owner_user
+                                    .clone()
+                                    .or_else(|| notify_target.clone())
                             };
 
                             // Try the configured channel first, fall back to
                             // broadcasting on all channels.
                             let targeted_ok = if let Some(ref channel) = notify_channel {
-                                let target = effective_user.as_deref().or(notify_target.as_deref());
-                                if let Some(user) = target {
+                                let delivery_channel = resolve_channel_notification_dispatch_key(
+                                    extension_manager.as_ref(),
+                                    Some(channel),
+                                    effective_owner_user.as_deref(),
+                                )
+                                .await
+                                .unwrap_or_else(|| channel.clone());
+                                if let Some(user) = effective_target.as_deref() {
                                     channels
-                                        .broadcast(channel, user, response.clone())
+                                        .broadcast(&delivery_channel, user, response.clone())
                                         .await
                                         .is_ok()
                                 } else {
@@ -946,7 +993,8 @@ impl Agent {
                             };
 
                             if !targeted_ok {
-                                let fallback = effective_user.as_deref().or(notify_user.as_deref());
+                                let fallback =
+                                    effective_owner_user.as_deref().or(notify_user.as_deref());
                                 if let Some(user) = fallback {
                                     let results = channels.broadcast_all(user, response).await;
                                     for (ch, result) in results {
@@ -1049,6 +1097,8 @@ impl Agent {
                                     .and_then(|v| v.as_str()),
                                 response.metadata.get("owner_id").and_then(|v| v.as_str()),
                             );
+                            let owner_scope_user =
+                                response.metadata.get("owner_id").and_then(|v| v.as_str());
                             let Some(user) = resolve_routine_notification_target(
                                 extension_manager.as_ref(),
                                 &response.metadata,
@@ -1065,13 +1115,23 @@ impl Agent {
                             // Try the configured channel first, fall back to
                             // broadcasting on all channels.
                             let targeted_ok = if let Some(ref channel) = notify_channel {
-                                match channels.broadcast(channel, &user, response.clone()).await {
+                                let delivery_channel = resolve_channel_notification_dispatch_key(
+                                    extension_manager.as_ref(),
+                                    Some(channel),
+                                    owner_scope_user,
+                                )
+                                .await
+                                .unwrap_or_else(|| channel.clone());
+                                match channels
+                                    .broadcast(&delivery_channel, &user, response.clone())
+                                    .await
+                                {
                                     Ok(()) => true,
                                     Err(e) => {
                                         let should_fallback =
                                             should_fallback_routine_notification(&e);
                                         tracing::warn!(
-                                            channel = %channel,
+                                            channel = %delivery_channel,
                                             user = %user,
                                             error = %e,
                                             should_fallback,
@@ -1639,9 +1699,11 @@ impl Agent {
                 // actual approvals, not messages about to become UserInput.
 
                 if thread.pending_approval.is_some() {
-                    let authorized = crate::agent::session::is_approval_authorized(
+                    let authorized = crate::agent::session::is_approval_authorized_for_instance(
                         thread.source_channel.as_deref(),
+                        thread.source_channel_instance_key.as_deref(),
                         &message.channel,
+                        Some(message.channel_dispatch_key()),
                     );
                     if !authorized {
                         tracing::warn!(
@@ -1660,9 +1722,10 @@ impl Agent {
                 sess.last_active_at = chrono::Utc::now();
                 drop(sess);
                 self.session_manager
-                    .register_thread(
+                    .register_thread_for_channel_instance(
                         &message.user_id,
                         &message.channel,
+                        message.channel_dispatch_key(),
                         target_thread_id,
                         Arc::clone(&session),
                     )
@@ -1671,9 +1734,10 @@ impl Agent {
             } else {
                 drop(sess);
                 self.session_manager
-                    .resolve_thread_with_parsed_uuid(
+                    .resolve_thread_with_parsed_uuid_for_channel_instance(
                         &message.user_id,
                         &message.channel,
+                        message.channel_dispatch_key(),
                         message.conversation_scope(),
                         approval_thread_uuid,
                     )
@@ -1681,9 +1745,10 @@ impl Agent {
             }
         } else {
             self.session_manager
-                .resolve_thread(
+                .resolve_thread_for_channel_instance(
                     &message.user_id,
                     &message.channel,
+                    message.channel_dispatch_key(),
                     message.conversation_scope(),
                 )
                 .await
@@ -2161,8 +2226,10 @@ impl Agent {
 #[cfg(test)]
 mod tests {
     use super::{
-        chat_tool_execution_metadata, is_single_message_repl, resolve_routine_notification_user,
-        should_fallback_routine_notification, truncate_for_preview,
+        chat_tool_execution_metadata, is_single_message_repl,
+        resolve_channel_notification_dispatch_key, resolve_channel_notification_user,
+        resolve_routine_notification_user, should_fallback_routine_notification,
+        truncate_for_preview,
     };
     use crate::agent::agent_loop::{Agent, AgentDeps, HandleOutcome};
     use crate::agent::cost_guard::{CostGuard, CostGuardConfig};
@@ -2224,6 +2291,56 @@ mod tests {
                 cache_creation_input_tokens: 0,
             })
         }
+    }
+
+    async fn seed_test_user(store: &Arc<dyn crate::db::Database>, user_id: &str) {
+        store
+            .get_or_create_user(crate::db::UserRecord {
+                id: user_id.to_string(),
+                role: "member".to_string(),
+                display_name: user_id.to_string(),
+                status: "active".to_string(),
+                email: None,
+                last_login_at: None,
+                created_by: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .expect("seed test user");
+    }
+
+    async fn make_test_extension_manager_with_db() -> (
+        Arc<crate::extensions::ExtensionManager>,
+        Arc<dyn crate::db::Database>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        tempfile::TempDir,
+    ) {
+        let (db, db_tmp) = crate::testing::test_db().await;
+        let tools_dir = tempfile::tempdir().expect("temp tools dir");
+        let channels_dir = tempfile::tempdir().expect("temp channels dir");
+        let master_key =
+            secrecy::SecretString::from(crate::testing::credentials::TEST_CRYPTO_KEY.to_string());
+        let crypto = Arc::new(
+            crate::secrets::SecretsCrypto::new(master_key).expect("create secrets crypto"),
+        );
+        let manager = Arc::new(crate::extensions::ExtensionManager::new(
+            Arc::new(crate::tools::mcp::session::McpSessionManager::new()),
+            Arc::new(crate::tools::mcp::process::McpProcessManager::new()),
+            Arc::new(crate::secrets::InMemorySecretsStore::new(crypto)),
+            Arc::new(crate::tools::ToolRegistry::new()),
+            None,
+            None,
+            tools_dir.path().to_path_buf(),
+            channels_dir.path().to_path_buf(),
+            None,
+            "test".to_string(),
+            Some(Arc::clone(&db)),
+            Vec::new(),
+        ));
+        (manager, db, db_tmp, tools_dir, channels_dir)
     }
 
     fn make_legacy_handle_message_test_agent() -> Agent {
@@ -2381,6 +2498,78 @@ mod tests {
         });
 
         assert_eq!(resolve_routine_notification_user(&metadata), None); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_notification_user_prefers_tenant_binding() {
+        let (extension_manager, db, _db_tmp, _tools_tmp, _channels_tmp) =
+            make_test_extension_manager_with_db().await;
+        seed_test_user(&db, "tenant-b").await;
+        db.set_setting(
+            "tenant-b",
+            "channels.wasm_channel_owner_ids.telegram",
+            &serde_json::json!(424242_i64),
+        )
+        .await
+        .expect("persist tenant telegram target");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-b:primary".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant channel instance");
+
+        let resolved = resolve_channel_notification_user(
+            Some(&extension_manager),
+            Some("telegram"),
+            None,
+            Some("tenant-b"),
+        )
+        .await;
+
+        assert_eq!(resolved.as_deref(), Some("424242"));
+    }
+
+    #[tokio::test]
+    async fn resolve_channel_notification_dispatch_key_prefers_tenant_instance() {
+        let (extension_manager, db, _db_tmp, _tools_tmp, _channels_tmp) =
+            make_test_extension_manager_with_db().await;
+        seed_test_user(&db, "tenant-b").await;
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-b:primary".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant channel instance");
+
+        let resolved = resolve_channel_notification_dispatch_key(
+            Some(&extension_manager),
+            Some("telegram"),
+            Some("tenant-b"),
+        )
+        .await;
+
+        assert_eq!(resolved.as_deref(), Some("telegram:tenant-b:primary"));
     }
 
     #[test]

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -2461,6 +2461,7 @@ mod tests {
         IncomingMessage {
             id: Uuid::new_v4(),
             channel: channel.to_string(),
+            channel_instance_key: None,
             user_id: user_id.to_string(),
             sender_id: user_id.to_string(),
             user_name: None,

--- a/src/agent/session.rs
+++ b/src/agent/session.rs
@@ -310,6 +310,9 @@ pub struct Thread {
     /// Channel that created this thread (for approval authorization).
     #[serde(default)]
     pub source_channel: Option<String>,
+    /// Internal runtime/dispatch key for the originating channel instance.
+    #[serde(default)]
+    pub source_channel_instance_key: Option<String>,
 }
 
 /// Maximum number of messages that can be queued while a thread is processing.
@@ -336,10 +339,27 @@ pub const TRUSTED_APPROVAL_CHANNELS: &[&str] = &["web", "gateway"];
 /// - requesting is in `TRUSTED_APPROVAL_CHANNELS` -> always authorized
 /// - Otherwise -> denied
 pub fn is_approval_authorized(source: Option<&str>, requesting: &str) -> bool {
-    match source {
+    is_approval_authorized_for_instance(source, None, requesting, None)
+}
+
+/// Like [`is_approval_authorized`], but additionally constrains approvals to a
+/// specific channel instance when the source thread records one.
+pub fn is_approval_authorized_for_instance(
+    source_channel: Option<&str>,
+    source_channel_instance_key: Option<&str>,
+    requesting_channel: &str,
+    requesting_channel_instance_key: Option<&str>,
+) -> bool {
+    match source_channel {
         None => false,
         Some(src) if src == BOOTSTRAP_SOURCE_CHANNEL => true,
-        Some(src) => src == requesting || TRUSTED_APPROVAL_CHANNELS.contains(&requesting),
+        Some(_) if TRUSTED_APPROVAL_CHANNELS.contains(&requesting_channel) => true,
+        Some(src) => match source_channel_instance_key {
+            Some(source_instance_key) => {
+                requesting_channel_instance_key == Some(source_instance_key)
+            }
+            None => src == requesting_channel,
+        },
     }
 }
 
@@ -359,6 +379,7 @@ impl Thread {
             pending_auth: None,
             pending_messages: VecDeque::new(),
             source_channel: source_channel.map(String::from),
+            source_channel_instance_key: None,
         }
     }
 
@@ -377,7 +398,18 @@ impl Thread {
             pending_auth: None,
             pending_messages: VecDeque::new(),
             source_channel: source_channel.map(String::from),
+            source_channel_instance_key: None,
         }
+    }
+
+    /// Set the internal runtime/dispatch key for the channel instance that
+    /// created this thread.
+    pub fn with_source_channel_instance_key(
+        mut self,
+        source_channel_instance_key: Option<String>,
+    ) -> Self {
+        self.source_channel_instance_key = source_channel_instance_key;
+        self
     }
 
     /// Get the current turn number (1-indexed for display).
@@ -1972,6 +2004,16 @@ mod tests {
     }
 
     #[test]
+    fn test_thread_can_store_source_channel_instance_key() {
+        let thread = Thread::new(Uuid::new_v4(), Some("telegram"))
+            .with_source_channel_instance_key(Some("tenant-a:telegram".to_string()));
+        assert_eq!(
+            thread.source_channel_instance_key.as_deref(),
+            Some("tenant-a:telegram")
+        );
+    }
+
+    #[test]
     fn test_thread_new_none_channel() {
         let thread = Thread::new(Uuid::new_v4(), None);
         assert!(thread.source_channel.is_none());
@@ -2001,6 +2043,32 @@ mod tests {
             is_approval_authorized(Some("telegram"), "telegram"),
             "same channel should be authorized"
         );
+    }
+
+    #[test]
+    fn test_approval_authorized_requires_matching_instance_key_for_non_trusted_channels() {
+        assert!(is_approval_authorized_for_instance(
+            Some("telegram"),
+            Some("tenant-a:telegram"),
+            "telegram",
+            Some("tenant-a:telegram"),
+        ));
+        assert!(!is_approval_authorized_for_instance(
+            Some("telegram"),
+            Some("tenant-a:telegram"),
+            "telegram",
+            Some("tenant-b:telegram"),
+        ));
+    }
+
+    #[test]
+    fn test_approval_authorized_trusted_channel_bypasses_instance_match() {
+        assert!(is_approval_authorized_for_instance(
+            Some("telegram"),
+            Some("tenant-a:telegram"),
+            "gateway",
+            None,
+        ));
     }
 
     #[test]

--- a/src/agent/session_manager.rs
+++ b/src/agent/session_manager.rs
@@ -20,6 +20,8 @@ const SESSION_COUNT_WARNING_THRESHOLD: usize = 1000;
 #[derive(Clone, Hash, Eq, PartialEq)]
 struct ThreadKey {
     user_id: String,
+    /// Internal channel dispatch identity used to isolate concrete runtime
+    /// instances that may share the same semantic channel kind.
     channel: String,
     external_thread_id: Option<String>,
 }
@@ -110,8 +112,27 @@ impl SessionManager {
         channel: &str,
         external_thread_id: Option<&str>,
     ) -> (Arc<Mutex<Session>>, Uuid) {
-        self.resolve_thread_with_parsed_uuid(user_id, channel, external_thread_id, None)
+        self.resolve_thread_for_channel_instance(user_id, channel, channel, external_thread_id)
             .await
+    }
+
+    /// Resolve an external thread ID while preserving a semantic source
+    /// channel separate from the internal channel dispatch key.
+    pub async fn resolve_thread_for_channel_instance(
+        &self,
+        user_id: &str,
+        source_channel: &str,
+        channel_dispatch_key: &str,
+        external_thread_id: Option<&str>,
+    ) -> (Arc<Mutex<Session>>, Uuid) {
+        self.resolve_thread_with_parsed_uuid_for_channel_instance(
+            user_id,
+            source_channel,
+            channel_dispatch_key,
+            external_thread_id,
+            None,
+        )
+        .await
     }
 
     /// Like [`resolve_thread`](Self::resolve_thread), but accepts a pre-parsed
@@ -127,11 +148,32 @@ impl SessionManager {
         external_thread_id: Option<&str>,
         parsed_uuid: Option<Uuid>,
     ) -> (Arc<Mutex<Session>>, Uuid) {
+        self.resolve_thread_with_parsed_uuid_for_channel_instance(
+            user_id,
+            channel,
+            channel,
+            external_thread_id,
+            parsed_uuid,
+        )
+        .await
+    }
+
+    /// Like [`resolve_thread_with_parsed_uuid`](Self::resolve_thread_with_parsed_uuid),
+    /// but distinguishes the semantic source channel from the internal channel
+    /// dispatch key used to isolate concrete runtime instances.
+    pub async fn resolve_thread_with_parsed_uuid_for_channel_instance(
+        &self,
+        user_id: &str,
+        source_channel: &str,
+        channel_dispatch_key: &str,
+        external_thread_id: Option<&str>,
+        parsed_uuid: Option<Uuid>,
+    ) -> (Arc<Mutex<Session>>, Uuid) {
         let session = self.get_or_create_session(user_id).await;
 
         let key = ThreadKey {
             user_id: user_id.to_string(),
-            channel: channel.to_string(),
+            channel: channel_dispatch_key.to_string(),
             external_thread_id: external_thread_id.map(String::from),
         };
 
@@ -218,10 +260,11 @@ impl SessionManager {
 
             let mut sess = session.lock().await;
             let thread = if let Some(uuid) = safe_ext_uuid {
-                sess.create_thread_with_id(uuid, Some(channel))
+                sess.create_thread_with_id(uuid, Some(source_channel))
             } else {
-                sess.create_thread(Some(channel))
+                sess.create_thread(Some(source_channel))
             };
+            thread.source_channel_instance_key = Some(channel_dispatch_key.to_string());
             thread.id
         };
 
@@ -250,9 +293,23 @@ impl SessionManager {
         thread_id: Uuid,
         session: Arc<Mutex<Session>>,
     ) {
+        self.register_thread_for_channel_instance(user_id, channel, channel, thread_id, session)
+            .await;
+    }
+
+    /// Register a hydrated thread with a separate semantic source channel and
+    /// internal dispatch key.
+    pub async fn register_thread_for_channel_instance(
+        &self,
+        user_id: &str,
+        _source_channel: &str,
+        channel_dispatch_key: &str,
+        thread_id: Uuid,
+        session: Arc<Mutex<Session>>,
+    ) {
         let key = ThreadKey {
             user_id: user_id.to_string(),
-            channel: channel.to_string(),
+            channel: channel_dispatch_key.to_string(),
             external_thread_id: Some(thread_id.to_string()),
         };
 
@@ -586,6 +643,46 @@ mod tests {
 
         // Same user + same external ID but different channels = different threads
         assert_ne!(t1, t2);
+    }
+
+    #[tokio::test]
+    async fn test_resolve_thread_same_semantic_channel_different_dispatch_keys_isolated() {
+        let manager = SessionManager::new();
+
+        let (session, t1) = manager
+            .resolve_thread_for_channel_instance(
+                "user-1",
+                "telegram",
+                "tenant-a:telegram",
+                Some("thread-x"),
+            )
+            .await;
+        let (_, t2) = manager
+            .resolve_thread_for_channel_instance(
+                "user-1",
+                "telegram",
+                "tenant-b:telegram",
+                Some("thread-x"),
+            )
+            .await;
+
+        assert_ne!(t1, t2);
+
+        let session = session.lock().await;
+        assert_eq!(
+            session
+                .threads
+                .get(&t1)
+                .and_then(|thread| thread.source_channel.as_deref()),
+            Some("telegram")
+        );
+        assert_eq!(
+            session
+                .threads
+                .get(&t2)
+                .and_then(|thread| thread.source_channel.as_deref()),
+            Some("telegram")
+        );
     }
 
     #[tokio::test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -360,6 +360,14 @@ fn gate_display_parameters(pending: &PendingGate) -> serde_json::Value {
         .unwrap_or_else(|| pending.parameters.clone())
 }
 
+fn engine_conversation_key(message: &IncomingMessage) -> String {
+    let channel_key = message.channel_dispatch_key();
+    match message.conversation_scope() {
+        Some(scope_id) => format!("{}:{}", channel_key, scope_id),
+        None => channel_key.to_string(),
+    }
+}
+
 /// Resolve the owning extension name for a tool action, falling back to a
 /// credential name when the action isn't extension-backed. This is the
 /// shared core of the auth-gate display + submit routing logic — the same
@@ -772,6 +780,7 @@ async fn requeue_auth_pending_gate(
         scope_thread_id: pending.scope_thread_id.clone(),
         conversation_id: pending.conversation_id,
         source_channel: pending.source_channel.clone(),
+        source_channel_instance_key: pending.source_channel_instance_key.clone(),
         action_name: pending.action_name.clone(),
         call_id: pending.call_id.clone(),
         parameters: pending.parameters.clone(),
@@ -802,6 +811,7 @@ fn pairing_pending_gate_from_auth(pending: &PendingGate, extension_name: &str) -
         scope_thread_id: pending.scope_thread_id.clone(),
         conversation_id: pending.conversation_id,
         source_channel: pending.source_channel.clone(),
+        source_channel_instance_key: pending.source_channel_instance_key.clone(),
         action_name: pending.action_name.clone(),
         call_id: pending.call_id.clone(),
         parameters: pending.parameters.clone(),
@@ -1146,6 +1156,7 @@ async fn execute_pending_gate_action(
                 scope_thread_id: pending.scope_thread_id.clone(),
                 conversation_id: pending.conversation_id,
                 source_channel: message.channel.clone(),
+                source_channel_instance_key: Some(message.channel_dispatch_key().to_string()),
                 action_name: action_name.clone(),
                 call_id,
                 parameters: *parameters,
@@ -2480,7 +2491,12 @@ pub async fn resolve_gate(
 
     let pending = state
         .pending_gates
-        .take_verified(&key, request_id, &message.channel)
+        .take_verified_for_channel_instance(
+            &key,
+            request_id,
+            &message.channel,
+            Some(message.channel_dispatch_key()),
+        )
         .await
         .map_err(|e| {
             use crate::gate::store::GateStoreError;
@@ -2964,9 +2980,10 @@ pub async fn handle_interrupt(
         .as_ref()
         .ok_or_else(|| engine_err("init", "engine state is empty"))?;
 
+    let conversation_key = engine_conversation_key(message);
     let conv_id = state
         .conversation_manager
-        .get_or_create_conversation(&message.channel, &message.user_id)
+        .get_or_create_conversation(&conversation_key, &message.user_id)
         .await
         .map_err(|e| engine_err("conversation error", e))?;
 
@@ -3038,16 +3055,12 @@ pub async fn handle_expected(
         .as_ref()
         .ok_or_else(|| engine_err("init", "engine state is empty"))?;
 
-    // Find the conversation for this channel+user
-    let scope = message.conversation_scope();
-    let channel_key = match scope {
-        Some(tid) => format!("{}:{}", message.channel, tid),
-        None => message.channel.clone(),
-    };
+    // Find the conversation for this channel instance + user.
+    let conversation_key = engine_conversation_key(message);
 
     let conv_id = state
         .conversation_manager
-        .get_or_create_conversation(&channel_key, &message.user_id)
+        .get_or_create_conversation(&conversation_key, &message.user_id)
         .await
         .map_err(|e| engine_err("conversation error", e))?;
 
@@ -3207,9 +3220,10 @@ async fn clear_engine_conversation(agent: &Agent, message: &IncomingMessage) -> 
         .as_ref()
         .ok_or_else(|| engine_err("init", "engine state is empty"))?;
 
+    let conversation_key = engine_conversation_key(message);
     let conv_id = state
         .conversation_manager
-        .get_or_create_conversation(&message.channel, &message.user_id)
+        .get_or_create_conversation(&conversation_key, &message.user_id)
         .await
         .map_err(|e| engine_err("conversation error", e))?;
 
@@ -3615,15 +3629,12 @@ async fn handle_with_engine_inner(
     // engine conversation. Without this, all threads share one conversation
     // and messages appear in the wrong place.
     let scope = message.conversation_scope();
-    let channel_key = match scope {
-        Some(tid) => format!("{}:{}", message.channel, tid),
-        None => message.channel.clone(),
-    };
+    let conversation_key = engine_conversation_key(message);
 
-    // Get or create conversation for this scoped channel+user
+    // Get or create conversation for this scoped channel instance + user.
     let conv_id = state
         .conversation_manager
-        .get_or_create_conversation(&channel_key, &message.user_id)
+        .get_or_create_conversation(&conversation_key, &message.user_id)
         .await
         .map_err(|e| engine_err("conversation error", e))?;
 
@@ -3950,6 +3961,7 @@ async fn await_thread_outcome(
                     }),
                     conversation_id: conv_id,
                     source_channel: message.channel.clone(),
+                    source_channel_instance_key: Some(message.channel_dispatch_key().to_string()),
                     action_name: "authentication_fallback".into(),
                     call_id: format!("fallback-auth-{thread_id}"),
                     parameters: serde_json::json!({ "credential_name": cred_name }),
@@ -4090,6 +4102,7 @@ async fn await_thread_outcome(
                 }),
                 conversation_id: conv_id,
                 source_channel: message.channel.clone(),
+                source_channel_instance_key: Some(message.channel_dispatch_key().to_string()),
                 action_name: action_name.clone(),
                 call_id,
                 parameters,
@@ -6118,6 +6131,26 @@ mod tests {
         );
     }
 
+    #[test]
+    fn engine_conversation_key_prefers_channel_instance_key() {
+        let message = IncomingMessage::new("telegram", "alice", "hello")
+            .with_channel_instance_key("tenant-a:telegram")
+            .with_conversation_scope("chat-42");
+
+        assert_eq!(
+            engine_conversation_key(&message),
+            "tenant-a:telegram:chat-42"
+        );
+    }
+
+    #[test]
+    fn engine_conversation_key_falls_back_to_semantic_channel_name() {
+        let message =
+            IncomingMessage::new("telegram", "alice", "hello").with_conversation_scope("chat-42");
+
+        assert_eq!(engine_conversation_key(&message), "telegram:chat-42");
+    }
+
     /// When the SSE stream is already rendering the failure to the
     /// originating channel (gateway web UI), the helper must return
     /// `NoResponse` so `channel.respond()` does not broadcast a second
@@ -6447,6 +6480,7 @@ mod tests {
             scope_thread_id: None,
             conversation_id: ironclaw_engine::ConversationId::new(),
             source_channel: "web".into(),
+            source_channel_instance_key: Some("web".into()),
             action_name: "shell".into(),
             call_id: format!("call-{thread_id}"),
             parameters: serde_json::json!({"cmd": "ls"}),

--- a/src/channels/channel.rs
+++ b/src/channels/channel.rs
@@ -68,8 +68,11 @@ pub struct IncomingAttachment {
 pub struct IncomingMessage {
     /// Unique message ID.
     pub id: Uuid,
-    /// Channel this message came from.
+    /// Semantic channel kind this message came from (e.g. `telegram`).
     pub channel: String,
+    /// Internal runtime/dispatch identity for this message's originating
+    /// channel instance. When unset, callers should fall back to `channel`.
+    pub channel_instance_key: Option<String>,
     /// Resolved owner identity for this message.
     ///
     /// For owner-capable channels this is the stable instance owner ID when the
@@ -139,6 +142,7 @@ impl IncomingMessage {
         Self {
             id: Uuid::new_v4(),
             channel: channel.into(),
+            channel_instance_key: None,
             sender_id: user_id.clone(),
             user_id,
             user_name: None,
@@ -221,6 +225,20 @@ impl IncomingMessage {
         self.conversation_scope_id = Some(thread_id.as_str().to_string());
         self.thread_id = Some(thread_id);
         self
+    }
+
+    /// Set the internal runtime/dispatch key for the originating channel instance.
+    pub fn with_channel_instance_key(mut self, channel_instance_key: impl Into<String>) -> Self {
+        self.channel_instance_key = Some(channel_instance_key.into());
+        self
+    }
+
+    /// Effective internal dispatch key for routing responses/status back to the
+    /// originating channel instance.
+    pub fn channel_dispatch_key(&self) -> &str {
+        self.channel_instance_key
+            .as_deref()
+            .unwrap_or(self.channel.as_str())
     }
 
     /// Set the channel-specific sender/actor identifier.
@@ -863,8 +881,14 @@ impl ChatApprovalPrompt {
 /// a unified format. They also handle sending responses back.
 #[async_trait]
 pub trait Channel: Send + Sync {
-    /// Get the channel name (e.g., "cli", "slack", "telegram", "http").
+    /// Get the semantic channel name/kind (e.g., "cli", "slack", "telegram", "http").
     fn name(&self) -> &str;
+
+    /// Get the internal dispatch key used to route responses back to this
+    /// concrete runtime instance.
+    fn dispatch_key(&self) -> &str {
+        self.name()
+    }
 
     /// Start listening for messages.
     ///
@@ -1089,6 +1113,26 @@ mod tests {
     fn test_incoming_message_with_timezone() {
         let msg = IncomingMessage::new("test", "user1", "hello").with_timezone("America/New_York");
         assert_eq!(msg.timezone.as_deref(), Some("America/New_York"));
+    }
+
+    #[test]
+    fn test_incoming_message_prefers_instance_key_for_dispatch() {
+        let msg = IncomingMessage::new("telegram", "user1", "hello")
+            .with_channel_instance_key("tenant-a:telegram");
+
+        assert_eq!(msg.channel, "telegram");
+        assert_eq!(
+            msg.channel_instance_key.as_deref(),
+            Some("tenant-a:telegram")
+        );
+        assert_eq!(msg.channel_dispatch_key(), "tenant-a:telegram");
+    }
+
+    #[test]
+    fn test_incoming_message_dispatch_key_falls_back_to_channel_name() {
+        let msg = IncomingMessage::new("telegram", "user1", "hello");
+
+        assert_eq!(msg.channel_dispatch_key(), "telegram");
     }
 
     #[test]

--- a/src/channels/manager.rs
+++ b/src/channels/manager.rs
@@ -41,12 +41,12 @@ impl ChannelManager {
 
     /// Add a channel to the manager.
     pub async fn add(&self, channel: Box<dyn Channel>) {
-        let name = channel.name().to_string();
+        let dispatch_key = channel.dispatch_key().to_string();
         self.channels
             .write()
             .await
-            .insert(name.clone(), Arc::from(channel));
-        tracing::debug!("Added channel: {}", name);
+            .insert(dispatch_key.clone(), Arc::from(channel));
+        tracing::debug!(channel = %dispatch_key, "Added channel");
     }
 
     /// Hot-add a channel to a running agent.
@@ -55,14 +55,14 @@ impl ChannelManager {
     /// and spawns a task that forwards its stream messages through `inject_tx` into
     /// the agent loop.
     pub async fn hot_add(&self, channel: Box<dyn Channel>) -> Result<(), ChannelError> {
-        let name = channel.name().to_string();
+        let dispatch_key = channel.dispatch_key().to_string();
 
-        // Shut down any existing channel with the same name to avoid parallel consumers.
-        // The old forwarding task will stop when the channel's stream ends after shutdown.
+        // Shut down any existing channel with the same dispatch key to avoid
+        // parallel consumers for the same runtime instance.
         {
             let channels = self.channels.read().await;
-            if let Some(existing) = channels.get(&name) {
-                tracing::debug!(channel = %name, "Shutting down existing channel before hot-add replacement");
+            if let Some(existing) = channels.get(&dispatch_key) {
+                tracing::debug!(channel = %dispatch_key, "Shutting down existing channel before hot-add replacement");
                 let _ = existing.shutdown().await;
             }
         }
@@ -73,7 +73,7 @@ impl ChannelManager {
         self.channels
             .write()
             .await
-            .insert(name.clone(), Arc::from(channel));
+            .insert(dispatch_key.clone(), Arc::from(channel));
 
         // Forward stream messages through inject_tx
         let tx = self.inject_tx.clone();
@@ -82,11 +82,11 @@ impl ChannelManager {
             let mut stream = stream;
             while let Some(msg) = stream.next().await {
                 if tx.send(msg).await.is_err() {
-                    tracing::warn!(channel = %name, "Inject channel closed, stopping hot-added channel");
+                    tracing::warn!(channel = %dispatch_key, "Inject channel closed, stopping hot-added channel");
                     break;
                 }
             }
-            tracing::debug!(channel = %name, "Hot-added channel stream ended");
+            tracing::debug!(channel = %dispatch_key, "Hot-added channel stream ended");
         });
 
         Ok(())
@@ -138,12 +138,13 @@ impl ChannelManager {
         msg: &IncomingMessage,
         response: OutgoingResponse,
     ) -> Result<(), ChannelError> {
+        let dispatch_key = msg.channel_dispatch_key();
         let channels = self.channels.read().await;
-        if let Some(channel) = channels.get(&msg.channel) {
+        if let Some(channel) = channels.get(dispatch_key) {
             channel.respond(msg, response).await
         } else {
             Err(ChannelError::SendFailed {
-                name: msg.channel.clone(),
+                name: dispatch_key.to_string(),
                 reason: "Channel not found".to_string(),
             })
         }
@@ -230,9 +231,16 @@ impl ChannelManager {
         Ok(())
     }
 
-    /// Get list of channel names.
+    /// Get the set of semantic channel names currently registered.
     pub async fn channel_names(&self) -> Vec<String> {
-        self.channels.read().await.keys().cloned().collect()
+        let channels = self.channels.read().await;
+        let mut names: Vec<String> = channels
+            .values()
+            .map(|channel| channel.name().to_string())
+            .collect();
+        names.sort();
+        names.dedup();
+        names
     }
 
     /// Get a channel by name.
@@ -307,6 +315,46 @@ mod tests {
         let msg = IncomingMessage::new("nonexistent", "user1", "test");
         let result = manager.respond(&msg, OutgoingResponse::text("hi")).await;
         assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_same_semantic_channel_names_can_coexist_with_distinct_dispatch_keys() {
+        let manager = ChannelManager::new();
+        let (stub_a, _tx_a) = StubChannel::with_dispatch_key("telegram", "tenant-a:telegram");
+        let (stub_b, _tx_b) = StubChannel::with_dispatch_key("telegram", "tenant-b:telegram");
+
+        manager.add(Box::new(stub_a)).await;
+        manager.add(Box::new(stub_b)).await;
+
+        let channels = manager.channels.read().await;
+        assert_eq!(channels.len(), 2);
+        assert!(channels.contains_key("tenant-a:telegram"));
+        assert!(channels.contains_key("tenant-b:telegram"));
+    }
+
+    #[tokio::test]
+    async fn test_respond_routes_by_instance_key_before_semantic_channel_name() {
+        let manager = ChannelManager::new();
+        let (stub_a, _tx_a) = StubChannel::with_dispatch_key("telegram", "tenant-a:telegram");
+        let (stub_b, _tx_b) = StubChannel::with_dispatch_key("telegram", "tenant-b:telegram");
+
+        let responses_a = stub_a.captured_responses_handle();
+        let responses_b = stub_b.captured_responses_handle();
+
+        manager.add(Box::new(stub_a)).await;
+        manager.add(Box::new(stub_b)).await;
+
+        let msg = IncomingMessage::new("telegram", "user1", "request")
+            .with_channel_instance_key("tenant-b:telegram");
+        manager
+            .respond(&msg, OutgoingResponse::text("reply"))
+            .await
+            .expect("respond failed");
+
+        assert!(responses_a.lock().expect("poisoned").is_empty());
+        let captured_b = responses_b.lock().expect("poisoned");
+        assert_eq!(captured_b.len(), 1);
+        assert_eq!(captured_b[0].1.content, "reply");
     }
 
     #[tokio::test]

--- a/src/channels/wasm/router.rs
+++ b/src/channels/wasm/router.rs
@@ -295,6 +295,14 @@ async fn health_handler(State(state): State<RouterState>) -> impl IntoResponse {
     })
 }
 
+fn is_valid_webhook_dispatch_path(path: &str) -> bool {
+    !path.is_empty()
+        && !path.contains('/')
+        && !path.contains('\\')
+        && !path.contains('\0')
+        && !path.contains("..")
+}
+
 /// Generic webhook handler that routes to the appropriate WASM channel.
 async fn webhook_handler(
     State(state): State<RouterState>,
@@ -304,6 +312,16 @@ async fn webhook_handler(
     headers: HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    if !is_valid_webhook_dispatch_path(&path) {
+        tracing::warn!(path = %path, "Rejected invalid webhook dispatch path");
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "Invalid webhook path",
+            })),
+        );
+    }
+
     let full_path = format!("/webhook/{}", path);
 
     tracing::info!(
@@ -1483,6 +1501,25 @@ mod tests {
             resp.status(),
             StatusCode::UNAUTHORIZED,
             "Valid Telegram webhook secret should not return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_webhook_rejects_invalid_dispatch_key_path_segments() {
+        let app = create_wasm_channel_router(Arc::new(WasmChannelRouter::new()), None);
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/tenant-a..telegram")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"update_id":1}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "Invalid dispatch-key path segments should be rejected at the webhook boundary"
         );
     }
 

--- a/src/channels/wasm/router.rs
+++ b/src/channels/wasm/router.rs
@@ -333,18 +333,20 @@ async fn webhook_handler(
 
     tracing::info!(
         channel = %channel.channel_name(),
+        dispatch_key = %channel.channel_dispatch_key(),
         "Found channel for webhook"
     );
 
     let channel_name = channel.channel_name();
+    let channel_dispatch_key = channel.channel_dispatch_key();
 
     // Track whether any authentication was performed and passed.
     let mut did_authenticate = false;
 
     // Check if secret is required
-    if state.router.requires_secret(channel_name).await {
+    if state.router.requires_secret(channel_dispatch_key).await {
         // Get the secret header name for this channel (from capabilities or default)
-        let secret_header_name = state.router.get_secret_header(channel_name).await;
+        let secret_header_name = state.router.get_secret_header(channel_dispatch_key).await;
 
         // Try to get secret from query param or the channel's configured header
         let provided_secret = query
@@ -377,7 +379,11 @@ async fn webhook_handler(
 
         match provided_secret {
             Some(secret) => {
-                if !state.router.validate_secret(channel_name, &secret).await {
+                if !state
+                    .router
+                    .validate_secret(channel_dispatch_key, &secret)
+                    .await
+                {
                     tracing::warn!(
                         channel = %channel_name,
                         "Webhook secret validation failed"
@@ -408,7 +414,7 @@ async fn webhook_handler(
     }
 
     // Ed25519 signature verification (Discord-style)
-    if let Some(pub_key_hex) = state.router.get_signature_key(channel_name).await {
+    if let Some(pub_key_hex) = state.router.get_signature_key(channel_dispatch_key).await {
         let sig_hex = headers
             .get("x-signature-ed25519")
             .and_then(|v| v.to_str().ok());
@@ -460,7 +466,7 @@ async fn webhook_handler(
     }
 
     // HMAC-SHA256 signature verification (Slack-style)
-    if let Some(hmac_secret) = state.router.get_hmac_secret(channel_name).await {
+    if let Some(hmac_secret) = state.router.get_hmac_secret(channel_dispatch_key).await {
         let timestamp = headers
             .get("x-slack-request-timestamp")
             .and_then(|v| v.to_str().ok());
@@ -1397,6 +1403,30 @@ mod tests {
         (wasm_router, app)
     }
 
+    async fn setup_telegram_dispatch_secret_router() -> (Arc<WasmChannelRouter>, AxumRouter) {
+        let wasm_router = Arc::new(WasmChannelRouter::new());
+        let channel = create_test_channel_with_dispatch_key("telegram", "tenant-a:telegram");
+
+        let endpoints = vec![RegisteredEndpoint {
+            channel_name: "tenant-a:telegram".to_string(),
+            path: "/webhook/tenant-a:telegram".to_string(),
+            methods: vec!["POST".to_string()],
+            require_secret: true,
+        }];
+
+        wasm_router
+            .register(
+                channel,
+                endpoints,
+                Some("tenant-a-secret".to_string()),
+                Some("X-Telegram-Bot-Api-Secret-Token".to_string()),
+            )
+            .await;
+
+        let app = create_wasm_channel_router(wasm_router.clone(), None);
+        (wasm_router, app)
+    }
+
     #[tokio::test]
     async fn test_telegram_webhook_secret_rejects_missing_header() {
         let (_wasm_router, app) = setup_telegram_secret_router().await;
@@ -1453,6 +1483,46 @@ mod tests {
             resp.status(),
             StatusCode::UNAUTHORIZED,
             "Valid Telegram webhook secret should not return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_key_webhook_secret_rejects_invalid_header() {
+        let (_wasm_router, app) = setup_telegram_dispatch_secret_router().await;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/tenant-a:telegram")
+            .header("content-type", "application/json")
+            .header("X-Telegram-Bot-Api-Secret-Token", "wrong-secret")
+            .body(Body::from(r#"{"update_id":1}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Invalid dispatch-key Telegram webhook secret should return 401"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_key_webhook_secret_accepts_valid_header() {
+        let (_wasm_router, app) = setup_telegram_dispatch_secret_router().await;
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/webhook/tenant-a:telegram")
+            .header("content-type", "application/json")
+            .header("X-Telegram-Bot-Api-Secret-Token", "tenant-a-secret")
+            .body(Body::from(r#"{"update_id":1}"#))
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_ne!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "Valid dispatch-key Telegram webhook secret should not return 401"
         );
     }
 

--- a/src/channels/wasm/router.rs
+++ b/src/channels/wasm/router.rs
@@ -22,7 +22,7 @@ use crate::channels::wasm::wrapper::WasmChannel;
 /// A registered HTTP endpoint for a WASM channel.
 #[derive(Debug, Clone)]
 pub struct RegisteredEndpoint {
-    /// Channel name that owns this endpoint.
+    /// Channel dispatch key that owns this endpoint.
     pub channel_name: String,
     /// HTTP path (e.g., "/webhook/slack").
     pub path: String,
@@ -76,31 +76,36 @@ impl WasmChannelRouter {
         secret: Option<String>,
         secret_header: Option<String>,
     ) {
-        let name = channel.channel_name().to_string();
+        let semantic_name = channel.channel_name().to_string();
+        let dispatch_key = channel.channel_dispatch_key().to_string();
 
-        // Store the channel
-        self.channels.write().await.insert(name.clone(), channel);
+        // Store the channel by its concrete runtime dispatch key.
+        self.channels
+            .write()
+            .await
+            .insert(dispatch_key.clone(), channel);
 
-        // Register path mappings
+        // Register path mappings.
         let mut path_map = self.path_to_channel.write().await;
         for endpoint in endpoints {
-            path_map.insert(endpoint.path.clone(), name.clone());
+            path_map.insert(endpoint.path.clone(), dispatch_key.clone());
             tracing::info!(
-                channel = %name,
+                channel = %semantic_name,
+                dispatch_key = %dispatch_key,
                 path = %endpoint.path,
                 methods = ?endpoint.methods,
                 "Registered WASM channel HTTP endpoint"
             );
         }
 
-        // Store secret if provided
+        // Store secret if provided.
         if let Some(s) = secret {
-            self.secrets.write().await.insert(name.clone(), s);
+            self.secrets.write().await.insert(dispatch_key.clone(), s);
         }
 
-        // Store secret header if provided
+        // Store secret header if provided.
         if let Some(h) = secret_header {
-            self.secret_headers.write().await.insert(name, h);
+            self.secret_headers.write().await.insert(dispatch_key, h);
         }
     }
 
@@ -173,7 +178,7 @@ impl WasmChannelRouter {
         self.secrets.read().await.contains_key(channel_name)
     }
 
-    /// List all registered channels.
+    /// List all registered channel dispatch keys.
     pub async fn list_channels(&self) -> Vec<String> {
         self.channels.read().await.keys().cloned().collect()
     }
@@ -662,6 +667,10 @@ mod tests {
     use crate::tools::wasm::ResourceLimits;
 
     fn create_test_channel(name: &str) -> Arc<WasmChannel> {
+        create_test_channel_with_dispatch_key(name, name)
+    }
+
+    fn create_test_channel_with_dispatch_key(name: &str, dispatch_key: &str) -> Arc<WasmChannel> {
         let config = WasmChannelRuntimeConfig::for_testing();
         let runtime = Arc::new(WasmChannelRuntime::new(config).unwrap());
 
@@ -675,15 +684,18 @@ mod tests {
         let capabilities =
             ChannelCapabilities::for_channel(name).with_path(format!("/webhook/{}", name));
 
-        Arc::new(WasmChannel::new(
-            runtime,
-            prepared,
-            capabilities,
-            "default",
-            "{}".to_string(),
-            Arc::new(PairingStore::new_noop()),
-            None,
-        ))
+        Arc::new(
+            WasmChannel::new(
+                runtime,
+                prepared,
+                capabilities,
+                "default",
+                "{}".to_string(),
+                Arc::new(PairingStore::new_noop()),
+                None,
+            )
+            .with_dispatch_key(dispatch_key),
+        )
     }
 
     #[tokio::test]
@@ -710,6 +722,70 @@ mod tests {
         // Should not find non-existent path
         let not_found = router.get_channel_for_path("/webhook/telegram").await;
         assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_router_keeps_distinct_dispatch_instances_for_same_semantic_channel() {
+        let router = WasmChannelRouter::new();
+        let channel_a = create_test_channel_with_dispatch_key("telegram", "tenant-a:telegram");
+        let channel_b = create_test_channel_with_dispatch_key("telegram", "tenant-b:telegram");
+
+        router
+            .register(
+                channel_a,
+                vec![RegisteredEndpoint {
+                    channel_name: "tenant-a:telegram".to_string(),
+                    path: "/webhook/tenant-a-telegram".to_string(),
+                    methods: vec!["POST".to_string()],
+                    require_secret: true,
+                }],
+                Some("secret-a".to_string()),
+                None,
+            )
+            .await;
+        router
+            .register(
+                channel_b,
+                vec![RegisteredEndpoint {
+                    channel_name: "tenant-b:telegram".to_string(),
+                    path: "/webhook/tenant-b-telegram".to_string(),
+                    methods: vec!["POST".to_string()],
+                    require_secret: true,
+                }],
+                Some("secret-b".to_string()),
+                None,
+            )
+            .await;
+
+        let found_a = router
+            .get_channel_for_path("/webhook/tenant-a-telegram")
+            .await
+            .expect("tenant A path should resolve");
+        assert_eq!(found_a.channel_name(), "telegram");
+        assert_eq!(found_a.channel_dispatch_key(), "tenant-a:telegram");
+
+        let found_b = router
+            .get_channel_for_path("/webhook/tenant-b-telegram")
+            .await
+            .expect("tenant B path should resolve");
+        assert_eq!(found_b.channel_name(), "telegram");
+        assert_eq!(found_b.channel_dispatch_key(), "tenant-b:telegram");
+
+        assert!(
+            router
+                .validate_secret("tenant-a:telegram", "secret-a")
+                .await
+        );
+        assert!(
+            !router
+                .validate_secret("tenant-a:telegram", "secret-b")
+                .await
+        );
+        assert!(
+            router
+                .validate_secret("tenant-b:telegram", "secret-b")
+                .await
+        );
     }
 
     #[tokio::test]

--- a/src/channels/wasm/wrapper.rs
+++ b/src/channels/wasm/wrapper.rs
@@ -728,8 +728,11 @@ impl near::agent::channel_host::Host for ChannelStoreData {
 /// A WASM-based channel implementing the Channel trait.
 #[allow(dead_code)]
 pub struct WasmChannel {
-    /// Channel name.
+    /// Semantic channel kind/name.
     name: String,
+
+    /// Internal dispatch key for this concrete runtime instance.
+    dispatch_key: String,
 
     /// Runtime for WASM execution.
     runtime: Arc<WasmChannelRuntime>,
@@ -1070,6 +1073,7 @@ impl WasmChannel {
         let rate_limiter = ChannelEmitRateLimiter::new(capabilities.emit_rate_limit.clone());
 
         Self {
+            dispatch_key: name.clone(),
             name,
             runtime,
             prepared,
@@ -1105,6 +1109,12 @@ impl WasmChannel {
     /// the target host (e.g., Bearer token for api.slack.com).
     pub fn with_secrets_store(mut self, store: Arc<dyn SecretsStore + Send + Sync>) -> Self {
         self.secrets_store = Some(store);
+        self
+    }
+
+    /// Override the internal dispatch key for this concrete runtime instance.
+    pub fn with_dispatch_key(mut self, dispatch_key: impl Into<String>) -> Self {
+        self.dispatch_key = dispatch_key.into();
         self
     }
 
@@ -1249,9 +1259,14 @@ impl WasmChannel {
         }
     }
 
-    /// Get the channel name.
+    /// Get the semantic channel name/kind.
     pub fn channel_name(&self) -> &str {
         &self.name
+    }
+
+    /// Get the internal dispatch key for this runtime instance.
+    pub fn channel_dispatch_key(&self) -> &str {
+        &self.dispatch_key
     }
 
     /// Settings key for persisted broadcast metadata.
@@ -1404,6 +1419,7 @@ impl WasmChannel {
         owner_actor_id: Arc<tokio::sync::RwLock<Option<String>>>,
     ) {
         let channel_name = self.name.clone();
+        let dispatch_key = self.dispatch_key.clone();
         let runtime = Arc::clone(&self.runtime);
         let prepared = Arc::clone(&self.prepared);
         let capabilities = Self::inject_workspace_reader(&self.capabilities, &self.workspace_store);
@@ -1564,6 +1580,7 @@ impl WasmChannel {
                                                         poll_guard,
                                                         WebsocketPollContext {
                                                             channel_name: channel_name.clone(),
+                                                            dispatch_key: dispatch_key.clone(),
                                                             runtime: Arc::clone(&runtime),
                                                             prepared: Arc::clone(&prepared),
                                                             capabilities: capabilities.clone(),
@@ -2848,6 +2865,7 @@ impl WasmChannel {
 
             // Convert to IncomingMessage
             let mut msg = IncomingMessage::new(&self.name, &resolved_user_id, &emitted.content)
+                .with_channel_instance_key(self.dispatch_key.clone())
                 .with_sender_id(&emitted.user_id);
 
             if let Some(name) = emitted.user_name {
@@ -2964,6 +2982,7 @@ impl WasmChannel {
         owner_actor_id: Arc<tokio::sync::RwLock<Option<String>>>,
     ) -> tokio::task::JoinHandle<()> {
         let channel_name = self.name.clone();
+        let dispatch_key = self.dispatch_key.clone();
         let runtime = Arc::clone(&self.runtime);
         let prepared = Arc::clone(&self.prepared);
         let poll_capabilities = self.capabilities.clone();
@@ -3026,6 +3045,7 @@ impl WasmChannel {
                                     && let Err(e) = Self::dispatch_emitted_messages(
                                         EmitDispatchContext {
                                             channel_name: &channel_name,
+                                            dispatch_key: &dispatch_key,
                                             owner_scope_id: &owner_scope_id,
                                             owner_actor_id: current_owner.as_deref(),
                                             pairing_store: pairing_store.as_ref(),
@@ -3245,6 +3265,7 @@ impl WasmChannel {
             // Convert to IncomingMessage
             let mut msg =
                 IncomingMessage::new(dispatch.channel_name, &resolved_user_id, &emitted.content)
+                    .with_channel_instance_key(dispatch.dispatch_key)
                     .with_sender_id(&emitted.user_id);
 
             if let Some(name) = emitted.user_name {
@@ -3328,6 +3349,7 @@ impl WasmChannel {
 
 struct EmitDispatchContext<'a> {
     channel_name: &'a str,
+    dispatch_key: &'a str,
     owner_scope_id: &'a str,
     owner_actor_id: Option<&'a str>,
     pairing_store: &'a PairingStore,
@@ -3341,6 +3363,10 @@ struct EmitDispatchContext<'a> {
 impl Channel for WasmChannel {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn dispatch_key(&self) -> &str {
+        &self.dispatch_key
     }
 
     async fn start(&self) -> Result<MessageStream, ChannelError> {
@@ -4053,6 +4079,7 @@ fn drain_guest_logs(
 /// single cloneable context so the call site stays readable.
 struct WebsocketPollContext {
     channel_name: String,
+    dispatch_key: String,
     runtime: Arc<WasmChannelRuntime>,
     prepared: Arc<PreparedChannelModule>,
     capabilities: ChannelCapabilities,
@@ -4129,6 +4156,7 @@ fn spawn_websocket_poll(poll_guard: tokio::sync::OwnedMutexGuard<()>, ctx: Webso
                         && let Err(error) = WasmChannel::dispatch_emitted_messages(
                             EmitDispatchContext {
                                 channel_name: &ctx.channel_name,
+                                dispatch_key: &ctx.dispatch_key,
                                 owner_scope_id: &ctx.owner_scope_id,
                                 owner_actor_id: current_owner.as_deref(),
                                 pairing_store: ctx.pairing_store.as_ref(),
@@ -4359,6 +4387,7 @@ impl std::fmt::Debug for WasmChannel {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("WasmChannel")
             .field("name", &self.name)
+            .field("dispatch_key", &self.dispatch_key)
             .field("prepared", &self.prepared.name)
             .finish()
     }
@@ -4401,6 +4430,10 @@ impl std::fmt::Debug for SharedWasmChannel {
 impl Channel for SharedWasmChannel {
     fn name(&self) -> &str {
         self.inner.name()
+    }
+
+    fn dispatch_key(&self) -> &str {
+        self.inner.channel_dispatch_key()
     }
 
     async fn start(&self) -> Result<MessageStream, ChannelError> {
@@ -5853,6 +5886,14 @@ mod tests {
     }
 
     #[test]
+    fn test_wasm_channel_can_override_dispatch_key_without_changing_name() {
+        let channel = create_test_channel().with_dispatch_key("tenant-a:test");
+
+        assert_eq!(channel.name(), "test");
+        assert_eq!(Channel::dispatch_key(&channel), "tenant-a:test");
+    }
+
+    #[test]
     fn test_http_response_ok() {
         let response = HttpResponse::ok();
         assert_eq!(response.status, 200);
@@ -6108,6 +6149,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "test-channel",
+                dispatch_key: "test-channel",
                 owner_scope_id: "default",
                 owner_actor_id: None,
                 pairing_store: &pairing_store,
@@ -6126,6 +6168,11 @@ mod tests {
         let msg1 = rx.try_recv().expect("Should receive first message"); // safety: test-only assertion
         assert_eq!(msg1.user_id, "user1"); // safety: test-only assertion
         assert_eq!(msg1.content, "Hello from polling!"); // safety: test-only assertion
+        assert_eq!(
+            msg1.channel_instance_key.as_deref(),
+            Some("test-channel"),
+            "legacy dispatch should fall back to semantic channel name"
+        );
 
         let msg2 = rx.try_recv().expect("Should receive second message"); // safety: test-only assertion
         assert_eq!(msg2.user_id, "user2"); // safety: test-only assertion
@@ -6133,6 +6180,45 @@ mod tests {
 
         // No more messages
         assert!(rx.try_recv().is_err()); // safety: test-only assertion
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_emitted_messages_tags_messages_with_instance_dispatch_key() {
+        use crate::channels::wasm::host::EmittedMessage;
+
+        let (tx, mut rx) = tokio::sync::mpsc::channel(10);
+        let message_tx = Arc::new(tokio::sync::RwLock::new(Some(tx)));
+        let pairing_store = PairingStore::new_noop();
+        let rate_limiter = Arc::new(tokio::sync::RwLock::new(
+            crate::channels::wasm::host::ChannelEmitRateLimiter::new(
+                crate::channels::wasm::capabilities::EmitRateLimitConfig::default(),
+            ),
+        ));
+        let last_broadcast_metadata = Arc::new(tokio::sync::RwLock::new(None));
+
+        let result = WasmChannel::dispatch_emitted_messages(
+            EmitDispatchContext {
+                channel_name: "telegram",
+                dispatch_key: "tenant-a:telegram",
+                owner_scope_id: "default",
+                owner_actor_id: None,
+                pairing_store: &pairing_store,
+                message_tx: &message_tx,
+                rate_limiter: &rate_limiter,
+                last_broadcast_metadata: &last_broadcast_metadata,
+                settings_store: None,
+            },
+            vec![EmittedMessage::new("user1", "Hello from polling!")],
+        )
+        .await;
+
+        assert!(result.is_ok());
+        let msg = rx.try_recv().expect("Should receive message");
+        assert_eq!(msg.channel, "telegram");
+        assert_eq!(
+            msg.channel_instance_key.as_deref(),
+            Some("tenant-a:telegram")
+        );
     }
 
     #[tokio::test]
@@ -6159,6 +6245,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "test-channel",
+                dispatch_key: "test-channel",
                 owner_scope_id: "default",
                 owner_actor_id: None,
                 pairing_store: &pairing_store,
@@ -6201,6 +6288,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "test-channel",
+                dispatch_key: "test-channel",
                 owner_scope_id: "default",
                 owner_actor_id: None,
                 pairing_store: &pairing_store,
@@ -7463,6 +7551,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "test-channel",
+                dispatch_key: "test-channel",
                 owner_scope_id: "default",
                 owner_actor_id: None,
                 pairing_store: &pairing_store,
@@ -7526,6 +7615,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "telegram",
+                dispatch_key: "telegram",
                 owner_scope_id: "owner-scope",
                 owner_actor_id: Some("telegram-owner"),
                 pairing_store: &pairing_store,
@@ -7603,6 +7693,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "telegram",
+                dispatch_key: "telegram",
                 owner_scope_id: "owner-scope",
                 owner_actor_id: Some("telegram-owner"),
                 pairing_store: &pairing_store,
@@ -7660,6 +7751,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "telegram",
+                dispatch_key: "telegram",
                 owner_scope_id: "owner-scope",
                 owner_actor_id: Some("telegram-owner"),
                 pairing_store: &pairing_store,
@@ -7746,6 +7838,7 @@ mod tests {
         let result = WasmChannel::dispatch_emitted_messages(
             EmitDispatchContext {
                 channel_name: "test-channel",
+                dispatch_key: "test-channel",
                 owner_scope_id: "default",
                 owner_actor_id: None,
                 pairing_store: &pairing_store,

--- a/src/channels/web/features/extensions/mod.rs
+++ b/src/channels/web/features/extensions/mod.rs
@@ -1488,6 +1488,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_extensions_list_handler_falls_back_to_legacy_active_name_when_user_has_no_instance()
+     {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let (ext_mgr, db, _secrets, state, _db_dir, _tools_dir, channels_dir) =
+            make_multi_tenant_extension_test_fixture().await;
+        insert_test_user(&db, "tenant-a", "member").await;
+        insert_test_user(&db, "tenant-b", "member").await;
+        std::fs::write(channels_dir.path().join("telegram.wasm"), b"fake-wasm")
+            .expect("write fake telegram wasm");
+        std::fs::write(
+            channels_dir.path().join("telegram.capabilities.json"),
+            serde_json::json!({
+                "type": "channel",
+                "name": "telegram",
+                "description": "Telegram",
+                "setup": { "required_secrets": [{ "name": "BOT_TOKEN", "prompt": "Enter bot token" }] },
+                "capabilities": {
+                    "channel": {
+                        "allowed_paths": ["/webhook/telegram"]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write telegram capabilities");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant-b instance");
+        ext_mgr
+            .set_active_channels(vec!["telegram".to_string()])
+            .await;
+
+        let app = Router::new()
+            .route("/api/extensions", get(extensions_list_handler))
+            .with_state(state);
+
+        let mut req_tenant_a = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("tenant-a request");
+        req_tenant_a.extensions_mut().insert(UserIdentity {
+            user_id: "tenant-a".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp_tenant_a = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req_tenant_a)
+            .await
+            .expect("tenant-a response");
+        assert_eq!(resp_tenant_a.status(), StatusCode::OK);
+        let body_tenant_a = axum::body::to_bytes(resp_tenant_a.into_body(), 1024 * 64)
+            .await
+            .expect("tenant-a body");
+        let parsed_tenant_a: serde_json::Value =
+            serde_json::from_slice(&body_tenant_a).expect("tenant-a json");
+        let telegram_tenant_a = parsed_tenant_a["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("tenant-a telegram entry");
+        assert_eq!(telegram_tenant_a["active"], true);
+    }
+
+    #[tokio::test]
     async fn test_extensions_list_handler_isolates_owner_binding_status_per_tenant_instance() {
         use crate::secrets::CreateSecretParams;
         use axum::body::Body;

--- a/src/channels/web/features/extensions/mod.rs
+++ b/src/channels/web/features/extensions/mod.rs
@@ -118,10 +118,16 @@ pub(crate) async fn extensions_list_handler(
     let mut paired_channels = std::collections::HashSet::new();
     for ext in &installed {
         if ext.kind == crate::extensions::ExtensionKind::WasmChannel {
-            if ext_mgr.has_wasm_channel_owner_binding(&ext.name).await {
+            if ext_mgr
+                .has_wasm_channel_owner_binding_for_user(&ext.name, &user.user_id)
+                .await
+            {
                 owner_bound_channels.insert(ext.name.clone());
             }
-            if ext_mgr.has_wasm_channel_pairing(&ext.name).await {
+            if ext_mgr
+                .has_wasm_channel_pairing_for_user(&ext.name, &user.user_id)
+                .await
+            {
                 paired_channels.insert(ext.name.clone());
             }
         }
@@ -661,6 +667,8 @@ pub(crate) async fn extensions_setup_submit_handler(
 #[cfg(test)]
 mod tests {
 
+    use std::sync::Arc;
+
     use axum::{
         Router,
         http::StatusCode,
@@ -677,7 +685,8 @@ mod tests {
     };
 
     use crate::channels::web::test_helpers::{
-        test_ext_mgr, test_ext_mgr_with_db, test_gateway_state, test_secrets_store,
+        insert_test_user, test_ext_mgr, test_ext_mgr_with_db, test_gateway_state,
+        test_gateway_state_with_dependencies, test_secrets_store,
     };
     use crate::channels::web::types::*;
     use crate::channels::web::types::{
@@ -687,6 +696,42 @@ mod tests {
 
     use super::{derive_activation_status, derive_onboarding};
     use crate::channels::web::types::ChannelOnboardingState;
+
+    async fn make_multi_tenant_extension_test_fixture() -> (
+        Arc<crate::extensions::ExtensionManager>,
+        Arc<dyn crate::db::Database>,
+        Arc<dyn crate::secrets::SecretsStore + Send + Sync>,
+        Arc<crate::channels::web::platform::state::GatewayState>,
+        tempfile::TempDir,
+        tempfile::TempDir,
+        tempfile::TempDir,
+    ) {
+        let (db, db_dir) = crate::testing::test_db().await;
+        let secrets = test_secrets_store();
+        let tools_dir = tempfile::tempdir().expect("temp wasm tools dir");
+        let channels_dir = tempfile::tempdir().expect("temp wasm channels dir");
+        let ext_mgr = Arc::new(crate::extensions::ExtensionManager::new(
+            Arc::new(crate::tools::mcp::session::McpSessionManager::new()),
+            Arc::new(crate::tools::mcp::process::McpProcessManager::new()),
+            Arc::clone(&secrets),
+            Arc::new(crate::tools::ToolRegistry::new()),
+            None,
+            None,
+            tools_dir.path().to_path_buf(),
+            channels_dir.path().to_path_buf(),
+            None,
+            "test".to_string(),
+            Some(Arc::clone(&db)),
+            Vec::new(),
+        ));
+        let state = test_gateway_state_with_dependencies(
+            Some(Arc::clone(&ext_mgr)),
+            Some(Arc::clone(&db)),
+            None,
+            None,
+        );
+        (ext_mgr, db, secrets, state, db_dir, tools_dir, channels_dir)
+    }
 
     fn active_authenticated_wasm_channel(name: &str) -> InstalledExtension {
         InstalledExtension {
@@ -1321,6 +1366,263 @@ mod tests {
         assert_eq!(telegram["kind"], "wasm_channel");
         assert_eq!(telegram["active"], false);
         assert_eq!(telegram["activation_status"], "installed");
+    }
+
+    #[tokio::test]
+    async fn test_extensions_list_handler_isolates_active_flag_per_tenant_instance() {
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let (ext_mgr, db, _secrets, state, _db_dir, _tools_dir, channels_dir) =
+            make_multi_tenant_extension_test_fixture().await;
+        insert_test_user(&db, "tenant-a", "member").await;
+        insert_test_user(&db, "tenant-b", "member").await;
+        std::fs::write(channels_dir.path().join("telegram.wasm"), b"fake-wasm")
+            .expect("write fake telegram wasm");
+        std::fs::write(
+            channels_dir.path().join("telegram.capabilities.json"),
+            serde_json::json!({
+                "type": "channel",
+                "name": "telegram",
+                "description": "Telegram",
+                "setup": { "required_secrets": [{ "name": "BOT_TOKEN", "prompt": "Enter bot token" }] },
+                "capabilities": {
+                    "channel": {
+                        "allowed_paths": ["/webhook/telegram"]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write telegram capabilities");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-a".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-a:primary".to_string(),
+            display_name: "Tenant A Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant-a instance");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant-b instance");
+        ext_mgr
+            .set_active_channels(vec!["telegram".to_string()])
+            .await;
+
+        let app = Router::new()
+            .route("/api/extensions", get(extensions_list_handler))
+            .with_state(state);
+
+        let mut req_tenant_a = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("tenant-a request");
+        req_tenant_a.extensions_mut().insert(UserIdentity {
+            user_id: "tenant-a".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp_tenant_a =
+            ServiceExt::<axum::http::Request<Body>>::oneshot(app.clone(), req_tenant_a)
+                .await
+                .expect("tenant-a response");
+        assert_eq!(resp_tenant_a.status(), StatusCode::OK);
+        let body_tenant_a = axum::body::to_bytes(resp_tenant_a.into_body(), 1024 * 64)
+            .await
+            .expect("tenant-a body");
+        let parsed_tenant_a: serde_json::Value =
+            serde_json::from_slice(&body_tenant_a).expect("tenant-a json");
+        let telegram_tenant_a = parsed_tenant_a["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("tenant-a telegram entry");
+        assert_eq!(telegram_tenant_a["active"], false);
+
+        let mut req_tenant_b = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("tenant-b request");
+        req_tenant_b.extensions_mut().insert(UserIdentity {
+            user_id: "tenant-b".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp_tenant_b = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req_tenant_b)
+            .await
+            .expect("tenant-b response");
+        assert_eq!(resp_tenant_b.status(), StatusCode::OK);
+        let body_tenant_b = axum::body::to_bytes(resp_tenant_b.into_body(), 1024 * 64)
+            .await
+            .expect("tenant-b body");
+        let parsed_tenant_b: serde_json::Value =
+            serde_json::from_slice(&body_tenant_b).expect("tenant-b json");
+        let telegram_tenant_b = parsed_tenant_b["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("tenant-b telegram entry");
+        assert_eq!(telegram_tenant_b["active"], true);
+    }
+
+    #[tokio::test]
+    async fn test_extensions_list_handler_isolates_owner_binding_status_per_tenant_instance() {
+        use crate::secrets::CreateSecretParams;
+        use axum::body::Body;
+        use tower::ServiceExt;
+
+        let (ext_mgr, db, secrets, state, _db_dir, _tools_dir, channels_dir) =
+            make_multi_tenant_extension_test_fixture().await;
+        insert_test_user(&db, "tenant-a", "member").await;
+        insert_test_user(&db, "tenant-b", "member").await;
+        std::fs::write(channels_dir.path().join("telegram.wasm"), b"fake-wasm")
+            .expect("write fake telegram wasm");
+        std::fs::write(
+            channels_dir.path().join("telegram.capabilities.json"),
+            serde_json::json!({
+                "type": "channel",
+                "name": "telegram",
+                "description": "Telegram",
+                "setup": { "required_secrets": [{ "name": "BOT_TOKEN", "prompt": "Enter bot token" }] },
+                "capabilities": {
+                    "channel": {
+                        "allowed_paths": ["/webhook/telegram"]
+                    }
+                }
+            })
+            .to_string(),
+        )
+        .expect("write telegram capabilities");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-a".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-a:primary".to_string(),
+            display_name: "Tenant A Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant-a instance");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-b:primary".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant-b instance");
+        secrets
+            .create("tenant-a", CreateSecretParams::new("BOT_TOKEN", "token-a"))
+            .await
+            .expect("seed tenant-a secret");
+        secrets
+            .create("tenant-b", CreateSecretParams::new("BOT_TOKEN", "token-b"))
+            .await
+            .expect("seed tenant-b secret");
+        db.set_setting(
+            "tenant-b",
+            "channels.wasm_channel_owner_ids.telegram",
+            &serde_json::json!(424242_i64),
+        )
+        .await
+        .expect("seed tenant-b owner binding");
+        ext_mgr
+            .set_active_channels(vec![
+                "telegram:tenant-a:primary".to_string(),
+                "telegram:tenant-b:primary".to_string(),
+            ])
+            .await;
+
+        let app = Router::new()
+            .route("/api/extensions", get(extensions_list_handler))
+            .with_state(state);
+
+        let mut req_tenant_a = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("tenant-a request");
+        req_tenant_a.extensions_mut().insert(UserIdentity {
+            user_id: "tenant-a".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp_tenant_a =
+            ServiceExt::<axum::http::Request<Body>>::oneshot(app.clone(), req_tenant_a)
+                .await
+                .expect("tenant-a response");
+        assert_eq!(resp_tenant_a.status(), StatusCode::OK);
+        let body_tenant_a = axum::body::to_bytes(resp_tenant_a.into_body(), 1024 * 64)
+            .await
+            .expect("tenant-a body");
+        let parsed_tenant_a: serde_json::Value =
+            serde_json::from_slice(&body_tenant_a).expect("tenant-a json");
+        let telegram_tenant_a = parsed_tenant_a["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("tenant-a telegram entry");
+        assert_eq!(telegram_tenant_a["activation_status"], "pairing");
+
+        let mut req_tenant_b = axum::http::Request::builder()
+            .method("GET")
+            .uri("/api/extensions")
+            .body(Body::empty())
+            .expect("tenant-b request");
+        req_tenant_b.extensions_mut().insert(UserIdentity {
+            user_id: "tenant-b".to_string(),
+            role: "member".to_string(),
+            workspace_read_scopes: Vec::new(),
+        });
+        let resp_tenant_b = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req_tenant_b)
+            .await
+            .expect("tenant-b response");
+        assert_eq!(resp_tenant_b.status(), StatusCode::OK);
+        let body_tenant_b = axum::body::to_bytes(resp_tenant_b.into_body(), 1024 * 64)
+            .await
+            .expect("tenant-b body");
+        let parsed_tenant_b: serde_json::Value =
+            serde_json::from_slice(&body_tenant_b).expect("tenant-b json");
+        let telegram_tenant_b = parsed_tenant_b["extensions"]
+            .as_array()
+            .and_then(|items| items.iter().find(|item| item["name"] == "telegram"))
+            .expect("tenant-b telegram entry");
+        assert_eq!(telegram_tenant_b["activation_status"], "active");
     }
 
     /// Caller-level wire-contract regression for nearai/ironclaw#2235.

--- a/src/channels/web/features/pairing/mod.rs
+++ b/src/channels/web/features/pairing/mod.rs
@@ -160,7 +160,7 @@ pub(crate) async fn pairing_approve_handler(
     // Propagate owner binding to the running channel.
     let propagation_failed = if let Some(ext_mgr) = state.extension_manager.as_ref() {
         match ext_mgr
-            .complete_pairing_approval(&channel, &approval.external_id)
+            .complete_pairing_approval(&channel, &user.user_id, &approval.external_id)
             .await
         // dispatch-exempt: runtime channel mutation; pairing tool migration tracked as follow-up
         {

--- a/src/db/libsql/channel_instances.rs
+++ b/src/db/libsql/channel_instances.rs
@@ -1,0 +1,443 @@
+//! ChannelInstanceStore implementation for LibSqlBackend.
+
+use async_trait::async_trait;
+use libsql::params;
+
+use super::{LibSqlBackend, fmt_ts, get_i64, get_json, get_opt_text, get_ts, opt_text};
+use crate::db::{ChannelInstanceRecord, ChannelInstanceStore, DatabaseError};
+
+fn row_to_channel_instance(row: &libsql::Row) -> Result<ChannelInstanceRecord, DatabaseError> {
+    let id: String = row
+        .get(0)
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+    Ok(ChannelInstanceRecord {
+        id: uuid::Uuid::parse_str(&id).map_err(|e| DatabaseError::Query(e.to_string()))?,
+        user_id: row
+            .get(1)
+            .map_err(|e| DatabaseError::Query(e.to_string()))?,
+        channel_kind: row
+            .get(2)
+            .map_err(|e| DatabaseError::Query(e.to_string()))?,
+        instance_key: row
+            .get(3)
+            .map_err(|e| DatabaseError::Query(e.to_string()))?,
+        display_name: row
+            .get(4)
+            .map_err(|e| DatabaseError::Query(e.to_string()))?,
+        is_primary: get_i64(row, 5) != 0,
+        enabled: get_i64(row, 6) != 0,
+        config: get_json(row, 7),
+        metadata: get_json(row, 8),
+        last_error: get_opt_text(row, 9),
+        created_at: get_ts(row, 10),
+        updated_at: get_ts(row, 11),
+    })
+}
+
+#[async_trait]
+impl ChannelInstanceStore for LibSqlBackend {
+    async fn create_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(&instance.channel_kind);
+        let config_str = serde_json::to_string(&instance.config)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        let metadata_str = serde_json::to_string(&instance.metadata)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        let conn = self.connect().await?;
+        conn.execute(
+            "INSERT INTO channel_instances (
+                 id, user_id, channel_kind, instance_key, display_name,
+                 is_primary, enabled, config, metadata, last_error, created_at, updated_at
+             ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)",
+            params![
+                instance.id.to_string(),
+                instance.user_id.as_str(),
+                channel_kind.as_str(),
+                instance.instance_key.as_str(),
+                instance.display_name.as_str(),
+                if instance.is_primary { 1i64 } else { 0i64 },
+                if instance.enabled { 1i64 } else { 0i64 },
+                config_str.as_str(),
+                metadata_str.as_str(),
+                opt_text(instance.last_error.as_deref()),
+                fmt_ts(&instance.created_at),
+                fmt_ts(&instance.updated_at),
+            ],
+        )
+        .await
+        .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn update_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(&instance.channel_kind);
+        let config_str = serde_json::to_string(&instance.config)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        let metadata_str = serde_json::to_string(&instance.metadata)
+            .map_err(|e| DatabaseError::Serialization(e.to_string()))?;
+        let conn = self.connect().await?;
+        let updated = conn
+            .execute(
+                "UPDATE channel_instances
+                 SET channel_kind = ?1,
+                     display_name = ?2,
+                     is_primary = ?3,
+                     enabled = ?4,
+                     config = ?5,
+                     metadata = ?6,
+                     last_error = ?7,
+                     updated_at = ?8
+                 WHERE instance_key = ?9",
+                params![
+                    channel_kind.as_str(),
+                    instance.display_name.as_str(),
+                    if instance.is_primary { 1i64 } else { 0i64 },
+                    if instance.enabled { 1i64 } else { 0i64 },
+                    config_str.as_str(),
+                    metadata_str.as_str(),
+                    opt_text(instance.last_error.as_deref()),
+                    fmt_ts(&instance.updated_at),
+                    instance.instance_key.as_str(),
+                ],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        if updated == 0 {
+            return Err(DatabaseError::NotFound {
+                entity: "channel_instance".to_string(),
+                id: instance.instance_key.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn get_channel_instance_by_key(
+        &self,
+        instance_key: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE instance_key = ?1",
+                params![instance_key],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(row) => row_to_channel_instance(&row).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_channel_instances_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = ?1
+                 ORDER BY channel_kind ASC, display_name ASC, instance_key ASC",
+                params![user_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let mut result = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            result.push(row_to_channel_instance(&row)?);
+        }
+        Ok(result)
+    }
+
+    async fn list_channel_instances_for_user_and_kind(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(channel_kind);
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = ?1 AND channel_kind = ?2
+                 ORDER BY is_primary DESC, display_name ASC, instance_key ASC",
+                params![user_id, channel_kind.as_str()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let mut result = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            result.push(row_to_channel_instance(&row)?);
+        }
+        Ok(result)
+    }
+
+    async fn get_primary_channel_instance(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(channel_kind);
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = ?1 AND channel_kind = ?2 AND is_primary = 1
+                 LIMIT 1",
+                params![user_id, channel_kind.as_str()],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        match rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            Some(row) => row_to_channel_instance(&row).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    async fn list_enabled_channel_instances(
+        &self,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE enabled = 1
+                 ORDER BY user_id ASC, channel_kind ASC, instance_key ASC",
+                (),
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        let mut result = Vec::new();
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?
+        {
+            result.push(row_to_channel_instance(&row)?);
+        }
+        Ok(result)
+    }
+
+    async fn delete_channel_instance(&self, instance_key: &str) -> Result<bool, DatabaseError> {
+        let conn = self.connect().await?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM channel_instances WHERE instance_key = ?1",
+                params![instance_key],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(deleted > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::db::libsql::LibSqlBackend;
+    use crate::db::{ChannelInstanceRecord, ChannelInstanceStore, Database, UserRecord, UserStore};
+
+    async fn setup_db() -> (LibSqlBackend, tempfile::TempDir) {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("channel_instances_test.db");
+        let db = LibSqlBackend::new_local(&db_path).await.unwrap();
+        db.run_migrations().await.unwrap();
+        (db, dir)
+    }
+
+    async fn setup_db_with_user(user_id: &str) -> (LibSqlBackend, tempfile::TempDir) {
+        let (db, dir) = setup_db().await;
+        db.get_or_create_user(UserRecord {
+            id: user_id.to_string(),
+            role: "member".to_string(),
+            display_name: user_id.to_string(),
+            status: "active".to_string(),
+            email: None,
+            last_login_at: None,
+            created_by: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            metadata: serde_json::json!({}),
+        })
+        .await
+        .unwrap();
+        (db, dir)
+    }
+
+    fn sample_instance(
+        user_id: &str,
+        channel_kind: &str,
+        instance_key: &str,
+    ) -> ChannelInstanceRecord {
+        let now = chrono::Utc::now();
+        ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: user_id.to_string(),
+            channel_kind: channel_kind.to_string(),
+            instance_key: instance_key.to_string(),
+            display_name: format!("{} {}", user_id, channel_kind),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({"polling": true}),
+            metadata: serde_json::json!({"source": "test"}),
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_fetch_channel_instance_roundtrip() {
+        let (db, _dir) = setup_db_with_user("alice").await;
+        let instance = sample_instance("alice", "TeLeGrAm", "telegram:alice:primary");
+
+        db.create_channel_instance(&instance).await.unwrap();
+
+        let fetched = db
+            .get_channel_instance_by_key("telegram:alice:primary")
+            .await
+            .unwrap()
+            .expect("instance should exist");
+        assert_eq!(fetched.instance_key, "telegram:alice:primary");
+        assert_eq!(fetched.user_id, "alice");
+        assert_eq!(fetched.channel_kind, "telegram");
+        assert!(fetched.enabled);
+        assert!(fetched.is_primary);
+        assert_eq!(fetched.config, serde_json::json!({"polling": true}));
+        assert_eq!(fetched.metadata, serde_json::json!({"source": "test"}));
+    }
+
+    #[tokio::test]
+    async fn test_update_channel_instance_persists_state() {
+        let (db, _dir) = setup_db_with_user("alice").await;
+        let mut instance = sample_instance("alice", "telegram", "telegram:alice:primary");
+        db.create_channel_instance(&instance).await.unwrap();
+
+        instance.display_name = "Alice Telegram Bot".to_string();
+        instance.enabled = false;
+        instance.last_error = Some("bot token invalid".to_string());
+        instance.config = serde_json::json!({"polling": false});
+        instance.metadata = serde_json::json!({"source": "updated"});
+        instance.updated_at = chrono::Utc::now() + chrono::Duration::seconds(30);
+
+        db.update_channel_instance(&instance).await.unwrap();
+
+        let fetched = db
+            .get_channel_instance_by_key("telegram:alice:primary")
+            .await
+            .unwrap()
+            .expect("instance should still exist");
+        assert_eq!(fetched.display_name, "Alice Telegram Bot");
+        assert!(!fetched.enabled);
+        assert_eq!(fetched.last_error.as_deref(), Some("bot token invalid"));
+        assert_eq!(fetched.config, serde_json::json!({"polling": false}));
+        assert_eq!(fetched.metadata, serde_json::json!({"source": "updated"}));
+    }
+
+    #[tokio::test]
+    async fn test_get_primary_channel_instance_filters_to_primary_instance() {
+        let (db, _dir) = setup_db_with_user("alice").await;
+        let primary = sample_instance("alice", "telegram", "telegram:alice:primary");
+        let mut secondary = sample_instance("alice", "telegram", "telegram:alice:backup");
+        secondary.id = uuid::Uuid::new_v4();
+        secondary.instance_key = "telegram:alice:backup".to_string();
+        secondary.display_name = "Alice Telegram Backup".to_string();
+        secondary.is_primary = false;
+
+        db.create_channel_instance(&primary).await.unwrap();
+        db.create_channel_instance(&secondary).await.unwrap();
+
+        let resolved = db
+            .get_primary_channel_instance("alice", "TeLeGrAm")
+            .await
+            .unwrap()
+            .expect("primary instance should resolve");
+        assert_eq!(resolved.instance_key, "telegram:alice:primary");
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_primary_instance_for_same_user_and_kind_is_rejected() {
+        let (db, _dir) = setup_db_with_user("alice").await;
+        let primary = sample_instance("alice", "telegram", "telegram:alice:primary");
+        let mut duplicate_primary =
+            sample_instance("alice", "telegram", "telegram:alice:second-primary");
+        duplicate_primary.id = uuid::Uuid::new_v4();
+
+        db.create_channel_instance(&primary).await.unwrap();
+        let err = db.create_channel_instance(&duplicate_primary).await;
+        assert!(
+            err.is_err(),
+            "a second primary instance for the same user+kind should fail"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_list_enabled_channel_instances_filters_disabled_rows() {
+        let (db, _dir) = setup_db().await;
+        for user_id in ["alice", "bob"] {
+            db.get_or_create_user(UserRecord {
+                id: user_id.to_string(),
+                role: "member".to_string(),
+                display_name: user_id.to_string(),
+                status: "active".to_string(),
+                email: None,
+                last_login_at: None,
+                created_by: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .unwrap();
+        }
+
+        let enabled = sample_instance("alice", "telegram", "telegram:alice:primary");
+        let mut disabled = sample_instance("bob", "telegram", "telegram:bob:primary");
+        disabled.id = uuid::Uuid::new_v4();
+        disabled.enabled = false;
+
+        db.create_channel_instance(&enabled).await.unwrap();
+        db.create_channel_instance(&disabled).await.unwrap();
+
+        let enabled_rows = db.list_enabled_channel_instances().await.unwrap();
+        assert_eq!(enabled_rows.len(), 1);
+        assert_eq!(enabled_rows[0].instance_key, "telegram:alice:primary");
+    }
+}

--- a/src/db/libsql/mod.rs
+++ b/src/db/libsql/mod.rs
@@ -6,6 +6,7 @@
 //! - Turso cloud with embedded replica (sync to cloud)
 //! - In-memory (for testing)
 
+mod channel_instances;
 mod conversations;
 mod identities;
 mod jobs;
@@ -688,6 +689,13 @@ mod tests {
         // pairing_requests exists with expected columns
         conn.execute(
             "SELECT id, channel, code, owner_id FROM pairing_requests LIMIT 0",
+            (),
+        )
+        .await
+        .unwrap();
+        // channel_instances exists with expected columns
+        conn.execute(
+            "SELECT id, user_id, channel_kind, instance_key, enabled FROM channel_instances LIMIT 0",
             (),
         )
         .await

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -674,6 +674,31 @@ CREATE TABLE IF NOT EXISTS pairing_requests (
 );
 CREATE INDEX IF NOT EXISTS idx_pairing_requests_channel ON pairing_requests (channel, external_id);
 
+-- ==================== Channel Instances (V25) ====================
+
+CREATE TABLE IF NOT EXISTS channel_instances (
+    id           TEXT    NOT NULL PRIMARY KEY,
+    user_id      TEXT    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_kind TEXT    NOT NULL CHECK (channel_kind = lower(channel_kind)),
+    instance_key TEXT    NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL,
+    is_primary   INTEGER NOT NULL DEFAULT 1,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    config       TEXT    NOT NULL DEFAULT '{}',
+    metadata     TEXT    NOT NULL DEFAULT '{}',
+    last_error   TEXT,
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_channel_instances_user_kind
+    ON channel_instances(user_id, channel_kind);
+CREATE INDEX IF NOT EXISTS idx_channel_instances_enabled
+    ON channel_instances(enabled)
+    WHERE enabled = 1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_instances_primary_per_kind
+    ON channel_instances(user_id, channel_kind)
+    WHERE is_primary = 1;
+
 "#;
 
 /// Incremental migrations applied after the base schema.
@@ -990,6 +1015,34 @@ ALTER TABLE agent_jobs ADD COLUMN restart_params TEXT;
         "llm_calls_created_at_index",
         r#"
 CREATE INDEX IF NOT EXISTS idx_llm_calls_created_at ON llm_calls(created_at);
+"#,
+    ),
+    (
+        25,
+        "channel_instances",
+        r#"
+CREATE TABLE IF NOT EXISTS channel_instances (
+    id           TEXT    NOT NULL PRIMARY KEY,
+    user_id      TEXT    NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    channel_kind TEXT    NOT NULL CHECK (channel_kind = lower(channel_kind)),
+    instance_key TEXT    NOT NULL UNIQUE,
+    display_name TEXT    NOT NULL,
+    is_primary   INTEGER NOT NULL DEFAULT 1,
+    enabled      INTEGER NOT NULL DEFAULT 1,
+    config       TEXT    NOT NULL DEFAULT '{}',
+    metadata     TEXT    NOT NULL DEFAULT '{}',
+    last_error   TEXT,
+    created_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at   TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_channel_instances_user_kind
+    ON channel_instances(user_id, channel_kind);
+CREATE INDEX IF NOT EXISTS idx_channel_instances_enabled
+    ON channel_instances(enabled)
+    WHERE enabled = 1;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_instances_primary_per_kind
+    ON channel_instances(user_id, channel_kind)
+    WHERE is_primary = 1;
 "#,
     ),
 ];

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1107,6 +1107,29 @@ pub struct AdminUsageSummary {
     pub usage_cost: Decimal,
 }
 
+/// Durable tenant-owned channel instance metadata.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ChannelInstanceRecord {
+    pub id: Uuid,
+    pub user_id: String,
+    /// Semantic channel kind (e.g. `telegram`). Always stored lowercased.
+    pub channel_kind: String,
+    /// Opaque runtime dispatch key for this concrete channel instance.
+    pub instance_key: String,
+    pub display_name: String,
+    /// Whether this instance is the default outbound target for `(user, kind)`.
+    pub is_primary: bool,
+    /// Desired runtime state. Enabled rows should be restored on startup.
+    pub enabled: bool,
+    /// Small non-secret configuration blob owned by the control plane.
+    pub config: serde_json::Value,
+    /// Debug/admin metadata for the instance record.
+    pub metadata: serde_json::Value,
+    pub last_error: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
 /// A pending pairing request.
 #[derive(Debug, Clone)]
 pub struct PairingRequestRecord {
@@ -1127,6 +1150,56 @@ pub struct PairingApprovalRecord {
     pub external_id: String,
     pub owner_id: String,
     pub previous_owner_id: Option<String>,
+}
+
+/// Tenant-owned channel instance control-plane operations.
+#[async_trait]
+pub trait ChannelInstanceStore: Send + Sync {
+    /// Create a new channel instance row.
+    async fn create_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError>;
+
+    /// Update an existing channel instance row, addressed by `instance_key`.
+    async fn update_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError>;
+
+    /// Fetch a channel instance by its opaque runtime dispatch key.
+    async fn get_channel_instance_by_key(
+        &self,
+        instance_key: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError>;
+
+    /// List all channel instances owned by a user.
+    async fn list_channel_instances_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError>;
+
+    /// List channel instances owned by a user for a semantic channel kind.
+    async fn list_channel_instances_for_user_and_kind(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError>;
+
+    /// Resolve the primary/default instance for `(user_id, channel_kind)`.
+    async fn get_primary_channel_instance(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError>;
+
+    /// List all enabled instances across all users. Used for process-global restore.
+    async fn list_enabled_channel_instances(
+        &self,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError>;
+
+    /// Delete a channel instance by dispatch key.
+    async fn delete_channel_instance(&self, instance_key: &str) -> Result<bool, DatabaseError>;
 }
 
 /// Pairing and channel identity operations.
@@ -1260,6 +1333,7 @@ pub trait Database:
     + SettingsStore
     + WorkspaceStore
     + UserStore
+    + ChannelInstanceStore
     + ChannelPairingStore
     + IdentityStore
     + Send

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -16,9 +16,10 @@ use crate::agent::routine::{Routine, RoutineRun, RunStatus};
 use crate::config::DatabaseConfig;
 use crate::context::{ActionRecord, JobContext, JobState};
 use crate::db::{
-    ApiTokenRecord, ChannelPairingStore, ConversationStore, Database, IdentityStore, JobStore,
-    PairingRequestRecord, RoutineStore, SandboxStore, SettingsStore, ToolFailureStore,
-    UserIdentityRecord, UserRecord, UserStore, WorkspaceStore,
+    ApiTokenRecord, ChannelInstanceRecord, ChannelInstanceStore, ChannelPairingStore,
+    ConversationStore, Database, IdentityStore, JobStore, PairingRequestRecord, RoutineStore,
+    SandboxStore, SettingsStore, ToolFailureStore, UserIdentityRecord, UserRecord, UserStore,
+    WorkspaceStore,
 };
 use crate::error::{DatabaseError, WorkspaceError};
 use crate::history::{
@@ -1099,6 +1100,247 @@ impl UserStore for PgBackend {
         self.store
             .create_user_with_token(user, token_name, token_hash, token_prefix, expires_at)
             .await
+    }
+}
+
+// ==================== ChannelInstanceStore ====================
+
+fn row_to_channel_instance(row: &tokio_postgres::Row) -> ChannelInstanceRecord {
+    ChannelInstanceRecord {
+        id: row.get("id"),
+        user_id: row.get("user_id"),
+        channel_kind: row.get("channel_kind"),
+        instance_key: row.get("instance_key"),
+        display_name: row.get("display_name"),
+        is_primary: row.get("is_primary"),
+        enabled: row.get("enabled"),
+        config: row.get("config"),
+        metadata: row.get("metadata"),
+        last_error: row.get("last_error"),
+        created_at: row.get("created_at"),
+        updated_at: row.get("updated_at"),
+    }
+}
+
+#[async_trait]
+impl ChannelInstanceStore for PgBackend {
+    async fn create_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(&instance.channel_kind);
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        client
+            .execute(
+                "INSERT INTO channel_instances (
+                     id, user_id, channel_kind, instance_key, display_name,
+                     is_primary, enabled, config, metadata, last_error, created_at, updated_at
+                 ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+                &[
+                    &instance.id,
+                    &instance.user_id,
+                    &channel_kind,
+                    &instance.instance_key,
+                    &instance.display_name,
+                    &instance.is_primary,
+                    &instance.enabled,
+                    &instance.config,
+                    &instance.metadata,
+                    &instance.last_error,
+                    &instance.created_at,
+                    &instance.updated_at,
+                ],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn update_channel_instance(
+        &self,
+        instance: &ChannelInstanceRecord,
+    ) -> Result<(), DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(&instance.channel_kind);
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let updated = client
+            .execute(
+                "UPDATE channel_instances
+                 SET channel_kind = $1,
+                     display_name = $2,
+                     is_primary = $3,
+                     enabled = $4,
+                     config = $5,
+                     metadata = $6,
+                     last_error = $7,
+                     updated_at = $8
+                 WHERE instance_key = $9",
+                &[
+                    &channel_kind,
+                    &instance.display_name,
+                    &instance.is_primary,
+                    &instance.enabled,
+                    &instance.config,
+                    &instance.metadata,
+                    &instance.last_error,
+                    &instance.updated_at,
+                    &instance.instance_key,
+                ],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        if updated == 0 {
+            return Err(DatabaseError::NotFound {
+                entity: "channel_instance".to_string(),
+                id: instance.instance_key.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn get_channel_instance_by_key(
+        &self,
+        instance_key: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError> {
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let row = client
+            .query_opt(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE instance_key = $1",
+                &[&instance_key],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(row.map(|r| row_to_channel_instance(&r)))
+    }
+
+    async fn list_channel_instances_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = $1
+                 ORDER BY channel_kind ASC, display_name ASC, instance_key ASC",
+                &[&user_id],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(rows.iter().map(row_to_channel_instance).collect())
+    }
+
+    async fn list_channel_instances_for_user_and_kind(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(channel_kind);
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = $1 AND channel_kind = $2
+                 ORDER BY is_primary DESC, display_name ASC, instance_key ASC",
+                &[&user_id, &channel_kind],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(rows.iter().map(row_to_channel_instance).collect())
+    }
+
+    async fn get_primary_channel_instance(
+        &self,
+        user_id: &str,
+        channel_kind: &str,
+    ) -> Result<Option<ChannelInstanceRecord>, DatabaseError> {
+        let channel_kind = crate::pairing::normalize_channel_name(channel_kind);
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let row = client
+            .query_opt(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE user_id = $1 AND channel_kind = $2 AND is_primary = TRUE
+                 LIMIT 1",
+                &[&user_id, &channel_kind],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(row.map(|r| row_to_channel_instance(&r)))
+    }
+
+    async fn list_enabled_channel_instances(
+        &self,
+    ) -> Result<Vec<ChannelInstanceRecord>, DatabaseError> {
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let rows = client
+            .query(
+                "SELECT id, user_id, channel_kind, instance_key, display_name,
+                        is_primary, enabled, config, metadata, last_error,
+                        created_at, updated_at
+                 FROM channel_instances
+                 WHERE enabled = TRUE
+                 ORDER BY user_id ASC, channel_kind ASC, instance_key ASC",
+                &[],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(rows.iter().map(row_to_channel_instance).collect())
+    }
+
+    async fn delete_channel_instance(&self, instance_key: &str) -> Result<bool, DatabaseError> {
+        let client = self
+            .pool()
+            .get()
+            .await
+            .map_err(|e| DatabaseError::Pool(e.to_string()))?;
+        let deleted = client
+            .execute(
+                "DELETE FROM channel_instances WHERE instance_key = $1",
+                &[&instance_key],
+            )
+            .await
+            .map_err(|e| DatabaseError::Query(e.to_string()))?;
+        Ok(deleted > 0)
     }
 }
 

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1295,17 +1295,58 @@ impl ExtensionManager {
     /// Persist the set of active channel names to the settings store.
     ///
     /// Saved under key `activated_channels` so channels auto-activate on restart.
+    /// When tenant-owned channel instances are active, persist only the kinds
+    /// owned by `user_id` so one tenant's runtime state cannot leak into
+    /// another tenant's compatibility snapshot.
     async fn persist_active_channels(&self, user_id: &str) {
         let Some(store) = self.settings_store() else {
             return;
         };
-        let names: Vec<String> = self
-            .active_channel_names
-            .read()
-            .await
-            .iter()
-            .cloned()
-            .collect();
+
+        let active_names = self.active_channel_names.read().await.clone();
+        let active_dispatch_keys = self.active_channel_dispatch_keys.read().await.clone();
+
+        let mut names: Vec<String> = if let Some(instance_store) = self.channel_instance_store() {
+            match (
+                instance_store
+                    .list_channel_instances_for_user(user_id)
+                    .await,
+                instance_store.list_enabled_channel_instances().await,
+            ) {
+                (Ok(user_instances), Ok(enabled_instances)) => {
+                    let user_instance_kinds: HashSet<String> = user_instances
+                        .into_iter()
+                        .filter(|instance| {
+                            instance.enabled
+                                && active_dispatch_keys.contains(&instance.instance_key)
+                        })
+                        .map(|instance| instance.channel_kind)
+                        .collect();
+                    let tenant_managed_kinds: HashSet<String> = enabled_instances
+                        .into_iter()
+                        .map(|instance| instance.channel_kind)
+                        .collect();
+                    active_names
+                        .into_iter()
+                        .filter(|name| {
+                            !tenant_managed_kinds.contains(name)
+                                || user_instance_kinds.contains(name)
+                        })
+                        .collect()
+                }
+                (Err(e), _) => {
+                    tracing::warn!(error = %e, "Failed to load user channel instances while persisting activated_channels");
+                    active_names.into_iter().collect()
+                }
+                (_, Err(e)) => {
+                    tracing::warn!(error = %e, "Failed to load enabled channel instances while persisting activated_channels");
+                    active_names.into_iter().collect()
+                }
+            }
+        } else {
+            active_names.into_iter().collect()
+        };
+        names.sort();
         let value = serde_json::json!(names);
         if let Err(e) = store
             .set_setting(user_id, "activated_channels", &value)
@@ -1590,11 +1631,32 @@ impl ExtensionManager {
             )));
         }
 
+        let mut instance_key = channel_kind.clone();
+        if store
+            .get_channel_instance_by_key(&instance_key)
+            .await
+            .map_err(|e| ExtensionError::Other(e.to_string()))?
+            .is_some()
+        {
+            loop {
+                let candidate = format!("{}:{}", channel_kind, uuid::Uuid::new_v4());
+                if store
+                    .get_channel_instance_by_key(&candidate)
+                    .await
+                    .map_err(|e| ExtensionError::Other(e.to_string()))?
+                    .is_none()
+                {
+                    instance_key = candidate;
+                    break;
+                }
+            }
+        }
+
         let instance = crate::db::ChannelInstanceRecord {
             id: uuid::Uuid::new_v4(),
             user_id: user_id.to_string(),
             channel_kind: channel_kind.clone(),
-            instance_key: format!("{}:{}", channel_kind, uuid::Uuid::new_v4()),
+            instance_key,
             display_name: Self::default_channel_instance_display_name(&channel_kind),
             is_primary: true,
             enabled: true,
@@ -2379,49 +2441,43 @@ impl ExtensionManager {
         {
             match crate::channels::wasm::discover_channels(&self.wasm_channels_dir).await {
                 Ok(channels) => {
-                    let errors = self.activation_errors.read().await;
-                    let enabled_instances = if let Some(store) = self.channel_instance_store() {
-                        store
-                            .list_enabled_channel_instances()
+                    let errors = self.activation_errors.read().await.clone();
+                    let active_dispatch_keys =
+                        self.active_channel_dispatch_keys.read().await.clone();
+                    let active_names = self.active_channel_names.read().await.clone();
+                    let mut user_instances_by_kind: HashMap<
+                        String,
+                        crate::db::ChannelInstanceRecord,
+                    > = HashMap::new();
+                    if let Some(store) = self.channel_instance_store() {
+                        let user_instances = store
+                            .list_channel_instances_for_user(user_id)
                             .await
                             .ok()
-                            .unwrap_or_default()
-                    } else {
-                        Vec::new()
-                    };
+                            .unwrap_or_default();
+                        for instance in user_instances {
+                            let should_replace = user_instances_by_kind
+                                .get(&instance.channel_kind)
+                                .map(|current| !current.is_primary && instance.is_primary)
+                                .unwrap_or(true);
+                            if should_replace {
+                                user_instances_by_kind
+                                    .insert(instance.channel_kind.clone(), instance);
+                            }
+                        }
+                    }
                     for (name, discovered) in channels {
-                        let user_instance = enabled_instances
-                            .iter()
-                            .find(|instance| {
-                                instance.user_id == user_id && instance.channel_kind == name
-                            })
-                            .cloned();
-                        let any_instance_for_kind = enabled_instances
-                            .iter()
-                            .any(|instance| instance.channel_kind == name);
-                        let active = if let Some(instance) = user_instance.as_ref() {
+                        let user_instance = user_instances_by_kind.get(&name);
+                        let active = if let Some(instance) = user_instance {
                             instance.enabled
-                                && self
-                                    .active_channel_dispatch_keys
-                                    .read()
-                                    .await
-                                    .contains(&instance.instance_key)
-                        } else if any_instance_for_kind {
-                            false
+                                && active_dispatch_keys.contains(&instance.instance_key)
                         } else {
-                            self.active_channel_names.read().await.contains(&name)
+                            active_names.contains(&name)
                         };
                         let auth_state = self.check_channel_auth_status(&name, user_id).await;
                         let activation_error = user_instance
-                            .as_ref()
                             .and_then(|instance| instance.last_error.clone())
-                            .or_else(|| {
-                                if any_instance_for_kind {
-                                    None
-                                } else {
-                                    errors.get(&name).cloned()
-                                }
-                            });
+                            .or_else(|| errors.get(&name).cloned());
                         let registry_entry = self
                             .registry
                             .get_with_kind(&name, Some(ExtensionKind::WasmChannel))
@@ -5509,24 +5565,16 @@ impl ExtensionManager {
             ExtensionKind::McpServer => self.mcp_clients.read().await.contains_key(name),
             ExtensionKind::WasmTool => self.tool_registry.has(name).await,
             ExtensionKind::WasmChannel => {
-                if let Some(store) = self.channel_instance_store() {
-                    if let Ok(Some(instance)) =
-                        store.get_primary_channel_instance(user_id, name).await
-                    {
-                        return instance.enabled
-                            && self
-                                .active_channel_dispatch_keys
-                                .read()
-                                .await
-                                .contains(&instance.instance_key);
-                    }
-                    if let Ok(instances) = store.list_enabled_channel_instances().await
-                        && instances
-                            .iter()
-                            .any(|instance| instance.channel_kind == name)
-                    {
-                        return false;
-                    }
+                if let Some(store) = self.channel_instance_store()
+                    && let Ok(instances) = store
+                        .list_channel_instances_for_user_and_kind(user_id, name)
+                        .await
+                    && !instances.is_empty()
+                {
+                    let active_dispatch_keys = self.active_channel_dispatch_keys.read().await;
+                    return instances.iter().any(|instance| {
+                        instance.enabled && active_dispatch_keys.contains(&instance.instance_key)
+                    });
                 }
                 self.active_channel_names.read().await.contains(name)
             }
@@ -7452,6 +7500,12 @@ impl ExtensionManager {
             self.load_tool_setup_fields(&name).await.unwrap_or_default()
         };
 
+        let setup_field_scope_user_id = if kind == ExtensionKind::WasmChannel {
+            user_id
+        } else {
+            self.user_id.as_str()
+        };
+
         for (field_name, field_value) in fields {
             if !allowed_fields.contains(field_name.as_str()) {
                 return Err(ExtensionError::Other(format!(
@@ -7472,7 +7526,9 @@ impl ExtensionManager {
                     if let Some(setting_path) = &def.setting_path {
                         Self::validate_setup_setting_path(&name, setting_path)?;
                         if let Some(store) = self.settings_store() {
-                            let _ = store.delete_setting(user_id, setting_path).await;
+                            let _ = store
+                                .delete_setting(setup_field_scope_user_id, setting_path)
+                                .await;
                         }
                     }
                 }
@@ -7492,7 +7548,7 @@ impl ExtensionManager {
                 })?;
                 store
                     .set_setting(
-                        user_id,
+                        setup_field_scope_user_id,
                         setting_path,
                         &serde_json::Value::String(trimmed.to_string()),
                     )
@@ -8192,8 +8248,8 @@ mod tests {
         read_crate_name_from_cargo_toml, send_telegram_text_message, telegram_bot_api_url,
     };
     use crate::extensions::{
-        AuthHint, ExtensionError, ExtensionKind, ExtensionSource, InstallResult, RegistryEntry,
-        ToolAuthState,
+        AuthHint, EnsureReadyIntent, EnsureReadyOutcome, ExtensionError, ExtensionKind,
+        ExtensionSource, InstallResult, RegistryEntry, ToolAuthState,
     };
     use crate::pairing::PairingStore;
     use crate::secrets::CreateSecretParams;
@@ -8657,7 +8713,7 @@ mod tests {
         assert_eq!(tenant_instance.user_id, "tenant-a");
         assert_eq!(tenant_instance.channel_kind, "tenant_chat");
         assert!(tenant_instance.enabled);
-        assert!(tenant_instance.instance_key.starts_with("tenant_chat:"));
+        assert_eq!(tenant_instance.instance_key, "tenant_chat");
 
         let owner_instance = store
             .get_primary_channel_instance("test", "tenant_chat")
@@ -8809,6 +8865,13 @@ mod tests {
             .expect("load tenant-b instance")
             .expect("tenant-b instance");
         assert_ne!(instance_a.instance_key, instance_b.instance_key);
+        assert_eq!(instance_a.instance_key, "tenant_chat");
+        let tenant_b_suffix = instance_b
+            .instance_key
+            .strip_prefix("tenant_chat:")
+            .expect("second tenant should use an opaque dispatch-key suffix");
+        uuid::Uuid::parse_str(tenant_b_suffix)
+            .expect("second tenant dispatch key suffix should be a UUID");
         assert!(
             channel_manager
                 .get_channel(&instance_a.instance_key)
@@ -8837,6 +8900,125 @@ mod tests {
                 .is_some(),
             "tenant-b webhook path should be registered"
         );
+    }
+
+    #[tokio::test]
+    async fn persist_active_channels_scopes_tenant_managed_kinds_to_request_user() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        seed_test_user(&store, "tenant-b").await;
+        let mgr = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+
+        store
+            .create_channel_instance(&test_channel_instance_record(
+                "tenant-a",
+                "tenant_chat",
+                "tenant_chat:tenant-a:primary",
+            ))
+            .await
+            .expect("seed tenant-a instance");
+        store
+            .create_channel_instance(&test_channel_instance_record(
+                "tenant-b",
+                "tenant_chat",
+                "tenant_chat",
+            ))
+            .await
+            .expect("seed tenant-b instance");
+
+        mgr.active_channel_names
+            .write()
+            .await
+            .insert("tenant_chat".to_string());
+        mgr.active_channel_dispatch_keys
+            .write()
+            .await
+            .insert("tenant_chat".to_string());
+
+        mgr.persist_active_channels("tenant-a").await;
+        let tenant_a_names: Vec<String> = serde_json::from_value(
+            store
+                .get_setting("tenant-a", "activated_channels")
+                .await
+                .expect("load tenant-a activated_channels")
+                .expect("tenant-a activated_channels setting"),
+        )
+        .expect("tenant-a activated_channels json");
+        assert!(
+            tenant_a_names.is_empty(),
+            "tenant-a should not persist tenant-b's active tenant-managed channel"
+        );
+
+        mgr.persist_active_channels("tenant-b").await;
+        let tenant_b_names: Vec<String> = serde_json::from_value(
+            store
+                .get_setting("tenant-b", "activated_channels")
+                .await
+                .expect("load tenant-b activated_channels")
+                .expect("tenant-b activated_channels setting"),
+        )
+        .expect("tenant-b activated_channels json");
+        assert_eq!(tenant_b_names, vec!["tenant_chat"]);
+    }
+
+    #[tokio::test]
+    async fn ensure_extension_ready_falls_back_to_legacy_active_name_per_user() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        seed_test_user(&store, "tenant-b").await;
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": []
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+
+        store
+            .create_channel_instance(&test_channel_instance_record(
+                "tenant-b",
+                "tenant_chat",
+                "tenant_chat",
+            ))
+            .await
+            .expect("seed tenant-b instance");
+        mgr.active_channel_names
+            .write()
+            .await
+            .insert("tenant_chat".to_string());
+        mgr.active_channel_dispatch_keys
+            .write()
+            .await
+            .insert("tenant_chat".to_string());
+
+        let outcome = mgr
+            .ensure_extension_ready("tenant_chat", "tenant-a", EnsureReadyIntent::UseCapability)
+            .await
+            .expect(
+                "ensure_extension_ready should treat the legacy active name as ready for tenant-a",
+            );
+
+        assert!(matches!(
+            outcome,
+            EnsureReadyOutcome::Ready {
+                kind: ExtensionKind::WasmChannel,
+                ..
+            }
+        ));
     }
 
     #[tokio::test]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -1371,7 +1371,7 @@ impl ExtensionManager {
     }
 
     /// Load enabled tenant-owned channel instances for process-global startup restore.
-    pub async fn load_enabled_channel_instances_for_startup(
+    async fn load_enabled_channel_instances_for_startup(
         &self,
     ) -> Vec<crate::db::ChannelInstanceRecord> {
         let Some(store) = self.channel_instance_store() else {

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -372,12 +372,14 @@ pub struct ExtensionManager {
     /// When set, settings reads/writes go through this cache-backed store
     /// instead of the raw `Database`. Populated via `with_settings_store()`.
     settings_override: Option<Arc<dyn crate::db::SettingsStore + Send + Sync>>,
-    /// Names of WASM/relay channels that are actively running in this process.
+    /// Semantic channel kinds that are actively running in this process.
     ///
     /// This is runtime state, not install/discovery state. Installed WASM
     /// channels are still discovered from disk in `list()`, but only channels
     /// present in this set are reported as active.
     active_channel_names: RwLock<HashSet<String>>,
+    /// Concrete runtime dispatch keys for active channel instances.
+    active_channel_dispatch_keys: RwLock<HashSet<String>>,
     /// Installed channel-relay extensions (no on-disk artifact, tracked in memory).
     installed_relay_extensions: RwLock<HashSet<String>>,
     /// Last activation error for each WASM channel (ephemeral, cleared on success).
@@ -629,6 +631,7 @@ impl ExtensionManager {
             store,
             settings_override: None,
             active_channel_names: RwLock::new(HashSet::new()),
+            active_channel_dispatch_keys: RwLock::new(HashSet::new()),
             installed_relay_extensions: RwLock::new(HashSet::new()),
             activation_errors: RwLock::new(HashMap::new()),
             sse_manager: RwLock::new(None),
@@ -842,26 +845,36 @@ impl ExtensionManager {
         });
     }
 
-    async fn current_channel_owner_id(&self, name: &str) -> Option<i64> {
+    async fn current_channel_owner_id_for_user(
+        &self,
+        name: &str,
+        user_id: &str,
+        dispatch_key: Option<&str>,
+    ) -> Option<i64> {
         {
             let rt_guard = self.channel_runtime.read().await;
-            if let Some(owner_id) = rt_guard
-                .as_ref()
-                .and_then(|rt| rt.wasm_channel_owner_ids.get(name).copied())
-            {
-                return Some(owner_id);
+            if let Some(rt) = rt_guard.as_ref() {
+                if let Some(dispatch_key) = dispatch_key
+                    && let Some(owner_id) = rt.wasm_channel_owner_ids.get(dispatch_key).copied()
+                {
+                    return Some(owner_id);
+                }
+                if let Some(owner_id) = rt.wasm_channel_owner_ids.get(name).copied() {
+                    return Some(owner_id);
+                }
             }
         }
 
         let store = self.settings_store()?;
         let key = format!("channels.wasm_channel_owner_ids.{name}");
-        match store.get_setting(&self.user_id, &key).await {
+        match store.get_setting(user_id, &key).await {
             Ok(Some(serde_json::Value::Number(n))) => n.as_i64(),
             Ok(Some(serde_json::Value::String(s))) => s.parse::<i64>().ok(),
             Ok(Some(_)) | Ok(None) => None,
             Err(e) => {
                 tracing::debug!(
                     channel = %name,
+                    user_id = %user_id,
                     error = %e,
                     "Failed to read persisted wasm channel owner id"
                 );
@@ -870,21 +883,41 @@ impl ExtensionManager {
         }
     }
 
-    async fn current_channel_owner_actor_id(&self, name: &str) -> Option<String> {
-        if let Some(owner_id) = self.current_channel_owner_id(name).await {
+    async fn current_channel_owner_actor_id_for_user(
+        &self,
+        name: &str,
+        user_id: &str,
+        dispatch_key: Option<&str>,
+    ) -> Option<String> {
+        if let Some(owner_id) = self
+            .current_channel_owner_id_for_user(name, user_id, dispatch_key)
+            .await
+        {
             return Some(owner_id.to_string());
         }
 
-        let rt_guard = self.channel_runtime.read().await;
-        let rt = (*rt_guard).as_ref()?;
-        rt.pairing_store
-            .external_id_for_owner(
-                name,
-                &crate::ownership::UserId::from_trusted(
-                    self.user_id.clone(),
-                    crate::ownership::UserRole::Regular,
-                ),
-            )
+        {
+            let rt_guard = self.channel_runtime.read().await;
+            if let Some(rt) = (*rt_guard).as_ref()
+                && let Ok(owner) = rt
+                    .pairing_store
+                    .external_id_for_owner(
+                        name,
+                        &crate::ownership::UserId::from_trusted(
+                            user_id.to_string(),
+                            crate::ownership::UserRole::Regular,
+                        ),
+                    )
+                    .await
+                && owner.is_some()
+            {
+                return owner;
+            }
+        }
+
+        let store = self.store.as_ref()?;
+        store
+            .resolve_channel_external_id_for_owner(name, user_id)
             .await
             .ok()
             .flatten()
@@ -893,13 +926,14 @@ impl ExtensionManager {
     async fn load_channel_runtime_config_overrides(
         &self,
         name: &str,
+        user_id: &str,
     ) -> HashMap<String, serde_json::Value> {
         let mut overrides = HashMap::new();
 
         if name == TELEGRAM_CHANNEL_NAME
             && let Some(store) = self.settings_store()
             && let Ok(Some(serde_json::Value::String(username))) = store
-                .get_setting(&self.user_id, &bot_username_setting_key(name))
+                .get_setting(user_id, &bot_username_setting_key(name))
                 .await
             && !username.trim().is_empty()
         {
@@ -913,7 +947,17 @@ impl ExtensionManager {
     }
 
     pub async fn has_wasm_channel_owner_binding(&self, name: &str) -> bool {
-        self.current_channel_owner_actor_id(name).await.is_some()
+        self.has_wasm_channel_owner_binding_for_user(name, &self.user_id)
+            .await
+    }
+
+    pub async fn has_wasm_channel_owner_binding_for_user(&self, name: &str, user_id: &str) -> bool {
+        let dispatch_key = self
+            .notification_channel_dispatch_key_for_user(name, user_id)
+            .await;
+        self.current_channel_owner_actor_id_for_user(name, user_id, Some(&dispatch_key))
+            .await
+            .is_some()
     }
 
     async fn channel_activation_lock(&self, name: &str) -> Arc<tokio::sync::Mutex<()>> {
@@ -934,13 +978,34 @@ impl ExtensionManager {
     pub async fn complete_pairing_approval(
         &self,
         channel_name: &str,
+        user_id: &str,
         external_id: &str,
     ) -> Result<(), ExtensionError> {
         // Normalize to lowercase — pairing storage and webhook routes are
         // lowercase, so mixed-case requests must resolve consistently.
         let channel_name = channel_name.to_ascii_lowercase();
         let channel_name = channel_name.as_str();
-        let activation_lock = self.channel_activation_lock(channel_name).await;
+        let dispatch_key = if let Some(store) = self.channel_instance_store() {
+            match store
+                .get_primary_channel_instance(user_id, channel_name)
+                .await
+            {
+                Ok(Some(instance)) => instance.instance_key,
+                Ok(None) => channel_name.to_string(),
+                Err(error) => {
+                    tracing::warn!(
+                        channel = %channel_name,
+                        user_id = %user_id,
+                        error = %error,
+                        "Failed to load channel instance for pairing approval; falling back to semantic channel routing"
+                    );
+                    channel_name.to_string()
+                }
+            }
+        } else {
+            channel_name.to_string()
+        };
+        let activation_lock = self.channel_activation_lock(&dispatch_key).await;
         let _guard = activation_lock.lock().await;
 
         let router = {
@@ -951,19 +1016,19 @@ impl ExtensionManager {
             }
         };
 
-        let webhook_path = format!("/webhook/{}", channel_name);
+        let webhook_path = format!("/webhook/{}", dispatch_key);
         let Some(existing_channel) = router.get_channel_for_path(&webhook_path).await else {
             return Ok(());
         };
 
         let external_id = crate::pairing::ExternalId::from(external_id.to_string());
         let config_overrides = self
-            .load_channel_runtime_config_overrides(channel_name)
+            .load_channel_runtime_config_overrides(channel_name, user_id)
             .await;
         let deps = crate::pairing::approval::ApprovalDeps {
             tunnel_url: self.tunnel_url.as_deref(),
             store: self.store.as_ref(),
-            user_id: &self.user_id,
+            user_id,
             config_overrides,
         };
         let result = crate::pairing::approval::propagate_approval(
@@ -984,7 +1049,7 @@ impl ExtensionManager {
             let mut rt_guard = self.channel_runtime.write().await;
             if let Some(rt) = rt_guard.as_mut() {
                 rt.wasm_channel_owner_ids
-                    .insert(channel_name.to_string(), owner_id_numeric);
+                    .insert(dispatch_key, owner_id_numeric);
             }
         }
 
@@ -998,25 +1063,80 @@ impl ExtensionManager {
     /// Returns false if no DB-backed pairing store is available — the noop
     /// pairing store cannot have rows. See nearai/ironclaw#1921.
     pub async fn has_wasm_channel_pairing(&self, name: &str) -> bool {
+        self.has_wasm_channel_pairing_for_user(name, &self.user_id)
+            .await
+    }
+
+    pub async fn has_wasm_channel_pairing_for_user(&self, name: &str, user_id: &str) -> bool {
+        let channel_name = canonicalize_extension_name(name).unwrap_or_else(|_| name.to_string());
+
+        if let Some(store) = self.store.as_ref() {
+            match store
+                .resolve_channel_external_id_for_owner(&channel_name, user_id)
+                .await
+            {
+                Ok(Some(_)) => return true,
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::debug!(
+                        channel = %channel_name,
+                        user_id = %user_id,
+                        error = %error,
+                        "Failed to read paired sender from database-backed pairing store"
+                    );
+                }
+            }
+        }
+
         let rt_guard = self.channel_runtime.read().await;
         let Some(ref rt) = *rt_guard else {
             return false;
         };
-        match rt.pairing_store.read_allow_from(name).await {
-            Ok(allow) => !allow.is_empty(),
-            Err(error) => {
-                tracing::debug!(
-                    channel = %name,
-                    error = %error,
-                    "Failed to read paired senders from pairing store"
-                );
-                false
-            }
+        rt.pairing_store
+            .external_id_for_owner(
+                &channel_name,
+                &crate::ownership::UserId::from_trusted(
+                    user_id.to_string(),
+                    crate::ownership::UserRole::Regular,
+                ),
+            )
+            .await
+            .ok()
+            .flatten()
+            .is_some()
+    }
+
+    pub(crate) async fn notification_channel_dispatch_key_for_user(
+        &self,
+        name: &str,
+        user_id: &str,
+    ) -> String {
+        let channel_name = canonicalize_extension_name(name).unwrap_or_else(|_| name.to_string());
+        if let Some(store) = self.channel_instance_store()
+            && let Ok(Some(instance)) = store
+                .get_primary_channel_instance(user_id, &channel_name)
+                .await
+        {
+            return instance.instance_key;
         }
+        channel_name
+    }
+
+    pub(crate) async fn notification_target_for_channel_for_user(
+        &self,
+        name: &str,
+        user_id: &str,
+    ) -> Option<String> {
+        let dispatch_key = self
+            .notification_channel_dispatch_key_for_user(name, user_id)
+            .await;
+        self.current_channel_owner_actor_id_for_user(name, user_id, Some(&dispatch_key))
+            .await
     }
 
     pub(crate) async fn notification_target_for_channel(&self, name: &str) -> Option<String> {
-        self.current_channel_owner_actor_id(name).await
+        self.notification_target_for_channel_for_user(name, &self.user_id)
+            .await
     }
 
     /// Set just the channel manager for relay channel hot-activation.
@@ -1148,13 +1268,28 @@ impl ExtensionManager {
         self.mcp_clients.write().await.insert(name, client);
     }
 
+    fn dispatch_key_matches_channel_name(dispatch_key: &str, channel_name: &str) -> bool {
+        dispatch_key == channel_name || dispatch_key.starts_with(&format!("{channel_name}:"))
+    }
+
+    async fn remove_active_channel_dispatch_keys_for_name(&self, channel_name: &str) {
+        self.active_channel_dispatch_keys
+            .write()
+            .await
+            .retain(|dispatch_key| {
+                !Self::dispatch_key_matches_channel_name(dispatch_key, channel_name)
+            });
+    }
+
     /// Register channel names that are already running in the current process.
     ///
     /// Startup uses this after restoring persisted active channels; hot
     /// activation updates the same set after a channel is successfully started.
     pub async fn set_active_channels(&self, names: Vec<String>) {
         let mut active = self.active_channel_names.write().await;
-        active.extend(names);
+        active.extend(names.iter().cloned());
+        let mut dispatch_keys = self.active_channel_dispatch_keys.write().await;
+        dispatch_keys.extend(names);
     }
 
     /// Persist the set of active channel names to the settings store.
@@ -1235,6 +1370,107 @@ impl ExtensionManager {
         }
     }
 
+    /// Load enabled tenant-owned channel instances for process-global startup restore.
+    pub async fn load_enabled_channel_instances_for_startup(
+        &self,
+    ) -> Vec<crate::db::ChannelInstanceRecord> {
+        let Some(store) = self.channel_instance_store() else {
+            return Vec::new();
+        };
+        match store.list_enabled_channel_instances().await {
+            Ok(instances) => instances,
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to load enabled channel instances for startup restore");
+                Vec::new()
+            }
+        }
+    }
+
+    /// Restore all enabled tenant-owned WASM channel instances.
+    ///
+    /// Returns the number of enabled channel-instance rows that were treated as
+    /// authoritative startup state. A zero means callers may fall back to the
+    /// legacy `activated_channels` compatibility path.
+    pub async fn restore_enabled_wasm_channel_instances(&self) -> usize {
+        let instances = self.load_enabled_channel_instances_for_startup().await;
+        if instances.is_empty() {
+            return 0;
+        }
+
+        let mut seen_dispatch_keys = std::collections::HashSet::new();
+        for instance in instances {
+            if !seen_dispatch_keys.insert(instance.instance_key.clone()) {
+                tracing::warn!(
+                    channel = %instance.channel_kind,
+                    dispatch_key = %instance.instance_key,
+                    user_id = %instance.user_id,
+                    "Skipping duplicate enabled channel instance row during startup restore"
+                );
+                continue;
+            }
+
+            if self
+                .active_channel_dispatch_keys
+                .read()
+                .await
+                .contains(&instance.instance_key)
+            {
+                continue;
+            }
+
+            match self
+                .ensure_extension_ready(
+                    &instance.channel_kind,
+                    &instance.user_id,
+                    crate::extensions::EnsureReadyIntent::ExplicitActivate,
+                )
+                .await
+            {
+                Ok(crate::extensions::EnsureReadyOutcome::Ready { activation, .. }) => {
+                    let message = activation.map(|result| result.message).unwrap_or_else(|| {
+                        format!("Channel '{}' already ready", instance.channel_kind)
+                    });
+                    tracing::debug!(
+                        channel = %instance.channel_kind,
+                        dispatch_key = %instance.instance_key,
+                        user_id = %instance.user_id,
+                        message = %message,
+                        "Restored enabled WASM channel instance"
+                    );
+                }
+                Ok(crate::extensions::EnsureReadyOutcome::NeedsAuth { auth, .. }) => {
+                    tracing::warn!(
+                        channel = %instance.channel_kind,
+                        dispatch_key = %instance.instance_key,
+                        user_id = %instance.user_id,
+                        instructions = ?auth.instructions(),
+                        "Enabled WASM channel instance still needs authentication at startup"
+                    );
+                }
+                Ok(crate::extensions::EnsureReadyOutcome::NeedsSetup { instructions, .. }) => {
+                    tracing::warn!(
+                        channel = %instance.channel_kind,
+                        dispatch_key = %instance.instance_key,
+                        user_id = %instance.user_id,
+                        instructions = %instructions,
+                        "Enabled WASM channel instance still needs setup at startup"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        channel = %instance.channel_kind,
+                        dispatch_key = %instance.instance_key,
+                        user_id = %instance.user_id,
+                        error = %e,
+                        "Failed to restore enabled WASM channel instance"
+                    );
+                }
+            }
+        }
+
+        seen_dispatch_keys.len()
+    }
+
     /// Set the SSE broadcast sender for pushing extension status events to the web UI.
     pub async fn set_sse_sender(&self, sse: Arc<crate::channels::web::sse::SseManager>) {
         *self.sse_manager.write().await = Some(sse);
@@ -1279,6 +1515,13 @@ impl ExtensionManager {
         }
     }
 
+    /// Access the channel-instance control-plane store.
+    fn channel_instance_store(&self) -> Option<&dyn crate::db::ChannelInstanceStore> {
+        self.store
+            .as_ref()
+            .map(|db| db.as_ref() as &dyn crate::db::ChannelInstanceStore)
+    }
+
     /// Attach a cached settings store so settings reads/writes route through
     /// the cache layer, keeping the agent loop's view coherent.
     pub fn with_settings_store(
@@ -1287,6 +1530,111 @@ impl ExtensionManager {
     ) -> Self {
         self.settings_override = Some(store);
         self
+    }
+
+    fn default_channel_instance_display_name(channel_kind: &str) -> String {
+        channel_kind.replace('_', " ")
+    }
+
+    async fn upsert_primary_channel_instance_record(
+        &self,
+        channel_kind: &str,
+        user_id: &str,
+    ) -> Result<Option<crate::db::ChannelInstanceRecord>, ExtensionError> {
+        let Some(store) = self.channel_instance_store() else {
+            return Ok(None);
+        };
+        let channel_kind = canonicalize_extension_name(channel_kind)?;
+        let now = chrono::Utc::now();
+
+        if let Some(mut existing) = store
+            .get_primary_channel_instance(user_id, &channel_kind)
+            .await
+            .map_err(|e| ExtensionError::Other(e.to_string()))?
+        {
+            if existing.display_name.trim().is_empty() {
+                existing.display_name = Self::default_channel_instance_display_name(&channel_kind);
+            }
+            existing.enabled = true;
+            existing.is_primary = true;
+            existing.updated_at = now;
+            store
+                .update_channel_instance(&existing)
+                .await
+                .map_err(|e| ExtensionError::Other(e.to_string()))?;
+            return Ok(Some(existing));
+        }
+
+        let existing_same_kind = store
+            .list_channel_instances_for_user_and_kind(user_id, &channel_kind)
+            .await
+            .map_err(|e| ExtensionError::Other(e.to_string()))?;
+        if existing_same_kind.len() == 1 {
+            let mut existing = existing_same_kind[0].clone();
+            if existing.display_name.trim().is_empty() {
+                existing.display_name = Self::default_channel_instance_display_name(&channel_kind);
+            }
+            existing.enabled = true;
+            existing.is_primary = true;
+            existing.updated_at = now;
+            store
+                .update_channel_instance(&existing)
+                .await
+                .map_err(|e| ExtensionError::Other(e.to_string()))?;
+            return Ok(Some(existing));
+        }
+        if existing_same_kind.len() > 1 {
+            return Err(ExtensionError::Other(format!(
+                "Multiple '{}' channel instances exist for user '{}'; unable to choose a primary instance",
+                channel_kind, user_id
+            )));
+        }
+
+        let instance = crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: user_id.to_string(),
+            channel_kind: channel_kind.clone(),
+            instance_key: format!("{}:{}", channel_kind, uuid::Uuid::new_v4()),
+            display_name: Self::default_channel_instance_display_name(&channel_kind),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        };
+        store
+            .create_channel_instance(&instance)
+            .await
+            .map_err(|e| ExtensionError::Other(e.to_string()))?;
+        Ok(Some(instance))
+    }
+
+    async fn update_channel_instance_activation_error(
+        &self,
+        channel_kind: &str,
+        user_id: &str,
+        error: Option<&str>,
+    ) {
+        let Some(store) = self.channel_instance_store() else {
+            return;
+        };
+        let Ok(channel_kind) = canonicalize_extension_name(channel_kind) else {
+            return;
+        };
+        let Ok(Some(mut instance)) = store
+            .get_primary_channel_instance(user_id, &channel_kind)
+            .await
+        else {
+            return;
+        };
+        instance.enabled = true;
+        instance.last_error = error.map(str::to_string);
+        instance.updated_at = chrono::Utc::now();
+        if let Err(e) = store.update_channel_instance(&instance).await {
+            tracing::debug!(channel = %channel_kind, user_id = %user_id, error = %e, "Failed to update channel instance activation error state");
+        }
     }
 
     async fn clear_pending_extension_auth(&self, name: &str) {
@@ -1658,7 +2006,10 @@ impl ExtensionManager {
             } => {}
         }
 
-        if self.is_extension_active(&name, kind).await {
+        if self
+            .is_extension_active_for_user(&name, kind, user_id)
+            .await
+        {
             return Ok(EnsureReadyOutcome::Ready {
                 name,
                 kind,
@@ -2028,12 +2379,49 @@ impl ExtensionManager {
         {
             match crate::channels::wasm::discover_channels(&self.wasm_channels_dir).await {
                 Ok(channels) => {
-                    let active_names = self.active_channel_names.read().await;
                     let errors = self.activation_errors.read().await;
+                    let enabled_instances = if let Some(store) = self.channel_instance_store() {
+                        store
+                            .list_enabled_channel_instances()
+                            .await
+                            .ok()
+                            .unwrap_or_default()
+                    } else {
+                        Vec::new()
+                    };
                     for (name, discovered) in channels {
-                        let active = active_names.contains(&name);
+                        let user_instance = enabled_instances
+                            .iter()
+                            .find(|instance| {
+                                instance.user_id == user_id && instance.channel_kind == name
+                            })
+                            .cloned();
+                        let any_instance_for_kind = enabled_instances
+                            .iter()
+                            .any(|instance| instance.channel_kind == name);
+                        let active = if let Some(instance) = user_instance.as_ref() {
+                            instance.enabled
+                                && self
+                                    .active_channel_dispatch_keys
+                                    .read()
+                                    .await
+                                    .contains(&instance.instance_key)
+                        } else if any_instance_for_kind {
+                            false
+                        } else {
+                            self.active_channel_names.read().await.contains(&name)
+                        };
                         let auth_state = self.check_channel_auth_status(&name, user_id).await;
-                        let activation_error = errors.get(&name).cloned();
+                        let activation_error = user_instance
+                            .as_ref()
+                            .and_then(|instance| instance.last_error.clone())
+                            .or_else(|| {
+                                if any_instance_for_kind {
+                                    None
+                                } else {
+                                    errors.get(&name).cloned()
+                                }
+                            });
                         let registry_entry = self
                             .registry
                             .get_with_kind(&name, Some(ExtensionKind::WasmChannel))
@@ -2272,6 +2660,8 @@ impl ExtensionManager {
 
                 // Remove from active set and persist
                 self.active_channel_names.write().await.remove(&name);
+                self.remove_active_channel_dispatch_keys_for_name(&name)
+                    .await;
                 self.persist_active_channels(user_id).await;
 
                 // Clear stale activation errors so reinstall starts clean
@@ -2322,6 +2712,10 @@ impl ExtensionManager {
                     for candidate in &candidate_names {
                         active_channels.remove(candidate);
                     }
+                }
+                for candidate in &candidate_names {
+                    self.remove_active_channel_dispatch_keys_for_name(candidate)
+                        .await;
                 }
                 self.persist_active_channels(user_id).await;
                 self.activation_errors.write().await.remove(&name);
@@ -5101,12 +5495,42 @@ impl ExtensionManager {
     }
 
     async fn is_extension_active(&self, name: &str, kind: ExtensionKind) -> bool {
+        self.is_extension_active_for_user(name, kind, &self.user_id)
+            .await
+    }
+
+    async fn is_extension_active_for_user(
+        &self,
+        name: &str,
+        kind: ExtensionKind,
+        user_id: &str,
+    ) -> bool {
         match kind {
             ExtensionKind::McpServer => self.mcp_clients.read().await.contains_key(name),
             ExtensionKind::WasmTool => self.tool_registry.has(name).await,
-            ExtensionKind::WasmChannel | ExtensionKind::ChannelRelay => {
+            ExtensionKind::WasmChannel => {
+                if let Some(store) = self.channel_instance_store() {
+                    if let Ok(Some(instance)) =
+                        store.get_primary_channel_instance(user_id, name).await
+                    {
+                        return instance.enabled
+                            && self
+                                .active_channel_dispatch_keys
+                                .read()
+                                .await
+                                .contains(&instance.instance_key);
+                    }
+                    if let Ok(instances) = store.list_enabled_channel_instances().await
+                        && instances
+                            .iter()
+                            .any(|instance| instance.channel_kind == name)
+                    {
+                        return false;
+                    }
+                }
                 self.active_channel_names.read().await.contains(name)
             }
+            ExtensionKind::ChannelRelay => self.active_channel_names.read().await.contains(name),
             ExtensionKind::AcpAgent => true,
         }
     }
@@ -5577,16 +6001,25 @@ impl ExtensionManager {
         name: &str,
         user_id: &str,
     ) -> Result<ActivateResult, ExtensionError> {
-        let activation_lock = self.channel_activation_lock(name).await;
+        let channel_instance_record = self
+            .upsert_primary_channel_instance_record(name, user_id)
+            .await?;
+        let dispatch_key = channel_instance_record
+            .as_ref()
+            .map(|record| record.instance_key.clone())
+            .unwrap_or_else(|| name.to_string());
+
+        let activation_lock = self.channel_activation_lock(&dispatch_key).await;
         let _guard = activation_lock.lock().await;
 
-        // If already active, re-inject credentials and refresh webhook secret.
-        // Handles the case where a channel was loaded at startup before the
-        // user saved secrets via the web UI.
+        // If this concrete instance is already active, re-inject credentials
+        // and refresh the host-managed webhook state in place.
         {
-            let active = self.active_channel_names.read().await;
-            if active.contains(name) {
-                return self.refresh_active_channel(name, user_id).await;
+            let active = self.active_channel_dispatch_keys.read().await;
+            if active.contains(&dispatch_key) {
+                return self
+                    .refresh_active_channel(name, user_id, &dispatch_key)
+                    .await;
             }
         }
 
@@ -5641,7 +6074,7 @@ impl ExtensionManager {
                 Arc::clone(&channel_runtime),
                 Arc::clone(&pairing_store),
                 settings_store,
-                self.user_id.clone(),
+                user_id.to_string(),
             )
             .with_secrets_store(Arc::clone(&self.secrets));
             loader
@@ -5657,7 +6090,7 @@ impl ExtensionManager {
                 Arc::clone(&channel_runtime),
                 Arc::clone(&pairing_store),
                 settings_store,
-                self.user_id.clone(),
+                user_id.to_string(),
             )
             .with_secrets_store(Arc::clone(&self.secrets));
             loader
@@ -5666,12 +6099,18 @@ impl ExtensionManager {
                 .map_err(|e| ExtensionError::ActivationFailed(e.to_string()))?
         };
 
+        let loaded = LoadedChannel {
+            channel: loaded.channel.with_dispatch_key(dispatch_key.clone()),
+            capabilities_file: loaded.capabilities_file,
+        };
+
         self.complete_loaded_wasm_channel_activation(
             name,
             loaded,
             &channel_manager,
             &wasm_channel_router,
             wasm_channel_owner_ids.get(name).copied(),
+            user_id,
         )
         .await
     }
@@ -5683,8 +6122,10 @@ impl ExtensionManager {
         channel_manager: &Arc<ChannelManager>,
         wasm_channel_router: &Arc<WasmChannelRouter>,
         owner_id: Option<i64>,
+        user_id: &str,
     ) -> Result<ActivateResult, ExtensionError> {
         let channel_name = loaded.name().to_string();
+        let channel_dispatch_key = loaded.channel.channel_dispatch_key().to_string();
         if is_reserved_wasm_channel_name(&channel_name) {
             return Err(ExtensionError::ActivationFailed(format!(
                 "Channel '{}' uses a reserved name and cannot be activated.",
@@ -5696,7 +6137,14 @@ impl ExtensionManager {
         // -> pairing_store external id -> capabilities file.
         let owner_actor_id = if let Some(owner_id) = owner_id {
             Some(owner_id.to_string())
-        } else if let Some(id) = self.current_channel_owner_actor_id(&channel_name).await {
+        } else if let Some(id) = self
+            .current_channel_owner_actor_id_for_user(
+                &channel_name,
+                user_id,
+                Some(&channel_dispatch_key),
+            )
+            .await
+        {
             Some(id)
         } else {
             owner_id_from_capabilities(loaded.capabilities_file.as_ref(), &channel_name)
@@ -5716,7 +6164,7 @@ impl ExtensionManager {
         // Get webhook secret from secrets store
         let webhook_secret = self
             .secrets
-            .get_decrypted(&self.user_id, &webhook_secret_name)
+            .get_decrypted(user_id, &webhook_secret_name)
             .await
             .ok()
             .map(|s| s.expose().to_string());
@@ -5731,12 +6179,12 @@ impl ExtensionManager {
                 owner_actor_id.as_deref(),
             );
             config_updates.extend(
-                self.load_channel_runtime_config_overrides(&channel_name)
+                self.load_channel_runtime_config_overrides(&channel_name, user_id)
                     .await,
             );
             inject_wasm_channel_secret_config_mappings(
                 &channel_name,
-                &self.user_id,
+                user_id,
                 self.secrets.as_ref(),
                 &secret_config_mappings,
                 &mut config_updates,
@@ -5747,6 +6195,7 @@ impl ExtensionManager {
                 channel_arc.update_config(config_updates).await;
                 tracing::info!(
                     channel = %channel_name,
+                    dispatch_key = %channel_dispatch_key,
                     has_tunnel = self.tunnel_url.is_some(),
                     has_webhook_secret = webhook_secret.is_some(),
                     "Injected runtime config into hot-activated channel"
@@ -5761,9 +6210,9 @@ impl ExtensionManager {
             } else {
                 None
             };
-            let webhook_path = format!("/webhook/{}", channel_name);
+            let webhook_path = format!("/webhook/{}", channel_dispatch_key);
             let endpoints = vec![RegisteredEndpoint {
-                channel_name: channel_name.clone(),
+                channel_name: channel_dispatch_key.clone(),
                 path: webhook_path,
                 methods: vec!["POST".to_string()],
                 require_secret: host_webhook_secret.is_some(),
@@ -5777,39 +6226,36 @@ impl ExtensionManager {
                     secret_header,
                 )
                 .await;
-            tracing::info!(channel = %channel_name, "Registered hot-activated channel with webhook router");
+            tracing::info!(channel = %channel_name, dispatch_key = %channel_dispatch_key, "Registered hot-activated channel with webhook router");
 
             // Register Ed25519 signature key if declared in capabilities
             if let Some(ref sig_key_name) = sig_key_secret_name
-                && let Ok(key_secret) = self
-                    .secrets
-                    .get_decrypted(&self.user_id, sig_key_name)
-                    .await
+                && let Ok(key_secret) = self.secrets.get_decrypted(user_id, sig_key_name).await
             {
                 match wasm_channel_router
-                    .register_signature_key(&channel_name, key_secret.expose())
+                    .register_signature_key(&channel_dispatch_key, key_secret.expose())
                     .await
                 {
                     Ok(()) => {
-                        tracing::info!(channel = %channel_name, "Registered signature key for hot-activated channel")
+                        tracing::info!(channel = %channel_name, dispatch_key = %channel_dispatch_key, "Registered signature key for hot-activated channel")
                     }
                     Err(e) => {
-                        tracing::error!(channel = %channel_name, error = %e, "Failed to register signature key")
+                        tracing::error!(channel = %channel_name, dispatch_key = %channel_dispatch_key, error = %e, "Failed to register signature key")
                     }
                 }
             }
 
             // Register HMAC signing secret if declared in capabilities
             if let Some(hmac_name) = &hmac_secret_name {
-                match self.secrets.get_decrypted(&self.user_id, hmac_name).await {
+                match self.secrets.get_decrypted(user_id, hmac_name).await {
                     Ok(secret) => {
                         wasm_channel_router
-                            .register_hmac_secret(&channel_name, secret.expose())
+                            .register_hmac_secret(&channel_dispatch_key, secret.expose())
                             .await;
-                        tracing::info!(channel = %channel_name, "Registered HMAC signing secret for hot-activated channel");
+                        tracing::info!(channel = %channel_name, dispatch_key = %channel_dispatch_key, "Registered HMAC signing secret for hot-activated channel");
                     }
                     Err(e) => {
-                        tracing::warn!(channel = %channel_name, error = %e, "HMAC secret not found");
+                        tracing::warn!(channel = %channel_name, dispatch_key = %channel_dispatch_key, error = %e, "HMAC secret not found");
                     }
                 }
             }
@@ -5820,7 +6266,7 @@ impl ExtensionManager {
             &channel_arc,
             Some(self.secrets.as_ref()),
             &channel_name,
-            &self.user_id,
+            user_id,
         )
         .await
         {
@@ -5828,6 +6274,7 @@ impl ExtensionManager {
                 if count > 0 {
                     tracing::info!(
                         channel = %channel_name,
+                        dispatch_key = %channel_dispatch_key,
                         credentials_injected = count,
                         "Credentials injected into hot-activated channel"
                     );
@@ -5836,6 +6283,7 @@ impl ExtensionManager {
             Err(e) => {
                 tracing::error!(
                     channel = %channel_name,
+                    dispatch_key = %channel_dispatch_key,
                     error = %e,
                     "Failed to inject credentials into hot-activated channel"
                 );
@@ -5853,9 +6301,15 @@ impl ExtensionManager {
             .write()
             .await
             .insert(channel_name.clone());
+        self.active_channel_dispatch_keys
+            .write()
+            .await
+            .insert(channel_dispatch_key.clone());
 
-        // Persist activation state so the channel auto-activates on restart
-        self.persist_active_channels(&self.user_id).await;
+        // Persist activation state so the channel auto-activates on restart.
+        // This remains semantic-name based for compatibility; channel_instances
+        // are the long-term source of truth for per-tenant restore.
+        self.persist_active_channels(user_id).await;
 
         tracing::info!(channel = %channel_name, "Hot-activated WASM channel");
 
@@ -5875,6 +6329,7 @@ impl ExtensionManager {
         &self,
         name: &str,
         user_id: &str,
+        dispatch_key: &str,
     ) -> Result<ActivateResult, ExtensionError> {
         let router = {
             let rt_guard = self.channel_runtime.read().await;
@@ -5891,7 +6346,7 @@ impl ExtensionManager {
             }
         };
 
-        let webhook_path = format!("/webhook/{}", name);
+        let webhook_path = format!("/webhook/{}", dispatch_key);
         let existing_channel = match router.get_channel_for_path(&webhook_path).await {
             Some(ch) => ch,
             None => {
@@ -5953,7 +6408,7 @@ impl ExtensionManager {
             .unwrap_or_default();
 
         let owner_actor_id = self
-            .current_channel_owner_actor_id(name)
+            .current_channel_owner_actor_id_for_user(name, user_id, Some(dispatch_key))
             .await
             .or_else(|| owner_id_from_capabilities(capabilities_file.as_ref(), name));
         let mut config_updates = build_wasm_channel_runtime_config_updates(
@@ -5961,10 +6416,13 @@ impl ExtensionManager {
             None,
             owner_actor_id.as_deref(),
         );
-        config_updates.extend(self.load_channel_runtime_config_overrides(name).await);
+        config_updates.extend(
+            self.load_channel_runtime_config_overrides(name, user_id)
+                .await,
+        );
         inject_wasm_channel_secret_config_mappings(
             name,
-            &self.user_id,
+            user_id,
             self.secrets.as_ref(),
             &secret_config_mappings,
             &mut config_updates,
@@ -5980,7 +6438,7 @@ impl ExtensionManager {
                 .await
         {
             router
-                .update_secret(name, secret.expose().to_string())
+                .update_secret(dispatch_key, secret.expose().to_string())
                 .await;
             config_updates.insert(
                 RUNTIME_CONFIG_KEY_WEBHOOK_SECRET.to_string(),
@@ -5994,7 +6452,7 @@ impl ExtensionManager {
             && let Ok(key_secret) = self.secrets.get_decrypted(user_id, sig_key_name).await
         {
             match router
-                .register_signature_key(name, key_secret.expose())
+                .register_signature_key(dispatch_key, key_secret.expose())
                 .await
             {
                 Ok(()) => {
@@ -6014,7 +6472,9 @@ impl ExtensionManager {
                 .await
             {
                 Ok(secret) => {
-                    router.register_hmac_secret(name, secret.expose()).await;
+                    router
+                        .register_hmac_secret(dispatch_key, secret.expose())
+                        .await;
                     tracing::info!(channel = %name, "Refreshed HMAC signing secret");
                 }
                 Err(e) => {
@@ -6596,21 +7056,29 @@ impl ExtensionManager {
         name: &str,
         fields: &HashMap<String, String>,
     ) -> Result<(), ExtensionError> {
+        let user_id = self.user_id.clone();
+        self.save_tool_setup_fields_for(name, &user_id, fields)
+            .await
+    }
+
+    async fn save_tool_setup_fields_for(
+        &self,
+        name: &str,
+        user_id: &str,
+        fields: &HashMap<String, String>,
+    ) -> Result<(), ExtensionError> {
         let store = self.settings_store().ok_or_else(|| {
             ExtensionError::Other("Settings store unavailable for setup field persistence".into())
         })?;
         let key = Self::setup_fields_setting_key(name);
         let value = serde_json::to_value(fields)
             .map_err(|e| ExtensionError::Other(format!("Failed to encode setup fields: {}", e)))?;
-        store
-            .set_setting(&self.user_id, &key, &value)
-            .await
-            .map_err(|e| {
-                ExtensionError::Other(format!(
-                    "Failed to persist setup fields for '{}': {}",
-                    name, e
-                ))
-            })
+        store.set_setting(user_id, &key, &value).await.map_err(|e| {
+            ExtensionError::Other(format!(
+                "Failed to persist setup fields for '{}': {}",
+                name, e
+            ))
+        })
     }
 
     /// Owner-scoped wrapper around [`is_tool_setup_field_provided_for`]. Used
@@ -6976,7 +7444,13 @@ impl ExtensionManager {
                 .map_err(|e| ExtensionError::AuthFailed(e.to_string()))?;
         }
 
-        let mut stored_fields = self.load_tool_setup_fields(&name).await.unwrap_or_default();
+        let mut stored_fields = if kind == ExtensionKind::WasmChannel {
+            self.load_tool_setup_fields_for(&name, user_id)
+                .await
+                .unwrap_or_default()
+        } else {
+            self.load_tool_setup_fields(&name).await.unwrap_or_default()
+        };
 
         for (field_name, field_value) in fields {
             if !allowed_fields.contains(field_name.as_str()) {
@@ -6998,7 +7472,7 @@ impl ExtensionManager {
                     if let Some(setting_path) = &def.setting_path {
                         Self::validate_setup_setting_path(&name, setting_path)?;
                         if let Some(store) = self.settings_store() {
-                            let _ = store.delete_setting(&self.user_id, setting_path).await;
+                            let _ = store.delete_setting(user_id, setting_path).await;
                         }
                     }
                 }
@@ -7018,7 +7492,7 @@ impl ExtensionManager {
                 })?;
                 store
                     .set_setting(
-                        &self.user_id,
+                        user_id,
                         setting_path,
                         &serde_json::Value::String(trimmed.to_string()),
                     )
@@ -7033,17 +7507,26 @@ impl ExtensionManager {
         }
 
         if !allowed_fields.is_empty() && !fields.is_empty() {
-            self.save_tool_setup_fields(&name, &stored_fields).await?;
+            if kind == ExtensionKind::WasmChannel {
+                self.save_tool_setup_fields_for(&name, user_id, &stored_fields)
+                    .await?;
+            } else {
+                self.save_tool_setup_fields(&name, &stored_fields).await?;
+            }
         }
 
         for field_def in setup_field_defs.values() {
             if field_def.optional {
                 continue;
             }
-            if !self
-                .is_tool_setup_field_provided(&name, field_def, &stored_fields)
-                .await
-            {
+            let provided = if kind == ExtensionKind::WasmChannel {
+                self.is_tool_setup_field_provided_for(&name, user_id, field_def, &stored_fields)
+                    .await
+            } else {
+                self.is_tool_setup_field_provided(&name, field_def, &stored_fields)
+                    .await
+            };
+            if !provided {
                 return Err(ExtensionError::Other(format!(
                     "Required field '{}' is missing for extension '{}'",
                     field_def.name, name
@@ -7097,7 +7580,7 @@ impl ExtensionManager {
                 && let Some(store) = self.store.as_ref()
                 && let Err(e) = store
                     .set_setting(
-                        &self.user_id,
+                        user_id,
                         &bot_username_setting_key(&name),
                         &serde_json::json!(username),
                     )
@@ -7109,6 +7592,13 @@ impl ExtensionManager {
                     "Failed to persist bot username; mention detection may be degraded"
                 );
             }
+        }
+
+        let mut channel_instance_record = None;
+        if kind == ExtensionKind::WasmChannel {
+            channel_instance_record = self
+                .upsert_primary_channel_instance_record(&name, user_id)
+                .await?;
         }
 
         // For tools, save and attempt auto-activation, then check auth.
@@ -7236,12 +7726,18 @@ impl ExtensionManager {
         match activate_result {
             Ok(result) => {
                 self.activation_errors.write().await.remove(&name);
+                if channel_instance_record.is_some() {
+                    self.update_channel_instance_activation_error(&name, user_id, None)
+                        .await;
+                }
                 self.broadcast_extension_status(&name, "active", None).await;
 
                 // Check if the channel needs pairing (no owner binding yet).
                 let needs_pairing = kind == ExtensionKind::WasmChannel
-                    && !self.has_wasm_channel_owner_binding(&name).await
-                    && !self.has_wasm_channel_pairing(&name).await;
+                    && !self
+                        .has_wasm_channel_owner_binding_for_user(&name, user_id)
+                        .await
+                    && !self.has_wasm_channel_pairing_for_user(&name, user_id).await;
 
                 if needs_pairing && let Some(ref sse) = *self.sse_manager.read().await {
                     let onboarding = crate::channels::web::features::extensions::derive_onboarding(
@@ -7310,6 +7806,10 @@ impl ExtensionManager {
                     .write()
                     .await
                     .insert(name.to_string(), error_msg.clone());
+                if channel_instance_record.is_some() {
+                    self.update_channel_instance_activation_error(&name, user_id, Some(&error_msg))
+                        .await;
+                }
                 self.broadcast_extension_status(&name, "failed", Some(&error_msg))
                     .await;
                 Ok(ConfigureResult {
@@ -7926,6 +8426,46 @@ mod tests {
         crate::testing::test_db().await
     }
 
+    async fn seed_test_user(store: &Arc<dyn crate::db::Database>, user_id: &str) {
+        store
+            .get_or_create_user(crate::db::UserRecord {
+                id: user_id.to_string(),
+                role: "member".to_string(),
+                display_name: user_id.to_string(),
+                status: "active".to_string(),
+                email: None,
+                last_login_at: None,
+                created_by: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .expect("seed test user");
+    }
+
+    fn test_channel_instance_record(
+        user_id: &str,
+        channel_kind: &str,
+        instance_key: &str,
+    ) -> crate::db::ChannelInstanceRecord {
+        let now = chrono::Utc::now();
+        crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: user_id.to_string(),
+            channel_kind: channel_kind.to_string(),
+            instance_key: instance_key.to_string(),
+            display_name: format!("{} {}", user_id, channel_kind),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
     /// Build a minimal ExtensionManager suitable for unit tests.
     fn make_test_manager_with_dirs(
         wasm_runtime: Option<Arc<crate::tools::wasm::WasmToolRuntime>>,
@@ -8068,6 +8608,434 @@ mod tests {
         assert!(
             actual.is_empty(),
             "an explicit empty activated_channels setting should keep all channels inactive"
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_wasm_channel_creates_primary_channel_instance_for_request_user() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": [
+                        { "name": "api_token", "prompt": "API token" }
+                    ]
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+
+        let secrets =
+            std::collections::HashMap::from([("api_token".to_string(), "test-token".to_string())]);
+        let result = mgr
+            .configure(
+                "tenant_chat",
+                &secrets,
+                &std::collections::HashMap::new(),
+                "tenant-a",
+            )
+            .await
+            .expect("configure should succeed even if activation fails");
+        assert!(
+            !result.activated,
+            "no runtime means activation should fail in test"
+        );
+
+        let tenant_instance = store
+            .get_primary_channel_instance("tenant-a", "tenant_chat")
+            .await
+            .expect("load tenant instance")
+            .expect("tenant instance should exist");
+        assert_eq!(tenant_instance.user_id, "tenant-a");
+        assert_eq!(tenant_instance.channel_kind, "tenant_chat");
+        assert!(tenant_instance.enabled);
+        assert!(tenant_instance.instance_key.starts_with("tenant_chat:"));
+
+        let owner_instance = store
+            .get_primary_channel_instance("test", "tenant_chat")
+            .await
+            .expect("load owner instance");
+        assert!(
+            owner_instance.is_none(),
+            "channel instance must be scoped to the request user, not ExtensionManager::user_id"
+        );
+    }
+
+    #[tokio::test]
+    async fn configure_wasm_channel_upserts_existing_primary_instance() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": [
+                        { "name": "api_token", "prompt": "API token" }
+                    ]
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+        let secrets =
+            std::collections::HashMap::from([("api_token".to_string(), "test-token".to_string())]);
+
+        mgr.configure(
+            "tenant_chat",
+            &secrets,
+            &std::collections::HashMap::new(),
+            "tenant-a",
+        )
+        .await
+        .expect("first configure");
+        let first = store
+            .get_primary_channel_instance("tenant-a", "tenant_chat")
+            .await
+            .expect("load first")
+            .expect("instance after first configure");
+
+        mgr.configure(
+            "tenant_chat",
+            &secrets,
+            &std::collections::HashMap::new(),
+            "tenant-a",
+        )
+        .await
+        .expect("second configure");
+        let after = store
+            .list_channel_instances_for_user_and_kind("tenant-a", "tenant_chat")
+            .await
+            .expect("list tenant channel instances");
+
+        assert_eq!(after.len(), 1, "configure should upsert, not duplicate");
+        assert_eq!(after[0].instance_key, first.instance_key);
+    }
+
+    #[tokio::test]
+    async fn configure_wasm_channel_activates_distinct_instances_per_user() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        seed_test_user(&store, "tenant-b").await;
+
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": [
+                        { "name": "api_token", "prompt": "API token" }
+                    ]
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+        let channel_manager = Arc::new(ChannelManager::new());
+        let runtime = Arc::new(
+            WasmChannelRuntime::new(WasmChannelRuntimeConfig::for_testing()).expect("runtime init"),
+        );
+        let pairing_store = Arc::new(PairingStore::new_noop());
+        let router = Arc::new(WasmChannelRouter::new());
+        mgr.set_channel_runtime(
+            Arc::clone(&channel_manager),
+            Arc::clone(&runtime),
+            Arc::clone(&pairing_store),
+            Arc::clone(&router),
+            std::collections::HashMap::new(),
+        )
+        .await;
+        mgr.set_test_wasm_channel_loader(Arc::new({
+            let runtime = Arc::clone(&runtime);
+            let pairing_store = Arc::clone(&pairing_store);
+            move |_name| {
+                Ok(make_test_loaded_channel(
+                    Arc::clone(&runtime),
+                    "tenant_chat",
+                    Arc::clone(&pairing_store),
+                ))
+            }
+        }))
+        .await;
+
+        let secrets =
+            std::collections::HashMap::from([("api_token".to_string(), "test-token".to_string())]);
+        let result_a = mgr
+            .configure(
+                "tenant_chat",
+                &secrets,
+                &std::collections::HashMap::new(),
+                "tenant-a",
+            )
+            .await
+            .expect("configure tenant-a");
+        let result_b = mgr
+            .configure(
+                "tenant_chat",
+                &secrets,
+                &std::collections::HashMap::new(),
+                "tenant-b",
+            )
+            .await
+            .expect("configure tenant-b");
+
+        assert!(result_a.activated, "tenant-a should activate");
+        assert!(result_b.activated, "tenant-b should activate");
+
+        let instance_a = store
+            .get_primary_channel_instance("tenant-a", "tenant_chat")
+            .await
+            .expect("load tenant-a instance")
+            .expect("tenant-a instance");
+        let instance_b = store
+            .get_primary_channel_instance("tenant-b", "tenant_chat")
+            .await
+            .expect("load tenant-b instance")
+            .expect("tenant-b instance");
+        assert_ne!(instance_a.instance_key, instance_b.instance_key);
+        assert!(
+            channel_manager
+                .get_channel(&instance_a.instance_key)
+                .await
+                .is_some(),
+            "tenant-a dispatch key should be hot-added"
+        );
+        assert!(
+            channel_manager
+                .get_channel(&instance_b.instance_key)
+                .await
+                .is_some(),
+            "tenant-b dispatch key should be hot-added"
+        );
+        assert!(
+            router
+                .get_channel_for_path(&format!("/webhook/{}", instance_a.instance_key))
+                .await
+                .is_some(),
+            "tenant-a webhook path should be registered"
+        );
+        assert!(
+            router
+                .get_channel_for_path(&format!("/webhook/{}", instance_b.instance_key))
+                .await
+                .is_some(),
+            "tenant-b webhook path should be registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn restore_enabled_wasm_channel_instances_activates_multiple_tenants() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        seed_test_user(&store, "tenant-b").await;
+        store
+            .create_channel_instance(&test_channel_instance_record(
+                "tenant-a",
+                "tenant_chat",
+                "tenant_chat:tenant-a:primary",
+            ))
+            .await
+            .expect("seed tenant-a instance");
+        store
+            .create_channel_instance(&test_channel_instance_record(
+                "tenant-b",
+                "tenant_chat",
+                "tenant_chat:tenant-b:primary",
+            ))
+            .await
+            .expect("seed tenant-b instance");
+
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": []
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+        let channel_manager = Arc::new(ChannelManager::new());
+        let runtime = Arc::new(
+            WasmChannelRuntime::new(WasmChannelRuntimeConfig::for_testing()).expect("runtime init"),
+        );
+        let pairing_store = Arc::new(PairingStore::new_noop());
+        let router = Arc::new(WasmChannelRouter::new());
+        mgr.set_channel_runtime(
+            Arc::clone(&channel_manager),
+            Arc::clone(&runtime),
+            Arc::clone(&pairing_store),
+            Arc::clone(&router),
+            std::collections::HashMap::new(),
+        )
+        .await;
+        mgr.set_test_wasm_channel_loader(Arc::new({
+            let runtime = Arc::clone(&runtime);
+            let pairing_store = Arc::clone(&pairing_store);
+            move |_name| {
+                Ok(make_test_loaded_channel(
+                    Arc::clone(&runtime),
+                    "tenant_chat",
+                    Arc::clone(&pairing_store),
+                ))
+            }
+        }))
+        .await;
+
+        let restored = mgr.restore_enabled_wasm_channel_instances().await;
+        assert_eq!(
+            restored, 2,
+            "startup restore should treat both enabled instances as authoritative"
+        );
+        assert!(
+            channel_manager
+                .get_channel("tenant_chat:tenant-a:primary")
+                .await
+                .is_some(),
+            "tenant-a startup instance should be active"
+        );
+        assert!(
+            channel_manager
+                .get_channel("tenant_chat:tenant-b:primary")
+                .await
+                .is_some(),
+            "tenant-b startup instance should be active"
+        );
+        assert!(
+            router
+                .get_channel_for_path("/webhook/tenant_chat:tenant-a:primary")
+                .await
+                .is_some(),
+            "tenant-a startup webhook path should be registered"
+        );
+        assert!(
+            router
+                .get_channel_for_path("/webhook/tenant_chat:tenant-b:primary")
+                .await
+                .is_some(),
+            "tenant-b startup webhook path should be registered"
+        );
+    }
+
+    #[tokio::test]
+    async fn complete_pairing_approval_updates_matching_tenant_instance() {
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        seed_test_user(&store, "tenant-a").await;
+        seed_test_user(&store, "tenant-b").await;
+
+        let tools_dir = dir.path().join("tools");
+        let channels_dir = write_test_channel(
+            dir.path(),
+            "tenant_chat",
+            r#"{
+                "name": "tenant_chat",
+                "description": "Test tenant channel",
+                "setup": {
+                    "required_secrets": []
+                }
+            }"#,
+        );
+        let mgr =
+            make_test_manager_with_dirs(None, tools_dir, channels_dir, Some(Arc::clone(&store)));
+        let channel_manager = Arc::new(ChannelManager::new());
+        let runtime = Arc::new(
+            WasmChannelRuntime::new(WasmChannelRuntimeConfig::for_testing()).expect("runtime init"),
+        );
+        let pairing_store = Arc::new(PairingStore::new_noop());
+        let router = Arc::new(WasmChannelRouter::new());
+        mgr.set_channel_runtime(
+            Arc::clone(&channel_manager),
+            Arc::clone(&runtime),
+            Arc::clone(&pairing_store),
+            Arc::clone(&router),
+            std::collections::HashMap::new(),
+        )
+        .await;
+        mgr.set_test_wasm_channel_loader(Arc::new({
+            let runtime = Arc::clone(&runtime);
+            let pairing_store = Arc::clone(&pairing_store);
+            move |_name| {
+                Ok(make_test_loaded_channel(
+                    Arc::clone(&runtime),
+                    "tenant_chat",
+                    Arc::clone(&pairing_store),
+                ))
+            }
+        }))
+        .await;
+
+        mgr.configure(
+            "tenant_chat",
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+            "tenant-a",
+        )
+        .await
+        .expect("configure tenant-a");
+        mgr.configure(
+            "tenant_chat",
+            &std::collections::HashMap::new(),
+            &std::collections::HashMap::new(),
+            "tenant-b",
+        )
+        .await
+        .expect("configure tenant-b");
+
+        let tenant_a = store
+            .get_primary_channel_instance("tenant-a", "tenant_chat")
+            .await
+            .expect("load tenant-a instance")
+            .expect("tenant-a instance");
+        let tenant_b = store
+            .get_primary_channel_instance("tenant-b", "tenant_chat")
+            .await
+            .expect("load tenant-b instance")
+            .expect("tenant-b instance");
+
+        mgr.complete_pairing_approval("tenant_chat", "tenant-b", "tg-user-b")
+            .await
+            .expect("propagate pairing approval");
+
+        let tenant_a_channel = router
+            .get_channel_for_path(&format!("/webhook/{}", tenant_a.instance_key))
+            .await
+            .expect("tenant-a runtime channel");
+        let tenant_b_channel = router
+            .get_channel_for_path(&format!("/webhook/{}", tenant_b.instance_key))
+            .await
+            .expect("tenant-b runtime channel");
+
+        assert_eq!(tenant_a_channel.owner_actor_id_for_test().await, None);
+        assert_eq!(
+            tenant_b_channel.owner_actor_id_for_test().await,
+            Some("tg-user-b".to_string())
+        );
+        assert_eq!(
+            tenant_b_channel.get_config().await.get("owner_id"),
+            Some(&serde_json::json!("tg-user-b")),
+            "pairing approval should update the matched tenant runtime config"
         );
     }
 
@@ -9628,6 +10596,7 @@ mod tests {
                 &channel_manager,
                 &router,
                 None,
+                "test",
             )
             .await
             .map_err(|e| format!("activation failed: {e}"))?;
@@ -9663,7 +10632,11 @@ mod tests {
     #[tokio::test]
     async fn test_current_channel_owner_id_uses_runtime_state() -> Result<(), String> {
         let manager = make_manager_with_temp_dirs();
-        if manager.current_channel_owner_id("telegram").await.is_some() {
+        if manager
+            .current_channel_owner_id_for_user("telegram", "test", None)
+            .await
+            .is_some()
+        {
             return Err("expected no owner id for telegram before runtime setup".to_string());
         }
 
@@ -9683,10 +10656,18 @@ mod tests {
             .set_channel_runtime(channels, runtime, pairing_store, router, owner_ids)
             .await;
 
-        if manager.current_channel_owner_id("telegram").await != Some(12345_i64) {
+        if manager
+            .current_channel_owner_id_for_user("telegram", "test", None)
+            .await
+            != Some(12345_i64)
+        {
             return Err("expected runtime owner id fast-path for telegram".to_string());
         }
-        if manager.current_channel_owner_id("slack").await.is_some() {
+        if manager
+            .current_channel_owner_id_for_user("slack", "test", None)
+            .await
+            .is_some()
+        {
             return Err("expected no owner id for slack".to_string());
         }
 
@@ -9742,7 +10723,11 @@ mod tests {
             Vec::new(),
         );
 
-        if manager.current_channel_owner_id("telegram").await.is_some() {
+        if manager
+            .current_channel_owner_id_for_user("telegram", "test", None)
+            .await
+            .is_some()
+        {
             return Err("expected no owner id before settings seed".to_string());
         }
 
@@ -9754,7 +10739,11 @@ mod tests {
         .await
         .map_err(|e| format!("persist owner id in settings failed: {e}"))?;
 
-        if manager.current_channel_owner_id("telegram").await != Some(54321_i64) {
+        if manager
+            .current_channel_owner_id_for_user("telegram", "test", None)
+            .await
+            != Some(54321_i64)
+        {
             return Err("expected store fallback owner id for telegram".to_string());
         }
 
@@ -9773,7 +10762,11 @@ mod tests {
             .set_channel_runtime(channels, runtime, pairing_store, router, owner_ids)
             .await;
 
-        if manager.current_channel_owner_id("telegram").await != Some(12345_i64) {
+        if manager
+            .current_channel_owner_id_for_user("telegram", "test", None)
+            .await
+            != Some(12345_i64)
+        {
             return Err("expected runtime fast-path owner id precedence".to_string());
         }
 

--- a/src/gate/pending.rs
+++ b/src/gate/pending.rs
@@ -47,6 +47,10 @@ pub struct PendingGate {
     /// Channel that originated the request.
     /// Resolution MUST come from the same channel (or a trusted channel).
     pub source_channel: String,
+    /// Internal runtime/dispatch key for the channel instance that originated
+    /// the request. Non-trusted resolutions must match this when present.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_channel_instance_key: Option<String>,
     /// Tool that triggered the gate.
     pub action_name: String,
     /// Tool call ID from the LLM.
@@ -151,6 +155,7 @@ mod tests {
             scope_thread_id: None,
             conversation_id: ironclaw_engine::ConversationId::new(),
             source_channel: "telegram".into(),
+            source_channel_instance_key: None,
             action_name: "shell".into(),
             call_id: "call_1".into(),
             parameters: serde_json::json!({"command": "ls"}),

--- a/src/gate/persistence.rs
+++ b/src/gate/persistence.rs
@@ -150,6 +150,7 @@ mod tests {
             scope_thread_id: None,
             conversation_id: ConversationId::new(),
             source_channel: "web".into(),
+            source_channel_instance_key: Some("web".into()),
             action_name: "shell".into(),
             call_id: "call_1".into(),
             parameters: serde_json::json!({"cmd":"ls"}),

--- a/src/gate/store.rs
+++ b/src/gate/store.rs
@@ -135,6 +135,19 @@ impl PendingGateStore {
         request_id: Uuid,
         responding_channel: &str,
     ) -> Result<PendingGate, GateStoreError> {
+        self.take_verified_for_channel_instance(key, request_id, responding_channel, None)
+            .await
+    }
+
+    /// Like [`take_verified`](Self::take_verified), but also verifies the
+    /// internal channel-instance dispatch key for non-trusted channels.
+    pub async fn take_verified_for_channel_instance(
+        &self,
+        key: &PendingGateKey,
+        request_id: Uuid,
+        responding_channel: &str,
+        responding_channel_instance_key: Option<&str>,
+    ) -> Result<PendingGate, GateStoreError> {
         let gate = {
             let mut inner = self.inner.lock().await;
 
@@ -145,13 +158,24 @@ impl PendingGateStore {
                 return Err(GateStoreError::RequestIdMismatch);
             }
 
-            // Verify channel authorization
-            let channel_authorized = gate.source_channel == responding_channel
-                || TRUSTED_GATE_CHANNELS.contains(&responding_channel);
+            // Verify channel authorization.
+            let channel_authorized = if TRUSTED_GATE_CHANNELS.contains(&responding_channel) {
+                true
+            } else if let Some(source_instance_key) = gate.source_channel_instance_key.as_deref() {
+                gate.source_channel == responding_channel
+                    && responding_channel_instance_key == Some(source_instance_key)
+            } else {
+                gate.source_channel == responding_channel
+            };
             if !channel_authorized {
                 return Err(GateStoreError::ChannelMismatch {
-                    expected: gate.source_channel.clone(),
-                    actual: responding_channel.to_string(),
+                    expected: gate
+                        .source_channel_instance_key
+                        .clone()
+                        .unwrap_or_else(|| gate.source_channel.clone()),
+                    actual: responding_channel_instance_key
+                        .unwrap_or(responding_channel)
+                        .to_string(),
                 });
             }
 
@@ -353,6 +377,7 @@ mod tests {
             scope_thread_id: None,
             conversation_id: ConversationId::new(),
             source_channel: channel.into(),
+            source_channel_instance_key: None,
             action_name: "shell".into(),
             call_id: "call_1".into(),
             parameters: serde_json::json!({"command": "ls"}),
@@ -484,6 +509,59 @@ mod tests {
             store.take_verified(&key, request_id, "slack").await,
             Err(GateStoreError::ChannelMismatch { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn test_take_verified_requires_matching_instance_key_for_non_trusted_channels() {
+        let store = PendingGateStore::in_memory();
+        let mut gate = sample_gate("telegram");
+        gate.source_channel_instance_key = Some("tenant-a:telegram".into());
+        let key = gate.key();
+        let request_id = gate.request_id;
+        store.insert(gate).await.unwrap();
+
+        assert!(matches!(
+            store
+                .take_verified_for_channel_instance(
+                    &key,
+                    request_id,
+                    "telegram",
+                    Some("tenant-b:telegram"),
+                )
+                .await,
+            Err(GateStoreError::ChannelMismatch { .. })
+        ));
+
+        let taken = store
+            .take_verified_for_channel_instance(
+                &key,
+                request_id,
+                "telegram",
+                Some("tenant-a:telegram"),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            taken.source_channel_instance_key.as_deref(),
+            Some("tenant-a:telegram")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_take_verified_trusted_channel_bypasses_instance_key_match() {
+        let store = PendingGateStore::in_memory();
+        let mut gate = sample_gate("telegram");
+        gate.source_channel_instance_key = Some("tenant-a:telegram".into());
+        let key = gate.key();
+        let request_id = gate.request_id;
+        store.insert(gate).await.unwrap();
+
+        assert!(
+            store
+                .take_verified_for_channel_instance(&key, request_id, "gateway", None)
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1117,54 +1117,62 @@ async fn async_main() -> anyhow::Result<()> {
             .await;
         tracing::debug!("Channel runtime wired into extension manager for hot-activation");
 
-        // Auto-activate WASM channels that were active in a previous session.
-        // Relay channels are handled separately below via restore_relay_channels().
-        for name in &persisted_active_wasm_channels {
-            if active_at_startup.contains(name)
-                || ext_mgr.is_relay_channel(name, &ext_user_id).await
-            {
-                continue;
-            }
-            match ext_mgr
-                .ensure_extension_ready(
-                    name,
-                    &ext_user_id,
-                    ironclaw::extensions::EnsureReadyIntent::ExplicitActivate,
-                )
-                .await
-            {
-                Ok(ironclaw::extensions::EnsureReadyOutcome::Ready { activation, .. }) => {
-                    let message = activation
-                        .map(|result| result.message)
-                        .unwrap_or_else(|| format!("Channel '{}' already ready", name));
-                    tracing::debug!(
-                        channel = %name,
-                        message = %message,
-                        "Auto-activated persisted WASM channel"
-                    );
+        // Prefer the new process-global channel-instance control plane when it
+        // has enabled rows. Fall back to the legacy owner-scoped
+        // `activated_channels` compatibility path only when no instance rows
+        // exist yet. Relay channels are handled separately below via
+        // restore_relay_channels().
+        let restored_from_channel_instances =
+            ext_mgr.restore_enabled_wasm_channel_instances().await;
+        if restored_from_channel_instances == 0 {
+            for name in &persisted_active_wasm_channels {
+                if active_at_startup.contains(name)
+                    || ext_mgr.is_relay_channel(name, &ext_user_id).await
+                {
+                    continue;
                 }
-                Ok(ironclaw::extensions::EnsureReadyOutcome::NeedsAuth { auth, .. }) => {
-                    tracing::warn!(
-                        channel = %name,
-                        instructions = ?auth.instructions(),
-                        "Persisted WASM channel still needs authentication"
-                    );
-                }
-                Ok(ironclaw::extensions::EnsureReadyOutcome::NeedsSetup {
-                    instructions, ..
-                }) => {
-                    tracing::warn!(
-                        channel = %name,
-                        instructions = %instructions,
-                        "Persisted WASM channel still needs setup"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(
-                        channel = %name,
-                        error = %e,
-                        "Failed to auto-activate persisted WASM channel"
-                    );
+                match ext_mgr
+                    .ensure_extension_ready(
+                        name,
+                        &ext_user_id,
+                        ironclaw::extensions::EnsureReadyIntent::ExplicitActivate,
+                    )
+                    .await
+                {
+                    Ok(ironclaw::extensions::EnsureReadyOutcome::Ready { activation, .. }) => {
+                        let message = activation
+                            .map(|result| result.message)
+                            .unwrap_or_else(|| format!("Channel '{}' already ready", name));
+                        tracing::debug!(
+                            channel = %name,
+                            message = %message,
+                            "Auto-activated persisted WASM channel"
+                        );
+                    }
+                    Ok(ironclaw::extensions::EnsureReadyOutcome::NeedsAuth { auth, .. }) => {
+                        tracing::warn!(
+                            channel = %name,
+                            instructions = ?auth.instructions(),
+                            "Persisted WASM channel still needs authentication"
+                        );
+                    }
+                    Ok(ironclaw::extensions::EnsureReadyOutcome::NeedsSetup {
+                        instructions,
+                        ..
+                    }) => {
+                        tracing::warn!(
+                            channel = %name,
+                            instructions = %instructions,
+                            "Persisted WASM channel still needs setup"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            channel = %name,
+                            error = %e,
+                            "Failed to auto-activate persisted WASM channel"
+                        );
+                    }
                 }
             }
         }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -255,6 +255,7 @@ impl LlmProvider for StubLlm {
 /// ```
 pub struct StubChannel {
     name: String,
+    dispatch_key: String,
     rx: tokio::sync::Mutex<Option<mpsc::Receiver<IncomingMessage>>>,
     responses: Arc<Mutex<Vec<(IncomingMessage, OutgoingResponse)>>>,
     statuses: Arc<Mutex<Vec<StatusUpdate>>>,
@@ -267,9 +268,19 @@ impl StubChannel {
     /// The sender is used by tests to inject messages into the channel's stream.
     /// The channel captures all responses and status updates for later assertion.
     pub fn new(name: impl Into<String>) -> (Self, mpsc::Sender<IncomingMessage>) {
+        let name = name.into();
+        Self::with_dispatch_key(name.clone(), name)
+    }
+
+    /// Create a stub channel with distinct semantic name and internal dispatch key.
+    pub fn with_dispatch_key(
+        name: impl Into<String>,
+        dispatch_key: impl Into<String>,
+    ) -> (Self, mpsc::Sender<IncomingMessage>) {
         let (tx, rx) = mpsc::channel(64);
         let channel = Self {
             name: name.into(),
+            dispatch_key: dispatch_key.into(),
             rx: tokio::sync::Mutex::new(Some(rx)),
             responses: Arc::new(Mutex::new(Vec::new())),
             statuses: Arc::new(Mutex::new(Vec::new())),
@@ -313,6 +324,10 @@ impl StubChannel {
 impl Channel for StubChannel {
     fn name(&self) -> &str {
         &self.name
+    }
+
+    fn dispatch_key(&self) -> &str {
+        &self.dispatch_key
     }
 
     async fn start(&self) -> Result<MessageStream, ChannelError> {

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -387,7 +387,7 @@ impl Tool for MessageTool {
                 .await
             {
                 Ok(()) => {
-                    tracing::info!(
+                    tracing::debug!(
                         message_sent = true,
                         channel = %delivery_channel,
                         target = %target,
@@ -439,7 +439,7 @@ impl Tool for MessageTool {
                 };
                 Err(ToolError::ExecutionFailed(err_msg))
             } else {
-                tracing::info!(
+                tracing::debug!(
                     message_sent = true,
                     channels = ?succeeded,
                     target = %target,

--- a/src/tools/builtin/message.rs
+++ b/src/tools/builtin/message.rs
@@ -94,18 +94,27 @@ fn channel_matches_source(resolved_channel: Option<&str>, source_channel: Option
     }
 }
 
+fn effective_owner_scope_user<'a>(
+    owner_scope_target: Option<&'a str>,
+    ctx_user_id: &'a str,
+) -> &'a str {
+    owner_scope_target.unwrap_or(ctx_user_id)
+}
+
 async fn resolve_channel_fallback_target(
     extension_manager: Option<&Arc<ExtensionManager>>,
     channel: Option<&str>,
     owner_scope_target: Option<&str>,
     ctx_user_id: &str,
 ) -> Option<String> {
+    let owner_scope_user = effective_owner_scope_user(owner_scope_target, ctx_user_id);
+
     // Prefer an explicit channel binding when the extension manager knows the
     // durable delivery target (for example, a bound Telegram chat ID).
     if let Some(channel_name) = channel
         && let Some(extension_manager) = extension_manager
         && let Some(target) = extension_manager
-            .notification_target_for_channel(channel_name)
+            .notification_target_for_channel_for_user(channel_name, owner_scope_user)
             .await
     {
         return Some(target);
@@ -117,6 +126,24 @@ async fn resolve_channel_fallback_target(
     owner_scope_target
         .map(ToOwned::to_owned)
         .or_else(|| Some(ctx_user_id.to_string()))
+}
+
+async fn resolve_channel_dispatch_key(
+    extension_manager: Option<&Arc<ExtensionManager>>,
+    channel: Option<&str>,
+    owner_scope_target: Option<&str>,
+    ctx_user_id: &str,
+) -> Option<String> {
+    let channel_name = channel?;
+    if let Some(extension_manager) = extension_manager {
+        let owner_scope_user = effective_owner_scope_user(owner_scope_target, ctx_user_id);
+        return Some(
+            extension_manager
+                .notification_channel_dispatch_key_for_user(channel_name, owner_scope_user)
+                .await,
+        );
+    }
+    Some(channel_name.to_string())
 }
 
 struct MessageTargetResolution<'a> {
@@ -279,7 +306,7 @@ impl Tool for MessageTool {
             extension_manager: self.extension_manager.as_ref(),
             explicit_target,
             metadata_target,
-            owner_scope_target,
+            owner_scope_target: owner_scope_target.clone(),
             default_target,
             channel: channel.as_deref(),
             metadata_channel: metadata_channel.as_deref(),
@@ -344,21 +371,30 @@ impl Tool for MessageTool {
         }
 
         if let Some(ref channel) = channel {
+            let delivery_channel = resolve_channel_dispatch_key(
+                self.extension_manager.as_ref(),
+                Some(channel),
+                owner_scope_target.as_deref(),
+                &ctx.user_id,
+            )
+            .await
+            .unwrap_or_else(|| channel.clone());
+
             // Send to a specific channel
             match self
                 .channel_manager
-                .broadcast(channel, &target, response)
+                .broadcast(&delivery_channel, &target, response)
                 .await
             {
                 Ok(()) => {
                     tracing::info!(
                         message_sent = true,
-                        channel = %channel,
+                        channel = %delivery_channel,
                         target = %target,
                         attachments = attachment_count,
                         "Message sent via message tool"
                     );
-                    let msg = format!("Sent message to {}:{}", channel, target);
+                    let msg = format!("Sent message to {}:{}", delivery_channel, target);
                     Ok(ToolOutput::text(msg, start.elapsed()))
                 }
                 Err(e) => {
@@ -366,12 +402,12 @@ impl Tool for MessageTool {
                     let err_msg = if available.is_empty() {
                         format!(
                             "Failed to send to {}:{}: {}. No channels connected.",
-                            channel, target, e
+                            delivery_channel, target, e
                         )
                     } else {
                         format!(
                             "Failed to send to {}:{}. Available channels: {}. Error: {}",
-                            channel, target, available, e
+                            delivery_channel, target, available, e
                         )
                     };
                     Err(ToolError::ExecutionFailed(err_msg))
@@ -438,13 +474,90 @@ impl Tool for MessageTool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::testing::{BroadcastCapture, RecordingBroadcastChannel};
+    use crate::channels::{Channel, IncomingMessage, MessageStream, StatusUpdate};
+    use crate::error::ChannelError;
+    use crate::testing::BroadcastCapture;
+
+    struct TestBroadcastChannel {
+        name: &'static str,
+        dispatch_key: &'static str,
+        captures: BroadcastCapture,
+    }
+
+    impl TestBroadcastChannel {
+        fn new(name: &'static str) -> (Self, BroadcastCapture) {
+            Self::with_dispatch_key(name, name)
+        }
+
+        fn with_dispatch_key(
+            name: &'static str,
+            dispatch_key: &'static str,
+        ) -> (Self, BroadcastCapture) {
+            let captures = Arc::new(tokio::sync::Mutex::new(Vec::new()));
+            (
+                Self {
+                    name,
+                    dispatch_key,
+                    captures: Arc::clone(&captures),
+                },
+                captures,
+            )
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Channel for TestBroadcastChannel {
+        fn name(&self) -> &str {
+            self.name
+        }
+
+        fn dispatch_key(&self) -> &str {
+            self.dispatch_key
+        }
+
+        async fn start(&self) -> Result<MessageStream, ChannelError> {
+            let (_tx, rx) = tokio::sync::mpsc::channel::<IncomingMessage>(1);
+            Ok(Box::pin(tokio_stream::wrappers::ReceiverStream::new(rx)))
+        }
+
+        async fn respond(
+            &self,
+            _msg: &IncomingMessage,
+            _response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn send_status(
+            &self,
+            _status: StatusUpdate,
+            _metadata: &serde_json::Value,
+        ) -> Result<(), ChannelError> {
+            Ok(())
+        }
+
+        async fn broadcast(
+            &self,
+            user_id: &str,
+            response: OutgoingResponse,
+        ) -> Result<(), ChannelError> {
+            self.captures
+                .lock()
+                .await
+                .push((user_id.to_string(), response));
+            Ok(())
+        }
+
+        async fn health_check(&self) -> Result<(), ChannelError> {
+            Ok(())
+        }
+    }
 
     async fn message_tool_with_recording_channels()
     -> (MessageTool, BroadcastCapture, BroadcastCapture) {
         let channel_manager = ChannelManager::new();
-        let (gateway, gateway_captures) = RecordingBroadcastChannel::new("gateway");
-        let (telegram, telegram_captures) = RecordingBroadcastChannel::new("telegram");
+        let (gateway, gateway_captures) = TestBroadcastChannel::new("gateway");
+        let (telegram, telegram_captures) = TestBroadcastChannel::new("telegram");
         channel_manager.add(Box::new(gateway)).await;
         channel_manager.add(Box::new(telegram)).await;
 
@@ -453,6 +566,24 @@ mod tests {
             gateway_captures,
             telegram_captures,
         )
+    }
+
+    async fn seed_test_user(store: &Arc<dyn crate::db::Database>, user_id: &str) {
+        store
+            .get_or_create_user(crate::db::UserRecord {
+                id: user_id.to_string(),
+                role: "member".to_string(),
+                display_name: user_id.to_string(),
+                status: "active".to_string(),
+                email: None,
+                last_login_at: None,
+                created_by: None,
+                created_at: chrono::Utc::now(),
+                updated_at: chrono::Utc::now(),
+                metadata: serde_json::json!({}),
+            })
+            .await
+            .expect("seed test user");
     }
 
     #[test]
@@ -919,6 +1050,84 @@ mod tests {
         assert_eq!(telegram.len(), 1);
         assert_eq!(telegram[0].0, "interactive-chat-user");
         assert_eq!(telegram[0].1.content, "NEAR price is $5");
+    }
+
+    #[tokio::test]
+    async fn message_tool_owner_scoped_channel_uses_tenant_dispatch_key() {
+        let (db, _db_dir) = crate::testing::test_db().await;
+        seed_test_user(&db, "tenant-b").await;
+        db.set_setting(
+            "tenant-b",
+            "channels.wasm_channel_owner_ids.telegram",
+            &serde_json::json!(424242_i64),
+        )
+        .await
+        .expect("persist tenant telegram target");
+        db.create_channel_instance(&crate::db::ChannelInstanceRecord {
+            id: uuid::Uuid::new_v4(),
+            user_id: "tenant-b".to_string(),
+            channel_kind: "telegram".to_string(),
+            instance_key: "telegram:tenant-b:primary".to_string(),
+            display_name: "Tenant B Telegram".to_string(),
+            is_primary: true,
+            enabled: true,
+            config: serde_json::json!({}),
+            metadata: serde_json::json!({}),
+            last_error: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+        })
+        .await
+        .expect("create tenant channel instance");
+
+        let tools_dir = tempfile::tempdir().expect("temp tools dir");
+        let channels_dir = tempfile::tempdir().expect("temp channels dir");
+        let master_key =
+            secrecy::SecretString::from(crate::testing::credentials::TEST_CRYPTO_KEY.to_string());
+        let crypto = Arc::new(
+            crate::secrets::SecretsCrypto::new(master_key).expect("create secrets crypto"),
+        );
+        let extension_manager = Arc::new(crate::extensions::ExtensionManager::new(
+            Arc::new(crate::tools::mcp::session::McpSessionManager::new()),
+            Arc::new(crate::tools::mcp::process::McpProcessManager::new()),
+            Arc::new(crate::secrets::InMemorySecretsStore::new(crypto)),
+            Arc::new(crate::tools::ToolRegistry::new()),
+            None,
+            None,
+            tools_dir.path().to_path_buf(),
+            channels_dir.path().to_path_buf(),
+            None,
+            "test".to_string(),
+            Some(Arc::clone(&db)),
+            Vec::new(),
+        ));
+
+        let channel_manager = ChannelManager::new();
+        let (telegram, telegram_captures) =
+            TestBroadcastChannel::with_dispatch_key("telegram", "telegram:tenant-b:primary");
+        channel_manager.add(Box::new(telegram)).await;
+        let tool = MessageTool::new(Arc::new(channel_manager))
+            .with_extension_manager(Arc::clone(&extension_manager));
+
+        let mut ctx = crate::context::JobContext::with_user("owner-scope", "test", "test");
+        ctx.metadata = serde_json::json!({
+            "notify_channel": "telegram",
+            "owner_id": "tenant-b",
+        });
+
+        let result = tool
+            .execute(serde_json::json!({"content": "hello"}), &ctx)
+            .await
+            .expect("tenant-scoped telegram notification should resolve via dispatch key");
+
+        assert_eq!(
+            result.result.as_str(),
+            Some("Sent message to telegram:tenant-b:primary:424242")
+        );
+        let telegram = telegram_captures.lock().await.clone();
+        assert_eq!(telegram.len(), 1);
+        assert_eq!(telegram[0].0, "424242");
+        assert_eq!(telegram[0].1.content, "hello");
     }
 
     #[tokio::test]

--- a/tests/e2e/CLAUDE.md
+++ b/tests/e2e/CLAUDE.md
@@ -33,6 +33,13 @@ pytest scenarios/
 pytest scenarios/test_chat.py
 pytest scenarios/test_sse_reconnect.py
 
+# Run the Telegram-focused batch
+pytest -v \
+  scenarios/test_telegram_token_validation.py \
+  scenarios/test_telegram_hot_activation.py \
+  scenarios/test_telegram_e2e.py \
+  scenarios/test_multi_tenant_channels.py
+
 # Run with verbose output
 pytest scenarios/ -v
 
@@ -55,6 +62,8 @@ HEADED=1 pytest scenarios/
 | `test_tool_approval.py` | Approval card appears, buttons disable on approve/deny, parameters toggle via `page.evaluate("showApproval(...)")`; the waiting-approval regression uses a real HTTP tool call |
 | `test_extension_uninstall_cleanup.py` | Real install/setup/remove coverage for WASM tools, WASM channels, OAuth-backed shared Google tools, and MCP servers; verifies uninstall deletes stored secrets from the libSQL `secrets` table while preserving shared credentials until the last referencing extension is removed |
 | `test_oauth_refresh.py` | Hosted Gmail OAuth regression: complete setup via `/oauth/callback`, expire the stored access token in libSQL, trigger a real `gmail` tool call through `/api/chat/send`, and verify refresh goes through the mock `/oauth/refresh` proxy without forwarding `client_secret` |
+| `test_telegram_e2e.py` | Full-process Telegram activation, pairing, webhook delivery, webhook-secret enforcement, polling mode, markdown fallback, rate limiting, attachment download failures, and malformed payload resilience |
+| `test_multi_tenant_channels.py` | Full-process multi-tenant Telegram isolation: two tenants activate Telegram independently, get distinct dispatch-key webhook paths, and stay isolated for routing, threads, secrets, and per-user extension state |
 | `test_dom_resource_limits.py` | DOM pruning at MAX_DOM_MESSAGES cap, no setInterval timer leaks across SSE reconnect cycles, streaming message preservation during pruning |
 
 ## `helpers.py`

--- a/tests/e2e/scenarios/test_multi_tenant_channels.py
+++ b/tests/e2e/scenarios/test_multi_tenant_channels.py
@@ -1,0 +1,463 @@
+"""Multi-tenant Telegram channel E2E tests.
+
+Two users independently activate the same Telegram WASM channel, each
+getting a unique dispatch key and webhook path. Verifies:
+
+1. Both tenants get distinct dispatch keys (webhook paths)
+2. Webhook messages route to the correct tenant's replies
+3. Cross-tenant webhook delivery (wrong secret) is rejected
+4. Thread isolation: no shared thread IDs between tenants
+5. Extensions list shows correct per-tenant active status
+6. An unactivated user sees Telegram as inactive
+"""
+
+import asyncio
+import json
+import os
+import re
+import time
+from itertools import count
+
+import httpx
+import pytest
+
+from helpers import api_get, api_post, auth_headers, create_member_user
+
+# Per-tenant bot tokens (distinct so they're traceable in the fake API)
+ALICE_BOT_TOKEN = "111ALICE:FAKE_ALICE_TOKEN"
+BOB_BOT_TOKEN = "222BOB:FAKE_BOB_TOKEN"
+
+# Per-tenant webhook secrets
+ALICE_WEBHOOK_SECRET = "e2e-alice-webhook-secret"
+BOB_WEBHOOK_SECRET = "e2e-bob-webhook-secret"
+
+# Per-tenant Telegram user IDs (used in webhook payloads)
+ALICE_TG_USER_ID = 100001
+BOB_TG_USER_ID = 200002
+
+PAIRING_CODE_RE = re.compile(r"approve telegram ([A-Z0-9]+)|`([A-Z0-9]+)`")
+
+# Monotonic update IDs that don't collide with other Telegram E2E test modules.
+_UPDATE_IDS = count(5000)
+
+
+def _next_update_id() -> int:
+    return next(_UPDATE_IDS)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+async def reset_fake_tg(fake_tg_url: str):
+    async with httpx.AsyncClient() as c:
+        await c.post(f"{fake_tg_url}/__mock/reset")
+
+
+async def wait_for_sent_messages(
+    fake_tg_url: str,
+    *,
+    min_count: int = 1,
+    timeout: float = 30,
+) -> list[dict]:
+    deadline = time.monotonic() + timeout
+    async with httpx.AsyncClient() as c:
+        while time.monotonic() < deadline:
+            r = await c.get(f"{fake_tg_url}/__mock/sent_messages", timeout=5)
+            messages = r.json().get("messages", [])
+            if len(messages) >= min_count:
+                return messages
+            await asyncio.sleep(0.5)
+    raise TimeoutError(
+        f"Expected at least {min_count} sent messages within {timeout}s"
+    )
+
+
+async def get_active_dispatch_keys(http_url: str) -> list[str]:
+    """Get all active WASM channel dispatch keys from the router health endpoint."""
+    async with httpx.AsyncClient() as c:
+        r = await c.get(f"{http_url}/wasm-channels/health", timeout=5)
+        r.raise_for_status()
+        return r.json().get("channels", [])
+
+
+async def install_telegram(base_url: str):
+    r = await api_post(
+        base_url,
+        "/api/extensions/install",
+        json={"name": "telegram", "kind": "wasm_channel"},
+        timeout=180,
+    )
+    assert r.status_code in (200, 409), (
+        f"Telegram install failed ({r.status_code}): {r.text}"
+    )
+
+
+def patch_capabilities_for_testing(channels_dir: str):
+    """Remove validation_endpoint and ensure webhook secret is declared."""
+    cap_path = os.path.join(channels_dir, "telegram.capabilities.json")
+    assert os.path.exists(cap_path), (
+        f"Capabilities not found: {os.listdir(channels_dir)}"
+    )
+    with open(cap_path, "r") as f:
+        caps = json.load(f)
+    if "setup" in caps and "validation_endpoint" in caps["setup"]:
+        del caps["setup"]["validation_endpoint"]
+    setup = caps.setdefault("setup", {})
+    required = setup.setdefault("required_secrets", [])
+    if not any(s.get("name") == "telegram_webhook_secret" for s in required):
+        required.append({
+            "name": "telegram_webhook_secret",
+            "prompt": "Webhook secret",
+            "optional": True,
+            "auto_generate": {"length": 64},
+        })
+    channel = caps.setdefault("capabilities", {}).setdefault("channel", {})
+    webhook = channel.setdefault("webhook", {})
+    webhook.setdefault("secret_name", "telegram_webhook_secret")
+    webhook.setdefault("secret_header", "X-Telegram-Bot-Api-Secret-Token")
+    with open(cap_path, "w") as f:
+        json.dump(caps, f, indent=2)
+
+
+def extract_pairing_code(messages: list[dict]) -> str | None:
+    for message in reversed(messages):
+        text = message.get("text", "")
+        match = PAIRING_CODE_RE.search(text)
+        if match:
+            return match.group(1) or match.group(2)
+    return None
+
+
+async def post_webhook(
+    http_url: str,
+    dispatch_key: str,
+    update: dict,
+    *,
+    secret: str | None = None,
+) -> httpx.Response:
+    """POST a Telegram-shaped update to a specific dispatch key's webhook path."""
+    headers = {"Content-Type": "application/json"}
+    if secret is not None:
+        headers["X-Telegram-Bot-Api-Secret-Token"] = secret
+    async with httpx.AsyncClient() as c:
+        return await c.post(
+            f"{http_url}/webhook/{dispatch_key}",
+            json=update,
+            headers=headers,
+            timeout=10,
+        )
+
+
+async def approve_pairing(base_url: str, code: str, *, token: str) -> None:
+    async with httpx.AsyncClient() as c:
+        response = await c.post(
+            f"{base_url}/api/pairing/telegram/approve",
+            headers=auth_headers(token),
+            json={"code": code},
+            timeout=10,
+        )
+    response.raise_for_status()
+    body = response.json()
+    assert body.get("success"), f"Pairing approval failed: {body}"
+
+
+async def activate_tenant_telegram(
+    base_url: str,
+    http_url: str,
+    fake_tg_url: str,
+    *,
+    user_token: str,
+    bot_token: str,
+    webhook_secret: str,
+    tg_user_id: int,
+    first_name: str,
+) -> str:
+    """Activate Telegram for a specific tenant. Returns the dispatch key.
+
+    1. Snapshots active dispatch keys before activation
+    2. Calls the setup API with per-tenant credentials
+    3. Discovers the new dispatch key by diffing the health endpoint
+    4. Completes the pairing flow so the Telegram user can chat
+    """
+    keys_before = set(await get_active_dispatch_keys(http_url))
+    await reset_fake_tg(fake_tg_url)
+
+    r = await api_post(
+        base_url,
+        "/api/extensions/telegram/setup",
+        token=user_token,
+        json={
+            "secrets": {
+                "telegram_bot_token": bot_token,
+                "telegram_webhook_secret": webhook_secret,
+            },
+            "fields": {},
+        },
+        timeout=30,
+    )
+    r.raise_for_status()
+    body = r.json()
+    assert body.get("activated"), f"Tenant setup did not activate: {body}"
+
+    # Discover the new dispatch key by polling the health endpoint
+    dispatch_key = None
+    deadline = time.monotonic() + 15
+    while time.monotonic() < deadline:
+        keys_after = set(await get_active_dispatch_keys(http_url))
+        new_keys = keys_after - keys_before
+        telegram_keys = [k for k in new_keys if k.startswith("telegram")]
+        if telegram_keys:
+            dispatch_key = telegram_keys[0]
+            break
+        await asyncio.sleep(0.5)
+
+    assert dispatch_key is not None, (
+        f"Failed to discover dispatch key for {first_name}. "
+        f"Keys before: {keys_before}, keys after activation: "
+        f"{set(await get_active_dispatch_keys(http_url))}"
+    )
+
+    # Complete pairing: send a message, extract pairing code, approve
+    await reset_fake_tg(fake_tg_url)
+    pairing_resp = await post_webhook(
+        http_url,
+        dispatch_key,
+        {
+            "update_id": _next_update_id(),
+            "message": {
+                "message_id": 1,
+                "from": {
+                    "id": tg_user_id,
+                    "is_bot": False,
+                    "first_name": first_name,
+                },
+                "chat": {"id": tg_user_id, "type": "private"},
+                "date": int(time.time()),
+                "text": "hello",
+            },
+        },
+        secret=webhook_secret,
+    )
+    assert pairing_resp.status_code == 200
+
+    messages = await wait_for_sent_messages(fake_tg_url, min_count=1, timeout=60)
+    code = extract_pairing_code(messages)
+    if code:
+        await approve_pairing(base_url, code, token=user_token)
+
+    await reset_fake_tg(fake_tg_url)
+    return dispatch_key
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+
+async def test_multi_tenant_telegram_channel_isolation(isolated_telegram_e2e_server):
+    """Two tenants activate Telegram independently; verify full isolation."""
+    base_url = isolated_telegram_e2e_server["base_url"]
+    http_url = isolated_telegram_e2e_server["http_url"]
+    fake_tg_url = isolated_telegram_e2e_server["fake_tg_url"]
+    channels_dir = isolated_telegram_e2e_server["channels_dir"]
+
+    # ── Setup: create three users, activate Telegram for two ──
+
+    alice = await create_member_user(base_url, display_name="Alice Tenant")
+    bob = await create_member_user(base_url, display_name="Bob Tenant")
+    charlie = await create_member_user(base_url, display_name="Charlie Inactive")
+
+    await install_telegram(base_url)
+    patch_capabilities_for_testing(channels_dir)
+
+    alice_dk = await activate_tenant_telegram(
+        base_url, http_url, fake_tg_url,
+        user_token=alice["token"],
+        bot_token=ALICE_BOT_TOKEN,
+        webhook_secret=ALICE_WEBHOOK_SECRET,
+        tg_user_id=ALICE_TG_USER_ID,
+        first_name="Alice TG",
+    )
+
+    bob_dk = await activate_tenant_telegram(
+        base_url, http_url, fake_tg_url,
+        user_token=bob["token"],
+        bot_token=BOB_BOT_TOKEN,
+        webhook_secret=BOB_WEBHOOK_SECRET,
+        tg_user_id=BOB_TG_USER_ID,
+        first_name="Bob TG",
+    )
+
+    # ── Assert 1: dispatch keys are unique and well-formed ──
+
+    assert alice_dk != bob_dk, f"Both tenants got same dispatch key: {alice_dk}"
+    assert alice_dk.startswith("telegram:"), (
+        f"Unexpected Alice dispatch key format: {alice_dk}"
+    )
+    assert bob_dk.startswith("telegram:"), (
+        f"Unexpected Bob dispatch key format: {bob_dk}"
+    )
+
+    # ── Assert 2: Alice's webhook → reply targets Alice's chat_id ──
+
+    await reset_fake_tg(fake_tg_url)
+    resp = await post_webhook(
+        http_url,
+        alice_dk,
+        {
+            "update_id": _next_update_id(),
+            "message": {
+                "message_id": 100,
+                "from": {
+                    "id": ALICE_TG_USER_ID,
+                    "is_bot": False,
+                    "first_name": "Alice TG",
+                },
+                "chat": {"id": ALICE_TG_USER_ID, "type": "private"},
+                "date": int(time.time()),
+                "text": "hello from alice",
+            },
+        },
+        secret=ALICE_WEBHOOK_SECRET,
+    )
+    assert resp.status_code == 200
+    alice_msgs = await wait_for_sent_messages(fake_tg_url, min_count=1, timeout=60)
+    assert any(m["chat_id"] == ALICE_TG_USER_ID for m in alice_msgs), (
+        f"Expected reply to Alice's chat_id {ALICE_TG_USER_ID}, got: {alice_msgs}"
+    )
+
+    # ── Assert 3: Bob's webhook → reply targets Bob's chat_id ──
+
+    await reset_fake_tg(fake_tg_url)
+    resp = await post_webhook(
+        http_url,
+        bob_dk,
+        {
+            "update_id": _next_update_id(),
+            "message": {
+                "message_id": 200,
+                "from": {
+                    "id": BOB_TG_USER_ID,
+                    "is_bot": False,
+                    "first_name": "Bob TG",
+                },
+                "chat": {"id": BOB_TG_USER_ID, "type": "private"},
+                "date": int(time.time()),
+                "text": "hello from bob",
+            },
+        },
+        secret=BOB_WEBHOOK_SECRET,
+    )
+    assert resp.status_code == 200
+    bob_msgs = await wait_for_sent_messages(fake_tg_url, min_count=1, timeout=60)
+    assert any(m["chat_id"] == BOB_TG_USER_ID for m in bob_msgs), (
+        f"Expected reply to Bob's chat_id {BOB_TG_USER_ID}, got: {bob_msgs}"
+    )
+
+    # ── Assert 4: threads are isolated per tenant ──
+
+    alice_threads_r = await api_get(
+        base_url, "/api/chat/threads", token=alice["token"]
+    )
+    alice_threads_r.raise_for_status()
+    alice_threads = alice_threads_r.json().get("threads", [])
+
+    bob_threads_r = await api_get(
+        base_url, "/api/chat/threads", token=bob["token"]
+    )
+    bob_threads_r.raise_for_status()
+    bob_threads = bob_threads_r.json().get("threads", [])
+
+    alice_thread_ids = {t["id"] for t in alice_threads}
+    bob_thread_ids = {t["id"] for t in bob_threads}
+    assert alice_thread_ids.isdisjoint(bob_thread_ids), (
+        f"Thread IDs overlap between tenants: "
+        f"alice={alice_thread_ids}, bob={bob_thread_ids}"
+    )
+
+    # ── Assert 5: cross-tenant secret is rejected ──
+
+    resp = await post_webhook(
+        http_url,
+        alice_dk,
+        {
+            "update_id": _next_update_id(),
+            "message": {
+                "message_id": 300,
+                "from": {
+                    "id": BOB_TG_USER_ID,
+                    "is_bot": False,
+                    "first_name": "Bob TG",
+                },
+                "chat": {"id": BOB_TG_USER_ID, "type": "private"},
+                "date": int(time.time()),
+                "text": "trying to reach alice with wrong secret",
+            },
+        },
+        secret=BOB_WEBHOOK_SECRET,
+    )
+    assert resp.status_code in (401, 403), (
+        f"Expected 401/403 for cross-tenant secret on Alice's path, "
+        f"got {resp.status_code}: {resp.text}"
+    )
+
+    # ── Assert 6: nonexistent dispatch key returns 404 ──
+
+    resp = await post_webhook(
+        http_url,
+        "telegram:nonexistent-key",
+        {
+            "update_id": _next_update_id(),
+            "message": {
+                "message_id": 400,
+                "from": {"id": 999, "is_bot": False, "first_name": "Ghost"},
+                "chat": {"id": 999, "type": "private"},
+                "date": int(time.time()),
+                "text": "nobody home",
+            },
+        },
+        secret="irrelevant",
+    )
+    assert resp.status_code == 404, (
+        f"Expected 404 for nonexistent dispatch key, got {resp.status_code}"
+    )
+
+    # ── Assert 7: extensions list shows correct per-tenant active status ──
+
+    alice_exts_r = await api_get(
+        base_url, "/api/extensions", token=alice["token"]
+    )
+    alice_exts_r.raise_for_status()
+    alice_exts = alice_exts_r.json().get("extensions", [])
+    alice_tg = next((e for e in alice_exts if e["name"] == "telegram"), None)
+    assert alice_tg is not None, (
+        f"Telegram not in Alice's extensions: {alice_exts}"
+    )
+    assert alice_tg["active"] is True, (
+        f"Expected Telegram active for Alice: {alice_tg}"
+    )
+
+    bob_exts_r = await api_get(
+        base_url, "/api/extensions", token=bob["token"]
+    )
+    bob_exts_r.raise_for_status()
+    bob_exts = bob_exts_r.json().get("extensions", [])
+    bob_tg = next((e for e in bob_exts if e["name"] == "telegram"), None)
+    assert bob_tg is not None, (
+        f"Telegram not in Bob's extensions: {bob_exts}"
+    )
+    assert bob_tg["active"] is True, (
+        f"Expected Telegram active for Bob: {bob_tg}"
+    )
+
+    # Charlie never activated — should show inactive
+    charlie_exts_r = await api_get(
+        base_url, "/api/extensions", token=charlie["token"]
+    )
+    charlie_exts_r.raise_for_status()
+    charlie_exts = charlie_exts_r.json().get("extensions", [])
+    charlie_tg = next((e for e in charlie_exts if e["name"] == "telegram"), None)
+    assert charlie_tg is not None, (
+        f"Telegram not in Charlie's extensions: {charlie_exts}"
+    )
+    assert charlie_tg["active"] is False, (
+        f"Expected Telegram inactive for Charlie (never activated): {charlie_tg}"
+    )

--- a/tests/e2e/scenarios/test_multi_tenant_channels.py
+++ b/tests/e2e/scenarios/test_multi_tenant_channels.py
@@ -24,8 +24,8 @@ import pytest
 from helpers import api_get, api_post, auth_headers, create_member_user
 
 # Per-tenant bot tokens (distinct so they're traceable in the fake API)
-ALICE_BOT_TOKEN = "111ALICE:FAKE_ALICE_TOKEN"
-BOB_BOT_TOKEN = "222BOB:FAKE_BOB_TOKEN"
+ALICE_BOT_TOKEN = "111222333:FAKE_ALICE_TOKEN"
+BOB_BOT_TOKEN = "444555666:FAKE_BOB_TOKEN"
 
 # Per-tenant webhook secrets
 ALICE_WEBHOOK_SECRET = "e2e-alice-webhook-secret"

--- a/tests/e2e/scenarios/test_telegram_e2e.py
+++ b/tests/e2e/scenarios/test_telegram_e2e.py
@@ -31,7 +31,7 @@ PAIRING_CODE_RE = re.compile(r"approve telegram ([A-Z0-9]+)|`([A-Z0-9]+)`")
 # Scenario-specific assertions use much larger IDs (100, 200, ...), so these
 # bootstrap/pairing helper IDs stay out of the way.
 _TEST_UPDATE_IDS = count(1)
-_ACTIVATED_TELEGRAM_SERVERS: set[str] = set()
+_ACTIVATED_TELEGRAM_SERVERS: dict[str, str] = {}
 
 
 # ── helpers ──────────────────────────────────────────────────────────────
@@ -57,6 +57,62 @@ async def install_telegram(base_url: str):
     # 200 = freshly installed, 409 = already installed — both are fine.
     assert r.status_code in (200, 409), (
         f"Telegram install failed ({r.status_code}): {r.text}"
+    )
+
+
+async def get_active_dispatch_keys(http_url: str) -> list[str]:
+    """Get all active WASM channel dispatch keys from the router health endpoint."""
+    async with httpx.AsyncClient() as c:
+        response = await c.get(f"{http_url}/wasm-channels/health", timeout=5)
+        response.raise_for_status()
+        return response.json().get("channels", [])
+
+
+async def resolve_telegram_dispatch_key(
+    http_url: str,
+    *,
+    known_keys: set[str] | None = None,
+    timeout: float = 15,
+) -> str:
+    """Resolve the active Telegram dispatch key for webhook delivery.
+
+    When known_keys is provided, waits for a newly-activated Telegram dispatch
+    key to appear relative to that snapshot. Otherwise expects exactly one
+    active Telegram dispatch key.
+    """
+    deadline = time.monotonic() + timeout
+    last_seen: set[str] = set()
+    while time.monotonic() < deadline:
+        telegram_keys = {
+            key for key in await get_active_dispatch_keys(http_url) if key.startswith("telegram")
+        }
+        last_seen = telegram_keys
+        if known_keys is not None:
+            new_keys = telegram_keys - known_keys
+            if len(new_keys) == 1:
+                return next(iter(new_keys))
+            if len(new_keys) > 1:
+                raise AssertionError(
+                    f"Expected one new Telegram dispatch key, got: {sorted(new_keys)}"
+                )
+        else:
+            if len(telegram_keys) == 1:
+                return next(iter(telegram_keys))
+            if len(telegram_keys) > 1:
+                raise AssertionError(
+                    "Expected exactly one active Telegram dispatch key for legacy E2E, "
+                    f"got: {sorted(telegram_keys)}"
+                )
+        await asyncio.sleep(0.5)
+
+    if known_keys is not None:
+        raise AssertionError(
+            f"Timed out resolving new Telegram dispatch key. Known keys: {sorted(known_keys)}, "
+            f"last seen: {sorted(last_seen)}"
+        )
+
+    raise AssertionError(
+        f"Timed out resolving active Telegram dispatch key. Last seen: {sorted(last_seen)}"
     )
 
 
@@ -110,7 +166,7 @@ def _patch_capabilities_for_testing(channels_dir: str):
 
 async def activate_telegram(
     base_url: str, http_url: str, fake_tg_url: str, channels_dir: str
-) -> None:
+) -> str:
     """Install (if needed) and run the Telegram setup flow.
 
     The E2E fixtures reuse the same Telegram server process across multiple tests,
@@ -121,7 +177,11 @@ async def activate_telegram(
     ensures the shared server is activated and paired exactly once.
     """
     if base_url in _ACTIVATED_TELEGRAM_SERVERS:
-        return
+        return _ACTIVATED_TELEGRAM_SERVERS[base_url]
+
+    keys_before = {
+        key for key in await get_active_dispatch_keys(http_url) if key.startswith("telegram")
+    }
 
     await reset_fake_tg(fake_tg_url)
     await install_telegram(base_url)
@@ -153,6 +213,11 @@ async def activate_telegram(
     # straight to activation and use the generic pairing flow for ownership.
     assert body1.get("activated"), f"Setup call did not activate Telegram: {body1}"
 
+    dispatch_key = await resolve_telegram_dispatch_key(
+        http_url,
+        known_keys=keys_before,
+    )
+
     await reset_fake_tg(fake_tg_url)
 
     # Complete the pairing flow so OWNER_USER_ID can chat normally in the
@@ -174,6 +239,7 @@ async def activate_telegram(
             },
         },
         secret=WEBHOOK_SECRET,
+        dispatch_key=dispatch_key,
     )
     assert pairing_resp.status_code == 200
 
@@ -181,8 +247,9 @@ async def activate_telegram(
     code = extract_pairing_code(messages)
     if code:
         await approve_pairing(base_url, code)
-    _ACTIVATED_TELEGRAM_SERVERS.add(base_url)
+    _ACTIVATED_TELEGRAM_SERVERS[base_url] = dispatch_key
     await reset_fake_tg(fake_tg_url)
+    return dispatch_key
 
 
 @pytest.fixture
@@ -193,9 +260,9 @@ async def active_telegram(telegram_e2e_server):
     fake_tg_url = telegram_e2e_server["fake_tg_url"]
     channels_dir = telegram_e2e_server["channels_dir"]
 
-    await activate_telegram(base_url, http_url, fake_tg_url, channels_dir)
+    dispatch_key = await activate_telegram(base_url, http_url, fake_tg_url, channels_dir)
     await reset_fake_tg(fake_tg_url)
-    return telegram_e2e_server
+    return {**telegram_e2e_server, "dispatch_key": dispatch_key}
 
 
 @pytest.fixture
@@ -206,9 +273,9 @@ async def active_telegram_with_routines(telegram_e2e_server_with_routines):
     fake_tg_url = telegram_e2e_server_with_routines["fake_tg_url"]
     channels_dir = telegram_e2e_server_with_routines["channels_dir"]
 
-    await activate_telegram(base_url, http_url, fake_tg_url, channels_dir)
+    dispatch_key = await activate_telegram(base_url, http_url, fake_tg_url, channels_dir)
     await reset_fake_tg(fake_tg_url)
-    return telegram_e2e_server_with_routines
+    return {**telegram_e2e_server_with_routines, "dispatch_key": dispatch_key}
 
 
 def extract_pairing_code(messages: list[dict]) -> str | None:
@@ -376,14 +443,16 @@ async def post_telegram_webhook(
     update: dict,
     *,
     secret: str | None = None,
+    dispatch_key: str | None = None,
 ) -> httpx.Response:
     """POST a Telegram-shaped update to IronClaw's webhook endpoint."""
     headers = {"Content-Type": "application/json"}
     if secret is not None:
         headers["X-Telegram-Bot-Api-Secret-Token"] = secret
+    resolved_dispatch_key = dispatch_key or await resolve_telegram_dispatch_key(http_url)
     async with httpx.AsyncClient() as c:
         return await c.post(
-            f"{http_url}/webhook/telegram",
+            f"{http_url}/webhook/{resolved_dispatch_key}",
             json=update,
             headers=headers,
             timeout=10,
@@ -1061,6 +1130,7 @@ async def test_telegram_malformed_payload_resilience(active_telegram):
     base_url = active_telegram["base_url"]
     http_url = active_telegram["http_url"]
     fake_tg_url = active_telegram["fake_tg_url"]
+    dispatch_key = active_telegram["dispatch_key"]
 
     # Send a completely malformed payload (not valid Telegram update JSON)
     headers = {
@@ -1069,7 +1139,7 @@ async def test_telegram_malformed_payload_resilience(active_telegram):
     }
     async with httpx.AsyncClient() as c:
         resp = await c.post(
-            f"{http_url}/webhook/telegram",
+            f"{http_url}/webhook/{dispatch_key}",
             content=b'{"not_a_valid_update": true}',
             headers=headers,
             timeout=10,

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -656,6 +656,7 @@ fn sample_pending_gate(
         scope_thread_id: None,
         conversation_id: ironclaw_engine::ConversationId::new(),
         source_channel: channel.into(),
+        source_channel_instance_key: Some(channel.into()),
         action_name: "http".into(),
         call_id: "call_1".into(),
         parameters: serde_json::json!({"url": "https://example.com"}),


### PR DESCRIPTION
## Summary

Phase 1 of #2392 — introduces a `channel_instances` DB table and dispatch-key routing in the shared channel/runtime control plane used by both v1 and v2, so each tenant owns their own channel instance with a unique dispatch key and same-kind multi-tenant coexistence becomes possible (e.g. two Telegram bots for two tenants).

This PR also includes the engine-specific plumbing needed on each side of that shared foundation:
- legacy session/thread isolation updates for v1
- instance-aware conversation/gate plumbing in the v2 bridge

## Problem

The production symptom was observed on multi-tenant v1 staging: web setup wrote Telegram secrets under the authenticated request user, but hot activation read/injected them under `ExtensionManager`'s `config.owner_id`, causing startup-time 404s when different tenants' Telegram bots tried to activate.

This PR fixes that at the shared tenant/channel-instance control plane rather than as a v1-only workaround, and carries the instance identity through both engine paths so same-kind tenant channels do not collide.

## Changes

### Database
- New `channel_instances` table (PostgreSQL migration V25 + libSQL) with `user_id`, `channel_kind`, `instance_key`, `display_name`, `is_primary`, `enabled`, `config`, `metadata`, `last_error`
- `ChannelInstanceStore` trait added to `Database` supertrait with both backend implementations

### Dispatch Key Routing
- `Channel::dispatch_key()` trait method (defaults to `name()`)
- `IncomingMessage.channel_instance_key` for instance-scoped routing
- `ChannelManager` registers/routes by dispatch key instead of semantic name
- WASM channel wrapper carries and emits dispatch key

### Engine Coverage
- Shared activation/routing/pairing/startup changes live in `src/` channel/runtime code and apply to both v1 and v2
- Legacy agent session/thread resolution is now instance-aware so same-kind tenant channels do not collide on the v1 path
- Bridge router uses channel instance keys for v2 conversation and gate identity

### Instance-Aware State
- `PendingGate.source_channel_instance_key` for instance-scoped gate resolution
- `Thread.source_channel_instance_key` for instance-scoped thread resolution
- Bridge router uses channel instance key for engine conversation keys

### Tenant-Scoped Operations
- `complete_pairing_approval(channel_name, user_id, external_id)` resolves dispatch key from DB
- Heartbeat and routine notifications resolve per-user dispatch keys
- Extensions list derives active/error/pairing status per requesting user

### Webhook/Auth Isolation
- Instance-backed webhook paths use dispatch keys end to end
- WASM webhook secret/signature/HMAC validation now resolves auth material by dispatch key, so per-instance webhook auth is enforced correctly

### Startup
- Process-global restore from `channel_instances` rows; legacy `activated_channels` fallback when zero rows exist

### E2E Coverage
- Added a full-process multi-tenant Telegram scenario covering distinct dispatch keys, routing isolation, thread isolation, wrong-secret rejection, and per-user extension state
- Updated legacy Telegram E2Es to discover the active dispatch key from `/wasm-channels/health` instead of assuming a singleton `/webhook/telegram` path
- Added a dedicated Telegram E2E batch so token validation, hot activation, full Telegram round-trips, and multi-tenant isolation run together

## Testing
- Unit tests for restore, pairing, message routing, notification resolution, extensions list isolation
- `cargo check --all-features`
- `cargo test dispatch_key_webhook_secret --lib`
- `pytest -v scenarios/test_telegram_e2e.py scenarios/test_telegram_hot_activation.py -s --timeout=600`
- `pytest -v scenarios/test_telegram_token_validation.py scenarios/test_telegram_hot_activation.py scenarios/test_telegram_e2e.py scenarios/test_multi_tenant_channels.py -s --timeout=600` (23 passed)

Refs #2392
