### PR TITLE
feat(bridge): project 7 more engine events to AppEvents

### DIFF
--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -578,21 +578,19 @@ pub enum AppEvent {
     /// Background self-improvement lifecycle event.
     ///
     /// Bridged from engine `EventKind::SelfImprovement{Started,Complete,Failed}`.
-    /// Collapses the three engine variants into one wire event with a
-    /// phase discriminator — consumers only need one handler, and the
-    /// per-phase fields carry the variant-specific payload.
+    /// The three engine variants collapse into one wire event with a
+    /// nested `SelfImprovementPhase` carrying per-phase data — consumers
+    /// need one handler, and the compiler enforces that phase-specific
+    /// fields travel with their phase (no `Option<T>` sentinels that
+    /// claim "maybe present" when the phase excludes them).
+    ///
+    /// Wire shape uses `#[serde(flatten)]` + the phase enum's
+    /// `#[serde(tag = "phase")]`, so the JSON payload is flat:
+    /// `{"type": "self_improvement", "phase": "complete", "prompt_updated": true, ...}`.
     #[serde(rename = "self_improvement")]
     SelfImprovement {
+        #[serde(flatten)]
         phase: SelfImprovementPhase,
-        /// Set on `Complete` phase.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        prompt_updated: Option<bool>,
-        /// Set on `Complete` phase.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        patterns_added: Option<usize>,
-        /// Set on `Failed` phase.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        error: Option<String>,
         #[serde(skip_serializing_if = "Option::is_none")]
         thread_id: Option<String>,
     },
@@ -612,17 +610,28 @@ pub enum AppEvent {
     },
 }
 
-/// Phase discriminator for `AppEvent::SelfImprovement`.
+/// Phase data for `AppEvent::SelfImprovement`.
 ///
 /// Mirrors engine `EventKind::SelfImprovement{Started,Complete,Failed}`
-/// collapsed into a single wire variant. Per `.claude/rules/types.md`
-/// "Wire-stable enums" — snake_case serde, no stringly-typed status.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+/// as a single typed wire enum. Variant-specific fields are part of the
+/// variant, not optional fields on the outer event — per
+/// `.claude/rules/types.md` the compiler should reject a `Failed` value
+/// carrying `prompt_updated`, which an `Option`-field approach cannot.
+///
+/// Serialized with an internally-tagged `phase` discriminator; the
+/// outer `AppEvent::SelfImprovement` flattens this into its payload so
+/// the wire shape stays a single flat JSON object.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "phase", rename_all = "snake_case")]
 pub enum SelfImprovementPhase {
     Started,
-    Complete,
-    Failed,
+    Complete {
+        prompt_updated: bool,
+        patterns_added: usize,
+    },
+    Failed {
+        error: String,
+    },
 }
 
 /// Wire-side mirror of `ironclaw_engine::CodeExecutionFailure`.
@@ -916,9 +925,6 @@ mod tests {
             },
             AppEvent::SelfImprovement {
                 phase: SelfImprovementPhase::Started,
-                prompt_updated: None,
-                patterns_added: None,
-                error: None,
                 thread_id: None,
             },
             AppEvent::OrchestratorRollback {

--- a/crates/ironclaw_common/src/event.rs
+++ b/crates/ironclaw_common/src/event.rs
@@ -538,6 +538,91 @@ pub enum AppEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         thread_id: Option<String>,
     },
