### PR TITLE
fix(wasm): remove stale 10M fuel limit from settings DB

### DIFF
--- a/migrations/V25__wasm_fuel_limit_bump.sql
+++ b/migrations/V25__wasm_fuel_limit_bump.sql
@@ -1,0 +1,7 @@
+-- The code default for wasm.default_fuel_limit was bumped from 10M to 500M
+-- (limits.rs, config/wasm.rs), but databases that persisted the old 10M value
+-- in the settings table still read it back at startup (DB-first resolution).
+-- Delete the stale row so the code default takes effect.
+DELETE FROM settings
+WHERE key = 'wasm.default_fuel_limit'
+  AND CAST(value AS BIGINT) <= 10000000;

--- a/migrations/V25__wasm_fuel_limit_bump.sql
+++ b/migrations/V25__wasm_fuel_limit_bump.sql
@@ -4,4 +4,4 @@
 -- Delete the stale row so the code default takes effect.
 DELETE FROM settings
 WHERE key = 'wasm.default_fuel_limit'
-  AND CAST(value AS BIGINT) <= 10000000;
+  AND (value#>>'{}')::BIGINT = 10000000;

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -37,3 +37,4 @@ V21__backfill_conversation_source_channel = 4041142068103384561
 V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
+V25__wasm_fuel_limit_bump = 3853448876315404150

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -37,4 +37,4 @@ V21__backfill_conversation_source_channel = 4041142068103384561
 V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
-V25__wasm_fuel_limit_bump = 3853448876315404150
+V25__wasm_fuel_limit_bump = 8924323300096627270

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -992,6 +992,21 @@ ALTER TABLE agent_jobs ADD COLUMN restart_params TEXT;
 CREATE INDEX IF NOT EXISTS idx_llm_calls_created_at ON llm_calls(created_at);
 "#,
     ),
+    (
+        25,
+        "wasm_fuel_limit_bump",
+        // The code default for wasm.default_fuel_limit was bumped from 10M to
+        // 500M (limits.rs, config/wasm.rs), but databases that persisted the
+        // old 10M value in the settings table still read it back at startup
+        // (DB-first resolution). Delete the stale row so the code default
+        // takes effect; users who intentionally lowered the limit can re-set
+        // it via the settings API.
+        r#"
+DELETE FROM settings
+WHERE key = 'wasm.default_fuel_limit'
+  AND CAST(value AS INTEGER) <= 10000000;
+"#,
+    ),
 ];
 
 /// Migrations whose ADD COLUMN should be skipped when the column already

--- a/src/db/libsql_migrations.rs
+++ b/src/db/libsql_migrations.rs
@@ -1004,7 +1004,7 @@ CREATE INDEX IF NOT EXISTS idx_llm_calls_created_at ON llm_calls(created_at);
         r#"
 DELETE FROM settings
 WHERE key = 'wasm.default_fuel_limit'
-  AND CAST(value AS INTEGER) <= 10000000;
+  AND CAST(json_extract(value, '$') AS INTEGER) = 10000000;
 "#,
     ),
 ];


### PR DESCRIPTION
## Summary

- Databases that persisted `wasm.default_fuel_limit = 10000000` before the code default was bumped to 500M still read the old value at startup (DB-first resolution in `config/wasm.rs`), causing WASM tools like `google_slides` to fail with "Fuel exhausted: execution exceeded 10000000 fuel units"
- Adds migration V25 (PostgreSQL + libSQL) that deletes the stale setting row when its value is <= 10M, so the 500M code default takes effect
- Users who intentionally set a custom limit above 10M are unaffected

## Test plan

- [x] `released_migrations_are_immutable` test passes with new checksum
- [x] Verified locally: after migration, google_slides tool executes successfully with 500M fuel budget
- [ ] Verify on staging that existing databases with stale 10M setting get upgraded

🤖 Generated with [Claude Code](https://claude.com/claude-code)