### PR TITLE
fix(bridge): surface latent WASM provider actions to the LLM (#2883)

### DIFF
--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -158,15 +158,19 @@ impl ActionProjector {
         // requires auth first — so the LLM never calls them and the
         // auth-on-first-call gate never fires. See issue #2883.
         if let Some(auth_manager) = auth_manager {
-            for latent in auth_manager
-                .latent_provider_actions(&context.user_id)
-                .await
-            {
-                if !seen.insert(latent.action_name.clone()) {
+            for latent in auth_manager.latent_provider_actions(&context.user_id).await {
+                // Normalize hyphen→underscore to match the first loop's
+                // `td.name.replace('-', '_')`. This keeps the action name
+                // stable for the LLM before and after auth (registered
+                // tools surface as underscores) and ensures the `seen`
+                // dedup correctly suppresses overlap with tools already
+                // added above.
+                let name = latent.action_name.replace('-', "_");
+                if !seen.insert(name.clone()) {
                     continue;
                 }
                 actions.push(ActionDef {
-                    name: latent.action_name,
+                    name,
                     description: latent.description,
                     parameters_schema: latent.parameters_schema,
                     effects: vec![],

--- a/src/bridge/action_projector.rs
+++ b/src/bridge/action_projector.rs
@@ -118,8 +118,9 @@ impl ActionProjector {
             });
         }
 
+        let mut seen: HashSet<String> = actions.iter().map(|a| a.name.clone()).collect();
+
         if let Some(registry) = capability_registry.as_ref() {
-            let mut seen: HashSet<String> = actions.iter().map(|a| a.name.clone()).collect();
             for lease in leases {
                 if lease.capability_name == "tools" {
                     continue;
@@ -147,6 +148,30 @@ impl ActionProjector {
                     }
                     actions.push(action.clone());
                 }
+            }
+        }
+
+        // Surface installed-but-not-yet-ready provider tools (primarily
+        // WASM tools pending OAuth) as callable actions. Without this,
+        // unauthenticated WASM tools are invisible to the LLM — they're
+        // registered in `tool_registry` only after activation, which
+        // requires auth first — so the LLM never calls them and the
+        // auth-on-first-call gate never fires. See issue #2883.
+        if let Some(auth_manager) = auth_manager {
+            for latent in auth_manager
+                .latent_provider_actions(&context.user_id)
+                .await
+            {
+                if !seen.insert(latent.action_name.clone()) {
+                    continue;
+                }
+                actions.push(ActionDef {
+                    name: latent.action_name,
+                    description: latent.description,
+                    parameters_schema: latent.parameters_schema,
+                    effects: vec![],
+                    requires_approval: false,
+                });
             }
         }
 

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -4268,8 +4268,14 @@ mod tests {
         }
     }
 
+    /// Regression for #2883: latent provider actions (installed but not yet
+    /// ready — primarily WASM tools pending OAuth) must surface as callable
+    /// actions so the LLM can attempt them and trigger the auth-on-first-call
+    /// gate. Before the fix, unauthenticated WASM tools were invisible to the
+    /// LLM because `tool_definitions()` only returns registered tools and WASM
+    /// tools register only at activation (which requires auth first).
     #[tokio::test]
-    async fn available_actions_omit_latent_inactive_provider_actions() {
+    async fn available_actions_include_latent_inactive_provider_actions() {
         use crate::secrets::InMemorySecretsStore;
         use crate::secrets::SecretsCrypto;
         use crate::tools::mcp::process::McpProcessManager;
@@ -4332,7 +4338,11 @@ mod tests {
             .available_actions(&[], &exec_ctx(ironclaw_engine::ThreadId::new(), None))
             .await
             .expect("actions");
-        assert!(!actions.iter().any(|action| action.name == "latent_tool"));
+        assert!(
+            actions.iter().any(|action| action.name == "latent_tool"),
+            "latent WASM tool should appear in available_actions so the LLM can call it and trigger auth; got: {:?}",
+            actions.iter().map(|a| &a.name).collect::<Vec<_>>()
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #2883 — after `d33fecb1` centralized the action vs capability surface policy, WASM tools pending OAuth became invisible to the LLM, so the auth-on-first-call gate never fired. User-visible symptom: asking the assistant to connect Gmail returns "secrets are missing" without triggering the OAuth prompt.

## Root cause

`d33fecb1` dropped the latent-iteration loop from `ActionProjector::project`. Latent provider actions are tools owned by installed extensions that are not yet ready — primarily WASM tools pending OAuth. WASM tools register in `tool_registry` only at activation, and activation requires auth first, so if they aren't surfaced as callable `ActionDef`s the LLM never attempts them and the gate never triggers.

## Fix

Re-add the latent-iteration loop at the end of `ActionProjector::project`, sharing the `seen` dedup set with the capability-lease pass so the same action name isn't emitted twice. Latent actions use `effects: vec![]` and `requires_approval: false`; approval/effects are enforced at auth-gate and capability-lease time, not in the action-projection surface.

## Tests

Flipped the previously-negative `available_actions_omit_latent_inactive_provider_actions` assertion into a positive `available_actions_include_latent_inactive_provider_actions` regression test, with an explanatory docstring pointing at #2883.

- `cargo test -p ironclaw bridge::effect_adapter::tests::available_actions` - 7/7 pass
- Full bridge suite - 374/374 pass
- `cargo clippy` - clean

## Manual verification

Built from this branch with `ENGINE_V2=true` and repro'd the Gmail flow that was reported in #2883 — the OAuth auth gate now fires on first call instead of silently reporting missing secrets.

Fixes #2883