+
+    /// A capability lease was granted to a thread.
+    ///
+    /// Bridged from engine `EventKind::LeaseGranted`. Security-visible:
+    /// capability grants should be auditable in the UI.
+    #[serde(rename = "lease_granted")]
+    LeaseGranted {
+        lease_id: String,
+        capability_name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
+    /// A capability lease was explicitly revoked.
+    ///
+    /// Bridged from engine `EventKind::LeaseRevoked`. `reason` is the
+    /// engine's revocation message, surfaced so users can tell a
+    /// revocation apart from an expiry.
+    #[serde(rename = "lease_revoked")]
+    LeaseRevoked {
+        lease_id: String,
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
+    /// A capability lease reached its TTL and expired.
+    ///
+    /// Bridged from engine `EventKind::LeaseExpired`. Without this, tools
+    /// begin failing after a lease's TTL with no visible explanation.
+    #[serde(rename = "lease_expired")]
+    LeaseExpired {
+        lease_id: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
+    /// Background self-improvement lifecycle event.
+    ///
+    /// Bridged from engine `EventKind::SelfImprovement{Started,Complete,Failed}`.
+    /// Collapses the three engine variants into one wire event with a
+    /// phase discriminator — consumers only need one handler, and the
+    /// per-phase fields carry the variant-specific payload.
+    #[serde(rename = "self_improvement")]
+    SelfImprovement {
+        phase: SelfImprovementPhase,
+        /// Set on `Complete` phase.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        prompt_updated: Option<bool>,
+        /// Set on `Complete` phase.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        patterns_added: Option<usize>,
+        /// Set on `Failed` phase.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        error: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+
+    /// Orchestrator version was rolled back.
+    ///
+    /// Bridged from engine `EventKind::OrchestratorRollback`. Operator-
+    /// facing; surfaces the from/to versions so failures after an
+    /// upgrade are correlatable with the rollback point.
+    #[serde(rename = "orchestrator_rollback")]
+    OrchestratorRollback {
+        from_version: u64,
+        to_version: u64,
+        reason: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        thread_id: Option<String>,
+    },
+}
+
+/// Phase discriminator for `AppEvent::SelfImprovement`.
+///
+/// Mirrors engine `EventKind::SelfImprovement{Started,Complete,Failed}`
+/// collapsed into a single wire variant. Per `.claude/rules/types.md`
+/// "Wire-stable enums" — snake_case serde, no stringly-typed status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SelfImprovementPhase {
+    Started,
+    Complete,
+    Failed,
 }
 
 /// Wire-side mirror of `ironclaw_engine::CodeExecutionFailure`.
@@ -603,6 +688,11 @@ impl AppEvent {
             Self::MissionThreadSpawned { .. } => "mission_thread_spawned",
             Self::PlanUpdate { .. } => "plan_update",
             Self::CodeExecutionFailed { .. } => "code_execution_failed",
+            Self::LeaseGranted { .. } => "lease_granted",
+            Self::LeaseRevoked { .. } => "lease_revoked",
+            Self::LeaseExpired { .. } => "lease_expired",
+            Self::SelfImprovement { .. } => "self_improvement",
+            Self::OrchestratorRollback { .. } => "orchestrator_rollback",
         }
     }
 
@@ -808,6 +898,33 @@ mod tests {
                 error: String::new(),
                 duration_ms: 0,
                 code_hash: None,
+                thread_id: None,
+            },
+            AppEvent::LeaseGranted {
+                lease_id: String::new(),
+                capability_name: String::new(),
+                thread_id: None,
+            },
+            AppEvent::LeaseRevoked {
+                lease_id: String::new(),
+                reason: String::new(),
+                thread_id: None,
+            },
+            AppEvent::LeaseExpired {
+                lease_id: String::new(),
+                thread_id: None,
+            },
+            AppEvent::SelfImprovement {
+                phase: SelfImprovementPhase::Started,
+                prompt_updated: None,
+                patterns_added: None,
+                error: None,
+                thread_id: None,
+            },
+            AppEvent::OrchestratorRollback {
+                from_version: 0,
+                to_version: 0,
+                reason: String::new(),
                 thread_id: None,
             },
         ];

--- a/crates/ironclaw_common/src/lib.rs
+++ b/crates/ironclaw_common/src/lib.rs
@@ -7,7 +7,7 @@ mod util;
 
 pub use event::{
     AppEvent, CodeExecutionFailureCategory, JobResultStatus, JobResultStatusParseError,
-    OnboardingStateDto, PlanStepDto, ToolDecisionDto,
+    OnboardingStateDto, PlanStepDto, SelfImprovementPhase, ToolDecisionDto,
 };
 pub use identity::{
     CredentialName, ExtensionName, ExternalThreadId, ExternalThreadIdError, IdentityError,

--- a/crates/ironclaw_engine/src/types/error.rs
+++ b/crates/ironclaw_engine/src/types/error.rs
@@ -221,3 +221,9 @@ impl fmt::Display for ProjectId {
         write!(f, "{}", self.0)
     }
 }
