### PR TITLE
feat(cli): add standalone gateway lifecycle commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3917,6 +3917,7 @@ dependencies = [
  "json5",
  "jsonschema",
  "jsonwebtoken",
+ "libc",
  "libsql",
  "lru 0.16.3",
  "mime_guess",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -211,6 +211,7 @@ security-framework = "3"
 
 # PTY allocation for Claude CLI stdout buffering fix (Unix only)
 [target.'cfg(unix)'.dependencies]
+libc = "0.2"
 pty-process = { version = "0.5", features = ["async"] }
 
 # Linux secret-service (GNOME Keyring, KWallet)

--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -156,7 +156,7 @@ This document tracks feature parity between IronClaw (Rust implementation) and O
 |---------|----------|----------|----------|-------|
 | `run` (agent) | ✅ | ✅ | - | Default command |
 | `tool install/list/remove` | ✅ | ✅ | - | WASM tools |
-| `gateway start/stop` | ✅ | ❌ | P2 | |
+| `gateway serve/start/stop/status` | ✅ | ✅ | - | `serve` (foreground), `start` (background daemon), `stop` (SIGTERM, Unix-only), `status` (PID + health). Standalone mode serves gateway APIs without the full agent loop; agent-dependent endpoints return 503. |
 | `onboard` (wizard) | ✅ | ✅ | - | Interactive setup |
 | `tui` | ✅ | ✅ | - | Ratatui TUI |
 | `config` | ✅ | ✅ | - | Read/write config plus validate/path helpers |

--- a/src/bootstrap.rs
+++ b/src/bootstrap.rs
@@ -517,6 +517,21 @@ pub fn pid_lock_path() -> PathBuf {
     ironclaw_base_dir().join("ironclaw.pid")
 }
 
+/// Path to the standalone gateway PID lock file: `~/.ironclaw/gateway.pid`.
+pub fn gateway_pid_lock_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.pid")
+}
+
+/// Path to the standalone gateway log file: `~/.ironclaw/gateway.log`.
+pub fn gateway_log_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.log")
+}
+
+/// Path to the standalone gateway auth token file: `~/.ironclaw/gateway.token`.
+pub fn gateway_token_path() -> PathBuf {
+    ironclaw_base_dir().join("gateway.token")
+}
+
 /// A PID-based lock that prevents multiple IronClaw instances from running
 /// simultaneously.
 ///
@@ -551,8 +566,8 @@ impl PidLock {
         Self::acquire_at(pid_lock_path())
     }
 
-    /// Acquire at a specific path (for testing).
-    fn acquire_at(path: PathBuf) -> Result<Self, PidLockError> {
+    /// Acquire at a specific path (for testing and standalone gateway lifecycle).
+    pub(crate) fn acquire_at(path: PathBuf) -> Result<Self, PidLockError> {
         use fs4::FileExt;
         use std::fs::OpenOptions;
         use std::io::Write;

--- a/src/channels/web/mod.rs
+++ b/src/channels/web/mod.rs
@@ -621,6 +621,11 @@ impl GatewayChannel {
         self.auth.env_auth.first_token().unwrap_or("")
     }
 
+    /// Get the combined auth state used by the router.
+    pub fn auth(&self) -> &CombinedAuthState {
+        &self.auth
+    }
+
     /// Get a reference to the shared gateway state (for the agent to push SSE events).
     pub fn state(&self) -> &Arc<GatewayState> {
         &self.state
@@ -655,7 +660,8 @@ impl Channel for GatewayChannel {
                 ),
             })?;
 
-        platform::router::start_server(addr, self.state.clone(), self.auth.clone()).await?;
+        let (_bound_addr, _server_handle) =
+            platform::router::start_server(addr, self.state.clone(), self.auth.clone()).await?;
 
         Ok(Box::pin(ReceiverStream::new(rx)))
     }

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -101,12 +101,13 @@ use crate::channels::web::features::status::gateway_status_handler;
 
 /// Start the gateway HTTP server.
 ///
