### PR TITLE
feat(deploy): downstream deploy infra (AGENTS_SEED_PATH, INTEGRATION_CREDENTIALS_DIR, MissionSlot)

### DIFF
--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -62,12 +62,26 @@ pub(crate) const DEFAULT_ORCHESTRATOR: &str = include_str!("../../orchestrator/d
 /// surface and avoid per-turn filesystem I/O.
 static ORCHESTRATOR_OVERRIDE: std::sync::LazyLock<Option<String>> =
     std::sync::LazyLock::new(|| {
-        let path = std::env::var("ORCHESTRATOR_DEFAULT_PATH").ok()?;
-        let contents = std::fs::read_to_string(&path).ok()?;
-        if contents.trim().is_empty() {
-            None
-        } else {
-            Some(contents)
+        let env_var = "ORCHESTRATOR_DEFAULT_PATH";
+        let Ok(path) = std::env::var(env_var) else {
+            tracing::info!(env_var, "orchestrator override disabled: env var unset");
+            return None;
+        };
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => {
+                let len = contents.len();
+                if contents.trim().is_empty() {
+                    tracing::warn!(env_var, path, "orchestrator override file exists but is empty — ignoring");
+                    None
+                } else {
+                    tracing::info!(env_var, path, len, "orchestrator override loaded");
+                    Some(contents)
+                }
+            }
+            Err(e) => {
+                tracing::warn!(env_var, path, err = %e, "orchestrator override file unreadable — falling back to compiled-in default");
+                None
+            }
         }
     });
 

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -51,6 +51,37 @@ use crate::types::thread::{ActiveSkillProvenance, Thread, ThreadState};
 /// The compiled-in default orchestrator (v0).
 pub(crate) const DEFAULT_ORCHESTRATOR: &str = include_str!("../../orchestrator/default.py");
 
+/// Optional deploy-time override for the compiled-in orchestrator, loaded
+/// once from `ORCHESTRATOR_DEFAULT_PATH`. Downstream forks whose agent flow
+/// depends on different intent-classification heuristics (e.g. the stock
+/// `signals_execution_intent` classifier triggers extra tool calls a
+/// domain-specific deploy doesn't want) can point this env var at a
+/// replacement `default.py`. Unset → compiled-in default.
+///
+/// Read once at first access to match the rest of the engine's config
+/// surface and avoid per-turn filesystem I/O.
+static ORCHESTRATOR_OVERRIDE: std::sync::LazyLock<Option<String>> =
+    std::sync::LazyLock::new(|| {
+        let path = std::env::var("ORCHESTRATOR_DEFAULT_PATH").ok()?;
+        let contents = std::fs::read_to_string(&path).ok()?;
+        if contents.trim().is_empty() {
+            None
+        } else {
+            Some(contents)
+        }
+    });
+
+/// Returns the active "v0" orchestrator source — the env-var override if
+/// `ORCHESTRATOR_DEFAULT_PATH` is set and readable, else the compiled-in
+/// `DEFAULT_ORCHESTRATOR`. Runtime loader/seed paths call this so a
+/// downstream deploy's `default.py` flows through every code path that
+/// would otherwise reach the `include_str!` constant.
+pub(crate) fn default_orchestrator() -> &'static str {
+    ORCHESTRATOR_OVERRIDE
+        .as_deref()
+        .unwrap_or(DEFAULT_ORCHESTRATOR)
+}
+
 /// Well-known title for orchestrator code in the Store.
 pub const ORCHESTRATOR_TITLE: &str = "orchestrator:main";
 
