### PR TITLE
test(harness): add Phase 2 replay and gateway coverage

### DIFF
--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -6180,7 +6180,7 @@ mod tests {
     use crate::hooks::HookRegistry;
     use crate::testing::{StubChannel, StubLlm};
     use crate::tools::ToolRegistry;
-    use futures::{StreamExt, stream};
+    use futures::{FutureExt, StreamExt, stream};
     use ironclaw_safety::SafetyLayer;
     use rust_decimal::Decimal;
 
@@ -9103,6 +9103,22 @@ mod tests {
         }
     }
 
+    async fn with_installed_engine_state<T, F>(state: EngineState, future: F) -> T
+    where
+        F: std::future::Future<Output = T>,
+    {
+        let lock = ENGINE_STATE.get_or_init(|| TokioRwLock::new(None));
+        *lock.write().await = Some(state);
+
+        let outcome = std::panic::AssertUnwindSafe(future).catch_unwind().await;
+
+        *lock.write().await = None;
+        match outcome {
+            Ok(value) => value,
+            Err(panic) => std::panic::resume_unwind(panic),
+        }
+    }
+
     /// Caller-level regression: the text-based auth fallback inside
     /// `handle_with_engine_inner()` must convert a completed thread
     /// response containing `authentication_required` into a pending auth
@@ -9111,19 +9127,16 @@ mod tests {
     #[tokio::test]
     async fn handle_with_engine_text_auth_fallback_emits_pending_gate_for_registered_credential() {
         let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
-        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
-        *lock.write().await = None;
 
-        let outcome = async {
-            let store = Arc::new(TestStore::new());
-            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
-                text: r#"{"error":"authentication_required","credential_name":"github_pat"}"#
-                    .to_string(),
-            });
-            let state = make_expected_test_state_with_llm(store, llm);
-            let pending_gates = Arc::clone(&state.pending_gates);
-            *lock.write().await = Some(state);
+        let store = Arc::new(TestStore::new());
+        let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+            text: r#"{"error":"authentication_required","credential_name":"github_pat"}"#
+                .to_string(),
+        });
+        let state = make_expected_test_state_with_llm(store, llm);
+        let pending_gates = Arc::clone(&state.pending_gates);
 
+        let outcome = with_installed_engine_state(state, async move {
             let (mut agent, statuses) = make_test_agent_with_status_channel("web").await;
 
             let credential_registry = Arc::new(crate::tools::wasm::SharedCredentialRegistry::new());
@@ -9163,10 +9176,9 @@ mod tests {
             assert_eq!(pending[0].parameters["credential_name"], "github_pat");
 
             Ok::<(), crate::error::Error>(())
-        }
+        })
         .await;
 
-        *lock.write().await = None;
         outcome.expect("registered auth fallback should create pending gate");
     }
 
@@ -9176,19 +9188,16 @@ mod tests {
     #[tokio::test]
     async fn handle_with_engine_text_auth_fallback_passthrough_for_unregistered_credential() {
         let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
-        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
-        *lock.write().await = None;
 
-        let outcome = async {
-            let store = Arc::new(TestStore::new());
-            let raw = r#"{"error":"authentication_required","credential_name":"github_pat"}"#;
-            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
-                text: raw.to_string(),
-            });
-            let state = make_expected_test_state_with_llm(store, llm);
-            let pending_gates = Arc::clone(&state.pending_gates);
-            *lock.write().await = Some(state);
+        let store = Arc::new(TestStore::new());
+        let raw = r#"{"error":"authentication_required","credential_name":"github_pat"}"#;
+        let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+            text: raw.to_string(),
+        });
+        let state = make_expected_test_state_with_llm(store, llm);
+        let pending_gates = Arc::clone(&state.pending_gates);
 
+        let outcome = with_installed_engine_state(state, async move {
             let (agent, statuses) = make_test_agent_with_status_channel("web").await;
             let message = IncomingMessage::new("web", "alice", "call the github api");
             let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
@@ -9214,10 +9223,9 @@ mod tests {
             );
 
             Ok::<(), crate::error::Error>(())
-        }
+        })
         .await;
 
-        *lock.write().await = None;
         outcome.expect("unregistered auth fallback should pass through raw text");
     }
 
@@ -9228,19 +9236,16 @@ mod tests {
     #[tokio::test]
     async fn handle_with_engine_text_auth_fallback_rejects_invalid_credential_name() {
         let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
-        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
-        *lock.write().await = None;
 
-        let outcome = async {
-            let store = Arc::new(TestStore::new());
-            let raw = r#"{"error":"authentication_required","credential_name":"github-pat"}"#;
-            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
-                text: raw.to_string(),
-            });
-            let state = make_expected_test_state_with_llm(store, llm);
-            let pending_gates = Arc::clone(&state.pending_gates);
-            *lock.write().await = Some(state);
+        let store = Arc::new(TestStore::new());
+        let raw = r#"{"error":"authentication_required","credential_name":"github-pat"}"#;
+        let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+            text: raw.to_string(),
+        });
+        let state = make_expected_test_state_with_llm(store, llm);
+        let pending_gates = Arc::clone(&state.pending_gates);
 
+        let outcome = with_installed_engine_state(state, async move {
             let (agent, statuses) = make_test_agent_with_status_channel("web").await;
             let message = IncomingMessage::new("web", "alice", "call the github api");
             let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
@@ -9266,10 +9271,9 @@ mod tests {
             );
 
             Ok::<(), crate::error::Error>(())
-        }
+        })
         .await;
 
-        *lock.write().await = None;
         outcome.expect("invalid credential names should be rejected by caller path");
     }
 

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -9080,6 +9080,199 @@ mod tests {
         assert_eq!(result.unwrap().id, tid);
     }
 
+    struct CompletedTextLlm {
+        text: String,
+    }
+
+    #[async_trait::async_trait]
+    impl ironclaw_engine::LlmBackend for CompletedTextLlm {
+        async fn complete(
+            &self,
+            _messages: &[ironclaw_engine::ThreadMessage],
+            _actions: &[ironclaw_engine::ActionDef],
+            _config: &ironclaw_engine::LlmCallConfig,
+        ) -> Result<ironclaw_engine::LlmOutput, ironclaw_engine::EngineError> {
+            Ok(ironclaw_engine::LlmOutput {
+                response: ironclaw_engine::LlmResponse::Text(self.text.clone()),
+                usage: ironclaw_engine::TokenUsage::default(),
+            })
+        }
+
+        fn model_name(&self) -> &str {
+            "completed-text-llm"
+        }
+    }
+
+    /// Caller-level regression: the text-based auth fallback inside
+    /// `handle_with_engine_inner()` must convert a completed thread
+    /// response containing `authentication_required` into a pending auth
+    /// gate **only when** the parsed credential name survives both the
+    /// helper parse and the credential-registry trust check.
+    #[tokio::test]
+    async fn handle_with_engine_text_auth_fallback_emits_pending_gate_for_registered_credential() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+                text: r#"{"error":"authentication_required","credential_name":"github_pat"}"#
+                    .to_string(),
+            });
+            let state = make_expected_test_state_with_llm(store, llm);
+            let pending_gates = Arc::clone(&state.pending_gates);
+            *lock.write().await = Some(state);
+
+            let (mut agent, statuses) = make_test_agent_with_status_channel("web").await;
+
+            let credential_registry = Arc::new(crate::tools::wasm::SharedCredentialRegistry::new());
+            credential_registry.add_mappings([crate::secrets::CredentialMapping::bearer(
+                "github_pat",
+                "api.github.com",
+            )]);
+            let secrets: Arc<dyn crate::secrets::SecretsStore + Send + Sync> =
+                Arc::new(crate::testing::credentials::test_secrets_store());
+            agent.deps.tools = Arc::new(
+                crate::tools::ToolRegistry::new().with_credentials(credential_registry, secrets),
+            );
+
+            let message = IncomingMessage::new("web", "alice", "call the github api");
+            let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
+                .await
+                .expect("handle_with_engine_inner");
+
+            assert!(matches!(result, BridgeOutcome::Pending));
+
+            let statuses = statuses.lock().expect("poisoned").clone();
+            assert!(
+                statuses.iter().any(|status| matches!(
+                    status,
+                    StatusUpdate::AuthRequired {
+                        extension_name,
+                        request_id: Some(_),
+                        ..
+                    } if extension_name.as_str() == "github_pat"
+                )),
+                "expected AuthRequired with request_id, got: {statuses:?}"
+            );
+
+            let pending = pending_gates.list_for_user("alice").await;
+            assert_eq!(pending.len(), 1, "expected one pending auth gate");
+            assert_eq!(pending[0].action_name, "authentication_fallback");
+            assert_eq!(pending[0].parameters["credential_name"], "github_pat");
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("registered auth fallback should create pending gate");
+    }
+
+    /// Negative caller-level branch: if the parsed credential name is not
+    /// registered, `handle_with_engine_inner()` must NOT surface an auth
+    /// card. It must hand the original response text back to the caller.
+    #[tokio::test]
+    async fn handle_with_engine_text_auth_fallback_passthrough_for_unregistered_credential() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let raw = r#"{"error":"authentication_required","credential_name":"github_pat"}"#;
+            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+                text: raw.to_string(),
+            });
+            let state = make_expected_test_state_with_llm(store, llm);
+            let pending_gates = Arc::clone(&state.pending_gates);
+            *lock.write().await = Some(state);
+
+            let (agent, statuses) = make_test_agent_with_status_channel("web").await;
+            let message = IncomingMessage::new("web", "alice", "call the github api");
+            let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
+                .await
+                .expect("handle_with_engine_inner");
+
+            let BridgeOutcome::Respond(text) = result else {
+                panic!("expected Respond passthrough, got {result:?}");
+            };
+            assert_eq!(text, raw);
+            let seen_auth_required = statuses
+                .lock()
+                .expect("poisoned")
+                .iter()
+                .any(|status| matches!(status, StatusUpdate::AuthRequired { .. }));
+            assert!(
+                !seen_auth_required,
+                "no AuthRequired should be emitted when credential is unregistered"
+            );
+            assert!(
+                pending_gates.list_for_user("alice").await.is_empty(),
+                "no pending gate should be inserted for unregistered credentials"
+            );
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("unregistered auth fallback should pass through raw text");
+    }
+
+    /// Security-focused negative branch: invalid credential names must be
+    /// rejected by the helper parse and therefore never become a real auth
+    /// gate, even when the surrounding response otherwise matches the
+    /// `authentication_required` shape.
+    #[tokio::test]
+    async fn handle_with_engine_text_auth_fallback_rejects_invalid_credential_name() {
+        let _guard = ENGINE_STATE_TEST_LOCK.lock().await;
+        let lock = ENGINE_STATE.get_or_init(|| RwLock::new(None));
+        *lock.write().await = None;
+
+        let outcome = async {
+            let store = Arc::new(TestStore::new());
+            let raw = r#"{"error":"authentication_required","credential_name":"github-pat"}"#;
+            let llm: Arc<dyn ironclaw_engine::LlmBackend> = Arc::new(CompletedTextLlm {
+                text: raw.to_string(),
+            });
+            let state = make_expected_test_state_with_llm(store, llm);
+            let pending_gates = Arc::clone(&state.pending_gates);
+            *lock.write().await = Some(state);
+
+            let (agent, statuses) = make_test_agent_with_status_channel("web").await;
+            let message = IncomingMessage::new("web", "alice", "call the github api");
+            let result = handle_with_engine_inner(&agent, &message, &message.content, 0)
+                .await
+                .expect("handle_with_engine_inner");
+
+            let BridgeOutcome::Respond(text) = result else {
+                panic!("expected Respond passthrough, got {result:?}");
+            };
+            assert_eq!(text, raw);
+            let seen_auth_required = statuses
+                .lock()
+                .expect("poisoned")
+                .iter()
+                .any(|status| matches!(status, StatusUpdate::AuthRequired { .. }));
+            assert!(
+                !seen_auth_required,
+                "invalid credential names must not emit AuthRequired"
+            );
+            assert!(
+                pending_gates.list_for_user("alice").await.is_empty(),
+                "invalid credential names must not create pending gates"
+            );
+
+            Ok::<(), crate::error::Error>(())
+        }
+        .await;
+
+        *lock.write().await = None;
+        outcome.expect("invalid credential names should be rejected by caller path");
+    }
+
     #[test]
     fn parse_credential_name_full_json() {
         let text = r#"{"error":"authentication_required","credential_name":"github_pat"}"#;

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -282,6 +282,20 @@ impl ToolRegistry {
         }
     }
 
