### PR TITLE
docs: update minimum Rust version to 1.92 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ IronClaw is the AI assistant you can actually trust with your personal and profe
 
 ### Prerequisites
 
-- Rust 1.85+
+- Rust 1.92+
 - PostgreSQL 15+ with [pgvector](https://github.com/pgvector/pgvector) extension
 - NEAR AI account (authentication handled via setup wizard)
 


### PR DESCRIPTION
Fixes #2898

## Problem
`README.md` advertises `Rust 1.85+` as the minimum required version, but `Cargo.toml` already enforces `rust-version = "1.92"` at the workspace level. Users who have Rust 1.85–1.91 installed get a confusing build failure (e.g. from wasmtime 43.x requiring rustc ≥ 1.91) that doesn't match the documented prerequisite.

## Solution
Align the documented prerequisite with the enforced MSRV: update the README to say `Rust 1.92+`.

## Testing
No code changed; documentation-only fix. The `rust-version` field in `Cargo.toml` is the authoritative source of truth and remains unchanged.