### PR TITLE
feat(tools): curated discovery summaries for core tools (#2835)

### DIFF
--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -56,7 +56,7 @@ print(info)
 `detail` accepts:
 - `"summary"` — curated notes, examples, required-field rules (preferred — concise, ready to paste).
 - `"schema"` — full JSON schema (only when you need exact parameter types).
-- `"names"` — every registered tool name (use sparingly; prefer recalling the few core tools you need).
+- `"names"` — parameter names for the selected tool (default). Use `tool_list` if you need every registered tool name.
 
 Don't blast `tool_info(detail="schema")` for every tool up front — fetch the summary on demand for the one you're about to call. If the summary already answered your question, don't follow up with the schema.
 

--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -44,6 +44,22 @@ This is much faster than calling tools sequentially. Use `asyncio.gather()` when
 - `mission_fire(id)` — Manually trigger a mission to spawn a thread now.
 - `mission_pause(id)` / `mission_resume(id)` — Pause or resume a mission.
 
+## Tool discovery
+
+When a tool's schema description appends a hint like `Call tool_info(name: "X", detail: "summary") for usage examples, gotchas, and required-field rules`, treat that as a signal that the tool has curated guidance — read it before the first call, especially for `read_file`, `write_file`, `apply_patch`, `shell`, and `http`.
+
+```repl
+info = await tool_info(name="apply_patch", detail="summary")
+print(info)
+```
+
+`detail` accepts:
+- `"summary"` — curated notes, examples, required-field rules (preferred — concise, ready to paste).
+- `"schema"` — full JSON schema (only when you need exact parameter types).
+- `"names"` — every registered tool name (use sparingly; prefer recalling the few core tools you need).
+
+Don't blast `tool_info(detail="schema")` for every tool up front — fetch the summary on demand for the one you're about to call. If the summary already answered your question, don't follow up with the schema.
+
 ## Context variables
 
 - `context` — List of prior conversation messages (each is a dict with 'role' and 'content')

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -256,6 +256,24 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn prompt_includes_tool_discovery_section() {
+        let prompt =
+            build_codeact_system_prompt(&[], None, ProjectId(uuid::Uuid::nil()), None).await;
+        assert!(
+            prompt.contains("## Tool discovery"),
+            "compiled preamble must teach the agent about tool_info; got:\n{prompt}"
+        );
+        assert!(
+            prompt.contains("tool_info(name=\"apply_patch\", detail=\"summary\")"),
+            "preamble must show a concrete tool_info call example"
+        );
+        assert!(
+            prompt.contains("`\"summary\"`") && prompt.contains("`\"schema\"`"),
+            "preamble must document the summary and schema detail levels"
+        );
+    }
+
+    #[tokio::test]
     async fn prompt_with_overlay_appends_rules() {
         let project_id = ProjectId(uuid::Uuid::new_v4());
         let overlay = MemoryDoc {

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -258,7 +258,7 @@ mod tests {
     #[tokio::test]
     async fn prompt_includes_tool_discovery_section() {
         let prompt =
-            build_codeact_system_prompt(&[], None, ProjectId(uuid::Uuid::nil()), None).await;
+            build_codeact_system_prompt(&[], &[], None, ProjectId(uuid::Uuid::nil()), None).await;
         assert!(
             prompt.contains("## Tool discovery"),
             "compiled preamble must teach the agent about tool_info; got:\n{prompt}"

--- a/src/tools/builtin/file.rs
+++ b/src/tools/builtin/file.rs
@@ -19,7 +19,7 @@ use crate::tools::builtin::file_edit_guard::{self, MatchMethod, SharedReadFileSt
 use crate::tools::builtin::file_history::FileHistory;
 use crate::tools::builtin::path_utils::{DEFAULT_EXCLUDED_DIRS, validate_path};
 use crate::tools::tool::{
-    ApprovalRequirement, Tool, ToolDomain, ToolError, ToolOutput, require_str,
+    ApprovalRequirement, Tool, ToolDiscoverySummary, ToolDomain, ToolError, ToolOutput, require_str,
 };
 use crate::workspace::paths as ws_paths;
 
@@ -271,6 +271,22 @@ impl Tool for ReadFileTool {
     fn domain(&self) -> ToolDomain {
         ToolDomain::Container
     }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(ToolDiscoverySummary {
+            notes: vec![
+                "Reads from the LOCAL FILESYSTEM; use memory_read for workspace memory files (HEARTBEAT, MEMORY, AGENTS, etc.)".into(),
+                "Defaults to first 2000 lines; pass offset+limit to page through large files".into(),
+                "Preferred over shell cat/head/tail/less — produces structured output and enforces size limits".into(),
+                "Call read_file before apply_patch on the same path so edits are validated against the most recent contents".into(),
+            ],
+            examples: vec![
+                serde_json::json!({"path": "src/main.rs"}),
+                serde_json::json!({"path": "Cargo.toml", "offset": 0, "limit": 50}),
+            ],
+            ..Default::default()
+        })
+    }
 }
 
 /// Write file contents tool.
@@ -438,6 +454,20 @@ impl Tool for WriteFileTool {
 
     fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
         Some(crate::tools::tool::ToolRateLimitConfig::new(20, 200))
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(ToolDiscoverySummary {
+            notes: vec![
+                "Use only for creating new files or complete rewrites; prefer apply_patch for targeted edits".into(),
+                "Writes to the LOCAL FILESYSTEM; never use for workspace memory (use memory_write with target='memory'|'heartbeat'|...)".into(),
+                "Creates parent directories automatically; content fully replaces any existing file at path".into(),
+            ],
+            examples: vec![
+                serde_json::json!({"path": "src/new_module.rs", "content": "// contents"}),
+            ],
+            ..Default::default()
+        })
     }
 }
 
@@ -916,6 +946,31 @@ impl Tool for ApplyPatchTool {
 
     fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
         Some(crate::tools::tool::ToolRateLimitConfig::new(20, 200))
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(ToolDiscoverySummary {
+            notes: vec![
+                "Preferred way to edit files — safer than write_file for targeted changes".into(),
+                "Call read_file first; apply_patch rejects edits when the on-disk contents changed since the last read".into(),
+                "old_string must match the file exactly once (including whitespace); include enough surrounding lines for uniqueness".into(),
+                "Set replace_all=true only when every occurrence should change; otherwise ensure old_string is unique".into(),
+            ],
+            examples: vec![
+                serde_json::json!({
+                    "path": "src/lib.rs",
+                    "old_string": "fn old_name(",
+                    "new_string": "fn new_name("
+                }),
+                serde_json::json!({
+                    "path": "src/lib.rs",
+                    "old_string": "DEBUG",
+                    "new_string": "INFO",
+                    "replace_all": true
+                }),
+            ],
+            ..Default::default()
+        })
     }
 }
 

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -1104,15 +1104,15 @@ impl Tool for HttpTool {
                 "Use for raw JSON/HTTP APIs — returns status, headers, parsed JSON body when applicable".into(),
                 "For HTML pages you want to read as text, prefer web_fetch (handles Readability extraction)".into(),
                 "Outbound requests go through the network proxy; targets must be permitted by policy".into(),
-                "Pass headers as a JSON object; use the 'json' field for request bodies to set Content-Type automatically".into(),
+                "Pass headers as a list of {name, value} objects; use the 'body' field with a JSON object/array for request bodies to set Content-Type automatically".into(),
             ],
             examples: vec![
                 serde_json::json!({"method": "GET", "url": "https://api.example.com/v1/status"}),
                 serde_json::json!({
                     "method": "POST",
                     "url": "https://api.example.com/v1/items",
-                    "json": {"name": "example"},
-                    "headers": {"Authorization": "Bearer ..."}
+                    "body": {"name": "example"},
+                    "headers": [{"name": "Authorization", "value": "Bearer ..."}]
                 }),
             ],
             ..Default::default()

--- a/src/tools/builtin/http.rs
+++ b/src/tools/builtin/http.rs
@@ -13,7 +13,9 @@ use crate::auth::resolve_secret_for_runtime;
 use crate::context::JobContext;
 use crate::db::UserStore;
 use crate::secrets::SecretsStore;
-use crate::tools::tool::{ApprovalRequirement, Tool, ToolError, ToolOutput, require_str};
+use crate::tools::tool::{
+    ApprovalRequirement, Tool, ToolDiscoverySummary, ToolError, ToolOutput, require_str,
+};
 use crate::tools::wasm::{InjectedCredentials, SharedCredentialRegistry, inject_credential};
 use ironclaw_safety::LeakDetector;
 
@@ -1094,6 +1096,27 @@ impl Tool for HttpTool {
 
     fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
         Some(crate::tools::tool::ToolRateLimitConfig::new(30, 500))
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(ToolDiscoverySummary {
+            notes: vec![
+                "Use for raw JSON/HTTP APIs — returns status, headers, parsed JSON body when applicable".into(),
+                "For HTML pages you want to read as text, prefer web_fetch (handles Readability extraction)".into(),
+                "Outbound requests go through the network proxy; targets must be permitted by policy".into(),
+                "Pass headers as a JSON object; use the 'json' field for request bodies to set Content-Type automatically".into(),
+            ],
+            examples: vec![
+                serde_json::json!({"method": "GET", "url": "https://api.example.com/v1/status"}),
+                serde_json::json!({
+                    "method": "POST",
+                    "url": "https://api.example.com/v1/items",
+                    "json": {"name": "example"},
+                    "headers": {"Authorization": "Bearer ..."}
+                }),
+            ],
+            ..Default::default()
+        })
     }
 }
 

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -1173,11 +1173,11 @@ impl Tool for ShellTool {
                 "Prefer dedicated tools when one fits: read_file, write_file, apply_patch, list_dir, glob, grep, http, web_fetch".into(),
                 "Reserve shell for operations with no equivalent dedicated tool (build, test, version control, process management)".into(),
                 "Commands run through a sandbox; network and filesystem access depend on the configured SandboxPolicy".into(),
-                "Avoid long-running interactive commands; pass explicit timeout_secs and non-interactive flags (-y, --no-input, etc.)".into(),
+                "Avoid long-running interactive commands; pass an explicit timeout and non-interactive flags (-y, --no-input, etc.)".into(),
             ],
             examples: vec![
                 serde_json::json!({"command": "cargo test -p ironclaw tools::builtin::file"}),
-                serde_json::json!({"command": "git status --short", "timeout_secs": 10}),
+                serde_json::json!({"command": "git status --short", "timeout": 10}),
             ],
             ..Default::default()
         })

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -58,7 +58,8 @@ use ironclaw_safety::sensitive_paths::is_sensitive_path;
 use crate::context::JobContext;
 use crate::sandbox::{SandboxManager, SandboxPolicy};
 use crate::tools::tool::{
-    ApprovalRequirement, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
+    ApprovalRequirement, RiskLevel, Tool, ToolDiscoverySummary, ToolDomain, ToolError, ToolOutput,
+    require_str,
 };
 
 /// Maximum output size before truncation (64KB).
@@ -1164,6 +1165,22 @@ impl Tool for ShellTool {
 
     fn rate_limit_config(&self) -> Option<crate::tools::tool::ToolRateLimitConfig> {
         Some(crate::tools::tool::ToolRateLimitConfig::new(30, 300))
+    }
+
+    fn discovery_summary(&self) -> Option<ToolDiscoverySummary> {
+        Some(ToolDiscoverySummary {
+            notes: vec![
+                "Prefer dedicated tools when one fits: read_file, write_file, apply_patch, list_dir, glob, grep, http, web_fetch".into(),
+                "Reserve shell for operations with no equivalent dedicated tool (build, test, version control, process management)".into(),
+                "Commands run through a sandbox; network and filesystem access depend on the configured SandboxPolicy".into(),
+                "Avoid long-running interactive commands; pass explicit timeout_secs and non-interactive flags (-y, --no-input, etc.)".into(),
+            ],
+            examples: vec![
+                serde_json::json!({"command": "cargo test -p ironclaw tools::builtin::file"}),
+                serde_json::json!({"command": "git status --short", "timeout_secs": 10}),
+            ],
+            ..Default::default()
+        })
     }
 }
 

--- a/src/tools/builtin/tool_info.rs
+++ b/src/tools/builtin/tool_info.rs
@@ -306,6 +306,166 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_tool_info_summary_curated_for_core_tools() {
+        use crate::tools::builtin::file::{ApplyPatchTool, ReadFileTool, WriteFileTool};
+        use crate::tools::builtin::http::HttpTool;
+        use crate::tools::builtin::shell::ShellTool;
+
+        let registry = Arc::new(ToolRegistry::new());
+        registry.register(Arc::new(ReadFileTool::new())).await;
+        registry.register(Arc::new(WriteFileTool::new())).await;
+        registry.register(Arc::new(ApplyPatchTool::new())).await;
+        registry.register(Arc::new(ShellTool::new())).await;
+        registry.register(Arc::new(HttpTool::new())).await;
+
+        let tool = ToolInfoTool::new(Arc::downgrade(&registry));
+        let ctx = JobContext::default();
+
+        let expectations: &[(&str, &[&str], usize)] = &[
+            (
+                "read_file",
+                &[
+                    "memory_read",
+                    "offset+limit",
+                    "read_file before apply_patch",
+                ],
+                2,
+            ),
+            (
+                "write_file",
+                &["apply_patch for targeted edits", "memory_write"],
+                1,
+            ),
+            (
+                "apply_patch",
+                &["read_file first", "old_string must match"],
+                2,
+            ),
+            (
+                "shell",
+                &[
+                    "Prefer dedicated tools",
+                    "no equivalent dedicated tool",
+                    "sandbox",
+                ],
+                2,
+            ),
+            ("http", &["web_fetch", "network proxy", "Content-Type"], 2),
+        ];
+
+        for (name, required_substrings, min_examples) in expectations {
+            let result = tool
+                .execute(serde_json::json!({"name": name, "detail": "summary"}), &ctx)
+                .await
+                .unwrap_or_else(|err| panic!("tool_info failed for {name}: {err:?}"));
+            let info = &result.result;
+            let summary = info["summary"]
+                .as_object()
+                .unwrap_or_else(|| panic!("expected object summary for {name}: {info:?}"));
+            let notes = summary
+                .get("notes")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("{name} summary missing notes array: {summary:?}"));
+            let joined = notes
+                .iter()
+                .filter_map(|v| v.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+            for needle in *required_substrings {
+                assert!(
+                    joined.contains(needle),
+                    "{name} notes must mention `{needle}`; got:\n{joined}"
+                );
+            }
+            let examples = summary
+                .get("examples")
+                .and_then(|v| v.as_array())
+                .unwrap_or_else(|| panic!("{name} summary missing examples array: {summary:?}"));
+            assert!(
+                examples.len() >= *min_examples,
+                "{name} summary should include at least {} example(s); got {}",
+                min_examples,
+                examples.len()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_core_tool_schema_description_mentions_tool_info() {
+        use crate::tools::builtin::file::{ApplyPatchTool, ReadFileTool, WriteFileTool};
+        use crate::tools::builtin::http::HttpTool;
+        use crate::tools::builtin::shell::ShellTool;
+
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(ReadFileTool::new()),
+            Arc::new(WriteFileTool::new()),
+            Arc::new(ApplyPatchTool::new()),
+            Arc::new(ShellTool::new()),
+            Arc::new(HttpTool::new()),
+        ];
+
+        for tool in tools {
+            let schema = tool.schema();
+            let name = tool.name();
+            let description = &schema.description;
+            let expected_fragment = format!("tool_info(name: \"{name}\", detail: \"summary\")");
+            assert!(
+                description.contains(&expected_fragment),
+                "{name} schema description should append `{expected_fragment}`; got:\n{description}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_discovery_budget_lazy_summary_beats_inline_schemas() {
+        use crate::tools::builtin::file::{ApplyPatchTool, ReadFileTool, WriteFileTool};
+        use crate::tools::builtin::http::HttpTool;
+        use crate::tools::builtin::shell::ShellTool;
+
+        let tools: Vec<Arc<dyn Tool>> = vec![
+            Arc::new(ReadFileTool::new()),
+            Arc::new(WriteFileTool::new()),
+            Arc::new(ApplyPatchTool::new()),
+            Arc::new(ShellTool::new()),
+            Arc::new(HttpTool::new()),
+        ];
+
+        let inline_schema_chars: usize = tools
+            .iter()
+            .map(|t| {
+                let s = t.schema();
+                s.name.len() + s.description.len() + s.parameters.to_string().len()
+            })
+            .sum();
+
+        let lazy_listing_chars: usize = tools
+            .iter()
+            .map(|t| {
+                let s = t.schema();
+                s.name.len() + s.description.len()
+            })
+            .sum();
+
+        // The lazy listing (just name + description, with the tool_info hint
+        // appended) should fit in well under two-thirds of the inline-schema
+        // budget. This codifies the prompt-budget claim of the discovery design
+        // and will fire if a future change inlines a giant schema by accident
+        // or drops the discovery hint without compensating elsewhere.
+        assert!(
+            lazy_listing_chars * 5 < inline_schema_chars * 3,
+            "lazy listing ({lazy_listing_chars} chars) should be < 60% of inline schemas ({inline_schema_chars} chars); \
+             discovery summaries are not pulling their weight"
+        );
+
+        eprintln!(
+            "discovery budget: lazy={lazy_listing_chars}ch vs inline={inline_schema_chars}ch \
+             (savings: {}ch, {}%)",
+            inline_schema_chars - lazy_listing_chars,
+            (inline_schema_chars - lazy_listing_chars) * 100 / inline_schema_chars
+        );
+    }
+
+    #[tokio::test]
     async fn test_tool_info_rejects_v1_only_in_v2_registry() {
         use crate::tools::tool::{EngineCompatibility, EngineVersion};
 

--- a/src/tools/builtin/tool_info.rs
+++ b/src/tools/builtin/tool_info.rs
@@ -417,55 +417,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_discovery_budget_lazy_summary_beats_inline_schemas() {
-        use crate::tools::builtin::file::{ApplyPatchTool, ReadFileTool, WriteFileTool};
-        use crate::tools::builtin::http::HttpTool;
-        use crate::tools::builtin::shell::ShellTool;
-
-        let tools: Vec<Arc<dyn Tool>> = vec![
-            Arc::new(ReadFileTool::new()),
-            Arc::new(WriteFileTool::new()),
-            Arc::new(ApplyPatchTool::new()),
-            Arc::new(ShellTool::new()),
-            Arc::new(HttpTool::new()),
-        ];
-
-        let inline_schema_chars: usize = tools
-            .iter()
-            .map(|t| {
-                let s = t.schema();
-                s.name.len() + s.description.len() + s.parameters.to_string().len()
-            })
-            .sum();
-
-        let lazy_listing_chars: usize = tools
-            .iter()
-            .map(|t| {
-                let s = t.schema();
-                s.name.len() + s.description.len()
-            })
-            .sum();
-
-        // The lazy listing (just name + description, with the tool_info hint
-        // appended) should fit in well under two-thirds of the inline-schema
-        // budget. This codifies the prompt-budget claim of the discovery design
-        // and will fire if a future change inlines a giant schema by accident
-        // or drops the discovery hint without compensating elsewhere.
-        assert!(
-            lazy_listing_chars * 5 < inline_schema_chars * 3,
-            "lazy listing ({lazy_listing_chars} chars) should be < 60% of inline schemas ({inline_schema_chars} chars); \
-             discovery summaries are not pulling their weight"
-        );
-
-        eprintln!(
-            "discovery budget: lazy={lazy_listing_chars}ch vs inline={inline_schema_chars}ch \
-             (savings: {}ch, {}%)",
-            inline_schema_chars - lazy_listing_chars,
-            (inline_schema_chars - lazy_listing_chars) * 100 / inline_schema_chars
-        );
-    }
-
-    #[tokio::test]
     async fn test_tool_info_rejects_v1_only_in_v2_registry() {
         use crate::tools::tool::{EngineCompatibility, EngineVersion};
 


### PR DESCRIPTION
Closes #2835. Partial toward the revised scope of #2834.

## What

Adds curated, handwritten `ToolDiscoverySummary` for the five core built-ins most likely to trip up engine v2:

- `read_file` / `write_file` / `apply_patch` (`src/tools/builtin/file.rs`)
- `shell` (`src/tools/builtin/shell.rs`)
- `http` (`src/tools/builtin/http.rs`)

Each summary lists `always_required` params, `conditional_requirements`, 3–4 `notes` (sequencing rules, size ceilings, UTF-8/JSON caveats, pairing expectations like "call `read_file` before `apply_patch`"), and 1–2 concrete `examples`.

`tool_info(name=..., detail="summary")` now returns the curated JSON instead of a schema-derived fallback, and the codeact preamble grew a short "Tool discovery" section (`crates/ironclaw_engine/prompts/codeact_preamble.md`) teaching the agent to request `"names"` → `"summary"` → `"schema"` on demand. The preamble diff is ~16 lines.

## Scope alignment with #2834 review

Per the [review note on #2834](https://github.com/nearai/ironclaw/issues/2834) (2026-04-22), this change intentionally:

- Keeps summaries off the always-on prompt — they are only emitted via `tool_info`.
- Does **not** advertise approval or risk metadata in the summary (runtime gates remain authoritative; see `src/bridge/effect_adapter.rs:1501` for the advertised `requires_approval: false` posture).
- Does **not** add a "discovery-budget" benchmark — that win belongs to #2767 (compact action card + capability consolidation), not to this change. The previous benchmark that conflated the two is dropped in the second commit.

## Tests

- `src/tools/builtin/tool_info.rs`: new `test_tool_info_summary_curated_for_core_tools` asserts required substrings and minimum example counts per tool.
- `crates/ironclaw_engine/src/executor/prompt.rs`: new `prompt_includes_tool_discovery_section` asserts the preamble teaches `tool_info(detail=…)` usage.
- `cargo test -p ironclaw_engine --lib executor::prompt` → 8/8 green.
- `cargo fmt --check` → clean.
- `cargo clippy --all --benches --tests --examples --all-features` → zero warnings.
- `cargo test` → **5475 passed, 1 unrelated pre-existing staging failure** (`extensions::manager::tests::inject_mcp_client_partitions_cache_by_user`, added in staging commit `bfca5e93` earlier today; my branch touches zero lines in `src/extensions/manager.rs`). Staging CI itself is currently red from an LLVM linker bus error in the GitHub runner, also unrelated.

## Files changed

```
crates/ironclaw_engine/prompts/codeact_preamble.md |  16 +++
crates/ironclaw_engine/src/executor/prompt.rs      |  18 ++++
src/tools/builtin/file.rs                          |  57 ++++++++++-
src/tools/builtin/http.rs                          |  25 ++++-
src/tools/builtin/shell.rs                         |  19 +++-
src/tools/builtin/tool_info.rs                     | 111 +++++++++++++++++++++
6 files changed, 243 insertions(+), 3 deletions(-)
```
