### PR TITLE
Add engine v2 action discovery metadata

### DIFF
--- a/crates/ironclaw_engine/src/capability/planner.rs
+++ b/crates/ironclaw_engine/src/capability/planner.rs
@@ -97,6 +97,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects,
             requires_approval,
+            discovery: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/capability/policy.rs
+++ b/crates/ironclaw_engine/src/capability/policy.rs
@@ -215,6 +215,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects,
             requires_approval,
+            discovery: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/capability/registry.rs
+++ b/crates/ironclaw_engine/src/capability/registry.rs
@@ -89,6 +89,7 @@ mod tests {
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![EffectType::WriteExternal, EffectType::CredentialedNetwork],
                     requires_approval: false,
+                    discovery: None,
                 },
                 ActionDef {
                     name: "list_prs".into(),
@@ -96,6 +97,7 @@ mod tests {
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![EffectType::ReadExternal, EffectType::CredentialedNetwork],
                     requires_approval: false,
+                    discovery: None,
                 },
             ],
             knowledge: vec!["When creating issues, always add labels.".into()],
@@ -144,6 +146,7 @@ mod tests {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             }],
             knowledge: vec![],
             policies: vec![],

--- a/crates/ironclaw_engine/src/executor/context.rs
+++ b/crates/ironclaw_engine/src/executor/context.rs
@@ -183,6 +183,7 @@ mod tests {
                 user_timezone: None,
                 thread_goal: Some("search the web".into()),
                 available_actions_snapshot: None,
+                available_action_inventory_snapshot: None,
             },
         )
         .await
@@ -222,6 +223,7 @@ mod tests {
                 user_timezone: None,
                 thread_goal: Some("hello".into()),
                 available_actions_snapshot: None,
+                available_action_inventory_snapshot: None,
             },
         )
         .await
@@ -257,6 +259,7 @@ mod tests {
                 user_timezone: None,
                 thread_goal: Some("hello".into()),
                 available_actions_snapshot: None,
+                available_action_inventory_snapshot: None,
             },
         )
         .await

--- a/crates/ironclaw_engine/src/executor/context.rs
+++ b/crates/ironclaw_engine/src/executor/context.rs
@@ -182,6 +182,7 @@ mod tests {
                 source_channel: None,
                 user_timezone: None,
                 thread_goal: Some("search the web".into()),
+                available_actions_snapshot: None,
             },
         )
         .await
@@ -220,6 +221,7 @@ mod tests {
                 source_channel: None,
                 user_timezone: None,
                 thread_goal: Some("hello".into()),
+                available_actions_snapshot: None,
             },
         )
         .await
@@ -254,6 +256,7 @@ mod tests {
                 source_channel: None,
                 user_timezone: None,
                 thread_goal: Some("hello".into()),
+                available_actions_snapshot: None,
             },
         )
         .await

--- a/crates/ironclaw_engine/src/executor/loop_engine.rs
+++ b/crates/ironclaw_engine/src/executor/loop_engine.rs
@@ -650,6 +650,7 @@ mod tests {
             parameters_schema: serde_json::json!({"type": "object"}),
             effects: vec![EffectType::ReadLocal],
             requires_approval: false,
+            discovery: None,
         }
     }
 