-/// Returns the actual bound `SocketAddr` (useful when binding to port 0).
+/// Returns the actual bound `SocketAddr` (useful when binding to port 0)
+/// plus a join handle for the spawned server task.
 pub async fn start_server(
     addr: SocketAddr,
     state: Arc<GatewayState>,
     auth: CombinedAuthState,
-) -> Result<SocketAddr, crate::error::ChannelError> {
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), crate::error::ChannelError> {
     let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
         crate::error::ChannelError::StartupFailed {
             name: "gateway".to_string(),
@@ -571,7 +572,7 @@ pub async fn start_server(
     let (shutdown_tx, shutdown_rx) = oneshot::channel();
     *state.shutdown_tx.write().await = Some(shutdown_tx);
 
-    tokio::spawn(async move {
+    let server_handle = tokio::spawn(async move {
         if let Err(e) = axum::serve(listener, app)
             .with_graceful_shutdown(async {
                 let _ = shutdown_rx.await;
@@ -583,5 +584,5 @@ pub async fn start_server(
         }
     });
 
-    Ok(bound_addr)
+    Ok((bound_addr, server_handle))
 }

--- a/src/channels/web/platform/router.rs
+++ b/src/channels/web/platform/router.rs
@@ -99,15 +99,10 @@ use crate::channels::web::features::settings::{
 };
 use crate::channels::web::features::status::gateway_status_handler;
 
-/// Start the gateway HTTP server.
-///
-/// Returns the actual bound `SocketAddr` (useful when binding to port 0)
-/// plus a join handle for the spawned server task.
-pub async fn start_server(
+/// Bind the gateway TCP listener and return the actual bound address.
+pub async fn bind_listener(
     addr: SocketAddr,
-    state: Arc<GatewayState>,
-    auth: CombinedAuthState,
-) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), crate::error::ChannelError> {
+) -> Result<(tokio::net::TcpListener, SocketAddr), crate::error::ChannelError> {
     let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
         crate::error::ChannelError::StartupFailed {
             name: "gateway".to_string(),
@@ -121,7 +116,19 @@ pub async fn start_server(
                 name: "gateway".to_string(),
                 reason: format!("Failed to get local addr: {}", e),
             })?;
+    Ok((listener, bound_addr))
+}
 
+/// Start the gateway HTTP server from an already-bound listener.
+///
+/// Returns the actual bound `SocketAddr` (useful when binding to port 0)
+/// plus a join handle for the spawned server task.
+pub async fn start_server_with_listener(
+    listener: tokio::net::TcpListener,
+    bound_addr: SocketAddr,
+    state: Arc<GatewayState>,
+    auth: CombinedAuthState,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), crate::error::ChannelError> {
     // Public routes (no auth)
     let public = Router::new()
         .route("/api/health", get(health_handler))
@@ -490,21 +497,24 @@ pub async fn start_server(
     //
     // `SocketAddr`'s `Display` handles IPv6 bracketing correctly
     // (`[::1]:8080` rather than `::1:8080`), so building the origin off the
-    // whole `addr` avoids a broken URL on v6 binds. Parse errors here would
-    // mean the `SocketAddr` itself produced an invalid HTTP origin — a
-    // startup bug, not a request-time error — so we fail the bootstrap
-    // with `ChannelError::StartupFailed` rather than panic.
-    let ip_origin = format!("http://{addr}").parse().map_err(|e| {
+    // whole bound address avoids a broken URL on v6 binds. Parse errors here
+    // would mean the `SocketAddr` itself produced an invalid HTTP origin — a
+    // startup bug, not a request-time error — so we fail the bootstrap with
+    // `ChannelError::StartupFailed` rather than panic.
+    let ip_origin = format!("http://{bound_addr}").parse().map_err(|e| {
         crate::error::ChannelError::StartupFailed {
             name: "gateway".to_string(),
-            reason: format!("Invalid CORS origin for bound addr {addr}: {e}"),
+            reason: format!("Invalid CORS origin for bound addr {bound_addr}: {e}"),
         }
     })?;
-    let localhost_origin = format!("http://localhost:{}", addr.port())
+    let localhost_origin = format!("http://localhost:{}", bound_addr.port())
         .parse()
         .map_err(|e| crate::error::ChannelError::StartupFailed {
             name: "gateway".to_string(),
-            reason: format!("Invalid CORS origin for localhost:{}: {e}", addr.port()),
+            reason: format!(
+                "Invalid CORS origin for localhost:{}: {e}",
+                bound_addr.port()
+            ),
         })?;
     let cors = CorsLayer::new()
         .allow_origin([ip_origin, localhost_origin])
@@ -585,4 +595,17 @@ pub async fn start_server(
     });
 
     Ok((bound_addr, server_handle))
+}
+
+/// Start the gateway HTTP server.
+///
+/// Returns the actual bound `SocketAddr` (useful when binding to port 0)
+/// plus a join handle for the spawned server task.
+pub async fn start_server(
+    addr: SocketAddr,
+    state: Arc<GatewayState>,
+    auth: CombinedAuthState,
+) -> Result<(SocketAddr, tokio::task::JoinHandle<()>), crate::error::ChannelError> {
+    let (listener, bound_addr) = bind_listener(addr).await?;
+    start_server_with_listener(listener, bound_addr, state, auth).await
 }

--- a/src/channels/web/platform/static_files.rs
+++ b/src/channels/web/platform/static_files.rs
@@ -992,7 +992,7 @@ mod tests {
             "test-token".to_string(),
             "test".to_string(),
         ));
-        let bound = start_server(addr, state.clone(), auth)
+        let (bound, _server_handle) = start_server(addr, state.clone(), auth)
             .await
             .expect("server should start");
 

--- a/src/channels/web/test_helpers.rs
+++ b/src/channels/web/test_helpers.rs
@@ -149,7 +149,7 @@ impl TestGatewayBuilder {
         let addr: SocketAddr = "127.0.0.1:0"
             .parse()
             .expect("hard-coded address must parse"); // safety: constant literal
-        let bound = start_server(addr, state.clone(), auth.into()).await?;
+        let (bound, _server_handle) = start_server(addr, state.clone(), auth.into()).await?;
         Ok((bound, state))
     }
 
@@ -163,7 +163,7 @@ impl TestGatewayBuilder {
         let addr: SocketAddr = "127.0.0.1:0"
             .parse()
             .expect("hard-coded address must parse"); // safety: constant literal
-        let bound = start_server(addr, state.clone(), auth.into()).await?;
+        let (bound, _server_handle) = start_server(addr, state.clone(), auth.into()).await?;
         Ok((bound, state))
     }
 }

--- a/src/cli/gateway.rs
+++ b/src/cli/gateway.rs
@@ -1,0 +1,812 @@
+//! Gateway management CLI commands.
+//!
+//! Provides standalone gateway lifecycle management:
+//!
+//! - `gateway serve`  — foreground mode (Ctrl-C to stop), for dev/debug
+//! - `gateway start`  — background daemon, spawns `serve` as detached child
+//! - `gateway stop`   — sends SIGTERM to background daemon via PID file
+//! - `gateway status` — checks PID liveness + health probe
+//!
+//! Read-only APIs work in standalone mode (health, threads, history, memory,
+//! settings, skills, extensions, logs). Endpoints that require the agent loop
+//! (chat send/ws, routine trigger, job restart/cancel/prompt) return 503. For
+//! the full runtime, use `ironclaw run`.
+
+use std::io::IsTerminal;
+use std::net::{IpAddr, SocketAddr};
+use std::path::Path;
+use std::sync::Arc;
+
+use clap::Subcommand;
+
+use crate::app::{AppBuilder, AppBuilderFlags};
+use crate::bootstrap::{PidLock, gateway_log_path, gateway_pid_lock_path, gateway_token_path};
+use crate::channels::GatewayChannel;
+use crate::channels::web::log_layer::{LogBroadcaster, init_tracing};
+use crate::channels::web::platform::{router as gateway_router, state::ActiveConfigSnapshot};
+use crate::config::Config;
+use crate::llm::create_session_manager;
+
+/// Maximum time to wait for the background gateway to become healthy.
+const START_HEALTH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Polling interval when waiting for health check.
+const START_HEALTH_POLL: std::time::Duration = std::time::Duration::from_millis(300);
+
+/// Maximum time to wait for graceful shutdown before aborting the server task.
+const GRACEFUL_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum GatewayCommand {
+    /// Run the web gateway in the foreground (Ctrl-C to stop).
+    Serve,
+
+    /// Start the web gateway as a background daemon.
+    Start,
+
+    /// Stop a running background gateway.
+    Stop,
+
+    /// Show standalone gateway status.
+    Status,
+}
+
+/// Run the gateway CLI subcommand.
+pub async fn run_gateway_command(
+    cmd: GatewayCommand,
+    config_path: Option<&Path>,
+) -> anyhow::Result<()> {
+    #[cfg(not(unix))]
+    match cmd {
+        GatewayCommand::Serve | GatewayCommand::Status => {}
+        GatewayCommand::Start => anyhow::bail!("`gateway start` is currently Unix-only"),
+        GatewayCommand::Stop => anyhow::bail!("`gateway stop` is currently Unix-only"),
+    }
+
+    match cmd {
+        GatewayCommand::Serve => cmd_serve(config_path).await,
+        GatewayCommand::Start => cmd_start(config_path).await,
+        GatewayCommand::Stop => cmd_stop().await,
+        GatewayCommand::Status => cmd_status(config_path).await,
+    }
+}
+
+async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
+    let config = Config::from_env_with_toml(config_path).await?;
+    let gw_config = config
+        .channels
+        .gateway
+        .as_ref()
+        .ok_or_else(|| anyhow::anyhow!("Gateway is not enabled. Set GATEWAY_ENABLED=true"))?;
+    let _validated_addr = parse_gateway_addr(&gw_config.host, gw_config.port)?;
+
+    let _pid_lock = PidLock::acquire_at(gateway_pid_lock_path())
+        .map_err(|e| anyhow::anyhow!("Cannot start gateway: {e}"))?;
+
+    let log_broadcaster = Arc::new(LogBroadcaster::new());
+    let log_level_handle = init_tracing(Arc::clone(&log_broadcaster), false);
+
+    tracing::info!("Starting standalone gateway...");
+
+    let session = create_session_manager(config.llm.session.clone()).await;
+    let flags = AppBuilderFlags { no_db: false };
+    let components = AppBuilder::new(
+        config,
+        flags,
+        config_path.map(std::path::PathBuf::from),
+        session,
+        Arc::clone(&log_broadcaster),
+    )
+    .build_all()
+    .await?;
+
+    let runtime_config = &components.config;
+    let gw_config = runtime_config
+        .channels
+        .gateway
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Gateway is not enabled. Set GATEWAY_ENABLED=true"))?;
+
+    let mut gw = GatewayChannel::new(gw_config.clone(), runtime_config.owner_id.clone());
+    gw = gw.with_multi_tenant_mode(runtime_config.is_multi_tenant_deployment());
+    gw = gw.with_llm_provider(Arc::clone(&components.llm));
+    if let Some(ref ws) = components.workspace {
+        gw = gw.with_workspace(Arc::clone(ws));
+    }
+    if let Some(ref db) = components.db {
+        gw = gw.with_db_backing_from_config(
+            runtime_config,
+            Arc::clone(db),
+            components.embeddings.clone(),
+        );
+    }
+    gw = gw.with_session_manager(Arc::clone(&components.agent_session_manager));
+    gw = gw.with_llm_session_manager(Arc::clone(&components.session));
+    if let Some(ref reload) = components.llm_reload {
+        gw = gw.with_llm_reload(Arc::clone(reload));
+    }
+    if let Some(config_path) = config_path {
+        gw = gw.with_config_toml_path(std::path::PathBuf::from(config_path));
+    }
+    gw = gw.with_log_broadcaster(Arc::clone(&log_broadcaster));
+    gw = gw.with_log_level_handle(Arc::clone(&log_level_handle));
+    gw = gw.with_tool_registry(Arc::clone(&components.tools));
+    if let Some(ref db) = components.db {
+        let dispatcher = Arc::new(crate::tools::dispatch::ToolDispatcher::new(
+            Arc::clone(&components.tools),
+            Arc::clone(&components.safety),
+            Arc::clone(db),
+        ));
+        gw = gw.with_tool_dispatcher(dispatcher);
+    }
+    if let Some(ref ext_mgr) = components.extension_manager {
+        let gw_base = runtime_config
+            .tunnel
+            .public_url
+            .clone()
+            .unwrap_or_else(|| oauth_base_url(&gw_config.host, gw_config.port));
+        ext_mgr.enable_gateway_mode(gw_base).await;
+        gw = gw.with_extension_manager(Arc::clone(ext_mgr));
+    }
+    if !components.catalog_entries.is_empty() {
+        gw = gw.with_registry_entries(components.catalog_entries.clone());
+    }
+    if let Some(ref db) = components.db {
+        gw = gw.with_store(Arc::clone(db));
+        if let Some(ref settings_cache) = components.settings_cache {
+            gw = gw.with_settings_cache(Arc::clone(settings_cache));
+        }
+        gw = gw.with_db_auth(Arc::clone(db));
+        if let Some(ref secrets_store) = components.secrets_store {
+            gw = gw.with_secrets_store(Arc::clone(secrets_store));
+        }
+    }
+    if let Some(ref skill_registry) = components.skill_registry {
+        gw = gw.with_skill_registry(Arc::clone(skill_registry));
+    }
+    if let Some(ref skill_catalog) = components.skill_catalog {
+        gw = gw.with_skill_catalog(Arc::clone(skill_catalog));
+    }
+    gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
+    gw = gw.with_oauth(runtime_config.oauth.clone(), gw_config.port);
+    gw = gw.with_active_config(ActiveConfigSnapshot {
+        llm_backend: runtime_config.llm.backend.to_string(),
+        llm_model: components.llm.model_name().to_string(),
+        enabled_channels: vec!["gateway".to_string()],
+        default_timezone: runtime_config.agent.default_timezone.clone(),
+    });
+
+    let addr = parse_gateway_addr(&gw_config.host, gw_config.port)?;
+
+    let state = Arc::clone(gw.state());
+    let auth_token = gw.auth_token().to_string();
+    let (bound_addr, server_handle) =
+        gateway_router::start_server(addr, Arc::clone(&state), gw.auth().clone()).await?;
+
+    let token_path = gateway_token_path();
+    if let Err(e) = write_gateway_token_file(&token_path, &auth_token) {
+        tracing::warn!("Failed to write token file {}: {e}", token_path.display());
+    }
+
+    println!("Gateway running at http://{bound_addr}/");
+    if std::io::stdout().is_terminal() {
+        println!("Auth token: {auth_token}");
+        println!("Web UI: http://{bound_addr}/?token={auth_token}");
+    } else {
+        println!("Auth token written to {}", token_path.display());
+    }
+    println!();
+    println!("Standalone mode: chat endpoints return 503 (no agent loop).");
+    println!("Press Ctrl-C to stop.");
+
+    wait_for_shutdown_signal().await;
+
+    tracing::info!("Shutting down gateway...");
+    if let Some(tx) = state.shutdown_tx.write().await.take() {
+        let _ = tx.send(());
+    }
+
+    let mut server_handle = server_handle;
+    tokio::select! {
+        result = &mut server_handle => {
+            if let Err(error) = result {
+                tracing::warn!(%error, "Gateway server task exited during shutdown");
+            }
+        }
+        _ = tokio::time::sleep(GRACEFUL_SHUTDOWN_TIMEOUT) => {
+            tracing::warn!(
+                timeout_secs = GRACEFUL_SHUTDOWN_TIMEOUT.as_secs(),
+                "Gateway server did not shut down in time; aborting task"
+            );
+            server_handle.abort();
+            let _ = server_handle.await;
+        }
+    }
+
+    cleanup_gateway_token_file(&token_path);
+    Ok(())
+}
+
+async fn wait_for_shutdown_signal() {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{SignalKind, signal};
+        if let Ok(mut sigterm) = signal(SignalKind::terminate()) {
+            tokio::select! {
+                _ = tokio::signal::ctrl_c() => {},
+                _ = sigterm.recv() => {},
+            }
+        } else {
+            let _ = tokio::signal::ctrl_c().await;
+        }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = tokio::signal::ctrl_c().await;
+    }
+}
+
+fn write_gateway_token_file(path: &Path, auth_token: &str) -> std::io::Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    #[cfg(unix)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        file.write_all(auth_token.as_bytes())?;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    #[cfg(windows)]
+    {
+        use std::fs::OpenOptions;
+        use std::io::Write;
+
+        let mut file = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(path)?;
+        file.write_all(auth_token.as_bytes())?;
+        drop(file);
+
+        restrict_windows_file_permissions(path);
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::fs::write(path, auth_token)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(windows)]
+fn restrict_windows_file_permissions(path: &Path) {
+    let username = std::env::var("USERNAME").unwrap_or_default();
+    if username.is_empty() {
+        tracing::warn!("Cannot restrict token file permissions: %USERNAME% not set");
+        return;
+    }
+
+    let path_str = path.to_string_lossy();
+    let grant_arg = format!("{username}:F");
+    let result = std::process::Command::new("icacls")
+        .args([path_str.as_ref(), "/inheritance:r", "/grant:r", &grant_arg])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status();
+
+    match result {
+        Ok(status) if status.success() => {}
+        Ok(status) => {
+            tracing::warn!(
+                "icacls returned non-zero ({}) for {}; token file may be world-readable",
+                status,
+                path.display()
+            );
+        }
+        Err(e) => {
+            tracing::warn!(
+                "Failed to run icacls for {}: {e}; token file may be world-readable",
+                path.display()
+            );
+        }
+    }
+}
+
+fn open_log_file(path: &Path) -> std::io::Result<std::fs::File> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .mode(0o600)
+            .open(path)?;
+        restrict_unix_file_permissions(path)?;
+        Ok(file)
+    }
+    #[cfg(windows)]
+    {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)?;
+        restrict_windows_file_permissions(path);
+        Ok(file)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    }
+}
+
+#[cfg(unix)]
+fn restrict_unix_file_permissions(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+fn cleanup_gateway_token_file(path: &Path) {
+    if let Err(e) = std::fs::remove_file(path)
+        && e.kind() != std::io::ErrorKind::NotFound
+    {
+        tracing::warn!("Failed to remove token file {}: {e}", path.display());
+    }
+}
+
+async fn cmd_start(config_path: Option<&Path>) -> anyhow::Result<()> {
+    let config = Config::from_env_with_toml(config_path).await?;
+    let gw_config = config
+        .channels
+        .gateway
+        .clone()
+        .ok_or_else(|| anyhow::anyhow!("Gateway is not enabled. Set GATEWAY_ENABLED=true"))?;
+    if gw_config.port == 0 {
+        anyhow::bail!(
+            "gateway start does not support port 0; set a fixed GATEWAY_PORT or use `gateway serve`"
+        );
+    }
+
+    let exe = std::env::current_exe()
+        .map_err(|e| anyhow::anyhow!("Cannot determine own executable path: {e}"))?;
+
+    let log_path = gateway_log_path();
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| anyhow::anyhow!("Cannot create directory {}: {e}", parent.display()))?;
+    }
+    let log_file = open_log_file(&log_path)
+        .map_err(|e| anyhow::anyhow!("Cannot open log file {}: {e}", log_path.display()))?;
+    let stderr_file = log_file
+        .try_clone()
+        .map_err(|e| anyhow::anyhow!("Cannot clone log file handle: {e}"))?;
+
+    let mut cmd = std::process::Command::new(exe);
+    // Args are passed directly to the child process — no shell involved.
+    cmd.arg("gateway").arg("serve");
+    if let Some(cp) = config_path {
+        cmd.arg("--config").arg(cp);
+    }
+    cmd.stdout(log_file)
+        .stderr(stderr_file)
+        .stdin(std::process::Stdio::null());
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| anyhow::anyhow!("Failed to spawn gateway process: {e}"))?;
+
+    let child_pid = child.id();
+    println!("Gateway starting in background (PID {child_pid})...");
+    println!("Log file: {}", log_path.display());
+
+    let health_host = normalize_probe_host(&gw_config.host);
+    let health_url = format!("http://{health_host}:{}/api/health", gw_config.port);
+    let deadline = std::time::Instant::now() + START_HEALTH_TIMEOUT;
+    let mut healthy = false;
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()
+        .map_err(|e| anyhow::anyhow!("Cannot create HTTP client: {e}"))?;
+
+    while std::time::Instant::now() < deadline {
+        tokio::time::sleep(START_HEALTH_POLL).await;
+
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                anyhow::bail!(
+                    "Gateway process exited with {status}. Check logs: {}",
+                    log_path.display()
+                );
+            }
+            Ok(None) => {}
+            Err(e) => {
+                tracing::warn!("Failed to check child process status: {e}");
+            }
+        }
+
+        if probe_health(&http_client, &health_url)
+            .await
+            .unwrap_or(false)
+        {
+            healthy = true;
+            break;
+        }
+    }
+
+    if healthy {
+        let base_url = format!("http://{}:{}", gw_config.host, gw_config.port);
+        println!("Gateway is running at {base_url}/");
+
+        let token_path = gateway_token_path();
+        if let Ok(token) = std::fs::read_to_string(&token_path) {
+            let token = token.trim();
+            if !token.is_empty() {
+                println!("Auth token: {token}");
+                println!("Web UI: {base_url}/?token={token}");
+            }
+        } else {
+            println!(
+                "Auth token: could not read {}; the gateway may still be starting",
+                token_path.display()
+            );
+        }
+    } else {
+        println!(
+            "Warning: gateway process started but health check did not pass within {}s.",
+            START_HEALTH_TIMEOUT.as_secs()
+        );
+        println!("Check logs: {}", log_path.display());
+    }
+
+    Ok(())
+}
+
+async fn cmd_stop() -> anyhow::Result<()> {
+    #[cfg(not(unix))]
+    {
+        anyhow::bail!("gateway stop is currently Unix-only");
+    }
+
+    #[cfg(unix)]
+    {
+        let pid_path = gateway_pid_lock_path();
+        let pid_str = std::fs::read_to_string(&pid_path).map_err(|_| {
+            anyhow::anyhow!(
+                "Gateway is not running (no PID file at {})",
+                pid_path.display()
+            )
+        })?;
+
+        let pid: u32 = pid_str.trim().parse().map_err(|_| {
+            anyhow::anyhow!(
+                "Invalid PID in {}: '{}'",
+                pid_path.display(),
+                pid_str.trim()
+            )
+        })?;
+
+        if !is_pid_lock_held(&pid_path) {
+            let _ = std::fs::remove_file(&pid_path);
+            cleanup_gateway_token_file(&gateway_token_path());
+            anyhow::bail!("Gateway process (PID {pid}) is not running (stale PID file removed)");
+        }
+
+        if !is_process_alive(pid) {
+            let _ = std::fs::remove_file(&pid_path);
+            cleanup_gateway_token_file(&gateway_token_path());
+            anyhow::bail!("Gateway process (PID {pid}) is not running (stale PID file removed)");
+        }
+
+        if !is_pid_lock_held(&pid_path) {
+            let _ = std::fs::remove_file(&pid_path);
+            cleanup_gateway_token_file(&gateway_token_path());
+            anyhow::bail!(
+                "Gateway process (PID {pid}) no longer holds the lock file (stale PID file removed)"
+            );
+        }
+
+        let pid_t = to_pid_t(pid).ok_or_else(|| anyhow::anyhow!("PID {pid} overflows i32"))?;
+        let ret = unsafe { libc::kill(pid_t, libc::SIGTERM) };
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ESRCH) {
+                let _ = std::fs::remove_file(&pid_path);
+                cleanup_gateway_token_file(&gateway_token_path());
+                anyhow::bail!(
+                    "Gateway process (PID {pid}) exited before SIGTERM could be delivered (stale PID file removed)"
+                );
+            }
+            anyhow::bail!("Failed to send SIGTERM to PID {pid}: {err}");
+        }
+        println!("Sent SIGTERM to gateway (PID {pid}).");
+
+        let stop_deadline = std::time::Instant::now() + GRACEFUL_SHUTDOWN_TIMEOUT;
+        while std::time::Instant::now() < stop_deadline {
+            if !is_process_alive(pid) {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+        }
+
+        if pid_path.exists() && !is_process_alive(pid) {
+            let _ = std::fs::remove_file(&pid_path);
+        }
+
+        if is_process_alive(pid) {
+            println!(
+                "Warning: process (PID {pid}) still running after {}s. You may need to `kill -9 {pid}`.",
+                GRACEFUL_SHUTDOWN_TIMEOUT.as_secs()
+            );
+        } else {
+            cleanup_gateway_token_file(&gateway_token_path());
+            println!("Gateway stopped.");
+        }
+
+        Ok(())
+    }
+}
+
+async fn cmd_status(config_path: Option<&Path>) -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        let pid_path = gateway_pid_lock_path();
+        match std::fs::read_to_string(&pid_path) {
+            Ok(pid_str) => match pid_str.trim().parse::<u32>() {
+                Ok(pid) => {
+                    if is_process_alive(pid) && is_pid_lock_held(&pid_path) {
+                        println!("Gateway is running (PID {pid}).");
+                    } else {
+                        println!("Gateway is not running (stale PID {pid}).");
+                        return Ok(());
+                    }
+                }
+                Err(_) => {
+                    println!("Gateway PID file exists but is invalid.");
+                    return Ok(());
+                }
+            },
+            Err(_) => {
+                println!("No PID file found.");
+            }
+        }
+    }
+
+    let config = Config::from_env_with_toml(config_path).await.ok();
+    let probe_addr = config
+        .as_ref()
+        .and_then(|c| c.channels.gateway.as_ref())
+        .map(|gw| {
+            let host = normalize_probe_host(&gw.host);
+            format!("{host}:{}", gw.port)
+        });
+
+    if let Some(ref addr) = probe_addr {
+        println!("Address: {addr}");
+
+        let url = format!("http://{addr}/api/health");
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(3))
+            .build();
+        match client {
+            Ok(c) => match probe_health(&c, &url).await {
+                Ok(true) => println!("Health:  ok"),
+                Ok(false) => println!("Health:  unhealthy"),
+                Err(reason) => println!("Health:  unreachable ({reason})"),
+            },
+            Err(e) => println!("Health:  cannot create client ({e})"),
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_pid_lock_held(path: &Path) -> bool {
+    use fs4::FileExt;
+    let Ok(file) = std::fs::OpenOptions::new().read(true).open(path) else {
+        return false;
+    };
+    match file.try_lock_exclusive() {
+        Ok(()) => {
+            let _ = file.unlock();
+            false
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => true,
+        Err(e) => {
+            tracing::debug!(
+                path = %path.display(),
+                error = %e,
+                "Failed to inspect PID lock state"
+            );
+            false
+        }
+    }
+}
+
+fn is_process_alive(pid: u32) -> bool {
+    #[cfg(unix)]
+    {
+        let Some(pid_t) = to_pid_t(pid) else {
+            return false;
+        };
+        unsafe { libc::kill(pid_t, 0) == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = pid;
+        false
+    }
+}
+
+#[cfg(unix)]
+fn to_pid_t(pid: u32) -> Option<libc::pid_t> {
+    libc::pid_t::try_from(pid).ok()
+}
+
+fn normalize_probe_host(host: &str) -> &str {
+    match host {
+        "0.0.0.0" | "::" | "[::]" => "127.0.0.1",
+        other => other,
+    }
+}
+
+async fn probe_health(client: &reqwest::Client, url: &str) -> Result<bool, String> {
+    let resp = client.get(url).send().await.map_err(|e| format!("{e}"))?;
+    Ok(resp.status().is_success())
+}
+
+fn parse_gateway_addr(host: &str, port: u16) -> anyhow::Result<SocketAddr> {
+    format!("{host}:{port}")
+        .parse()
+        .map_err(|e| anyhow::anyhow!("Invalid gateway address '{host}:{port}': {e}"))
+}
+
+fn oauth_base_url(host: &str, port: u16) -> String {
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    match trimmed.parse::<IpAddr>() {
+        Ok(IpAddr::V4(ip)) if ip.is_unspecified() => format!("http://localhost:{port}"),
+        Ok(IpAddr::V6(ip)) if ip.is_unspecified() => format!("http://localhost:{port}"),
+        Ok(IpAddr::V6(_)) => format!("http://[{trimmed}]:{port}"),
+        Ok(IpAddr::V4(_)) => format!("http://{trimmed}:{port}"),
+        Err(_) => format!("http://{host}:{port}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gateway_pid_lock_path_is_in_base_dir() {
+        let path = gateway_pid_lock_path();
+        assert!(
+            path.ends_with("gateway.pid"),
+            "expected gateway.pid, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn gateway_log_path_is_in_base_dir() {
+        let path = gateway_log_path();
+        assert!(
+            path.ends_with("gateway.log"),
+            "expected gateway.log, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn gateway_token_path_is_in_base_dir() {
+        let path = gateway_token_path();
+        assert!(
+            path.ends_with("gateway.token"),
+            "expected gateway.token, got: {}",
+            path.display()
+        );
+    }
+
+    #[test]
+    fn normalize_probe_host_rewrites_unspecified() {
+        assert_eq!(normalize_probe_host("0.0.0.0"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("::"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("[::]"), "127.0.0.1");
+        assert_eq!(normalize_probe_host("10.0.0.1"), "10.0.0.1");
+    }
+
+    #[test]
+    fn oauth_base_url_maps_unspecified_to_localhost() {
+        assert_eq!(oauth_base_url("0.0.0.0", 3033), "http://localhost:3033");
+        assert_eq!(oauth_base_url("::", 3033), "http://localhost:3033");
+        assert_eq!(oauth_base_url("[::]", 3033), "http://localhost:3033");
+    }
+
+    #[test]
+    fn token_file_round_trip() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let token_path = dir.path().join("gateway.token");
+        let token = "abc123def456";
+        write_gateway_token_file(&token_path, token).expect("write token");
+        let read_back = std::fs::read_to_string(&token_path).expect("read token");
+        assert_eq!(read_back.trim(), token);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn token_file_permissions_are_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let token_path = dir.path().join("gateway.token");
+        write_gateway_token_file(&token_path, "secret").expect("write token");
+
+        let mode = std::fs::metadata(&token_path)
+            .expect("token metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn open_log_file_tightens_existing_permissions() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let log_path = dir.path().join("gateway.log");
+        std::fs::write(&log_path, "old log").expect("seed log file");
+        std::fs::set_permissions(&log_path, std::fs::Permissions::from_mode(0o644))
+            .expect("loosen permissions");
+
+        let _file = open_log_file(&log_path).expect("open log file");
+
+        let mode = std::fs::metadata(&log_path)
+            .expect("log metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn pid_lock_prevents_double_start() {
+        let dir = tempfile::tempdir().expect("create temp dir");
+        let pid_path = dir.path().join("gateway.pid");
+
+        let lock1 = PidLock::acquire_at(pid_path.clone());
+        assert!(lock1.is_ok(), "first lock should succeed");
+
+        let lock2 = PidLock::acquire_at(pid_path);
+        assert!(lock2.is_err(), "second lock should fail");
+    }
+}

--- a/src/cli/gateway.rs
+++ b/src/cli/gateway.rs
@@ -182,16 +182,17 @@ async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
     let auth_token = gw.auth_token().to_string();
     let (bound_addr, server_handle) =
         gateway_router::start_server(addr, Arc::clone(&state), gw.auth().clone()).await?;
+    let base_url = format_http_base_url(&gw_config.host, bound_addr.port());
 
     let token_path = gateway_token_path();
     if let Err(e) = write_gateway_token_file(&token_path, &auth_token) {
         tracing::warn!("Failed to write token file {}: {e}", token_path.display());
     }
 
-    println!("Gateway running at http://{bound_addr}/");
+    println!("Gateway running at {base_url}/");
     if std::io::stdout().is_terminal() {
         println!("Auth token: {auth_token}");
-        println!("Web UI: http://{bound_addr}/?token={auth_token}");
+        println!("Web UI: {base_url}/?token={auth_token}");
     } else {
         println!("Auth token written to {}", token_path.display());
     }
@@ -382,6 +383,7 @@ async fn cmd_start(config_path: Option<&Path>) -> anyhow::Result<()> {
             "gateway start does not support port 0; set a fixed GATEWAY_PORT or use `gateway serve`"
         );
     }
+    let _validated_addr = parse_gateway_addr(&gw_config.host, gw_config.port)?;
 
     let exe = std::env::current_exe()
         .map_err(|e| anyhow::anyhow!("Cannot determine own executable path: {e}"))?;
@@ -428,8 +430,10 @@ async fn cmd_start(config_path: Option<&Path>) -> anyhow::Result<()> {
     println!("Gateway starting in background (PID {child_pid})...");
     println!("Log file: {}", log_path.display());
 
-    let health_host = normalize_probe_host(&gw_config.host);
-    let health_url = format!("http://{health_host}:{}/api/health", gw_config.port);
+    let health_url = format!(
+        "{}/api/health",
+        format_http_base_url(&gw_config.host, gw_config.port)
+    );
     let deadline = std::time::Instant::now() + START_HEALTH_TIMEOUT;
     let mut healthy = false;
     let http_client = reqwest::Client::builder()
@@ -463,7 +467,7 @@ async fn cmd_start(config_path: Option<&Path>) -> anyhow::Result<()> {
     }
 
     if healthy {
-        let base_url = format!("http://{}:{}", gw_config.host, gw_config.port);
+        let base_url = format_http_base_url(&gw_config.host, gw_config.port);
         println!("Gateway is running at {base_url}/");
 
         let token_path = gateway_token_path();
@@ -605,14 +609,15 @@ async fn cmd_status(config_path: Option<&Path>) -> anyhow::Result<()> {
         .as_ref()
         .and_then(|c| c.channels.gateway.as_ref())
         .map(|gw| {
-            let host = normalize_probe_host(&gw.host);
-            format!("{host}:{}", gw.port)
+            let addr = format_http_authority(&gw.host, gw.port);
+            let url = format_http_base_url(&gw.host, gw.port);
+            (addr, url)
         });
 
-    if let Some(ref addr) = probe_addr {
+    if let Some((addr, base_url)) = probe_addr {
         println!("Address: {addr}");
 
-        let url = format!("http://{addr}/api/health");
+        let url = format!("{base_url}/api/health");
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(3))
             .build();
@@ -679,13 +684,35 @@ fn normalize_probe_host(host: &str) -> &str {
     }
 }
 
+fn format_http_host(host: &str) -> String {
+    let normalized = normalize_probe_host(host);
+    let trimmed = normalized.trim_start_matches('[').trim_end_matches(']');
+    match trimmed.parse::<IpAddr>() {
+        Ok(IpAddr::V6(_)) => format!("[{trimmed}]"),
+        _ => trimmed.to_string(),
+    }
+}
+
+fn format_http_authority(host: &str, port: u16) -> String {
+    format!("{}:{port}", format_http_host(host))
+}
+
+fn format_http_base_url(host: &str, port: u16) -> String {
+    format!("http://{}", format_http_authority(host, port))
+}
+
 async fn probe_health(client: &reqwest::Client, url: &str) -> Result<bool, String> {
     let resp = client.get(url).send().await.map_err(|e| format!("{e}"))?;
     Ok(resp.status().is_success())
 }
 
 fn parse_gateway_addr(host: &str, port: u16) -> anyhow::Result<SocketAddr> {
-    format!("{host}:{port}")
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    let authority = match trimmed.parse::<IpAddr>() {
+        Ok(IpAddr::V6(_)) => format!("[{trimmed}]:{port}"),
+        _ => format!("{trimmed}:{port}"),
+    };
+    authority
         .parse()
         .map_err(|e| anyhow::anyhow!("Invalid gateway address '{host}:{port}': {e}"))
 }
@@ -748,6 +775,23 @@ mod tests {
         assert_eq!(oauth_base_url("0.0.0.0", 3033), "http://localhost:3033");
         assert_eq!(oauth_base_url("::", 3033), "http://localhost:3033");
         assert_eq!(oauth_base_url("[::]", 3033), "http://localhost:3033");
+    }
+
+    #[test]
+    fn format_http_base_url_handles_ipv6_and_wildcards() {
+        assert_eq!(
+            format_http_base_url("0.0.0.0", 3000),
+            "http://127.0.0.1:3000"
+        );
+        assert_eq!(format_http_base_url("::", 3000), "http://127.0.0.1:3000");
+        assert_eq!(format_http_base_url("::1", 3000), "http://[::1]:3000");
+        assert_eq!(format_http_base_url("[::1]", 3000), "http://[::1]:3000");
+    }
+
+    #[test]
+    fn parse_gateway_addr_accepts_bracketed_and_unbracketed_ipv6() {
+        assert!(parse_gateway_addr("::1", 3000).is_ok());
+        assert!(parse_gateway_addr("[::1]", 3000).is_ok());
     }
 
     #[test]

--- a/src/cli/gateway.rs
+++ b/src/cli/gateway.rs
@@ -140,12 +140,6 @@ async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
         gw = gw.with_tool_dispatcher(dispatcher);
     }
     if let Some(ref ext_mgr) = components.extension_manager {
-        let gw_base = runtime_config
-            .tunnel
-            .public_url
-            .clone()
-            .unwrap_or_else(|| oauth_base_url(&gw_config.host, gw_config.port));
-        ext_mgr.enable_gateway_mode(gw_base).await;
         gw = gw.with_extension_manager(Arc::clone(ext_mgr));
     }
     if !components.catalog_entries.is_empty() {
@@ -168,7 +162,6 @@ async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
         gw = gw.with_skill_catalog(Arc::clone(skill_catalog));
     }
     gw = gw.with_cost_guard(Arc::clone(&components.cost_guard));
-    gw = gw.with_oauth(runtime_config.oauth.clone(), gw_config.port);
     gw = gw.with_active_config(ActiveConfigSnapshot {
         llm_backend: runtime_config.llm.backend.to_string(),
         llm_model: components.llm.model_name().to_string(),
@@ -177,11 +170,30 @@ async fn cmd_serve(config_path: Option<&Path>) -> anyhow::Result<()> {
     });
 
     let addr = parse_gateway_addr(&gw_config.host, gw_config.port)?;
+    let (listener, bound_addr) = gateway_router::bind_listener(addr).await?;
+    let callback_base_url = effective_gateway_callback_base_url(
+        runtime_config.tunnel.public_url.as_deref(),
+        &gw_config.host,
+        bound_addr.port(),
+    );
+    if let Some(ref ext_mgr) = components.extension_manager {
+        ext_mgr.enable_gateway_mode(callback_base_url.clone()).await;
+    }
+    let mut oauth_config = runtime_config.oauth.clone();
+    if oauth_config.base_url.is_none() {
+        oauth_config.base_url = Some(callback_base_url);
+    }
+    gw = gw.with_oauth(oauth_config, bound_addr.port());
 
     let state = Arc::clone(gw.state());
     let auth_token = gw.auth_token().to_string();
-    let (bound_addr, server_handle) =
-        gateway_router::start_server(addr, Arc::clone(&state), gw.auth().clone()).await?;
+    let (bound_addr, server_handle) = gateway_router::start_server_with_listener(
+        listener,
+        bound_addr,
+        Arc::clone(&state),
+        gw.auth().clone(),
+    )
+    .await?;
     let base_url = format_http_base_url(&gw_config.host, bound_addr.port());
 
     let token_path = gateway_token_path();
@@ -663,13 +675,20 @@ fn is_process_alive(pid: u32) -> bool {
         let Some(pid_t) = to_pid_t(pid) else {
             return false;
         };
-        unsafe { libc::kill(pid_t, 0) == 0 }
+        // safety: `kill(pid, 0)` probes process existence without sending a signal.
+        let result = unsafe { libc::kill(pid_t, 0) };
+        process_exists_from_kill_result(result, std::io::Error::last_os_error().raw_os_error())
     }
     #[cfg(not(unix))]
     {
         let _ = pid;
         false
     }
+}
+
+#[cfg(unix)]
+fn process_exists_from_kill_result(result: i32, errno: Option<i32>) -> bool {
+    result == 0 || errno == Some(libc::EPERM)
 }
 
 #[cfg(unix)]
@@ -728,6 +747,12 @@ fn oauth_base_url(host: &str, port: u16) -> String {
     }
 }
 
+fn effective_gateway_callback_base_url(public_url: Option<&str>, host: &str, port: u16) -> String {
+    public_url
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| oauth_base_url(host, port))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -778,6 +803,22 @@ mod tests {
     }
 
     #[test]
+    fn effective_gateway_callback_base_url_uses_bound_port_for_dynamic_bind() {
+        assert_eq!(
+            effective_gateway_callback_base_url(None, "0.0.0.0", 45123),
+            "http://localhost:45123"
+        );
+    }
+
+    #[test]
+    fn effective_gateway_callback_base_url_preserves_configured_public_url() {
+        assert_eq!(
+            effective_gateway_callback_base_url(Some("https://gateway.example.com"), "0.0.0.0", 0),
+            "https://gateway.example.com"
+        );
+    }
+
+    #[test]
     fn format_http_base_url_handles_ipv6_and_wildcards() {
         assert_eq!(
             format_http_base_url("0.0.0.0", 3000),
@@ -792,6 +833,13 @@ mod tests {
     fn parse_gateway_addr_accepts_bracketed_and_unbracketed_ipv6() {
         assert!(parse_gateway_addr("::1", 3000).is_ok());
         assert!(parse_gateway_addr("[::1]", 3000).is_ok());
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn process_exists_treats_eperm_as_alive() {
+        assert!(process_exists_from_kill_result(-1, Some(libc::EPERM)));
+        assert!(!process_exists_from_kill_result(-1, Some(libc::ESRCH)));
     }
 
     #[test]

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -102,7 +102,7 @@ pub async fn run_logs_command(cmd: LogsCommand, config_path: Option<&Path>) -> a
 /// backwards in chunks to find the last `limit` newlines, so memory usage
 /// is proportional to the output size, not the file size.
 fn cmd_show(cmd: &LogsCommand) -> anyhow::Result<()> {
-    let log_path = crate::bootstrap::ironclaw_base_dir().join("gateway.log");
+    let log_path = crate::bootstrap::gateway_log_path();
     if !log_path.exists() {
         anyhow::bail!(
             "No gateway log file found at {}.\n\
@@ -456,11 +456,25 @@ async fn resolve_gateway_params(
         token.clone()
     } else if let Some(t) = gw_config.as_ref().and_then(|c| c.auth_token.clone()) {
         t
+    } else if let Ok(token) = std::fs::read_to_string(crate::bootstrap::gateway_token_path()) {
+        let token = token.trim().to_string();
+        if token.is_empty() {
+            std::env::var("GATEWAY_AUTH_TOKEN").map_err(|_| {
+                anyhow::anyhow!(
+                    "No auth token provided. Use --token <TOKEN>, set GATEWAY_AUTH_TOKEN, or read {}.\n\
+                     Standalone gateway start writes the token there.",
+                    crate::bootstrap::gateway_token_path().display()
+                )
+            })?
+        } else {
+            token
+        }
     } else {
         std::env::var("GATEWAY_AUTH_TOKEN").map_err(|_| {
             anyhow::anyhow!(
-                "No auth token provided. Use --token <TOKEN> or set GATEWAY_AUTH_TOKEN.\n\
-                 The token is printed when the gateway starts."
+                "No auth token provided. Use --token <TOKEN>, set GATEWAY_AUTH_TOKEN, or read {}.\n\
+                 Standalone gateway start writes the token there.",
+                crate::bootstrap::gateway_token_path().display()
             )
         })?
     };

--- a/src/cli/logs.rs
+++ b/src/cli/logs.rs
@@ -441,14 +441,14 @@ async fn resolve_gateway_params(
     let base_url = if let Some(url) = &cmd.url {
         url.trim_end_matches('/').to_string()
     } else if let Some(cfg) = &gw_config {
-        format!("http://{}:{}", cfg.host, cfg.port)
+        format_gateway_base_url(&cfg.host, cfg.port)
     } else {
         let host = std::env::var("GATEWAY_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
         let port: u16 = std::env::var("GATEWAY_PORT")
             .ok()
             .and_then(|p| p.parse().ok())
             .unwrap_or(3000);
-        format!("http://{}:{}", host, port)
+        format_gateway_base_url(&host, port)
     };
 
     // Token: --token flag > config TOML > env var.
@@ -489,6 +489,19 @@ async fn resolve_gateway_params(
 /// failure when it is missing, unreadable, or malformed.  When no path
 /// was given we fall back to env-only resolution and silently return
 /// `None` on failure so that `ironclaw logs` works without any config.
+fn format_gateway_base_url(host: &str, port: u16) -> String {
+    let trimmed = host.trim_start_matches('[').trim_end_matches(']');
+    let normalized = match trimmed {
+        "0.0.0.0" | "::" => "127.0.0.1",
+        other => other,
+    };
+    let display_host = match normalized.parse::<std::net::IpAddr>() {
+        Ok(std::net::IpAddr::V6(_)) => format!("[{normalized}]"),
+        _ => normalized.to_string(),
+    };
+    format!("http://{display_host}:{port}")
+}
+
 async fn load_gateway_config(
     config_path: Option<&Path>,
 ) -> anyhow::Result<Option<crate::config::GatewayConfig>> {
@@ -767,5 +780,20 @@ mod tests {
         let lines = vec!["test".to_string()];
         let result = filter_lines(lines, "[invalid", false, 0);
         assert!(result.unwrap_err().to_string().contains("Invalid regex"));
+    }
+
+    #[test]
+    fn test_format_gateway_base_url_handles_ipv6_and_wildcards() {
+        assert_eq!(
+            format_gateway_base_url("127.0.0.1", 3000),
+            "http://127.0.0.1:3000"
+        );
+        assert_eq!(
+            format_gateway_base_url("0.0.0.0", 3000),
+            "http://127.0.0.1:3000"
+        );
+        assert_eq!(format_gateway_base_url("::", 3000), "http://127.0.0.1:3000");
+        assert_eq!(format_gateway_base_url("::1", 3000), "http://[::1]:3000");
+        assert_eq!(format_gateway_base_url("[::1]", 3000), "http://[::1]:3000");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@ mod completion;
 mod config;
 mod doctor;
 pub mod fmt;
+mod gateway;
 mod hooks;
 #[cfg(feature = "import")]
 pub mod import;
@@ -42,6 +43,7 @@ pub use channels::{ChannelsCommand, run_channels_command};
 pub use completion::Completion;
 pub use config::{ConfigCommand, run_config_command};
 pub use doctor::run_doctor_command;
+pub use gateway::{GatewayCommand, run_gateway_command};
 pub use hooks::{HooksCommand, run_hooks_command};
 #[cfg(feature = "import")]
 pub use import::{ImportCommand, run_import_command};
@@ -247,6 +249,14 @@ pub enum Command {
         long_about = "Install, start, or stop service.\nExample: ironclaw service install"
     )]
     Service(ServiceCommand),
+
+    /// Manage standalone gateway lifecycle
+    #[command(
+        subcommand,
+        about = "Manage standalone gateway lifecycle",
+        long_about = "Run the web gateway without the full agent loop.\nExamples:\n  ironclaw gateway serve\n  ironclaw gateway start\n  ironclaw gateway status"
+    )]
+    Gateway(GatewayCommand),
 
     /// Manage SKILL.md-based skills
     #[command(
@@ -508,5 +518,17 @@ mod tests {
         let mut cmd = Cli::command();
         let help = cmd.render_long_help().to_string();
         assert_snapshot!(help);
+    }
+
+    #[test]
+    fn test_gateway_status_command_parses() {
+        let parsed = Cli::try_parse_from(["ironclaw", "gateway", "status"]);
+        assert!(parsed.is_ok(), "gateway status should parse: {parsed:?}");
+    }
+
+    #[test]
+    fn test_gateway_serve_command_parses() {
+        let parsed = Cli::try_parse_from(["ironclaw", "gateway", "serve"]);
+        assert!(parsed.is_ok(), "gateway serve should parse: {parsed:?}");
     }
 }

--- a/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__help_output_without_import.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 504
 expression: help
 ---
 Secure personal AI assistant that protects your data and expands its capabilities
@@ -19,6 +20,7 @@ Commands:
   pairing     Manage DM pairing
   profile     Manage deployment profiles
   service     Manage OS service
+  gateway     Manage standalone gateway lifecycle
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models

--- a/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
+++ b/src/cli/snapshots/ironclaw__cli__tests__long_help_output_without_import.snap
@@ -1,5 +1,6 @@
 ---
 source: src/cli/mod.rs
+assertion_line: 520
 expression: help
 ---
 IronClaw is a secure AI assistant.
@@ -33,6 +34,7 @@ Commands:
   pairing     Manage DM pairing
   profile     Manage deployment profiles
   service     Manage OS service
+  gateway     Manage standalone gateway lifecycle
   skills      Manage skills
   hooks       Manage lifecycle hooks
   models      Manage LLM providers and models

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,10 @@ async fn async_main() -> anyhow::Result<()> {
             init_cli_tracing();
             return run_service_command(service_cmd);
         }
+        Some(Command::Gateway(gateway_cmd)) => {
+            return ironclaw::cli::run_gateway_command(gateway_cmd.clone(), cli.config.as_deref())
+                .await;
+        }
         Some(Command::Skills(skills_cmd)) => {
             init_cli_tracing();
             return ironclaw::cli::run_skills_command(skills_cmd.clone(), cli.config.as_deref())

--- a/tests/gateway_startup_multi_tenant_integration.rs
+++ b/tests/gateway_startup_multi_tenant_integration.rs
@@ -62,7 +62,7 @@ mod tests {
 
         let auth =
             MultiAuthState::single(gateway.auth_token().to_string(), config.owner_id.clone());
-        let addr = start_server(
+        let (addr, _server_handle) = start_server(
             "127.0.0.1:0".parse().expect("localhost addr"),
             gateway.state().clone(),
             auth.into(),

--- a/tests/multi_tenant_integration.rs
+++ b/tests/multi_tenant_integration.rs
@@ -675,7 +675,7 @@ async fn start_owner_scoped_sender_server() -> (
 
     let auth = MultiAuthState::multi(tokens).into();
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound = start_server(addr, state.clone(), auth)
+    let (bound, _server_handle) = start_server(addr, state.clone(), auth)
         .await
         .expect("Failed to start owner-scoped sender test server");
 
@@ -1156,7 +1156,7 @@ async fn start_multi_user_server_with_db() -> (
     });
 
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound =
+    let (bound, _server_handle) =
         ironclaw::channels::web::platform::router::start_server(addr, state.clone(), auth.into())
             .await
             .expect("Failed to start server with DB");

--- a/tests/oauth_greeting_integration.rs
+++ b/tests/oauth_greeting_integration.rs
@@ -108,9 +108,10 @@ mod tests {
         });
 
         let addr: std::net::SocketAddr = "127.0.0.1:0".parse().unwrap();
-        start_server(addr, state, auth.into())
+        let (bound_addr, _server_handle) = start_server(addr, state, auth.into())
             .await
-            .expect("start server")
+            .expect("start server");
+        bound_addr
     }
 
     fn client() -> reqwest::Client {

--- a/tests/openai_compat_integration.rs
+++ b/tests/openai_compat_integration.rs
@@ -252,7 +252,7 @@ async fn start_test_server_with_provider(
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state.clone(), auth.into())
+    let (bound_addr, _server_handle) = start_server(addr, state.clone(), auth.into())
         .await
         .expect("Failed to start test server");
 
@@ -775,7 +775,7 @@ async fn test_no_llm_provider_returns_503() {
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state, auth.into()).await.unwrap();
+    let (bound_addr, _server_handle) = start_server(addr, state, auth.into()).await.unwrap();
 
     let url = format!("http://{}/v1/chat/completions", bound_addr);
     let resp = client()

--- a/tests/responses_api_path_prefix.rs
+++ b/tests/responses_api_path_prefix.rs
@@ -49,7 +49,7 @@ async fn start_test_server() -> (SocketAddr, Arc<GatewayState>, ServerGuard) {
     let addr: SocketAddr = "127.0.0.1:0"
         .parse()
         .expect("hard-coded address must parse");
-    let bound = start_server(addr, state.clone(), auth.into())
+    let (bound, _server_handle) = start_server(addr, state.clone(), auth.into())
         .await
         .expect("start gateway test server");
     let shutdown = state.shutdown_tx.write().await.take();

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -318,7 +318,7 @@ impl GatewayWorkflowHarness {
 
         let auth_token = "gateway-test-token".to_string();
         let auth = MultiAuthState::single(auth_token.clone(), user_id.clone());
-        let addr = start_server(
+        let (addr, _server_handle) = start_server(
             "127.0.0.1:0".parse().expect("valid localhost addr"),
             Arc::clone(&gateway_state),
             auth.into(),

--- a/tests/ws_gateway_integration.rs
+++ b/tests/ws_gateway_integration.rs
@@ -98,7 +98,7 @@ async fn start_test_server() -> (
         "test-user".to_string(),
     );
     let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-    let bound_addr = start_server(addr, state.clone(), auth.into())
+    let (bound_addr, _server_handle) = start_server(addr, state.clone(), auth.into())
         .await
         .expect("Failed to start test server");
 


### PR DESCRIPTION
## Summary

Replace the stale/conflicting gateway CLI branch from #2143 with a fresh implementation on current `staging`.

Adds standalone gateway lifecycle management:
- `ironclaw gateway serve` — foreground standalone gateway for dev/debug
- `ironclaw gateway start` — background daemonized standalone gateway
- `ironclaw gateway stop` — graceful SIGTERM shutdown via PID file (Unix-only)
- `ironclaw gateway status` — PID + `/api/health` probe

Also updates the standalone gateway plumbing to fit the current codebase:
- `platform::router::start_server()` now returns `(SocketAddr, JoinHandle)` so `gateway serve` can wait for graceful shutdown
- adds dedicated `~/.ironclaw/gateway.pid`, `gateway.log`, and `gateway.token` helpers
- teaches `ironclaw logs` to reuse the standalone `gateway.token` file when no explicit token/env token is provided
- updates CLI help snapshots and `FEATURE_PARITY.md`

Standalone mode intentionally does **not** wire the agent loop, scheduler, or job manager, so agent-dependent endpoints continue to return `503` while read-only gateway surfaces remain available.

Closes/replaces #2143.

## Change Type

- [x] New feature

## Linked Issue

part of #83

## Validation

- [x] `cargo fmt`
- [x] `cargo test --lib gateway_ -- --nocapture`
- [x] `cargo test --lib cli::tests -- --nocapture`
- [x] `cargo test --test gateway_workflow_integration --test multi_tenant_integration --test openai_compat_integration --test ws_gateway_integration --test gateway_startup_multi_tenant_integration --test oauth_greeting_integration --test responses_api_path_prefix`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