+
+impl fmt::Display for crate::types::capability::LeaseId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -9,9 +9,13 @@ ignore = [
     "RUSTSEC-2025-0111",
     # rustls-webpki advisories — 0.102.8 remains pinned by a libsql 0.6.0 transitive dep
     # (via rustls 0.22 → hyper-rustls 0.25); keep ignored until that pin is gone.
+    # RUSTSEC-2026-0104: panic on empty `onlySomeReasons` BIT STRING during CRL parsing.
+    # We do not use CRLs, and the advisory explicitly notes apps that don't parse CRLs
+    # are unaffected. Same transitive pin as 0049/0098/0099 — tracked with them.
     "RUSTSEC-2026-0049",
     "RUSTSEC-2026-0098",
     "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
     # rand unsoundness with custom logger calling rand::rng() during reseed — we don't use this pattern;
     # revisit/remove by 2026-06-30, or when transitive deps (tower, nanoid, phf_generator) release rand ≥0.9.3 compat
     "RUSTSEC-2026-0097",

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4730,26 +4730,22 @@ fn thread_event_to_app_events(
         }],
         EventKind::SelfImprovementStarted => vec![AppEvent::SelfImprovement {
             phase: ironclaw_common::SelfImprovementPhase::Started,
-            prompt_updated: None,
-            patterns_added: None,
-            error: None,
             thread_id: Some(thread_id.into()),
         }],
         EventKind::SelfImprovementComplete {
             prompt_updated,
             patterns_added,
         } => vec![AppEvent::SelfImprovement {
-            phase: ironclaw_common::SelfImprovementPhase::Complete,
-            prompt_updated: Some(*prompt_updated),
-            patterns_added: Some(*patterns_added),
-            error: None,
+            phase: ironclaw_common::SelfImprovementPhase::Complete {
+                prompt_updated: *prompt_updated,
+                patterns_added: *patterns_added,
+            },
             thread_id: Some(thread_id.into()),
         }],
         EventKind::SelfImprovementFailed { error } => vec![AppEvent::SelfImprovement {
-            phase: ironclaw_common::SelfImprovementPhase::Failed,
-            prompt_updated: None,
-            patterns_added: None,
-            error: Some(error.clone()),
+            phase: ironclaw_common::SelfImprovementPhase::Failed {
+                error: error.clone(),
+            },
             thread_id: Some(thread_id.into()),
         }],
         EventKind::OrchestratorRollback {
@@ -4762,7 +4758,26 @@ fn thread_event_to_app_events(
             reason: reason.clone(),
             thread_id: Some(thread_id.into()),
         }],
-        _ => vec![],
+
+        // Explicitly-dropped engine variants. These are NOT bridged to
+        // `AppEvent` because an equivalent event is emitted by a
+        // different source log today, and double-emission would have
+        // the UI rendering the same thing twice. Migration plan per
+        // #2792 Phase 1 PR 3:
+        //
+        // - `ApprovalRequested` / `ApprovalReceived` → migrate the gate
+        //   manager to emit through the engine event log (replacing its
+        //   current direct `AppEvent::GateRequired` / `GateResolved`
+        //   broadcasts), then drop these arms and let the bridge
+        //   project the engine events.
+        EventKind::ApprovalRequested { .. } => vec![],
+        EventKind::ApprovalReceived { .. } => vec![],
+
+        // Forward-compat catch-all in the engine enum (see
+        // `#[serde(other)] Unknown` in `ironclaw_engine::EventKind`).
+        // Nothing useful to show; the unknown variant would have been
+        // written by a newer binary during a rolling deploy.
+        EventKind::Unknown => vec![],
     }
 }
 
@@ -7333,26 +7348,21 @@ mod tests {
         let app_events = thread_event_to_app_events(&event, "thread-improve");
 
         assert_eq!(app_events.len(), 1);
-        let AppEvent::SelfImprovement {
-            phase,
-            prompt_updated,
-            patterns_added,
-            error,
-            thread_id,
-        } = &app_events[0]
-        else {
+        let AppEvent::SelfImprovement { phase, thread_id } = &app_events[0] else {
             panic!(
                 "expected AppEvent::SelfImprovement, got {:?}",
                 app_events[0]
             );
         };
-        assert_eq!(*phase, ironclaw_common::SelfImprovementPhase::Complete);
-        assert_eq!(*prompt_updated, Some(true));
-        assert_eq!(*patterns_added, Some(3));
-        assert!(
-            error.is_none(),
-            "error should be None on Complete phase, got {error:?}"
-        );
+        let ironclaw_common::SelfImprovementPhase::Complete {
+            prompt_updated,
+            patterns_added,
+        } = phase
+        else {
+            panic!("expected SelfImprovementPhase::Complete, got {phase:?}");
+        };
+        assert!(*prompt_updated);
+        assert_eq!(*patterns_added, 3);
         assert_eq!(thread_id.as_deref(), Some("thread-improve"));
     }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4774,17 +4774,19 @@ fn thread_event_to_app_events(
             }]
         }
 