+    /// Test-only: replace a registered tool regardless of protection.
+    ///
+    /// Used by the integration test rig to swap built-in tools (e.g.
+    /// `tool_activate`) for stubs that `register()` would otherwise
+    /// reject due to the `PROTECTED_TOOL_NAMES` guard.
+    #[doc(hidden)]
+    pub async fn replace_for_test(&self, tool: Arc<dyn Tool>) {
+        let name = tool.name().to_string();
+        let mut tools = self.tools.write().await;
+        tools.insert(name.clone(), tool);
+        let mut builtins = self.builtin_names.write().await;
+        builtins.insert(name);
+    }
+
     /// Resolve a tool name to the key under which it is registered,
     /// trying the exact name first, then hyphen→underscore and
     /// underscore→hyphen aliases.

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -282,20 +282,6 @@ impl ToolRegistry {
         }
     }
 
-    /// Test-only: replace a registered tool regardless of protection.
-    ///
-    /// Used by the integration test rig to swap built-in tools (e.g.
-    /// `tool_activate`) for stubs that `register()` would otherwise
-    /// reject due to the `PROTECTED_TOOL_NAMES` guard.
-    #[doc(hidden)]
-    pub async fn replace_for_test(&self, tool: Arc<dyn Tool>) {
-        let name = tool.name().to_string();
-        let mut tools = self.tools.write().await;
-        tools.insert(name.clone(), tool);
-        let mut builtins = self.builtin_names.write().await;
-        builtins.insert(name);
-    }
-
     /// Resolve a tool name to the key under which it is registered,
     /// trying the exact name first, then hyphen→underscore and
     /// underscore→hyphen aliases.

