### PR TITLE
feat(webhooks): tool-driven webhook ingress with Linear integration

### DIFF
--- a/skills/linear-webhook/SKILL.md
+++ b/skills/linear-webhook/SKILL.md
@@ -1,0 +1,367 @@
+---
+name: linear-webhook
+version: 0.1.0
+description: Set up and manage Linear webhook-driven automation — commitment sync on status changes and agent work triggered by @mentions in comments.
+activation:
+  keywords:
+    - linear webhook
+    - linear routine
+    - linear automation
+    - linear mention
+    - linear status sync
+    - linear trigger
+    - webhook setup
+    - linear event
+  patterns:
+    - "(?i)set.?up.*(linear).*(webhook|routine|automation)"
+    - "(?i)linear.*(mention|comment).*(trigger|work|action)"
+    - "(?i)sync.*(commitment|todo).*(linear)"
+    - "(?i)linear.*(status|state).*(sync|update|reflect)"
+  tags:
+    - linear
+    - webhook
+    - commitments
+    - automation
+    - routines
+  max_context_tokens: 3000
+requires:
+  skills:
+    - linear
+    - commitment-link-linear
+---
+
+# Linear Webhook Automation
+
+## Prerequisites check
+
+Before doing anything else, verify the required secrets are in place:
+
+```
+secret_get(name="linear_webhook_secret")
+secret_get(name="linear_api_key")
+```
+
+If `linear_webhook_secret` is missing:
+> "The Linear webhook signing secret is not set. You'll find it in Linear under **Settings → API → Webhooks** — create a new webhook (or open an existing one) and copy the signing secret shown there. Then run: `secret_store(name=\"linear_webhook_secret\", value=\"<your signing secret>\")`"
+
+If `linear_api_key` is missing:
+> "A Linear API key is required. Create one at **Linear → Settings → API → Personal API keys**, then run: `secret_store(name=\"linear_api_key\", value=\"<your API key>\")`"
+
+Do not proceed with setup or routine creation until both secrets are present.
+
+---
+
+IronClaw receives Linear events via `POST /webhook/tools/linear`. Two system events are emitted:
+
+- `linear.issue.update` — any issue field change (state, priority, assignee, title)
+- `linear.comment.create` — new comment posted on any issue
+
+Two routines listen for these events. This skill governs how to set them up and what each routine does when it fires.
+
+## How the full chain works
+
+```
+Linear (HTTP POST to /webhook/tools/linear)
+  → HMAC-SHA256 validated (secret: linear_webhook_secret)
+  → LinearWebhookTool parses payload
+  → emit_system_event("linear", "linear.issue.update"|"linear.comment.create", payload)
+  → matching routine fires with event payload injected into context
+    → agent executes the routine prompt
+```
+
+The event payload is available to the routine's agent as structured context — the agent can read `payload.identifier`, `payload.state`, `payload.body`, etc. from it directly.
+
+## One-time setup
+
+### 1. Fetch your Linear identity
+
+Before anything else, resolve which Linear account is tied to the current API key — this email is used to filter incoming webhook events so only your own comments trigger the mention-handler:
+
+```
+http(method="POST", url="https://api.linear.app/graphql", body={
+  "query": "{ viewer { id name email } }"
+})
+```
+
+Save the result:
+
+```
+memory_write(
+  target="context/intel/linear-identity.md",
+  content="# Linear Identity\n\nid: <viewer.id>\nname: <viewer.name>\nemail: <viewer.email>\n"
+)
+```
+
+Note the `viewer.email` — you will substitute it into the `routine_create` call below.
+
+### 2. Store the webhook secret
+
+Store the Linear webhook signing secret (shown once when you create the webhook in Linear — copy it immediately):
+
+```
+secret_store(name="linear_webhook_secret", value="<signing secret from Linear Settings → API → Webhooks>")
+```
+
+### 3. Configure the webhook in Linear
+
+- URL: `https://<your-tunnel-or-public-host>/webhook/tools/linear`
+- Events: **Issue updates**, **Comment created**
+- No additional auth needed — HMAC covers it
+
+## How routines receive context
+
+Each routine receives the triggering event's structured payload automatically injected into its prompt under `## Trigger Event`. The payload contains safe, structured fields only (identifiers, URLs, state, user name). Free-text fields (issue title, comment body) are intentionally excluded to prevent prompt injection — the routine fetches those via Linear API when needed.
+
+## Routine 1 — linear-issue-sync
+
+Fires when any issue updates. Queries Linear for recently changed issues, then patches matching commitment files.
+
+**Create with:**
+
+```
+routine_create(
+  name="linear-issue-sync",
+  description="Sync Linear issue state changes into commitment files",
+  prompt="""
+IMPORTANT: Never pass an `Authorization` header or a `headers` key in any http() call
+to api.linear.app. The credential injector adds the bearer token automatically.
+
+A Linear issue was just updated (you were woken up by a webhook event).
+
+The triggering event is injected above under ## Trigger Event. It contains:
+- identifier: the Linear issue ID (e.g. "TOB-73")
+- state: { name, type } — current state
+- url: issue URL
+
+Steps:
+1. Read the identifier from the injected ## Trigger Event payload.
+   If no payload is present, read the cached Linear identity from
+   `context/intel/linear-identity.md` to get your user_id, then query
+   (do NOT add Authorization or headers):
+   http(method="POST", url="https://api.linear.app/graphql", body={
+     "query": "query($uid: ID!) { issues(filter: { assignee: { id: { eq: $uid } }, updatedAt: { gte: \"-PT10M\" } }, first: 20) { nodes { id identifier title url state { name type } updatedAt } } }",
+     "variables": {"uid": "<cached user_id>"}
+   })
+
+2. Derive the commitment file path directly from the identifier — do NOT search:
+   filename = "linear-" + identifier.toLowerCase() + ".md"
+   (e.g. identifier "TOB-73" → "commitments/linear-tob-73.md")
+   Try to read this file directly. If it doesn't exist — skip silently.
+
+3. For each matched commitment:
+   a. If the state name is not already in the file, fetch the full issue to get
+      the current title and state details (the payload omits free-text fields):
+      http(method="POST", url="https://api.linear.app/graphql", body={
+        "query": "{ issue(id: \"<identifier>\") { title state { name type } } }"
+      })
+   b. Update status_at_last_check to the issue's current state name
+   c. Update last_checked to now (ISO-8601 UTC)
+   d. If state.type is "completed" or "canceled":
+      - Append a dated progress line to ## Progress: "YYYY-MM-DD [Linear]: → <state name>"
+      - Check commitments/.refresh-config.md for auto_offer_resolve_on_terminal
+      - If true: send one notification offering to resolve locally.
+        When calling the message tool, always pass attachments as an empty
+        array [], never null or undefined.
+      - If false: update silently
+   e. Otherwise: update silently, no notification
+
+4. Never send "nothing changed" messages.
+5. Never push changes back to Linear. Never create new commitment files.
+""",
+  request={
+    "kind": "system_event",
+    "source": "linear",
+    "event_type": "linear.issue.update"
+  },
+  execution={
+    "mode": "full_job"
+  },
+  advanced={
+    "cooldown_secs": 0
+  }
+)
+```
+
+## Routine 2 — linear-mention-handler
+
+Fires when a comment is created. Queries Linear for recent comments mentioning you, then does the work and replies.
+
+**Before creating this routine**, read `context/intel/linear-identity.md` (written during setup step 1) to get `viewer.email` and substitute it in the `user_email` filter below.
+
+**Create with:**
+
+```
+routine_create(
+  name="linear-mention-handler",
+  description="Execute work triggered by owner self-@-mentions in Linear comments",
+  prompt="""
+IMPORTANT: Never pass an `Authorization` header or a `headers` key in any http() call
+to api.linear.app. The credential injector adds the bearer token automatically.
+Adding it manually will cause a "Manual Authorization header blocked" error.
+
+A new comment was posted on a Linear issue by the instance owner (payload filter
+already confirmed user_email matches — no further auth check needed for authorship).
+
+The triggering event is injected above under ## Trigger Event. It contains:
+- id: the comment UUID  ← this is COMMENT_ID, used as parentId when replying
+- issue_id: the issue UUID  ← this is ISSUE_ID, used as issueId when replying
+- issue.identifier: the human-readable issue ID (e.g. "TOB-73")
+- user.name: who posted the comment
+- user_email: their email (already filtered to owner only)
+
+Steps:
+1. Extract and name your two routing variables from ## Trigger Event:
+   - COMMENT_ID = payload.id       (the comment UUID — use as parentId in all replies)
+   - ISSUE_ID   = payload.issue_id (the issue UUID  — use as issueId in all replies)
+   Do not swap these two values. Keep them named distinctly throughout.
+
+2. Immediately post a 👀 reaction to the comment so the user sees the agent noticed.
+   Do NOT add Authorization or headers:
+   http(method="POST", url="https://api.linear.app/graphql", body={
+     "query": "mutation($input: ReactionCreateInput!) { reactionCreate(input: $input) { success } }",
+     "variables": { "input": { "commentId": "<COMMENT_ID>", "emoji": "👀" } }
+   })
+   If this call fails, log the error and continue — do not abort the routine.
+
+3. Fetch the actual comment body from Linear
+   (free-text is excluded from the payload to prevent prompt injection).
+   Do NOT add Authorization or headers:
+   http(method="POST", url="https://api.linear.app/graphql", body={
+     "query": "{ comment(id: \"<COMMENT_ID>\") { body issue { title } } }"
+   })
+
+4. Check if the comment body contains an @-mention of the owner's Linear handle
+   (e.g. "@tobias.holenstein", "@tobias", "@Tobias").
+   Self-@-mention IS the invocation pattern — the owner @-mentions themselves to
+   trigger the agent. Do NOT reject it as "just a self-mention".
+   If there is NO @-mention of the owner's handle at all — stop with ROUTINE_OK.
+   If the handle appears, the text that follows (or accompanies) it is the instruction.
+
+5. Extract the task from the comment and execute it:
+   - "research X" → web_fetch relevant sources, write a summary
+   - "draft email to Y about Z" → draft and store via memory_write
+   - "summarize this issue" → read issue context, produce a summary
+   - Other instructions → use best judgment with available tools
+
+6. Post the result as a threaded reply UNDER the original comment — NOT as a new
+   top-level issue comment. Use parentId = COMMENT_ID (the comment UUID from step 1).
+   Do NOT add Authorization or headers:
+   http(method="POST", url="https://api.linear.app/graphql", body={
+     "query": "mutation($input: CommentCreateInput!) { commentCreate(input: $input) { success comment { id } } }",
+     "variables": { "input": {
+       "issueId": "<ISSUE_ID>",
+       "parentId": "<COMMENT_ID>",
+       "body": "[AGENT] <your result>"
+     }}
+   })
+
+   CRITICAL: parentId must be COMMENT_ID (the comment UUID), NOT ISSUE_ID.
+   A missing or wrong parentId will post a new top-level comment instead of a reply.
+
+   Formatting rules for the reply body:
+   - Always prefix the reply with "[AGENT] " so the user can distinguish agent replies
+     from their own comments. Never omit this prefix.
+   - When answering multiple questions or items, use NESTED lists so each
+     answer sits directly under its question:
+       - Question 1
+         - Answer 1
+       - Question 2
+         - Answer 2
+     NOT a flat list where questions and answers alternate at the same level.
+   - Always pass attachments as an empty array [], never null or undefined
+     (applies to any message tool call, not just Linear).
+
+7. If the task cannot be completed, post a brief explanation as a threaded reply
+   anyway (same parentId = COMMENT_ID pattern, same [AGENT] prefix). Never leave a mention unanswered.
+""",
+  request={
+    "kind": "system_event",
+    "source": "linear",
+    "event_type": "linear.comment.create",
+    "filters": {
+      "user_email": "<viewer.email from context/intel/linear-identity.md>"
+    }
+  },
+  execution={
+    "mode": "full_job"
+  },
+  advanced={
+    "cooldown_secs": 0
+  }
+)
+```
+
+**Why full_job:** mention-triggered work is open-ended. It needs the full tool scope.
+
+## Filter on specific event subtypes (optional)
+
+The routine engine supports payload filters: exact case-insensitive string match against top-level payload keys. Nested keys are not supported.
+
+Fields available for filtering in `linear.comment.create` payloads: `user_email` (already used above), `id`, `issue_id`. Fields in `linear.issue.update` payloads: `id`, `identifier`, `url`.
+
+To add a new top-level filter axis (e.g. team prefix), hoist it in `comment_events()` / `issue_events()` in `src/tools/builtin/linear_webhook.rs` and use it here.
+
+## Verifying the setup
+
+After creating both routines:
+
+1. `routine_fire(name="linear-issue-sync")` — fires manually with no payload; confirms the agent can reach the workspace and parse commitments.
+2. In Linear, update any tracked issue's state. The routine should fire within seconds of the webhook arriving.
+3. Post a comment with `@tobias do a quick test` on any issue. The mention-handler should reply within the job's execution window.
+
+## No public URL? Use polling instead
+
+If IronClaw is running locally without a tunnel, Linear can't reach the
+webhook endpoint. Use a scheduled polling routine as a fallback — it
+queries Linear every few minutes instead of waiting for a push event.
+
+Trade-offs vs webhook: ~5 min latency, consumes Linear API quota, no
+mention-handler (comments require real-time to be useful).
+
+**Create with:**
+
+```
+routine_create(
+  name="linear-issue-poll",
+  description="Poll Linear every 5 minutes for recently updated issues and sync into commitment files",
+  prompt="""
+IMPORTANT: Never pass an `Authorization` header or a `headers` key in any http() call
+to api.linear.app. The credential injector adds the bearer token automatically.
+
+Poll Linear for issues updated in the last 10 minutes that are assigned to you.
+
+1. Read cached identity from `context/intel/linear-identity.md` to get your user_id.
+   If missing or stale, bootstrap it first (see the linear skill).
+
+2. Query recently updated issues:
+   http(method="POST", url="https://api.linear.app/graphql", body={
+     "query": "query($uid: ID!) { issues(filter: { assignee: { id: { eq: $uid } }, updatedAt: { gte: \"-PT10M\" } }, first: 20, orderBy: updatedAt) { nodes { id identifier title url state { name type } updatedAt } } }",
+     "variables": {"uid": "<cached user_id>"}
+   })
+
+3. For each returned issue, derive the commitment file path:
+   filename = "linear-" + identifier.toLowerCase() + ".md"
+   Try to read it directly. If it doesn't exist — skip silently.
+
+4. For each matched commitment, apply the same sync logic as linear-issue-sync:
+   update status_at_last_check, last_checked, and append a progress line
+   if the state changed to completed or canceled.
+
+5. Never send "nothing changed" messages. Silent on no-op polls.
+""",
+  request={
+    "kind": "schedule",
+    "cron": "*/5 * * * *"
+  },
+  execution={
+    "mode": "full_job"
+  }
+)
+```
+
+## Hard rules
+
+- Never create a new commitment file from a webhook event — imports are deliberate, initiated by the user.
+- Never push changes back to Linear from the sync routine — sync is one-way (Linear → commitment).
+- The mention-handler must always post back a comment — even a failure message — so the thread doesn't go dark.
+- Both routines must stay silent on no-op events (untracked issue, comment without mention). No noise.