-        // Explicitly-dropped engine variants. These are NOT bridged to
-        // `AppEvent` because an equivalent event is emitted by a
-        // different source log today, and double-emission would have
-        // the UI rendering the same thing twice. Migration plan per
-        // #2792 Phase 1 PR 3:
+        // Temporarily-suppressed engine variants. These are NOT bridged
+        // to `AppEvent` today because equivalent gate events are still
+        // emitted directly by the gate manager, and forwarding them
+        // here as well would make the UI render the same state twice.
+        // Migration plan per #2792 Phase 1 PR 3:
         //
-        // - `ApprovalRequested` / `ApprovalReceived` → migrate the gate
-        //   manager to emit through the engine event log (replacing its
-        //   current direct `AppEvent::GateRequired` / `GateResolved`
-        //   broadcasts), then drop these arms and let the bridge
-        //   project the engine events.
+        // - `ApprovalRequested` / `ApprovalReceived` are suppressed
+        //   only until the gate manager stops broadcasting direct
+        //   `AppEvent::GateRequired` / `GateResolved` events.
+        // - Once that migration lands, this function remains the
+        //   bridge: map these engine variants to the corresponding
+        //   `AppEvent`s here (or remove the direct emits), rather
+        //   than treating them as permanently dropped.
         EventKind::ApprovalRequested { .. } => vec![],
         EventKind::ApprovalReceived { .. } => vec![],
 