--- a/tests/e2e_approval_traces.rs
+++ b/tests/e2e_approval_traces.rs
@@ -1,0 +1,251 @@
+//! Replay coverage for the v1 approval round-trip.
+//!
+//! Phase 2 of #2828 — these are the first fixture-driven tests that
+//! exercise the **full** approval cycle (pause → user resolution →
+//! resume) rather than only the pause invariant. Companion file:
+//! `tests/e2e_response_order.rs::no_done_emitted_while_awaiting_approval`,
+//! which covers the pause but not the resume.
+//!
+//! Three scenarios:
+//! - `approval_yes`: approve once → tool runs → final response
+//! - `approval_no`: deny once → tool does not run → final response
+//! - `approval_always`: allow-always on call 1 → call 2 runs without
+//!   re-prompting
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod approval_trace_tests {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+
+    use crate::support::test_rig::TestRigBuilder;
+    use crate::support::trace_llm::LlmTrace;
+    use ironclaw::channels::StatusUpdate;
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{ApprovalRequirement, Tool, ToolError, ToolOutput};
+
+    const TIMEOUT: Duration = Duration::from_secs(15);
+
+    /// Test tool whose approval requirement is `UnlessAutoApproved`. With
+    /// `with_auto_approve_tools(false)` the agent must pause for user
+    /// approval; an `always`-approve response should persist for the
+    /// remainder of the session and skip the pause on subsequent calls.
+    struct NeedsApprovalProbe {
+        executions: Arc<AtomicUsize>,
+    }
+
+    impl NeedsApprovalProbe {
+        fn new() -> (Arc<Self>, Arc<AtomicUsize>) {
+            let executions = Arc::new(AtomicUsize::new(0));
+            let tool = Arc::new(Self {
+                executions: executions.clone(),
+            });
+            (tool, executions)
+        }
+    }
+
+    #[async_trait]
+    impl Tool for NeedsApprovalProbe {
+        fn name(&self) -> &str {
+            "needs_approval_probe"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that requires approval unless auto-approved"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": { "value": { "type": "string" } },
+                "required": ["value"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::success(
+                serde_json::json!({"ok": true, "echoed": params}),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::UnlessAutoApproved
+        }
+    }
+
+    /// Poll `captured_status_events` until an `ApprovalNeeded` is observed
+    /// or the deadline elapses. Returns true on success.
+    async fn wait_for_approval_needed(
+        rig: &crate::support::test_rig::TestRig,
+        timeout: Duration,
+    ) -> bool {
+        let initial = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let count = rig
+                .captured_status_events()
+                .iter()
+                .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+                .count();
+            if count > initial {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn fixture_path(name: &str) -> String {
+        format!(
+            "{}/tests/fixtures/llm_traces/coverage/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        )
+    }
+
+    #[tokio::test]
+    async fn approval_yes_runs_tool_and_produces_final_response() {
+        let trace = LlmTrace::from_file(fixture_path("approval_yes.json"))
+            .expect("failed to load approval_yes.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the gated probe").await;
+
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "expected ApprovalNeeded status before approval was sent"
+        );
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            0,
+            "tool must not run before approval"
+        );
+
+        rig.send_message("yes").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "tool must run exactly once after approval"
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    /// On deny, the agent does **not** call the LLM again — it surfaces a
+    /// built-in rejection message directly to the user. The trace therefore
+    /// only needs the initial tool-call step; the rejection text comes from
+    /// the agent, not from a replayed LLM response.
+    #[tokio::test]
+    async fn approval_no_skips_tool_and_produces_final_response() {
+        let trace = LlmTrace::from_file(fixture_path("approval_no.json"))
+            .expect("failed to load approval_no.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the gated probe").await;
+
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "expected ApprovalNeeded status before denial was sent"
+        );
+
+        rig.send_message("no").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            0,
+            "tool must not run when approval is denied"
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    #[tokio::test]
+    async fn approval_always_persists_for_subsequent_calls() {
+        let trace = LlmTrace::from_file(fixture_path("approval_always.json"))
+            .expect("failed to load approval_always.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the gated probe twice").await;
+
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "expected ApprovalNeeded status before allow-always was sent"
+        );
+        let approval_needed_after_first = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        assert_eq!(
+            approval_needed_after_first, 1,
+            "exactly one ApprovalNeeded should be pending before resolving"
+        );
+
+        rig.send_message("always").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            2,
+            "both tool calls must run after allow-always"
+        );
+
+        let total_approval_needed = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        assert_eq!(
+            total_approval_needed, 1,
+            "second tool call must not re-prompt for approval after allow-always; got {} prompts",
+            total_approval_needed
+        );
+
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+}

--- a/tests/e2e_approval_traces.rs
+++ b/tests/e2e_approval_traces.rs
@@ -84,6 +84,59 @@ mod approval_trace_tests {
         }
     }
 
+    /// Test tool whose approval requirement is `Always` — the unbypassable
+    /// hard floor. Even an `allow-always` response must NOT auto-approve
+    /// subsequent calls of an `Always` tool. See dispatcher.rs:521-525 for
+    /// the design comment this guards.
+    struct AlwaysApprovalProbe {
+        executions: Arc<AtomicUsize>,
+    }
+
+    impl AlwaysApprovalProbe {
+        fn new() -> (Arc<Self>, Arc<AtomicUsize>) {
+            let executions = Arc::new(AtomicUsize::new(0));
+            let tool = Arc::new(Self {
+                executions: executions.clone(),
+            });
+            (tool, executions)
+        }
+    }
+
+    #[async_trait]
+    impl Tool for AlwaysApprovalProbe {
+        fn name(&self) -> &str {
+            "always_approval_probe"
+        }
+
+        fn description(&self) -> &str {
+            "Test tool that always requires explicit approval (unbypassable)"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": { "value": { "type": "string" } },
+                "required": ["value"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            Ok(ToolOutput::success(
+                serde_json::json!({"ok": true, "echoed": params}),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn requires_approval(&self, _params: &serde_json::Value) -> ApprovalRequirement {
+            ApprovalRequirement::Always
+        }
+    }
+
     /// Poll `captured_status_events` until an `ApprovalNeeded` is observed
     /// or the deadline elapses. Returns true on success.
     async fn wait_for_approval_needed(
@@ -245,6 +298,196 @@ mod approval_trace_tests {
             total_approval_needed
         );
 
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    /// `ApprovalRequirement::Always` is an unbypassable hard floor: an
+    /// `allow-always` response must NOT skip the pause on subsequent
+    /// calls of an `Always` tool. Two pauses for two calls.
+    #[tokio::test]
+    async fn always_requirement_ignores_allow_always_persistence() {
+        let trace = LlmTrace::from_file(fixture_path("approval_always_floor.json"))
+            .expect("failed to load approval_always_floor.json");
+        let (tool, executions) = AlwaysApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the always-gated probe twice").await;
+
+        // First pause + resolve with "always".
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "expected first ApprovalNeeded"
+        );
+        rig.send_message("always").await;
+
+        // Second pause must still happen because Always is unbypassable.
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "second ApprovalNeeded must fire even after allow-always: \
+             ApprovalRequirement::Always is the hard floor"
+        );
+        rig.send_message("yes").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+
+        let total_approval_needed = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        assert_eq!(
+            total_approval_needed, 2,
+            "two Always-gated calls must produce exactly two ApprovalNeeded events"
+        );
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            2,
+            "both gated calls must run after individual approvals"
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    /// Slash-prefixed `/approve` is parsed as `Submission::ApprovalResponse`
+    /// even though bare "yes" downgrades to UserInput when nothing is
+    /// pending. This guards the divergent routing in submission.rs.
+    #[tokio::test]
+    async fn slash_approve_routes_as_approval_response() {
+        let trace = LlmTrace::from_file(fixture_path("approval_slash.json"))
+            .expect("failed to load approval_slash.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the gated probe").await;
+
+        assert!(
+            wait_for_approval_needed(&rig, TIMEOUT).await,
+            "expected ApprovalNeeded before /approve was sent"
+        );
+
+        rig.send_message("/approve").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "tool must run after /approve"
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    /// Bare "yes" with no pending approval must downgrade to UserInput and
+    /// reach the LLM as a normal user message. The submission parser is
+    /// stateless, so the routing layer in agent_loop.rs is responsible
+    /// for the downgrade — this test pins that contract.
+    #[tokio::test]
+    async fn bare_yes_with_no_pending_approval_is_user_input() {
+        let trace = LlmTrace::from_file(fixture_path("approval_bare_yes_no_pending.json"))
+            .expect("failed to load approval_bare_yes_no_pending.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(false)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("yes").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+
+        // The LLM must have been called with "yes" as a user message,
+        // proving the routing layer downgraded the bare keyword.
+        let captured = rig.captured_llm_requests();
+        assert!(
+            !captured.is_empty(),
+            "LLM must have been called — if zero calls, the routing layer \
+             incorrectly treated bare 'yes' as an approval response"
+        );
+        let last_user_yes = captured.iter().any(|msgs| {
+            msgs.iter().any(|m| {
+                matches!(m.role, ironclaw::llm::Role::User)
+                    && m.content.trim().eq_ignore_ascii_case("yes")
+            })
+        });
+        assert!(
+            last_user_yes,
+            "LLM conversation must include 'yes' as a user message"
+        );
+
+        // No approval gate should have been emitted — nothing was pending.
+        let approval_needed = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        assert_eq!(
+            approval_needed, 0,
+            "no ApprovalNeeded should fire when nothing was pending"
+        );
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            0,
+            "probe tool must not run — LLM did not call it"
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    /// Agent-config `auto_approve_tools=true` is the master kill-switch: it
+    /// short-circuits the entire approval gate, so no `ApprovalNeeded` is
+    /// ever emitted, even for `UnlessAutoApproved` tools. Reuses the
+    /// approval_yes fixture and verifies the tool runs without any
+    /// resolution being sent.
+    #[tokio::test]
+    async fn config_auto_approve_bypasses_unless_auto_approved() {
+        let trace = LlmTrace::from_file(fixture_path("approval_yes.json"))
+            .expect("failed to load approval_yes.json");
+        let (tool, executions) = NeedsApprovalProbe::new();
+
+        let rig = TestRigBuilder::new()
+            .with_trace(trace.clone())
+            .with_extra_tools(vec![tool as Arc<dyn Tool>])
+            .with_auto_approve_tools(true)
+            .build()
+            .await;
+        rig.clear().await;
+
+        rig.send_message("Run the gated probe").await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "tool must run with auto_approve_tools=true and no resolution sent"
+        );
+        let approval_needed = rig
+            .captured_status_events()
+            .iter()
+            .filter(|s| matches!(s, StatusUpdate::ApprovalNeeded { .. }))
+            .count();
+        assert_eq!(
+            approval_needed, 0,
+            "no ApprovalNeeded should fire with auto_approve_tools=true"
+        );
         rig.verify_trace_expects(&trace, &responses);
         rig.shutdown();
     }

--- a/tests/e2e_auth_gate_traces.rs
+++ b/tests/e2e_auth_gate_traces.rs
@@ -1,0 +1,438 @@
+//! Replay coverage for the engine-v2 authentication gate round-trip.
+//!
+//! Phase 2 of #2828 — extends the approval fixtures with the typed
+//! `Submission::GateAuthResolution` / `Submission::ExternalCallback`
+//! path that only engine v2 recognizes. The tests drive the full
+//! cycle: LLM → `tool_activate` → GatePaused(Authentication) →
+//! typed resolution → re-run → final response.
+//!
+//! Scenarios:
+//! - `auth_credential_provided_resumes_action` — happy path
+//! - `auth_cancelled_stops_thread` — cancel path
+//! - `auth_retry_after_invalid_credential` — second pause gets a new request_id
+//! - `auth_external_callback_resolves_oauth_gate` — OAuth callback path
+//! - `auth_gate_emits_request_id_for_v2` — invariant: gate carries a Uuid
+
+#[cfg(feature = "libsql")]
+mod support;
+
+#[cfg(feature = "libsql")]
+mod auth_gate_trace_tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, OnceLock};
+    use std::time::Duration;
+
+    use async_trait::async_trait;
+    use tokio::sync::Mutex;
+
+    use crate::support::test_rig::{TestRig, TestRigBuilder};
+    use crate::support::trace_llm::LlmTrace;
+    use ironclaw::agent::submission::AuthGateResolution;
+    use ironclaw::channels::StatusUpdate;
+    use ironclaw::context::JobContext;
+    use ironclaw::tools::{Tool, ToolError, ToolOutput};
+
+    const TIMEOUT: Duration = Duration::from_secs(15);
+
+    /// Serialize all tests in this file because engine v2 stores its state
+    /// in a process-global `OnceLock<RwLock<Option<EngineState>>>`.
+    /// Running these tests in parallel would let one test's gate_paused
+    /// state leak into the next test's engine instance.
+    fn engine_v2_test_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Test stub for the `tool_activate` built-in. Returns a pre-configured
+    /// sequence of JSON outputs so the test can shape the GatePaused path.
+    ///
+    /// Each call pops the next output off the queue; after the queue is
+    /// drained the last output is reused (so resumes after the final
+    /// gate always see the "ready" state).
+    struct MockActivateTool {
+        outputs: Arc<std::sync::Mutex<Vec<serde_json::Value>>>,
+        executions: Arc<AtomicUsize>,
+    }
+
+    impl MockActivateTool {
+        fn new(outputs: Vec<serde_json::Value>) -> (Arc<Self>, Arc<AtomicUsize>) {
+            let executions = Arc::new(AtomicUsize::new(0));
+            let tool = Arc::new(Self {
+                outputs: Arc::new(std::sync::Mutex::new(outputs)),
+                executions: executions.clone(),
+            });
+            (tool, executions)
+        }
+    }
+
+    #[async_trait]
+    impl Tool for MockActivateTool {
+        fn name(&self) -> &str {
+            // Must match the protected built-in name so the effect adapter's
+            // `auth_gate_from_extension_result` path inspects our output.
+            "tool_activate"
+        }
+
+        fn description(&self) -> &str {
+            "Test stub for tool_activate that emits scripted auth-gate outputs"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": { "type": "string" },
+                    "token": { "type": "string" }
+                },
+                "required": ["name"]
+            })
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            self.executions.fetch_add(1, Ordering::SeqCst);
+            let mut q = self.outputs.lock().expect("outputs lock poisoned");
+            let next = if q.len() > 1 {
+                q.remove(0)
+            } else {
+                // Last output — reuse on every subsequent call so the
+                // post-credential re-run returns the "ready" state.
+                q.first().cloned().unwrap_or(serde_json::json!({}))
+            };
+            Ok(ToolOutput::success(next, Duration::from_millis(1)))
+        }
+    }
+
+    /// Poll `captured_status_events` until an `AuthRequired` with a
+    /// `request_id` is observed (past `initial_count`). Returns the first
+    /// new `request_id` as a `Uuid`.
+    async fn wait_for_auth_required(
+        rig: &TestRig,
+        initial_count: usize,
+        timeout: Duration,
+    ) -> Option<uuid::Uuid> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let events = rig.captured_status_events();
+            let with_id: Vec<_> = events
+                .iter()
+                .filter_map(|s| match s {
+                    StatusUpdate::AuthRequired {
+                        request_id: Some(id),
+                        ..
+                    } => Some(id.clone()),
+                    _ => None,
+                })
+                .collect();
+            if with_id.len() > initial_count
+                && let Some(raw) = with_id.get(initial_count)
+                && let Ok(uuid) = uuid::Uuid::parse_str(raw)
+            {
+                return Some(uuid);
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return None;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    }
+
+    fn fixture_path(name: &str) -> String {
+        format!(
+            "{}/tests/fixtures/llm_traces/coverage/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            name
+        )
+    }
+
+    /// Write a minimal SKILL.md that declares a credential spec for
+    /// `credential_name` into `skills_dir`. This is the bare-minimum fixture
+    /// that makes `AuthManager::submit_auth_token` accept the credential
+    /// (it requires a matching skill credential spec when no extension is
+    /// installed). The skill body is intentionally trivial — the test does
+    /// not exercise prompt/activation behavior.
+    fn plant_probe_skill(skills_dir: &std::path::Path, credential_name: &str) {
+        let skill_dir = skills_dir.join(format!("probe_{credential_name}"));
+        std::fs::create_dir_all(&skill_dir).expect("create probe skill dir");
+        let manifest = format!(
+            r#"---
+name: probe_{credential_name}
+version: "0.0.0"
+description: Probe skill for auth-gate replay coverage.
+activation:
+  keywords:
+    - "probe-skill-should-never-activate-in-this-test"
+credentials:
+  - name: {credential_name}
+    provider: test
+    location:
+      type: bearer
+    hosts:
+      - "example.com"
+---
+
+Probe skill.
+"#
+        );
+        std::fs::write(skill_dir.join("SKILL.md"), manifest).expect("write probe SKILL.md");
+    }
+
+    /// Common rig setup: engine v2 + a `MockActivateTool` override keyed by
+    /// the caller's scripted output sequence. Also plants a probe skill for
+    /// each credential name referenced in `outputs` so the auth-manager
+    /// credential-store path accepts the token during `CredentialProvided`.
+    async fn auth_rig(
+        trace: LlmTrace,
+        outputs: Vec<serde_json::Value>,
+    ) -> (TestRig, Arc<AtomicUsize>) {
+        // Extract credential names so we can plant matching probe skills.
+        let credential_names: std::collections::HashSet<String> = outputs
+            .iter()
+            .filter_map(|v| v.get("name").and_then(|n| n.as_str()).map(String::from))
+            .collect();
+
+        // Use `.into_path()` to release the tempdir from auto-cleanup so
+        // skill discovery can read from it after the builder finishes. OS
+        // cleanup handles the directory between runs.
+        let skills_tempdir = tempfile::tempdir().expect("probe skills tempdir");
+        let skills_path = skills_tempdir.keep();
+        for name in &credential_names {
+            plant_probe_skill(&skills_path, name);
+        }
+
+        let (tool, executions) = MockActivateTool::new(outputs);
+        let rig = TestRigBuilder::new()
+            .with_trace(trace)
+            .with_engine_v2()
+            .with_test_tool_override(tool as Arc<dyn Tool>)
+            .with_skills_dir(skills_path)
+            .build()
+            .await;
+        rig.clear().await;
+        (rig, executions)
+    }
+
+    #[tokio::test]
+    async fn auth_credential_provided_resumes_action() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::from_file(fixture_path("auth_credential_provided.json"))
+            .expect("failed to load auth_credential_provided.json");
+        let outputs = vec![
+            serde_json::json!({
+                "status": "awaiting_token",
+                "name": "test_credential",
+                "instructions": "Provide test token"
+            }),
+            serde_json::json!({
+                "status": "ready",
+                "name": "test_credential",
+                "message": "Credential configured"
+            }),
+        ];
+        let (rig, executions) = auth_rig(trace.clone(), outputs).await;
+
+        rig.send_message("Set up the test credential").await;
+
+        let request_id = wait_for_auth_required(&rig, 0, TIMEOUT)
+            .await
+            .expect("expected AuthRequired with request_id before token was provided");
+
+        rig.send_gate_auth_resolution(
+            request_id,
+            AuthGateResolution::CredentialProvided {
+                token: "test-token-value".to_string(),
+            },
+        )
+        .await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert!(
+            executions.load(Ordering::SeqCst) >= 2,
+            "tool must re-run after credential submission (executions={})",
+            executions.load(Ordering::SeqCst)
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    #[tokio::test]
+    async fn auth_cancelled_stops_thread() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::from_file(fixture_path("auth_cancelled.json"))
+            .expect("failed to load auth_cancelled.json");
+        let outputs = vec![serde_json::json!({
+            "status": "awaiting_token",
+            "name": "test_credential",
+            "instructions": "Provide test token"
+        })];
+        let (rig, executions) = auth_rig(trace.clone(), outputs).await;
+
+        rig.send_message("Set up the credential I'll cancel").await;
+
+        let request_id = wait_for_auth_required(&rig, 0, TIMEOUT)
+            .await
+            .expect("expected AuthRequired before cancel");
+
+        rig.send_gate_auth_resolution(request_id, AuthGateResolution::Cancelled)
+            .await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert_eq!(
+            executions.load(Ordering::SeqCst),
+            1,
+            "tool must run exactly once (cancel must not trigger a re-run)"
+        );
+        assert!(
+            responses.iter().any(|r| r.content.contains("Cancelled")),
+            "expected 'Cancelled.' response after auth-gate cancel, got: {:?}",
+            responses.iter().map(|r| &r.content).collect::<Vec<_>>()
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    #[tokio::test]
+    async fn auth_retry_after_invalid_credential() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::from_file(fixture_path("auth_retry_invalid_then_valid.json"))
+            .expect("failed to load auth_retry_invalid_then_valid.json");
+        // First two calls pause the gate (first token is "invalid"), third
+        // call returns ready. The mock doesn't actually validate tokens —
+        // it just emits the scripted output sequence.
+        let outputs = vec![
+            serde_json::json!({
+                "status": "awaiting_token",
+                "name": "test_credential",
+                "instructions": "Provide test token"
+            }),
+            serde_json::json!({
+                "status": "awaiting_token",
+                "name": "test_credential",
+                "instructions": "That token was invalid; try again"
+            }),
+            serde_json::json!({
+                "status": "ready",
+                "name": "test_credential"
+            }),
+        ];
+        let (rig, executions) = auth_rig(trace.clone(), outputs).await;
+
+        rig.send_message("Set up the credential").await;
+
+        let first_id = wait_for_auth_required(&rig, 0, TIMEOUT)
+            .await
+            .expect("expected first AuthRequired");
+        rig.send_gate_auth_resolution(
+            first_id,
+            AuthGateResolution::CredentialProvided {
+                token: "invalid".to_string(),
+            },
+        )
+        .await;
+
+        let second_id = wait_for_auth_required(&rig, 1, TIMEOUT)
+            .await
+            .expect("expected second AuthRequired after invalid token");
+        assert_ne!(
+            first_id, second_id,
+            "re-pause must emit a fresh request_id, not reuse the first"
+        );
+
+        rig.send_gate_auth_resolution(
+            second_id,
+            AuthGateResolution::CredentialProvided {
+                token: "valid".to_string(),
+            },
+        )
+        .await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert!(
+            executions.load(Ordering::SeqCst) >= 3,
+            "tool must run at least three times (initial + two resumes), got {}",
+            executions.load(Ordering::SeqCst)
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    #[tokio::test]
+    async fn auth_external_callback_resolves_oauth_gate() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::from_file(fixture_path("auth_external_callback.json"))
+            .expect("failed to load auth_external_callback.json");
+        let outputs = vec![
+            serde_json::json!({
+                "status": "awaiting_authorization",
+                "name": "oauth_service",
+                "auth_url": "https://example.com/oauth/start",
+                "instructions": "Complete the OAuth flow in your browser"
+            }),
+            serde_json::json!({
+                "status": "ready",
+                "name": "oauth_service"
+            }),
+        ];
+        let (rig, executions) = auth_rig(trace.clone(), outputs).await;
+
+        rig.send_message("Connect the OAuth service").await;
+
+        let request_id = wait_for_auth_required(&rig, 0, TIMEOUT)
+            .await
+            .expect("expected AuthRequired with request_id for OAuth");
+
+        // Confirm the gate carried an auth_url (OAuth shape, not bare token).
+        assert!(
+            rig.captured_status_events().iter().any(|s| matches!(
+                s,
+                StatusUpdate::AuthRequired { auth_url: Some(url), .. } if url.starts_with("https://example.com/oauth")
+            )),
+            "AuthRequired for OAuth must surface the auth_url"
+        );
+
+        rig.send_external_callback(request_id).await;
+
+        let responses = rig.wait_for_responses(1, TIMEOUT).await;
+        assert!(
+            executions.load(Ordering::SeqCst) >= 2,
+            "tool must re-run after external callback (executions={})",
+            executions.load(Ordering::SeqCst)
+        );
+        rig.verify_trace_expects(&trace, &responses);
+        rig.shutdown();
+    }
+
+    #[tokio::test]
+    async fn auth_gate_emits_request_id_for_v2() {
+        let _guard = engine_v2_test_lock().lock().await;
+        let trace = LlmTrace::from_file(fixture_path("auth_gate_request_id.json"))
+            .expect("failed to load auth_gate_request_id.json");
+        let outputs = vec![serde_json::json!({
+            "status": "awaiting_token",
+            "name": "probe_credential",
+            "instructions": "Provide"
+        })];
+        let (rig, _executions) = auth_rig(trace, outputs).await;
+
+        rig.send_message("Trigger the auth gate").await;
+
+        let request_id = wait_for_auth_required(&rig, 0, TIMEOUT)
+            .await
+            .expect("engine v2 must always emit a request_id on AuthRequired");
+        // Invariant: the gate's request_id must round-trip through Uuid parsing.
+        // (`wait_for_auth_required` already parsed it; this asserts non-nil.)
+        assert_ne!(
+            request_id,
+            uuid::Uuid::nil(),
+            "request_id on AuthRequired must be a real Uuid, not nil"
+        );
+
+        // Clean up the pending gate so the test doesn't leak an active thread.
+        rig.send_gate_auth_resolution(request_id, AuthGateResolution::Cancelled)
+            .await;
+        rig.shutdown();
+    }
+}

--- a/tests/e2e_auth_gate_traces.rs
+++ b/tests/e2e_auth_gate_traces.rs
@@ -108,12 +108,13 @@ mod auth_gate_trace_tests {
 
     /// Poll `captured_status_events` until an `AuthRequired` with a
     /// `request_id` is observed (past `initial_count`). Returns the first
-    /// new `request_id` as a `Uuid`.
+    /// new `request_id` as a `Uuid`, or a descriptive error when the
+    /// router emitted a malformed ID or the status never arrived.
     async fn wait_for_auth_required(
         rig: &TestRig,
         initial_count: usize,
         timeout: Duration,
-    ) -> Option<uuid::Uuid> {
+    ) -> Result<uuid::Uuid, String> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
             let events = rig.captured_status_events();
@@ -127,14 +128,17 @@ mod auth_gate_trace_tests {
                     _ => None,
                 })
                 .collect();
-            if with_id.len() > initial_count
-                && let Some(raw) = with_id.get(initial_count)
-                && let Ok(uuid) = uuid::Uuid::parse_str(raw)
-            {
-                return Some(uuid);
+            if with_id.len() > initial_count {
+                let raw = with_id
+                    .get(initial_count)
+                    .expect("length checked above; request_id must exist");
+                return uuid::Uuid::parse_str(raw)
+                    .map_err(|e| format!("malformed AuthRequired.request_id {raw:?}: {e}"));
             }
             if tokio::time::Instant::now() >= deadline {
-                return None;
+                return Err(format!(
+                    "timed out waiting for AuthRequired #{initial_count}; saw events: {events:?}"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }

--- a/tests/e2e_gateway_trace_harness.rs
+++ b/tests/e2e_gateway_trace_harness.rs
@@ -1,0 +1,207 @@
+//! Integration tests for the gateway-ops trace replay harness (#643).
+//!
+//! Exercises `TraceRunner` end-to-end against a real libSQL test database,
+//! ensuring the `Tool -> ActionRecord -> save_action` pipeline matches the
+//! declared `TraceExpectation`s in each fixture.
+
+#![cfg(feature = "libsql")]
+
+mod support {
+    pub mod trace_runner;
+}
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use ironclaw::db::Database;
+use ironclaw::db::libsql::LibSqlBackend;
+use ironclaw::tools::ToolRegistry;
+
+use support::trace_runner::{Trace, TraceResult, TraceRunner};
+
+fn fixture_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/gateway_traces")
+}
+
+fn load_trace(name: &str) -> Trace {
+    let path = fixture_dir().join(format!("{name}.json"));
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|e| panic!("read fixture {}: {e}", path.display()));
+    serde_json::from_slice(&bytes)
+        .unwrap_or_else(|e| panic!("parse fixture {}: {e}", path.display()))
+}
+
+/// Build a minimal libSQL-backed fixture: fresh DB + migrations +
+/// built-in tool registry. Returns the pieces the runner needs.
+///
+/// The `_temp_dir` guard must stay alive for the whole test so the
+/// database file isn't deleted mid-run.
+async fn fixture() -> (Arc<dyn Database>, Arc<ToolRegistry>, tempfile::TempDir) {
+    let temp_dir = tempfile::tempdir().expect("temp dir");
+    let db_path = temp_dir.path().join("trace_runner.db");
+    let backend = LibSqlBackend::new_local(&db_path)
+        .await
+        .expect("LibSqlBackend");
+    backend.run_migrations().await.expect("migrations");
+    let db: Arc<dyn Database> = Arc::new(backend);
+
+    let tools = Arc::new(ToolRegistry::new());
+    tools.register_builtin_tools();
+
+    (db, tools, temp_dir)
+}
+
+async fn run_trace(name: &str) -> (TraceResult, Arc<dyn Database>, tempfile::TempDir) {
+    let (db, tools, temp_dir) = fixture().await;
+    let runner = TraceRunner::new(Arc::clone(&tools), Arc::clone(&db), "trace-user");
+    let trace = load_trace(name);
+    let result = runner.replay(&trace).await.expect("replay should succeed");
+    (result, db, temp_dir)
+}
+
+#[tokio::test]
+async fn echo_roundtrip_records_one_success() {
+    let (result, _db, _guard) = run_trace("echo_roundtrip").await;
+    assert!(
+        result.failures.is_empty(),
+        "unexpected failures: {:#?}",
+        result.failures
+    );
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert!(record.success);
+    assert_eq!(record.tool_name, "echo");
+    assert_eq!(record.sequence, 0);
+}
+
+#[tokio::test]
+async fn idempotency_trace_produces_equal_outputs() {
+    let (result, _db, _guard) = run_trace("idempotency").await;
+    assert!(
+        result.failures.is_empty(),
+        "unexpected failures: {:#?}",
+        result.failures
+    );
+    assert_eq!(result.records.len(), 2);
+    assert!(result.records.iter().all(|r| r.success));
+    assert_eq!(
+        result.records[0].output_raw, result.records[1].output_raw,
+        "idempotent echo should produce byte-identical raw output across invocations"
+    );
+}
+
+#[tokio::test]
+async fn unknown_tool_is_recorded_as_failure() {
+    let (result, _db, _guard) = run_trace("unknown_tool_fails").await;
+    assert!(
+        result.failures.is_empty(),
+        "expectation was Failure, should not report a trace failure: {:#?}",
+        result.failures
+    );
+    assert_eq!(result.records.len(), 1);
+    let record = &result.records[0];
+    assert!(!record.success);
+    assert!(
+        record
+            .error
+            .as_deref()
+            .unwrap_or("")
+            .contains("not registered"),
+        "unexpected error message: {:?}",
+        record.error
+    );
+}
+
+#[tokio::test]
+async fn assertion_mix_reports_no_mismatches() {
+    let (result, _db, _guard) = run_trace("assertion_mix").await;
+    assert!(
+        result.failures.is_empty(),
+        "unexpected failures: {:#?}",
+        result.failures
+    );
+    assert_eq!(result.records.len(), 3);
+    assert!(result.records[0].success);
+    assert!(result.records[1].success);
+    assert!(!result.records[2].success);
+}
+
+/// Feeds the runner a programmatic trace whose declared expectation is
+/// deliberately wrong, then asserts `TraceResult::failures` reports the
+/// mismatch with the right index, tool name, and reason.
+#[tokio::test]
+async fn trace_failure_reports_mismatch_details() {
+    use serde_json::json;
+    use support::trace_runner::{TraceExpectation, TraceOperation};
+
+    let (db, tools, _guard) = fixture().await;
+    let runner = TraceRunner::new(Arc::clone(&tools), Arc::clone(&db), "trace-user");
+    let trace = Trace {
+        name: "force_mismatch".into(),
+        operations: vec![TraceOperation {
+            tool_name: "echo".into(),
+            params: json!({"message": "actual-output"}),
+            expected: TraceExpectation::Success {
+                assertions: json!({"contains_text": "never-emitted"}),
+            },
+        }],
+    };
+    let result = runner.replay(&trace).await.expect("replay");
+
+    assert_eq!(result.failures.len(), 1, "expected exactly one mismatch");
+    let failure = &result.failures[0];
+    assert_eq!(failure.operation_index, 0);
+    assert_eq!(failure.tool_name, "echo");
+    assert!(
+        failure.reason.contains("contains_text mismatch"),
+        "unexpected failure reason: {}",
+        failure.reason
+    );
+
+    // Even though the assertion failed, the underlying tool still
+    // succeeded; the ActionRecord reflects tool-level success, not
+    // assertion-level success.
+    assert_eq!(result.records.len(), 1);
+    assert!(result.records[0].success);
+}
+
+#[tokio::test]
+async fn action_records_are_persisted_to_db() {
+    let (result, db, _guard) = run_trace("idempotency").await;
+    let persisted = db
+        .get_job_actions(result.job_id)
+        .await
+        .expect("get_job_actions");
+    assert_eq!(
+        persisted.len(),
+        result.records.len(),
+        "expected {} persisted actions, got {}",
+        result.records.len(),
+        persisted.len()
+    );
+    for (in_mem, stored) in result.records.iter().zip(persisted.iter()) {
+        assert_eq!(in_mem.tool_name, stored.tool_name);
+        assert_eq!(in_mem.sequence, stored.sequence);
+        assert_eq!(in_mem.success, stored.success);
+    }
+}
+
+/// Replaying the same trace twice against fresh DBs should produce
+/// ActionRecords that match except for intentionally variable fields
+/// (ids, wall-clock timestamps, measured durations).
+#[tokio::test]
+async fn trace_replay_is_deterministic_across_runs() {
+    let (a, _db_a, _guard_a) = run_trace("echo_roundtrip").await;
+    let (b, _db_b, _guard_b) = run_trace("echo_roundtrip").await;
+
+    assert_eq!(a.records.len(), b.records.len());
+    for (ra, rb) in a.records.iter().zip(b.records.iter()) {
+        assert_eq!(ra.sequence, rb.sequence);
+        assert_eq!(ra.tool_name, rb.tool_name);
+        assert_eq!(ra.input, rb.input);
+        assert_eq!(ra.success, rb.success);
+        assert_eq!(ra.output_raw, rb.output_raw);
+        assert_eq!(ra.output_sanitized, rb.output_sanitized);
+        assert_eq!(ra.error, rb.error);
+    }
+}

--- a/tests/fixtures/gateway_traces/README.md
+++ b/tests/fixtures/gateway_traces/README.md
@@ -1,0 +1,92 @@
+# Gateway-ops trace fixtures
+
+These fixtures drive `TraceRunner` (see `src/testing/trace_runner.rs`) and
+replay an ordered list of tool invocations against a libSQL test database.
+They're distinct from the agentic LLM-stream fixtures under
+`tests/fixtures/llm_traces/`.
+
+## Why two systems
+
+- **`llm_traces/`**: replay an LLM stream, assert the agent re-produces the
+  same tool calls from the same user input — *"does the agent behave
+  deterministically?"*
+- **`gateway_traces/`**: replay an ordered caller-dispatched tool sequence,
+  assert the `Tool → ActionRecord → Database::save_action` pipeline works
+  and matches declared expectations — *"does the gateway-ops pipeline
+  preserve the actions we asked for?"*
+
+Both layers ultimately cover trace-replay coverage (#643 / Phase 2 of
+#2828), but they approach it from opposite directions.
+
+## Wire format
+
+```json
+{
+  "name": "human-readable-id",
+  "operations": [
+    {
+      "tool_name": "echo",
+      "params": { "message": "hi" },
+      "expected": {
+        "kind": "success",
+        "assertions": { "contains_text": "hi" }
+      }
+    },
+    {
+      "tool_name": "missing",
+      "params": {},
+      "expected": {
+        "kind": "failure",
+        "error_contains": "not registered"
+      }
+    }
+  ]
+}
+```
+
+`TraceExpectation::Success.assertions` supports three keys:
+
+| Key              | Meaning                                                                 |
+|------------------|-------------------------------------------------------------------------|
+| `eq`             | Deep equality against the entire tool output JSON                       |
+| `contains_text`  | The output (stringified) must contain this substring                    |
+| `fields`         | Object of dot-path → expected-value; each path must match in the output |
+
+Omit `assertions` (or set it to `null`) to skip output checks — useful when
+you only care that the tool *ran* successfully, not what it returned.
+
+`TraceExpectation::Failure.error_contains` is substring-matched against
+`ToolError::to_string()`.
+
+## Current fixtures
+
+| File | Scenario |
+|------|----------|
+| `echo_roundtrip.json` | Minimal success path (echo tool, sanity check) |
+| `idempotency.json` | Same input twice, both succeed with identical outputs |
+| `unknown_tool_fails.json` | Unregistered tool produces a `failure` outcome |
+| `assertion_mix.json` | Covers `eq`, `contains_text`, `fields`, and a deliberate failure path in one replay |
+
+## Deferred fixtures
+
+- **Settings CRUD** (`settings_set/get/delete`): blocked on #640 landing the
+  mutating `Submission` variants. Once those tools exist, add
+  `settings_crud.json` here.
+- **Extension lifecycle** (`tool_install/tool_remove/tool_list`): tool
+  install requires network fetch or pre-seeded local WASM. Deferred to a
+  follow-up that either stubs `ExtensionManager` or uses `sandbox::proxy`
+  to serve a local manifest. `tool_list` alone is not mutating, so it
+  doesn't exercise the interesting pipeline.
+
+## Determinism invariants
+
+When the same trace is replayed twice (same inputs, same DB migrations,
+no external I/O), the sequence of `ActionRecord` fields must match
+**except** for:
+
+- `id` (new `Uuid::new_v4()` per replay)
+- `executed_at` (wall-clock `Utc::now()`)
+- `duration` (measured via `Instant::now()`)
+
+`tests/e2e_gateway_trace_harness.rs` has an explicit determinism test
+that strips those fields before comparing.

--- a/tests/fixtures/gateway_traces/assertion_mix.json
+++ b/tests/fixtures/gateway_traces/assertion_mix.json
@@ -1,0 +1,28 @@
+{
+  "name": "assertion_mix",
+  "operations": [
+    {
+      "tool_name": "echo",
+      "params": { "message": "first" },
+      "expected": {
+        "kind": "success",
+        "assertions": { "contains_text": "first" }
+      }
+    },
+    {
+      "tool_name": "echo",
+      "params": { "message": "second" },
+      "expected": {
+        "kind": "success"
+      }
+    },
+    {
+      "tool_name": "unknown_tool_for_mix",
+      "params": {},
+      "expected": {
+        "kind": "failure",
+        "error_contains": "not registered"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/gateway_traces/echo_roundtrip.json
+++ b/tests/fixtures/gateway_traces/echo_roundtrip.json
@@ -1,0 +1,13 @@
+{
+  "name": "echo_roundtrip",
+  "operations": [
+    {
+      "tool_name": "echo",
+      "params": { "message": "hello from the trace runner" },
+      "expected": {
+        "kind": "success",
+        "assertions": { "contains_text": "hello from the trace runner" }
+      }
+    }
+  ]
+}

--- a/tests/fixtures/gateway_traces/idempotency.json
+++ b/tests/fixtures/gateway_traces/idempotency.json
@@ -1,0 +1,15 @@
+{
+  "name": "idempotency",
+  "operations": [
+    {
+      "tool_name": "echo",
+      "params": { "message": "same-input" },
+      "expected": { "kind": "success", "assertions": { "contains_text": "same-input" } }
+    },
+    {
+      "tool_name": "echo",
+      "params": { "message": "same-input" },
+      "expected": { "kind": "success", "assertions": { "contains_text": "same-input" } }
+    }
+  ]
+}

--- a/tests/fixtures/gateway_traces/unknown_tool_fails.json
+++ b/tests/fixtures/gateway_traces/unknown_tool_fails.json
@@ -1,0 +1,13 @@
+{
+  "name": "unknown_tool_fails",
+  "operations": [
+    {
+      "tool_name": "this_tool_does_not_exist",
+      "params": {},
+      "expected": {
+        "kind": "failure",
+        "error_contains": "tool not registered"
+      }
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/README.md
+++ b/tests/fixtures/llm_traces/README.md
@@ -340,9 +340,12 @@ llm_traces/
     injection_in_echo.json  # Prompt injection in tool output
     memory_full_cycle.json  # Full memory write/search/read cycle
     status_events_tool_chain.json
-    approval_yes.json       # Approval round-trip: user approves -> tool runs
-    approval_no.json        # Approval round-trip: user denies -> tool skipped
-    approval_always.json    # Approval round-trip: allow-always persists across calls
+    approval_yes.json              # Approval round-trip: user approves -> tool runs
+    approval_no.json               # Approval round-trip: user denies -> tool skipped
+    approval_always.json           # Approval round-trip: allow-always persists across calls
+    approval_always_floor.json     # ApprovalRequirement::Always is unbypassable (allow-always does NOT skip subsequent pauses)
+    approval_slash.json            # /approve slash form routes as ApprovalResponse
+    approval_bare_yes_no_pending.json # Bare "yes" with no pending approval is treated as user input
   advanced/                 # Multi-step and edge-case scenarios
     long_tool_chain.json    # Many sequential tool calls
     tool_error_recovery.json # Failed tool call -> retry with valid path

--- a/tests/fixtures/llm_traces/README.md
+++ b/tests/fixtures/llm_traces/README.md
@@ -340,6 +340,9 @@ llm_traces/
     injection_in_echo.json  # Prompt injection in tool output
     memory_full_cycle.json  # Full memory write/search/read cycle
     status_events_tool_chain.json
+    approval_yes.json       # Approval round-trip: user approves -> tool runs
+    approval_no.json        # Approval round-trip: user denies -> tool skipped
+    approval_always.json    # Approval round-trip: allow-always persists across calls
   advanced/                 # Multi-step and edge-case scenarios
     long_tool_chain.json    # Many sequential tool calls
     tool_error_recovery.json # Failed tool call -> retry with valid path

--- a/tests/fixtures/llm_traces/README.md
+++ b/tests/fixtures/llm_traces/README.md
@@ -346,6 +346,11 @@ llm_traces/
     approval_always_floor.json     # ApprovalRequirement::Always is unbypassable (allow-always does NOT skip subsequent pauses)
     approval_slash.json            # /approve slash form routes as ApprovalResponse
     approval_bare_yes_no_pending.json # Bare "yes" with no pending approval is treated as user input
+    auth_credential_provided.json       # Engine v2 auth gate: CredentialProvided resumes the paused tool
+    auth_cancelled.json                 # Engine v2 auth gate: Cancelled stops the thread (no re-run)
+    auth_retry_invalid_then_valid.json  # Engine v2 auth gate: second pause emits a fresh request_id
+    auth_external_callback.json         # Engine v2 auth gate: ExternalCallback resumes after OAuth redirect
+    auth_gate_request_id.json           # Engine v2 invariant: AuthRequired carries a real Uuid request_id
   advanced/                 # Multi-step and edge-case scenarios
     long_tool_chain.json    # Many sequential tool calls
     tool_error_recovery.json # Failed tool call -> retry with valid path

--- a/tests/fixtures/llm_traces/coverage/approval_always.json
+++ b/tests/fixtures/llm_traces/coverage/approval_always.json
@@ -1,0 +1,52 @@
+{
+  "model_name": "coverage-approval-always",
+  "expects": {
+    "tools_used": ["needs_approval_probe"],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  },
+  "turns": [
+    {
+      "user_input": "Run the gated probe twice",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "gated probe" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_probe_always_1",
+                "name": "needs_approval_probe",
+                "arguments": { "value": "first" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_probe_always_2",
+                "name": "needs_approval_probe",
+                "arguments": { "value": "second" }
+              }
+            ],
+            "input_tokens": 100,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Both calls completed after you allowed-always.",
+            "input_tokens": 140,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/approval_always_floor.json
+++ b/tests/fixtures/llm_traces/coverage/approval_always_floor.json
@@ -1,0 +1,52 @@
+{
+  "model_name": "coverage-approval-always-floor",
+  "expects": {
+    "tools_used": ["always_approval_probe"],
+    "all_tools_succeeded": true,
+    "min_responses": 1
+  },
+  "turns": [
+    {
+      "user_input": "Run the always-gated probe twice",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "always-gated" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_floor_1",
+                "name": "always_approval_probe",
+                "arguments": { "value": "first" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_floor_2",
+                "name": "always_approval_probe",
+                "arguments": { "value": "second" }
+              }
+            ],
+            "input_tokens": 100,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Both gated calls completed after you approved each one.",
+            "input_tokens": 140,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/approval_bare_yes_no_pending.json
+++ b/tests/fixtures/llm_traces/coverage/approval_bare_yes_no_pending.json
@@ -1,0 +1,24 @@
+{
+  "model_name": "coverage-approval-bare-yes-no-pending",
+  "expects": {
+    "tools_not_used": ["needs_approval_probe"],
+    "min_responses": 1,
+    "response_contains": ["acknowledged"]
+  },
+  "turns": [
+    {
+      "user_input": "yes",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "yes" },
+          "response": {
+            "type": "text",
+            "content": "Acknowledged. There was nothing pending — what would you like next?",
+            "input_tokens": 60,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/approval_no.json
+++ b/tests/fixtures/llm_traces/coverage/approval_no.json
@@ -1,0 +1,30 @@
+{
+  "model_name": "coverage-approval-no",
+  "expects": {
+    "tools_not_used": ["needs_approval_probe"],
+    "min_responses": 1,
+    "response_contains": ["rejected"]
+  },
+  "turns": [
+    {
+      "user_input": "Run the gated probe",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "gated probe" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_probe_no",
+                "name": "needs_approval_probe",
+                "arguments": { "value": "go" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/approval_slash.json
+++ b/tests/fixtures/llm_traces/coverage/approval_slash.json
@@ -1,0 +1,39 @@
+{
+  "model_name": "coverage-approval-slash",
+  "expects": {
+    "tools_used": ["needs_approval_probe"],
+    "all_tools_succeeded": true,
+    "min_responses": 1,
+    "response_contains": ["approved"]
+  },
+  "turns": [
+    {
+      "user_input": "Run the gated probe",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "gated probe" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_probe_slash",
+                "name": "needs_approval_probe",
+                "arguments": { "value": "go" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The probe ran after you approved it via slash.",
+            "input_tokens": 90,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/approval_yes.json
+++ b/tests/fixtures/llm_traces/coverage/approval_yes.json
@@ -1,0 +1,39 @@
+{
+  "model_name": "coverage-approval-yes",
+  "expects": {
+    "tools_used": ["needs_approval_probe"],
+    "all_tools_succeeded": true,
+    "min_responses": 1,
+    "response_contains": ["approved"]
+  },
+  "turns": [
+    {
+      "user_input": "Run the gated probe",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "gated probe" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_probe_yes",
+                "name": "needs_approval_probe",
+                "arguments": { "value": "go" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "The probe ran after you approved it.",
+            "input_tokens": 90,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/auth_cancelled.json
+++ b/tests/fixtures/llm_traces/coverage/auth_cancelled.json
@@ -1,0 +1,29 @@
+{
+  "model_name": "coverage-auth-cancelled",
+  "expects": {
+    "min_responses": 1,
+    "response_contains": ["Cancelled"]
+  },
+  "turns": [
+    {
+      "user_input": "Set up the credential I'll cancel",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "cancel" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_auth_cancel",
+                "name": "tool_activate",
+                "arguments": { "name": "test_credential" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/auth_credential_provided.json
+++ b/tests/fixtures/llm_traces/coverage/auth_credential_provided.json
@@ -1,0 +1,37 @@
+{
+  "model_name": "coverage-auth-credential-provided",
+  "expects": {
+    "min_responses": 1,
+    "response_contains": ["configured"]
+  },
+  "turns": [
+    {
+      "user_input": "Set up the test credential",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "test credential" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_auth_ok",
+                "name": "tool_activate",
+                "arguments": { "name": "test_credential" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Credential 'test_credential' is now configured.",
+            "input_tokens": 90,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/auth_external_callback.json
+++ b/tests/fixtures/llm_traces/coverage/auth_external_callback.json
@@ -1,0 +1,37 @@
+{
+  "model_name": "coverage-auth-external-callback",
+  "expects": {
+    "min_responses": 1,
+    "response_contains": ["connected"]
+  },
+  "turns": [
+    {
+      "user_input": "Connect the OAuth service",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "OAuth" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_oauth_callback",
+                "name": "tool_activate",
+                "arguments": { "name": "oauth_service" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "OAuth service is now connected.",
+            "input_tokens": 90,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/auth_gate_request_id.json
+++ b/tests/fixtures/llm_traces/coverage/auth_gate_request_id.json
@@ -1,0 +1,29 @@
+{
+  "model_name": "coverage-auth-gate-request-id",
+  "expects": {
+    "tools_used": ["tool_activate"],
+    "min_responses": 0
+  },
+  "turns": [
+    {
+      "user_input": "Trigger the auth gate",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "auth gate" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_auth_requestid",
+                "name": "tool_activate",
+                "arguments": { "name": "probe_credential" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/llm_traces/coverage/auth_retry_invalid_then_valid.json
+++ b/tests/fixtures/llm_traces/coverage/auth_retry_invalid_then_valid.json
@@ -1,0 +1,37 @@
+{
+  "model_name": "coverage-auth-retry",
+  "expects": {
+    "min_responses": 1,
+    "response_contains": ["configured"]
+  },
+  "turns": [
+    {
+      "user_input": "Set up the credential",
+      "steps": [
+        {
+          "request_hint": { "last_user_message_contains": "credential" },
+          "response": {
+            "type": "tool_calls",
+            "tool_calls": [
+              {
+                "id": "call_auth_retry",
+                "name": "tool_activate",
+                "arguments": { "name": "test_credential" }
+              }
+            ],
+            "input_tokens": 60,
+            "output_tokens": 20
+          }
+        },
+        {
+          "response": {
+            "type": "text",
+            "content": "Credential 'test_credential' is now configured.",
+            "input_tokens": 90,
+            "output_tokens": 15
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -12,3 +12,5 @@ pub mod replay_outcome;
 pub mod test_channel;
 pub mod test_rig;
 pub mod trace_llm;
+#[cfg(feature = "libsql")]
+pub mod trace_runner;

--- a/tests/support/test_channel.rs
+++ b/tests/support/test_channel.rs
@@ -110,6 +110,16 @@ impl TestChannel {
         self.tx.send(msg).await.expect("TestChannel tx closed");
     }
 
+    /// Channel name used for injected messages.
+    pub fn channel_name(&self) -> &str {
+        &self.channel_name
+    }
+
+    /// Default user ID used for injected messages.
+    pub fn user_id(&self) -> &str {
+        &self.user_id
+    }
+
     /// Inject a raw `IncomingMessage` (for tests that need attachments, etc.).
     pub async fn send_incoming(&self, msg: IncomingMessage) {
         self.tx.send(msg).await.expect("TestChannel tx closed");

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -861,12 +861,13 @@ impl TestRigBuilder {
         self
     }
 
-    /// Replace a tool by name regardless of protection status.
+    /// Replace a built-in or test tool by name after the normal registry
+    /// setup pass has completed.
     ///
-    /// Unlike `with_extra_tools`, this uses `ToolRegistry::replace_for_test`
-    /// which bypasses the `PROTECTED_TOOL_NAMES` guard in `register()`.
-    /// Use this to swap built-in tools (e.g. `tool_activate`, `tool_auth`)
-    /// with probe stubs that emit specific outputs for gate testing.
+    /// Unlike `with_extra_tools`, these overrides are applied at the end of
+    /// `build()` via `ToolRegistry::register_sync`, so a probe stub can
+    /// intentionally replace an earlier built-in registration (e.g.
+    /// `tool_activate`, `tool_auth`) for gate testing.
     pub fn with_test_tool_override(mut self, tool: Arc<dyn Tool>) -> Self {
         self.test_tool_overrides.push(tool);
         self
@@ -1248,7 +1249,7 @@ impl TestRigBuilder {
             // registrations) so these stubs take precedence over any
             // protected tool registered earlier.
             for tool in test_tool_overrides {
-                components.tools.replace_for_test(tool).await;
+                components.tools.register_sync(tool);
             }
 
             // Register WASM tools with the shared HTTP interceptor.

--- a/tests/support/test_rig.rs
+++ b/tests/support/test_rig.rs
@@ -243,6 +243,43 @@ impl TestRig {
         self.channel.send_incoming(msg).await;
     }
 
+    /// Resolve a pending auth gate by submitting a typed
+    /// `Submission::GateAuthResolution`.
+    ///
+    /// The `request_id` must be a `Uuid` matching the `request_id` field on
+    /// a previously-emitted `StatusUpdate::AuthRequired`. Use
+    /// `wait_for_auth_required` to observe it before calling this.
+    pub async fn send_gate_auth_resolution(
+        &self,
+        request_id: uuid::Uuid,
+        resolution: ironclaw::agent::submission::AuthGateResolution,
+    ) {
+        let submission = ironclaw::agent::submission::Submission::GateAuthResolution {
+            request_id,
+            resolution,
+        };
+        let msg = ironclaw::channels::IncomingMessage::new(
+            self.channel.channel_name(),
+            self.channel.user_id(),
+            "",
+        )
+        .with_structured_submission(submission);
+        self.channel.send_incoming(msg).await;
+    }
+
+    /// Resolve an OAuth-style gate by submitting a typed
+    /// `Submission::ExternalCallback`.
+    pub async fn send_external_callback(&self, request_id: uuid::Uuid) {
+        let submission = ironclaw::agent::submission::Submission::ExternalCallback { request_id };
+        let msg = ironclaw::channels::IncomingMessage::new(
+            self.channel.channel_name(),
+            self.channel.user_id(),
+            "",
+        )
+        .with_structured_submission(submission);
+        self.channel.send_incoming(msg).await;
+    }
+
     /// Return all message lists that were sent to the LLM provider.
     ///
     /// Only available when the rig was built with a `TraceLlm` (i.e., via `.with_trace()`).
@@ -670,6 +707,7 @@ pub struct TestRigBuilder {
     http_exchanges: Vec<HttpExchange>,
     http_interceptor_override: Option<Arc<dyn HttpInterceptor>>,
     extra_tools: Vec<Arc<dyn Tool>>,
+    test_tool_overrides: Vec<Arc<dyn Tool>>,
     wasm_tools: Vec<WasmToolSpec>,
     keep_bootstrap: bool,
     engine_v2: bool,
@@ -698,6 +736,7 @@ impl TestRigBuilder {
             http_exchanges: Vec::new(),
             http_interceptor_override: None,
             extra_tools: Vec::new(),
+            test_tool_overrides: Vec::new(),
             wasm_tools: Vec::new(),
             keep_bootstrap: false,
             engine_v2: false,
@@ -822,6 +861,17 @@ impl TestRigBuilder {
         self
     }
 
+    /// Replace a tool by name regardless of protection status.
+    ///
+    /// Unlike `with_extra_tools`, this uses `ToolRegistry::replace_for_test`
+    /// which bypasses the `PROTECTED_TOOL_NAMES` guard in `register()`.
+    /// Use this to swap built-in tools (e.g. `tool_activate`, `tool_auth`)
+    /// with probe stubs that emit specific outputs for gate testing.
+    pub fn with_test_tool_override(mut self, tool: Arc<dyn Tool>) -> Self {
+        self.test_tool_overrides.push(tool);
+        self
+    }
+
     /// Enable prompt injection detection in the safety layer.
     ///
     /// When enabled, tool outputs are scanned for injection patterns
@@ -918,6 +968,7 @@ impl TestRigBuilder {
             http_exchanges: explicit_http_exchanges,
             http_interceptor_override,
             extra_tools,
+            test_tool_overrides,
             wasm_tools,
             keep_bootstrap,
             engine_v2,
@@ -1190,6 +1241,14 @@ impl TestRigBuilder {
             // Register any extra test-specific tools.
             for tool in extra_tools {
                 components.tools.register(tool).await;
+            }
+
+            // Apply test-only tool replacements. Runs after the normal
+            // registration pass (including AppBuilder's built-in
+            // registrations) so these stubs take precedence over any
+            // protected tool registered earlier.
+            for tool in test_tool_overrides {
+                components.tools.replace_for_test(tool).await;
             }
 
             // Register WASM tools with the shared HTTP interceptor.

--- a/tests/support/trace_runner.rs
+++ b/tests/support/trace_runner.rs
@@ -217,6 +217,13 @@ fn evaluate_expectation(
             })
         }
         (Err(err), TraceExpectation::Failure { error_contains }) => {
+            if error_contains.trim().is_empty() {
+                return Some(TraceFailure {
+                    operation_index: index,
+                    tool_name: op.tool_name.clone(),
+                    reason: "failure expectations must set a non-empty error_contains".into(),
+                });
+            }
             let msg = err.to_string();
             if msg.contains(error_contains) {
                 None
@@ -368,6 +375,20 @@ mod tests {
             }
         });
         assert!(check_success_assertions(&out, &asserts).is_none());
+    }
+
+    #[test]
+    fn failure_expectation_rejects_empty_error_contains() {
+        let op = TraceOperation {
+            tool_name: "missing".into(),
+            params: serde_json::Value::Null,
+            expected: TraceExpectation::Failure {
+                error_contains: " ".into(),
+            },
+        };
+        let failure = evaluate_expectation(0, &op, &Err(ToolError::ExecutionFailed("boom".into())))
+            .expect("empty error_contains must be rejected");
+        assert!(failure.reason.contains("non-empty error_contains"));
     }
 
     #[test]

--- a/tests/support/trace_runner.rs
+++ b/tests/support/trace_runner.rs
@@ -1,0 +1,399 @@
+#![allow(dead_code)]
+//! Gateway-ops trace replay harness (#643).
+//!
+//! Complements the agentic [`TraceLlm`](super::trace_llm) replay system.
+//! Where `TraceLlm` replays a recorded LLM stream and asserts the agent
+//! produces the same tool calls, this harness takes the opposite
+//! direction: a caller supplies an ordered sequence of tool invocations
+//! (mimicking what a gateway handler would dispatch), and the runner
+//! executes them against real `Tool` implementations backed by a test DB.
+//!
+//! The runner:
+//! 1. Creates a parent `agent_jobs` row (the `job_actions` table has a
+//!    `FK → agent_jobs(id)` constraint that `save_action` depends on).
+//! 2. For each operation, looks up the tool by name, executes it, builds
+//!    the `ActionRecord`, and persists it via `Database::save_action`.
+//! 3. Checks each result against the declared `TraceExpectation`, logging
+//!    any mismatches as `TraceFailure` entries.
+//!
+//! See `tests/fixtures/gateway_traces/README.md` for the JSON wire format.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use ironclaw::context::{ActionRecord, JobContext};
+use ironclaw::db::Database;
+use ironclaw::tools::{ToolError, ToolOutput, ToolRegistry};
+
+/// An ordered sequence of tool invocations with expected outcomes.
+///
+/// Serialization format matches the fixture JSON files under
+/// `tests/fixtures/gateway_traces/`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Trace {
+    /// Human-readable identifier (used in error messages and logs).
+    pub name: String,
+    /// The sequence of operations to execute in order.
+    pub operations: Vec<TraceOperation>,
+}
+
+/// A single tool invocation within a trace.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TraceOperation {
+    /// Tool name as registered in the `ToolRegistry`.
+    pub tool_name: String,
+    /// Input parameters (JSON) passed to `Tool::execute`.
+    pub params: serde_json::Value,
+    /// What the runner should assert about the outcome.
+    pub expected: TraceExpectation,
+}
+
+/// What the runner should assert about an operation's outcome.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum TraceExpectation {
+    /// The tool call should succeed. Optional `assertions` is a JSON
+    /// object describing field matches on the tool output.
+    ///
+    /// Supported assertion keys:
+    /// - `eq`: deep equality against the entire tool output
+    /// - `contains_text`: the output (stringified) must contain this substring
+    /// - `fields`: an object whose keys are JSON paths (dot-separated) and
+    ///   whose values must match the value at that path in the output
+    Success {
+        #[serde(default)]
+        assertions: serde_json::Value,
+    },
+    /// The tool call should fail. The error's `Display` must contain
+    /// `error_contains`.
+    Failure { error_contains: String },
+}
+
+/// The result of replaying a trace.
+#[derive(Debug, Clone)]
+pub struct TraceResult {
+    /// Job-scoped id the runner created before persisting actions. Use
+    /// this with `Database::get_job_actions` to verify persistence.
+    pub job_id: Uuid,
+    /// Recorded `ActionRecord` for every operation (including failed ones).
+    pub records: Vec<ActionRecord>,
+    /// Any assertion mismatches encountered during the replay. An empty
+    /// vector means every operation matched its `TraceExpectation`.
+    pub failures: Vec<TraceFailure>,
+}
+
+/// A single assertion failure inside a trace replay.
+#[derive(Debug, Clone)]
+pub struct TraceFailure {
+    /// Zero-based index of the failing operation in `Trace::operations`.
+    pub operation_index: usize,
+    /// Tool name for the failing operation (for quick scanning).
+    pub tool_name: String,
+    /// Human-readable explanation (what was expected vs what happened).
+    pub reason: String,
+}
+
+/// Errors that can stop a trace before it finishes.
+#[derive(Debug, thiserror::Error)]
+pub enum TraceRunnerError {
+    /// The parent `agent_jobs` row could not be created.
+    #[error("failed to create parent job row: {0}")]
+    JobRowCreate(String),
+    /// Persisting an `ActionRecord` failed. The trace is aborted because
+    /// subsequent operations would be orphaned.
+    #[error("failed to persist ActionRecord at operation {index}: {reason}")]
+    PersistFailed { index: usize, reason: String },
+}
+
+/// Replays a [`Trace`] against a live `ToolRegistry` + `Database`.
+pub struct TraceRunner {
+    tools: Arc<ToolRegistry>,
+    store: Arc<dyn Database>,
+    user_id: String,
+}
+
+impl TraceRunner {
+    /// Construct a new runner.
+    pub fn new(
+        tools: Arc<ToolRegistry>,
+        store: Arc<dyn Database>,
+        user_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            tools,
+            store,
+            user_id: user_id.into(),
+        }
+    }
+
+    /// Replay a trace and return the recorded actions + any failures.
+    ///
+    /// Creates exactly one `agent_jobs` parent row so the `job_actions`
+    /// FK constraint is satisfied. Operations are executed sequentially;
+    /// a later op may depend on state mutated by an earlier one.
+    ///
+    /// A missing tool is treated as a `Failure` outcome: an `ActionRecord`
+    /// is still persisted with an error message, and the expectation is
+    /// checked against that. This mirrors how gateway handlers would
+    /// report an unknown tool to the caller.
+    pub async fn replay(&self, trace: &Trace) -> Result<TraceResult, TraceRunnerError> {
+        let ctx = JobContext::with_user(
+            self.user_id.clone(),
+            format!("trace:{}", trace.name),
+            "gateway-ops trace replay",
+        );
+
+        self.store
+            .save_job(&ctx)
+            .await
+            .map_err(|e| TraceRunnerError::JobRowCreate(e.to_string()))?;
+
+        let mut records = Vec::with_capacity(trace.operations.len());
+        let mut failures = Vec::new();
+
+        for (index, op) in trace.operations.iter().enumerate() {
+            let (result, duration) = run_one(&self.tools, op, &ctx).await;
+
+            let record = match &result {
+                Ok(output) => ActionRecord::new(index as u32, &op.tool_name, op.params.clone())
+                    .succeed(None, output.result.clone(), duration),
+                Err(err) => ActionRecord::new(index as u32, &op.tool_name, op.params.clone())
+                    .fail(err.to_string(), duration),
+            };
+
+            self.store
+                .save_action(ctx.job_id, &record)
+                .await
+                .map_err(|e| TraceRunnerError::PersistFailed {
+                    index,
+                    reason: e.to_string(),
+                })?;
+
+            if let Some(failure) = evaluate_expectation(index, op, &result) {
+                failures.push(failure);
+            }
+
+            records.push(record);
+        }
+
+        Ok(TraceResult {
+            job_id: ctx.job_id,
+            records,
+            failures,
+        })
+    }
+}
+
+async fn run_one(
+    tools: &Arc<ToolRegistry>,
+    op: &TraceOperation,
+    ctx: &JobContext,
+) -> (Result<ToolOutput, ToolError>, Duration) {
+    let start = Instant::now();
+    let result = match tools.get(&op.tool_name).await {
+        Some(tool) => tool.execute(op.params.clone(), ctx).await,
+        None => Err(ToolError::ExecutionFailed(format!(
+            "tool not registered: {}",
+            op.tool_name
+        ))),
+    };
+    (result, start.elapsed())
+}
+
+fn evaluate_expectation(
+    index: usize,
+    op: &TraceOperation,
+    result: &Result<ToolOutput, ToolError>,
+) -> Option<TraceFailure> {
+    match (result, &op.expected) {
+        (Ok(output), TraceExpectation::Success { assertions }) => {
+            check_success_assertions(&output.result, assertions).map(|reason| TraceFailure {
+                operation_index: index,
+                tool_name: op.tool_name.clone(),
+                reason,
+            })
+        }
+        (Err(err), TraceExpectation::Failure { error_contains }) => {
+            let msg = err.to_string();
+            if msg.contains(error_contains) {
+                None
+            } else {
+                Some(TraceFailure {
+                    operation_index: index,
+                    tool_name: op.tool_name.clone(),
+                    reason: format!("expected error containing {error_contains:?}, got {msg:?}"),
+                })
+            }
+        }
+        (Ok(_), TraceExpectation::Failure { error_contains }) => Some(TraceFailure {
+            operation_index: index,
+            tool_name: op.tool_name.clone(),
+            reason: format!("expected failure containing {error_contains:?}, got success instead"),
+        }),
+        (Err(err), TraceExpectation::Success { .. }) => Some(TraceFailure {
+            operation_index: index,
+            tool_name: op.tool_name.clone(),
+            reason: format!("expected success, got error: {err}"),
+        }),
+    }
+}
+
+/// Walk the assertion DSL and return `Some(reason)` on mismatch.
+fn check_success_assertions(
+    output: &serde_json::Value,
+    assertions: &serde_json::Value,
+) -> Option<String> {
+    if assertions.is_null() {
+        return None;
+    }
+
+    let Some(obj) = assertions.as_object() else {
+        return Some(format!(
+            "assertions must be a JSON object, got: {assertions}"
+        ));
+    };
+
+    for (key, expected) in obj {
+        match key.as_str() {
+            "eq" => {
+                if output != expected {
+                    return Some(format!("eq mismatch: expected {expected}, got {output}"));
+                }
+            }
+            "contains_text" => {
+                let Some(needle) = expected.as_str() else {
+                    return Some(format!("contains_text must be a string, got: {expected}"));
+                };
+                let haystack = output.to_string();
+                if !haystack.contains(needle) {
+                    return Some(format!(
+                        "contains_text mismatch: {haystack:?} does not contain {needle:?}"
+                    ));
+                }
+            }
+            "fields" => {
+                let Some(fields) = expected.as_object() else {
+                    return Some(format!("fields must be an object, got: {expected}"));
+                };
+                for (path, want) in fields {
+                    let got = json_path(output, path);
+                    if got != Some(want) {
+                        return Some(format!(
+                            "fields[{path}] mismatch: expected {want}, got {got:?}"
+                        ));
+                    }
+                }
+            }
+            other => {
+                return Some(format!("unknown assertion key: {other}"));
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve a dot-separated path in a JSON value. `a.b.c` walks objects;
+/// numeric segments index arrays.
+fn json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a serde_json::Value> {
+    let mut cur = value;
+    for seg in path.split('.') {
+        cur = match cur {
+            serde_json::Value::Object(map) => map.get(seg)?,
+            serde_json::Value::Array(arr) => {
+                let idx: usize = seg.parse().ok()?;
+                arr.get(idx)?
+            }
+            _ => return None,
+        };
+    }
+    Some(cur)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_path_walks_nested_objects() {
+        let v = serde_json::json!({"a": {"b": {"c": 42}}});
+        assert_eq!(json_path(&v, "a.b.c"), Some(&serde_json::Value::from(42)));
+        assert_eq!(json_path(&v, "a.b.missing"), None);
+    }
+
+    #[test]
+    fn json_path_indexes_arrays() {
+        let v = serde_json::json!({"items": ["x", "y", "z"]});
+        assert_eq!(
+            json_path(&v, "items.1"),
+            Some(&serde_json::Value::from("y"))
+        );
+        assert_eq!(json_path(&v, "items.99"), None);
+    }
+
+    #[test]
+    fn check_assertions_eq_matches() {
+        let out = serde_json::json!({"foo": 1});
+        let asserts = serde_json::json!({"eq": {"foo": 1}});
+        assert!(check_success_assertions(&out, &asserts).is_none());
+    }
+
+    #[test]
+    fn check_assertions_eq_reports_mismatch() {
+        let out = serde_json::json!({"foo": 1});
+        let asserts = serde_json::json!({"eq": {"foo": 2}});
+        let reason = check_success_assertions(&out, &asserts).expect("should fail");
+        assert!(reason.contains("eq mismatch"));
+    }
+
+    #[test]
+    fn check_assertions_contains_text() {
+        let out = serde_json::json!("hello world");
+        let asserts = serde_json::json!({"contains_text": "world"});
+        assert!(check_success_assertions(&out, &asserts).is_none());
+
+        let asserts_bad = serde_json::json!({"contains_text": "nope"});
+        assert!(check_success_assertions(&out, &asserts_bad).is_some());
+    }
+
+    #[test]
+    fn check_assertions_fields_paths() {
+        let out = serde_json::json!({"data": {"items": [{"id": 7}]}});
+        let asserts = serde_json::json!({
+            "fields": {
+                "data.items.0.id": 7,
+            }
+        });
+        assert!(check_success_assertions(&out, &asserts).is_none());
+    }
+
+    #[test]
+    fn trace_roundtrips_json() {
+        let trace = Trace {
+            name: "demo".into(),
+            operations: vec![
+                TraceOperation {
+                    tool_name: "echo".into(),
+                    params: serde_json::json!({"message": "hi"}),
+                    expected: TraceExpectation::Success {
+                        assertions: serde_json::json!({"contains_text": "hi"}),
+                    },
+                },
+                TraceOperation {
+                    tool_name: "missing".into(),
+                    params: serde_json::Value::Null,
+                    expected: TraceExpectation::Failure {
+                        error_contains: "not found".into(),
+                    },
+                },
+            ],
+        };
+        let j = serde_json::to_value(&trace).unwrap();
+        let back: Trace = serde_json::from_value(j).unwrap();
+        assert_eq!(back.name, "demo");
+        assert_eq!(back.operations.len(), 2);
+    }
+}


### PR DESCRIPTION
## Summary
- add deterministic replay coverage for approval flows
- add deterministic replay coverage for auth-gate flows
- add a gateway-ops trace replay harness with committed fixture coverage
- add engine-v2 caller-level router coverage for text-based auth fallback handling

## Included in this PR
### Approval replay fixtures
- adds approval replay fixtures and assertions for yes/no/always/slash-command handling
- expands coverage for missing approval scenarios and persistence behavior

### Auth-gate replay fixtures
- adds auth-gate replay fixtures covering credential submission, invalid-then-valid retry, external callback, cancellation, and request-id emission

### Gateway trace replay harness
- adds `tests/support/trace_runner.rs`
- adds `tests/e2e_gateway_trace_harness.rs`
- adds committed gateway trace fixtures under `tests/fixtures/gateway_traces/`
- covers echo roundtrip, assertion mix, idempotency, persisted action records, deterministic replay, and unknown-tool failure handling

### Engine-v2 caller-level runtime-boundary coverage
- adds router tests for `handle_with_engine_inner()` text-based auth fallback
- verifies registered credentials produce `BridgeOutcome::Pending` + `StatusUpdate::AuthRequired`
- verifies unregistered or invalid credential names fall back to plain response text instead of creating auth gates

Refs #2828
Refs #643

## Testing
- `cargo test --features libsql --no-default-features --test e2e_approval_traces`
- `cargo test --features libsql --no-default-features --test e2e_auth_gate_traces`
- `cargo test --features libsql --no-default-features --test e2e_gateway_trace_harness`
- `cargo test --features libsql --no-default-features --lib handle_with_engine_text_auth_fallback_`
- `cargo fmt --check`
- `cargo clippy --features libsql --no-default-features --lib --test e2e_approval_traces --test e2e_auth_gate_traces --test e2e_gateway_trace_harness`