--- a/src/agent/routine_engine.rs
+++ b/src/agent/routine_engine.rs
@@ -217,7 +217,12 @@ impl RoutineEngine {
         let triggered = self.matching_event_triggers(message, content).await;
         let fired = triggered.len();
         for triggered in triggered {
-            std::mem::drop(self.spawn_fire(triggered.routine, "event", Some(triggered.detail)));
+            std::mem::drop(self.spawn_fire(
+                triggered.routine,
+                "event",
+                Some(triggered.detail),
+                None,
+            ));
         }
         fired
     }
@@ -235,7 +240,9 @@ impl RoutineEngine {
         let fired = triggered.len();
         let handles: Vec<JoinHandle<()>> = triggered
             .into_iter()
-            .map(|triggered| self.spawn_fire(triggered.routine, "event", Some(triggered.detail)))
+            .map(|triggered| {
+                self.spawn_fire(triggered.routine, "event", Some(triggered.detail), None)
+            })
             .collect();
 
         for handle in handles {
@@ -417,7 +424,6 @@ impl RoutineEngine {
                     .get(key)
                     .and_then(crate::agent::routine::json_value_as_filter_string)
                 else {
-                    tracing::debug!(routine = %routine.name, filter_key = %key, "Filter key not found in payload");
                     matched = false;
                     break;
                 };
@@ -448,7 +454,12 @@ impl RoutineEngine {
             }
 
             let detail = truncate(&format!("{source}:{event_type}"), 200);
-            self.spawn_fire(routine.clone(), "system_event", Some(detail));
+            let event_payload = if payload.is_null() {
+                None
+            } else {
+                Some(payload.clone())
+            };
+            self.spawn_fire(routine.clone(), "system_event", Some(detail), event_payload);
             fired += 1;
         }
 
@@ -502,7 +513,7 @@ impl RoutineEngine {
                 None
             };
 
-            self.spawn_fire(routine, "cron", detail);
+            self.spawn_fire(routine, "cron", detail, None);
         }
     }
 
