### PR TITLE
feat(engine): type MessageAdded payload (id + optional narrative)

### DIFF
--- a/crates/ironclaw_engine/src/executor/trace.rs
+++ b/crates/ironclaw_engine/src/executor/trace.rs
@@ -448,6 +448,7 @@ mod tests {
         thread.add_message(ThreadMessage::assistant("calling tool"));
         // Manually construct a message with None call_id
         thread.add_message(ThreadMessage {
+            id: crate::types::message::MessageId::new(),
             role: crate::types::message::MessageRole::ActionResult,
             content: "result".into(),
             assistant_content: None,

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -42,7 +42,7 @@ pub use types::capability::{
 pub use types::error::{CapabilityError, EngineError, StepError, ThreadError};
 pub use types::event::{AssistantContentKind, EventId, EventKind, ThreadEvent};
 pub use types::memory::{DocId, DocType, MemoryDoc};
-pub use types::message::{MessageRole, ThreadMessage};
+pub use types::message::{MessageId, MessageRole, ThreadMessage};
 pub use types::mission::{Mission, MissionCadence, MissionId, MissionStatus, ValidTimezone};
 pub use types::project::{Project, ProjectId, ProjectMetric};
 pub use types::provenance::Provenance;

--- a/crates/ironclaw_engine/src/types/event.rs
+++ b/crates/ironclaw_engine/src/types/event.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
 use crate::types::capability::LeaseId;
+use crate::types::message::MessageId;
 
 /// Generate a short human-readable summary of tool parameters for display.
 ///
@@ -198,11 +199,25 @@ pub enum EventKind {
     },
 
     // ── Messages ────────────────────────────────────────────
+    /// A message was appended to the thread transcript.
+    ///
+    /// `message_id` lets consumers resolve the full typed payload via
+    /// `Thread::message` when they need more than the event carries inline.
+    ///
+    /// `narrative` is populated **only** for `UserVisibleNarrative` assistant
+    /// content — that's the single kind whose text the gateway status stream
+    /// actually renders. Other kinds (reasoning, final, user, action result)
+    /// are either suppressed at the router, duplicated by the `Response`
+    /// stream, or irrelevant to the status surface, so carrying the full text
+    /// inline for them would just inflate SSE frames without changing what
+    /// the UI shows.
     MessageAdded {
         role: String,
-        content_preview: String,
+        message_id: MessageId,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         assistant_content_kind: Option<AssistantContentKind>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        narrative: Option<String>,
     },
 
     // ── Thread tree ─────────────────────────────────────────

--- a/crates/ironclaw_engine/src/types/message.rs
+++ b/crates/ironclaw_engine/src/types/message.rs
@@ -5,9 +5,32 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 use crate::types::provenance::Provenance;
 use crate::types::step::{ActionCall, AssistantContent};
+
+/// Strongly-typed message identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct MessageId(pub Uuid);
+
+impl MessageId {
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+}
+
+impl Default for MessageId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl std::fmt::Display for MessageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
 
 /// Role of a message participant.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -22,6 +45,11 @@ pub enum MessageRole {
 /// A message in a thread's conversation history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ThreadMessage {
+    /// Stable identifier — `MessageAdded` events reference messages by this
+    /// id so consumers can resolve typed content without re-deriving it from
+    /// a truncated preview string.
+    #[serde(default)]
+    pub id: MessageId,
     pub role: MessageRole,
     pub content: String,
     /// Optional typed assistant-content semantics. This supplements the legacy
@@ -43,6 +71,7 @@ impl ThreadMessage {
     /// Create a system message.
     pub fn system(content: impl Into<String>) -> Self {
         Self {
+            id: MessageId::new(),
             role: MessageRole::System,
             content: content.into(),
             assistant_content: None,
@@ -57,6 +86,7 @@ impl ThreadMessage {
     /// Create a user message.
     pub fn user(content: impl Into<String>) -> Self {
         Self {
+            id: MessageId::new(),
             role: MessageRole::User,
             content: content.into(),
             assistant_content: None,
@@ -77,6 +107,7 @@ impl ThreadMessage {
     pub fn assistant_with_typed_content(content: AssistantContent) -> Self {
         let raw_content = content.text().to_string();
         Self {
+            id: MessageId::new(),
             role: MessageRole::Assistant,
             content: raw_content,
             assistant_content: Some(content),
@@ -91,6 +122,7 @@ impl ThreadMessage {
     /// Create an assistant message with action calls.
     pub fn assistant_with_actions(content: Option<String>, calls: Vec<ActionCall>) -> Self {
         Self {
+            id: MessageId::new(),
             role: MessageRole::Assistant,
             content: content.unwrap_or_default(),
             assistant_content: None,
@@ -112,6 +144,7 @@ impl ThreadMessage {
             .map(|content| content.text().to_string())
             .unwrap_or_default();
         Self {
+            id: MessageId::new(),
             role: MessageRole::Assistant,
             content: raw_content,
             assistant_content: content,
@@ -131,6 +164,7 @@ impl ThreadMessage {
     ) -> Self {
         let name: String = action_name.into();
         Self {
+            id: MessageId::new(),
             role: MessageRole::ActionResult,
             content: content.into(),
             assistant_content: None,

--- a/crates/ironclaw_engine/src/types/thread.rs
+++ b/crates/ironclaw_engine/src/types/thread.rs
@@ -13,8 +13,9 @@ use crate::types::capability::LeaseId;
 use crate::types::error::EngineError;
 use crate::types::event::{AssistantContentKind, EventKind, ThreadEvent};
 use crate::types::memory::DocId;
-use crate::types::message::ThreadMessage;
+use crate::types::message::{MessageId, ThreadMessage};
 use crate::types::project::ProjectId;
+use crate::types::step::AssistantContent;
 
 use super::{OwnerId, default_user_id};
 
@@ -378,22 +379,36 @@ impl Thread {
     }
 
     /// Add a message to this thread's conversation.
+    ///
+    /// Emits a typed `MessageAdded` event. The event carries `message_id`
+    /// so consumers can resolve the full payload via `Thread::message`, and
+    /// only populates inline `narrative` text when the assistant content
+    /// kind is `UserVisibleNarrative` — the only kind the gateway status
+    /// stream actually renders.
     pub fn add_message(&mut self, message: ThreadMessage) {
-        let preview = if message.content.chars().count() > 80 {
-            let p: String = message.content.chars().take(80).collect();
-            format!("{p}...")
-        } else {
-            message.content.clone()
+        let kind = message
+            .assistant_content
+            .as_ref()
+            .map(AssistantContentKind::from);
+        let narrative = match message.assistant_content.as_ref() {
+            Some(AssistantContent::UserVisibleNarrative(text)) => Some(text.clone()),
+            _ => None,
         };
         self.add_event(EventKind::MessageAdded {
             role: format!("{:?}", message.role),
-            content_preview: preview,
-            assistant_content_kind: message
-                .assistant_content
-                .as_ref()
-                .map(AssistantContentKind::from),
+            message_id: message.id,
+            assistant_content_kind: kind,
+            narrative,
         });
         self.messages.push(message);
+    }
+
+    /// Resolve a message by id.
+    ///
+    /// Consumers of `EventKind::MessageAdded` can call this to fetch the
+    /// full typed payload instead of reparsing a truncated preview string.
+    pub fn message(&self, id: MessageId) -> Option<&ThreadMessage> {
+        self.messages.iter().find(|m| m.id == id)
     }
 
     /// Add a message to the internal execution transcript without exposing it
@@ -552,17 +567,22 @@ mod tests {
     #[test]
     fn add_message_records_event() {
         let mut t = make_thread();
-        t.add_message(ThreadMessage::user("hello"));
+        let msg = ThreadMessage::user("hello");
+        let expected_id = msg.id;
+        t.add_message(msg);
         assert_eq!(t.messages.len(), 1);
         assert_eq!(t.events.len(), 1);
         match &t.events[0].kind {
             EventKind::MessageAdded {
                 role,
+                message_id,
                 assistant_content_kind,
-                ..
+                narrative,
             } => {
                 assert_eq!(role, "User");
+                assert_eq!(*message_id, expected_id);
                 assert!(assistant_content_kind.is_none());
+                assert!(narrative.is_none());
             }
             other => panic!("unexpected event: {other:?}"),
         }
@@ -571,25 +591,66 @@ mod tests {
     #[test]
     fn add_assistant_message_records_typed_content_kind() {
         let mut t = make_thread();
-        t.add_message(ThreadMessage::assistant_with_typed_content(
+        let msg = ThreadMessage::assistant_with_typed_content(
             AssistantContent::UserVisibleNarrative("Inspecting the page first...".to_string()),
-        ));
+        );
+        let expected_id = msg.id;
+        t.add_message(msg);
 
         match &t.events[0].kind {
             EventKind::MessageAdded {
                 role,
-                content_preview,
+                message_id,
                 assistant_content_kind,
+                narrative,
             } => {
                 assert_eq!(role, "Assistant");
-                assert_eq!(content_preview, "Inspecting the page first...");
+                assert_eq!(*message_id, expected_id);
                 assert_eq!(
                     *assistant_content_kind,
                     Some(AssistantContentKind::UserVisibleNarrative)
                 );
+                assert_eq!(narrative.as_deref(), Some("Inspecting the page first..."));
             }
             other => panic!("unexpected event: {other:?}"),
         }
+    }
+
+    #[test]
+    fn add_assistant_reasoning_message_omits_narrative() {
+        let mut t = make_thread();
+        let msg = ThreadMessage::assistant_with_typed_content(AssistantContent::InternalReasoning(
+            "Let me think about this step by step...".to_string(),
+        ));
+        let expected_id = msg.id;
+        t.add_message(msg);
+
+        match &t.events[0].kind {
+            EventKind::MessageAdded {
+                message_id,
+                assistant_content_kind,
+                narrative,
+                ..
+            } => {
+                assert_eq!(*message_id, expected_id);
+                assert_eq!(
+                    *assistant_content_kind,
+                    Some(AssistantContentKind::InternalReasoning)
+                );
+                assert!(narrative.is_none());
+            }
+            other => panic!("unexpected event: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn thread_message_resolves_by_id() {
+        let mut t = make_thread();
+        let msg = ThreadMessage::user("hello");
+        let id = msg.id;
+        t.add_message(msg);
+        let resolved = t.message(id).expect("message present");
+        assert_eq!(resolved.content, "hello");
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4163,20 +4163,25 @@ fn format_action_display_name(action_name: &str, params_summary: &Option<String>
 /// Interpret a MessageAdded event into a human-readable status message.
 /// Returns `None` for events that don't need UI surfacing.
 ///
+/// The only assistant kind that actually surfaces text to the status
+/// stream is `UserVisibleNarrative` — and that text is carried inline on
+/// the event as `narrative`, so the router never has to reach back into
+/// the thread's message list to render it.
+///
 /// User-role code-execution result messages (`[stdout]…`, `[code …]`,
 /// `Traceback`) no longer drive UI status — that surface is owned by the
 /// typed `CodeExecutionStarted`/`CodeExecutionCompleted`/`CodeExecutionFailed`
 /// events emitted by the executor.
 fn interpret_message_event(
     role: &str,
-    content_preview: &str,
     assistant_content_kind: Option<&ironclaw_engine::AssistantContentKind>,
+    narrative: Option<&str>,
 ) -> Option<String> {
     if role == "Assistant" {
         match assistant_content_kind {
             Some(ironclaw_engine::AssistantContentKind::InternalReasoning) => None,
             Some(ironclaw_engine::AssistantContentKind::UserVisibleNarrative) => {
-                Some(content_preview.to_string())
+                narrative.map(|t| t.to_string())
             }
             Some(ironclaw_engine::AssistantContentKind::Final) => {
                 // Final assistant responses are surfaced through the main
@@ -4555,11 +4560,12 @@ async fn forward_event_to_channel(
         }
         EventKind::MessageAdded {
             role,
-            content_preview,
             assistant_content_kind,
+            narrative,
+            ..
         } => {
             if let Some(text) =
-                interpret_message_event(role, content_preview, assistant_content_kind.as_ref())
+                interpret_message_event(role, assistant_content_kind.as_ref(), narrative.as_deref())
             {
                 let _ = channels
                     .send_status(channel_name, StatusUpdate::Thinking(text), metadata)
@@ -4691,9 +4697,10 @@ fn thread_event_to_app_events(
         }],
         EventKind::MessageAdded {
             role,
-            content_preview,
             assistant_content_kind,
-        } => interpret_message_event(role, content_preview, assistant_content_kind.as_ref())
+            narrative,
+            ..
+        } => interpret_message_event(role, assistant_content_kind.as_ref(), narrative.as_deref())
             .map(|text| AppEvent::Thinking {
                 message: text,
                 thread_id: Some(thread_id.into()),
@@ -7301,10 +7308,11 @@ mod tests {
             ironclaw_engine::ThreadId::new(),
             ironclaw_engine::EventKind::MessageAdded {
                 role: "Assistant".to_string(),
-                content_preview: "I should inspect the page before answering.".to_string(),
+                message_id: ironclaw_engine::MessageId::new(),
                 assistant_content_kind: Some(
                     ironclaw_engine::types::event::AssistantContentKind::InternalReasoning,
                 ),
+                narrative: None,
             },
         );
 
@@ -7319,10 +7327,11 @@ mod tests {
             ironclaw_engine::ThreadId::new(),
             ironclaw_engine::EventKind::MessageAdded {
                 role: "Assistant".to_string(),
-                content_preview: "Inspecting the page first...".to_string(),
+                message_id: ironclaw_engine::MessageId::new(),
                 assistant_content_kind: Some(
                     ironclaw_engine::types::event::AssistantContentKind::UserVisibleNarrative,
                 ),
+                narrative: Some("Inspecting the page first...".to_string()),
             },
         );
 
@@ -7337,15 +7346,37 @@ mod tests {
     }
 
     #[test]
+    fn thread_event_to_app_events_narrative_without_text_is_suppressed() {
+        // A defensive guard: if a narrative event arrives without inline
+        // text, we suppress it rather than emitting an empty Thinking bubble.
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::MessageAdded {
+                role: "Assistant".to_string(),
+                message_id: ironclaw_engine::MessageId::new(),
+                assistant_content_kind: Some(
+                    ironclaw_engine::types::event::AssistantContentKind::UserVisibleNarrative,
+                ),
+                narrative: None,
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-123");
+
+        assert!(app_events.is_empty());
+    }
+
+    #[test]
     fn thread_event_to_app_events_final_assistant_message_relies_on_response_stream() {
         let event = ironclaw_engine::ThreadEvent::new(
             ironclaw_engine::ThreadId::new(),
             ironclaw_engine::EventKind::MessageAdded {
                 role: "Assistant".to_string(),
-                content_preview: "Here is the answer".to_string(),
+                message_id: ironclaw_engine::MessageId::new(),
                 assistant_content_kind: Some(
                     ironclaw_engine::types::event::AssistantContentKind::Final,
                 ),
+                narrative: None,
             },
         );
 
@@ -7360,8 +7391,9 @@ mod tests {
             ironclaw_engine::ThreadId::new(),
             ironclaw_engine::EventKind::MessageAdded {
                 role: "Assistant".to_string(),
-                content_preview: "legacy assistant message".to_string(),
+                message_id: ironclaw_engine::MessageId::new(),
                 assistant_content_kind: None,
+                narrative: None,
             },
         );
 


### PR DESCRIPTION
## What

Replaces `EventKind::MessageAdded::content_preview: String` — a lossy, 80-char-truncated preview — with a typed payload that the router and UI can consume without reverse-engineering content semantics from a string:

```rust
MessageAdded {
    role: String,
    message_id: MessageId,                              // resolvable via Thread::message(id)
    assistant_content_kind: Option<AssistantContentKind>,
    narrative: Option<String>,                          // only populated for UserVisibleNarrative
}
```

## Why this shape

This was the design decision covered by mock `/tmp/message-added-ui-preview.html` (4-column comparison in our gateway chat UI). Only `UserVisibleNarrative` assistant content actually surfaces text to the status stream — every other kind is either:
- suppressed at the router (`InternalReasoning`)
- handled by the parallel `Response`/`ThreadOutcome` stream (`Final`)
- not a status-surface concern at all (user, action result)

So carrying full inline text for every kind would inflate SSE frames without changing what the user sees. At the same time, ID-only would force a REST round-trip just to render the narrative text we already have. This shape carries the one piece of text the UI needs, and nothing more.

The `message_id` is the durable handle for anything we later want to look up lazily (full typed content, action calls, provenance) via `Thread::message(id)`.

## Changes

- `crates/ironclaw_engine/src/types/message.rs` — new `MessageId` type (UUID-backed, matches `ThreadId` / `StepId` pattern) + `id` field on `ThreadMessage`; all 6 `ThreadMessage::*` constructors set it.
- `crates/ironclaw_engine/src/types/event.rs` — new `MessageAdded` shape with doc comment explaining the `narrative` population rule.
- `crates/ironclaw_engine/src/types/thread.rs` — `Thread::add_message` extracts narrative only for `AssistantContent::UserVisibleNarrative`; new `Thread::message(id) -> Option<&ThreadMessage>` resolver.
- `src/bridge/router.rs` — `interpret_message_event` takes `narrative: Option<&str>` instead of `content_preview: &str`; both callers updated; defensive branch suppresses narrative events that arrive without inline text.
- Test updates in engine and router + 3 new tests:
  - `add_assistant_reasoning_message_omits_narrative` (engine)
  - `thread_message_resolves_by_id` (engine)
  - `thread_event_to_app_events_narrative_without_text_is_suppressed` (router)

## Backwards compatibility

Breaking shape change on a runtime event. No on-disk migration needed — `ThreadEvent`s are replayed in-memory per process; persisted `Thread`s only store messages + state, not event enum variants. `ThreadMessage` gains an `id` field with `#[serde(default)]` so legacy persisted rows deserialize with a fresh id (the value is not reached back for after initial creation).

## Test results

- `cargo test -p ironclaw_engine --lib` → **468 passed**, 0 failed (+2 new)
- `cargo test --lib bridge::router` → **75 passed**, 0 failed (+1 new)
- `cargo fmt --all -- --check` clean
- `cargo clippy --all --tests --examples --all-features` clean

## Stacked

- Base: `feat/2823-typed-code-execution-events` (PR #2830)
- Parent stack: #2815 → #2822 → #2830 → **this**
- Follow-up planned: push `AssistantContent` through `LlmProvider` trait boundary so adapters don't have to re-infer kind.

Part of #2813.
