### PR TITLE
feat(llm): add Manifest as built-in LLM provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,6 +77,12 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_EXTRA_HEADERS=HTTP-Referer:https://myapp.com,X-Title:MyApp
 
 
+# === Manifest (smart model router) ===
+# LLM_BACKEND=manifest
+# MANIFEST_API_KEY=mnfst_...
+# MANIFEST_MODEL=auto                              # default; Manifest picks the best model per request
+# MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:2099/v1 for self-hosted
+
 # === Together AI (via OpenAI-compatible) ===
 # LLM_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo
 # LLM_BACKEND=openai_compatible

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BACKEND=manifest
 # MANIFEST_API_KEY=mnfst_...
 # MANIFEST_MODEL=auto                              # default; Manifest picks the best model per request
-# MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:3001/v1 for self-hosted
+# MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:2099/v1 for self-hosted
 
 # === Together AI (via OpenAI-compatible) ===
 # LLM_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo

--- a/.env.example
+++ b/.env.example
@@ -77,10 +77,10 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_EXTRA_HEADERS=HTTP-Referer:https://myapp.com,X-Title:MyApp
 
 
-# === Manifest (smart model router) ===
+# === Manifest (open-source LLM router) ===
 # LLM_BACKEND=manifest
 # MANIFEST_API_KEY=mnfst_...
-# MANIFEST_MODEL=auto                              # default; Manifest picks the best model per request
+# MANIFEST_MODEL=auto                              # default; smart routing across 16+ providers
 # MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:2099/v1 for self-hosted
 
 # === Together AI (via OpenAI-compatible) ===

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@ NEARAI_AUTH_URL=https://private.near.ai
 # LLM_BACKEND=manifest
 # MANIFEST_API_KEY=mnfst_...
 # MANIFEST_MODEL=auto                              # default; Manifest picks the best model per request
-# MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:2099/v1 for self-hosted
+# MANIFEST_BASE_URL=https://app.manifest.build/v1  # default (cloud); use http://localhost:3001/v1 for self-hosted
 
 # === Together AI (via OpenAI-compatible) ===
 # LLM_MODEL=meta-llama/Llama-3.3-70B-Instruct-Turbo

--- a/docs/capabilities/llm-providers.md
+++ b/docs/capabilities/llm-providers.md
@@ -30,6 +30,7 @@ ironclaw onboard --provider-only
 | MiniMax               | `minimax`           | `MINIMAX_API_KEY`      | MiniMax-M2.7 models             |
 | Cloudflare Workers AI | `cloudflare`        | `CLOUDFLARE_API_KEY`   | Access to Workers AI            |
 | GitHub Copilot        | `github_copilot`    | `GITHUB_COPILOT_TOKEN` | Multi-models                    |
+| Manifest              | `manifest`          | `MANIFEST_API_KEY`     | Open-source LLM router          |
 | Ollama                | `ollama`            | No                     | Local inference                 |
 | AWS Bedrock           | `bedrock`           | AWS credentials        | Native Converse API             |
 | OpenRouter            | `openai_compatible` | `LLM_API_KEY`          | 300+ models                     |
@@ -225,6 +226,24 @@ Set `BEDROCK_CROSS_REGION` to route requests across AWS regions for capacity:
 | Claude Haiku 4.5  | `anthropic.claude-haiku-4-5-20251001-v1:0`  |
 | Amazon Nova Pro   | `amazon.nova-pro-v1:0`                      |
 | Llama 4 Maverick  | `meta.llama4-maverick-17b-instruct-v1:0`    |
+
+---
+
+## Manifest (Open-Source LLM Router)
+
+[Manifest](https://manifest.build) is an open-source LLM router that cuts inference costs through smart routing across 16+ providers. You get full control over which model handles each request. Route by complexity tier, task-specificity (coding, web browsing, etc.) and custom tiers.
+
+```env
+LLM_BACKEND=manifest
+MANIFEST_API_KEY=mnfst_...
+MANIFEST_MODEL=auto
+```
+
+Manifest is open-source and can be self-hosted with Docker for fully private inference. Override the base URL to point to your local instance:
+
+```env
+MANIFEST_BASE_URL=http://localhost:2099/v1
+```
 
 ---
 

--- a/providers.json
+++ b/providers.json
@@ -140,6 +140,27 @@
     }
   },
   {
+    "id": "manifest",
+    "aliases": [
+      "mnfst"
+    ],
+    "protocol": "open_ai_completions",
+    "default_base_url": "https://app.manifest.build/v1",
+    "api_key_env": "MANIFEST_API_KEY",
+    "api_key_required": true,
+    "base_url_env": "MANIFEST_BASE_URL",
+    "model_env": "MANIFEST_MODEL",
+    "default_model": "auto",
+    "description": "Manifest smart model router (auto-routes to cheapest capable model)",
+    "setup": {
+      "kind": "api_key",
+      "secret_name": "llm_manifest_api_key",
+      "key_url": "https://app.manifest.build",
+      "display_name": "Manifest",
+      "can_list_models": false
+    }
+  },
+  {
     "id": "groq",
     "aliases": [],
     "protocol": "open_ai_completions",

--- a/providers.json
+++ b/providers.json
@@ -151,7 +151,7 @@
     "base_url_env": "MANIFEST_BASE_URL",
     "model_env": "MANIFEST_MODEL",
     "default_model": "auto",
-    "description": "Manifest smart model router (auto-routes to cheapest capable model)",
+    "description": "Manifest open-source LLM router (smart routing to cut inference costs)",
     "setup": {
       "kind": "api_key",
       "secret_name": "llm_manifest_api_key",


### PR DESCRIPTION
## Summary

- Add Manifest to the provider registry with OpenAI-compatible protocol
- Default model is `auto`, Manifest picks the right complexity tier per request
- Works with cloud (`app.manifest.build`) and self-hosted (`localhost:2099`) via `MANIFEST_BASE_URL`

## Configuration

```
LLM_BACKEND=manifest
MANIFEST_API_KEY=mnfst_...
MANIFEST_MODEL=auto
```

## Test plan

- [ ] `cargo test -- test_builtin_registry_loads` passes
- [ ] `cargo test -- test_find_by_id` passes
- [ ] `ironclaw onboard --step provider` shows "Manifest" in the list
- [ ] Setting `LLM_BACKEND=manifest` with a valid key routes requests through Manifest