### PR TITLE
fix(web): use conversation-only chat sidebar

### DIFF
--- a/crates/ironclaw_gateway/static/index.html
+++ b/crates/ironclaw_gateway/static/index.html
@@ -229,10 +229,6 @@
     <!-- Chat Tab -->
     <div class="tab-panel active" id="tab-chat">
       <div class="thread-sidebar" id="thread-sidebar">
-        <div class="assistant-item" id="assistant-thread">
-          <span class="assistant-label" id="assistant-label" data-i18n="chat.assistant">Assistant</span>
-          <span class="assistant-meta" id="assistant-meta"></span>
-        </div>
         <div class="threads-section-header">
           <span data-i18n="chat.conversations">Conversations</span>
           <div class="spacer"></div>

--- a/crates/ironclaw_gateway/static/js/core/bootstrap.js
+++ b/crates/ironclaw_gateway/static/js/core/bootstrap.js
@@ -80,7 +80,6 @@ let currentTab = 'chat';
 let currentThreadId = null;
 let currentThreadIsReadOnly = false;
 const threadChannelHints = new Map();
-let assistantThreadId = null;
 let hasMore = false;
 let oldestTimestamp = null;
 let loadingOlder = false;

--- a/crates/ironclaw_gateway/static/js/core/history.js
+++ b/crates/ironclaw_gateway/static/js/core/history.js
@@ -389,38 +389,16 @@ function loadThreads() {
 
   apiFetch('/api/chat/threads').then((data) => {
     const rememberedThreads = [];
-    // Pinned assistant thread
-    if (data.assistant_thread) {
-      assistantThreadId = data.assistant_thread.id;
-      rememberedThreads.push({
-        threadId: data.assistant_thread.id,
-        meta: {
-          label: I18n.t('thread.assistant'),
-          source: 'chat',
-        },
-      });
-      const el = document.getElementById('assistant-thread');
-      const isActive = currentThreadId === assistantThreadId;
-      el.className = 'assistant-item' + (isActive ? ' active' : '');
-      el.querySelectorAll('.thread-processing').forEach((node) => node.remove());
-      const labelEl = document.getElementById('assistant-label');
-      if (labelEl) {
-        labelEl.textContent = I18n.t('thread.assistant');
-      }
-      const meta = document.getElementById('assistant-meta');
-      meta.textContent = relativeTime(data.assistant_thread.updated_at);
-      if (data.assistant_thread.state === 'Processing' && !isActive) {
-        const spinner = document.createElement('span');
-        spinner.className = 'thread-processing';
-        spinner.innerHTML = '<div class="spinner"></div>';
-        el.appendChild(spinner);
-      }
-    }
+    const threads = [];
+    // Render one conversation list. The backend may still expose the legacy
+    // assistant conversation separately, but the sidebar should treat it like
+    // any other conversation row instead of pinning it above the list.
+    if (data.assistant_thread) threads.push(data.assistant_thread);
+    if (Array.isArray(data.threads)) threads.push(...data.threads);
+    threads.sort((a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime());
 
-    // Regular threads
     const list = document.getElementById('thread-list');
     list.innerHTML = '';
-    const threads = data.threads || [];
     for (const thread of threads) {
       rememberedThreads.push({
         threadId: thread.id,
@@ -485,8 +463,7 @@ function loadThreads() {
     if (window._pendingThreadRestore) {
       var pendingId = window._pendingThreadRestore;
       window._pendingThreadRestore = null;
-      var inSidebar = (pendingId === assistantThreadId) ||
-        threads.some(function(t) { return t.id === pendingId; });
+      var inSidebar = threads.some(function(t) { return t.id === pendingId; });
       if (!inSidebar && window.DEBUG_CHAT_RESTORE === true) {
         console.warn('[chat] thread', pendingId, 'not in sidebar list; loading via history API');
       }
@@ -503,31 +480,35 @@ function loadThreads() {
     // when the URL does not carry an explicit thread hash.
     if (!currentThreadId) {
       const activeThreadId = data.active_thread || null;
-      if (activeThreadId && activeThreadId === assistantThreadId) {
-        switchToAssistant();
-        return;
-      }
       if (activeThreadId && threads.some(t => t.id === activeThreadId)) {
-        // Skip external-channel threads (e.g. HTTP, Telegram) — they are
-        // read-only in the web UI, so auto-switching to one would leave the
-        // chat input disabled.  Fall through to the assistant thread instead.
         const activeThread = threads.find(t => t.id === activeThreadId);
-        if (!isReadOnlyChannel(activeThread.channel)) {
+        if (activeThread && !isReadOnlyChannel(activeThread.channel)) {
           switchThread(activeThreadId);
           return;
         }
       }
-      if (assistantThreadId) {
-        switchToAssistant();
+
+      // Prefer a writable gateway-style thread for first load, but still show
+      // the newest read-only conversation if that's all the user has.
+      const fallbackThread = threads.find(t => !isReadOnlyChannel(t.channel)) || threads[0];
+      if (fallbackThread) {
+        switchThread(fallbackThread.id);
         return;
       }
+
+      currentThreadIsReadOnly = false;
+      enableChatInput();
+      const container = document.getElementById('chat-messages');
+      if (container) {
+        container.innerHTML = '';
+        showWelcomeCard();
+      }
+      return;
     }
 
     // Enable/disable chat input based on channel type
     if (currentThreadId) {
-      const currentThread = currentThreadId === assistantThreadId
-        ? data.assistant_thread
-        : threads.find(t => t.id === currentThreadId);
+      const currentThread = threads.find(t => t.id === currentThreadId);
       const hintedChannel = currentThread
         ? currentThread.channel
         : threadChannelHints.get(currentThreadId);
@@ -550,24 +531,6 @@ function disableChatInputReadOnly() {
     input.placeholder = I18n.t('chat.readOnlyThread');
   }
   if (btn) btn.disabled = true;
-}
-
-function switchToAssistant() {
-  if (!assistantThreadId) return;
-  finalizeActivityGroup();
-  currentThreadId = assistantThreadId;
-  currentThreadIsReadOnly = false;
-  unreadThreads.delete(assistantThreadId);
-  hasMore = false;
-  oldestTimestamp = null;
-  loadHistory();
-  loadThreads();
-  updateHash();
-  if (window.innerWidth <= 768) {
-    const sidebar = document.getElementById('thread-sidebar');
-    sidebar.classList.remove('expanded-mobile');
-    document.getElementById('thread-toggle-btn').innerHTML = '&raquo;';
-  }
 }
 
 function switchThread(threadId) {

--- a/crates/ironclaw_gateway/static/js/core/routing.js
+++ b/crates/ironclaw_gateway/static/js/core/routing.js
@@ -8,7 +8,7 @@ function updateHash() {
 
   switch (currentTab) {
     case 'chat':
-      if (currentThreadId && currentThreadId !== assistantThreadId) {
+      if (currentThreadId) {
         parts.push(currentThreadId);
       }
       break;

--- a/crates/ironclaw_gateway/static/js/core/ui-helpers.js
+++ b/crates/ironclaw_gateway/static/js/core/ui-helpers.js
@@ -251,7 +251,6 @@ document.getElementById('restart-confirm-btn').addEventListener('click', () => c
 document.getElementById('restart-btn').addEventListener('click', () => triggerRestart());
 document.getElementById('thread-new-btn').addEventListener('click', () => createNewThread());
 document.getElementById('thread-toggle-btn').addEventListener('click', () => toggleThreadSidebar());
-document.getElementById('assistant-thread').addEventListener('click', () => switchToAssistant());
 document.getElementById('send-btn').addEventListener('click', () => sendMessage());
 document.getElementById('memory-edit-btn').addEventListener('click', () => startMemoryEdit());
 document.getElementById('memory-save-btn').addEventListener('click', () => saveMemoryEdit());

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -5969,6 +5969,11 @@ pub(crate) mod test_support {
             }
         }
 
+        let project_id = threads
+            .first()
+            .map(|thread| thread.project_id)
+            .unwrap_or_else(ProjectId::new);
+
         let store = Arc::new(ThreadTestStore::new());
         for thread in threads {
             store.save_thread(&thread).await.expect("seed thread"); // safety: cfg(test) fixture
@@ -5996,7 +6001,6 @@ pub(crate) mod test_support {
         ));
         let cm = Arc::new(ConversationManager::new(Arc::clone(&tm), store_dyn.clone()));
 
-        let project_id = ProjectId::new();
         let state = EngineState {
             thread_manager: tm,
             conversation_manager: cm,

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -5972,7 +5972,7 @@ pub(crate) mod test_support {
         let project_id = threads
             .first()
             .map(|thread| thread.project_id)
-            .unwrap_or_else(ProjectId::new);
+            .unwrap_or_default();
 
         let store = Arc::new(ThreadTestStore::new());
         for thread in threads {

--- a/src/channels/web/features/chat/mod.rs
+++ b/src/channels/web/features/chat/mod.rs
@@ -726,12 +726,14 @@ pub(crate) async fn chat_threads_handler(
                     });
                 }
 
-                // Keep the chat sidebar scoped to persisted chat conversations.
-                // Engine v2 foreground threads are assistant execution internals
-                // and can rotate per message, so surfacing them here makes
-                // ordinary prompts look like standalone `engine` threads.
-                // Explicit engine-thread history still works via
-                // `chat_history_handler` when the caller already has a thread id.
+                // Keep the chat sidebar scoped to persisted conversations.
+                // A conversation can span multiple foreground engine threads,
+                // so rendering each engine thread as its own row produces
+                // misleading per-turn labels like "try again" instead of a
+                // stable conversation label. Engine-thread history remains
+                // accessible when the caller already has a thread id via
+                // `chat_history_handler`.
+
                 let active_thread = session.lock().await.active_thread;
 
                 return Ok(Json(ThreadListResponse {
@@ -2018,7 +2020,7 @@ mod tests {
 
     #[cfg(feature = "libsql")]
     #[tokio::test]
-    async fn test_chat_threads_handler_hides_engine_threads_from_sidebar() {
+    async fn test_chat_threads_handler_hides_engine_threads_and_keeps_conversation_titles() {
         let _lock = crate::bridge::test_support::ENGINE_STATE_TEST_LOCK
             .lock()
             .await;
@@ -2026,22 +2028,42 @@ mod tests {
 
         let project_id =
             crate::bridge::test_support::install_engine_state_with_threads(Vec::new()).await;
-        let mut thread = ironclaw_engine::Thread::new(
+
+        let mut foreground_thread = ironclaw_engine::Thread::new(
             "assistant hello",
             ironclaw_engine::ThreadType::Foreground,
             project_id,
             "alice",
             ironclaw_engine::ThreadConfig::default(),
         );
-        thread
+        foreground_thread
             .messages
             .push(ironclaw_engine::ThreadMessage::user("hello"));
-        let engine_thread_id = thread.id.0;
-        crate::bridge::test_support::install_engine_state_with_threads(vec![thread]).await;
+        let foreground_thread_id = foreground_thread.id.0;
+
+        crate::bridge::test_support::install_engine_state_with_threads(vec![foreground_thread])
+            .await;
 
         let (db, _tmp) = crate::testing::test_db().await;
+        let assistant_id = db
+            .get_or_create_assistant_conversation("alice", "gateway")
+            .await
+            .expect("assistant conversation");
+        db.add_conversation_message(assistant_id, "user", "first assistant ask")
+            .await
+            .expect("seed assistant conversation");
+
+        let channel_thread_id = db
+            .create_conversation("telegram", "alice", None)
+            .await
+            .expect("create telegram conversation");
+        db.add_conversation_message(channel_thread_id, "user", "ping")
+            .await
+            .expect("seed telegram conversation");
+
         let session_manager = Arc::new(SessionManager::new());
-        let state = test_gateway_state_with_store_and_session_manager(db, session_manager);
+        let state =
+            test_gateway_state_with_store_and_session_manager(Arc::clone(&db), session_manager);
 
         let response = chat_threads_handler(
             axum::extract::State(state),
@@ -2054,20 +2076,35 @@ mod tests {
         .await
         .expect("handler ok");
 
-        assert!(response.assistant_thread.is_some());
+        assert_eq!(
+            response
+                .assistant_thread
+                .as_ref()
+                .and_then(|thread| thread.title.as_deref()),
+            Some("first assistant ask"),
+            "assistant conversation should carry the first user message as its title"
+        );
+        assert!(
+            response.threads.iter().any(|thread| {
+                thread.id == channel_thread_id
+                    && thread.channel.as_deref() == Some("telegram")
+                    && thread.title.as_deref() == Some("ping")
+            }),
+            "chat sidebar must keep persisted channel conversations"
+        );
         assert!(
             response
                 .threads
                 .iter()
-                .all(|thread| thread.id != engine_thread_id),
-            "chat sidebar must not surface engine execution threads"
+                .all(|thread| thread.id != foreground_thread_id),
+            "chat sidebar must not surface separate engine execution threads"
         );
         assert!(
             response
                 .threads
                 .iter()
                 .all(|thread| thread.channel.as_deref() != Some("engine")),
-            "chat sidebar must stay scoped to chat conversations"
+            "chat sidebar rows should stay conversation-based rather than engine-thread-based"
         );
 
         crate::bridge::test_support::clear_engine_state().await;

--- a/tests/e2e/scenarios/test_chat.py
+++ b/tests/e2e/scenarios/test_chat.py
@@ -128,6 +128,58 @@ async def test_send_message_and_receive_response(page):
     assert "4" in result["text"], f"Expected '4' in response, got: '{result['text']}'"
 
 
+async def test_first_gateway_conversation_appears_in_conversation_list(page):
+    """The chat sidebar should show one normal conversation row, not a pinned assistant row."""
+    thread_id = "00000000-0000-4000-8000-000000000001"
+
+    async def patch_threads_response(route):
+        await route.fulfill(
+            json={
+                "assistant_thread": {
+                    "id": thread_id,
+                    "state": "Idle",
+                    "turn_count": 1,
+                    "created_at": "2026-04-22T00:00:00Z",
+                    "updated_at": "2026-04-22T00:00:00Z",
+                    "title": "sidebar label regression check",
+                    "thread_type": "assistant",
+                    "channel": "gateway",
+                },
+                "threads": [],
+                "active_thread": thread_id,
+            }
+        )
+
+    async def patch_history_response(route):
+        await route.fulfill(
+            json={
+                "thread_id": thread_id,
+                "turns": [],
+                "has_more": False,
+                "oldest_timestamp": None,
+                "channel": "gateway",
+            }
+        )
+
+    await page.route("**/api/chat/threads", patch_threads_response)
+    await page.route("**/api/chat/history**", patch_history_response)
+
+    await page.evaluate(
+        """() => {
+            currentThreadId = null;
+            const list = document.getElementById('thread-list');
+            if (list) list.innerHTML = '';
+            loadThreads();
+        }"""
+    )
+
+    row = page.locator(f'#thread-list [data-thread-id="{thread_id}"] .thread-label').first
+    await row.wait_for(state="visible", timeout=15000)
+    assert (await row.text_content() or "").strip() == "sidebar label regression check"
+    assert await page.locator("#assistant-thread").count() == 0
+    await page.unroute_all(behavior="ignoreErrors")
+
+
 async def test_multiple_messages(page):
     """Send two messages, verify both get responses."""
     chat_input = page.locator(SEL["chat_input"])

--- a/tests/e2e/scenarios/test_sse_reconnect.py
+++ b/tests/e2e/scenarios/test_sse_reconnect.py
@@ -170,18 +170,15 @@ async def _create_new_user_thread(page) -> str:
     """Click the "new thread" button and return the newly created thread's id.
 
     The wait condition must check that ``currentThreadId`` changed to a *new*
-    non-assistant value. Just checking ``currentThreadId !== assistantThreadId``
-    is not enough: prior tests in the session may have left the server's
-    ``active_thread`` pointing at a user-created thread, in which case the
-    initial page load sets ``currentThreadId`` to that stale thread and the
-    wait would pass immediately — before ``createNewThread()`` resolves.
+    value. Prior tests in the session may have left the server's
+    ``active_thread`` pointing at an older user-created thread, in which case
+    the initial page load already sets ``currentThreadId`` and a looser wait
+    would pass immediately — before ``createNewThread()`` resolves.
     """
     prev_thread_id = await page.evaluate("() => currentThreadId")
     await page.locator("#thread-new-btn").click()
     await page.wait_for_function(
-        """(prev) => !!currentThreadId
-            && currentThreadId !== assistantThreadId
-            && currentThreadId !== prev""",
+        """(prev) => !!currentThreadId && currentThreadId !== prev""",
         arg=prev_thread_id,
         timeout=15000,
     )
@@ -235,17 +232,38 @@ async def test_refresh_without_hash_reopens_active_thread_history(browser, manag
 
 async def test_refresh_skips_readonly_external_active_thread(page):
     """When the server active_thread is an external-channel (HTTP/Telegram) thread,
-    a refresh without a hash should fall through to the assistant thread with
-    the chat input enabled, not land on the read-only thread."""
+    a refresh without a hash should fall through to the writable gateway
+    conversation with the chat input enabled, not land on the read-only thread."""
 
-    # 1. Create a secondary thread and send a message so it becomes active_thread
+    # 1. Create a secondary thread and send a message so it becomes active_thread.
+    # Seed it through the API instead of waiting on a browser round-trip here;
+    # this test only cares that refresh sees a writable gateway thread with
+    # persisted history before we patch its reported channel to read-only.
     ext_thread_id = await _create_new_user_thread(page)
+    base_url = await page.evaluate("() => location.origin")
 
-    result = await send_chat_and_wait_for_terminal_message(
-        page,
-        "Readonly channel test message",
+    response = await api_post(
+        base_url,
+        "/api/chat/send",
+        json={
+            "thread_id": ext_thread_id,
+            "content": "Readonly channel test message",
+        },
     )
-    assert result["role"] == "assistant"
+    assert response.status_code == 202, response.text
+
+    deadline = asyncio.get_running_loop().time() + 15
+    while asyncio.get_running_loop().time() < deadline:
+        history_response = await api_get(
+            base_url,
+            f"/api/chat/history?thread_id={ext_thread_id}",
+        )
+        assert history_response.status_code == 200, history_response.text
+        if history_response.json().get("turns"):
+            break
+        await asyncio.sleep(0.5)
+    else:
+        raise AssertionError("Timed out waiting for persisted history before refresh")
 
     # 2. Strip the URL hash so reload relies on active_thread
     await page.evaluate(
@@ -259,9 +277,14 @@ async def test_refresh_skips_readonly_external_active_thread(page):
     # with `page.unroute_all(behavior="ignoreErrors")` at test end to drain
     # in-flight callbacks, otherwise the cancelled fetch surfaces as a
     # TargetClosedError on the next test's Browser.new_context() call.
+    fallback_gateway_thread_id = None
+
     async def patch_threads_response(route):
+        nonlocal fallback_gateway_thread_id
         response = await route.fetch()
         body = await response.json()
+        assistant_thread = body.get("assistant_thread") or {}
+        fallback_gateway_thread_id = assistant_thread.get("id")
         for t in body.get("threads", []):
             if t["id"] == ext_thread_id:
                 t["channel"] = "http"
@@ -274,17 +297,22 @@ async def test_refresh_skips_readonly_external_active_thread(page):
     await page.wait_for_selector("#auth-screen", state="hidden", timeout=15000)
     await _wait_for_connected(page, timeout=15000)
 
-    # 5. Assert we landed on the assistant thread, not the external one
+    # 5. Assert we landed on the writable gateway conversation, not the
+    # patched read-only external thread, and that the legacy pinned assistant
+    # chrome is gone from the DOM.
+    assert fallback_gateway_thread_id, "expected a gateway fallback thread id"
     await page.wait_for_function(
-        "() => currentThreadId === assistantThreadId",
+        "(expected) => currentThreadId === expected",
+        arg=fallback_gateway_thread_id,
         timeout=15000,
     )
+    assert await page.locator("#assistant-thread").count() == 0
 
     # 6. Chat input should be enabled (not disabled by read-only state)
     chat_input = page.locator(SEL["chat_input"])
     await chat_input.wait_for(state="visible", timeout=5000)
     is_disabled = await chat_input.is_disabled()
-    assert not is_disabled, "Chat input should be enabled on the assistant thread"
+    assert not is_disabled, "Chat input should be enabled on the fallback gateway thread"
 
     # Drain in-flight route callbacks before the `page` fixture closes the
     # context (see the setup comment at step 3 for the root cause). The


### PR DESCRIPTION
## Summary
- remove the special pinned assistant row from the web chat sidebar and render a single conversation list
- treat the legacy assistant conversation like a normal row in the sidebar while preserving first-user-message titles
- add targeted regression coverage for sidebar rendering and refresh fallback behavior

## Verification
- `cargo test test_chat_threads_handler_hides_engine_threads_and_keeps_conversation_titles -- --nocapture`
- `cargo test test_chat_history_returns_engine_channel_hint_without_renderable_messages -- --nocapture`
- `cargo test test_chat_threads_handler_returns_in_memory_threads_without_db -- --nocapture`
- `cd tests/e2e && .venv/bin/python -m pytest scenarios/test_chat.py -k first_gateway_conversation_appears_in_conversation_list -q --timeout=900`
- `cd tests/e2e && .venv/bin/python -m pytest scenarios/test_sse_reconnect.py -k 'refresh_without_hash_reopens_active_thread_history or refresh_skips_readonly_external_active_thread' -q --timeout=900`

## Notes
- manual local validation confirmed the sidebar now looks correct
- keeps engine execution threads out of the conversation list