@@ -1594,6 +1595,7 @@ mod tests {
             parameters_schema: serde_json::json!({"type": "object"}),
             effects: vec![EffectType::WriteExternal],
             requires_approval: false,
+            discovery: None,
         };
 
         let llm = Arc::new(MockLlm::new(vec![

--- a/crates/ironclaw_engine/src/executor/loop_engine.rs
+++ b/crates/ironclaw_engine/src/executor/loop_engine.rs
@@ -237,8 +237,22 @@ impl ExecutionLoop {
                 Vec::new()
             }
         };
+        let inventory = match self
+            .effects
+            .available_action_inventory(&active_leases, &prompt_context)
+            .await
+        {
+            Ok(inventory) => inventory,
+            Err(error) => {
+                debug!(
+                    thread_id = %self.thread.id,
+                    "failed to load action inventory for system prompt refresh: {error}"
+                );
+                crate::types::capability::ActionInventory::default()
+            }
+        };
         let system_prompt = crate::executor::prompt::build_codeact_system_prompt_with_docs(
-            &[],
+            &inventory,
             &capabilities,
             system_docs,
             self.platform_info.as_ref(),
@@ -883,7 +897,9 @@ mod tests {
         }
 
         let bare_old_prompt = crate::executor::prompt::build_codeact_system_prompt_with_docs(
-            &[test_action()],
+            &crate::types::capability::ActionInventory {
+                inline: vec![test_action()],
+            },
             &[CapabilitySummary {
                 name: "telegram".into(),
                 display_name: Some("Telegram".into()),

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -1034,16 +1034,14 @@ async fn handle_execute_action(
     };
 
     // 2. Check policy
-    let action_def = available_actions
-        .into_iter()
-        .find(|a| a.matches_name(&name));
+    let action_def = available_actions.iter().find(|a| a.matches_name(&name));
 
     let canonical_name = action_def
         .as_ref()
         .map(|action| action.name.clone())
         .unwrap_or_else(|| name.clone());
 
-    if let Some(ref ad) = action_def {
+    if let Some(ad) = action_def {
         match policy.evaluate(ad, &lease, &[]) {
             crate::capability::policy::PolicyDecision::Deny { reason } => {
                 let output = serde_json::json!({"error": format!("Denied: {reason}")});

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -982,11 +982,12 @@ async fn handle_execute_action(
 
     let mut exec_ctx = thread_execution_context(thread, StepId::new(), Some(call_id.clone()));
     let active_leases = leases.active_for_thread(thread.id).await;
-    let available_actions = effects
+    let available_actions: Arc<[crate::types::capability::ActionDef]> = effects
         .available_actions(&active_leases, &exec_ctx)
         .await
-        .unwrap_or_default();
-    exec_ctx.available_actions_snapshot = Some(available_actions.clone());
+        .unwrap_or_default()
+        .into();
+    exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
 
     // Helper: emit event only. The orchestrator owns transcript recording.
     let emit_and_record = |thread: &mut Thread,
@@ -1334,10 +1335,11 @@ async fn handle_execute_actions_parallel(
     let step_id = StepId::new();
     let actions_context = thread_execution_context(thread, step_id, None);
     let active_leases = leases.active_for_thread(thread.id).await;
-    let available_actions = effects
+    let available_actions: Arc<[crate::types::capability::ActionDef]> = effects
         .available_actions(&active_leases, &actions_context)
         .await
-        .unwrap_or_default();
+        .unwrap_or_default()
+        .into();
 
     // ── Phase 1: Preflight (sequential) ─────────────────────────
     // Check leases and policies. Denied → error result. Approval → interrupt.
@@ -1385,7 +1387,7 @@ async fn handle_execute_actions_parallel(
 
         // Check policy
         let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
-        exec_ctx.available_actions_snapshot = Some(available_actions.clone());
+        exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
         let action_def = available_actions
             .iter()
             .find(|a| a.matches_name(&pc.name))
@@ -1555,7 +1557,7 @@ async fn handle_execute_actions_parallel(
             .map(|action| action.name.clone())
             .unwrap_or_else(|| pc.name.clone());
         let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
-        exec_ctx.available_actions_snapshot = Some(available_actions.clone());
+        exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
         let ps = summarize_params(&action_name, &pc.params);
         let (result_json, event, output) = execute_single_action(
             effects,
@@ -1590,7 +1592,7 @@ async fn handle_execute_actions_parallel(
             let effects = effects.clone();
             let lease = lease.clone();
             let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc_call_id.clone()));
-            exec_ctx.available_actions_snapshot = Some(available_actions.clone());
+            exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
             let ps = summarize_params(&pc_name, &pc_params);
 
             join_set.spawn(async move {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -1033,7 +1033,14 @@ async fn handle_execute_action(
     };
 
     // 2. Check policy
-    let action_def = available_actions.into_iter().find(|a| a.name == name);
+    let action_def = available_actions
+        .into_iter()
+        .find(|a| a.matches_name(&name));
+
+    let canonical_name = action_def
+        .as_ref()
+        .map(|action| action.name.clone())
+        .unwrap_or_else(|| name.clone());
 
     if let Some(ref ad) = action_def {
         match policy.evaluate(ad, &lease, &[]) {
@@ -1131,10 +1138,10 @@ async fn handle_execute_action(
     };
 
     // 4. Execute
-    let ps = summarize_params(&name, &params);
+    let ps = summarize_params(&canonical_name, &params);
     let execution_start = std::time::Instant::now();
     match effects
-        .execute_action(&name, params, &lease, &exec_ctx)
+        .execute_action(&canonical_name, params, &lease, &exec_ctx)
         .await
     {
         Ok(r) => {
@@ -1381,8 +1388,12 @@ async fn handle_execute_actions_parallel(
         exec_ctx.available_actions_snapshot = Some(available_actions.clone());
         let action_def = available_actions
             .iter()
-            .find(|a| a.name == pc.name)
+            .find(|a| a.matches_name(&pc.name))
             .cloned();
+        let action_name = action_def
+            .as_ref()
+            .map(|action| action.name.clone())
+            .unwrap_or_else(|| pc.name.clone());
 
         if let Some(ref ad) = action_def {
             match policy.evaluate(ad, &lease, &[]) {
@@ -1394,7 +1405,7 @@ async fn handle_execute_actions_parallel(
                     });
                     let event = EventKind::ActionFailed {
                         step_id,
-                        action_name: pc.name.clone(),
+                        action_name: action_name.clone(),
                         call_id: pc.call_id.clone(),
                         error: reason,
                         duration_ms: 0,
@@ -1538,12 +1549,17 @@ async fn handle_execute_actions_parallel(
         // Single call: execute directly
         let (idx, lease) = runnable.into_iter().next().unwrap(); // safety: len()==1 checked above
         let pc = &parsed[idx];
+        let action_name = available_actions
+            .iter()
+            .find(|action| action.matches_name(&pc.name))
+            .map(|action| action.name.clone())
+            .unwrap_or_else(|| pc.name.clone());
         let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
         exec_ctx.available_actions_snapshot = Some(available_actions.clone());
-        let ps = summarize_params(&pc.name, &pc.params);
+        let ps = summarize_params(&action_name, &pc.params);
         let (result_json, event, output) = execute_single_action(
             effects,
-            &pc.name,
+            &action_name,
             pc.params.clone(),
             &pc.call_id,
             &lease,
@@ -1564,7 +1580,11 @@ async fn handle_execute_actions_parallel(
         // Capture once outside the loop — the thread's metadata is stable
         // for the duration of the parallel batch.
         for (idx, lease) in runnable {
-            let pc_name = parsed[idx].name.clone();
+            let pc_name = available_actions
+                .iter()
+                .find(|action| action.matches_name(&parsed[idx].name))
+                .map(|action| action.name.clone())
+                .unwrap_or_else(|| parsed[idx].name.clone());
             let pc_params = parsed[idx].params.clone();
             let pc_call_id = parsed[idx].call_id.clone();
             let effects = effects.clone();

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -980,7 +980,13 @@ async fn handle_execute_action(
 
     let call_id = extract_string_kwarg(kwargs, "call_id").unwrap_or_default();
 
-    let exec_ctx = thread_execution_context(thread, StepId::new(), Some(call_id.clone()));
+    let mut exec_ctx = thread_execution_context(thread, StepId::new(), Some(call_id.clone()));
+    let active_leases = leases.active_for_thread(thread.id).await;
+    let available_actions = effects
+        .available_actions(&active_leases, &exec_ctx)
+        .await
+        .unwrap_or_default();
+    exec_ctx.available_actions_snapshot = Some(available_actions.clone());
 
     // Helper: emit event only. The orchestrator owns transcript recording.
     let emit_and_record = |thread: &mut Thread,
@@ -1027,11 +1033,7 @@ async fn handle_execute_action(
     };
 
     // 2. Check policy
-    let action_def = effects
-        .available_actions(std::slice::from_ref(&lease), &exec_ctx)
-        .await
-        .ok()
-        .and_then(|actions| actions.into_iter().find(|a| a.name == name));
+    let action_def = available_actions.into_iter().find(|a| a.name == name);
 
     if let Some(ref ad) = action_def {
         match policy.evaluate(ad, &lease, &[]) {
@@ -1323,6 +1325,12 @@ async fn handle_execute_actions_parallel(
     }
 
     let step_id = StepId::new();
+    let actions_context = thread_execution_context(thread, step_id, None);
+    let active_leases = leases.active_for_thread(thread.id).await;
+    let available_actions = effects
+        .available_actions(&active_leases, &actions_context)
+        .await
+        .unwrap_or_default();
 
     // ── Phase 1: Preflight (sequential) ─────────────────────────
     // Check leases and policies. Denied → error result. Approval → interrupt.
@@ -1369,12 +1377,12 @@ async fn handle_execute_actions_parallel(
         };
 
         // Check policy
-        let exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
-        let action_def = effects
-            .available_actions(std::slice::from_ref(&lease), &exec_ctx)
-            .await
-            .ok()
-            .and_then(|actions| actions.into_iter().find(|a| a.name == pc.name));
+        let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
+        exec_ctx.available_actions_snapshot = Some(available_actions.clone());
+        let action_def = available_actions
+            .iter()
+            .find(|a| a.name == pc.name)
+            .cloned();
 
         if let Some(ref ad) = action_def {
             match policy.evaluate(ad, &lease, &[]) {
@@ -1530,7 +1538,8 @@ async fn handle_execute_actions_parallel(
         // Single call: execute directly
         let (idx, lease) = runnable.into_iter().next().unwrap(); // safety: len()==1 checked above
         let pc = &parsed[idx];
-        let exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
+        let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
+        exec_ctx.available_actions_snapshot = Some(available_actions.clone());
         let ps = summarize_params(&pc.name, &pc.params);
         let (result_json, event, output) = execute_single_action(
             effects,
@@ -1560,7 +1569,8 @@ async fn handle_execute_actions_parallel(
             let pc_call_id = parsed[idx].call_id.clone();
             let effects = effects.clone();
             let lease = lease.clone();
-            let exec_ctx = thread_execution_context(thread, step_id, Some(pc_call_id.clone()));
+            let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc_call_id.clone()));
+            exec_ctx.available_actions_snapshot = Some(available_actions.clone());
             let ps = summarize_params(&pc_name, &pc_params);
 
             join_set.spawn(async move {

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -982,12 +982,16 @@ async fn handle_execute_action(
 
     let mut exec_ctx = thread_execution_context(thread, StepId::new(), Some(call_id.clone()));
     let active_leases = leases.active_for_thread(thread.id).await;
-    let available_actions: Arc<[crate::types::capability::ActionDef]> = effects
-        .available_actions(&active_leases, &exec_ctx)
-        .await
-        .unwrap_or_default()
-        .into();
+    let inventory = Arc::new(
+        effects
+            .available_action_inventory(&active_leases, &exec_ctx)
+            .await
+            .unwrap_or_default(),
+    );
+    let available_actions: Arc<[crate::types::capability::ActionDef]> =
+        inventory.inline.clone().into();
     exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
+    exec_ctx.available_action_inventory_snapshot = Some(Arc::clone(&inventory));
 
     // Helper: emit event only. The orchestrator owns transcript recording.
     let emit_and_record = |thread: &mut Thread,
@@ -1333,11 +1337,14 @@ async fn handle_execute_actions_parallel(
     let step_id = StepId::new();
     let actions_context = thread_execution_context(thread, step_id, None);
     let active_leases = leases.active_for_thread(thread.id).await;
-    let available_actions: Arc<[crate::types::capability::ActionDef]> = effects
-        .available_actions(&active_leases, &actions_context)
-        .await
-        .unwrap_or_default()
-        .into();
+    let inventory = Arc::new(
+        effects
+            .available_action_inventory(&active_leases, &actions_context)
+            .await
+            .unwrap_or_default(),
+    );
+    let available_actions: Arc<[crate::types::capability::ActionDef]> =
+        inventory.inline.clone().into();
 
     // ── Phase 1: Preflight (sequential) ─────────────────────────
     // Check leases and policies. Denied → error result. Approval → interrupt.
@@ -1524,7 +1531,6 @@ async fn handle_execute_actions_parallel(
     let mut slot_results: Vec<Option<serde_json::Value>> = vec![None; parsed.len()];
     let mut slot_events: Vec<Option<EventKind>> = vec![None; parsed.len()];
     let mut slot_outputs: Vec<Option<serde_json::Value>> = vec![None; parsed.len()];
-
     // Separate runnable from errors
     let mut runnable: Vec<(usize, crate::types::capability::CapabilityLease)> = Vec::new();
     for (idx, pf) in preflight.into_iter().enumerate() {
@@ -1556,6 +1562,7 @@ async fn handle_execute_actions_parallel(
             .unwrap_or_else(|| pc.name.clone());
         let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc.call_id.clone()));
         exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
+        exec_ctx.available_action_inventory_snapshot = Some(Arc::clone(&inventory));
         let ps = summarize_params(&action_name, &pc.params);
         let (result_json, event, output) = execute_single_action(
             effects,
@@ -1591,6 +1598,7 @@ async fn handle_execute_actions_parallel(
             let lease = lease.clone();
             let mut exec_ctx = thread_execution_context(thread, step_id, Some(pc_call_id.clone()));
             exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
+            exec_ctx.available_action_inventory_snapshot = Some(Arc::clone(&inventory));
             let ps = summarize_params(&pc_name, &pc_params);
 
             join_set.spawn(async move {

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 
 use crate::traits::store::Store;
 use crate::types::capability::{
-    ActionDef, CapabilityStatus, CapabilitySummary, CapabilitySummaryKind,
+    ActionInventory, CapabilityStatus, CapabilitySummary, CapabilitySummaryKind,
 };
 use crate::types::message::{MessageRole, ThreadMessage};
 use crate::types::project::ProjectId;
@@ -115,7 +115,7 @@ const MAX_PROMPT_OVERLAY_CHARS: usize = 4000;
 /// its content after the compiled preamble. This enables the self-improvement
 /// mission to evolve the system prompt at runtime.
 pub async fn build_codeact_system_prompt(
-    actions: &[ActionDef],
+    inventory: &ActionInventory,
     capabilities: &[CapabilitySummary],
     store: Option<&Arc<dyn Store>>,
     project_id: ProjectId,
@@ -126,7 +126,7 @@ pub async fn build_codeact_system_prompt(
     } else {
         None
     };
-    build_codeact_system_prompt_inner(actions, capabilities, overlay.as_deref(), platform)
+    build_codeact_system_prompt_inner(inventory, capabilities, overlay.as_deref(), platform)
 }
 
 /// Build the system prompt using pre-fetched memory docs.
@@ -135,18 +135,18 @@ pub async fn build_codeact_system_prompt(
 /// `load_orchestrator` fetched it), pass the docs here to avoid a duplicate
 /// Store query.
 pub fn build_codeact_system_prompt_with_docs(
-    actions: &[ActionDef],
+    inventory: &ActionInventory,
     capabilities: &[CapabilitySummary],
     system_docs: &[crate::types::memory::MemoryDoc],
     platform: Option<&PlatformInfo>,
 ) -> String {
     let overlay = extract_prompt_overlay(system_docs);
-    build_codeact_system_prompt_inner(actions, capabilities, overlay.as_deref(), platform)
+    build_codeact_system_prompt_inner(inventory, capabilities, overlay.as_deref(), platform)
 }
 
 /// Shared prompt builder used by both the async and pre-fetched-docs variants.
 fn build_codeact_system_prompt_inner(
-    _actions: &[ActionDef],
+    _inventory: &ActionInventory,
     capabilities: &[CapabilitySummary],
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
@@ -313,13 +313,24 @@ pub fn extract_prompt_overlay(docs: &[crate::types::memory::MemoryDoc]) -> Optio
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ActionDef;
     use crate::types::memory::{DocId, DocType, MemoryDoc};
     use crate::types::shared_owner_id;
 
+    fn empty_inventory() -> ActionInventory {
+        ActionInventory::default()
+    }
+
     #[tokio::test]
     async fn prompt_without_store_uses_compiled_preamble() {
-        let prompt =
-            build_codeact_system_prompt(&[], &[], None, ProjectId(uuid::Uuid::nil()), None).await;
+        let prompt = build_codeact_system_prompt(
+            &empty_inventory(),
+            &[],
+            None,
+            ProjectId(uuid::Uuid::nil()),
+            None,
+        )
+        .await;
         assert!(prompt.contains("Python REPL environment"));
         assert!(prompt.contains("Strategy"));
         assert!(!prompt.contains("Learned Rules"));
@@ -344,7 +355,7 @@ mod tests {
 
         let store = Arc::new(crate::tests::InMemoryStore::with_docs(vec![overlay]));
         let prompt = build_codeact_system_prompt(
-            &[],
+            &empty_inventory(),
             &[],
             Some(&(store as Arc<dyn Store>)),
             project_id,
@@ -377,7 +388,7 @@ mod tests {
 
         let store = Arc::new(crate::tests::InMemoryStore::with_docs(vec![overlay]));
         let prompt = build_codeact_system_prompt(
-            &[],
+            &empty_inventory(),
             &[],
             Some(&(store as Arc<dyn Store>)),
             project_id,
@@ -409,7 +420,7 @@ mod tests {
 
         let store = Arc::new(crate::tests::InMemoryStore::with_docs(vec![overlay]));
         let prompt = build_codeact_system_prompt(
-            &[],
+            &empty_inventory(),
             &[],
             Some(&(store as Arc<dyn Store>)),
             project_id,
@@ -431,9 +442,14 @@ mod tests {
             owner_id: Some("alice.near".into()),
             repo_url: Some("https://github.com/nearai/ironclaw".into()),
         };
-        let prompt =
-            build_codeact_system_prompt(&[], &[], None, ProjectId(uuid::Uuid::nil()), Some(&info))
-                .await;
+        let prompt = build_codeact_system_prompt(
+            &empty_inventory(),
+            &[],
+            None,
+            ProjectId(uuid::Uuid::nil()),
+            Some(&info),
+        )
+        .await;
         assert!(prompt.contains("IronClaw"));
         assert!(prompt.contains("1.2.3"));
         assert!(prompt.contains("nearai"));
@@ -446,15 +462,21 @@ mod tests {
 
     #[tokio::test]
     async fn prompt_without_platform_info_has_no_platform_section() {
-        let prompt =
-            build_codeact_system_prompt(&[], &[], None, ProjectId(uuid::Uuid::nil()), None).await;
+        let prompt = build_codeact_system_prompt(
+            &empty_inventory(),
+            &[],
+            None,
+            ProjectId(uuid::Uuid::nil()),
+            None,
+        )
+        .await;
         assert!(!prompt.contains("## Platform"));
     }
 
     #[test]
     fn prompt_with_capabilities_includes_background_statuses() {
         let prompt = build_codeact_system_prompt_with_docs(
-            &[],
+            &empty_inventory(),
             &[
                 CapabilitySummary {
                     name: "telegram".into(),
@@ -488,17 +510,19 @@ mod tests {
     #[test]
     fn prompt_no_longer_duplicates_callable_tool_inventory() {
         let prompt = build_codeact_system_prompt_with_docs(
-            &[ActionDef {
-                name: "message".into(),
-                description: "Send a message".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {"text": {"type": "string"}}
-                }),
-                effects: vec![],
-                requires_approval: false,
-                discovery: None,
-            }],
+            &ActionInventory {
+                inline: vec![ActionDef {
+                    name: "message".into(),
+                    description: "Send a message".into(),
+                    parameters_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {"text": {"type": "string"}}
+                    }),
+                    effects: vec![],
+                    requires_approval: false,
+                    discovery: None,
+                }],
+            },
             &[],
             &[],
             None,
@@ -509,10 +533,40 @@ mod tests {
     }
 
     #[test]
-    fn upsert_replaces_engine_owned_system_prompt() {
-        let old_prompt = build_codeact_system_prompt_with_docs(&[], &[], &[], None);
-        let new_prompt = build_codeact_system_prompt_with_docs(
+    fn prompt_keeps_callable_tools_out_of_extra_prompt_sections() {
+        let prompt = build_codeact_system_prompt_with_docs(
+            &ActionInventory {
+                inline: vec![ActionDef {
+                    name: "gmail".into(),
+                    description: "Gmail multi-action provider".into(),
+                    parameters_schema: serde_json::json!({
+                        "type": "object",
+                        "oneOf": [
+                            {"properties": {"query": {"type": "string"}}}
+                        ]
+                    }),
+                    effects: vec![],
+                    requires_approval: false,
+                    discovery: None,
+                }],
+            },
             &[],
+            &[],
+            None,
+        );
+
+        assert!(!prompt.contains("## Lookup-only tools"));
+        assert!(!prompt.contains("## Deferred large tools"));
+        assert!(!prompt.contains("inspect one on demand"));
+        assert!(!prompt.contains("oneOf"));
+        assert!(!prompt.contains("\"query\""));
+    }
+
+    #[test]
+    fn upsert_replaces_engine_owned_system_prompt() {
+        let old_prompt = build_codeact_system_prompt_with_docs(&empty_inventory(), &[], &[], None);
+        let new_prompt = build_codeact_system_prompt_with_docs(
+            &empty_inventory(),
             &[CapabilitySummary {
                 name: "telegram".into(),
                 display_name: None,
@@ -537,12 +591,12 @@ mod tests {
 
     #[test]
     fn refresh_preserves_step_zero_system_appends() {
-        let old_prompt = build_codeact_system_prompt_with_docs(&[], &[], &[], None);
+        let old_prompt = build_codeact_system_prompt_with_docs(&empty_inventory(), &[], &[], None);
         let existing = format!(
             "{old_prompt}\n\n## Prior Knowledge (from completed threads)\n\n### [LESSON] Use http\n\n<skill name=\"github\" version=\"1\">\nGitHub API Skill\n</skill>\n\nThe user explicitly requested slash skill(s) that are not installed."
         );
         let new_prompt = build_codeact_system_prompt_with_docs(
-            &[],
+            &empty_inventory(),
             &[CapabilitySummary {
                 name: "slack".into(),
                 display_name: None,
@@ -567,7 +621,7 @@ mod tests {
         let legacy_prompt = format!(
             "{CODEACT_LEGACY_OPENING}\n\nLegacy prompt body.\n\n```repl\nprint('hi')\n```\n{CODEACT_STRATEGY_HEADING}\nLegacy strategy text.\n"
         );
-        let new_prompt = build_codeact_system_prompt_with_docs(&[], &[], &[], None);
+        let new_prompt = build_codeact_system_prompt_with_docs(&empty_inventory(), &[], &[], None);
         let mut messages = vec![
             ThreadMessage::system(legacy_prompt),
             ThreadMessage::user("resume me"),
@@ -586,7 +640,7 @@ mod tests {
             "{CODEACT_LEGACY_OPENING}\n\nLegacy prompt body.\n\n```repl\nprint('hi')\n```\n{CODEACT_STRATEGY_HEADING}\nLegacy strategy text.\n{PRIOR_KNOWLEDGE_HEADING}\n### [LESSON] Use http\n\n## Active Skills\n\n<skill name=\"github\" version=\"1\">\nGitHub API Skill\n</skill>\n\nThe user explicitly requested slash skill(s) that are not installed or were not found: /missing."
         );
         let new_prompt = build_codeact_system_prompt_with_docs(
-            &[],
+            &empty_inventory(),
             &[CapabilitySummary {
                 name: "slack".into(),
                 display_name: None,

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -497,6 +497,7 @@ mod tests {
                 }),
                 effects: vec![],
                 requires_approval: false,
+                discovery: None,
             }],
             &[],
             &[],

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2037,6 +2037,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some(thread.goal.clone()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2001,6 +2001,7 @@ mod tests {
             parameters_schema: serde_json::json!({"type": "object"}),
             effects: vec![EffectType::ReadLocal],
             requires_approval: false,
+            discovery: None,
         }
     }
 
@@ -2025,6 +2026,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: Some(thread.goal.clone()),
+            available_actions_snapshot: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -1150,7 +1150,11 @@ async fn preflight_action(
         .available_actions(std::slice::from_ref(&lease), context)
         .await
         .ok()
-        .and_then(|actions| actions.into_iter().find(|a| a.name == action_name));
+        .and_then(|actions| actions.into_iter().find(|a| a.matches_name(action_name)));
+    let canonical_action_name = action_def
+        .as_ref()
+        .map(|action| action.name.as_str())
+        .unwrap_or(action_name);
 
     if let Some(ref action_def) = action_def {
         match policy.evaluate(action_def, &lease, capability_policies) {
@@ -1181,7 +1185,7 @@ async fn preflight_action(
                 return PreflightResult::GatePaused(
                     crate::runtime::messaging::ThreadOutcome::GatePaused {
                         gate_name: "approval".into(),
-                        action_name: action_name.into(),
+                        action_name: canonical_action_name.into(),
                         call_id: call_id.into(),
                         parameters: params.clone(),
                         resume_kind: crate::gate::ResumeKind::Approval { allow_always: true },

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -30,6 +30,7 @@ use crate::capability::lease::LeaseManager;
 use crate::capability::policy::{PolicyDecision, PolicyEngine};
 use crate::traits::effect::{EffectExecutor, ThreadExecutionContext};
 use crate::traits::llm::{LlmBackend, LlmCallConfig};
+use crate::types::capability::ActionDef;
 use crate::types::error::EngineError;
 use crate::types::event::EventKind;
 use crate::types::message::{MessageRole, ThreadMessage};
@@ -431,12 +432,16 @@ pub async fn execute_code_with_skills(
     // Without this, `mission_list()` in code raises NameError because Monty
     // resolves the name before calling it, and Undefined → NameError.
     let active_leases = leases.active_for_thread(thread.id).await;
-    let mut known_actions: std::collections::HashSet<String> = effects
+    let available_actions: Arc<[ActionDef]> = effects
         .available_actions(&active_leases, context)
         .await
         .unwrap_or_default()
-        .into_iter()
-        .map(|a| a.name)
+        .into();
+    let mut execution_context = context.clone();
+    execution_context.available_actions_snapshot = Some(Arc::clone(&available_actions));
+    let mut known_actions: std::collections::HashSet<String> = available_actions
+        .iter()
+        .map(|action| action.name.clone())
         .collect();
 
     // Register skill code snippet function names as additional known actions.
@@ -705,10 +710,9 @@ pub async fn execute_code_with_skills(
                     &action_name,
                     &params,
                     thread,
-                    effects,
                     leases,
                     policy,
-                    context,
+                    &execution_context,
                     capability_policies,
                     &str_call_id,
                     &mut events,
@@ -722,7 +726,7 @@ pub async fn execute_code_with_skills(
                         let name = action_name.clone();
                         let params_clone = params.clone();
                         let lease_clone = lease.clone();
-                        let mut ctx = context.clone();
+                        let mut ctx = execution_context.clone();
                         ctx.current_call_id = Some(str_call_id.clone());
                         let ps = crate::types::event::summarize_params(&name, &params);
 
@@ -1120,7 +1124,6 @@ async fn preflight_action(
     action_name: &str,
     params: &serde_json::Value,
     thread: &Thread,
-    effects: &Arc<dyn EffectExecutor>,
     leases: &LeaseManager,
     policy: &PolicyEngine,
     context: &ThreadExecutionContext,
@@ -1146,17 +1149,20 @@ async fn preflight_action(
         }
     };
 
-    let action_def = effects
-        .available_actions(std::slice::from_ref(&lease), context)
-        .await
-        .ok()
-        .and_then(|actions| actions.into_iter().find(|a| a.matches_name(action_name)));
+    let action_def = context
+        .available_actions_snapshot
+        .as_ref()
+        .and_then(|actions| {
+            actions
+                .iter()
+                .find(|action| action.matches_name(action_name))
+        });
     let canonical_action_name = action_def
         .as_ref()
         .map(|action| action.name.as_str())
         .unwrap_or(action_name);
 
-    if let Some(ref action_def) = action_def {
+    if let Some(action_def) = action_def {
         match policy.evaluate(action_def, &lease, capability_policies) {
             PolicyDecision::Deny { reason } => {
                 events.push(EventKind::ActionFailed {
@@ -2084,6 +2090,81 @@ mod tests {
             &serde_json::json!({}),
         )
         .await
+    }
+
+    struct SnapshotAwareToolInfoEffects;
+
+    #[async_trait::async_trait]
+    impl EffectExecutor for SnapshotAwareToolInfoEffects {
+        async fn execute_action(
+            &self,
+            action_name: &str,
+            parameters: serde_json::Value,
+            _lease: &CapabilityLease,
+            ctx: &ThreadExecutionContext,
+        ) -> Result<ActionResult, EngineError> {
+            let output = if action_name == "tool_info" {
+                let requested = parameters
+                    .get("name")
+                    .and_then(|value| value.as_str())
+                    .unwrap_or_default();
+                match ctx.available_actions_snapshot.as_ref().and_then(|actions| {
+                    actions.iter().find(|action| action.matches_name(requested))
+                }) {
+                    Some(action) => serde_json::json!({
+                        "name": action.name,
+                        "summary": {
+                            "always_required": ["name", "goal", "cadence"]
+                        }
+                    }),
+                    None => serde_json::json!({"error": "missing action snapshot"}),
+                }
+            } else {
+                serde_json::json!({"error": format!("unexpected action '{action_name}'")})
+            };
+
+            Ok(ActionResult {
+                call_id: String::new(),
+                action_name: action_name.to_string(),
+                is_error: output.get("error").is_some(),
+                output,
+                duration: Duration::from_millis(1),
+            })
+        }
+
+        async fn available_actions(
+            &self,
+            _leases: &[CapabilityLease],
+            _context: &ThreadExecutionContext,
+        ) -> Result<Vec<ActionDef>, EngineError> {
+            Ok(vec![
+                test_action("tool_info"),
+                ActionDef {
+                    name: "mission_create".into(),
+                    description: "Create a mission".into(),
+                    parameters_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "goal": {"type": "string"},
+                            "cadence": {"type": "string"}
+                        },
+                        "required": ["name", "goal", "cadence"]
+                    }),
+                    effects: vec![EffectType::WriteLocal],
+                    requires_approval: false,
+                    discovery: None,
+                },
+            ])
+        }
+
+        async fn available_capabilities(
+            &self,
+            _: &[CapabilityLease],
+            _: &ThreadExecutionContext,
+        ) -> Result<Vec<crate::types::capability::CapabilitySummary>, EngineError> {
+            Ok(vec![])
+        }
     }
 
     // ── Single await tool call ──────────────────────────────
@@ -3325,6 +3406,48 @@ except Exception as e:
 
         assert!(matches!(result, ExtFunctionResult::Error(_)));
         assert!(llm.calls.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn execute_code_propagates_snapshot_to_tool_execution_context() {
+        let thread = make_test_thread();
+        let effects: Arc<dyn EffectExecutor> = Arc::new(SnapshotAwareToolInfoEffects);
+        let leases = LeaseManager::new();
+        let policy = PolicyEngine::new();
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(thread.id, "tools", GrantedActions::All, None, None)
+            .await
+            .unwrap();
+
+        let result = execute_code(
+            r#"
+result = await tool_info(name="mission-create", detail="summary")
+"#,
+            &thread,
+            &(Arc::new(StubLlm) as Arc<dyn crate::traits::llm::LlmBackend>),
+            &effects,
+            &leases,
+            &policy,
+            &ctx,
+            &[],
+            &serde_json::json!({}),
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            result.failure.is_none(),
+            "unexpected failure: {:?}",
+            result.failure
+        );
+        assert_eq!(result.action_results.len(), 1);
+        assert!(!result.action_results[0].is_error);
+        assert_eq!(
+            result.action_results[0].output["name"],
+            serde_json::json!("mission_create")
+        );
     }
 
     // ── Error classification tests ──────────────────────────────

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -64,6 +64,11 @@ pub async fn execute_action_calls(
     let mut preflight_results: Vec<PreflightOutcome> = Vec::with_capacity(calls.len());
     let mut early_events = Vec::new();
     let mut early_results = Vec::new();
+    let active_leases = leases.active_for_thread(thread.id).await;
+    let available_actions: Arc<[crate::types::capability::ActionDef]> = effects
+        .available_actions(&active_leases, context)
+        .await?
+        .into();
 
     // ── Phase 1: Preflight (sequential) ─────────────────────────
     // Check leases and policies for every call. RequireApproval interrupts
@@ -104,13 +109,11 @@ pub async fn execute_action_calls(
         };
 
         // 2. Find the action definition and check policy
-        let action_def = effects
-            .available_actions(std::slice::from_ref(&lease), context)
-            .await?
-            .into_iter()
-            .find(|a| action_name_matches(&a.name, &call.action_name));
+        let action_def = available_actions
+            .iter()
+            .find(|action| action.matches_name(&call.action_name));
 
-        if let Some(ref action_def) = action_def {
+        if let Some(action_def) = action_def {
             let decision = policy.evaluate(action_def, &lease, capability_policies);
             match decision {
                 PolicyDecision::Deny { reason } => {
@@ -214,6 +217,7 @@ pub async fn execute_action_calls(
         let call = &calls[idx];
         let mut exec_ctx = context.clone();
         exec_ctx.current_call_id = Some(call.id.clone());
+        exec_ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
         let execution_start = Instant::now();
         let exec_result = effects
             .execute_action(
@@ -241,6 +245,7 @@ pub async fn execute_action_calls(
             let call = calls[idx].clone();
             let mut ctx = context.clone();
             ctx.current_call_id = Some(call.id.clone());
+            ctx.available_actions_snapshot = Some(Arc::clone(&available_actions));
             let effects = effects.clone();
             let lease = lease.clone();
 
@@ -449,17 +454,6 @@ fn classify_exec_result(
 
 fn interrupted_call_needs_refund(result: &Result<ActionResult, EngineError>) -> bool {
     matches!(result, Err(EngineError::GatePaused { .. }))
-}
-
-fn action_name_matches(candidate: &str, requested: &str) -> bool {
-    if candidate == requested {
-        return true;
-    }
-
-    let candidate_hyphenated = candidate.replace('_', "-");
-    let candidate_underscored = candidate.replace('-', "_");
-
-    requested == candidate_hyphenated || requested == candidate_underscored
 }
 
 #[cfg(test)]
@@ -1223,5 +1217,89 @@ mod tests {
         if let Some(EventKind::ActionExecuted { call_id, .. }) = result.events.first() {
             assert_eq!(call_id, mistral_id);
         }
+    }
+
+    struct SnapshotAwareEffects;
+
+    #[async_trait::async_trait]
+    impl EffectExecutor for SnapshotAwareEffects {
+        async fn execute_action(
+            &self,
+            name: &str,
+            _params: serde_json::Value,
+            _lease: &CapabilityLease,
+            ctx: &ThreadExecutionContext,
+        ) -> Result<ActionResult, EngineError> {
+            let canonical_name = ctx
+                .available_actions_snapshot
+                .as_ref()
+                .and_then(|actions| actions.iter().find(|action| action.matches_name(name)))
+                .map(|action| action.name.clone())
+                .unwrap_or_else(|| format!("missing_snapshot:{name}"));
+
+            Ok(ActionResult {
+                call_id: String::new(),
+                action_name: canonical_name,
+                output: serde_json::json!({"ok": true}),
+                is_error: false,
+                duration: Duration::from_millis(1),
+            })
+        }
+
+        async fn available_actions(
+            &self,
+            _leases: &[CapabilityLease],
+            _context: &ThreadExecutionContext,
+        ) -> Result<Vec<ActionDef>, EngineError> {
+            Ok(vec![test_action("create_issue")])
+        }
+
+        async fn available_capabilities(
+            &self,
+            _: &[CapabilityLease],
+            _: &ThreadExecutionContext,
+        ) -> Result<Vec<crate::types::capability::CapabilitySummary>, EngineError> {
+            Ok(vec![])
+        }
+    }
+
+    #[tokio::test]
+    async fn structured_execution_propagates_snapshot_to_executor_context() {
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+        let effects: Arc<dyn EffectExecutor> = Arc::new(SnapshotAwareEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(
+                thread.id,
+                "tools",
+                GrantedActions::Specific(vec!["create_issue".into()]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let calls = vec![ActionCall {
+            id: "call_snapshot_ctx".into(),
+            action_name: "create-issue".into(),
+            parameters: serde_json::json!({"title": "snapshot propagation"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(result.results.len(), 1);
+        assert_eq!(result.results[0].action_name, "create_issue");
+        assert!(!result.results[0].is_error);
     }
 }

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -535,6 +535,7 @@ mod tests {
             parameters_schema: serde_json::json!({"type": "object"}),
             effects: vec![EffectType::ReadLocal],
             requires_approval: false,
+            discovery: None,
         }
     }
 
@@ -549,6 +550,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: Some(thread.goal.clone()),
+            available_actions_snapshot: None,
         }
     }
 
@@ -825,6 +827,7 @@ mod tests {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: true,
+                discovery: None,
             }],
             vec![Ok(ActionResult {
                 call_id: String::new(),

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -545,6 +545,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some(thread.goal.clone()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/executor/thread_context.rs
+++ b/crates/ironclaw_engine/src/executor/thread_context.rs
@@ -28,5 +28,6 @@ pub(crate) fn thread_execution_context(
             .and_then(ValidTimezone::parse),
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     }
 }

--- a/crates/ironclaw_engine/src/executor/thread_context.rs
+++ b/crates/ironclaw_engine/src/executor/thread_context.rs
@@ -27,5 +27,6 @@ pub(crate) fn thread_execution_context(
             .and_then(|v| v.as_str())
             .and_then(ValidTimezone::parse),
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     }
 }

--- a/crates/ironclaw_engine/src/gate/lease.rs
+++ b/crates/ironclaw_engine/src/gate/lease.rs
@@ -88,6 +88,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects: vec![EffectType::ReadLocal],
             requires_approval: false,
+            discovery: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/gate/pipeline.rs
+++ b/crates/ironclaw_engine/src/gate/pipeline.rs
@@ -68,6 +68,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects: vec![EffectType::ReadLocal],
             requires_approval: false,
+            discovery: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/gate/tool_tier.rs
+++ b/crates/ironclaw_engine/src/gate/tool_tier.rs
@@ -101,6 +101,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects,
             requires_approval,
+            discovery: None,
         }
     }
 

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -36,9 +36,9 @@ pub mod workspace;
 // ── Re-exports: types ───────────────────────────────────────
 
 pub use types::capability::{
-    ActionDef, Capability, CapabilityLease, CapabilityStatus, CapabilitySummary,
-    CapabilitySummaryKind, EffectType, GrantedActions, LeaseId, PolicyCondition, PolicyEffect,
-    PolicyRule,
+    ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary, Capability, CapabilityLease,
+    CapabilityStatus, CapabilitySummary, CapabilitySummaryKind, EffectType, GrantedActions,
+    LeaseId, PolicyCondition, PolicyEffect, PolicyRule,
 };
 pub use types::error::{CapabilityError, EngineError, StepError, ThreadError};
 pub use types::event::{EventId, EventKind, ThreadEvent};

--- a/crates/ironclaw_engine/src/lib.rs
+++ b/crates/ironclaw_engine/src/lib.rs
@@ -36,9 +36,9 @@ pub mod workspace;
 // ── Re-exports: types ───────────────────────────────────────
 
 pub use types::capability::{
-    ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary, Capability, CapabilityLease,
-    CapabilityStatus, CapabilitySummary, CapabilitySummaryKind, EffectType, GrantedActions,
-    LeaseId, PolicyCondition, PolicyEffect, PolicyRule,
+    ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary, ActionInventory, Capability,
+    CapabilityLease, CapabilityStatus, CapabilitySummary, CapabilitySummaryKind, EffectType,
+    GrantedActions, LeaseId, PolicyCondition, PolicyEffect, PolicyRule,
 };
 pub use types::error::{CapabilityError, EngineError, StepError, ThreadError};
 pub use types::event::{EventId, EventKind, ThreadEvent};

--- a/crates/ironclaw_engine/src/runtime/manager.rs
+++ b/crates/ironclaw_engine/src/runtime/manager.rs
@@ -1005,6 +1005,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             }],
             knowledge: vec![],
             policies: vec![],
@@ -1031,6 +1032,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             }],
             knowledge: vec![],
             policies: vec![],
@@ -1061,6 +1063,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::WriteLocal],
                 requires_approval: false,
+                discovery: None,
             }],
             knowledge: vec![],
             policies: vec![],
@@ -1185,6 +1188,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects: vec![EffectType::WriteLocal],
             requires_approval: false,
+            discovery: None,
         }]);
         let mgr = make_manager_with_effects(MockLlm::text("done"), store, effects.clone());
 
@@ -1221,6 +1225,7 @@ mod tests {
                     parameters_schema: serde_json::json!({}),
                     effects: vec![EffectType::WriteLocal],
                     requires_approval: false,
+                    discovery: None,
                 },
                 ActionDef {
                     name: "notion_search".into(),
@@ -1228,6 +1233,7 @@ mod tests {
                     parameters_schema: serde_json::json!({}),
                     effects: vec![EffectType::ReadExternal],
                     requires_approval: false,
+                    discovery: None,
                 },
             ])
             .await;
@@ -1257,6 +1263,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::WriteLocal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "notion_search".into(),
@@ -1264,6 +1271,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::ReadExternal],
                 requires_approval: false,
+                discovery: None,
             },
         ]);
         let mgr = make_manager_with_effects(MockLlm::text("done"), store, effects);
@@ -1296,6 +1304,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects: vec![EffectType::WriteLocal],
             requires_approval: false,
+            discovery: None,
         }];
         let revealed_actions = vec![
             ActionDef {
@@ -1304,6 +1313,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::WriteLocal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "notion_search".into(),
@@ -1311,6 +1321,7 @@ mod tests {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::ReadExternal],
                 requires_approval: false,
+                discovery: None,
             },
         ];
         let effects = DynamicEffects::new(initial_actions);

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -2574,6 +2574,7 @@ async fn dispatch_protected_write(
         source_channel: None,
         user_timezone: None,
         thread_goal: None,
+        available_actions_snapshot: None,
     };
 
     effects

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -2575,6 +2575,7 @@ async fn dispatch_protected_write(
         user_timezone: None,
         thread_goal: None,
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     effects

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -4,6 +4,8 @@
 //! trait. The main crate implements it by wrapping `ToolRegistry` and
 //! `SafetyLayer` — the engine itself has no knowledge of specific tools.
 
+use std::sync::Arc;
+
 use crate::types::capability::{ActionDef, CapabilityLease, CapabilitySummary};
 use crate::types::error::EngineError;
 use crate::types::project::ProjectId;
@@ -37,7 +39,7 @@ pub struct ThreadExecutionContext {
     ///
     /// Populated by the orchestrator when an execution path needs on-demand
     /// discovery parity (for example `tool_info`).
-    pub available_actions_snapshot: Option<Vec<ActionDef>>,
+    pub available_actions_snapshot: Option<Arc<[ActionDef]>>,
 }
 
 /// Abstraction over capability action execution.

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -33,6 +33,11 @@ pub struct ThreadExecutionContext {
     /// Host adapters use this to distinguish immediate one-shot foreground
     /// requests from explicit mission/routine setup.
     pub thread_goal: Option<String>,
+    /// Snapshot of callable actions visible to the current step.
+    ///
+    /// Populated by the orchestrator when an execution path needs on-demand
+    /// discovery parity (for example `tool_info`).
+    pub available_actions_snapshot: Option<Vec<ActionDef>>,
 }
 
 /// Abstraction over capability action execution.

--- a/crates/ironclaw_engine/src/traits/effect.rs
+++ b/crates/ironclaw_engine/src/traits/effect.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use crate::types::capability::{ActionDef, CapabilityLease, CapabilitySummary};
+use crate::types::capability::{ActionDef, ActionInventory, CapabilityLease, CapabilitySummary};
 use crate::types::error::EngineError;
 use crate::types::project::ProjectId;
 use crate::types::step::{ActionResult, StepId};
@@ -40,6 +40,8 @@ pub struct ThreadExecutionContext {
     /// Populated by the orchestrator when an execution path needs on-demand
     /// discovery parity (for example `tool_info`).
     pub available_actions_snapshot: Option<Arc<[ActionDef]>>,
+    /// Snapshot of the full action inventory visible to the current step.
+    pub available_action_inventory_snapshot: Option<Arc<ActionInventory>>,
 }
 
 /// Abstraction over capability action execution.
@@ -74,6 +76,19 @@ pub trait EffectExecutor: Send + Sync {
         leases: &[CapabilityLease],
         context: &ThreadExecutionContext,
     ) -> Result<Vec<ActionDef>, EngineError>;
+
+    /// List the full action inventory for the current set of active leases.
+    ///
+    /// The default implementation mirrors `available_actions()`.
+    async fn available_action_inventory(
+        &self,
+        leases: &[CapabilityLease],
+        context: &ThreadExecutionContext,
+    ) -> Result<ActionInventory, EngineError> {
+        Ok(ActionInventory {
+            inline: self.available_actions(leases, context).await?,
+        })
+    }
 
     /// List capability background summaries given the current runtime state.
     async fn available_capabilities(

--- a/crates/ironclaw_engine/src/types/capability.rs
+++ b/crates/ironclaw_engine/src/types/capability.rs
@@ -191,6 +191,22 @@ impl ActionDef {
             .as_ref()
             .and_then(|metadata| metadata.summary.as_ref())
     }
+
+    /// Checks whether the given name resolves to this action.
+    pub fn matches_name(&self, name: &str) -> bool {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        if self.name == trimmed || self.discovery_name() == trimmed {
+            return true;
+        }
+        if trimmed.contains('-') {
+            let normalized = trimmed.replace('-', "_");
+            return self.name == normalized || self.discovery_name() == normalized;
+        }
+        false
+    }
 }
 
 /// Canonical model-visible status for capability background surfacing.
@@ -474,6 +490,42 @@ mod tests {
 
         lease.granted_actions = GrantedActions::Specific(vec!["list-prs".into()]);
         assert!(lease.covers_action("list_prs"));
+    }
+
+    #[test]
+    fn action_def_matches_exact_and_hyphenated_names() {
+        let action = ActionDef {
+            name: "mission_create".to_string(),
+            description: "Create mission".to_string(),
+            parameters_schema: json!({"type": "object"}),
+            effects: vec![],
+            requires_approval: false,
+            discovery: None,
+        };
+
+        assert!(action.matches_name("mission_create"));
+        assert!(action.matches_name("mission-create"));
+        assert!(!action.matches_name("mission_resume"));
+        assert!(!action.matches_name(" "));
+    }
+
+    #[test]
+    fn action_def_matches_discovery_aliases() {
+        let action = ActionDef {
+            name: "mission_create".to_string(),
+            description: "Create mission".to_string(),
+            parameters_schema: json!({"type": "object"}),
+            effects: vec![],
+            requires_approval: false,
+            discovery: Some(ActionDiscoveryMetadata {
+                name: "mission-create".to_string(),
+                summary: None,
+                schema_override: None,
+            }),
+        };
+
+        assert!(action.matches_name("mission-create"));
+        assert!(action.matches_name("mission_create"));
     }
 
     #[test]

--- a/crates/ironclaw_engine/src/types/capability.rs
+++ b/crates/ironclaw_engine/src/types/capability.rs
@@ -198,12 +198,14 @@ impl ActionDef {
         if trimmed.is_empty() {
             return false;
         }
-        if self.name == trimmed || self.discovery_name() == trimmed {
+        let discovery_name = self.discovery_name();
+        if self.name == trimmed || discovery_name == trimmed {
             return true;
         }
-        if trimmed.contains('-') {
+        if trimmed.contains('-') || self.name.contains('-') || discovery_name.contains('-') {
             let normalized = trimmed.replace('-', "_");
-            return self.name == normalized || self.discovery_name() == normalized;
+            return normalized == self.name.replace('-', "_")
+                || normalized == discovery_name.replace('-', "_");
         }
         false
     }
@@ -526,6 +528,21 @@ mod tests {
 
         assert!(action.matches_name("mission-create"));
         assert!(action.matches_name("mission_create"));
+    }
+
+    #[test]
+    fn action_def_matches_hyphenated_canonical_names_from_underscore_input() {
+        let action = ActionDef {
+            name: "mission-create".to_string(),
+            description: "Create mission".to_string(),
+            parameters_schema: json!({"type": "object"}),
+            effects: vec![],
+            requires_approval: false,
+            discovery: None,
+        };
+
+        assert!(action.matches_name("mission_create"));
+        assert!(action.matches_name("mission-create"));
     }
 
     #[test]

--- a/crates/ironclaw_engine/src/types/capability.rs
+++ b/crates/ironclaw_engine/src/types/capability.rs
@@ -133,6 +133,64 @@ pub struct ActionDef {
     pub effects: Vec<EffectType>,
     /// Whether this action requires user approval before execution.
     pub requires_approval: bool,
+    /// Optional discovery metadata used by `tool_info` and prompt guidance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub discovery: Option<ActionDiscoveryMetadata>,
+}
+
+/// Curated discovery guidance for a callable action.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ActionDiscoverySummary {
+    /// Parameters that are always required.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub always_required: Vec<String>,
+    /// Conditional requirements or cross-field invariants.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub conditional_requirements: Vec<String>,
+    /// Additional notes for correct tool selection/use.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
+    /// Optional structured examples.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<serde_json::Value>,
+}
+
+/// Optional discovery metadata layered on top of an executable action.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ActionDiscoveryMetadata {
+    /// Canonical discovery name shown to the model.
+    pub name: String,
+    /// Optional curated discovery guidance.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<ActionDiscoverySummary>,
+    /// Optional discovery schema when it differs from the callable schema.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub schema_override: Option<serde_json::Value>,
+}
+
+impl ActionDef {
+    /// Canonical discovery name for this action.
+    pub fn discovery_name(&self) -> &str {
+        self.discovery
+            .as_ref()
+            .map(|metadata| metadata.name.as_str())
+            .unwrap_or(self.name.as_str())
+    }
+
+    /// Discovery schema, defaulting to the callable schema.
+    pub fn discovery_schema(&self) -> &serde_json::Value {
+        self.discovery
+            .as_ref()
+            .and_then(|metadata| metadata.schema_override.as_ref())
+            .unwrap_or(&self.parameters_schema)
+    }
+
+    /// Curated discovery summary, when one exists.
+    pub fn discovery_summary(&self) -> Option<&ActionDiscoverySummary> {
+        self.discovery
+            .as_ref()
+            .and_then(|metadata| metadata.summary.as_ref())
+    }
 }
 
 /// Canonical model-visible status for capability background surfacing.

--- a/crates/ironclaw_engine/src/types/capability.rs
+++ b/crates/ironclaw_engine/src/types/capability.rs
@@ -121,7 +121,7 @@ pub enum EffectType {
 // ── Action definition ───────────────────────────────────────
 
 /// Definition of a single action within a capability.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ActionDef {
     /// Action name (e.g. "create_issue", "web_fetch").
     pub name: String,
@@ -136,6 +136,17 @@ pub struct ActionDef {
     /// Optional discovery metadata used by `tool_info` and prompt guidance.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub discovery: Option<ActionDiscoveryMetadata>,
+}
+
+/// Model-visible callable action inventory for a single execution step.
+///
+/// All actions in this inventory are callable. Richer schema/details remain
+/// available through `tool_info`, while non-callable runtime context belongs
+/// in capability background surfacing.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct ActionInventory {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub inline: Vec<ActionDef>,
 }
 
 /// Curated discovery guidance for a callable action.

--- a/src/bridge/action_discovery.rs
+++ b/src/bridge/action_discovery.rs
@@ -76,14 +76,7 @@ impl ActionDiscovery {
     }
 
     pub(crate) fn resolve<'a>(actions: &'a [ActionDef], name: &str) -> Option<&'a ActionDef> {
-        let normalized = name.replace('-', "_");
-
-        actions.iter().find(|action| {
-            action.name == name
-                || action.discovery_name() == name
-                || action.name == normalized
-                || action.discovery_name() == normalized
-        })
+        actions.iter().find(|action| action.matches_name(name))
     }
 }
 

--- a/src/bridge/action_discovery.rs
+++ b/src/bridge/action_discovery.rs
@@ -50,7 +50,7 @@ impl ActionDiscovery {
         let schema = action.discovery_schema();
         let mut info = serde_json::json!({
             "name": action.discovery_name(),
-            "description": action.description,
+            "description": action.description.as_str(),
             "parameters": schema_param_names(schema),
         });
 

--- a/src/bridge/action_discovery.rs
+++ b/src/bridge/action_discovery.rs
@@ -1,0 +1,207 @@
+use std::collections::BTreeSet;
+use std::time::Duration;
+
+use ironclaw_engine::{ActionDef, ActionDiscoverySummary};
+
+use crate::tools::require_str;
+use crate::tools::{ToolError, ToolOutput};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActionInfoDetail {
+    Names,
+    Summary,
+    Schema,
+}
+
+impl ActionInfoDetail {
+    fn parse(params: &serde_json::Value) -> Result<Self, ToolError> {
+        if params
+            .get("include_schema")
+            .and_then(|value| value.as_bool())
+            .unwrap_or(false)
+        {
+            return Ok(Self::Schema);
+        }
+
+        match params.get("detail").and_then(|value| value.as_str()) {
+            None | Some("names") => Ok(Self::Names),
+            Some("summary") => Ok(Self::Summary),
+            Some("schema") => Ok(Self::Schema),
+            Some(other) => Err(ToolError::InvalidParameters(format!(
+                "invalid detail '{other}' (expected 'names', 'summary', or 'schema')"
+            ))),
+        }
+    }
+}
+
+pub(crate) struct ActionDiscovery;
+
+impl ActionDiscovery {
+    pub(crate) fn tool_info(
+        params: &serde_json::Value,
+        actions: &[ActionDef],
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        let name = require_str(params, "name")?;
+        let detail = ActionInfoDetail::parse(params)?;
+        let Some(action) = Self::resolve(actions, name) else {
+            return Ok(None);
+        };
+
+        let schema = action.discovery_schema();
+        let mut info = serde_json::json!({
+            "name": action.discovery_name(),
+            "description": action.description,
+            "parameters": schema_param_names(schema),
+        });
+
+        match detail {
+            ActionInfoDetail::Names => {}
+            ActionInfoDetail::Summary => {
+                let summary = action
+                    .discovery_summary()
+                    .cloned()
+                    .unwrap_or_else(|| fallback_summary(schema));
+                info["summary"] = serde_json::to_value(summary).map_err(|error| {
+                    ToolError::ExecutionFailed(format!(
+                        "failed to serialize action discovery summary: {error}"
+                    ))
+                })?;
+            }
+            ActionInfoDetail::Schema => {
+                info["schema"] = schema.clone();
+            }
+        }
+
+        Ok(Some(ToolOutput::success(info, Duration::from_millis(1))))
+    }
+
+    pub(crate) fn resolve<'a>(actions: &'a [ActionDef], name: &str) -> Option<&'a ActionDef> {
+        let normalized = name.replace('-', "_");
+
+        actions.iter().find(|action| {
+            action.name == name
+                || action.discovery_name() == name
+                || action.name == normalized
+                || action.discovery_name() == normalized
+        })
+    }
+}
+
+fn schema_param_names(schema: &serde_json::Value) -> Vec<String> {
+    let mut names = BTreeSet::new();
+
+    if let Some(props) = schema.get("properties").and_then(|value| value.as_object()) {
+        names.extend(props.keys().cloned());
+    }
+
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(variants) = schema.get(key).and_then(|value| value.as_array()) {
+            for variant in variants {
+                if let Some(props) = variant
+                    .get("properties")
+                    .and_then(|value| value.as_object())
+                {
+                    names.extend(props.keys().cloned());
+                }
+            }
+        }
+    }
+
+    names.into_iter().collect()
+}
+
+fn fallback_summary(schema: &serde_json::Value) -> ActionDiscoverySummary {
+    ActionDiscoverySummary {
+        always_required: schema
+            .get("required")
+            .and_then(|value| value.as_array())
+            .map(|required| {
+                required
+                    .iter()
+                    .filter_map(|value| value.as_str().map(str::to_string))
+                    .collect()
+            })
+            .unwrap_or_default(),
+        ..ActionDiscoverySummary::default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ActionDiscovery;
+    use ironclaw_engine::{ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary};
+
+    fn action(name: &str) -> ActionDef {
+        ActionDef {
+            name: name.to_string(),
+            description: format!("Action {name}"),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"}
+                },
+                "required": ["id"]
+            }),
+            effects: vec![],
+            requires_approval: false,
+            discovery: None,
+        }
+    }
+
+    #[test]
+    fn resolves_underscored_and_hyphenated_names() {
+        let actions = vec![action("mission_create")];
+        assert!(ActionDiscovery::resolve(&actions, "mission_create").is_some());
+        assert!(ActionDiscovery::resolve(&actions, "mission-create").is_some());
+    }
+
+    #[test]
+    fn resolve_does_not_match_unrelated_action_before_alias_target() {
+        let actions = vec![action("echo"), action("mission_create")];
+        let resolved = ActionDiscovery::resolve(&actions, "mission-create")
+            .expect("hyphenated alias should resolve");
+        assert_eq!(resolved.name, "mission_create");
+    }
+
+    #[test]
+    fn tool_info_uses_curated_summary_when_present() {
+        let mut action = action("mission_create");
+        action.discovery = Some(ActionDiscoveryMetadata {
+            name: "mission_create".to_string(),
+            summary: Some(ActionDiscoverySummary {
+                always_required: vec!["name".to_string(), "goal".to_string()],
+                conditional_requirements: vec!["Use cadence for scheduled runs".to_string()],
+                notes: vec![],
+                examples: vec![],
+            }),
+            schema_override: None,
+        });
+
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "mission_create", "detail": "summary"}),
+            &[action],
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(
+            output.result["summary"]["always_required"],
+            serde_json::json!(["name", "goal"])
+        );
+    }
+
+    #[test]
+    fn tool_info_falls_back_to_required_fields_for_summary() {
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "mission_create", "detail": "summary"}),
+            &[action("mission_create")],
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(
+            output.result["summary"]["always_required"],
+            serde_json::json!(["id"])
+        );
+    }
+}

--- a/src/bridge/action_discovery.rs
+++ b/src/bridge/action_discovery.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 use std::time::Duration;
 
-use ironclaw_engine::{ActionDef, ActionDiscoverySummary};
+use ironclaw_engine::{ActionDef, ActionDiscoverySummary, ActionInventory};
 
 use crate::tools::require_str;
 use crate::tools::{ToolError, ToolOutput};
@@ -39,6 +39,13 @@ pub(crate) struct ActionDiscovery;
 impl ActionDiscovery {
     pub(crate) fn tool_info(
         params: &serde_json::Value,
+        inventory: &ActionInventory,
+    ) -> Result<Option<ToolOutput>, ToolError> {
+        Self::tool_info_from_actions(params, &inventory.inline)
+    }
+
+    pub(crate) fn tool_info_from_actions(
+        params: &serde_json::Value,
         actions: &[ActionDef],
     ) -> Result<Option<ToolOutput>, ToolError> {
         let name = require_str(params, "name")?;
@@ -47,6 +54,10 @@ impl ActionDiscovery {
             return Ok(None);
         };
 
+        Ok(Some(Self::tool_output(action, detail)?))
+    }
+
+    fn tool_output(action: &ActionDef, detail: ActionInfoDetail) -> Result<ToolOutput, ToolError> {
         let schema = action.discovery_schema();
         let mut info = serde_json::json!({
             "name": action.discovery_name(),
@@ -72,7 +83,7 @@ impl ActionDiscovery {
             }
         }
 
-        Ok(Some(ToolOutput::success(info, Duration::from_millis(1))))
+        Ok(ToolOutput::success(info, Duration::from_millis(1)))
     }
 
     pub(crate) fn resolve<'a>(actions: &'a [ActionDef], name: &str) -> Option<&'a ActionDef> {
@@ -122,7 +133,9 @@ fn fallback_summary(schema: &serde_json::Value) -> ActionDiscoverySummary {
 #[cfg(test)]
 mod tests {
     use super::ActionDiscovery;
-    use ironclaw_engine::{ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary};
+    use ironclaw_engine::{
+        ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary, ActionInventory,
+    };
 
     fn action(name: &str) -> ActionDef {
         ActionDef {
@@ -172,7 +185,9 @@ mod tests {
 
         let output = ActionDiscovery::tool_info(
             &serde_json::json!({"name": "mission_create", "detail": "summary"}),
-            &[action],
+            &ActionInventory {
+                inline: vec![action],
+            },
         )
         .expect("tool_info should succeed")
         .expect("action should resolve");
@@ -187,7 +202,9 @@ mod tests {
     fn tool_info_falls_back_to_required_fields_for_summary() {
         let output = ActionDiscovery::tool_info(
             &serde_json::json!({"name": "mission_create", "detail": "summary"}),
-            &[action("mission_create")],
+            &ActionInventory {
+                inline: vec![action("mission_create")],
+            },
         )
         .expect("tool_info should succeed")
         .expect("action should resolve");
@@ -196,5 +213,17 @@ mod tests {
             output.result["summary"]["always_required"],
             serde_json::json!(["id"])
         );
+    }
+
+    #[test]
+    fn tool_info_from_actions_reads_borrowed_snapshot() {
+        let output = ActionDiscovery::tool_info_from_actions(
+            &serde_json::json!({"name": "mission_create", "detail": "summary"}),
+            &[action("mission_create")],
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(output.result["name"], serde_json::json!("mission_create"));
     }
 }

--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -29,7 +29,7 @@ impl ActionProjector {
     /// instead of fetching from `auth_manager`. This allows the caller
     /// (typically `EffectBridgeAdapter`) to share a single fetch across
     /// both `ActionProjector` and `CapabilityProjector`.
-    pub(crate) async fn project(
+    pub(crate) async fn project_actions(
         tools: &ToolRegistry,
         auth_manager: Option<&AuthManager>,
         capability_registry: Option<Arc<CapabilityRegistry>>,
@@ -106,7 +106,8 @@ impl ActionProjector {
         }
 
         if let Some(registry) = capability_registry.as_ref() {
-            let mut seen: HashSet<String> = actions.iter().map(|a| a.name.clone()).collect();
+            let mut seen: HashSet<String> =
+                actions.iter().map(|action| action.name.clone()).collect();
             for lease in leases {
                 if lease.capability_name == "tools" {
                     continue;
@@ -347,7 +348,7 @@ mod tests {
             .await;
 
         let extension_map = HashMap::from([(extension.name.clone(), extension)]);
-        let actions = ActionProjector::project(
+        let actions = ActionProjector::project_actions(
             tools.as_ref(),
             None,
             None,
@@ -358,7 +359,7 @@ mod tests {
         .await
         .expect("project should succeed");
 
-        actions.into_iter().map(|a| a.name).collect()
+        actions.into_iter().map(|action| action.name).collect()
     }
 
     fn test_context() -> ThreadExecutionContext {
@@ -373,6 +374,7 @@ mod tests {
             user_timezone: None,
             thread_goal: None,
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         }
     }
 

--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -4,8 +4,8 @@ use std::sync::Arc;
 use tracing::debug;
 
 use ironclaw_engine::{
-    ActionDef, CapabilityLease, CapabilityRegistry, CapabilityStatus, EngineError,
-    ThreadExecutionContext,
+    ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary, CapabilityLease,
+    CapabilityRegistry, CapabilityStatus, EngineError, ThreadExecutionContext,
 };
 
 use crate::auth::extension::AuthManager;
@@ -37,7 +37,7 @@ impl ActionProjector {
         context: &ThreadExecutionContext,
         prefetched_extensions: Option<&HashMap<String, InstalledExtension>>,
     ) -> Result<Vec<ActionDef>, EngineError> {
-        let tool_defs = tools.tool_definitions().await;
+        let tool_defs = tools.all().await;
         let owned_statuses;
         let extension_statuses: Option<&HashMap<String, InstalledExtension>> = if let Some(
             prefetched,
@@ -72,20 +72,20 @@ impl ActionProjector {
         };
 
         let mut actions = Vec::with_capacity(tool_defs.len());
-        for td in tool_defs {
-            if crate::bridge::effect_adapter::is_v1_only_tool(&td.name) {
+        for tool in tool_defs {
+            if crate::bridge::effect_adapter::is_v1_only_tool(tool.name()) {
                 continue;
             }
-            if crate::bridge::effect_adapter::is_v1_auth_tool(&td.name) {
+            if crate::bridge::effect_adapter::is_v1_auth_tool(tool.name()) {
                 continue;
             }
 
-            if let Some(provider_extension) = tools.provider_extension_for_tool(&td.name).await {
+            if let Some(provider_extension) = tool.provider_extension() {
                 let Some(extension_statuses) = extension_statuses else {
                     continue;
                 };
                 let Some(extension) =
-                    provider_extension_status(extension_statuses, &provider_extension)
+                    provider_extension_status(extension_statuses, provider_extension)
                 else {
                     continue;
                 };
@@ -102,13 +102,7 @@ impl ActionProjector {
                 }
             }
 
-            actions.push(ActionDef {
-                name: td.name.replace('-', "_"),
-                description: td.description,
-                parameters_schema: td.parameters,
-                effects: vec![],
-                requires_approval: false,
-            });
+            actions.push(project_tool_action(tool.as_ref()));
         }
 
         if let Some(registry) = capability_registry.as_ref() {
@@ -148,6 +142,34 @@ impl ActionProjector {
     }
 }
 
+fn project_tool_action(tool: &dyn crate::tools::Tool) -> ActionDef {
+    let callable_name = tool.name().replace('-', "_");
+    let callable_schema = tool.parameters_schema();
+    let discovery_schema = tool.discovery_schema();
+    let summary = tool
+        .discovery_summary()
+        .map(|summary| ActionDiscoverySummary {
+            always_required: summary.always_required,
+            conditional_requirements: summary.conditional_requirements,
+            notes: summary.notes,
+            examples: summary.examples,
+        });
+    let schema_override = (discovery_schema != callable_schema).then_some(discovery_schema);
+
+    ActionDef {
+        name: callable_name.clone(),
+        description: tool.description().to_string(),
+        parameters_schema: callable_schema,
+        effects: vec![],
+        requires_approval: false,
+        discovery: Some(ActionDiscoveryMetadata {
+            name: callable_name,
+            summary,
+            schema_override,
+        }),
+    }
+}
+
 fn provider_extension_status<'a>(
     extension_statuses: &'a HashMap<String, InstalledExtension>,
     provider_extension: &str,
@@ -177,7 +199,7 @@ mod tests {
     use async_trait::async_trait;
     use ironclaw_engine::ThreadExecutionContext;
 
-    use super::{ActionProjector, provider_extension_status};
+    use super::{ActionProjector, project_tool_action, provider_extension_status};
     use crate::extensions::{ExtensionKind, InstalledExtension};
     use crate::tools::ToolRegistry;
 
@@ -264,6 +286,51 @@ mod tests {
         }
     }
 
+    struct DiscoveryTool;
+
+    #[async_trait]
+    impl crate::tools::Tool for DiscoveryTool {
+        fn name(&self) -> &str {
+            "mission_helper"
+        }
+
+        fn description(&self) -> &str {
+            "Mission helper"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object", "properties": {"id": {"type": "string"}}})
+        }
+
+        fn discovery_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string"},
+                    "mode": {"type": "string"}
+                },
+                "required": ["id"]
+            })
+        }
+
+        fn discovery_summary(&self) -> Option<crate::tools::ToolDiscoverySummary> {
+            Some(crate::tools::ToolDiscoverySummary {
+                always_required: vec!["id".to_string()],
+                conditional_requirements: vec!["mode is needed when updating".to_string()],
+                notes: vec!["Use for mission inspection".to_string()],
+                examples: vec![],
+            })
+        }
+
+        async fn execute(
+            &self,
+            _: serde_json::Value,
+            _: &crate::context::JobContext,
+        ) -> Result<crate::tools::ToolOutput, crate::tools::ToolError> {
+            unreachable!("not needed")
+        }
+    }
+
     async fn projected_action_names(
         tool_name: &'static str,
         description: &'static str,
@@ -305,6 +372,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: None,
+            available_actions_snapshot: None,
         }
     }
 
@@ -340,6 +408,26 @@ mod tests {
 
         assert_eq!(resolved.name, "linear-server");
         assert!(resolved.installed);
+    }
+
+    #[test]
+    fn project_tool_action_preserves_discovery_metadata() {
+        let tool = std::sync::Arc::new(DiscoveryTool);
+        let action = project_tool_action(tool.as_ref());
+
+        assert_eq!(action.description, "Mission helper");
+        assert!(
+            action.parameters_schema["properties"].get("mode").is_none(),
+            "callable schema should stay on the executable surface only"
+        );
+
+        let discovery = action.discovery.expect("discovery metadata");
+        assert_eq!(discovery.name, "mission_helper");
+        assert!(discovery.summary.is_some());
+        let schema_override = discovery
+            .schema_override
+            .expect("discovery schema override");
+        assert!(schema_override["properties"].get("mode").is_some());
     }
 
     #[tokio::test]

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -1000,7 +1000,26 @@ impl EffectBridgeAdapter {
                         duration: start.elapsed(),
                     });
                 }
-                Ok(None) => {}
+                Ok(None) => {
+                    let requested = parameters
+                        .get("name")
+                        .and_then(|value| value.as_str())
+                        .unwrap_or("<missing>");
+                    let error_msg = format!(
+                        "Tool tool_info failed: no callable action named '{requested}' is available in this execution context"
+                    );
+                    let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
+                    return Ok(ActionResult {
+                        call_id: context
+                            .current_call_id
+                            .clone()
+                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                        action_name: canonical_action_name.to_string(),
+                        output: serde_json::json!({"error": sanitized.content}),
+                        is_error: true,
+                        duration: start.elapsed(),
+                    });
+                }
                 Err(error) => {
                     let error_msg = format!("Tool {} failed: {}", "tool_info", error);
                     let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
@@ -2669,23 +2688,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn tool_info_falls_back_to_registry_when_snapshot_misses() {
-        use crate::tools::builtin::EchoTool;
-        use ironclaw_safety::SafetyConfig;
-
-        let tools = Arc::new(ToolRegistry::new());
-        tools.register(Arc::new(EchoTool)).await;
-        tools.register_tool_info();
-
-        let adapter = EffectBridgeAdapter::new(
-            Arc::clone(&tools),
-            Arc::new(SafetyLayer::new(&SafetyConfig {
-                max_output_length: 10_000,
-                injection_check_enabled: false,
-            })),
-            Arc::new(HookRegistry::default()),
-        );
-
+    async fn tool_info_rejects_actions_outside_callable_snapshot() {
+        let adapter = make_adapter();
         let mut ctx = exec_ctx(
             ironclaw_engine::ThreadId::new(),
             Some("call_tool_info_registry"),
@@ -2710,10 +2714,18 @@ mod tests {
                 &ctx,
             )
             .await
-            .expect("tool_info should fall back to the registry after a snapshot miss");
+            .expect("tool_info should return an error result for out-of-snapshot actions");
 
-        assert!(!result.is_error);
-        assert_eq!(result.output["name"], serde_json::json!("echo"));
+        assert!(result.is_error);
+        assert_eq!(result.action_name, "tool_info");
+        assert!(
+            result.output["error"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("no callable action named 'echo'"),
+            "unexpected error output: {:?}",
+            result.output
+        );
     }
 
     #[tokio::test]

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -16,8 +16,9 @@ use tokio::sync::RwLock;
 use tracing::debug;
 
 use ironclaw_engine::{
-    ActionDef, ActionResult, CapabilityLease, CapabilityRegistry, CapabilitySummary,
-    EffectExecutor, EngineError, MountError, Store, ThreadExecutionContext, WorkspaceMounts,
+    ActionDef, ActionInventory, ActionResult, CapabilityLease, CapabilityRegistry,
+    CapabilitySummary, EffectExecutor, EngineError, MountError, Store, ThreadExecutionContext,
+    WorkspaceMounts,
 };
 use ironclaw_skills::SkillRegistry;
 
@@ -984,55 +985,67 @@ impl EffectBridgeAdapter {
             });
         }
 
-        if canonical_action_name == "tool_info"
-            && let Some(actions) = context.available_actions_snapshot.as_ref()
-        {
-            match ActionDiscovery::tool_info(&parameters, actions.as_ref()) {
-                Ok(Some(output)) => {
-                    return Ok(ActionResult {
-                        call_id: context
-                            .current_call_id
-                            .clone()
-                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
-                        action_name: canonical_action_name.to_string(),
-                        output: output.result,
-                        is_error: false,
-                        duration: start.elapsed(),
-                    });
-                }
-                Ok(None) => {
-                    let requested = parameters
-                        .get("name")
-                        .and_then(|value| value.as_str())
-                        .unwrap_or("<missing>");
-                    let error_msg = format!(
-                        "Tool tool_info failed: no callable action named '{requested}' is available in this execution context"
-                    );
-                    let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
-                    return Ok(ActionResult {
-                        call_id: context
-                            .current_call_id
-                            .clone()
-                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
-                        action_name: canonical_action_name.to_string(),
-                        output: serde_json::json!({"error": sanitized.content}),
-                        is_error: true,
-                        duration: start.elapsed(),
-                    });
-                }
-                Err(error) => {
-                    let error_msg = format!("Tool {} failed: {}", "tool_info", error);
-                    let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
-                    return Ok(ActionResult {
-                        call_id: context
-                            .current_call_id
-                            .clone()
-                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
-                        action_name: canonical_action_name.to_string(),
-                        output: serde_json::json!({"error": sanitized.content}),
-                        is_error: true,
-                        duration: start.elapsed(),
-                    });
+        if canonical_action_name == "tool_info" {
+            let snapshot_result = context
+                .available_action_inventory_snapshot
+                .as_deref()
+                .map(|inventory| ActionDiscovery::tool_info(&parameters, inventory))
+                .or_else(|| {
+                    context
+                        .available_actions_snapshot
+                        .as_deref()
+                        .map(|actions| {
+                            ActionDiscovery::tool_info_from_actions(&parameters, actions)
+                        })
+                });
+            if let Some(snapshot_result) = snapshot_result {
+                match snapshot_result {
+                    Ok(Some(output)) => {
+                        return Ok(ActionResult {
+                            call_id: context
+                                .current_call_id
+                                .clone()
+                                .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                            action_name: canonical_action_name.to_string(),
+                            output: output.result,
+                            is_error: false,
+                            duration: start.elapsed(),
+                        });
+                    }
+                    Ok(None) => {
+                        let requested = parameters
+                            .get("name")
+                            .and_then(|value| value.as_str())
+                            .unwrap_or("<missing>");
+                        let error_msg = format!(
+                            "Tool tool_info failed: no callable action named '{requested}' is available in this execution context"
+                        );
+                        let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
+                        return Ok(ActionResult {
+                            call_id: context
+                                .current_call_id
+                                .clone()
+                                .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                            action_name: canonical_action_name.to_string(),
+                            output: serde_json::json!({"error": sanitized.content}),
+                            is_error: true,
+                            duration: start.elapsed(),
+                        });
+                    }
+                    Err(error) => {
+                        let error_msg = format!("Tool {} failed: {}", "tool_info", error);
+                        let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
+                        return Ok(ActionResult {
+                            call_id: context
+                                .current_call_id
+                                .clone()
+                                .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                            action_name: canonical_action_name.to_string(),
+                            output: serde_json::json!({"error": sanitized.content}),
+                            is_error: true,
+                            duration: start.elapsed(),
+                        });
+                    }
                 }
             }
         }
@@ -1639,12 +1652,23 @@ impl EffectExecutor for EffectBridgeAdapter {
         leases: &[CapabilityLease],
         context: &ThreadExecutionContext,
     ) -> Result<Vec<ActionDef>, EngineError> {
+        Ok(self
+            .available_action_inventory(leases, context)
+            .await?
+            .inline)
+    }
+
+    async fn available_action_inventory(
+        &self,
+        leases: &[CapabilityLease],
+        context: &ThreadExecutionContext,
+    ) -> Result<ActionInventory, EngineError> {
         let auth_manager = self.auth_manager.read().await.clone();
         let capability_registry = self.capability_registry.read().await.clone();
         let extensions = self
             .fetch_extension_map(auth_manager.as_deref(), context)
             .await;
-        ActionProjector::project(
+        let actions = ActionProjector::project_actions(
             self.tools.as_ref(),
             auth_manager.as_deref(),
             capability_registry,
@@ -1652,7 +1676,9 @@ impl EffectExecutor for EffectBridgeAdapter {
             context,
             extensions.as_ref(),
         )
-        .await
+        .await?;
+
+        Ok(ActionInventory { inline: actions })
     }
 
     async fn available_capabilities(
@@ -2627,6 +2653,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some("test goal".to_string()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         }
     }
 
@@ -2725,6 +2752,54 @@ mod tests {
                 .contains("no callable action named 'echo'"),
             "unexpected error output: {:?}",
             result.output
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_info_reads_action_inventory_snapshot() {
+        let adapter = make_adapter();
+        let mut ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_tool_info"));
+        ctx.available_action_inventory_snapshot = Some(Arc::new(ActionInventory {
+            inline: vec![ActionDef {
+                name: "github_search".to_string(),
+                description: "Search GitHub".to_string(),
+                parameters_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"}
+                    },
+                    "required": ["query"]
+                }),
+                effects: vec![],
+                requires_approval: false,
+                discovery: Some(ironclaw_engine::ActionDiscoveryMetadata {
+                    name: "github_search".to_string(),
+                    summary: Some(ironclaw_engine::ActionDiscoverySummary {
+                        always_required: vec!["query".to_string()],
+                        conditional_requirements: vec![],
+                        notes: vec!["Schema available through tool_info".to_string()],
+                        examples: vec![],
+                    }),
+                    schema_override: None,
+                }),
+            }],
+        }));
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "github_search", "detail": "summary"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should resolve action inventory discovery");
+
+        assert!(!result.is_error);
+        assert_eq!(result.output["name"], serde_json::json!("github_search"));
+        assert_eq!(
+            result.output["summary"]["always_required"],
+            serde_json::json!(["query"])
         );
     }
 
@@ -3636,6 +3711,7 @@ mod tests {
                 "Summarize the product feedback for me right now. Do it immediately.".to_string(),
             ),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3656,6 +3732,7 @@ mod tests {
                 "Create a daily routine to summarize product feedback and run it now.".to_string(),
             ),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -3674,6 +3751,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some("Summarize every product feedback item right now.".to_string()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3692,6 +3770,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some("Set up the product feedback summary right now.".to_string()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3713,6 +3792,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some("Set up monitoring now.".to_string()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         // Should NOT be rejected — "monitoring" implies scheduling intent.
@@ -3732,6 +3812,7 @@ mod tests {
             user_timezone: None,
             thread_goal: Some("Summarize feedback immediately.".to_string()),
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -3955,6 +4036,7 @@ mod tests {
                 user_timezone: None,
                 thread_goal: Some(goal.to_string()),
                 available_actions_snapshot: None,
+                available_action_inventory_snapshot: None,
             }
         }
 
@@ -4237,6 +4319,7 @@ mod tests {
             user_timezone: None,
             thread_goal: None,
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         let result = adapter.execute_action("http", params, &lease, &ctx).await;
@@ -4334,6 +4417,7 @@ mod tests {
             user_timezone: None,
             thread_goal: None,
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         let result = adapter
@@ -4445,6 +4529,7 @@ mod tests {
             user_timezone: None,
             thread_goal: None,
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         let result = adapter
@@ -4635,6 +4720,7 @@ mod tests {
         name: String,
         description: String,
         provider_extension: String,
+        parameters_schema: serde_json::Value,
     }
 
     struct ProviderFixture {
@@ -4653,7 +4739,7 @@ mod tests {
         }
 
         fn parameters_schema(&self) -> serde_json::Value {
-            serde_json::json!({"type": "object"})
+            self.parameters_schema.clone()
         }
 
         async fn execute(
@@ -4676,6 +4762,7 @@ mod tests {
         provider_name: &str,
         action_name: &str,
         capabilities: serde_json::Value,
+        parameters_schema: serde_json::Value,
     ) -> ProviderFixture {
         use crate::secrets::InMemorySecretsStore;
         use crate::secrets::SecretsCrypto;
@@ -4709,6 +4796,7 @@ mod tests {
                 name: action_name.to_string(),
                 description: format!("{action_name} test action"),
                 provider_extension: provider_name.to_string(),
+                parameters_schema,
             }))
             .await;
 
@@ -4770,6 +4858,7 @@ mod tests {
                     }
                 }
             }),
+            serde_json::json!({"type": "object"}),
         )
         .await;
 
@@ -4796,6 +4885,7 @@ mod tests {
                     ]
                 }
             }),
+            serde_json::json!({"type": "object"}),
         )
         .await;
 
@@ -4815,6 +4905,7 @@ mod tests {
             serde_json::json!({
                 "description": "GitHub provider fixture"
             }),
+            serde_json::json!({"type": "object"}),
         )
         .await;
 
@@ -4824,6 +4915,59 @@ mod tests {
             .await
             .expect("actions");
         assert!(!actions.iter().any(|action| action.name == "github_search"));
+    }
+
+    #[tokio::test]
+    async fn available_action_inventory_keeps_provider_actions_inline_callable() {
+        let fixture = make_adapter_with_installed_provider_fixture(
+            "gmail",
+            "gmail",
+            serde_json::json!({
+                "description": "Gmail provider fixture"
+            }),
+            serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }),
+        )
+        .await;
+
+        let base_ctx = exec_ctx(ironclaw_engine::ThreadId::new(), None);
+        let inventory = fixture
+            .adapter
+            .available_action_inventory(&[], &base_ctx)
+            .await
+            .expect("inventory");
+
+        assert!(
+            inventory.inline.iter().any(|action| action.name == "gmail"),
+            "provider action should stay inline-callable"
+        );
+        let gmail = inventory
+            .inline
+            .iter()
+            .find(|action| action.name == "gmail")
+            .expect("provider action should be inline");
+        assert_eq!(gmail.description, "gmail test action");
+        assert_eq!(
+            gmail.parameters_schema,
+            serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            })
+        );
+
+        let actions = fixture
+            .adapter
+            .available_actions(&[], &base_ctx)
+            .await
+            .expect("actions");
+        assert!(
+            actions.iter().any(|action| action.name == "gmail"),
+            "provider action must remain callable in the provider surface"
+        );
     }
 
     #[tokio::test]
@@ -4897,6 +5041,7 @@ mod tests {
             user_timezone: None,
             thread_goal: None,
             available_actions_snapshot: None,
+            available_action_inventory_snapshot: None,
         };
 
         let capabilities = adapter

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -947,9 +947,18 @@ impl EffectBridgeAdapter {
         approval_already_granted: bool,
     ) -> Result<ActionResult, EngineError> {
         let start = Instant::now();
+        let canonical_action_name = context
+            .available_actions_snapshot
+            .as_ref()
+            .and_then(|actions| ActionDiscovery::resolve(actions, action_name))
+            .map(|action| action.name.as_str())
+            .unwrap_or(action_name);
 
-        let resolved_name = self.tools.resolve_name(action_name).await;
-        let mut lookup_name = resolved_name.as_deref().unwrap_or(action_name).to_string();
+        let resolved_name = self.tools.resolve_name(canonical_action_name).await;
+        let mut lookup_name = resolved_name
+            .as_deref()
+            .unwrap_or(canonical_action_name)
+            .to_string();
 
         // ── Per-step call limit (prevent amplification loops) ──
         const MAX_CALLS_PER_STEP: u32 = 50;
@@ -966,7 +975,7 @@ impl EffectBridgeAdapter {
         }
 
         if let Some(result) = self
-            .handle_mission_call(action_name, &parameters, context)
+            .handle_mission_call(canonical_action_name, &parameters, context)
             .await
         {
             return result.map(|mut r| {
@@ -975,7 +984,7 @@ impl EffectBridgeAdapter {
             });
         }
 
-        if action_name == "tool_info"
+        if canonical_action_name == "tool_info"
             && let Some(actions) = context.available_actions_snapshot.as_ref()
         {
             match ActionDiscovery::tool_info(&parameters, actions) {
@@ -984,8 +993,8 @@ impl EffectBridgeAdapter {
                         call_id: context
                             .current_call_id
                             .clone()
-                            .unwrap_or_else(|| synthetic_action_call_id(action_name)),
-                        action_name: action_name.to_string(),
+                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                        action_name: canonical_action_name.to_string(),
                         output: output.result,
                         is_error: false,
                         duration: start.elapsed(),
@@ -999,8 +1008,8 @@ impl EffectBridgeAdapter {
                         call_id: context
                             .current_call_id
                             .clone()
-                            .unwrap_or_else(|| synthetic_action_call_id(action_name)),
-                        action_name: action_name.to_string(),
+                            .unwrap_or_else(|| synthetic_action_call_id(canonical_action_name)),
+                        action_name: canonical_action_name.to_string(),
                         output: serde_json::json!({"error": sanitized.content}),
                         is_error: true,
                         duration: start.elapsed(),
@@ -2653,6 +2662,80 @@ mod tests {
         assert_eq!(
             result.output["summary"]["always_required"],
             serde_json::json!(["name", "goal", "cadence"])
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_info_falls_back_to_registry_when_snapshot_misses() {
+        use crate::tools::builtin::EchoTool;
+        use ironclaw_safety::SafetyConfig;
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(EchoTool)).await;
+        tools.register_tool_info();
+
+        let adapter = EffectBridgeAdapter::new(
+            Arc::clone(&tools),
+            Arc::new(SafetyLayer::new(&SafetyConfig {
+                max_output_length: 10_000,
+                injection_check_enabled: false,
+            })),
+            Arc::new(HookRegistry::default()),
+        );
+
+        let mut ctx = exec_ctx(
+            ironclaw_engine::ThreadId::new(),
+            Some("call_tool_info_registry"),
+        );
+        ctx.available_actions_snapshot = Some(vec![ActionDef {
+            name: "mission_create".to_string(),
+            description: "Create a mission".to_string(),
+            parameters_schema: serde_json::json!({"type": "object"}),
+            effects: vec![],
+            requires_approval: false,
+            discovery: None,
+        }]);
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "echo", "detail": "summary"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should fall back to the registry after a snapshot miss");
+
+        assert!(!result.is_error);
+        assert_eq!(result.output["name"], serde_json::json!("echo"));
+    }
+
+    #[tokio::test]
+    async fn hyphenated_engine_native_action_uses_snapshot_canonical_name() {
+        let adapter = make_adapter_with_missions().await;
+        let mut ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_mission_alias"));
+        ctx.available_actions_snapshot =
+            Some(crate::bridge::engine_actions::mission_capability_actions());
+
+        let result = adapter
+            .execute_action(
+                "mission-create",
+                serde_json::json!({
+                    "name": "daily check",
+                    "goal": "check systems",
+                    "cadence": "manual"
+                }),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("hyphenated mission action should canonicalize through the snapshot");
+
+        assert!(!result.is_error, "got error: {}", result.output);
+        assert_eq!(result.action_name, "mission_create");
+        assert_eq!(
+            result.output.get("status").and_then(|value| value.as_str()),
+            Some("created")
         );
     }
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -950,7 +950,7 @@ impl EffectBridgeAdapter {
         let canonical_action_name = context
             .available_actions_snapshot
             .as_ref()
-            .and_then(|actions| ActionDiscovery::resolve(actions, action_name))
+            .and_then(|actions| ActionDiscovery::resolve(actions.as_ref(), action_name))
             .map(|action| action.name.as_str())
             .unwrap_or(action_name);
 
@@ -987,7 +987,7 @@ impl EffectBridgeAdapter {
         if canonical_action_name == "tool_info"
             && let Some(actions) = context.available_actions_snapshot.as_ref()
         {
-            match ActionDiscovery::tool_info(&parameters, actions) {
+            match ActionDiscovery::tool_info(&parameters, actions.as_ref()) {
                 Ok(Some(output)) => {
                     return Ok(ActionResult {
                         call_id: context
@@ -2615,37 +2615,40 @@ mod tests {
     async fn tool_info_reads_callable_action_snapshot_for_engine_native_actions() {
         let adapter = make_adapter();
         let mut ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_tool_info"));
-        ctx.available_actions_snapshot = Some(vec![ActionDef {
-            name: "mission_create".to_string(),
-            description: "Create a mission".to_string(),
-            parameters_schema: serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "name": {"type": "string"},
-                    "goal": {"type": "string"},
-                    "cadence": {"type": "string"}
-                },
-                "required": ["name", "goal", "cadence"]
-            }),
-            effects: vec![],
-            requires_approval: false,
-            discovery: Some(ironclaw_engine::ActionDiscoveryMetadata {
+        ctx.available_actions_snapshot = Some(
+            vec![ActionDef {
                 name: "mission_create".to_string(),
-                summary: Some(ironclaw_engine::ActionDiscoverySummary {
-                    always_required: vec![
-                        "name".to_string(),
-                        "goal".to_string(),
-                        "cadence".to_string(),
-                    ],
-                    conditional_requirements: vec![
-                        "Use this only for recurring or scheduled work".to_string(),
-                    ],
-                    notes: vec![],
-                    examples: vec![],
+                description: "Create a mission".to_string(),
+                parameters_schema: serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string"},
+                        "goal": {"type": "string"},
+                        "cadence": {"type": "string"}
+                    },
+                    "required": ["name", "goal", "cadence"]
                 }),
-                schema_override: None,
-            }),
-        }]);
+                effects: vec![],
+                requires_approval: false,
+                discovery: Some(ironclaw_engine::ActionDiscoveryMetadata {
+                    name: "mission_create".to_string(),
+                    summary: Some(ironclaw_engine::ActionDiscoverySummary {
+                        always_required: vec![
+                            "name".to_string(),
+                            "goal".to_string(),
+                            "cadence".to_string(),
+                        ],
+                        conditional_requirements: vec![
+                            "Use this only for recurring or scheduled work".to_string(),
+                        ],
+                        notes: vec![],
+                        examples: vec![],
+                    }),
+                    schema_override: None,
+                }),
+            }]
+            .into(),
+        );
 
         let result = adapter
             .execute_action(
@@ -2687,14 +2690,17 @@ mod tests {
             ironclaw_engine::ThreadId::new(),
             Some("call_tool_info_registry"),
         );
-        ctx.available_actions_snapshot = Some(vec![ActionDef {
-            name: "mission_create".to_string(),
-            description: "Create a mission".to_string(),
-            parameters_schema: serde_json::json!({"type": "object"}),
-            effects: vec![],
-            requires_approval: false,
-            discovery: None,
-        }]);
+        ctx.available_actions_snapshot = Some(
+            vec![ActionDef {
+                name: "mission_create".to_string(),
+                description: "Create a mission".to_string(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![],
+                requires_approval: false,
+                discovery: None,
+            }]
+            .into(),
+        );
 
         let result = adapter
             .execute_action(
@@ -2715,7 +2721,7 @@ mod tests {
         let adapter = make_adapter_with_missions().await;
         let mut ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_mission_alias"));
         ctx.available_actions_snapshot =
-            Some(crate::bridge::engine_actions::mission_capability_actions());
+            Some(crate::bridge::engine_actions::mission_capability_actions().into());
 
         let result = adapter
             .execute_action(

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -23,6 +23,7 @@ use ironclaw_skills::SkillRegistry;
 
 use crate::auth::extension::{AuthCheckResult, AuthManager, LatentActionExecution, ToolReadiness};
 use crate::auth::oauth::sanitize_auth_url;
+use crate::bridge::action_discovery::ActionDiscovery;
 use crate::bridge::action_projector::ActionProjector;
 use crate::bridge::capability_projector::CapabilityProjector;
 use crate::bridge::router::synthetic_action_call_id;
@@ -972,6 +973,40 @@ impl EffectBridgeAdapter {
                 r.duration = start.elapsed();
                 r
             });
+        }
+
+        if action_name == "tool_info"
+            && let Some(actions) = context.available_actions_snapshot.as_ref()
+        {
+            match ActionDiscovery::tool_info(&parameters, actions) {
+                Ok(Some(output)) => {
+                    return Ok(ActionResult {
+                        call_id: context
+                            .current_call_id
+                            .clone()
+                            .unwrap_or_else(|| synthetic_action_call_id(action_name)),
+                        action_name: action_name.to_string(),
+                        output: output.result,
+                        is_error: false,
+                        duration: start.elapsed(),
+                    });
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    let error_msg = format!("Tool {} failed: {}", "tool_info", error);
+                    let sanitized = self.safety.sanitize_tool_output("tool_info", &error_msg);
+                    return Ok(ActionResult {
+                        call_id: context
+                            .current_call_id
+                            .clone()
+                            .unwrap_or_else(|| synthetic_action_call_id(action_name)),
+                        action_name: action_name.to_string(),
+                        output: serde_json::json!({"error": sanitized.content}),
+                        is_error: true,
+                        duration: start.elapsed(),
+                    });
+                }
+            }
         }
 
         if is_v1_only_tool(&lookup_name) {
@@ -2563,7 +2598,62 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: Some("test goal".to_string()),
+            available_actions_snapshot: None,
         }
+    }
+
+    #[tokio::test]
+    async fn tool_info_reads_callable_action_snapshot_for_engine_native_actions() {
+        let adapter = make_adapter();
+        let mut ctx = exec_ctx(ironclaw_engine::ThreadId::new(), Some("call_tool_info"));
+        ctx.available_actions_snapshot = Some(vec![ActionDef {
+            name: "mission_create".to_string(),
+            description: "Create a mission".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "goal": {"type": "string"},
+                    "cadence": {"type": "string"}
+                },
+                "required": ["name", "goal", "cadence"]
+            }),
+            effects: vec![],
+            requires_approval: false,
+            discovery: Some(ironclaw_engine::ActionDiscoveryMetadata {
+                name: "mission_create".to_string(),
+                summary: Some(ironclaw_engine::ActionDiscoverySummary {
+                    always_required: vec![
+                        "name".to_string(),
+                        "goal".to_string(),
+                        "cadence".to_string(),
+                    ],
+                    conditional_requirements: vec![
+                        "Use this only for recurring or scheduled work".to_string(),
+                    ],
+                    notes: vec![],
+                    examples: vec![],
+                }),
+                schema_override: None,
+            }),
+        }]);
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "mission_create", "detail": "summary"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should succeed through callable action discovery");
+
+        assert!(!result.is_error);
+        assert_eq!(result.output["name"], serde_json::json!("mission_create"));
+        assert_eq!(
+            result.output["summary"]["always_required"],
+            serde_json::json!(["name", "goal", "cadence"])
+        );
     }
 
     #[tokio::test]
@@ -3444,6 +3534,7 @@ mod tests {
             thread_goal: Some(
                 "Summarize the product feedback for me right now. Do it immediately.".to_string(),
             ),
+            available_actions_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3463,6 +3554,7 @@ mod tests {
             thread_goal: Some(
                 "Create a daily routine to summarize product feedback and run it now.".to_string(),
             ),
+            available_actions_snapshot: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -3480,6 +3572,7 @@ mod tests {
             source_channel: Some("gateway".to_string()),
             user_timezone: None,
             thread_goal: Some("Summarize every product feedback item right now.".to_string()),
+            available_actions_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3497,6 +3590,7 @@ mod tests {
             source_channel: Some("gateway".to_string()),
             user_timezone: None,
             thread_goal: Some("Set up the product feedback summary right now.".to_string()),
+            available_actions_snapshot: None,
         };
 
         assert!(should_reject_immediate_mission_create(&ctx));
@@ -3517,6 +3611,7 @@ mod tests {
             source_channel: Some("gateway".to_string()),
             user_timezone: None,
             thread_goal: Some("Set up monitoring now.".to_string()),
+            available_actions_snapshot: None,
         };
 
         // Should NOT be rejected — "monitoring" implies scheduling intent.
@@ -3535,6 +3630,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: Some("Summarize feedback immediately.".to_string()),
+            available_actions_snapshot: None,
         };
 
         assert!(!should_reject_immediate_mission_create(&ctx));
@@ -3757,6 +3853,7 @@ mod tests {
                 source_channel: Some("gateway".to_string()),
                 user_timezone: None,
                 thread_goal: Some(goal.to_string()),
+                available_actions_snapshot: None,
             }
         }
 
@@ -4038,6 +4135,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: None,
+            available_actions_snapshot: None,
         };
 
         let result = adapter.execute_action("http", params, &lease, &ctx).await;
@@ -4134,6 +4232,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: None,
+            available_actions_snapshot: None,
         };
 
         let result = adapter
@@ -4244,6 +4343,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: None,
+            available_actions_snapshot: None,
         };
 
         let result = adapter
@@ -4695,6 +4795,7 @@ mod tests {
             source_channel: None,
             user_timezone: None,
             thread_goal: None,
+            available_actions_snapshot: None,
         };
 
         let capabilities = adapter
@@ -5951,29 +6052,7 @@ Use this skill to set up a Pika meeting.
         ironclaw_engine::Capability {
             name: "missions".into(),
             description: "Mission lifecycle".into(),
-            actions: vec![
-                ActionDef {
-                    name: "mission_create".into(),
-                    description: "Create a mission".into(),
-                    parameters_schema: serde_json::json!({"type": "object"}),
-                    effects: vec![],
-                    requires_approval: false,
-                },
-                ActionDef {
-                    name: "mission_list".into(),
-                    description: "List missions".into(),
-                    parameters_schema: serde_json::json!({"type": "object"}),
-                    effects: vec![],
-                    requires_approval: false,
-                },
-                ActionDef {
-                    name: "mission_complete".into(),
-                    description: "Complete a mission".into(),
-                    parameters_schema: serde_json::json!({"type": "object"}),
-                    effects: vec![],
-                    requires_approval: false,
-                },
-            ],
+            actions: crate::bridge::engine_actions::mission_capability_actions(),
             knowledge: vec![],
             policies: vec![],
         }
@@ -6022,6 +6101,33 @@ Use this skill to set up a Pika meeting.
                 "expected {expected} in advertised actions, got: {names:?}"
             );
         }
+
+        let mission_create = actions
+            .iter()
+            .find(|action| action.name == "mission_create")
+            .expect("mission_create should be advertised");
+        assert_eq!(
+            mission_create.parameters_schema["required"],
+            serde_json::json!(["name", "goal", "cadence"])
+        );
+        let create_summary = mission_create
+            .discovery_summary()
+            .expect("mission_create should carry curated discovery guidance");
+        assert_eq!(
+            create_summary.always_required,
+            vec![
+                "name".to_string(),
+                "goal".to_string(),
+                "cadence".to_string()
+            ]
+        );
+
+        let mission_list = actions
+            .iter()
+            .find(|action| action.name == "mission_list")
+            .expect("mission_list should be advertised");
+        assert!(mission_list.discovery.is_some());
+        assert!(mission_list.discovery_summary().is_none());
     }
 
     #[tokio::test]
@@ -6177,6 +6283,7 @@ Use this skill to set up a Pika meeting.
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![],
                     requires_approval: false,
+                    discovery: None,
                 },
                 ActionDef {
                     name: "tool_auth".into(), // v1 auth tool
@@ -6184,6 +6291,7 @@ Use this skill to set up a Pika meeting.
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![],
                     requires_approval: false,
+                    discovery: None,
                 },
                 ActionDef {
                     name: "safe_action".into(),
@@ -6191,6 +6299,7 @@ Use this skill to set up a Pika meeting.
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![],
                     requires_approval: false,
+                    discovery: None,
                 },
             ],
             knowledge: vec![],

--- a/src/bridge/engine_actions.rs
+++ b/src/bridge/engine_actions.rs
@@ -140,14 +140,11 @@ pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
                     "cadence": {"type": "string", "description": "New cadence: manual, cron, event:<channel>:<pattern>, or webhook:<path>"},
                     "timezone": {"type": "string", "description": "IANA timezone for cron scheduling"},
                     "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to notify with results"},
-                    "project_id": {"type": "string", "description": "Project ID to move the mission into"},
                     "cooldown_secs": {"type": "integer", "minimum": 0, "description": "Minimum seconds between triggers"},
                     "max_concurrent": {"type": "integer", "minimum": 0, "description": "Maximum simultaneous runs"},
                     "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Duplicate event suppression window"},
                     "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Daily thread budget"},
-                    "success_criteria": {"type": "string", "description": "Completion criteria"},
-                    "paused": {"type": "boolean", "description": "Whether the mission is paused"},
-                    "config": {"type": "object", "description": "Optional cadence-specific config object for advanced updates"}
+                    "success_criteria": {"type": "string", "description": "Completion criteria"}
                 },
                 "required": ["id"]
             }),
@@ -208,6 +205,14 @@ mod tests {
     fn mission_update_has_curated_summary_but_minimal_actions_do_not() {
         let update = action("mission_update");
         assert!(update.discovery_summary().is_some());
+        let props = update
+            .parameters_schema
+            .get("properties")
+            .and_then(|value| value.as_object())
+            .expect("mission_update properties");
+        assert!(!props.contains_key("project_id"));
+        assert!(!props.contains_key("paused"));
+        assert!(!props.contains_key("config"));
 
         let list = action("mission_list");
         assert!(list.discovery.is_some());

--- a/src/bridge/engine_actions.rs
+++ b/src/bridge/engine_actions.rs
@@ -1,0 +1,217 @@
+use ironclaw_engine::{ActionDef, ActionDiscoveryMetadata, ActionDiscoverySummary};
+
+fn action_discovery_summary(
+    always_required: &[&str],
+    conditional_requirements: &[&str],
+    notes: &[&str],
+) -> ActionDiscoverySummary {
+    ActionDiscoverySummary {
+        always_required: always_required
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        conditional_requirements: conditional_requirements
+            .iter()
+            .map(|value| (*value).to_string())
+            .collect(),
+        notes: notes.iter().map(|value| (*value).to_string()).collect(),
+        examples: Vec::new(),
+    }
+}
+
+fn mission_action(
+    name: &str,
+    description: &str,
+    parameters_schema: serde_json::Value,
+    summary: Option<ActionDiscoverySummary>,
+) -> ActionDef {
+    ActionDef {
+        name: name.to_string(),
+        description: description.to_string(),
+        parameters_schema,
+        effects: vec![],
+        requires_approval: false,
+        discovery: Some(ActionDiscoveryMetadata {
+            name: name.to_string(),
+            summary,
+            schema_override: None,
+        }),
+    }
+}
+
+pub(crate) fn mission_capability_actions() -> Vec<ActionDef> {
+    vec![
+        mission_action(
+            "mission_create",
+            "Create a new mission (routine). Use only when the user explicitly wants to set up a recurring task, scheduled check, automation, monitor, or persistent manual mission. Do not use for immediate one-shot requests like 'do it now', 'right now', or 'immediately'; complete those in the current thread. Results are delivered to the current channel by default.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Short name for the mission/routine"},
+                    "goal": {"type": "string", "description": "What this mission should accomplish each run"},
+                    "cadence": {"type": "string", "description": "Required. How to trigger: 'manual', a cron expression (e.g. '0 9 * * *'), 'event:<channel>:<regex_pattern>' (e.g. 'event:telegram:.*', use 'event:*:<pattern>' for any channel), or 'webhook:<path>'"},
+                    "timezone": {"type": "string", "description": "IANA timezone for cron scheduling (e.g. 'America/New_York'). Defaults to the user's channel timezone."},
+                    "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl']). Defaults to current channel."},
+                    "project_id": {"type": "string", "description": "Project ID to scope this mission to. If omitted, uses the current thread's project."},
+                    "cooldown_secs": {"type": "integer", "minimum": 0, "description": "Minimum seconds between triggers (default: 300 for event/webhook, 0 for cron/manual)"},
+                    "max_concurrent": {"type": "integer", "minimum": 0, "description": "Max simultaneous running threads (default: 1 for event/webhook, unlimited for cron/manual)"},
+                    "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Suppress duplicate event triggers within this window in seconds (default: 0)"},
+                    "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Daily thread budget (default: 24 for event/webhook, 10 for cron/manual)"},
+                    "success_criteria": {"type": "string", "description": "Criteria for declaring mission complete"}
+                },
+                "required": ["name", "goal", "cadence"]
+            }),
+            Some(action_discovery_summary(
+                &["name", "goal", "cadence"],
+                &[
+                    "Use mission_create only when the user explicitly wants a recurring, scheduled, event-driven, webhook, or manual reusable mission.",
+                    "For immediate one-shot work, complete the task in the current thread instead of creating a mission.",
+                    "Use notify_channels to override where results are delivered; otherwise the current channel is used by default.",
+                ],
+                &[
+                    "cadence accepts manual, cron, event:<channel>:<pattern>, or webhook:<path>",
+                    "timezone only matters for cron-based schedules",
+                ],
+            )),
+        ),
+        mission_action(
+            "mission_list",
+            "List all missions and routines in the current project.",
+            serde_json::json!({"type": "object"}),
+            None,
+        ),
+        mission_action(
+            "mission_get",
+            "Get detailed status and results of a specific mission or routine. Returns the mission state, approach history, and recent thread outputs. Use when the user asks about mission results, outcome, or progress.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to retrieve"}
+                },
+                "required": ["id"]
+            }),
+            None,
+        ),
+        mission_action(
+            "mission_fire",
+            "Manually trigger a mission or routine to run immediately.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to trigger"}
+                },
+                "required": ["id"]
+            }),
+            None,
+        ),
+        mission_action(
+            "mission_pause",
+            "Pause a running mission or routine.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to pause"}
+                },
+                "required": ["id"]
+            }),
+            None,
+        ),
+        mission_action(
+            "mission_resume",
+            "Resume a paused mission or routine.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to resume"}
+                },
+                "required": ["id"]
+            }),
+            None,
+        ),
+        mission_action(
+            "mission_update",
+            "Update an existing mission or routine. Only include fields you want to change; omitted fields remain unchanged.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to update"},
+                    "name": {"type": "string", "description": "New display name"},
+                    "goal": {"type": "string", "description": "New mission goal"},
+                    "cadence": {"type": "string", "description": "New cadence: manual, cron, event:<channel>:<pattern>, or webhook:<path>"},
+                    "timezone": {"type": "string", "description": "IANA timezone for cron scheduling"},
+                    "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to notify with results"},
+                    "project_id": {"type": "string", "description": "Project ID to move the mission into"},
+                    "cooldown_secs": {"type": "integer", "minimum": 0, "description": "Minimum seconds between triggers"},
+                    "max_concurrent": {"type": "integer", "minimum": 0, "description": "Maximum simultaneous runs"},
+                    "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Duplicate event suppression window"},
+                    "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Daily thread budget"},
+                    "success_criteria": {"type": "string", "description": "Completion criteria"},
+                    "paused": {"type": "boolean", "description": "Whether the mission is paused"},
+                    "config": {"type": "object", "description": "Optional cadence-specific config object for advanced updates"}
+                },
+                "required": ["id"]
+            }),
+            Some(action_discovery_summary(
+                &["id"],
+                &[
+                    "Only include the fields you want to change; omitted fields keep their existing values.",
+                    "When updating cadence, keep timezone aligned with cron-based schedules.",
+                ],
+                &[
+                    "Use mission_update for edits to an existing mission; use mission_create only for a brand new mission.",
+                ],
+            )),
+        ),
+        mission_action(
+            "mission_complete",
+            "Mark a mission or routine complete.",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "id": {"type": "string", "description": "Mission/routine ID to complete"}
+                },
+                "required": ["id"]
+            }),
+            None,
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mission_capability_actions;
+
+    fn action(name: &str) -> ironclaw_engine::ActionDef {
+        mission_capability_actions()
+            .into_iter()
+            .find(|action| action.name == name)
+            .unwrap_or_else(|| panic!("missing mission action {name}"))
+    }
+
+    #[test]
+    fn mission_create_exposes_full_schema_and_curated_summary() {
+        let action = action("mission_create");
+        assert_eq!(action.discovery_name(), "mission_create");
+        assert_eq!(
+            action
+                .parameters_schema
+                .get("required")
+                .expect("required fields"),
+            &serde_json::json!(["name", "goal", "cadence"])
+        );
+        let summary = action.discovery_summary().expect("curated summary");
+        assert_eq!(summary.always_required, vec!["name", "goal", "cadence"]);
+        assert!(!summary.conditional_requirements.is_empty());
+    }
+
+    #[test]
+    fn mission_update_has_curated_summary_but_minimal_actions_do_not() {
+        let update = action("mission_update");
+        assert!(update.discovery_summary().is_some());
+
+        let list = action("mission_list");
+        assert!(list.discovery.is_some());
+        assert!(list.discovery_summary().is_none());
+        assert_eq!(list.discovery_schema(), &list.parameters_schema);
+    }
+}

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -418,9 +418,21 @@ fn thread_msg_to_chat(msg: &ThreadMessage) -> ChatMessage {
 }
 
 fn action_def_to_tool_def(action: &ActionDef) -> ToolDefinition {
+    let has_discovery_hint = action.discovery_summary().is_some()
+        || action.discovery_schema() != &action.parameters_schema;
+    let description = if has_discovery_hint {
+        format!(
+            "{} (call tool_info(name: \"{}\", detail: \"summary\") for rules/examples or detail: \"schema\" for the full discovery schema)",
+            action.description,
+            action.discovery_name()
+        )
+    } else {
+        action.description.clone()
+    };
+
     ToolDefinition {
         name: action.name.clone(),
-        description: action.description.clone(),
+        description,
         parameters: action.parameters_schema.clone(),
     }
 }
@@ -828,6 +840,42 @@ mod tests {
                 cache_creation_input_tokens: 0,
             })
         }
+    }
+
+    #[test]
+    fn action_def_to_tool_def_preserves_tool_info_hint_for_discovery_metadata() {
+        let action = ActionDef {
+            name: "gmail_send".to_string(),
+            description: "Send email".to_string(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "to": { "type": "string" }
+                },
+                "required": ["to"]
+            }),
+            effects: vec![EffectType::WriteExternal],
+            requires_approval: false,
+            discovery: Some(ironclaw_engine::ActionDiscoveryMetadata {
+                name: "gmail_send".to_string(),
+                summary: Some(ironclaw_engine::ActionDiscoverySummary {
+                    notes: vec!["Subject/body rules".to_string()],
+                    ..ironclaw_engine::ActionDiscoverySummary::default()
+                }),
+                schema_override: Some(serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "to": { "type": "string" },
+                        "subject": { "type": "string" }
+                    },
+                    "required": ["to", "subject"]
+                })),
+            }),
+        };
+
+        let tool_def = action_def_to_tool_def(&action);
+        assert!(tool_def.description.contains("tool_info"));
+        assert!(tool_def.parameters["properties"].get("subject").is_none());
     }
 
     #[tokio::test]

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -675,6 +675,7 @@ mod tests {
             }),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }
     }
 
@@ -1020,6 +1021,7 @@ mod tests {
                     parameters_schema: serde_json::json!({"type": "object"}),
                     effects: vec![EffectType::ReadLocal],
                     requires_approval: false,
+                    discovery: None,
                 }],
                 &config,
             )

--- a/src/bridge/mod.rs
+++ b/src/bridge/mod.rs
@@ -4,10 +4,12 @@
 //! route through the engine instead of the existing agentic loop. All
 //! existing behavior is unchanged when the flag is off.
 
+mod action_discovery;
 mod action_projector;
 mod capability_projector;
 mod cost_guard_gate;
 mod effect_adapter;
+mod engine_actions;
 mod llm_adapter;
 mod router;
 pub mod sandbox;

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1086,6 +1086,7 @@ async fn execute_pending_gate_action(
             .and_then(ironclaw_engine::ValidTimezone::parse),
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     state.effect_adapter.reset_call_count();

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -17,6 +17,7 @@ use ironclaw_engine::types::{is_shared_owner, shared_owner_id};
 use crate::agent::Agent;
 use crate::auth::extension::AuthManager;
 use crate::bridge::effect_adapter::EffectBridgeAdapter;
+use crate::bridge::engine_actions::mission_capability_actions;
 use crate::bridge::llm_adapter::LlmBridgeAdapter;
 use crate::bridge::store_adapter::HybridStore;
 use crate::channels::web::GATEWAY_CHANNEL_NAME;
@@ -1084,6 +1085,7 @@ async fn execute_pending_gate_action(
             .and_then(|v| v.as_str())
             .and_then(ironclaw_engine::ValidTimezone::parse),
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     };
 
     state.effect_adapter.reset_call_count();
@@ -1601,126 +1603,7 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
     capabilities.register(Capability {
         name: "missions".into(),
         description: "Mission and routine lifecycle management".into(),
-        actions: vec![
-            ironclaw_engine::ActionDef {
-                name: "mission_create".into(),
-                description: "Create a new mission (routine). Use only when the user explicitly wants to set up a recurring task, scheduled check, automation, monitor, or persistent manual mission. Do not use for immediate one-shot requests like 'do it now', 'right now', or 'immediately'; complete those in the current thread. Results are delivered to the current channel by default.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "name": {"type": "string", "description": "Short name for the mission/routine"},
-                        "goal": {"type": "string", "description": "What this mission should accomplish each run"},
-                        "cadence": {"type": "string", "description": "Required. How to trigger: 'manual', a cron expression (e.g. '0 9 * * *'), 'event:<channel>:<regex_pattern>' (e.g. 'event:telegram:.*', use 'event:*:<pattern>' for any channel), or 'webhook:<path>'"},
-                        "timezone": {"type": "string", "description": "IANA timezone for cron scheduling (e.g. 'America/New_York'). Defaults to the user's channel timezone."},
-                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl']). Defaults to current channel."},
-                        "project_id": {"type": "string", "description": "Project ID to scope this mission to. If omitted, uses the current thread's project."},
-                        "cooldown_secs": {"type": "integer", "minimum": 0, "description": "Minimum seconds between triggers (default: 300 for event/webhook, 0 for cron/manual)"},
-                        "max_concurrent": {"type": "integer", "minimum": 0, "description": "Max simultaneous running threads (default: 1 for event/webhook, unlimited for cron/manual)"},
-                        "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Suppress duplicate event triggers within this window in seconds (default: 0)"},
-                        "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Daily thread budget (default: 24 for event/webhook, 10 for cron/manual)"},
-                        "success_criteria": {"type": "string", "description": "Criteria for declaring mission complete"}
-                    },
-                    "required": ["name", "goal", "cadence"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_list".into(),
-                description: "List all missions and routines in the current project.".into(),
-                parameters_schema: serde_json::json!({"type": "object"}),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_get".into(),
-                description: "Get detailed status and results of a specific mission or routine. Returns the mission state, approach history, and recent thread outputs. Use when the user asks about mission results, outcome, or progress.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to retrieve"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_fire".into(),
-                description: "Manually trigger a mission or routine to run immediately.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to trigger"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_pause".into(),
-                description: "Pause a running mission or routine.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to pause"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_resume".into(),
-                description: "Resume a paused mission or routine.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to resume"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_update".into(),
-                description: "Update a mission/routine. Change name, goal, cadence, guardrails, notification channels, daily budget, or success criteria. Only provided fields are changed.".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to update"},
-                        "name": {"type": "string", "description": "New name"},
-                        "goal": {"type": "string", "description": "New goal"},
-                        "cadence": {"type": "string", "description": "New cadence: 'manual', cron expression (e.g. '0 9 * * *'), 'event:<channel>:<regex_pattern>' (e.g. 'event:telegram:.*', use 'event:*:<pattern>' for any channel), or 'webhook:<path>'"},
-                        "timezone": {"type": "string", "description": "IANA timezone for cron scheduling (e.g. 'America/New_York'). Defaults to the user's channel timezone."},
-                        "notify_channels": {"type": "array", "items": {"type": "string"}, "description": "Channels to deliver results to (e.g. ['gateway', 'repl'])"},
-                        "max_threads_per_day": {"type": "integer", "minimum": 0, "description": "Max threads per day (0 = unlimited)"},
-                        "cooldown_secs": {"type": "integer", "minimum": 0, "description": "Minimum seconds between triggers"},
-                        "max_concurrent": {"type": "integer", "minimum": 0, "description": "Max simultaneous running threads"},
-                        "dedup_window_secs": {"type": "integer", "minimum": 0, "description": "Suppress duplicate event triggers within this window in seconds"},
-                        "success_criteria": {"type": "string", "description": "Criteria for declaring mission complete"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-            ironclaw_engine::ActionDef {
-                name: "mission_complete".into(),
-                description: "Mark a mission or routine as completed (sets status to completed).".into(),
-                parameters_schema: serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "id": {"type": "string", "description": "Mission/routine ID to mark completed"}
-                    },
-                    "required": ["id"]
-                }),
-                effects: vec![],
-                requires_approval: false,
-            },
-        ],
+        actions: mission_capability_actions(),
         knowledge: vec![],
         policies: vec![],
     });

--- a/src/channels/web/handlers/llm.rs
+++ b/src/channels/web/handlers/llm.rs
@@ -568,7 +568,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_llm_providers_returns_nearai_with_env_vars() {
-        // SAFETY: test-only; tokio::test runs single-threaded by default.
+        let _guard = crate::config::helpers::lock_env();
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::set_var("NEARAI_API_KEY", "test-key-123");
             std::env::set_var("NEARAI_MODEL", "test-model");
@@ -604,6 +605,7 @@ mod tests {
         assert_eq!(nearai.get("builtin").and_then(|v| v.as_bool()), Some(true));
 
         // Clean up
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
             std::env::remove_var("NEARAI_MODEL");

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -7950,8 +7950,10 @@ mod tests {
     };
     use crate::pairing::PairingStore;
     use crate::secrets::CreateSecretParams;
-    use crate::tools::mcp::McpServerConfig;
+    use crate::tools::ToolError;
     use crate::tools::mcp::config::NEARAI_MCP_SERVER_NAME;
+    use crate::tools::mcp::{McpClient, McpRequest, McpResponse, McpServerConfig, McpTransport};
+    use async_trait::async_trait;
 
     fn require(condition: bool, message: impl Into<String>) -> Result<(), String> {
         if condition {
@@ -8242,6 +8244,76 @@ mod tests {
         make_test_manager_with_dirs(wasm_runtime, tools_dir.clone(), tools_dir, None)
     }
 
+    struct StaticMcpTransport {
+        responses: std::sync::Mutex<std::collections::VecDeque<McpResponse>>,
+    }
+
+    impl StaticMcpTransport {
+        fn with_single_tool(tool_name: &str, description: &str) -> Self {
+            let init_response = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: Some(1),
+                result: Some(serde_json::json!({
+                    "protocolVersion": "2024-11-05",
+                    "capabilities": {},
+                    "serverInfo": {"name": "test", "version": "1.0"}
+                })),
+                error: None,
+            };
+            let notification_ack = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: None,
+                result: None,
+                error: None,
+            };
+            let list_response = McpResponse {
+                jsonrpc: "2.0".to_string(),
+                id: Some(2),
+                result: Some(serde_json::json!({
+                    "tools": [
+                        {
+                            "name": tool_name,
+                            "description": description,
+                            "inputSchema": {"type": "object"}
+                        }
+                    ]
+                })),
+                error: None,
+            };
+
+            Self {
+                responses: std::sync::Mutex::new(std::collections::VecDeque::from(vec![
+                    init_response,
+                    notification_ack,
+                    list_response,
+                ])),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl McpTransport for StaticMcpTransport {
+        async fn send(
+            &self,
+            _request: &McpRequest,
+            _headers: &std::collections::HashMap<String, String>,
+        ) -> Result<McpResponse, ToolError> {
+            self.responses
+                .lock()
+                .unwrap()
+                .pop_front()
+                .ok_or_else(|| ToolError::ExternalService("No more mock responses".to_string()))
+        }
+
+        async fn shutdown(&self) -> Result<(), ToolError> {
+            Ok(())
+        }
+
+        fn supports_http_features(&self) -> bool {
+            false
+        }
+    }
+
     #[tokio::test]
     async fn inject_mcp_client_partitions_cache_by_user() {
         let dir = tempfile::tempdir().expect("tempdir");
@@ -8252,13 +8324,27 @@ mod tests {
             None,
         );
 
-        let client_a = Arc::new(crate::tools::mcp::McpClient::new_with_name(
+        let client_a = Arc::new(McpClient::new_with_transport(
             "notion",
-            "http://localhost:3001",
+            Arc::new(StaticMcpTransport::with_single_tool(
+                "search",
+                "Search Notion",
+            )),
+            None,
+            None,
+            "default",
+            None,
         ));
-        let client_b = Arc::new(crate::tools::mcp::McpClient::new_with_name(
+        let client_b = Arc::new(McpClient::new_with_transport(
             "notion",
-            "http://localhost:3002",
+            Arc::new(StaticMcpTransport::with_single_tool(
+                "search",
+                "Search Notion",
+            )),
+            None,
+            None,
+            "default",
+            None,
         ));
 
         manager

--- a/src/gate/approval.rs
+++ b/src/gate/approval.rs
@@ -330,6 +330,7 @@ mod tests {
             parameters_schema: serde_json::json!({}),
             effects: vec![EffectType::ReadLocal],
             requires_approval,
+            discovery: None,
         }
     }
 

--- a/src/llm/nearai_chat.rs
+++ b/src/llm/nearai_chat.rs
@@ -1925,6 +1925,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_bearer_token_session_beats_env_var() {
+        struct EnvLockGuard {
+            _guard: std::sync::MutexGuard<'static, ()>,
+        }
+        impl EnvLockGuard {
+            fn new() -> Self {
+                Self {
+                    _guard: crate::config::helpers::lock_env(),
+                }
+            }
+        }
+
+        let _guard = EnvLockGuard::new();
         // Session token takes priority over NEARAI_API_KEY env var.
         // This prevents unexpected auth mode switches mid-run.
         let mut cfg = test_nearai_config("http://localhost:8318");
@@ -1936,6 +1948,7 @@ mod tests {
 
         // Set env var that should NOT be used when session token exists
         #[allow(unused_unsafe)]
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::set_var("NEARAI_API_KEY", "env-api-key-should-not-win");
         }
@@ -1951,6 +1964,7 @@ mod tests {
         );
 
         #[allow(unused_unsafe)]
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
         }
@@ -1958,6 +1972,18 @@ mod tests {
 
     #[tokio::test]
     async fn test_resolve_bearer_token_config_beats_session_and_env() {
+        struct EnvLockGuard {
+            _guard: std::sync::MutexGuard<'static, ()>,
+        }
+        impl EnvLockGuard {
+            fn new() -> Self {
+                Self {
+                    _guard: crate::config::helpers::lock_env(),
+                }
+            }
+        }
+
+        let _guard = EnvLockGuard::new();
         // Config API key should win even when session token AND env var are set.
         let cfg = test_nearai_config("http://localhost:8318");
         let session = test_session();
@@ -1966,6 +1992,7 @@ mod tests {
             .await;
 
         #[allow(unused_unsafe)]
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::set_var("NEARAI_API_KEY", "env-key");
         }
@@ -1981,6 +2008,7 @@ mod tests {
         );
 
         #[allow(unused_unsafe)]
+        // SAFETY: serialized via ENV_MUTEX.
         unsafe {
             std::env::remove_var("NEARAI_API_KEY");
         }

--- a/src/llm/recording.rs
+++ b/src/llm/recording.rs
@@ -1356,7 +1356,8 @@ mod tests {
 
     #[test]
     fn from_env_returns_none_when_unset() {
-        // SAFETY: This test is single-threaded and no other thread reads this var.
+        let _env_lock = crate::config::helpers::lock_env();
+        // SAFETY: Tests serialize env access with lock_env().
         unsafe { std::env::remove_var("IRONCLAW_RECORD_TRACE") };
         let stub = Arc::new(StubLlm::new("response"));
         let result = RecordingLlm::from_env(stub);

--- a/src/tools/builtin/restart.rs
+++ b/src/tools/builtin/restart.rs
@@ -166,12 +166,58 @@ impl Tool for RestartTool {
 mod tests {
     use super::*;
 
-    /// Helper to simulate Docker environment for testing
-    fn enable_docker_env() {
-        unsafe {
-            std::env::set_var("IRONCLAW_IN_DOCKER", "true");
-            // Keep restart tests from terminating the shared lib-test process.
-            std::env::set_var("IRONCLAW_DISABLE_RESTART", "true");
+    struct EnvLockGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvLockGuard {
+        fn new() -> Self {
+            Self {
+                _guard: crate::config::helpers::lock_env(),
+            }
+        }
+    }
+
+    struct DockerEnvGuard {
+        _lock: EnvLockGuard,
+        original_in_docker: Option<String>,
+        original_disable_restart: Option<String>,
+    }
+
+    impl DockerEnvGuard {
+        fn enable() -> Self {
+            let lock = EnvLockGuard::new();
+            let original_in_docker = std::env::var("IRONCLAW_IN_DOCKER").ok();
+            let original_disable_restart = std::env::var("IRONCLAW_DISABLE_RESTART").ok();
+            // SAFETY: Tests serialize env access with lock_env().
+            unsafe {
+                std::env::set_var("IRONCLAW_IN_DOCKER", "true");
+                // Keep restart tests from terminating the shared lib-test process.
+                std::env::set_var("IRONCLAW_DISABLE_RESTART", "true");
+            }
+            Self {
+                _lock: lock,
+                original_in_docker,
+                original_disable_restart,
+            }
+        }
+    }
+
+    impl Drop for DockerEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: Tests serialize env access with lock_env().
+            unsafe {
+                if let Some(ref value) = self.original_in_docker {
+                    std::env::set_var("IRONCLAW_IN_DOCKER", value);
+                } else {
+                    std::env::remove_var("IRONCLAW_IN_DOCKER");
+                }
+                if let Some(ref value) = self.original_disable_restart {
+                    std::env::set_var("IRONCLAW_DISABLE_RESTART", value);
+                } else {
+                    std::env::remove_var("IRONCLAW_DISABLE_RESTART");
+                }
+            }
         }
     }
 
@@ -212,9 +258,9 @@ mod tests {
         assert!(!tool.requires_sanitization());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_delay_parameter_validation() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -235,9 +281,9 @@ mod tests {
         assert!(text.contains("Restarting in 2 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_delay_clamping() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -289,9 +335,9 @@ mod tests {
         assert!(delay_schema.get("description").is_some());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_boundary_values() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -323,9 +369,9 @@ mod tests {
         assert!(text.contains("Restarting in 15 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_invalid_parameter_types() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -357,9 +403,9 @@ mod tests {
         assert!(text.contains("Restarting in 2 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_output_structure() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -377,9 +423,9 @@ mod tests {
         assert!(output.raw.is_none()); // No raw output stored
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_extra_parameters_ignored() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -401,9 +447,9 @@ mod tests {
         assert!(text.contains("Restarting in 5 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_negative_numbers() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -418,9 +464,9 @@ mod tests {
         assert!(text.contains("Restarting in 2 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_very_large_numbers() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -434,9 +480,9 @@ mod tests {
         assert!(text.contains("Restarting in 30 second(s)"));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_restart_tool_empty_object() {
-        enable_docker_env();
+        let _docker_env = DockerEnvGuard::enable();
         let tool = RestartTool;
         let ctx = crate::context::JobContext::new("test", "test restart");
 
@@ -467,6 +513,7 @@ mod tests {
 
     #[test]
     fn test_restart_tool_requires_docker_environment() {
+        let _env_lock = crate::config::helpers::lock_env();
         // Test that restart is rejected when not in Docker (IRONCLAW_IN_DOCKER not set or false)
         // Uses sync test to avoid async/env var ordering issues with test parallelization.
         let in_docker = std::env::var("IRONCLAW_IN_DOCKER")

--- a/src/tools/builtin/shell.rs
+++ b/src/tools/builtin/shell.rs
@@ -1198,6 +1198,47 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    struct EnvLockGuard {
+        _guard: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl EnvLockGuard {
+        fn new() -> Self {
+            Self {
+                _guard: crate::config::helpers::lock_env(),
+            }
+        }
+    }
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            // SAFETY: Tests serialize env access with lock_env().
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // SAFETY: Tests serialize env access with lock_env().
+            unsafe {
+                if let Some(ref value) = self.original {
+                    std::env::set_var(self.key, value);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
     async fn execute_shell(
         tool: &ShellTool,
         params: serde_json::Value,
@@ -1619,10 +1660,10 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_env_scrubbing_hides_secrets() {
+        let _env_lock = EnvLockGuard::new();
         // Set a fake secret in the current process environment.
-        // SAFETY: test-only, single-threaded tokio runtime, no concurrent env access.
         let secret_var = "IRONCLAW_TEST_SECRET_KEY";
-        unsafe { std::env::set_var(secret_var, "super_secret_value_12345") };
+        let _secret_guard = EnvVarGuard::set(secret_var, "super_secret_value_12345");
 
         let tool = ShellTool::new();
         let ctx = JobContext::default();
@@ -1650,10 +1691,6 @@ mod tests {
             output.contains("PATH="),
             "PATH should be forwarded to child processes"
         );
-
-        // Clean up
-        // SAFETY: test-only, single-threaded tokio runtime.
-        unsafe { std::env::remove_var(secret_var) };
     }
 
     #[tokio::test]
@@ -1682,6 +1719,7 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn test_env_scrubbing_common_secret_patterns() {
+        let _env_lock = EnvLockGuard::new();
         // Simulate common secret env vars that agents/tools might set
         let secrets = [
             ("OPENAI_API_KEY", "sk-test-fake-key-123"),
@@ -1690,10 +1728,10 @@ mod tests {
             ("DATABASE_URL", "postgres://user:pass@localhost/db"),
         ];
 
-        // SAFETY: test-only, single-threaded tokio runtime, no concurrent env access.
-        for (name, value) in &secrets {
-            unsafe { std::env::set_var(name, value) };
-        }
+        let _secret_guards: Vec<_> = secrets
+            .iter()
+            .map(|(name, value)| EnvVarGuard::set(name, value))
+            .collect();
 
         let tool = ShellTool::new();
         let ctx = JobContext::default();
@@ -1710,12 +1748,6 @@ mod tests {
                 !output.contains(value),
                 "{name} value leaked through env scrubbing!"
             );
-        }
-
-        // Clean up
-        // SAFETY: test-only, single-threaded tokio runtime.
-        for (name, _) in &secrets {
-            unsafe { std::env::remove_var(name) };
         }
     }
 
@@ -1819,15 +1851,16 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_env_scrubbing_custom_var_hidden() {
+        let _env_lock = EnvLockGuard::new();
         // Verify that arbitrary env vars from the parent process
         // are NOT visible to child commands (end-to-end, not just unit).
         let tool = ShellTool::new();
         let ctx = JobContext::default();
 
         // Set a fake secret in the parent process env
-        unsafe { std::env::set_var("IRONCLAW_QA_TEST_SECRET", "supersecret123") };
+        let _secret_guard = EnvVarGuard::set("IRONCLAW_QA_TEST_SECRET", "supersecret123");
 
         let result = tool
             .execute(serde_json::json!({"command": "env"}), &ctx)
@@ -1843,9 +1876,6 @@ mod tests {
             !output.contains("supersecret123"),
             "secret value must not appear in child env output"
         );
-
-        // Clean up
-        unsafe { std::env::remove_var("IRONCLAW_QA_TEST_SECRET") };
     }
 
     #[tokio::test]

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -17,6 +17,7 @@ pub mod mcp;
 pub mod permissions;
 pub mod rate_limiter;
 pub mod redaction;
+pub(crate) mod schema_metrics;
 pub mod schema_validator;
 pub mod wasm;
 

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -37,6 +37,6 @@ pub use rate_limiter::RateLimiter;
 pub use registry::{ToolRegistry, is_protected_tool_name};
 pub use tool::{
     ApprovalContext, ApprovalRequirement, EngineCompatibility, EngineVersion, RiskLevel, Tool,
-    ToolDomain, ToolError, ToolOutput, ToolRateLimitConfig, check_approval_in_context,
-    redact_params, validate_tool_schema,
+    ToolDiscoverySummary, ToolDomain, ToolError, ToolOutput, ToolRateLimitConfig,
+    check_approval_in_context, redact_params, require_param, require_str, validate_tool_schema,
 };

--- a/src/tools/schema_metrics.rs
+++ b/src/tools/schema_metrics.rs
@@ -1,0 +1,65 @@
+fn schema_is_typed_property(schema: &serde_json::Value) -> bool {
+    matches!(
+        schema.get("type"),
+        Some(serde_json::Value::String(_)) | Some(serde_json::Value::Array(_))
+    ) || schema.get("$ref").is_some()
+        || schema.get("anyOf").is_some()
+        || schema.get("oneOf").is_some()
+        || schema.get("allOf").is_some()
+        || schema.get("items").is_some()
+        || schema
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .is_some()
+        || schema
+            .get("additionalProperties")
+            .is_some_and(serde_json::Value::is_object)
+}
+
+pub(crate) fn is_permissive_schema(schema: &serde_json::Value) -> bool {
+    if schema
+        .get("properties")
+        .and_then(|p| p.as_object())
+        .is_some_and(|p| !p.is_empty())
+    {
+        return false;
+    }
+
+    for key in ["oneOf", "anyOf", "allOf"] {
+        if let Some(variants) = schema.get(key).and_then(|v| v.as_array())
+            && variants.iter().any(|variant| {
+                variant
+                    .get("properties")
+                    .and_then(|p| p.as_object())
+                    .is_some_and(|p| !p.is_empty())
+            })
+        {
+            return false;
+        }
+    }
+
+    true
+}
+
+pub(crate) fn typed_property_count(schema: &serde_json::Value) -> usize {
+    let mut all_props = serde_json::Map::new();
+
+    if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
+        all_props.extend(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+    }
+
+    for key in ["allOf", "oneOf", "anyOf"] {
+        if let Some(variants) = schema.get(key).and_then(|v| v.as_array()) {
+            for variant in variants {
+                if let Some(props) = variant.get("properties").and_then(|p| p.as_object()) {
+                    all_props.extend(props.iter().map(|(k, v)| (k.clone(), v.clone())));
+                }
+            }
+        }
+    }
+
+    all_props
+        .values()
+        .filter(|prop| schema_is_typed_property(prop))
+        .count()
+}

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -653,51 +653,11 @@ impl WasmToolSchemas {
     }
 
     fn is_permissive_schema(schema: &serde_json::Value) -> bool {
-        if schema
-            .get("properties")
-            .and_then(|p| p.as_object())
-            .is_some_and(|p| !p.is_empty())
-        {
-            return false;
-        }
-
-        // Schemas with combinator variants containing properties are not permissive
-        for key in ["oneOf", "anyOf", "allOf"] {
-            if let Some(variants) = schema.get(key).and_then(|v| v.as_array())
-                && variants.iter().any(|v| {
-                    v.get("properties")
-                        .and_then(|p| p.as_object())
-                        .is_some_and(|p| !p.is_empty())
-                })
-            {
-                return false;
-            }
-        }
-
-        true
+        crate::tools::schema_metrics::is_permissive_schema(schema)
     }
 
     fn typed_property_count(schema: &serde_json::Value) -> usize {
-        let mut all_props = serde_json::Map::new();
-
-        if let Some(props) = schema.get("properties").and_then(|p| p.as_object()) {
-            all_props.extend(props.iter().map(|(k, v)| (k.clone(), v.clone())));
-        }
-
-        for key in ["allOf", "oneOf", "anyOf"] {
-            if let Some(variants) = schema.get(key).and_then(|v| v.as_array()) {
-                for variant in variants {
-                    if let Some(props) = variant.get("properties").and_then(|p| p.as_object()) {
-                        all_props.extend(props.iter().map(|(k, v)| (k.clone(), v.clone())));
-                    }
-                }
-            }
-        }
-
-        all_props
-            .values()
-            .filter(|prop| schema_is_typed_property(prop))
-            .count()
+        crate::tools::schema_metrics::typed_property_count(schema)
     }
 
     fn new(discovery: serde_json::Value) -> Self {
@@ -2881,7 +2841,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn test_resolve_host_credentials_refreshes_via_proxy_without_direct_token_url_validation()
     {
         use crate::secrets::{
@@ -2890,19 +2850,31 @@ mod tests {
         use crate::tools::wasm::capabilities::HttpCapability;
         use crate::tools::wasm::wrapper::{OAuthRefreshConfig, resolve_host_credentials};
 
+        struct EnvLockGuard {
+            _guard: std::sync::MutexGuard<'static, ()>,
+        }
+        impl EnvLockGuard {
+            fn new() -> Self {
+                Self {
+                    _guard: crate::config::helpers::lock_env(),
+                }
+            }
+        }
+
         // The OAuth proxy URL is now SSRF-validated. The mock proxy below
         // binds to a loopback address, which is normally rejected; opt into
         // the loopback escape hatch so the test can exercise the proxy
         // refresh path end-to-end. The escape hatch only affects this
         // process and is not exposed to operators.
+        let _env_lock = EnvLockGuard::new();
         struct EnvGuard;
         impl Drop for EnvGuard {
             fn drop(&mut self) {
-                // safety: env mutation in tests; var is test-only.
+                // SAFETY: Tests serialize env access with lock_env().
                 unsafe { std::env::remove_var("IRONCLAW_OAUTH_PROXY_ALLOW_LOOPBACK") };
             }
         }
-        // safety: env mutation in tests; var is test-only.
+        // SAFETY: Tests serialize env access with lock_env().
         unsafe { std::env::set_var("IRONCLAW_OAUTH_PROXY_ALLOW_LOOPBACK", "1") };
         let _proxy_loopback_guard = EnvGuard;
 

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -20,8 +20,8 @@ use tokio::sync::RwLock;
 
 use ironclaw_engine::types::capability::{EffectType, LeaseId};
 use ironclaw_engine::{
-    ActionDef, ActionResult, Capability, CapabilityLease, CapabilityRegistry, DocId,
-    EffectExecutor, EngineError, GrantedActions, LeaseManager, LlmBackend, LlmCallConfig,
+    ActionDef, ActionInventory, ActionResult, Capability, CapabilityLease, CapabilityRegistry,
+    DocId, EffectExecutor, EngineError, GrantedActions, LeaseManager, LlmBackend, LlmCallConfig,
     LlmOutput, LlmResponse, MemoryDoc, Mission, MissionId, MissionStatus, PolicyEngine, Project,
     ProjectId, ResumeKind, Step, Store, Thread, ThreadConfig, ThreadEvent, ThreadId, ThreadManager,
     ThreadMessage, ThreadOutcome, ThreadState, ThreadType, TokenUsage,
@@ -69,6 +69,54 @@ impl LlmBackend for ScriptedLlm {
     }
     fn model_name(&self) -> &str {
         "scripted-mock"
+    }
+}
+
+struct ActionCapturingScriptedLlm {
+    responses: std::sync::Mutex<Vec<LlmOutput>>,
+    seen_action_names: std::sync::Mutex<Vec<Vec<String>>>,
+}
+
+impl ActionCapturingScriptedLlm {
+    fn new(responses: Vec<LlmOutput>) -> Arc<Self> {
+        Arc::new(Self {
+            responses: std::sync::Mutex::new(responses),
+            seen_action_names: std::sync::Mutex::new(Vec::new()),
+        })
+    }
+
+    fn seen_action_names(&self) -> Vec<Vec<String>> {
+        self.seen_action_names.lock().unwrap().clone()
+    }
+}
+
+#[async_trait::async_trait]
+impl LlmBackend for ActionCapturingScriptedLlm {
+    async fn complete(
+        &self,
+        _messages: &[ThreadMessage],
+        actions: &[ActionDef],
+        _config: &LlmCallConfig,
+    ) -> Result<LlmOutput, EngineError> {
+        self.seen_action_names.lock().unwrap().push(
+            actions
+                .iter()
+                .map(|action| action.name.clone())
+                .collect::<Vec<_>>(),
+        );
+        let mut queue = self.responses.lock().unwrap();
+        if queue.is_empty() {
+            Ok(LlmOutput {
+                response: LlmResponse::Text("done".into()),
+                usage: TokenUsage::default(),
+            })
+        } else {
+            Ok(queue.remove(0))
+        }
+    }
+
+    fn model_name(&self) -> &str {
+        "action-capturing-scripted-mock"
     }
 }
 
@@ -389,6 +437,110 @@ impl EffectExecutor for GateMockEffects {
                 discovery: None,
             },
         ])
+    }
+
+    async fn available_capabilities(
+        &self,
+        _leases: &[CapabilityLease],
+        _context: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<Vec<ironclaw_engine::CapabilitySummary>, EngineError> {
+        Ok(vec![])
+    }
+}
+
+struct ToolInfoCallableEffects;
+
+#[async_trait::async_trait]
+impl EffectExecutor for ToolInfoCallableEffects {
+    async fn execute_action(
+        &self,
+        action_name: &str,
+        parameters: serde_json::Value,
+        _lease: &CapabilityLease,
+        _context: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<ActionResult, EngineError> {
+        let output = match action_name {
+            "tool_info" => serde_json::json!({
+                "name": "gmail",
+                "description": "Gmail tool",
+                "parameters": ["query"],
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"}
+                    },
+                    "required": ["query"]
+                }
+            }),
+            "gmail" => serde_json::json!({
+                "status": "ok",
+                "result": "gmail called",
+                "params": parameters
+            }),
+            other => serde_json::json!({
+                "status": "ok",
+                "result": format!("{other} called")
+            }),
+        };
+
+        Ok(ActionResult {
+            call_id: String::new(),
+            action_name: action_name.to_string(),
+            output,
+            is_error: false,
+            duration: Duration::from_millis(1),
+        })
+    }
+
+    async fn available_actions(
+        &self,
+        leases: &[CapabilityLease],
+        context: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<Vec<ActionDef>, EngineError> {
+        Ok(self
+            .available_action_inventory(leases, context)
+            .await?
+            .inline)
+    }
+
+    async fn available_action_inventory(
+        &self,
+        _leases: &[CapabilityLease],
+        _context: &ironclaw_engine::ThreadExecutionContext,
+    ) -> Result<ActionInventory, EngineError> {
+        let tool_info = ActionDef {
+            name: "tool_info".into(),
+            description: "Inspect a tool".into(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "detail": {"type": "string"}
+                },
+                "required": ["name"]
+            }),
+            effects: vec![EffectType::ReadLocal],
+            requires_approval: false,
+            discovery: None,
+        };
+        let gmail = ActionDef {
+            name: "gmail".into(),
+            description: "Gmail tool".into(),
+            parameters_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"}
+                },
+                "required": ["query"]
+            }),
+            effects: vec![EffectType::ReadExternal],
+            requires_approval: false,
+            discovery: None,
+        };
+
+        Ok(ActionInventory {
+            inline: vec![gmail, tool_info],
+        })
     }
 
     async fn available_capabilities(
@@ -923,6 +1075,78 @@ async fn gate_paused_thread_resumes_to_completion() {
 }
 
 #[tokio::test]
+async fn tool_info_does_not_gate_callable_tool_into_next_llm_callable_set() {
+    let project_id = ProjectId::new();
+    let effects: Arc<dyn EffectExecutor> = Arc::new(ToolInfoCallableEffects);
+    let llm = ActionCapturingScriptedLlm::new(vec![
+        LlmOutput {
+            response: LlmResponse::ActionCalls {
+                calls: vec![ironclaw_engine::ActionCall {
+                    id: "call_tool_info_1".into(),
+                    action_name: "tool_info".into(),
+                    parameters: serde_json::json!({
+                        "name": "gmail",
+                        "detail": "schema"
+                    }),
+                }],
+                content: None,
+            },
+            usage: TokenUsage::default(),
+        },
+        LlmOutput {
+            response: LlmResponse::Text("done".into()),
+            usage: TokenUsage::default(),
+        },
+    ]);
+
+    let store = TestStore::new();
+    let mgr = ThreadManager::new(
+        llm.clone(),
+        effects,
+        store.clone() as Arc<dyn Store>,
+        Arc::new(make_caps(false)),
+        Arc::new(LeaseManager::new()),
+        Arc::new(PolicyEngine::new()),
+    );
+
+    let tid = mgr
+        .spawn_thread(
+            "inspect the gmail tool and continue",
+            ThreadType::Foreground,
+            project_id,
+            ThreadConfig::default(),
+            None,
+            "test-user",
+        )
+        .await
+        .expect("spawn_thread");
+
+    let outcome = mgr.join_thread(tid).await.expect("join");
+    assert!(matches!(outcome, ThreadOutcome::Completed { .. }));
+
+    let seen_action_names = llm.seen_action_names();
+    assert!(
+        seen_action_names.len() >= 2,
+        "expected at least two LLM calls, got {seen_action_names:?}"
+    );
+    assert!(
+        seen_action_names[0].contains(&"tool_info".to_string()),
+        "tool_info should be callable on the first step: {:?}",
+        seen_action_names[0]
+    );
+    assert!(
+        seen_action_names[0].contains(&"gmail".to_string()),
+        "gmail should already be callable on the first step: {:?}",
+        seen_action_names[0]
+    );
+    assert!(
+        seen_action_names[1].contains(&"gmail".to_string()),
+        "gmail should remain callable on the next step after tool_info: {:?}",
+        seen_action_names[1]
+    );
+}
+
+#[tokio::test]
 async fn approval_resolution_executes_pending_call_directly() {
     let project_id = ProjectId::new();
     let tools = Arc::new(ToolRegistry::new());
@@ -1017,6 +1241,7 @@ async fn approval_resolution_executes_pending_call_directly() {
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     let tool_result = effects
@@ -1154,6 +1379,7 @@ async fn auth_resolution_retries_same_pending_action_without_second_pause() {
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     effects.mark_authenticated("http").await;
@@ -1266,6 +1492,7 @@ async fn approval_chains_directly_into_auth_for_install_flow() {
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     effects.mark_approved("tool_install").await;
@@ -1408,6 +1635,7 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     };
 
     effects.mark_authenticated("tool_install").await;

--- a/tests/engine_v2_gate_integration.rs
+++ b/tests/engine_v2_gate_integration.rs
@@ -245,6 +245,7 @@ impl EffectExecutor for InstallThenAliasEffects {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "create-issue".into(),
@@ -252,6 +253,7 @@ impl EffectExecutor for InstallThenAliasEffects {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
         ])
     }
@@ -368,6 +370,7 @@ impl EffectExecutor for GateMockEffects {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "echo".into(),
@@ -375,6 +378,7 @@ impl EffectExecutor for GateMockEffects {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "tool_install".into(),
@@ -382,6 +386,7 @@ impl EffectExecutor for GateMockEffects {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
         ])
     }
@@ -593,6 +598,7 @@ fn make_caps(require_approval: bool) -> CapabilityRegistry {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: require_approval,
+                discovery: None,
             },
             ActionDef {
                 name: "echo".into(),
@@ -600,6 +606,7 @@ fn make_caps(require_approval: bool) -> CapabilityRegistry {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "tool_install".into(),
@@ -607,6 +614,7 @@ fn make_caps(require_approval: bool) -> CapabilityRegistry {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: require_approval,
+                discovery: None,
             },
         ],
         knowledge: vec![],
@@ -626,6 +634,7 @@ fn make_caps_with_approval_tool() -> CapabilityRegistry {
             parameters_schema: serde_json::json!({"type": "object"}),
             effects: vec![EffectType::WriteExternal],
             requires_approval: false,
+            discovery: None,
         }],
         knowledge: vec![],
         policies: vec![],
@@ -645,6 +654,7 @@ fn make_caps_with_install_and_alias_followup() -> CapabilityRegistry {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "create_issue".into(),
@@ -652,6 +662,7 @@ fn make_caps_with_install_and_alias_followup() -> CapabilityRegistry {
                 parameters_schema: serde_json::json!({"type": "object"}),
                 effects: vec![EffectType::WriteExternal],
                 requires_approval: false,
+                discovery: None,
             },
         ],
         knowledge: vec![],
@@ -1005,6 +1016,7 @@ async fn approval_resolution_executes_pending_call_directly() {
         source_channel: None,
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     };
 
     let tool_result = effects
@@ -1141,6 +1153,7 @@ async fn auth_resolution_retries_same_pending_action_without_second_pause() {
         source_channel: None,
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     };
 
     effects.mark_authenticated("http").await;
@@ -1252,6 +1265,7 @@ async fn approval_chains_directly_into_auth_for_install_flow() {
         source_channel: None,
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     };
 
     effects.mark_approved("tool_install").await;
@@ -1393,6 +1407,7 @@ async fn install_auth_resume_followed_by_aliased_tool_call_completes_without_han
         source_channel: None,
         user_timezone: None,
         thread_goal: Some(thread.goal.clone()),
+        available_actions_snapshot: None,
     };
 
     effects.mark_authenticated("tool_install").await;
@@ -1749,6 +1764,7 @@ async fn lease_planner_mission_excludes_denylisted() {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::ReadLocal],
                 requires_approval: false,
+                discovery: None,
             },
             ActionDef {
                 name: "routine_create".into(),
@@ -1756,6 +1772,7 @@ async fn lease_planner_mission_excludes_denylisted() {
                 parameters_schema: serde_json::json!({}),
                 effects: vec![EffectType::WriteLocal],
                 requires_approval: false,
+                discovery: None,
             },
         ],
         knowledge: vec![],
@@ -1895,6 +1912,7 @@ async fn lease_gate_denies_without_lease() {
         parameters_schema: serde_json::json!({}),
         effects: vec![EffectType::WriteLocal],
         requires_approval: true,
+        discovery: None,
     };
     let auto = std::collections::HashSet::new();
     let params = serde_json::json!({});
@@ -1941,6 +1959,7 @@ async fn lease_gate_allows_with_valid_lease() {
         parameters_schema: serde_json::json!({}),
         effects: vec![EffectType::WriteLocal],
         requires_approval: true,
+        discovery: None,
     };
     let auto = std::collections::HashSet::new();
     let params = serde_json::json!({});
@@ -2011,6 +2030,7 @@ async fn pipeline_first_deny_wins() {
         parameters_schema: serde_json::json!({}),
         effects: vec![],
         requires_approval: false,
+        discovery: None,
     };
     let auto = std::collections::HashSet::new();
     let params = serde_json::json!({});
@@ -2102,6 +2122,7 @@ async fn auto_approve_mode_still_pauses_always_tools() {
         parameters_schema: serde_json::json!({}),
         effects: vec![EffectType::WriteExternal],
         requires_approval: true, // This maps to Always in the real system
+        discovery: None,
     };
     let auto = std::collections::HashSet::new();
     let params = serde_json::json!({});

--- a/tests/engine_v2_sandbox_integration.rs
+++ b/tests/engine_v2_sandbox_integration.rs
@@ -92,6 +92,7 @@ fn make_context(project_id: ProjectId) -> ThreadExecutionContext {
         source_channel: None,
         user_timezone: None,
         thread_goal: None,
+        available_actions_snapshot: None,
     }
 }
 

--- a/tests/engine_v2_sandbox_integration.rs
+++ b/tests/engine_v2_sandbox_integration.rs
@@ -93,6 +93,7 @@ fn make_context(project_id: ProjectId) -> ThreadExecutionContext {
         user_timezone: None,
         thread_goal: None,
         available_actions_snapshot: None,
+        available_action_inventory_snapshot: None,
     }
 }
 

--- a/tests/engine_v2_skill_codeact.rs
+++ b/tests/engine_v2_skill_codeact.rs
@@ -215,6 +215,7 @@ impl EffectExecutor for HttpMockEffects {
             }),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }])
     }
 
@@ -297,6 +298,7 @@ impl EffectExecutor for PausingHttpMockEffects {
             }),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }])
     }
 
@@ -601,6 +603,7 @@ FINAL(str(result))
             parameters_schema: serde_json::json!({"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }],
         knowledge: vec![],
         policies: vec![],
@@ -708,6 +711,7 @@ FINAL(str(result))
             parameters_schema: serde_json::json!({"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }],
         knowledge: vec![],
         policies: vec![],
@@ -851,6 +855,7 @@ async fn skill_prompt_context_survives_pause_and_resume() {
             parameters_schema: serde_json::json!({"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }],
         knowledge: vec![],
         policies: vec![],
@@ -972,6 +977,7 @@ async fn skill_prompt_context_survives_compaction_and_resume() {
             parameters_schema: serde_json::json!({"type": "object", "properties": {"url": {"type": "string"}}, "required": ["url"]}),
             effects: vec![EffectType::ReadExternal],
             requires_approval: false,
+            discovery: None,
         }],
         knowledge: vec![],
         policies: vec![],


### PR DESCRIPTION
## Summary
- add canonical discovery metadata to `ActionDef` and expose it through the engine crate
- map registry-backed tool discovery metadata into projected engine-v2 actions and move mission action metadata into a dedicated bridge module
- make engine-v2 `tool_info` read from the callable action snapshot first so advertised actions like `mission_create` are discoverable without changing callable exposure policy

## Testing
- cargo fmt --all
- cargo test action_projector --lib
- cargo test action_discovery --lib
- cargo test tool_info_reads_callable_action_snapshot_for_engine_native_actions --lib
- cargo test available_actions_surfaces_leased_mission_capability --lib
- cargo test available_actions_respects_partial_lease_grant --lib
- cargo test available_actions_omits_capability_without_lease --lib
- cargo test mission_create_exposes_full_schema_and_curated_summary --lib
- cargo test mission_update_has_curated_summary_but_minimal_actions_do_not --lib
- cargo test --test engine_v2_gate_integration --no-run
- cargo test --test engine_v2_skill_codeact --no-run
- cargo test --test engine_v2_sandbox_integration --no-run

Closes #2793
Part of #2834 and Section 6 of #2767.