### PR TITLE
feat(tools): mission tool family (engine v2)

### DIFF
--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1826,6 +1826,15 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
     mission_manager_inner =
         mission_manager_inner.with_insights_interval(missions_config.insights_interval);
     let mission_manager = Arc::new(mission_manager_inner);
+    // Register the engine-v2 mission tool family now that the manager
+    // exists. Tools constructed here capture `Arc::clone(&mission_manager)`
+    // directly; the call also fills `ToolRegistry::mission_slot` so any
+    // downstream integration tool registered through the plugin seam
+    // (see `ExternalToolRegistrar`) sees the same manager.
+    agent
+        .tools()
+        .register_mission_tools(Arc::clone(&mission_manager), project_id)
+        .await;
     if let Err(e) = thread_manager.recover_project_threads(project_id).await {
         debug!("engine v2: recover_project_threads failed: {e}");
     }

--- a/src/tools/builtin/mission.rs
+++ b/src/tools/builtin/mission.rs
@@ -1,0 +1,710 @@
+//! LLM-facing tools for managing missions (engine v2).
+//!
+//! Six tools let the agent manage missions conversationally:
+//! - `mission_create` - Create a new long-running mission
+//! - `mission_list` - List all missions with status
+//! - `mission_update` - Modify a mission's settings
+//! - `mission_delete` - Remove a mission
+//! - `mission_fire` - Manually trigger a mission
+//! - `mission_pause` / `mission_resume` - Pause or resume a mission
+
+use std::sync::Arc;
+use std::time::Instant;
+
+use async_trait::async_trait;
+use serde_json::json;
+
+use ironclaw_engine::types::mission::MissionCadence;
+use ironclaw_engine::{MissionManager, MissionUpdate, ProjectId};
+
+use crate::context::JobContext;
+use crate::tools::tool::{
+    EngineCompatibility, RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
+};
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// Parse a cadence string into a MissionCadence.
+fn parse_cadence(s: &str) -> MissionCadence {
+    let trimmed = s.trim().to_lowercase();
+    if trimmed == "manual" {
+        MissionCadence::Manual
+    } else if trimmed.contains(' ') && trimmed.split_whitespace().count() >= 5 {
+        MissionCadence::Cron {
+            expression: s.trim().to_string(),
+            timezone: None,
+        }
+    } else if let Some(pattern) = trimmed.strip_prefix("event:") {
+        MissionCadence::OnEvent {
+            event_pattern: pattern.trim().to_string(),
+            channel: None,
+        }
+    } else if let Some(path) = trimmed.strip_prefix("webhook:") {
+        MissionCadence::Webhook {
+            path: path.trim().to_string(),
+            secret: None,
+        }
+    } else {
+        MissionCadence::Manual
+    }
+}
+
+fn parse_mission_id(params: &serde_json::Value) -> Result<ironclaw_engine::MissionId, ToolError> {
+    let id_str = require_str(params, "id")?;
+    uuid::Uuid::parse_str(id_str)
+        .map(ironclaw_engine::MissionId)
+        .map_err(|e| ToolError::InvalidParameters(format!("invalid mission id: {e}")))
+}
+
+/// Extract notify_channels from params, falling back to the job context channel.
+fn extract_notify_channels(params: &serde_json::Value, ctx: &JobContext) -> Vec<String> {
+    if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
+        arr.iter()
+            .filter_map(|v| v.as_str().map(String::from))
+            .collect()
+    } else if let Some(ch) = ctx.metadata.get("notify_channel").and_then(|v| v.as_str()) {
+        vec![ch.to_string()]
+    } else {
+        vec![]
+    }
+}
+
+// ===========================================================================
+// mission_create
+// ===========================================================================
+
+pub struct MissionCreateTool {
+    manager: Arc<MissionManager>,
+    project_id: ProjectId,
+}
+
+impl MissionCreateTool {
+    pub fn new(manager: Arc<MissionManager>, project_id: ProjectId) -> Self {
+        Self {
+            manager,
+            project_id,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionCreateTool {
+    fn name(&self) -> &str {
+        "mission_create"
+    }
+
+    fn description(&self) -> &str {
+        "Create a new long-running mission that spawns threads over time. \
+         Supports cron schedules (e.g. '0 */6 * * *'), event patterns ('event:<pattern>'), \
+         webhooks ('webhook:<path>'), or manual triggers."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable mission name"
+                },
+                "goal": {
+                    "type": "string",
+                    "description": "What the mission should accomplish"
+                },
+                "cadence": {
+                    "type": "string",
+                    "description": "Trigger cadence: 'manual', cron expression (e.g. '0 9 * * *'), 'event:<pattern>', or 'webhook:<path>'. Default: 'manual'."
+                },
+                "notify_channels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Channels to notify on completion (e.g. ['gateway', 'telegram']). Defaults to current channel."
+                },
+                "success_criteria": {
+                    "type": "string",
+                    "description": "Optional criteria for declaring the mission complete"
+                }
+            },
+            "required": ["name", "goal"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let name = require_str(&params, "name")?;
+        let goal = require_str(&params, "goal")?;
+        let cadence_str = params
+            .get("cadence")
+            .and_then(|v| v.as_str())
+            .unwrap_or("manual");
+        let notify_channels = extract_notify_channels(&params, ctx);
+
+        let id = self
+            .manager
+            .create_mission(
+                self.project_id,
+                &ctx.user_id,
+                name,
+                goal,
+                parse_cadence(cadence_str),
+                notify_channels,
+            )
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to create mission: {e}")))?;
+
+        // Set success_criteria if provided
+        if let Some(criteria) = params.get("success_criteria").and_then(|v| v.as_str()) {
+            let updates = MissionUpdate {
+                success_criteria: Some(criteria.to_string()),
+                ..Default::default()
+            };
+            let _ = self.manager.update_mission(id, &ctx.user_id, updates).await;
+        }
+
+        let result = json!({"mission_id": id.to_string(), "status": "created"});
+        Ok(ToolOutput::success(result, start.elapsed()))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Low
+    }
+}
+
+// ===========================================================================
+// mission_list
+// ===========================================================================
+
+pub struct MissionListTool {
+    manager: Arc<MissionManager>,
+    project_id: ProjectId,
+}
+
+impl MissionListTool {
+    pub fn new(manager: Arc<MissionManager>, project_id: ProjectId) -> Self {
+        Self {
+            manager,
+            project_id,
+        }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionListTool {
+    fn name(&self) -> &str {
+        "mission_list"
+    }
+
+    fn description(&self) -> &str {
+        "List all missions with their status, goal, and current focus."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {},
+            "required": []
+        })
+    }
+
+    async fn execute(
+        &self,
+        _params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let missions = self
+            .manager
+            .list_missions(self.project_id, &ctx.user_id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to list missions: {e}")))?;
+
+        let list: Vec<serde_json::Value> = missions
+            .iter()
+            .map(|m| {
+                json!({
+                    "id": m.id.to_string(),
+                    "name": m.name,
+                    "goal": m.goal,
+                    "status": format!("{:?}", m.status),
+                    "threads": m.thread_history.len(),
+                    "current_focus": m.current_focus,
+                    "notify_channels": m.notify_channels,
+                })
+            })
+            .collect();
+
+        Ok(ToolOutput::success(json!(list), start.elapsed()))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Low
+    }
+}
+
+// ===========================================================================
+// mission_fire
+// ===========================================================================
+
+pub struct MissionFireTool {
+    manager: Arc<MissionManager>,
+}
+
+impl MissionFireTool {
+    pub fn new(manager: Arc<MissionManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionFireTool {
+    fn name(&self) -> &str {
+        "mission_fire"
+    }
+
+    fn description(&self) -> &str {
+        "Manually trigger a mission to spawn a thread now."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Mission ID to fire"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let id = parse_mission_id(&params)?;
+
+        match self
+            .manager
+            .fire_mission(id, &ctx.user_id, None)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to fire mission: {e}")))?
+        {
+            Some(tid) => Ok(ToolOutput::success(
+                json!({"thread_id": tid.to_string(), "status": "fired"}),
+                start.elapsed(),
+            )),
+            None => Ok(ToolOutput::success(
+                json!({"status": "not_fired", "reason": "mission is terminal or budget exhausted"}),
+                start.elapsed(),
+            )),
+        }
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Medium
+    }
+}
+
+// ===========================================================================
+// mission_pause / mission_resume
+// ===========================================================================
+
+pub struct MissionPauseTool {
+    manager: Arc<MissionManager>,
+}
+
+impl MissionPauseTool {
+    pub fn new(manager: Arc<MissionManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionPauseTool {
+    fn name(&self) -> &str {
+        "mission_pause"
+    }
+
+    fn description(&self) -> &str {
+        "Pause a mission so it stops spawning new threads."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Mission ID to pause"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let id = parse_mission_id(&params)?;
+
+        self.manager
+            .pause_mission(id, &ctx.user_id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to pause mission: {e}")))?;
+
+        Ok(ToolOutput::success(
+            json!({"status": "paused"}),
+            start.elapsed(),
+        ))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Medium
+    }
+}
+
+pub struct MissionResumeTool {
+    manager: Arc<MissionManager>,
+}
+
+impl MissionResumeTool {
+    pub fn new(manager: Arc<MissionManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionResumeTool {
+    fn name(&self) -> &str {
+        "mission_resume"
+    }
+
+    fn description(&self) -> &str {
+        "Resume a paused mission so it starts spawning threads again."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Mission ID to resume"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let id = parse_mission_id(&params)?;
+
+        self.manager
+            .resume_mission(id, &ctx.user_id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to resume mission: {e}")))?;
+
+        Ok(ToolOutput::success(
+            json!({"status": "resumed"}),
+            start.elapsed(),
+        ))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Medium
+    }
+}
+
+// ===========================================================================
+// mission_delete
+// ===========================================================================
+
+pub struct MissionDeleteTool {
+    manager: Arc<MissionManager>,
+}
+
+impl MissionDeleteTool {
+    pub fn new(manager: Arc<MissionManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionDeleteTool {
+    fn name(&self) -> &str {
+        "mission_delete"
+    }
+
+    fn description(&self) -> &str {
+        "Delete a mission. This marks the mission as completed and stops all future thread spawning."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Mission ID to delete"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let id = parse_mission_id(&params)?;
+
+        self.manager
+            .complete_mission(id)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to delete mission: {e}")))?;
+
+        Ok(ToolOutput::success(
+            json!({"status": "deleted"}),
+            start.elapsed(),
+        ))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::High
+    }
+}
+
+// ===========================================================================
+// mission_update
+// ===========================================================================
+
+pub struct MissionUpdateTool {
+    manager: Arc<MissionManager>,
+}
+
+impl MissionUpdateTool {
+    pub fn new(manager: Arc<MissionManager>) -> Self {
+        Self { manager }
+    }
+}
+
+#[async_trait]
+impl Tool for MissionUpdateTool {
+    fn name(&self) -> &str {
+        "mission_update"
+    }
+
+    fn description(&self) -> &str {
+        "Update a mission's name, goal, cadence, notification channels, budget, or success criteria."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string",
+                    "description": "Mission ID to update"
+                },
+                "name": {
+                    "type": "string",
+                    "description": "New mission name"
+                },
+                "goal": {
+                    "type": "string",
+                    "description": "New mission goal"
+                },
+                "cadence": {
+                    "type": "string",
+                    "description": "New cadence: 'manual', cron expression, 'event:<pattern>', or 'webhook:<path>'"
+                },
+                "notify_channels": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "New notification channels"
+                },
+                "max_threads_per_day": {
+                    "type": "integer",
+                    "description": "Maximum threads per day (0 = unlimited)"
+                },
+                "success_criteria": {
+                    "type": "string",
+                    "description": "Criteria for declaring the mission complete"
+                }
+            },
+            "required": ["id"]
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+        let id = parse_mission_id(&params)?;
+
+        let mut updates = MissionUpdate::default();
+        if let Some(name) = params.get("name").and_then(|v| v.as_str()) {
+            updates.name = Some(name.to_string());
+        }
+        if let Some(goal) = params.get("goal").and_then(|v| v.as_str()) {
+            updates.goal = Some(goal.to_string());
+        }
+        if let Some(cadence) = params.get("cadence").and_then(|v| v.as_str()) {
+            updates.cadence = Some(parse_cadence(cadence));
+        }
+        if let Some(arr) = params.get("notify_channels").and_then(|v| v.as_array()) {
+            updates.notify_channels = Some(
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect(),
+            );
+        }
+        if let Some(max) = params.get("max_threads_per_day").and_then(|v| v.as_u64()) {
+            updates.max_threads_per_day = Some(max as u32);
+        }
+        if let Some(criteria) = params.get("success_criteria").and_then(|v| v.as_str()) {
+            updates.success_criteria = Some(criteria.to_string());
+        }
+
+        self.manager
+            .update_mission(id, &ctx.user_id, updates)
+            .await
+            .map_err(|e| ToolError::ExecutionFailed(format!("failed to update mission: {e}")))?;
+
+        Ok(ToolOutput::success(
+            json!({"status": "updated"}),
+            start.elapsed(),
+        ))
+    }
+
+    fn engine_compatibility(&self) -> EngineCompatibility {
+        EngineCompatibility::V2Only
+    }
+
+    fn domain(&self) -> ToolDomain {
+        ToolDomain::Orchestrator
+    }
+
+    fn risk_level_for(&self, _params: &serde_json::Value) -> RiskLevel {
+        RiskLevel::Medium
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_cadence_manual() {
+        assert!(matches!(parse_cadence("manual"), MissionCadence::Manual));
+        assert!(matches!(parse_cadence("MANUAL"), MissionCadence::Manual));
+    }
+
+    #[test]
+    fn test_parse_cadence_cron() {
+        match parse_cadence("0 */6 * * *") {
+            MissionCadence::Cron { expression, .. } => {
+                assert_eq!(expression, "0 */6 * * *");
+            }
+            other => panic!("expected Cron, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cadence_event() {
+        match parse_cadence("event:price_alert") {
+            MissionCadence::OnEvent { event_pattern, .. } => {
+                assert_eq!(event_pattern, "price_alert");
+            }
+            other => panic!("expected OnEvent, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cadence_webhook() {
+        match parse_cadence("webhook:/hooks/deploy") {
+            MissionCadence::Webhook { path, secret } => {
+                assert_eq!(path, "/hooks/deploy");
+                assert!(secret.is_none());
+            }
+            other => panic!("expected Webhook, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_cadence_unknown_defaults_manual() {
+        assert!(matches!(
+            parse_cadence("something_weird"),
+            MissionCadence::Manual
+        ));
+    }
+}

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -12,6 +12,7 @@ mod job;
 mod json;
 pub mod memory;
 mod message;
+pub mod mission;
 pub mod path_utils;
 mod plan;
 mod restart;
@@ -41,6 +42,10 @@ pub use job::{
 pub use json::JsonTool;
 pub use memory::{MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool};
 pub use message::MessageTool;
+pub use mission::{
+    MissionCreateTool, MissionDeleteTool, MissionFireTool, MissionListTool, MissionPauseTool,
+    MissionResumeTool, MissionUpdateTool,
+};
 pub use plan::PlanUpdateTool;
 pub use restart::RestartTool;
 pub use routine::{

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -109,6 +109,14 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
     "plan_update",
     // Permission tools
     "tool_permission_set",
+    // Mission tools (engine v2)
+    "mission_create",
+    "mission_list",
+    "mission_update",
+    "mission_delete",
+    "mission_fire",
+    "mission_pause",
+    "mission_resume",
     // Aliases (web_fetch is an alias for http in some contexts)
     "web_fetch",
 ];
@@ -120,6 +128,26 @@ const PROTECTED_TOOL_NAMES: &[&str] = &[
 pub fn is_protected_tool_name(name: &str) -> bool {
     PROTECTED_TOOL_NAMES.contains(&name)
 }
+
+/// Shared slot for deferred mission-manager injection.
+///
+/// The `MissionManager` is constructed inside the engine's init path
+/// (bridge/router.rs), which runs well after `ToolRegistry` is built in
+/// `AppBuilder::init_tools`. Any tool that needs to create or fire a
+/// mission (the engine-v2 `mission_*` built-ins, downstream integration
+/// tools like abound's `abound_send_wire` wait-action) takes an
+/// `Arc<MissionSlot>` at construction time and reads through it at
+/// execute time. The slot is empty until the engine fills it via
+/// [`ToolRegistry::set_mission_slot`], at which point every tool that
+/// holds the `Arc` sees the manager.
+pub type MissionSlot = Arc<
+    tokio::sync::RwLock<
+        Option<(
+            Arc<ironclaw_engine::MissionManager>,
+            ironclaw_engine::ProjectId,
+        )>,
+    >,
+>;
 
 /// Registry of available tools.
 pub struct ToolRegistry {
@@ -143,6 +171,10 @@ pub struct ToolRegistry {
     /// Active engine version. Controls which tools are visible via
     /// `tool_definitions()`, `all()`, etc. Defaults to V1.
     engine_version: EngineVersion,
+    /// Deferred-injection slot for the engine's `MissionManager`. See
+    /// [`MissionSlot`] for the lifetime contract. Shared by `Arc::clone`
+    /// into every tool that needs mission access.
+    pub(crate) mission_slot: MissionSlot,
 }
 
 impl ToolRegistry {
@@ -172,6 +204,7 @@ impl ToolRegistry {
             http_interceptor: None,
             message_tool: RwLock::new(None),
             engine_version: EngineVersion::V1,
+            mission_slot: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 
@@ -236,6 +269,64 @@ impl ToolRegistry {
 
     pub fn role_lookup(&self) -> Option<&Arc<dyn UserStore>> {
         self.role_lookup.as_ref()
+    }
+
+    /// Borrow the shared mission slot. Downstream tools that need to
+    /// create or fire missions should `Arc::clone` the returned value
+    /// and read through it at execute time; see [`MissionSlot`].
+    pub fn mission_slot(&self) -> &MissionSlot {
+        &self.mission_slot
+    }
+
+    /// Populate the shared mission slot. Called by the engine bootstrap
+    /// after `MissionManager` is constructed. Every tool that holds an
+    /// `Arc<MissionSlot>` sees the manager immediately after this
+    /// returns.
+    pub async fn set_mission_slot(
+        &self,
+        manager: Arc<ironclaw_engine::MissionManager>,
+        project_id: ironclaw_engine::ProjectId,
+    ) {
+        let mut guard = self.mission_slot.write().await;
+        *guard = Some((manager, project_id));
+    }
+
+    /// Register the engine-v2 `mission_*` tool family. Takes an
+    /// `Arc<MissionManager>` directly because each tool binds its own
+    /// immutable `Arc`; the shared [`MissionSlot`] is reserved for
+    /// tools whose registration happens before the manager exists
+    /// (typically downstream integration tools plugged in through
+    /// [`crate::tools::ExternalToolRegistrar`]).
+    ///
+    /// Also populates the shared mission slot so those
+    /// downstream tools see the manager after this call.
+    pub async fn register_mission_tools(
+        &self,
+        manager: Arc<ironclaw_engine::MissionManager>,
+        project_id: ironclaw_engine::ProjectId,
+    ) {
+        use crate::tools::builtin::{
+            MissionCreateTool, MissionDeleteTool, MissionFireTool, MissionListTool,
+            MissionPauseTool, MissionResumeTool, MissionUpdateTool,
+        };
+        self.register_sync(Arc::new(MissionCreateTool::new(
+            Arc::clone(&manager),
+            project_id,
+        )));
+        self.register_sync(Arc::new(MissionListTool::new(
+            Arc::clone(&manager),
+            project_id,
+        )));
+        self.register_sync(Arc::new(MissionFireTool::new(Arc::clone(&manager))));
+        self.register_sync(Arc::new(MissionPauseTool::new(Arc::clone(&manager))));
+        self.register_sync(Arc::new(MissionResumeTool::new(Arc::clone(&manager))));
+        self.register_sync(Arc::new(MissionDeleteTool::new(Arc::clone(&manager))));
+        self.register_sync(Arc::new(MissionUpdateTool::new(Arc::clone(&manager))));
+        tracing::debug!("Registered 7 mission management tools");
+
+        // Fill the shared slot so downstream tools (e.g. integrations
+        // that use the plugin seam) see the manager.
+        self.set_mission_slot(manager, project_id).await;
     }
 
     /// Register a tool. Rejects dynamic tools that try to shadow a protected built-in name.


### PR DESCRIPTION
## Summary

Exposes the engine-v2 mission framework to the LLM via seven built-in tools:
\`mission_create\`, \`mission_list\`, \`mission_update\`, \`mission_delete\`,
\`mission_fire\`, \`mission_pause\`, \`mission_resume\`.

Also adds \`MissionSlot\` — a deferred-injection handle on \`ToolRegistry\` — so tools whose registration pre-dates the engine's \`MissionManager\` construction (typically downstream integration tools plugged in through [#2871 \`ExternalToolRegistrar\`]) can read the manager through a shared \`Arc\` at execute time.

## Changes

- **New**: \`src/tools/builtin/mission.rs\` (+705 LOC) — seven \`Tool\` impls. Cadence strings parse into \`MissionCadence\` (\`cron\`, \`event:\`, \`webhook:\`, \`manual\`).
- **Modified**: \`src/tools/builtin/mod.rs\` — module declaration + \`pub use\` of the seven tools.
- **Modified**: \`src/tools/registry.rs\`:
  - \`PROTECTED_TOOL_NAMES\` gains the seven \`mission_*\` entries.
  - New \`pub type MissionSlot\` + \`mission_slot: MissionSlot\` field on \`ToolRegistry\` + \`mission_slot()\` accessor + \`set_mission_slot(manager, project_id)\` populator.
  - \`register_mission_tools(manager, project_id)\` instantiates all seven tools against the supplied manager and fills the slot.
- **Modified**: \`src/bridge/router.rs\` \`init_engine()\` — calls \`agent.tools().register_mission_tools(...)\` once \`MissionManager\` is constructed, immediately before the bootstrap/resume calls.

## Motivation

Two use cases:

1. **Upstream agent functionality**: gives the engine-v2 LLM a way to manage missions conversationally, replacing the previous split where mission creation required the host code to call \`MissionManager\` directly.
2. **Downstream forks**: \`nearai/ironclaw-abound\` (private) has an \`abound_send_wire\` wait-action that needs to create an hourly rate-monitoring mission. With this PR and [#2871], the fork's registrar can register integration tools that read \`MissionManager\` through \`MissionSlot\` at execute time.

## Test plan

- [x] \`cargo check --all-features\` / \`cargo check --all-features --tests\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] \`cargo clippy --all --benches --tests --examples --all-features\` — zero warnings
- [ ] End-to-end: hit \`mission_create\` from the LLM, confirm the mission persists and fires on its cron.

## Follow-ups

- Full LLM-facing cadence parser tests (currently coverage is limited to the manager's own tests, not the tool layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)