@@ -7348,6 +7350,100 @@ mod tests {
         assert_eq!(lease_id, &lease.to_string());
         assert_eq!(capability_name, "http_fetch");
         assert_eq!(thread_id.as_deref(), Some("thread-lease"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_lease_revoked() {
+        let lease = ironclaw_engine::LeaseId::new();
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::LeaseRevoked {
+                lease_id: lease,
+                reason: "policy check failed".to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-revoke");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::LeaseRevoked {
+            lease_id,
+            reason,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!("expected AppEvent::LeaseRevoked, got {:?}", app_events[0]);
+        };
+        assert_eq!(lease_id, &lease.to_string());
+        assert_eq!(reason, "policy check failed");
+        assert_eq!(thread_id.as_deref(), Some("thread-revoke"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_lease_expired() {
+        let lease = ironclaw_engine::LeaseId::new();
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::LeaseExpired { lease_id: lease },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-expire");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::LeaseExpired {
+            lease_id,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!("expected AppEvent::LeaseExpired, got {:?}", app_events[0]);
+        };
+        assert_eq!(lease_id, &lease.to_string());
+        assert_eq!(thread_id.as_deref(), Some("thread-expire"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_self_improvement_started() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::SelfImprovementStarted,
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-improve-start");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::SelfImprovement { phase, thread_id } = &app_events[0] else {
+            panic!(
+                "expected AppEvent::SelfImprovement, got {:?}",
+                app_events[0]
+            );
+        };
+        assert_eq!(phase, &ironclaw_common::SelfImprovementPhase::Started);
+        assert_eq!(thread_id.as_deref(), Some("thread-improve-start"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_self_improvement_failed() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::SelfImprovementFailed {
+                error: "diagnosis prompt timed out".to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-improve-fail");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::SelfImprovement { phase, thread_id } = &app_events[0] else {
+            panic!(
+                "expected AppEvent::SelfImprovement, got {:?}",
+                app_events[0]
+            );
+        };
+        let ironclaw_common::SelfImprovementPhase::Failed { error } = phase else {
+            panic!("expected SelfImprovementPhase::Failed, got {phase:?}");
+        };
+        assert_eq!(error, "diagnosis prompt timed out");
+        assert_eq!(thread_id.as_deref(), Some("thread-improve-fail"));
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4562,10 +4562,6 @@ async fn forward_event_to_channel(
     }
 }
 
-/// Convert a ThreadEvent to AppEvents for the web gateway SSE stream.
-///
-/// Returns multiple events when needed (e.g., ToolStarted + ToolCompleted
-/// so the frontend creates the card then resolves it).
 /// Bridge engine-side `CodeExecutionFailure` to its wire mirror
 /// `CodeExecutionFailureCategory` in `ironclaw_common`.
 ///
@@ -4591,6 +4587,10 @@ fn code_execution_category_to_wire(
     }
 }
 
+/// Convert a `ThreadEvent` to `AppEvent`s for the web gateway SSE stream.
+///
+/// Returns multiple events when needed (e.g., `ToolStarted` + `ToolCompleted`
+/// so the frontend creates the card then resolves it).
 fn thread_event_to_app_events(
     event: &ironclaw_engine::ThreadEvent,
     thread_id: &str,
@@ -4710,6 +4710,57 @@ fn thread_event_to_app_events(
             skill_names: skill_names.clone(),
             thread_id: Some(thread_id.into()),
             feedback: Vec::new(),
+        }],
+        EventKind::LeaseGranted {
+            lease_id,
+            capability_name,
+        } => vec![AppEvent::LeaseGranted {
+            lease_id: lease_id.to_string(),
+            capability_name: capability_name.clone(),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::LeaseRevoked { lease_id, reason } => vec![AppEvent::LeaseRevoked {
+            lease_id: lease_id.to_string(),
+            reason: reason.clone(),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::LeaseExpired { lease_id } => vec![AppEvent::LeaseExpired {
+            lease_id: lease_id.to_string(),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::SelfImprovementStarted => vec![AppEvent::SelfImprovement {
+            phase: ironclaw_common::SelfImprovementPhase::Started,
+            prompt_updated: None,
+            patterns_added: None,
+            error: None,
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::SelfImprovementComplete {
+            prompt_updated,
+            patterns_added,
+        } => vec![AppEvent::SelfImprovement {
+            phase: ironclaw_common::SelfImprovementPhase::Complete,
+            prompt_updated: Some(*prompt_updated),
+            patterns_added: Some(*patterns_added),
+            error: None,
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::SelfImprovementFailed { error } => vec![AppEvent::SelfImprovement {
+            phase: ironclaw_common::SelfImprovementPhase::Failed,
+            prompt_updated: None,
+            patterns_added: None,
+            error: Some(error.clone()),
+            thread_id: Some(thread_id.into()),
+        }],
+        EventKind::OrchestratorRollback {
+            from_version,
+            to_version,
+            reason,
+        } => vec![AppEvent::OrchestratorRollback {
+            from_version: *from_version,
+            to_version: *to_version,
+            reason: reason.clone(),
+            thread_id: Some(thread_id.into()),
         }],
         _ => vec![],
     }
@@ -7240,6 +7291,101 @@ mod tests {
         assert_eq!(*duration_ms, 42);
         assert_eq!(code_hash.as_deref(), Some("abc123"));
         assert_eq!(thread_id.as_deref(), Some("thread-codeact"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_lease_granted() {
+        let lease = ironclaw_engine::LeaseId::new();
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::LeaseGranted {
+                lease_id: lease,
+                capability_name: "http_fetch".to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-lease");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::LeaseGranted {
+            lease_id,
+            capability_name,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!("expected AppEvent::LeaseGranted, got {:?}", app_events[0]);
+        };
+        assert_eq!(lease_id, &lease.to_string());
+        assert_eq!(capability_name, "http_fetch");
+        assert_eq!(thread_id.as_deref(), Some("thread-lease"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_self_improvement_complete() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::SelfImprovementComplete {
+                prompt_updated: true,
+                patterns_added: 3,
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-improve");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::SelfImprovement {
+            phase,
+            prompt_updated,
+            patterns_added,
+            error,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!(
+                "expected AppEvent::SelfImprovement, got {:?}",
+                app_events[0]
+            );
+        };
+        assert_eq!(*phase, ironclaw_common::SelfImprovementPhase::Complete);
+        assert_eq!(*prompt_updated, Some(true));
+        assert_eq!(*patterns_added, Some(3));
+        assert!(
+            error.is_none(),
+            "error should be None on Complete phase, got {error:?}"
+        );
+        assert_eq!(thread_id.as_deref(), Some("thread-improve"));
+    }
+
+    #[test]
+    fn thread_event_to_app_events_bridges_orchestrator_rollback() {
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::OrchestratorRollback {
+                from_version: 7,
+                to_version: 6,
+                reason: "health probe failed after upgrade".to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-rollback");
+
+        assert_eq!(app_events.len(), 1);
+        let AppEvent::OrchestratorRollback {
+            from_version,
+            to_version,
+            reason,
+            thread_id,
+        } = &app_events[0]
+        else {
+            panic!(
+                "expected AppEvent::OrchestratorRollback, got {:?}",
+                app_events[0]
+            );
+        };
+        assert_eq!(*from_version, 7);
+        assert_eq!(*to_version, 6);
+        assert_eq!(reason, "health probe failed after upgrade");
+        assert_eq!(thread_id.as_deref(), Some("thread-rollback"));
     }
 
     #[test]

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -4752,12 +4752,27 @@ fn thread_event_to_app_events(
             from_version,
             to_version,
             reason,
-        } => vec![AppEvent::OrchestratorRollback {
-            from_version: *from_version,
-            to_version: *to_version,
-            reason: reason.clone(),
-            thread_id: Some(thread_id.into()),
-        }],
+        } => {
+            // `reason` originates from `format!("execution failed: {e}")`
+            // in the engine's rollback path, where `e: EngineError` can
+            // render DB connection strings, file paths, or raw upstream
+            // HTTP bodies. SSE error-adjacent frames reach every
+            // authenticated consumer, so the wire carries a classified
+            // operator-facing message and the raw text stays in the log.
+            tracing::debug!(
+                from_version = *from_version,
+                to_version = *to_version,
+                raw_reason = %reason,
+                "orchestrator rollback event"
+            );
+            vec![AppEvent::OrchestratorRollback {
+                from_version: *from_version,
+                to_version: *to_version,
+                reason: crate::bridge::user_facing_errors::user_facing_rollback_reason(reason)
+                    .to_string(),
+                thread_id: Some(thread_id.into()),
+            }]
+        }
 
         // Explicitly-dropped engine variants. These are NOT bridged to
         // `AppEvent` because an equivalent event is emitted by a
@@ -7394,8 +7409,75 @@ mod tests {
         };
         assert_eq!(*from_version, 7);
         assert_eq!(*to_version, 6);
-        assert_eq!(reason, "health probe failed after upgrade");
+        // Unknown-shape reasons collapse to the safe generic classification.
+        assert_eq!(reason, "execution failed");
         assert_eq!(thread_id.as_deref(), Some("thread-rollback"));
+    }
+
+    #[test]
+    fn orchestrator_rollback_does_not_leak_engine_error_detail() {
+        // Regression for PR #2844 review: the engine rollback path emits
+        // `format!("execution failed: {e}")` where `e: EngineError`.
+        // Variants like `Store { reason }` / `Llm { reason }` can render
+        // DB connection strings, file paths, and raw upstream HTTP bodies.
+        // The bridge must sanitize before broadcasting to SSE consumers.
+        let leaky = "execution failed: store error: connection string \
+            'postgres://bob:hunter2@db.internal:5432/ironclaw' refused: \
+            File \"/home/runner/.ironclaw/state.db\" not found";
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::OrchestratorRollback {
+                from_version: 3,
+                to_version: 2,
+                reason: leaky.to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-leak");
+
+        let AppEvent::OrchestratorRollback { reason, .. } = &app_events[0] else {
+            panic!("expected AppEvent::OrchestratorRollback");
+        };
+        assert!(
+            !reason.contains("postgres://"),
+            "leaked connection string: {reason}"
+        );
+        assert!(!reason.contains("hunter2"), "leaked password: {reason}");
+        assert!(
+            !reason.contains("/home/runner"),
+            "leaked filesystem path: {reason}"
+        );
+        assert!(
+            !reason.contains("store error"),
+            "leaked internal wrap: {reason}"
+        );
+        assert!(
+            !reason.contains("state.db"),
+            "leaked internal filename: {reason}"
+        );
+    }
+
+    #[test]
+    fn orchestrator_rollback_classifies_known_upstream_failures() {
+        // A 502 in the rollback reason should still render a classified
+        // operator-facing message, not the bare "execution failed" fallback.
+        let event = ironclaw_engine::ThreadEvent::new(
+            ironclaw_engine::ThreadId::new(),
+            ironclaw_engine::EventKind::OrchestratorRollback {
+                from_version: 4,
+                to_version: 3,
+                reason: "execution failed: LLM error: Provider nearai request failed: \
+                     HTTP 502 Bad Gateway"
+                    .to_string(),
+            },
+        );
+
+        let app_events = thread_event_to_app_events(&event, "thread-502");
+
+        let AppEvent::OrchestratorRollback { reason, .. } = &app_events[0] else {
+            panic!("expected AppEvent::OrchestratorRollback");
+        };
+        assert_eq!(reason, "LLM provider unavailable");
     }
 
     #[test]

--- a/src/bridge/user_facing_errors.rs
+++ b/src/bridge/user_facing_errors.rs
@@ -444,14 +444,36 @@ mod tests {
         // Regression for PR #2844: `EventKind::OrchestratorRollback.reason`
         // originates from `format!("execution failed: {e}")` in the engine,
         // where `e: EngineError` can render DB connection strings, file
-        // paths, and upstream HTTP bodies. The sanitizer must strip those.
-        let raw = "execution failed: store error: connection 'postgres://bob:hunter2@db:5432/x' refused: \
+        // paths, tokens, and upstream HTTP bodies. The sanitizer must
+        // produce an output that is fully independent of the raw engine
+        // detail — two unrelated leaky strings must collapse to the same
+        // classified message. `assert_eq!(msg_a, msg_b)` is the load-
+        // bearing check; the `contains` probes below are sentinel sniffs
+        // for the specific leak shapes the fix is meant to prevent.
+        let raw_a = "execution failed: store error: connection \
+            'postgres://bob:hunter2@db:5432/x' refused: \
             File \"/home/runner/.ironclaw/state.db\" not found";
-        let msg = user_facing_rollback_reason(raw);
-        assert_eq!(msg, "execution failed");
-        assert!(!msg.contains("postgres://"));
-        assert!(!msg.contains("hunter2"));
-        assert!(!msg.contains("/home/runner"));
+        // Deliberately avoid any substring that the classifier recognises
+        // (no `upstream`, no `http 5xx`, no `rate limited`, etc.) so both
+        // inputs fall into the `Unknown` category — the test is about
+        // sanitisation, not classification.
+        let raw_b = "execution failed: store error: leaked \
+            token sk_live_123 and request id req_abc123 at /etc/secrets/keyring";
+
+        let msg_a = user_facing_rollback_reason(raw_a);
+        let msg_b = user_facing_rollback_reason(raw_b);
+
+        assert_eq!(msg_a, "execution failed");
+        assert_eq!(msg_b, "execution failed");
+        assert_eq!(
+            msg_a, msg_b,
+            "sanitized rollback reason must be independent of raw engine detail"
+        );
+        assert!(!msg_a.contains("postgres://"));
+        assert!(!msg_a.contains("hunter2"));
+        assert!(!msg_a.contains("/home/runner"));
+        assert!(!msg_b.contains("sk_live_123"));
+        assert!(!msg_b.contains("req_abc123"));
     }
 
     #[test]

--- a/src/bridge/user_facing_errors.rs
+++ b/src/bridge/user_facing_errors.rs
@@ -81,6 +81,27 @@ pub(crate) fn user_facing_thread_failure(error: &str) -> String {
     }
 }
 
+/// Convert a raw orchestrator-rollback reason into a short,
+/// operator-facing classification that is safe to broadcast over SSE.
+///
+/// The rollback event's source string is
+/// `format!("execution failed: {e}")` where `e` is an `EngineError` —
+/// variants like `Store { reason }` and `Llm { reason }` can carry DB
+/// connection strings, file paths, and raw upstream HTTP bodies. That
+/// raw text must not reach every authenticated SSE consumer. Callers
+/// should log the raw `reason` at `debug!` before calling this so
+/// operators retain the diagnostic detail server-side.
+pub(crate) fn user_facing_rollback_reason(reason: &str) -> &'static str {
+    match classify_failure(reason) {
+        FailureCategory::LlmUnavailable => "LLM provider unavailable",
+        FailureCategory::LlmRateLimited => "LLM provider rate-limited",
+        FailureCategory::ContextTooLarge => "context too large for provider",
+        FailureCategory::AuthFailure => "LLM provider authentication failed",
+        FailureCategory::IterationLimit => "execution step limit reached",
+        FailureCategory::Unknown => "execution failed",
+    }
+}
+
 /// Classify a raw failure string. Public(crate) so tests can assert on the
 /// category independently of the user-facing wording.
 pub(crate) fn classify_failure(error: &str) -> FailureCategory {
@@ -415,6 +436,45 @@ mod tests {
         assert!(
             msg.contains("re-authenticate"),
             "auth failure copy should guide users to re-authenticate: {msg}"
+        );
+    }
+
+    #[test]
+    fn rollback_reason_drops_engine_error_detail() {
+        // Regression for PR #2844: `EventKind::OrchestratorRollback.reason`
+        // originates from `format!("execution failed: {e}")` in the engine,
+        // where `e: EngineError` can render DB connection strings, file
+        // paths, and upstream HTTP bodies. The sanitizer must strip those.
+        let raw = "execution failed: store error: connection 'postgres://bob:hunter2@db:5432/x' refused: \
+            File \"/home/runner/.ironclaw/state.db\" not found";
+        let msg = user_facing_rollback_reason(raw);
+        assert_eq!(msg, "execution failed");
+        assert!(!msg.contains("postgres://"));
+        assert!(!msg.contains("hunter2"));
+        assert!(!msg.contains("/home/runner"));
+    }
+
+    #[test]
+    fn rollback_reason_classifies_known_upstream_failures() {
+        assert_eq!(
+            user_facing_rollback_reason("execution failed: LLM error: HTTP 502 Bad Gateway"),
+            "LLM provider unavailable"
+        );
+        assert_eq!(
+            user_facing_rollback_reason("execution failed: HTTP 429 Too Many Requests"),
+            "LLM provider rate-limited"
+        );
+        assert_eq!(
+            user_facing_rollback_reason("execution failed: HTTP 413 Payload Too Large"),
+            "context too large for provider"
+        );
+        assert_eq!(
+            user_facing_rollback_reason("execution failed: HTTP 401 Unauthorized"),
+            "LLM provider authentication failed"
+        );
+        assert_eq!(
+            user_facing_rollback_reason("execution failed: max iterations reached"),
+            "execution step limit reached"
         );
     }
 


### PR DESCRIPTION
## Summary

Second slice of engine→`AppEvent` bridge coverage under #2792 Phase 1, building on #2797 (StepFailed / ChildCompleted / CodeExecutionFailed). Closes the remaining cheap `EventKind` drops.

| `EventKind` | `AppEvent` | UX gap before |
|---|---|---|
| `LeaseGranted` | new `LeaseGranted` | Capability grants invisible — no audit trail on the UI |
| `LeaseRevoked` | new `LeaseRevoked` | Capability yanked mid-turn, no feedback |
| `LeaseExpired` | new `LeaseExpired` | Tools fail after TTL with no visible reason |
| `SelfImprovement{Started,Complete,Failed}` (3 variants) | new `SelfImprovement { phase, … }` | Background self-improvement fully invisible |
| `OrchestratorRollback` | new `OrchestratorRollback` | Version rollback hidden from operator |

## Design

**Self-improvement collapse.** The three engine `SelfImprovement*` variants become one wire event with a `SelfImprovementPhase` discriminator (`started` / `complete` / `failed`). Frontend gets a single handler; phase-scoped fields (`prompt_updated`, `patterns_added`, `error`) are optional by phase. Follows `.claude/rules/types.md` "Wire-stable enums" — snake_case serde, typed phase, not a stringly-typed status.

**Lease events kept separate.** Grant/revoke/expire carry different fields and are security-visible. Collapsing them would hide the structural difference between "explicit revocation" and "TTL hit."

## Incidental fixes

- `impl fmt::Display for LeaseId` in the engine, alongside existing `ThreadId` / `ProjectId` impls. Bridge stringifies for the wire; missing `Display` blocked first compile.
- Moved the `thread_event_to_app_events` docstring back to where it belongs (it was attached to `code_execution_category_to_wire` after the #2797 refactor — stale-comment lesson).

## Still deferred

`EventKind::ApprovalRequested` / `ApprovalReceived` — would duplicate the gate manager's direct `GateRequired` / `GateResolved` emits until the gate manager is migrated to engine-event-first. Bundled with Phase 1 PR 3 migration.

## Refs

- Epic: #2792 — gateway state convergence
- Tracking: #2654 — engine→AppEvent coverage gaps
- Predecessor: #2797 — first 3 bridge drops
- Sibling in flight: #2840 — projection-exempt lint + gateway-events.md rule

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all --benches --tests --examples --all-features` — clean (after adding `Display for LeaseId`)
- [x] `cargo test --lib bridge::router::tests::thread_event_to_app_events` — 7 passed (4 pre-existing + 3 new: lease grant, self-improvement complete, orchestrator rollback)
- [x] `cargo test -p ironclaw_common event_type_matches_serde_type_field` — passes with 5 new variants covered
- [ ] Manual verification on staging: trigger a capability lease grant → `LeaseGranted` event visible; trigger self-improvement → three events (started/complete) visible; trigger orchestrator rollback via test harness → event visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)