@@ -833,7 +844,7 @@ impl RoutineEngine {
         };
 
         tokio::spawn(async move {
-            execute_routine(engine, routine, run).await;
+            execute_routine(engine, routine, run, None).await;
         });
 
         Ok(run_id)
@@ -919,7 +930,7 @@ impl RoutineEngine {
         };
 
         tokio::spawn(async move {
-            execute_routine(engine, routine, run).await;
+            execute_routine(engine, routine, run, None).await;
         });
 
         Ok(run_id)
@@ -931,6 +942,7 @@ impl RoutineEngine {
         routine: Routine,
         trigger_type: &str,
         trigger_detail: Option<String>,
+        event_payload: Option<serde_json::Value>,
     ) -> JoinHandle<()> {
         let run = RoutineRun {
             id: Uuid::new_v4(),
@@ -977,7 +989,7 @@ impl RoutineEngine {
                 tracing::error!(routine = %routine.name, "Failed to record run: {}", e);
                 return;
             }
-            execute_routine(engine, routine, run).await;
+            execute_routine(engine, routine, run, event_payload).await;
         })
     }
 
@@ -1110,7 +1122,12 @@ struct EngineContext {
 }
 
 /// Execute a routine run. Handles both lightweight and full_job modes.
-async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineRun) {
+async fn execute_routine(
+    ctx: EngineContext,
+    mut routine: Routine,
+    run: RoutineRun,
+    event_payload: Option<serde_json::Value>,
+) {
     // Increment running count (atomic: survives panics in the execution below)
     ctx.running_count.fetch_add(1, Ordering::Relaxed);
 
@@ -1186,6 +1203,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
                         *max_tokens,
                         *use_tools,
                         *max_tool_rounds,
+                        event_payload.as_ref(),
                     )
                     .await
                 }