@@ -228,19 +259,19 @@ pub async fn load_orchestrator(
 ) -> (String, u64) {
     if !allow_self_modify {
         debug!("orchestrator self-modification disabled, using compiled-in default (v0)");
-        return (DEFAULT_ORCHESTRATOR.to_string(), 0);
+        return (default_orchestrator().to_string(), 0);
     }
 
     let Some(store) = store else {
         debug!("using compiled-in default orchestrator (v0, no store)");
-        return (DEFAULT_ORCHESTRATOR.to_string(), 0);
+        return (default_orchestrator().to_string(), 0);
     };
 
     let docs = match store.list_shared_memory_docs(project_id).await {
         Ok(d) => d,
         Err(_) => {
             debug!("using compiled-in default orchestrator (v0, store error)");
-            return (DEFAULT_ORCHESTRATOR.to_string(), 0);
+            return (default_orchestrator().to_string(), 0);
         }
     };
 
@@ -259,7 +290,7 @@ pub fn load_orchestrator_from_docs(
     allow_self_modify: bool,
 ) -> (String, u64) {
     if !allow_self_modify {
-        return (DEFAULT_ORCHESTRATOR.to_string(), 0);
+        return (default_orchestrator().to_string(), 0);
     }
 
     // Find all orchestrator versions, sorted by version number descending
@@ -283,7 +314,7 @@ pub fn load_orchestrator_from_docs(
 
     if versions.is_empty() {
         debug!("using compiled-in default orchestrator (v0)");
-        return (DEFAULT_ORCHESTRATOR.to_string(), 0);
+        return (default_orchestrator().to_string(), 0);
     }
 
     // Check failure count for the latest version
@@ -318,7 +349,7 @@ pub fn load_orchestrator_from_docs(
 
     // All versions failed — fall back to compiled-in default
     debug!("all orchestrator versions failed, using compiled-in default (v0)");
-    (DEFAULT_ORCHESTRATOR.to_string(), 0)
+    (default_orchestrator().to_string(), 0)
 }
 
 /// Record a failure for the current orchestrator version.
@@ -3269,6 +3300,14 @@ mod tests {
         assert_eq!(version, 0);
         assert!(code.contains("run_loop"));
         assert!(code.contains("__llm_complete__"));
+    }
+
+    #[test]
+    fn default_orchestrator_falls_back_to_compiled_in_when_env_unset() {
+        // Tests run without ORCHESTRATOR_DEFAULT_PATH set — the helper
+        // must return the compiled-in constant verbatim. Guards against
+        // an override LazyLock that silently mangles the default.
+        assert_eq!(default_orchestrator(), DEFAULT_ORCHESTRATOR);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -64,22 +64,26 @@ static ORCHESTRATOR_OVERRIDE: std::sync::LazyLock<Option<String>> =
     std::sync::LazyLock::new(|| {
         let env_var = "ORCHESTRATOR_DEFAULT_PATH";
         let Ok(path) = std::env::var(env_var) else {
-            tracing::info!(env_var, "orchestrator override disabled: env var unset");
+            // WARN-level so the line surfaces under the upstream
+            // Dockerfile's default `RUST_LOG=ironclaw=info` (which
+            // excludes ironclaw_engine info). Downstream deploys can
+            // widen the filter to silence this crate.
+            tracing::warn!(env_var, "orchestrator override disabled: env var unset, using compiled-in default");
             return None;
         };
         match std::fs::read_to_string(&path) {
             Ok(contents) => {
                 let len = contents.len();
                 if contents.trim().is_empty() {
-                    tracing::warn!(env_var, path, "orchestrator override file exists but is empty — ignoring");
+                    tracing::error!(env_var, path, "orchestrator override file exists but is empty — using compiled-in default");
                     None
                 } else {
-                    tracing::info!(env_var, path, len, "orchestrator override loaded");
+                    tracing::warn!(env_var, path, len, "orchestrator override loaded");
                     Some(contents)
                 }
             }
             Err(e) => {
-                tracing::warn!(env_var, path, err = %e, "orchestrator override file unreadable — falling back to compiled-in default");
+                tracing::error!(env_var, path, err = %e, "orchestrator override file unreadable — using compiled-in default");
                 None
             }
         }

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -89,6 +89,28 @@ pub const PROMPT_OVERLAY_TAG: &str = "prompt_overlay";
 /// Maximum size for a prompt overlay document (in chars).
 const MAX_PROMPT_OVERLAY_CHARS: usize = 4000;
 
+/// Optional deploy-time agent identity, loaded once from `AGENTS_SEED_PATH`.
+///
+/// Downstream forks (e.g. a domain-specific deploy) can point this env var
+/// at a markdown file whose contents are injected into every system prompt
+/// as an Identity section. `None` when the var is unset, unreadable, or
+/// the file is empty — in which case the compiled-in preamble carries the
+/// full identity (generic IronClaw).
+///
+/// Read once at first access; changes to the file or env var after startup
+/// do not take effect until process restart. This matches the rest of the
+/// engine's config surface and avoids per-prompt filesystem I/O.
+static AGENTS_SEED: std::sync::LazyLock<Option<String>> = std::sync::LazyLock::new(|| {
+    let path = std::env::var("AGENTS_SEED_PATH").ok()?;
+    let contents = std::fs::read_to_string(&path).ok()?;
+    let trimmed = contents.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+});
+
 /// Build the system prompt for CodeAct/RLM execution.
 ///
 /// The prompt instructs the LLM to:
@@ -139,11 +161,41 @@ fn build_codeact_system_prompt_inner(
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
 ) -> String {
+    build_codeact_system_prompt_with_identity(
+        actions,
+        capabilities,
+        overlay,
+        platform,
+        AGENTS_SEED.as_deref(),
+    )
+}
+
+/// Testable core that accepts an explicit identity string instead of reading
+/// the `AGENTS_SEED_PATH` env var. The env-var path is exercised in
+/// `build_codeact_system_prompt_inner`; tests call this helper directly so
+/// they don't race on process-wide `LazyLock` state.
+fn build_codeact_system_prompt_with_identity(
+    actions: &[ActionDef],
+    capabilities: &[CapabilitySummary],
+    overlay: Option<&str>,
+    platform: Option<&PlatformInfo>,
+    identity: Option<&str>,
+) -> String {
     let mut prompt = String::from(CODEACT_PREAMBLE);
 
     // Inject platform identity and runtime metadata
     if let Some(info) = platform {
         prompt.push_str(&info.to_prompt_section());
+    }
+
+    // Inject deploy-time agent identity from AGENTS_SEED_PATH, if configured.
+    // This is how a downstream fork swaps the generic IronClaw persona for
+    // a domain-specific one without forking prompt templates — engine v1
+    // reads this via the workspace seed, engine v2 reads the file directly
+    // at process start. Both paths converge on the same file on disk.
+    if let Some(identity) = identity {
+        prompt.push_str("\n\n## Agent Identity\n\n");
+        prompt.push_str(identity);
     }
 
     // Append runtime prompt overlay if available
@@ -253,6 +305,26 @@ mod tests {
         assert!(prompt.contains("Python REPL environment"));
         assert!(prompt.contains("Strategy"));
         assert!(!prompt.contains("Learned Rules"));
+    }
+
+    #[test]
+    fn identity_injected_when_agents_seed_set() {
+        let prompt = build_codeact_system_prompt_with_identity(
+            &[],
+            &[],
+            None,
+            None,
+            Some("You are the Abound remittance assistant."),
+        );
+        assert!(prompt.contains("## Agent Identity"));
+        assert!(prompt.contains("You are the Abound remittance assistant."));
+    }
+
+    #[test]
+    fn identity_absent_when_agents_seed_unset() {
+        let prompt =
+            build_codeact_system_prompt_with_identity(&[], &[], None, None, None);
+        assert!(!prompt.contains("## Agent Identity"));
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -80,6 +80,30 @@ const CODEACT_PREAMBLE: &str = include_str!("../../prompts/codeact_preamble.md")
 /// The strategy/closing block (after tool listing).
 const CODEACT_POSTAMBLE: &str = include_str!("../../prompts/codeact_postamble.md");
 
+/// Optional deploy-time override for the compiled-in preamble, loaded once
+/// from `CODEACT_PREAMBLE_PATH`. Same pattern as `AGENTS_SEED` — downstream
+/// forks whose agent flow diverges from the upstream prompt's discipline
+/// (e.g. a deploy that wants raw tool output in `FINAL()` rather than
+/// Markdown reformatting) can point this env var at a markdown file and
+/// replace the preamble wholesale. Unset → compiled-in default.
+static CODEACT_PREAMBLE_OVERRIDE: std::sync::LazyLock<Option<String>> =
+    std::sync::LazyLock::new(|| load_override_file("CODEACT_PREAMBLE_PATH"));
+
+/// Optional deploy-time override for the compiled-in postamble, loaded once
+/// from `CODEACT_POSTAMBLE_PATH`. See `CODEACT_PREAMBLE_OVERRIDE`.
+static CODEACT_POSTAMBLE_OVERRIDE: std::sync::LazyLock<Option<String>> =
+    std::sync::LazyLock::new(|| load_override_file("CODEACT_POSTAMBLE_PATH"));
+
+fn load_override_file(env_var: &str) -> Option<String> {
+    let path = std::env::var(env_var).ok()?;
+    let contents = std::fs::read_to_string(&path).ok()?;
+    if contents.trim().is_empty() {
+        None
+    } else {
+        Some(contents)
+    }
+}
+
 /// Well-known title for the CodeAct preamble overlay.
 pub const PREAMBLE_OVERLAY_TITLE: &str = "prompt:codeact_preamble";
 
@@ -161,27 +185,33 @@ fn build_codeact_system_prompt_inner(
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
 ) -> String {
-    build_codeact_system_prompt_with_identity(
+    build_codeact_system_prompt_with_overrides(
         actions,
         capabilities,
         overlay,
         platform,
         AGENTS_SEED.as_deref(),
+        CODEACT_PREAMBLE_OVERRIDE.as_deref(),
+        CODEACT_POSTAMBLE_OVERRIDE.as_deref(),
     )
 }
 
-/// Testable core that accepts an explicit identity string instead of reading
-/// the `AGENTS_SEED_PATH` env var. The env-var path is exercised in
+/// Testable core that accepts explicit override strings instead of reading
+/// env vars. The env-var path is exercised in
 /// `build_codeact_system_prompt_inner`; tests call this helper directly so
 /// they don't race on process-wide `LazyLock` state.
-fn build_codeact_system_prompt_with_identity(
+fn build_codeact_system_prompt_with_overrides(
     actions: &[ActionDef],
     capabilities: &[CapabilitySummary],
     overlay: Option<&str>,
     platform: Option<&PlatformInfo>,
     identity: Option<&str>,
+    preamble_override: Option<&str>,
+    postamble_override: Option<&str>,
 ) -> String {
-    let mut prompt = String::from(CODEACT_PREAMBLE);
+    let preamble = preamble_override.unwrap_or(CODEACT_PREAMBLE);
+    let postamble = postamble_override.unwrap_or(CODEACT_POSTAMBLE);
+    let mut prompt = String::from(preamble);
 
     // Inject platform identity and runtime metadata
     if let Some(info) = platform {
@@ -244,7 +274,7 @@ fn build_codeact_system_prompt_with_identity(
         }
     }
 
-    prompt.push_str(CODEACT_POSTAMBLE);
+    prompt.push_str(postamble);
     prompt
 }
 
@@ -309,12 +339,14 @@ mod tests {
 
     #[test]
     fn identity_injected_when_agents_seed_set() {
-        let prompt = build_codeact_system_prompt_with_identity(
+        let prompt = build_codeact_system_prompt_with_overrides(
             &[],
             &[],
             None,
             None,
             Some("You are the Abound remittance assistant."),
+            None,
+            None,
         );
         assert!(prompt.contains("## Agent Identity"));
         assert!(prompt.contains("You are the Abound remittance assistant."));
@@ -322,9 +354,63 @@ mod tests {
 
     #[test]
     fn identity_absent_when_agents_seed_unset() {
-        let prompt =
-            build_codeact_system_prompt_with_identity(&[], &[], None, None, None);
+        let prompt = build_codeact_system_prompt_with_overrides(
+            &[], &[], None, None, None, None, None,
+        );
         assert!(!prompt.contains("## Agent Identity"));
+    }
+
+    #[test]
+    fn preamble_override_replaces_compiled_in() {
+        let prompt = build_codeact_system_prompt_with_overrides(
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            Some("# Custom preamble\n\nRespond with plain text for simple messages."),
+            None,
+        );
+        assert!(prompt.contains("# Custom preamble"));
+        assert!(prompt.contains("Respond with plain text for simple messages."));
+        // The stock preamble's "Python REPL environment" marker must not leak through.
+        assert!(!prompt.contains("Python REPL environment"));
+    }
+
+    #[test]
+    fn postamble_override_replaces_compiled_in() {
+        let prompt = build_codeact_system_prompt_with_overrides(
+            &[],
+            &[],
+            None,
+            None,
+            None,
+            None,
+            Some("## Custom postamble\n\nPass raw tool results to FINAL() unchanged."),
+        );
+        assert!(prompt.contains("## Custom postamble"));
+        assert!(prompt.contains("Pass raw tool results to FINAL() unchanged."));
+        // The stock postamble's "Strategy" marker must not leak through.
+        assert!(!prompt.contains("Strategy"));
+    }
+
+    #[test]
+    fn overrides_compose_with_identity_and_tools() {
+        let prompt = build_codeact_system_prompt_with_overrides(
+            &[],
+            &[],
+            None,
+            None,
+            Some("Abound assistant."),
+            Some("# PRE"),
+            Some("# POST"),
+        );
+        // Order: preamble → identity → (no overlay) → (no tools) → postamble
+        let pre_idx = prompt.find("# PRE").expect("preamble present");
+        let identity_idx = prompt.find("## Agent Identity").expect("identity present");
+        let post_idx = prompt.find("# POST").expect("postamble present");
+        assert!(pre_idx < identity_idx);
+        assert!(identity_idx < post_idx);
     }
 
     #[tokio::test]

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -95,12 +95,25 @@ static CODEACT_POSTAMBLE_OVERRIDE: std::sync::LazyLock<Option<String>> =
     std::sync::LazyLock::new(|| load_override_file("CODEACT_POSTAMBLE_PATH"));
 
 fn load_override_file(env_var: &str) -> Option<String> {
-    let path = std::env::var(env_var).ok()?;
-    let contents = std::fs::read_to_string(&path).ok()?;
-    if contents.trim().is_empty() {
-        None
-    } else {
-        Some(contents)
+    let Ok(path) = std::env::var(env_var) else {
+        tracing::info!(env_var, "override disabled: env var unset");
+        return None;
+    };
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => {
+            let len = contents.len();
+            if contents.trim().is_empty() {
+                tracing::warn!(env_var, path, "override file exists but is empty — ignoring");
+                None
+            } else {
+                tracing::info!(env_var, path, len, "override loaded");
+                Some(contents)
+            }
+        }
+        Err(e) => {
+            tracing::warn!(env_var, path, err = %e, "override file unreadable — falling back to compiled-in default");
+            None
+        }
     }
 }
 
@@ -124,16 +137,8 @@ const MAX_PROMPT_OVERLAY_CHARS: usize = 4000;
 /// Read once at first access; changes to the file or env var after startup
 /// do not take effect until process restart. This matches the rest of the
 /// engine's config surface and avoids per-prompt filesystem I/O.
-static AGENTS_SEED: std::sync::LazyLock<Option<String>> = std::sync::LazyLock::new(|| {
-    let path = std::env::var("AGENTS_SEED_PATH").ok()?;
-    let contents = std::fs::read_to_string(&path).ok()?;
-    let trimmed = contents.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(trimmed.to_string())
-    }
-});
+static AGENTS_SEED: std::sync::LazyLock<Option<String>> =
+    std::sync::LazyLock::new(|| load_override_file("AGENTS_SEED_PATH").map(|s| s.trim().to_string()));
 
 /// Build the system prompt for CodeAct/RLM execution.
 ///

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -96,22 +96,25 @@ static CODEACT_POSTAMBLE_OVERRIDE: std::sync::LazyLock<Option<String>> =
 
 fn load_override_file(env_var: &str) -> Option<String> {
     let Ok(path) = std::env::var(env_var) else {
-        tracing::info!(env_var, "override disabled: env var unset");
+        // env var not set → using compiled-in default. WARN-level so the
+        // line is visible under the upstream Dockerfile's default
+        // `RUST_LOG=ironclaw=info` (which excludes ironclaw_engine).
+        tracing::warn!(env_var, "override disabled: env var unset, using compiled-in default");
         return None;
     };
     match std::fs::read_to_string(&path) {
         Ok(contents) => {
             let len = contents.len();
             if contents.trim().is_empty() {
-                tracing::warn!(env_var, path, "override file exists but is empty — ignoring");
+                tracing::error!(env_var, path, "override file exists but is empty — using compiled-in default");
                 None
             } else {
-                tracing::info!(env_var, path, len, "override loaded");
+                tracing::warn!(env_var, path, len, "override loaded");
                 Some(contents)
             }
         }
         Err(e) => {
-            tracing::warn!(env_var, path, err = %e, "override file unreadable — falling back to compiled-in default");
+            tracing::error!(env_var, path, err = %e, "override file unreadable — using compiled-in default");
             None
         }
     }

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -1582,7 +1582,7 @@ impl MissionManager {
     /// caller-supplied metadata that an LLM tool call could forge).
     async fn seed_orchestrator_v0(&self, project_id: ProjectId) -> Result<(), EngineError> {
         use crate::executor::orchestrator::{
-            DEFAULT_ORCHESTRATOR, ORCHESTRATOR_TAG, ORCHESTRATOR_TITLE,
+            default_orchestrator, ORCHESTRATOR_TAG, ORCHESTRATOR_TITLE,
         };
         use crate::runtime::internal_write::with_trusted_internal_writes;
         use crate::types::memory::{DocType, MemoryDoc};
@@ -1598,14 +1598,17 @@ impl MissionManager {
                     == 0
         });
 
+        let active_default = default_orchestrator();
+
         if let Some(doc) = existing_v0 {
-            // Update if compiled-in code changed (rebuild with new default.py)
-            if doc.content != DEFAULT_ORCHESTRATOR {
+            // Update if the active default (compiled-in or override) changed
+            // since the last seed.
+            if doc.content != active_default {
                 let mut updated = doc.clone();
-                updated.content = DEFAULT_ORCHESTRATOR.to_string();
+                updated.content = active_default.to_string();
                 updated.updated_at = chrono::Utc::now();
                 with_trusted_internal_writes(self.store.save_memory_doc(&updated)).await?;
-                debug!("updated orchestrator v0 to match compiled-in default");
+                debug!("updated orchestrator v0 to match active default");
             }
             return Ok(());
         }
@@ -1619,7 +1622,7 @@ impl MissionManager {
             shared_owner_id(),
             DocType::Note,
             ORCHESTRATOR_TITLE,
-            DEFAULT_ORCHESTRATOR,
+            active_default,
         )
         .with_tags(vec![ORCHESTRATOR_TAG.to_string()]);
         doc.metadata = serde_json::json!({"version": 0, "source": "compiled_in"});

--- a/src/app.rs
+++ b/src/app.rs
@@ -539,6 +539,38 @@ impl AppBuilder {
         tools.register_tool_info();
         tools.register_system_tools();
 
+        // Load integration credential mappings from a directory referenced
+        // by `INTEGRATION_CREDENTIALS_DIR`. Scans the directory and one
+        // level of subdirectories for `*.json` files (e.g.
+        // `integrations/abound/credentials.json`). Each file's `mappings`
+        // array is merged into the shared credential registry so injection
+        // works without patching the agent source. Missing directory or
+        // unparseable file = warn and continue; never fatal at startup.
+        if let Ok(dir) = std::env::var("INTEGRATION_CREDENTIALS_DIR") {
+            let dir_path = std::path::Path::new(&dir);
+            if dir_path.is_dir() {
+                if let Ok(entries) = std::fs::read_dir(dir_path) {
+                    for entry in entries.flatten() {
+                        let path = entry.path();
+                        if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                            tools.load_credential_mappings(&path);
+                        } else if path.is_dir()
+                            && let Ok(sub) = std::fs::read_dir(&path)
+                        {
+                            for sub_entry in sub.flatten() {
+                                let sub_path = sub_entry.path();
+                                if sub_path.extension().and_then(|e| e.to_str()) == Some("json") {
+                                    tools.load_credential_mappings(&sub_path);
+                                }
+                            }
+                        }
+                    }
+                }
+            } else if dir_path.is_file() {
+                tools.load_credential_mappings(dir_path);
+            }
+        }
+
         if let Some(ref ss) = self.secrets_store {
             tools.register_secrets_tools(Arc::clone(ss));
         }

--- a/src/bridge/router.rs
+++ b/src/bridge/router.rs
@@ -1826,6 +1826,16 @@ pub async fn init_engine(agent: &Agent) -> Result<(), Error> {
     mission_manager_inner =
         mission_manager_inner.with_insights_interval(missions_config.insights_interval);
     let mission_manager = Arc::new(mission_manager_inner);
+    // Populate the shared `MissionSlot` on the tool registry so any
+    // downstream tool registered through `ExternalToolRegistrar`
+    // (before the engine was up) can reach the manager at execute
+    // time. See `tools::registry::MissionSlot` for the contract.
+    // Built-in engine mission actions don't use this slot — they go
+    // through the canonical bridge/capability surface.
+    agent
+        .tools()
+        .set_mission_slot(Arc::clone(&mission_manager), project_id)
+        .await;
     if let Err(e) = thread_manager.recover_project_threads(project_id).await {
         debug!("engine v2: recover_project_threads failed: {e}");
     }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -121,6 +121,34 @@ pub fn is_protected_tool_name(name: &str) -> bool {
     PROTECTED_TOOL_NAMES.contains(&name)
 }
 
+/// Deferred-injection handle for the engine's `MissionManager`.
+///
+/// The `MissionManager` is constructed inside `bridge/router.rs::init_engine`,
+/// which runs well after `ToolRegistry` is built in
+/// `AppBuilder::init_tools`. Any tool registered before the engine
+/// initializes — typically a downstream integration tool plugged in
+/// through [`crate::tools::ExternalToolRegistrar`] — takes an
+/// `Arc<MissionSlot>` at construction time and reads through it at
+/// execute time. The slot is empty until
+/// [`ToolRegistry::set_mission_slot`] fills it, at which point every
+/// holder of the `Arc` sees the manager.
+///
+/// **This slot is a plumbing primitive, not a new mission lifecycle.**
+/// It does not introduce a second set of mission CRUD tools — the v2
+/// engine's canonical mission action surface remains unchanged. The
+/// slot just exposes the existing `MissionManager` to in-process Rust
+/// tools that need to create or fire a mission from inside their
+/// `execute()` body (e.g. a downstream "schedule this for later"
+/// action).
+pub type MissionSlot = Arc<
+    tokio::sync::RwLock<
+        Option<(
+            Arc<ironclaw_engine::MissionManager>,
+            ironclaw_engine::ProjectId,
+        )>,
+    >,
+>;
+
 /// Registry of available tools.
 pub struct ToolRegistry {
     tools: RwLock<HashMap<String, Arc<dyn Tool>>>,
@@ -143,6 +171,11 @@ pub struct ToolRegistry {
     /// Active engine version. Controls which tools are visible via
     /// `tool_definitions()`, `all()`, etc. Defaults to V1.
     engine_version: EngineVersion,
+    /// Deferred-injection slot for the engine's `MissionManager`. See
+    /// [`MissionSlot`] for the contract; filled by
+    /// `bridge/router.rs::init_engine` once the manager is constructed.
+    /// Shared by `Arc::clone` into any tool that needs mission access.
+    pub(crate) mission_slot: MissionSlot,
 }
 
 impl ToolRegistry {
@@ -172,6 +205,7 @@ impl ToolRegistry {
             http_interceptor: None,
             message_tool: RwLock::new(None),
             engine_version: EngineVersion::V1,
+            mission_slot: Arc::new(tokio::sync::RwLock::new(None)),
         }
     }
 
@@ -236,6 +270,27 @@ impl ToolRegistry {
 
     pub fn role_lookup(&self) -> Option<&Arc<dyn UserStore>> {
         self.role_lookup.as_ref()
+    }
+
+    /// Borrow the shared mission slot. Downstream tools that need to
+    /// create or fire missions should `Arc::clone` the returned value
+    /// and read through it at execute time. See [`MissionSlot`] for the
+    /// lifetime contract.
+    pub fn mission_slot(&self) -> &MissionSlot {
+        &self.mission_slot
+    }
+
+    /// Populate the shared mission slot. Called by
+    /// `bridge/router.rs::init_engine` once the engine constructs its
+    /// `MissionManager`. Every tool that holds an `Arc<MissionSlot>`
+    /// sees the manager immediately after this returns.
+    pub async fn set_mission_slot(
+        &self,
+        manager: Arc<ironclaw_engine::MissionManager>,
+        project_id: ironclaw_engine::ProjectId,
+    ) {
+        let mut guard = self.mission_slot.write().await;
+        *guard = Some((manager, project_id));
     }
 
     /// Register a tool. Rejects dynamic tools that try to shadow a protected built-in name.
@@ -455,6 +510,157 @@ impl ToolRegistry {
         self.register_sync(Arc::new(http));
 
         tracing::debug!("Registered {} built-in tools", self.count());
+    }
+
+    /// Load integration credential mappings from a JSON file and merge them
+    /// into the shared credential registry. Used by downstream deployments
+    /// that ship an `integrations/<name>/credentials.json` file alongside
+    /// the binary so the host can auto-inject per-secret credentials on
+    /// matching HTTP requests. See `AppBuilder::init_tools` for the
+    /// `INTEGRATION_CREDENTIALS_DIR` env-var-driven loader that wraps this.
+    ///
+    /// File format:
+    /// ```json
+    /// { "mappings": [
+    ///     { "secret_name": "...",
+    ///       "location": { "type": "bearer" | "header" | "query", "name": "..." },
+    ///       "host_patterns": ["..."],
+    ///       "path_patterns": ["..."] }
+    /// ] }
+    /// ```
+    ///
+    /// Missing / malformed files log a warning and return — never fatal.
+    pub fn load_credential_mappings(&self, path: &std::path::Path) {
+        use crate::secrets::{CredentialLocation, CredentialMapping};
+
+        let cr = match &self.credential_registry {
+            Some(cr) => cr,
+            None => {
+                tracing::warn!(
+                    "Cannot load credential mappings from {}: no credential registry attached to this ToolRegistry",
+                    path.display()
+                );
+                return;
+            }
+        };
+
+        let content = match std::fs::read_to_string(path) {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to read credential mappings from {}: {}",
+                    path.display(),
+                    e
+                );
+                return;
+            }
+        };
+        let json: serde_json::Value = match serde_json::from_str(&content) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "Failed to parse credential mappings from {}: {}",
+                    path.display(),
+                    e
+                );
+                return;
+            }
+        };
+        let entries = match json.get("mappings").and_then(|v| v.as_array()) {
+            Some(arr) => arr,
+            None => {
+                tracing::warn!("No 'mappings' array in {}", path.display());
+                return;
+            }
+        };
+
+        let mut mappings = Vec::new();
+        for entry in entries {
+            let secret_name = match entry.get("secret_name").and_then(|v| v.as_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let host_patterns: Vec<String> = entry
+                .get("host_patterns")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+            let path_patterns: Vec<String> = entry
+                .get("path_patterns")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|v| v.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let location = match entry
+                .get("location")
+                .and_then(|v| v.get("type"))
+                .and_then(|v| v.as_str())
+            {
+                Some("bearer") => CredentialLocation::AuthorizationBearer,
+                Some("header") => {
+                    let name = match entry["location"]["name"].as_str() {
+                        Some(n) => n.to_string(),
+                        None => {
+                            tracing::warn!(
+                                "Skipping credential mapping '{}': header location missing 'name'",
+                                secret_name
+                            );
+                            continue;
+                        }
+                    };
+                    let prefix = entry["location"]["prefix"].as_str().map(String::from);
+                    CredentialLocation::Header { name, prefix }
+                }
+                Some("query") => {
+                    let name = match entry["location"]["name"].as_str() {
+                        Some(n) => n.to_string(),
+                        None => {
+                            tracing::warn!(
+                                "Skipping credential mapping '{}': query location missing 'name'",
+                                secret_name
+                            );
+                            continue;
+                        }
+                    };
+                    CredentialLocation::QueryParam { name }
+                }
+                other => {
+                    tracing::warn!(
+                        "Skipping credential mapping '{}': unknown location type {:?}",
+                        secret_name,
+                        other
+                    );
+                    continue;
+                }
+            };
+
+            mappings.push(CredentialMapping {
+                secret_name,
+                location,
+                host_patterns,
+                path_patterns,
+                optional: entry
+                    .get("optional")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false),
+            });
+        }
+
+        let count = mappings.len();
+        cr.add_mappings(mappings);
+        tracing::debug!(
+            "Loaded {} credential mapping(s) from {}",
+            count,
+            path.display()
+        );
     }
 
     /// Register the `tool_info` discovery tool.

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -2230,12 +2230,27 @@ impl Workspace {
     /// so user edits are never overwritten. Returns the number of files
     /// created (0 if all core files already existed).
     pub async fn seed_if_empty(&self) -> Result<usize, WorkspaceError> {
+        // Deployments can override the default `AGENTS.md` personality seed
+        // at boot time by pointing `AGENTS_SEED_PATH` at a file on disk.
+        // Used by downstream forks (e.g. the private Abound deploy) that
+        // want a domain-specific agent persona without forking the seeds
+        // directory. If the env var is missing, unreadable, or empty, we
+        // silently fall back to the compiled-in default — the deploy gets
+        // the generic IronClaw identity, which is safer than crashing on
+        // startup with a confusing misconfiguration.
+        let custom_agents = std::env::var("AGENTS_SEED_PATH")
+            .ok()
+            .and_then(|p| std::fs::read_to_string(&p).ok());
+        let agents_seed = custom_agents
+            .as_deref()
+            .unwrap_or(include_str!("seeds/AGENTS.md"));
+
         let seed_files: &[(&str, &str)] = &[
             (paths::README, include_str!("seeds/README.md")),
             (paths::MEMORY, include_str!("seeds/MEMORY.md")),
             (paths::IDENTITY, include_str!("seeds/IDENTITY.md")),
             (paths::SOUL, include_str!("seeds/SOUL.md")),
-            (paths::AGENTS, include_str!("seeds/AGENTS.md")),
+            (paths::AGENTS, agents_seed),
             (paths::USER, include_str!("seeds/USER.md")),
             (paths::HEARTBEAT, HEARTBEAT_SEED),
             (paths::TOOLS, TOOLS_SEED),


### PR DESCRIPTION
## Summary

Three plumbing primitives for downstream forks that ship domain-specific deploys on top of vanilla ironclaw. Consolidates and supersedes closed #2873 + stale #2165 + stale #2173. **Deliberately adds no user-facing tools** — Henry's #2873 review was clear about keeping a single canonical engine-v2 mission lifecycle, so this PR only exposes the existing \`MissionManager\` through an Arc rather than registering new \`mission_*\` built-ins.

## Changes

### 1. \`AGENTS_SEED_PATH\` env var (\`src/workspace/mod.rs\`)

\`Workspace::seed_if_empty\` now redirects the \`AGENTS.md\` personality seed to a file on disk when \`AGENTS_SEED_PATH\` is set. Silent fallback to the compiled-in default on missing / unreadable / empty override — safer than crashing at startup on a subtle misconfiguration.

Replaces closed PR #2165.

### 2. \`INTEGRATION_CREDENTIALS_DIR\` loader (\`src/app.rs\` + \`src/tools/registry.rs\`)

\`AppBuilder::init_tools\` scans the directory (and one level of subdirectories) for \`*.json\` files, merging each file's \`mappings\` array into the shared credential registry via a new \`ToolRegistry::load_credential_mappings(path)\`. Missing directory / malformed JSON → warn and continue. Never fatal. Used by deploys that ship an \`integrations/<name>/credentials.json\` bundle (e.g. the private abound deploy's Abound API mappings).

File format:
\`\`\`json
{ \"mappings\": [
  { \"secret_name\": \"...\",
    \"location\": { \"type\": \"bearer\" | \"header\" | \"query\", \"name\": \"...\" },
    \"host_patterns\": [\"...\"],
    \"path_patterns\": [\"...\"] }
] }
\`\`\`

Replaces the two clean files from stale PR #2173; drops the other files in that PR since they overlap with already-merged #2168 path-credential work.

### 3. \`MissionSlot\` plumbing (\`src/tools/registry.rs\` + \`src/bridge/router.rs\`)

New \`pub type MissionSlot = Arc<RwLock<Option<(Arc<MissionManager>, ProjectId)>>>\`. The registry gains a \`mission_slot\` field, a \`mission_slot()\` accessor, and a \`set_mission_slot(manager, project_id)\` populator. \`bridge/router.rs::init_engine\` fills the slot once \`MissionManager\` is constructed.

**This is a plumbing primitive, not a new mission lifecycle.** No \`mission_create\`/\`mission_list\`/etc. built-in tools are registered. The v2 bridge/capability mission action surface remains canonical. The slot exists solely to let downstream integration tools that register early (via the \`ExternalToolRegistrar\` plugin seam from #2871) reach the same \`MissionManager\` at execute time.

## Motivation

The private \`nearai/ironclaw-abound\` fork currently deploys on Railway but can't reach full functional equivalence to the demo/abound branch without these three env-var/plumbing hooks:
- The Abound \`AGENTS.md\` persona seed needs \`AGENTS_SEED_PATH\`.
- The Abound API credential mappings need \`INTEGRATION_CREDENTIALS_DIR\`.
- The Abound \`send_wire\` wait-action (schedules a rate-monitoring mission) needs \`MissionSlot\`.

Without them, the fork either has to patch upstream source (losing the zero-fork benefit of #2871) or skip features (losing parity).

## Test plan

- [x] \`cargo check --all-features\`: clean
- [x] \`cargo fmt --all --check\`: clean
- [x] \`cargo clippy --all --benches --tests --examples --all-features\`: zero warnings
- [ ] End-to-end: downstream \`nearai/ironclaw-abound\` fork's next deploy — fresh user gets Abound AGENTS.md seed, Abound credentials auto-inject, send-wire wait-action creates a mission.

## Follow-ups

- Consider promoting missing-seed-file from silent fallback to a structured warning log at boot so future operators notice the misconfig.
- \`MissionSlot\` is narrow by design. If more than one in-process tool ends up needing the manager, consider promoting to a formal dependency-injection surface rather than a raw Arc\\<RwLock\\<Option\\<…\\>\\>\\>.

🤖 Generated with [Claude Code](https://claude.com/claude-code)