### PR TITLE
fix(llm): keep local openai-compatible mock providers without API key

### DIFF
--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -186,6 +186,7 @@ async fn try_fetch_models(provider_id: &str, config_path: Option<&Path>) -> Opti
             llm_config.provider = Some(crate::llm::RegistryProviderConfig {
                 protocol: def.protocol,
                 provider_id: def.id.clone(),
+                api_key_required: def.api_key_required,
                 model: def.default_model.clone(),
                 api_key: api_key.map(secrecy::SecretString::from),
                 base_url,

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -140,15 +140,10 @@ impl LlmConfig {
             .llm_custom_providers
             .iter()
             .any(|c| c.id == provider.provider_id);
-        let api_key_required = if is_custom {
-            true
-        } else if matches!(provider.protocol, ProviderProtocol::Ollama) {
+        let api_key_required = if matches!(provider.protocol, ProviderProtocol::Ollama) {
             false
         } else {
-            ProviderRegistry::load()
-                .find(&provider.provider_id)
-                .map(|def| def.api_key_required)
-                .unwrap_or(true)
+            provider.api_key_required
         };
 
         // Custom providers have no hardcoded base URL in the client layer —
@@ -646,6 +641,7 @@ impl LlmConfig {
         Ok(RegistryProviderConfig {
             protocol,
             provider_id: custom.id.clone(),
+            api_key_required: !matches!(protocol, ProviderProtocol::Ollama),
             api_key,
             base_url,
             model,
@@ -873,6 +869,7 @@ impl LlmConfig {
         Ok(RegistryProviderConfig {
             protocol,
             provider_id: canonical_id.to_string(),
+            api_key_required,
             api_key,
             base_url,
             model,
@@ -2727,6 +2724,34 @@ mod tests {
             provider.api_key.is_none(),
             "local mock endpoints should not require an API key"
         );
+    }
+
+    #[test]
+    fn resolve_does_not_fall_back_for_unknown_backend_using_openai_compatible_without_api_key() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::set_var("LLM_BACKEND", "some_custom_provider");
+            std::env::set_var("LLM_BASE_URL", "http://localhost:8080/v1");
+        }
+
+        let settings = Settings::default();
+        let cfg = LlmConfig::resolve_with_fallback(&settings)
+            .expect("unknown backend should inherit openai_compatible auth policy");
+        assert_eq!(cfg.backend, "openai_compatible");
+        let provider = cfg.provider.expect("provider config");
+        assert_eq!(provider.provider_id, "openai_compatible");
+        assert!(
+            provider.api_key.is_none(),
+            "unknown backend resolved via openai_compatible must not require an API key"
+        );
+
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::remove_var("LLM_BASE_URL");
+        }
     }
 
     #[test]

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -140,7 +140,16 @@ impl LlmConfig {
             .llm_custom_providers
             .iter()
             .any(|c| c.id == provider.provider_id);
-        let is_ollama = matches!(provider.protocol, ProviderProtocol::Ollama);
+        let api_key_required = if is_custom {
+            true
+        } else if matches!(provider.protocol, ProviderProtocol::Ollama) {
+            false
+        } else {
+            ProviderRegistry::load()
+                .find(&provider.provider_id)
+                .map(|def| def.api_key_required)
+                .unwrap_or(true)
+        };
 
         // Custom providers have no hardcoded base URL in the client layer —
         // an empty `base_url` here means requests will be sent to a bare
@@ -149,9 +158,11 @@ impl LlmConfig {
             return Some("missing base URL");
         }
 
-        // Ollama runs locally and has no API key concept. Every other
-        // provider needs at least one form of authentication.
-        if !is_ollama
+        // Respect the registry's auth policy. Generic OpenAI-compatible
+        // endpoints intentionally allow auth-less localhost/private-network
+        // backends (used by Ollama bridges and the E2E mock LLM), so only
+        // providers that explicitly require credentials should fall back.
+        if api_key_required
             && provider.api_key.is_none()
             && provider.oauth_token.is_none()
             && provider.refresh_token.is_none()
@@ -2688,6 +2699,34 @@ mod tests {
         let cfg = LlmConfig::resolve_with_fallback(&settings)
             .expect("resolve should succeed via fallback");
         assert_eq!(cfg.backend, "nearai");
+    }
+
+    #[test]
+    fn resolve_does_not_fall_back_for_openai_compatible_without_api_key() {
+        let _guard = lock_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_BACKEND");
+            std::env::remove_var("LLM_API_KEY");
+            std::env::remove_var("LLM_BASE_URL");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://localhost:11434/v1".to_string()),
+            selected_model: Some("mock-model".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve_with_fallback(&settings)
+            .expect("auth-less local openai_compatible endpoint should stay selected");
+        assert_eq!(cfg.backend, "openai_compatible");
+        let provider = cfg.provider.expect("provider config");
+        assert_eq!(provider.provider_id, "openai_compatible");
+        assert!(
+            provider.api_key.is_none(),
+            "local mock endpoints should not require an API key"
+        );
     }
 
     #[test]

--- a/src/llm/config.rs
+++ b/src/llm/config.rs
@@ -76,6 +76,8 @@ pub struct RegistryProviderConfig {
     pub protocol: ProviderProtocol,
     /// Provider identifier (e.g., "groq", "openai", "tinfoil").
     pub provider_id: String,
+    /// Whether this provider requires credentials to be usable.
+    pub api_key_required: bool,
     /// API key (optional for some providers like Ollama).
     /// For Anthropic OAuth, this is set to `OAUTH_PLACEHOLDER`.
     pub api_key: Option<SecretString>,

--- a/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
+++ b/tests/e2e/scenarios/test_v2_engine_tool_lifecycle.py
@@ -207,7 +207,8 @@ async def _wait_for_response(
         turns = last_history.get("turns", [])
         if turns:
             last = turns[-1]
-            debug_info = f"\nLast response: {last.get('response', '')[:200]!r}"
+            last_response = last.get("response")
+            debug_info = f"\nLast response: {repr(last_response)[:200]}"
 
     raise AssertionError(
         f"Timed out waiting for response in thread {thread_id}: "

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -140,6 +140,7 @@ impl GatewayWorkflowHarness {
         config.llm.provider = Some(RegistryProviderConfig {
             protocol: ProviderProtocol::OpenAiCompletions,
             provider_id: "openai_compatible".to_string(),
+            api_key_required: false,
             api_key: Some(SecretString::from("dummy".to_string())),
             base_url: base_url.to_string(),
             model: model.to_string(),


### PR DESCRIPTION
## Summary
- stop demoting local `openai_compatible` endpoints with no API key when the registry says credentials are optional
- keep the v2 E2E mock LLM fixtures on the configured localhost provider instead of falling back away before execution starts
- harden one v2 tool lifecycle timeout helper so debug output survives `response = None`

## Why separate
This is unrelated to #2868. The callable-cleanup PR exposed broad v2 E2E failures, but the shared root cause was LLM config fallback for local mock providers, not the callable-surface changes.

## Verification
- `cargo test -p ironclaw --lib config::llm::tests::resolve_does_not_fall_back_for_openai_compatible_without_api_key -- --nocapture`
- targeted reruns on the original worktree before splitting:
  - `test_v2_engine_tool_lifecycle.py::TestV2EngineSingleTool::test_echo_tool`
  - `test_v2_engine_approval_flow.py::TestV2EngineApprovalFlow::test_approval_yes`
  - `test_v2_engine_auth_flow.py::TestV2EngineSkillActivation::test_explicit_slash_skill_prompt_reaches_auth_flow`
- broader v2 subset on the equivalent code before splitting: `70 passed, 2 skipped`