@@ -1199,7 +1217,7 @@ async fn execute_routine(ctx: EngineContext, mut routine: Routine, run: RoutineR
                         description,
                         max_iterations: *max_iterations,
                     };
-                    execute_full_job(&ctx, &routine, &run, &execution).await
+                    execute_full_job(&ctx, &routine, &run, &execution, event_payload.as_ref()).await
                 }
             };
 
@@ -1416,6 +1434,7 @@ async fn execute_full_job(
     routine: &Routine,
     run: &RoutineRun,
     execution: &FullJobExecutionConfig<'_>,
+    event_payload: Option<&serde_json::Value>,
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
     // Full-job routines dispatch through the scheduler (same as /job
     // commands) — no Docker sandbox required when sandbox is disabled.
@@ -1449,12 +1468,17 @@ async fn execute_full_job(
 
     // Prepend execution context so the LLM knows it's already inside a
     // routine and should execute the task directly — not set up infrastructure.
+    let event_context = event_payload
+        .and_then(|p| serde_json::to_string_pretty(p).ok())
+        .map(|json| format!("\n\n## Trigger Event\n\n```json\n{json}\n```"))
+        .unwrap_or_default();
+
     let contextualized_description = format!(
         "IMPORTANT: You are executing inside routine \"{routine_name}\". \
          The routine and its schedule are already configured. \
          Tools and credentials are already set up. \
          Do NOT create routines, jobs, or try to discover/install/authenticate tools. \
-         Execute the task directly.\n\n{desc}",
+         Execute the task directly.\n\n{desc}{event_context}",
         routine_name = routine.name,
         desc = execution.description,
     );
@@ -1501,6 +1525,7 @@ async fn execute_full_job(
 ///
 /// If tools are enabled, this runs a simplified agentic loop (max 3-5 iterations).
 /// If tools are disabled, this does a single LLM call (original behavior).
+#[allow(clippy::too_many_arguments)]
 async fn execute_lightweight(
     ctx: &EngineContext,
     routine: &Routine,
@@ -1509,9 +1534,19 @@ async fn execute_lightweight(
     max_tokens: u32,
     use_tools: bool,
     max_tool_rounds: u32,
+    event_payload: Option<&serde_json::Value>,
 ) -> Result<(RunStatus, Option<String>, Option<i32>), RoutineError> {
     // Load context from workspace
     let mut context_parts = Vec::new();
+
+    // Inject the triggering event payload first so the routine has immediate
+    // access to the structured event data without an extra API call.
+    if let Some(payload) = event_payload
+        && let Ok(json) = serde_json::to_string_pretty(payload)
+    {
+        context_parts.push(format!("## Trigger Event\n\n```json\n{json}\n```"));
+    }
+
     for path in context_paths {
         match ctx.workspace.read(path).await {
             Ok(doc) => {

--- a/src/tools/builtin/linear_webhook.rs
+++ b/src/tools/builtin/linear_webhook.rs
@@ -1,0 +1,292 @@
+//! Linear webhook ingress tool.
+//!
+//! Receives Linear webhook events at `POST /webhook/tools/linear` and emits
+//! system events that routines can react to:
+//!
+//! - `linear.issue.create` / `linear.issue.update` / `linear.issue.remove`
+//! - `linear.comment.create` / `linear.comment.update` / `linear.comment.remove`
+//!
+//! Auth: HMAC-SHA256 via `Linear-Signature` header. Store the signing secret
+//! as `linear_webhook_secret` in the secrets store.
+
+use std::time::Instant;
+
+use async_trait::async_trait;
+
+use crate::context::JobContext;
+use crate::tools::tool::{Tool, ToolError, ToolOutput};
+use crate::tools::wasm::WebhookCapability;
+
+pub struct LinearWebhookTool;
+
+#[async_trait]
+impl Tool for LinearWebhookTool {
+    fn name(&self) -> &str {
+        "linear"
+    }
+
+    fn description(&self) -> &str {
+        "Receives Linear webhook events (issue updates, comments) and emits system events \
+         that routines can react to for commitment sync and triggered agent work."
+    }
+
+    fn parameters_schema(&self) -> serde_json::Value {
+        serde_json::json!({ "type": "object" })
+    }
+
+    fn webhook_capability(&self) -> Option<WebhookCapability> {
+        Some(WebhookCapability {
+            // Secret stored under this name in the secrets store.
+            hmac_secret_name: Some("linear_webhook_secret".to_string()),
+            // Linear sends `Linear-Signature: <raw-hex>` — no prefix.
+            hmac_signature_header: Some("linear-signature".to_string()),
+            hmac_prefix: Some("".to_string()),
+            ..Default::default()
+        })
+    }
+
+    async fn execute(
+        &self,
+        params: serde_json::Value,
+        _ctx: &JobContext,
+    ) -> Result<ToolOutput, ToolError> {
+        let start = Instant::now();
+
+        let body = params
+            .get("webhook")
+            .and_then(|w| w.get("body_json"))
+            .ok_or_else(|| {
+                ToolError::InvalidParameters(
+                    "linear tool is webhook-only; invoke via POST /webhook/tools/linear"
+                        .to_string(),
+                )
+            })?;
+
+        let events = extract_events(body);
+
+        Ok(ToolOutput::success(
+            serde_json::json!({ "emit_events": events }),
+            start.elapsed(),
+        ))
+    }
+
+    fn requires_sanitization(&self) -> bool {
+        false
+    }
+}
+
+/// Parse a Linear webhook payload into system event intents.
+///
+/// Linear webhook shape:
+/// ```json
+/// { "type": "Issue"|"Comment"|..., "action": "create"|"update"|"remove",
+///   "data": { ... }, "updatedFrom": { ... } }
+/// ```
+fn extract_events(body: &serde_json::Value) -> Vec<serde_json::Value> {
+    let event_type = body.get("type").and_then(|v| v.as_str()).unwrap_or("");
+    let action = body.get("action").and_then(|v| v.as_str()).unwrap_or("");
+
+    match (event_type, action) {
+        ("Issue", action) => issue_events(body, action),
+        ("Comment", action) => comment_events(body, action),
+        _ => vec![],
+    }
+}
+
+fn issue_events(body: &serde_json::Value, action: &str) -> Vec<serde_json::Value> {
+    let Some(data) = body.get("data") else {
+        return vec![];
+    };
+    // title is user-controlled free text — excluded to prevent prompt injection.
+    // The routine can fetch it from Linear if needed.
+    vec![serde_json::json!({
+        "source": "linear",
+        "event_type": format!("linear.issue.{action}"),
+        "payload": {
+            "id": data.get("id"),
+            "identifier": data.get("identifier"),
+            "url": data.get("url"),
+            "state": data.get("state"),
+            "priority": data.get("priority"),
+            "assignee": data.get("assignee"),
+            "updated_from": body.get("updatedFrom"),
+        }
+    })]
+}
+
+fn comment_events(body: &serde_json::Value, action: &str) -> Vec<serde_json::Value> {
+    let Some(data) = body.get("data") else {
+        return vec![];
+    };
+    // body and issue.title are user-controlled free text — excluded to prevent
+    // prompt injection. The routine fetches comment content via Linear API.
+    let issue = data.get("issue").map(|i| {
+        serde_json::json!({
+            "id": i.get("id"),
+            "identifier": i.get("identifier"),
+            "url": i.get("url"),
+        })
+    });
+    // user_email lifted to top level so routines can filter on it without an
+    // LLM call (e.g. only fire for comments from the instance owner).
+    let user_email = data
+        .get("user")
+        .and_then(|u| u.get("email"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+    vec![serde_json::json!({
+        "source": "linear",
+        "event_type": format!("linear.comment.{action}"),
+        "payload": {
+            "id": data.get("id"),
+            "issue_id": data.get("issueId"),
+            "issue": issue,
+            "user": data.get("user"),
+            "user_email": user_email,
+        }
+    })]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ctx() -> JobContext {
+        JobContext::with_user("test", "webhook", "test")
+    }
+
+    #[test]
+    fn webhook_capability_uses_linear_hmac_config() {
+        let cap = LinearWebhookTool.webhook_capability().unwrap();
+        assert_eq!(
+            cap.hmac_secret_name.as_deref(),
+            Some("linear_webhook_secret")
+        );
+        assert_eq!(
+            cap.hmac_signature_header.as_deref(),
+            Some("linear-signature")
+        );
+        assert_eq!(cap.hmac_prefix.as_deref(), Some(""));
+        assert!(cap.secret_name.is_none());
+        assert!(cap.signature_key_secret_name.is_none());
+    }
+
+    #[tokio::test]
+    async fn execute_without_webhook_context_returns_error() {
+        let err = LinearWebhookTool
+            .execute(serde_json::json!({}), &ctx())
+            .await
+            .unwrap_err();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+
+    #[tokio::test]
+    async fn issue_update_emits_event() {
+        let payload = serde_json::json!({
+            "webhook": {
+                "body_json": {
+                    "type": "Issue",
+                    "action": "update",
+                    "data": {
+                        "id": "issue-uuid",
+                        "identifier": "ENG-42",
+                        "title": "Fix the bug",
+                        "url": "https://linear.app/team/issue/ENG-42",
+                        "state": { "name": "Done", "type": "completed" },
+                        "priority": 2,
+                        "assignee": { "name": "Tobias" }
+                    },
+                    "updatedFrom": { "stateId": "old-state-uuid" }
+                }
+            }
+        });
+
+        let out = LinearWebhookTool.execute(payload, &ctx()).await.unwrap();
+        let events = out.result["emit_events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        let ev = &events[0];
+        assert_eq!(ev["source"], "linear");
+        assert_eq!(ev["event_type"], "linear.issue.update");
+        assert_eq!(ev["payload"]["identifier"], "ENG-42");
+        assert_eq!(ev["payload"]["state"]["type"], "completed");
+        // title is user-controlled free text — must not appear in payload
+        assert!(ev["payload"]["title"].is_null());
+    }
+
+    #[tokio::test]
+    async fn comment_create_emits_event() {
+        let payload = serde_json::json!({
+            "webhook": {
+                "body_json": {
+                    "type": "Comment",
+                    "action": "create",
+                    "data": {
+                        "id": "comment-uuid",
+                        "body": "@tobias please research X",
+                        "issueId": "issue-uuid",
+                        "issue": {
+                            "id": "issue-uuid",
+                            "identifier": "ENG-42",
+                            "title": "Research task",
+                            "url": "https://linear.app/team/issue/ENG-42"
+                        },
+                        "user": {
+                            "name": "Alice",
+                            "email": "alice@example.com"
+                        }
+                    }
+                }
+            }
+        });
+
+        let out = LinearWebhookTool.execute(payload, &ctx()).await.unwrap();
+        let events = out.result["emit_events"].as_array().unwrap();
+        assert_eq!(events.len(), 1);
+        let ev = &events[0];
+        assert_eq!(ev["event_type"], "linear.comment.create");
+        assert_eq!(ev["payload"]["issue"]["identifier"], "ENG-42");
+        // body and issue.title are user-controlled free text — must not appear in payload
+        assert!(ev["payload"]["body"].is_null());
+        assert!(ev["payload"]["issue"]["title"].is_null());
+        // id and issue_id are still present for routing
+        assert_eq!(ev["payload"]["id"], "comment-uuid");
+        assert_eq!(ev["payload"]["issue_id"], "issue-uuid");
+        // user_email is lifted to top level for pre-LLM payload filtering
+        assert_eq!(ev["payload"]["user_email"], "alice@example.com");
+        // user_email is null when user has no email in the webhook
+        let payload_no_email = serde_json::json!({
+            "webhook": {
+                "body_json": {
+                    "type": "Comment",
+                    "action": "create",
+                    "data": {
+                        "id": "comment-uuid",
+                        "issueId": "issue-uuid",
+                        "issue": { "id": "issue-uuid", "identifier": "ENG-42", "url": "" },
+                        "user": { "name": "Bot" }
+                    }
+                }
+            }
+        });
+        let out2 = LinearWebhookTool.execute(payload_no_email, &ctx()).await.unwrap();
+        let ev2 = &out2.result["emit_events"][0];
+        assert!(ev2["payload"]["user_email"].is_null());
+    }
+
+    #[tokio::test]
+    async fn unknown_event_type_emits_nothing() {
+        let payload = serde_json::json!({
+            "webhook": {
+                "body_json": {
+                    "type": "Project",
+                    "action": "update",
+                    "data": { "id": "proj-uuid" }
+                }
+            }
+        });
+
+        let out = LinearWebhookTool.execute(payload, &ctx()).await.unwrap();
+        assert_eq!(out.result["emit_events"].as_array().unwrap().len(), 0);
+    }
+
+}

--- a/src/tools/builtin/mod.rs
+++ b/src/tools/builtin/mod.rs
@@ -10,6 +10,7 @@ mod grep_tool;
 mod http;
 mod job;
 mod json;
+mod linear_webhook;
 pub mod memory;
 mod message;
 pub mod path_utils;
@@ -39,6 +40,7 @@ pub use job::{
     PromptQueue, SchedulerSlot,
 };
 pub use json::JsonTool;
+pub use linear_webhook::LinearWebhookTool;
 pub use memory::{MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool};
 pub use message::MessageTool;
 pub use plan::PlanUpdateTool;

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -18,11 +18,11 @@ use crate::tools::builder::{
 use crate::tools::builtin::{
     ApplyPatchTool, CancelJobTool, CreateJobTool, EchoTool, ExtensionInfoTool, FileUndoTool,
     GlobTool, GrepTool, HttpTool, JobEventsTool, JobPromptTool, JobStatusTool, JsonTool,
-    ListDirTool, ListJobsTool, MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool,
-    PlanUpdateTool, PromptQueue, ReadFileTool, ShellTool, SkillInstallTool, SkillListTool,
-    SkillRemoveTool, SkillSearchTool, TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool,
-    ToolListTool, ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
-    WriteFileTool, shared_file_history, shared_read_file_state,
+    LinearWebhookTool, ListDirTool, ListJobsTool, MemoryReadTool, MemorySearchTool, MemoryTreeTool,
+    MemoryWriteTool, PlanUpdateTool, PromptQueue, ReadFileTool, ShellTool, SkillInstallTool,
+    SkillListTool, SkillRemoveTool, SkillSearchTool, TimeTool, ToolActivateTool, ToolAuthTool,
+    ToolInstallTool, ToolListTool, ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool,
+    ToolUpgradeTool, WriteFileTool, shared_file_history, shared_read_file_state,
 };
 use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::tool::{
@@ -453,6 +453,8 @@ impl ToolRegistry {
             http = http.with_role_lookup(Arc::clone(role_lookup));
         }
         self.register_sync(Arc::new(http));
+
+        self.register_sync(Arc::new(LinearWebhookTool));
 
         tracing::debug!("Registered {} built-in tools", self.count());
     }

--- a/src/webhooks/mod.rs
+++ b/src/webhooks/mod.rs
@@ -709,4 +709,201 @@ mod tests {
             .expect("response");
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
     }
+
+    struct ParamCaptureTool {
+        captured: Arc<tokio::sync::Mutex<Option<serde_json::Value>>>,
+    }
+
+    #[async_trait]
+    impl Tool for ParamCaptureTool {
+        fn name(&self) -> &str {
+            "capture_webhook"
+        }
+
+        fn description(&self) -> &str {
+            "captures params for testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(
+            &self,
+            params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            *self.captured.lock().await = Some(params);
+            Ok(ToolOutput::success(
+                serde_json::json!({"emit_events": []}),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn webhook_capability(&self) -> Option<crate::tools::wasm::WebhookCapability> {
+            Some(crate::tools::wasm::WebhookCapability {
+                secret_name: Some("capture_secret".to_string()),
+                secret_header: Some("x-webhook-secret".to_string()),
+                ..Default::default()
+            })
+        }
+    }
+
+    struct EventEmittingTool;
+
+    #[async_trait]
+    impl Tool for EventEmittingTool {
+        fn name(&self) -> &str {
+            "emitting_webhook"
+        }
+
+        fn description(&self) -> &str {
+            "emits events for testing"
+        }
+
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &JobContext,
+        ) -> Result<ToolOutput, ToolError> {
+            Ok(ToolOutput::success(
+                serde_json::json!({
+                    "emit_events": [
+                        {"source": "test", "event_type": "test.event", "payload": {}}
+                    ]
+                }),
+                Duration::from_millis(1),
+            ))
+        }
+
+        fn webhook_capability(&self) -> Option<crate::tools::wasm::WebhookCapability> {
+            Some(crate::tools::wasm::WebhookCapability {
+                secret_name: Some("emitting_secret".to_string()),
+                secret_header: Some("x-webhook-secret".to_string()),
+                ..Default::default()
+            })
+        }
+    }
+
+    // ── Test 1: body_raw is Some only when body is not valid JSON ─────────────
+
+    #[tokio::test]
+    async fn body_raw_only_when_body_is_not_json() {
+        let make_secrets = || {
+            let secrets = Arc::new(InMemorySecretsStore::new(Arc::new(
+                SecretsCrypto::new(secrecy::SecretString::from(
+                    "test-key-at-least-32-chars-long!!".to_string(),
+                ))
+                .expect("crypto"),
+            )));
+            futures::executor::block_on(
+                secrets.create("test", CreateSecretParams::new("capture_secret", "s3cret")),
+            )
+            .expect("secret create");
+            secrets
+        };
+
+        // ── Sub-case A: valid JSON body → body_json present, body_raw absent ──
+        let captured_a: Arc<tokio::sync::Mutex<Option<serde_json::Value>>> =
+            Arc::new(tokio::sync::Mutex::new(None));
+        let tool_a = Arc::new(ParamCaptureTool {
+            captured: Arc::clone(&captured_a),
+        });
+        let tools_a = Arc::new(ToolRegistry::new());
+        tools_a.register(tool_a).await;
+        let app_a = routes(ToolWebhookState {
+            tools: tools_a,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            user_id: "test".to_string(),
+            secrets_store: Some(make_secrets()),
+        });
+
+        let req_a = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/tools/capture_webhook")
+            .header("content-type", "application/json")
+            .header("x-webhook-secret", "s3cret")
+            .body(Body::from(r#"{"ok":true}"#))
+            .expect("request");
+        let resp_a = ServiceExt::<axum::http::Request<Body>>::oneshot(app_a, req_a)
+            .await
+            .expect("response");
+        assert_eq!(resp_a.status(), StatusCode::ACCEPTED);
+
+        let params_a = captured_a.lock().await.clone().expect("params captured");
+        assert_eq!(params_a["webhook"]["body_json"], serde_json::json!({"ok": true}));
+        assert!(params_a["webhook"]["body_raw"].is_null());
+
+        // ── Sub-case B: non-JSON body → body_raw present, body_json absent ────
+        let captured_b: Arc<tokio::sync::Mutex<Option<serde_json::Value>>> =
+            Arc::new(tokio::sync::Mutex::new(None));
+        let tool_b = Arc::new(ParamCaptureTool {
+            captured: Arc::clone(&captured_b),
+        });
+        let tools_b = Arc::new(ToolRegistry::new());
+        tools_b.register(tool_b).await;
+        let app_b = routes(ToolWebhookState {
+            tools: tools_b,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            user_id: "test".to_string(),
+            secrets_store: Some(make_secrets()),
+        });
+
+        let req_b = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/tools/capture_webhook")
+            .header("x-webhook-secret", "s3cret")
+            .body(Body::from("not-json"))
+            .expect("request");
+        let resp_b = ServiceExt::<axum::http::Request<Body>>::oneshot(app_b, req_b)
+            .await
+            .expect("response");
+        assert_eq!(resp_b.status(), StatusCode::ACCEPTED);
+
+        let params_b = captured_b.lock().await.clone().expect("params captured");
+        assert_eq!(params_b["webhook"]["body_raw"], "not-json");
+        assert!(params_b["webhook"]["body_json"].is_null());
+    }
+
+    // ── Test 2: SERVICE_UNAVAILABLE when events emitted but engine slot empty ──
+
+    #[tokio::test]
+    async fn returns_service_unavailable_when_events_emitted_but_engine_empty() {
+        let secrets = Arc::new(InMemorySecretsStore::new(Arc::new(
+            SecretsCrypto::new(secrecy::SecretString::from(
+                "test-key-at-least-32-chars-long!!".to_string(),
+            ))
+            .expect("crypto"),
+        )));
+        secrets
+            .create("test", CreateSecretParams::new("emitting_secret", "s3cret"))
+            .await
+            .expect("secret create");
+
+        let tools = Arc::new(ToolRegistry::new());
+        tools.register(Arc::new(EventEmittingTool)).await;
+
+        let app = routes(ToolWebhookState {
+            tools,
+            routine_engine: Arc::new(tokio::sync::RwLock::new(None)),
+            user_id: "test".to_string(),
+            secrets_store: Some(secrets),
+        });
+
+        let req = axum::http::Request::builder()
+            .method("POST")
+            .uri("/webhook/tools/emitting_webhook")
+            .header("content-type", "application/json")
+            .header("x-webhook-secret", "s3cret")
+            .body(Body::from(r#"{"trigger":true}"#))
+            .expect("request");
+        let resp = ServiceExt::<axum::http::Request<Body>>::oneshot(app, req)
+            .await
+            .expect("response");
+        assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    }
 }


### PR DESCRIPTION
## Summary

Adds a generic HTTP webhook ingress that lets any registered tool receive
external webhooks and emit system events that routines can react to.
Ships with a Linear integration as the first consumer.

## Generic infra (`src/webhooks/`)

- `POST /webhook/tools/{tool}` — dispatches to any tool declaring
  `webhook_capability()`; also supports `/{tool}/{*rest}` for providers
  that embed sub-paths in the URL
- `GET /webhook/tools/{tool}` — health check
- Three auth mechanisms, all constant-time:
  - Shared secret header
  - HMAC-SHA256 (GitHub/Linear-style — configurable header and prefix)
  - Ed25519 (Discord-style timestamp + signature)
- Tool returns `emit_events` array; handler fires matching routines via
  `RoutineEngine::emit_system_event`
- 64 KB body limit

## Routine engine — event payload injection (`src/agent/routine_engine.rs`)

`execute_routine` and `spawn_fire` now accept an
`event_payload: Option<serde_json::Value>`. When a system-event routine
fires, the triggering payload is injected into the routine's prompt
under a `## Trigger Event` block (pretty-printed JSON) before execution.

This is necessary because webhook-triggered routines need to know *which
specific issue or comment* woke them up — without it, a routine receiving
a `linear.issue.update` event has no way to identify the issue and would
have to fall back to polling all recently-changed issues on every
invocation. The payload injection gives the routine immediate, structured
context so it can act precisely on the triggering event.

Cron and message-triggered routines pass `None` — no behavior change for
existing routines.

## Linear webhook tool (`src/tools/builtin/linear_webhook.rs`)

- Emits `linear.issue.{create,update,remove}` and
  `linear.comment.{create,update,remove}` system events
- Free-text fields (issue title, comment body) excluded from event
  payload to prevent prompt injection — routines fetch via API
- `user_email` hoisted to top level for pre-LLM routine filtering
- HMAC-SHA256 auth via `linear_webhook_secret` in the secrets store

## Skill (`skills/linear-webhook/SKILL.md`)

- Prerequisites check for `linear_webhook_secret` and `linear_api_key`
  with exact setup instructions if either is missing
- One-time setup guide: identity bootstrap, secret storage, Linear
  webhook configuration
- Two ready-to-create routine templates: `linear-issue-sync` and
  `linear-mention-handler`
- Polling fallback (`linear-issue-poll`) for instances without a
  public URL

## Tests

- 15 unit tests covering auth rejection, health check, `body_raw`
  mutual exclusivity, and `SERVICE_UNAVAILABLE` on missing engine slot
- 5 unit tests covering Linear event extraction and prompt-injection
  field exclusion

## Test plan

- [ ] `POST /webhook/tools/linear` with valid HMAC — confirm
  `linear.issue.update` fires a matching routine
- [ ] Comment payload with `user_email` filter — confirm only matching
  email triggers
- [ ] `GET /webhook/tools/linear` → 200; unknown tool → 404
- [ ] Wrong `linear-signature` → 401