### PR TITLE
fix(config): decouple webhook listener bind from HTTP channel enablement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -143,12 +143,22 @@ SLACK_SIGNING_SECRET=...
 # Telegram Bot (optional)
 TELEGRAM_BOT_TOKEN=...
 
-# HTTP Webhook Server (optional)
-HTTP_HOST=0.0.0.0
-HTTP_PORT=8080
-HTTP_WEBHOOK_SECRET=your-webhook-secret
+# Unified Webhook Listener (shared by tool webhooks, WASM routes, and optional channel webhooks)
+WEBHOOK_HOST=127.0.0.1
+WEBHOOK_PORT=8080
+
+# HTTP Webhook Channel (optional route on the unified webhook listener)
+# Set HTTP_ENABLED=true to register POST /webhook.
+# If WEBHOOK_HOST/WEBHOOK_PORT are unset, HTTP_HOST/HTTP_PORT remain a compatibility
+# fallback for the unified listener bind.
+#
+# HTTP_ENABLED=true
+# HTTP_HOST=0.0.0.0
+# HTTP_PORT=8080
+# HTTP_WEBHOOK_SECRET=your-webhook-secret
+#
 # Webhook authentication uses HMAC-SHA256 signature verification.
-# Callers must send an X-IronClaw-Signature header with format: sha256=<hex_digest>
+# Callers must send an X-Hub-Signature-256 header with format: sha256=<hex_digest>
 # where the digest is HMAC-SHA256(HTTP_WEBHOOK_SECRET, raw_request_body) in lowercase hex.
 #
 # Example (bash):
@@ -156,7 +166,7 @@ HTTP_WEBHOOK_SECRET=your-webhook-secret
 #   SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$HTTP_WEBHOOK_SECRET" | cut -d' ' -f2)
 #   curl -X POST http://localhost:8080/webhook \
 #     -H "Content-Type: application/json" \
-#     -H "X-IronClaw-Signature: sha256=$SIG" \
+#     -H "X-Hub-Signature-256: sha256=$SIG" \
 #     -d "$BODY"
 #
 # DEPRECATED: Passing "secret" in the JSON body still works but will be removed in a future release.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ IronClaw is the AI assistant you can actually trust with your personal and profe
 
 ### Always Available
 
-- **Multi-channel** - REPL, HTTP webhooks, WASM channels (Telegram, Slack), and web gateway
+- **Multi-channel** - REPL, a unified webhook listener for tool and WASM ingress, an optional HTTP webhook channel, and web gateway
 - **Docker Sandbox** - Isolated container execution with per-job tokens and orchestrator/worker pattern
 - **Web Gateway** - Browser UI with real-time SSE/WebSocket streaming
 - **Routines** - Cron schedules, event triggers, webhook handlers for background automation

--- a/docs/channels/webhook.mdx
+++ b/docs/channels/webhook.mdx
@@ -1,55 +1,68 @@
 ---
 title: HTTP Webhook
 sidebarTitle: Webhook
-description: REST API for external integrations
+description: Receive HTTP webhook requests on the unified webhook listener
 ---
 
-The HTTP Webhook channel provides a REST API for integrating external services with IronClaw.
+The HTTP Webhook channel registers `POST /webhook` on IronClaw's unified webhook listener.
 
 <Note>
-If you haven't set up your agent yet, follow our [Quickstart guide](../quickstart)
+If you haven't set up your agent yet, follow our [Quickstart guide](../quickstart).
 </Note>
 
 ---
 
-## Enabling Webhooks
+## Listener Model
+
+IronClaw now separates two concerns:
+
+- The **unified webhook listener** bind address is configured with `WEBHOOK_HOST` / `WEBHOOK_PORT`.
+- The **named HTTP webhook channel** is enabled with `HTTP_ENABLED=true`.
+
+That means `HTTP_ENABLED=false` keeps the HTTP webhook channel disabled even if `HTTP_HOST` / `HTTP_PORT` are still present for compatibility.
 
 ```bash
+export WEBHOOK_HOST=127.0.0.1
+export WEBHOOK_PORT=8080
+
 export HTTP_ENABLED=true
-export HTTP_HOST=0.0.0.0
-export HTTP_PORT=8080
 export HTTP_WEBHOOK_SECRET=your-secret
 ```
 
-Or during onboarding:
-```
-Step 6: Channel Configuration
-→ Select "HTTP Webhook"
-→ Port: 8080
-```
+If `WEBHOOK_HOST` / `WEBHOOK_PORT` are unset, IronClaw can still fall back to legacy `HTTP_HOST` / `HTTP_PORT` listener settings for compatibility. New deployments should set `WEBHOOK_*` explicitly.
 
 ---
 
 ## Security
 
 <Warning>
-The HTTP webhook binds to `0.0.0.0:8080` by default. If you don't need external webhook delivery, set `HTTP_HOST=127.0.0.1`.
+The unified webhook listener binds to `127.0.0.1:8080` by default. If you need external delivery, expose it intentionally via a reverse proxy, tunnel, or an explicit `WEBHOOK_HOST` setting.
 </Warning>
 
-### Shared Secret Validation
+### Authentication
 
-Configure a webhook secret to validate requests:
+Configure a shared secret for the HTTP webhook channel:
 
 ```bash
 export HTTP_WEBHOOK_SECRET="your-secret-here"
 ```
 
-The secret is sent in the `X-Webhook-Secret` header.
+Clients should authenticate with HMAC-SHA256 using the raw request body:
 
-### Rate Limiting
+```text
+X-Hub-Signature-256: sha256=<hex_digest>
+```
 
-- **Body size**: 64 KB maximum
-- **Rate**: 60 requests per minute per IP
+The digest is `HMAC-SHA256(HTTP_WEBHOOK_SECRET, raw_request_body)` encoded as lowercase hex.
+
+The older JSON-body `secret` field is still accepted for compatibility, but it is deprecated.
+
+### Limits
+
+- Request body: 15 MB maximum
+- Message content: 32 KB maximum
+- Rate limit: 60 requests per minute
+- Pending synchronous responses: 100
 
 ---
 
@@ -58,104 +71,82 @@ The secret is sent in the `X-Webhook-Secret` header.
 ### Request Format
 
 ```bash
+BODY='{"content":"Hello, IronClaw!","wait_for_response":true}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$HTTP_WEBHOOK_SECRET" | cut -d' ' -f2)
+
 curl -X POST http://localhost:8080/webhook \
   -H "Content-Type: application/json" \
-  -H "X-Webhook-Secret: your-secret" \
-  -d '{
-    "user_id": "default",
-    "message": "Hello, IronClaw!"
-  }'
+  -H "X-Hub-Signature-256: sha256=$SIG" \
+  -d "$BODY"
 ```
+
+### Payload Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `content` | string | Yes | Message content |
+| `user_id` | string | No | Optional sender identifier for routing while keeping the configured owner scope |
+| `thread_id` | string | No | Continue an existing conversation thread |
+| `wait_for_response` | boolean | No | Wait up to 60 seconds for a synchronous response |
+| `attachments` | array | No | Base64 attachments or attachment URLs |
+| `secret` | string | No | Deprecated fallback for body-secret authentication |
 
 ### Response Format
 
 ```json
 {
-  "job_id": "uuid",
-  "status": "queued"
+  "message_id": "uuid",
+  "status": "accepted",
+  "response": "Hello! How can I help?"
 }
 ```
 
----
+- `message_id` is always returned
+- `status` is typically `accepted` or `error`
+- `response` is only populated when `wait_for_response=true`
 
-## Payload Fields
-
-| Field | Type | Required | Description |
-|-------|------|----------|-------------|
-| `user_id` | string | Yes | User identifier |
-| `message` | string | Yes | Message content |
-| `conversation_id` | string | No | Continue existing conversation |
-| `metadata` | object | No | Arbitrary metadata |
-
-## Response Fields
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `job_id` | string | Job UUID for status checking |
-| `status` | string | `queued`, `running`, `completed` |
-| `response` | string | Agent response (when complete) |
-
----
-
-## Checking Status
+### Health Check
 
 ```bash
-curl http://localhost:8080/jobs/{job_id} -H "X-Webhook-Secret: your-secret"
+curl http://localhost:8080/health
 ```
 
 Response:
+
 ```json
 {
-  "id": "uuid",
-  "status": "completed",
-  "response": "Hello! How can I help?",
-  "created_at": "2024-01-15T10:30:00Z",
-  "completed_at": "2024-01-15T10:30:05Z"
+  "status": "healthy",
+  "channel": "http"
 }
 ```
 
 ---
 
-## Error Responses
-
-| Status | Meaning |
-|--------|---------|
-| `400` | Invalid request body |
-| `401` | Missing or invalid secret |
-| `429` | Rate limit exceeded |
-| `500` | Server error |
-
----
-
-## Example Integrations
-
-### GitHub Webhook
-
-Configure GitHub to send events to your IronClaw webhook URL:
-
-```bash
-# GitHub webhook URL
-https://your-server:8080/webhook
-
-# Secret: your configured HTTP_WEBHOOK_SECRET
-```
-
-### Zapier
-
-Use Zapier's Webhook action to send events to IronClaw.
-
-### Custom Script
+## Example Client
 
 ```python
+import hashlib
+import hmac
+import json
 import requests
+
+secret = b"your-secret"
+body = json.dumps({
+    "content": "Process this data",
+    "user_id": "automation",
+}).encode()
+signature = hmac.new(secret, body, hashlib.sha256).hexdigest()
 
 response = requests.post(
     "http://localhost:8080/webhook",
-    headers={"X-Webhook-Secret": "your-secret"},
-    json={"user_id": "automation", "message": "Process this data"}
+    headers={
+        "Content-Type": "application/json",
+        "X-Hub-Signature-256": f"sha256={signature}",
+    },
+    data=body,
 )
 
-print(response.json()["job_id"])
+print(response.json())
 ```
 
 ---
@@ -165,23 +156,22 @@ print(response.json()["job_id"])
 <AccordionGroup>
   <Accordion title="Connection refused" icon="x-circle">
     - Check IronClaw is running
-    - Verify `HTTP_PORT` is correct
-    - Check firewall: `sudo ufw allow 8080`
+    - Verify `WEBHOOK_HOST` / `WEBHOOK_PORT`
+    - If `HTTP_ENABLED=true`, make sure the HTTP channel is enabled
   </Accordion>
 
   <Accordion title="401 Unauthorized" icon="key">
-    - Include `X-Webhook-Secret` header
-    - Verify secret matches configuration
+    - Include `X-Hub-Signature-256`
+    - Verify the signature uses the raw request body
+    - Confirm `HTTP_WEBHOOK_SECRET` matches on both sides
+  </Accordion>
+
+  <Accordion title="415 Unsupported Media Type" icon="file-warning">
+    - Send `Content-Type: application/json`
   </Accordion>
 
   <Accordion title="429 Too Many Requests" icon="clock">
-    - Rate limit: 60 requests/minute
-    - Implement exponential backoff
-  </Accordion>
-
-  <Accordion title="Messages not processed" icon="message-circle">
-    - Check logs: `RUST_LOG=ironclaw=debug ironclaw run`
-    - Verify JSON format
-    - Check `user_id` is valid
+    - Rate limit is 60 requests per minute
+    - Implement retries with backoff
   </Accordion>
 </AccordionGroup>

--- a/docs/channels/webhook.mdx
+++ b/docs/channels/webhook.mdx
@@ -31,6 +31,8 @@ export HTTP_WEBHOOK_SECRET=your-secret
 
 If `WEBHOOK_HOST` / `WEBHOOK_PORT` are unset, IronClaw can still fall back to legacy `HTTP_HOST` / `HTTP_PORT` listener settings for compatibility. New deployments should set `WEBHOOK_*` explicitly.
 
+`SIGHUP` only reloads the unified listener bind and the HTTP webhook secret. Enabling or disabling the named HTTP webhook channel still requires a restart because route topology is not rebuilt on reload.
+
 ---
 
 ## Security

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -89,11 +89,11 @@ We recommend using [NEAR AI](https://cloud.near.ai/) as your inference provider 
 
 <Accordion title="⚠️ Error: Failed to start webhook server">
 
-If you encounter the error `Error: Channel webhook_server failed to start: Failed to bind to 0.0.0.0:8080: Address already in use (os error 98)`, simply try setting a different HTTP port:
+If you encounter the error `Error: Channel webhook_server failed to start: Failed to bind to 127.0.0.1:8080: Address already in use (os error 98)`, simply try setting a different webhook listener port:
 
 ```
-# Change the default HTTP port to 8081
-export HTTP_PORT=8081
+# Change the default webhook listener port to 8081
+export WEBHOOK_PORT=8081
 
 # Then start the agent again
 ironclaw

--- a/docs/zh/channels/webhook.mdx
+++ b/docs/zh/channels/webhook.mdx
@@ -1,56 +1,70 @@
 ---
 title: HTTP Webhook
 sidebarTitle: Webhook
-description: 用于外部集成的 REST API
-icon: globe
+description: 在统一 webhook 监听器上接收 HTTP webhook 请求
 ---
 
-HTTP Webhook 频道提供 REST API，用于将外部服务与 IronClaw 集成。
+HTTP Webhook 通道在 IronClaw 的统一 webhook 监听器上注册 `POST /webhook` 路由。
 
 <Note>
-如果您还没有设置智能体，请先查看我们的[快速开始指南](../quickstart)
+如果您还未设置代理，请参考我们的[快速入门指南](../quickstart)。
 </Note>
 
 ---
 
-## 启用 Webhook
+## 监听器模型
+
+IronClaw 现在分离了两个关注点：
+
+- **统一 webhook 监听器**的绑定地址通过 `WEBHOOK_HOST` / `WEBHOOK_PORT` 配置。
+- **具名 HTTP webhook 通道**通过 `HTTP_ENABLED=true` 启用。
+
+这意味着 `HTTP_ENABLED=false` 会保持 HTTP webhook 通道禁用状态，即使 `HTTP_HOST` / `HTTP_PORT` 仍然存在用于兼容性。
 
 ```bash
+export WEBHOOK_HOST=127.0.0.1
+export WEBHOOK_PORT=8080
+
 export HTTP_ENABLED=true
-export HTTP_HOST=0.0.0.0
-export HTTP_PORT=8080
 export HTTP_WEBHOOK_SECRET=your-secret
 ```
 
-或在引导过程中：
-```
-Step 6: Channel Configuration
-→ Select "HTTP Webhook"
-→ Port: 8080
-```
+如果 `WEBHOOK_HOST` / `WEBHOOK_PORT` 未设置，IronClaw 仍可回退到旧版 `HTTP_HOST` / `HTTP_PORT` 监听器设置以保持兼容性。新部署应显式设置 `WEBHOOK_*` 变量。
+
+`SIGHUP` 只会重新加载统一 webhook 监听器的绑定地址以及 HTTP webhook 密钥。启用或禁用具名 HTTP webhook 通道仍然需要重启，因为重新加载不会重建路由拓扑。
 
 ---
 
-## 安全
+## 安全性
 
 <Warning>
-HTTP webhook 默认绑定到 `0.0.0.0:8080`。如果不需要外部 webhook 传递，请设置 `HTTP_HOST=127.0.0.1`。
+统一 webhook 监听器默认绑定到 `127.0.0.1:8080`。如果您需要外部访问，请通过反向代理、隧道或显式的 `WEBHOOK_HOST` 设置有意地暴露它。
 </Warning>
 
-### 共享密钥验证
+### 认证
 
-配置 webhook 密钥以验证请求：
+为 HTTP webhook 通道配置共享密钥：
 
 ```bash
 export HTTP_WEBHOOK_SECRET="your-secret-here"
 ```
 
-密钥通过 `X-Webhook-Secret` 请求头发送。
+客户端应使用原始请求体进行 HMAC-SHA256 认证：
 
-### 速率限制
+```text
+X-Hub-Signature-256: sha256=<hex_digest>
+```
 
-- **请求体大小**：最大 64 KB
-- **速率**：每个 IP 每分钟 60 个请求
+摘要是 `HMAC-SHA256(HTTP_WEBHOOK_SECRET, raw_request_body)` 编码为小写十六进制。
+
+旧版 JSON 正文中的 `secret` 字段仍被接受以保持兼容性，但已弃用。
+
+### 限制
+
+- 请求正文：最大 15 MB
+- 消息内容：最大 32 KB
+- 速率限制：每分钟 60 次请求
+- 待处理同步响应：100
 
 ---
 
@@ -59,104 +73,82 @@ export HTTP_WEBHOOK_SECRET="your-secret-here"
 ### 请求格式
 
 ```bash
+BODY='{"content":"Hello, IronClaw!","wait_for_response":true}'
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$HTTP_WEBHOOK_SECRET" | cut -d' ' -f2)
+
 curl -X POST http://localhost:8080/webhook \
   -H "Content-Type: application/json" \
-  -H "X-Webhook-Secret: your-secret" \
-  -d '{
-    "user_id": "default",
-    "message": "Hello, IronClaw!"
-  }'
+  -H "X-Hub-Signature-256: sha256=$SIG" \
+  -d "$BODY"
 ```
+
+### 载荷字段
+
+| 字段 | 类型 | 必需 | 描述 |
+|-------|------|----------|-------------|
+| `content` | string | 是 | 消息内容 |
+| `user_id` | string | 否 | 可选的发送者标识符，用于路由同时保持配置的所有者范围 |
+| `thread_id` | string | 否 | 继续现有对话线程 |
+| `wait_for_response` | boolean | 否 | 等待最多 60 秒以获取同步响应 |
+| `attachments` | array | 否 | Base64 附件或附件 URL |
+| `secret` | string | 否 | 已弃用的正文密钥认证回退 |
 
 ### 响应格式
 
 ```json
 {
-  "job_id": "uuid",
-  "status": "queued"
+  "message_id": "uuid",
+  "status": "accepted",
+  "response": "Hello! How can I help?"
 }
 ```
 
----
+- `message_id` 总是返回
+- `status` 通常是 `accepted` 或 `error`
+- `response` 仅在 `wait_for_response=true` 时填充
 
-## 请求字段
-
-| 字段 | 类型 | 必填 | 描述 |
-|-------|------|----------|-------------|
-| `user_id` | string | 是 | 用户标识符 |
-| `message` | string | 是 | 消息内容 |
-| `conversation_id` | string | 否 | 继续现有对话 |
-| `metadata` | object | 否 | 任意元数据 |
-
-## 响应字段
-
-| 字段 | 类型 | 描述 |
-|-------|------|-------------|
-| `job_id` | string | 用于状态检查的任务 UUID |
-| `status` | string | `queued`、`running`、`completed` |
-| `response` | string | 智能体响应（完成时） |
-
----
-
-## 检查状态
+### 健康检查
 
 ```bash
-curl http://localhost:8080/jobs/{job_id} -H "X-Webhook-Secret: your-secret"
+curl http://localhost:8080/health
 ```
 
 响应：
+
 ```json
 {
-  "id": "uuid",
-  "status": "completed",
-  "response": "Hello! How can I help?",
-  "created_at": "2024-01-15T10:30:00Z",
-  "completed_at": "2024-01-15T10:30:05Z"
+  "status": "healthy",
+  "channel": "http"
 }
 ```
 
 ---
 
-## 错误响应
-
-| 状态码 | 含义 |
-|--------|---------|
-| `400` | 无效的请求体 |
-| `401` | 缺少或无效的密钥 |
-| `429` | 超出速率限制 |
-| `500` | 服务器错误 |
-
----
-
-## 集成示例
-
-### GitHub Webhook
-
-配置 GitHub 将事件发送到您的 IronClaw webhook URL：
-
-```bash
-# GitHub webhook URL
-https://your-server:8080/webhook
-
-# Secret: 您配置的 HTTP_WEBHOOK_SECRET
-```
-
-### Zapier
-
-使用 Zapier 的 Webhook 操作将事件发送到 IronClaw。
-
-### 自定义脚本
+## 示例客户端
 
 ```python
+import hashlib
+import hmac
+import json
 import requests
+
+secret = b"your-secret"
+body = json.dumps({
+    "content": "Process this data",
+    "user_id": "automation",
+}).encode()
+signature = hmac.new(secret, body, hashlib.sha256).hexdigest()
 
 response = requests.post(
     "http://localhost:8080/webhook",
-    headers={"X-Webhook-Secret": "your-secret"},
-    json={"user_id": "automation", "message": "Process this data"}
+    headers={
+        "Content-Type": "application/json",
+        "X-Hub-Signature-256": f"sha256={signature}",
+    },
+    data=body,
 )
 
-print(response.json()["job_id"])
+print(response.json())
 ```
 
 ---
@@ -165,24 +157,23 @@ print(response.json()["job_id"])
 
 <AccordionGroup>
   <Accordion title="连接被拒绝" icon="x-circle">
-    - 检查 IronClaw 是否在运行
-    - 验证 `HTTP_PORT` 正确
-    - 检查防火墙：`sudo ufw allow 8080`
+    - 检查 IronClaw 是否正在运行
+    - 验证 `WEBHOOK_HOST` / `WEBHOOK_PORT`
+    - 如果 `HTTP_ENABLED=true`，确保 HTTP 通道已启用
   </Accordion>
 
   <Accordion title="401 未授权" icon="key">
-    - 包含 `X-Webhook-Secret` 请求头
-    - 验证密钥与配置匹配
+    - 包含 `X-Hub-Signature-256` 头
+    - 验证签名使用原始请求正文
+    - 确认两侧的 `HTTP_WEBHOOK_SECRET` 匹配
+  </Accordion>
+
+  <Accordion title="415 不支持的媒体类型" icon="file-warning">
+    - 发送 `Content-Type: application/json`
   </Accordion>
 
   <Accordion title="429 请求过多" icon="clock">
-    - 速率限制：每分钟 60 个请求
-    - 实现指数退避
-  </Accordion>
-
-  <Accordion title="消息未处理" icon="message-circle">
-    - 检查日志：`RUST_LOG=ironclaw=debug ironclaw run`
-    - 验证 JSON 格式
-    - 检查 `user_id` 有效
+    - 速率限制为每分钟 60 次请求
+    - 实施带退避的重试
   </Accordion>
 </AccordionGroup>

--- a/docs/zh/quickstart.mdx
+++ b/docs/zh/quickstart.mdx
@@ -89,11 +89,11 @@ ironclaw
 
 <Accordion title="⚠️ 错误：Webhook 服务器启动失败">
 
-如果遇到错误 `Error: Channel webhook_server failed to start: Failed to bind to 0.0.0.0:8080: Address already in use (os error 98)`，请尝试设置一个不同的 HTTP 端口：
+如果遇到错误 `Error: Channel webhook_server failed to start: Failed to bind to 127.0.0.1:8080: Address already in use (os error 98)`，请尝试设置一个不同的 webhook 监听器端口：
 
 ```
-# 将默认 HTTP 端口改为 8081
-export HTTP_PORT=8081
+# 将默认 webhook 监听器端口改为 8081
+export WEBHOOK_PORT=8081
 
 # 然后重新启动智能体
 ironclaw

--- a/src/NETWORK_SECURITY.md
+++ b/src/NETWORK_SECURITY.md
@@ -2,7 +2,7 @@
 
 This document catalogs every network-facing surface in IronClaw, its authentication mechanism, bind address, security controls, and known findings. Use this as the authoritative reference during code reviews that touch network-facing code.
 
-**Last updated:** 2026-02-18
+**Last updated:** 2026-04-24
 
 ---
 
@@ -31,7 +31,7 @@ IronClaw operates across four trust boundaries:
 | Listener | Default Port | Default Bind | Auth Mechanism | Config Env Var | Source |
 |----------|-------------|-------------|----------------|----------------|--------|
 | Web Gateway | 3000 | `127.0.0.1` | Bearer token (constant-time) | `GATEWAY_HOST`, `GATEWAY_PORT`, `GATEWAY_AUTH_TOKEN` | `server.rs` — `start_server()` |
-| HTTP Webhook Server | 8080 | `0.0.0.0` | Shared secret (body field) | `HTTP_HOST`, `HTTP_PORT`, `HTTP_WEBHOOK_SECRET` | `webhook_server.rs` — `start()` |
+| Unified Webhook Listener | 8080 | `127.0.0.1` | Route-specific auth (tool auth, channel secrets) | `WEBHOOK_HOST`, `WEBHOOK_PORT` (`HTTP_HOST`, `HTTP_PORT` compatibility fallback when unset) | `main.rs` — unified webhook server startup |
 | Orchestrator Internal API | 50051 | `127.0.0.1` (macOS/Win) / `0.0.0.0` (Linux) | Per-job bearer token (constant-time) | `ORCHESTRATOR_PORT` | `api.rs` — `OrchestratorApi::start()` |
 | OAuth Callback Listener | 9876 | `127.0.0.1` | None (ephemeral, 5-min timeout) | N/A (hardcoded) | `src/auth/oauth.rs` — `bind_callback_listener()` |
 | Sandbox HTTP Proxy | OS-assigned (ephemeral) | `127.0.0.1` | None (loopback only) | N/A (auto-assigned) | `proxy/http.rs` — `SandboxProxy::start()` |
@@ -128,37 +128,41 @@ Shutdown is triggered via a `oneshot::Sender` stored in `GatewayState::shutdown_
 
 ---
 
-## 2. HTTP Webhook Server
+## 2. Unified Webhook Listener
 
 **Source:** `src/channels/webhook_server.rs`, `src/channels/http.rs`
 
 ### Bind Address
 
-Configurable via `HTTP_HOST` (default `127.0.0.1`) and `HTTP_PORT` (default `8080`).
+Configurable via `WEBHOOK_HOST` (default `127.0.0.1`) and `WEBHOOK_PORT` (default `8080`).
 
-By default the webhook server binds to loopback only. For external webhook providers, expose it intentionally via a tunnel or set `HTTP_HOST` explicitly.
+If `WEBHOOK_HOST` / `WEBHOOK_PORT` are unset, existing deployments can still inherit the unified listener bind from `HTTP_HOST` / `HTTP_PORT` as a compatibility fallback. `HTTP_ENABLED` now controls only whether the named HTTP webhook channel is registered; it does not decide whether the unified listener exists.
+
+By default the unified listener binds to loopback only. For external webhook providers, expose it intentionally via a tunnel or set `WEBHOOK_HOST` explicitly.
 
 **`--cli-only` mode:** When the `--cli-only` flag is set, non-CLI network services and channel activations are suppressed — no webhook server, WASM channel endpoints, HTTP channel, Signal channel, relay channel restoration, gateway channel, managed tunnel, or sandbox orchestrator API will start.
 
 This mode suppresses network-facing services; it does not disable the job tool surface. Scheduler-backed job tools remain available, while sandbox/container-backed job dependencies are only injected when the orchestrator is running.
 
-**Reference:** `src/config/channels.rs` — `http_host` default (`"127.0.0.1"`), `http_port` default (`8080`)
+**Reference:** `src/config/channels.rs` — `webhook_listener` resolution and defaults; `src/main.rs` — unified webhook server bind
 
 ### Authentication
 
-Webhook secret is passed **in the JSON request body** (`secret` field), not as a header. The secret is compared using **constant-time** `subtle::ConstantTimeEq` (`ct_eq`).
+The optional named HTTP webhook channel registers `POST /webhook` on the unified listener when `HTTP_ENABLED=true`.
 
-The secret is required to start the channel — if `HTTP_WEBHOOK_SECRET` is not set, `start()` returns an error.
+Authentication for that route is HMAC-SHA256 via `X-Hub-Signature-256: sha256=<hex_digest>`. A deprecated JSON-body `secret` field is still accepted for compatibility. Secret comparisons use **constant-time** `subtle::ConstantTimeEq` (`ct_eq`).
 
-**CSRF note:** Because the secret is in the JSON body (not a cookie or header that browsers auto-attach), a cross-origin form POST cannot forge a valid request. Browsers would send `application/x-www-form-urlencoded`, which the `Json<T>` extractor rejects with HTTP 415. Even if `Content-Type` were spoofed via CORS preflight, the attacker would need the secret value, which is never stored in the browser.
+The secret is required to start the named HTTP channel — if `HTTP_WEBHOOK_SECRET` is not set, `start()` returns an error.
+
+**CSRF note:** Browsers do not auto-attach the HMAC signature header, and the deprecated body-secret fallback still requires attacker knowledge of the shared secret. A cross-origin form POST would also use `application/x-www-form-urlencoded`, which the handler rejects with HTTP 415 before JSON parsing. Even if `Content-Type` were spoofed via CORS preflight, the attacker would still need the secret value.
 
 **Reference:** `src/channels/http.rs` — `webhook_handler()` (secret validation with `ct_eq`), `start()` (required-secret check)
 
 ### Content-Type Validation
 
-The webhook endpoint uses axum's `Json<WebhookRequest>` extractor, which enforces `Content-Type: application/json`. Requests with missing or incorrect Content-Type are rejected with **HTTP 415 Unsupported Media Type** before the handler body executes. Malformed JSON bodies are rejected with **HTTP 422 Unprocessable Entity**.
+The webhook endpoint validates `Content-Type: application/json` explicitly from request headers before parsing the body. Requests with missing or incorrect content type are rejected with **HTTP 415 Unsupported Media Type**. Malformed JSON bodies are parsed manually with `serde_json::from_slice`; authenticated requests receive **HTTP 400 Bad Request**, while unauthenticated requests without a signature header are rejected earlier with **HTTP 401 Unauthorized**.
 
-**Reference:** `src/channels/http.rs` — `webhook_handler()` function signature (`Json(req): Json<WebhookRequest>`)
+**Reference:** `src/channels/http.rs` — `webhook_handler()` content-type check and manual JSON parsing
 
 ### Rate Limiting
 
@@ -168,7 +172,7 @@ The webhook endpoint uses axum's `Json<WebhookRequest>` extractor, which enforce
 
 ### Body Limits
 
-- JSON body: **64 KB** max (`MAX_BODY_BYTES`)
+- JSON body: **15 MB** max (`MAX_BODY_BYTES`)
 - Message content: **32 KB** max (`MAX_CONTENT_BYTES`)
 - Pending synchronous responses: **100 max** (`MAX_PENDING_RESPONSES`)
 - Synchronous response timeout: **60 seconds**
@@ -187,6 +191,12 @@ The webhook endpoint uses axum's `Json<WebhookRequest>` extractor, which enforce
 Shutdown is triggered via a `oneshot::Sender` stored on the `WebhookServer` struct. The server uses `axum::serve(...).with_graceful_shutdown(...)`. The public `shutdown()` method sends the signal and awaits the task join handle, ensuring a clean drain-and-wait.
 
 **Reference:** `src/channels/webhook_server.rs` — `shutdown()` method
+
+### SIGHUP Reload Contract
+
+Reload of the unified webhook listener is atomic for this surface: IronClaw validates the replacement listener config first, then only applies HTTP webhook secret updates if listener validation and any required rebind succeed. If the new listener config is invalid or rebinding fails, IronClaw keeps the existing listener and skips secret rotation for the HTTP webhook channel.
+
+**Reference:** `src/main.rs` — `prepare_sighup_reload()` and the SIGHUP handler restart/secret-update sequence
 
 ---
 

--- a/src/NETWORK_SECURITY.md
+++ b/src/NETWORK_SECURITY.md
@@ -196,6 +196,8 @@ Shutdown is triggered via a `oneshot::Sender` stored on the `WebhookServer` stru
 
 Reload of the unified webhook listener is atomic for this surface: IronClaw validates the replacement listener config first, then only applies HTTP webhook secret updates if listener validation and any required rebind succeed. If the new listener config is invalid or rebinding fails, IronClaw keeps the existing listener and skips secret rotation for the HTTP webhook channel.
 
+Route-topology changes are not part of `SIGHUP` reload. Changing `HTTP_ENABLED` or other route-registration state still requires a process restart because the merged webhook router is not rebuilt on reload.
+
 **Reference:** `src/main.rs` — `prepare_sighup_reload()` and the SIGHUP handler restart/secret-update sequence
 
 ---

--- a/src/channels/http.rs
+++ b/src/channels/http.rs
@@ -667,11 +667,7 @@ impl Channel for HttpChannel {
         let (tx, rx) = mpsc::channel(256);
         *self.state.tx.write().await = Some(tx);
 
-        tracing::info!(
-            "HTTP channel ready ({}:{})",
-            self.config.host,
-            self.config.port
-        );
+        tracing::debug!("HTTP channel route registered");
 
         Ok(Box::pin(ReceiverStream::new(rx)))
     }

--- a/src/channels/http.rs
+++ b/src/channels/http.rs
@@ -116,7 +116,12 @@ impl HttpChannel {
             .with_state(self.state.clone())
     }
 
-    /// Return the configured host and port for this channel.
+    /// Return the channel's configured compatibility bind values.
+    ///
+    /// The named HTTP channel is actually served by the unified webhook
+    /// listener. These values reflect the legacy `HTTP_HOST` / `HTTP_PORT`
+    /// configuration path, which can differ from the listener address when
+    /// `WEBHOOK_HOST` / `WEBHOOK_PORT` are set explicitly.
     pub fn addr(&self) -> (&str, u16) {
         (&self.config.host, self.config.port)
     }

--- a/src/cli/channels.rs
+++ b/src/cli/channels.rs
@@ -91,11 +91,19 @@ async fn cmd_list(
 
     // Built-in: HTTP webhook
     if let Some(ref http) = config.http {
+        let mut details = vec![
+            ("host", config.webhook_listener.host.clone()),
+            ("port", config.webhook_listener.port.to_string()),
+        ];
+        if http.host != config.webhook_listener.host || http.port != config.webhook_listener.port {
+            details.push(("legacy_bind_host", http.host.clone()));
+            details.push(("legacy_bind_port", http.port.to_string()));
+        }
         channels.push(ChannelInfo {
             name: "http".to_string(),
             kind: "built-in",
             enabled: true,
-            details: vec![("host", http.host.clone()), ("port", http.port.to_string())],
+            details,
         });
     } else {
         channels.push(ChannelInfo {

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -160,7 +160,7 @@ pub async fn run_status_command() -> anyhow::Result<()> {
         .clone()
         .unwrap_or_else(default_channels_dir);
     let mut channel_info = vec!["cli".to_string()];
-    if settings.channels.http_enabled {
+    if settings.channels.http_enabled.unwrap_or(false) {
         channel_info.push(format!(
             "http:{}",
             settings.channels.http_port.unwrap_or(3000)

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -67,11 +67,18 @@ fn required_legacy_http_bind<'a>(
     legacy_http_bind: Option<&'a WebhookListenerConfig>,
     context: &str,
 ) -> Result<&'a WebhookListenerConfig, ConfigError> {
-    legacy_http_bind.ok_or_else(|| {
-        ConfigError::ParseError(format!(
-            "internal config invariant violated: missing legacy HTTP bind for {context}"
-        ))
-    })
+    legacy_http_bind
+        .ok_or_else(|| ConfigError::ParseError(format!("missing legacy HTTP bind for {context}")))
+}
+
+fn validate_listener_port(key: &str, port: u16) -> Result<u16, ConfigError> {
+    if port == 0 {
+        return Err(ConfigError::InvalidValue {
+            key: key.to_string(),
+            message: "must be between 1 and 65535".to_string(),
+        });
+    }
+    Ok(port)
 }
 
 /// Maximum allowed broadcast buffer size to prevent OOM from misconfiguration.
@@ -177,19 +184,20 @@ impl ChannelsConfig {
             legacy_http_host_from_env.is_some() || legacy_http_port_from_env.is_some();
         let legacy_http_bind_configured =
             legacy_http_enable_by_env || cs.http_host.is_some() || cs.http_port.is_some();
-        let explicit_http_enabled = if cs.http_enabled != defaults.http_enabled {
-            Some(db_first_bool(
-                cs.http_enabled,
-                defaults.http_enabled,
-                "HTTP_ENABLED",
-            )?)
+        let explicit_http_enabled = if let Some(enabled) = cs.http_enabled {
+            if optional_env("HTTP_ENABLED")?.is_some() {
+                tracing::warn!("HTTP_ENABLED from settings is overriding the environment value.");
+            }
+            Some(enabled)
         } else if optional_env("HTTP_ENABLED")?.is_some() {
-            Some(parse_bool_env("HTTP_ENABLED", defaults.http_enabled)?)
+            Some(parse_bool_env("HTTP_ENABLED", false)?)
         } else {
             None
         };
         let webhook_host = optional_env("WEBHOOK_HOST")?;
-        let webhook_port = parse_option_env("WEBHOOK_PORT")?;
+        let webhook_port = parse_option_env("WEBHOOK_PORT")?
+            .map(|port| validate_listener_port("WEBHOOK_PORT", port))
+            .transpose()?;
         let http_enabled = explicit_http_enabled == Some(true)
             || (explicit_http_enabled.is_none() && legacy_http_enable_by_env);
         let webhook_host_uses_legacy_env_fallback =
@@ -211,8 +219,9 @@ impl ChannelsConfig {
             if explicit_http_enabled.is_none() && legacy_http_enable_by_env {
                 tracing::warn!(
                     "HTTP_HOST/HTTP_PORT enabled the named HTTP webhook channel without \
-                     HTTP_ENABLED=true. This compatibility path is deprecated; set \
-                     HTTP_ENABLED=true explicitly."
+                     HTTP_ENABLED=true. This compatibility path is deprecated; move the listener \
+                     bind to WEBHOOK_HOST/WEBHOOK_PORT and set HTTP_ENABLED=true explicitly to \
+                     keep the named HTTP webhook channel enabled."
                 );
             }
             Some(HttpConfig {
@@ -231,40 +240,30 @@ impl ChannelsConfig {
             tracing::warn!(
                 "WEBHOOK_HOST and/or WEBHOOK_PORT are unset; using legacy HTTP bind settings as a \
                  compatibility fallback for the unified webhook listener. Migrate to \
-                 WEBHOOK_HOST/WEBHOOK_PORT because HTTP_* now configures the named HTTP \
-                 webhook channel."
+                 WEBHOOK_HOST/WEBHOOK_PORT, then either set HTTP_ENABLED=true to keep the named \
+                 HTTP webhook channel or HTTP_ENABLED=false to disable it explicitly."
             );
         }
-        let webhook_listener_host = match (
-            webhook_host,
-            http.as_ref(),
-            webhook_host_uses_legacy_env_fallback,
-        ) {
-            (Some(host), _, _) => host,
-            (None, Some(http), _) => http.host.clone(),
-            (None, None, true) => required_legacy_http_bind(
+        let webhook_listener_host = match (webhook_host, webhook_host_uses_legacy_env_fallback) {
+            (Some(host), _) => host,
+            (None, true) => required_legacy_http_bind(
                 legacy_http_bind.as_ref(),
                 "webhook listener host fallback",
             )?
             .host
             .clone(),
-            (None, None, false) => DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+            (None, false) => DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
         };
-        let webhook_listener_port = match (
-            webhook_port,
-            http.as_ref(),
-            webhook_port_uses_legacy_env_fallback,
-        ) {
-            (Some(port), _, _) => port,
-            (None, Some(http), _) => http.port,
-            (None, None, true) => {
+        let webhook_listener_port = match (webhook_port, webhook_port_uses_legacy_env_fallback) {
+            (Some(port), _) => port,
+            (None, true) => {
                 required_legacy_http_bind(
                     legacy_http_bind.as_ref(),
                     "webhook listener port fallback",
                 )?
                 .port
             }
-            (None, None, false) => DEFAULT_WEBHOOK_LISTENER_PORT,
+            (None, false) => DEFAULT_WEBHOOK_LISTENER_PORT,
         };
         let webhook_listener = WebhookListenerConfig {
             host: webhook_listener_host,
@@ -561,9 +560,15 @@ fn resolve_legacy_http_bind(cs: &ChannelSettings) -> Result<WebhookListenerConfi
             .unwrap_or_else(|| DEFAULT_WEBHOOK_LISTENER_HOST.to_string()),
         port: {
             if let Some(ref db_port) = cs.http_port {
-                db_first_or_default(db_port, &DEFAULT_WEBHOOK_LISTENER_PORT, "HTTP_PORT")?
+                validate_listener_port(
+                    "HTTP_PORT",
+                    db_first_or_default(db_port, &DEFAULT_WEBHOOK_LISTENER_PORT, "HTTP_PORT")?,
+                )?
             } else {
-                parse_optional_env("HTTP_PORT", DEFAULT_WEBHOOK_LISTENER_PORT)?
+                validate_listener_port(
+                    "HTTP_PORT",
+                    parse_optional_env("HTTP_PORT", DEFAULT_WEBHOOK_LISTENER_PORT)?,
+                )?
             }
         },
     })
@@ -1075,12 +1080,55 @@ mod tests {
     }
 
     #[test]
+    fn resolve_rejects_zero_listener_ports_for_webhook_and_legacy_fallback_sources() {
+        let _guard = lock_env();
+
+        let webhook_port_err = {
+            let settings = Settings::default();
+            set_webhook_channel_env(&[("WEBHOOK_PORT", "0")]);
+            ChannelsConfig::resolve(&settings, "owner-scope")
+                .expect_err("WEBHOOK_PORT=0 should be rejected")
+        };
+        match webhook_port_err {
+            ConfigError::InvalidValue { key, .. } => assert_eq!(key, "WEBHOOK_PORT"),
+            other => panic!("expected invalid WEBHOOK_PORT error, got {other}"),
+        }
+
+        let legacy_env_port_err = {
+            let settings = Settings::default();
+            set_webhook_channel_env(&[("HTTP_HOST", "0.0.0.0"), ("HTTP_PORT", "0")]);
+            ChannelsConfig::resolve(&settings, "owner-scope")
+                .expect_err("HTTP_PORT=0 should be rejected for legacy fallback")
+        };
+        match legacy_env_port_err {
+            ConfigError::InvalidValue { key, .. } => assert_eq!(key, "HTTP_PORT"),
+            other => panic!("expected invalid HTTP_PORT error, got {other}"),
+        }
+
+        let persisted_legacy_port_err = {
+            clear_webhook_channel_env();
+            let mut settings = Settings::default();
+            settings.channels.http_enabled = Some(false);
+            settings.channels.http_host = Some("127.0.0.9".to_string());
+            settings.channels.http_port = Some(0);
+            ChannelsConfig::resolve(&settings, "owner-scope")
+                .expect_err("persisted HTTP_PORT=0 should be rejected for legacy fallback")
+        };
+        match persisted_legacy_port_err {
+            ConfigError::InvalidValue { key, .. } => assert_eq!(key, "HTTP_PORT"),
+            other => panic!("expected invalid persisted HTTP_PORT error, got {other}"),
+        }
+
+        clear_webhook_channel_env();
+    }
+
+    #[test]
     fn resolve_persisted_legacy_http_bind_keeps_http_disabled_but_sets_webhook_listener() {
         let _guard = lock_env();
         clear_webhook_channel_env();
 
         let mut settings = Settings::default();
-        settings.channels.http_enabled = false;
+        settings.channels.http_enabled = Some(false);
         settings.channels.http_host = Some("127.0.0.9".to_string());
         settings.channels.http_port = Some(9091);
 
@@ -1095,10 +1143,34 @@ mod tests {
     }
 
     #[test]
+    fn resolve_persisted_http_enabled_false_after_db_round_trip_does_not_allow_legacy_env_reenablement()
+     {
+        let _guard = lock_env();
+
+        let mut persisted = Settings::default();
+        persisted.channels.http_enabled = Some(false);
+        let persisted = Settings::from_db_map(&persisted.to_db_map());
+
+        set_webhook_channel_env(&[("HTTP_HOST", "0.0.0.0"), ("HTTP_PORT", "8089")]);
+
+        let cfg = ChannelsConfig::resolve(&persisted, "owner-scope").expect("resolve");
+
+        assert_eq!(persisted.channels.http_enabled, Some(false));
+        assert!(
+            cfg.http.is_none(),
+            "persisted HTTP disablement must survive DB round-trip and block legacy env re-enable"
+        );
+        assert_eq!(cfg.webhook_listener.host, "0.0.0.0");
+        assert_eq!(cfg.webhook_listener.port, 8089);
+
+        clear_webhook_channel_env();
+    }
+
+    #[test]
     fn resolve_uses_settings_channel_values_with_owner_scope_user_ids() {
         let _guard = lock_env();
         let mut settings = Settings::default();
-        settings.channels.http_enabled = true;
+        settings.channels.http_enabled = Some(true);
         settings.channels.http_host = Some("127.0.0.2".to_string());
         settings.channels.http_port = Some(8181);
         settings.channels.gateway_enabled = true;

--- a/src/config/channels.rs
+++ b/src/config/channels.rs
@@ -5,7 +5,7 @@ use crate::bootstrap::ironclaw_base_dir;
 use crate::channels::web::sse::{DEFAULT_BROADCAST_BUFFER, DEFAULT_MAX_CONNECTIONS};
 use crate::config::helpers::{
     db_first_bool, db_first_optional_string, db_first_or_default, optional_env, parse_bool_env,
-    parse_optional_env,
+    parse_option_env, parse_optional_env,
 };
 use crate::error::ConfigError;
 use crate::settings::{ChannelSettings, Settings};
@@ -16,6 +16,7 @@ use secrecy::SecretString;
 pub struct ChannelsConfig {
     pub cli: CliConfig,
     pub http: Option<HttpConfig>,
+    pub webhook_listener: WebhookListenerConfig,
     pub gateway: Option<GatewayConfig>,
     pub signal: Option<SignalConfig>,
     pub tui: Option<TuiChannelConfig>,
@@ -51,6 +52,26 @@ pub struct HttpConfig {
     pub port: u16,
     pub webhook_secret: Option<SecretString>,
     pub user_id: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebhookListenerConfig {
+    pub host: String,
+    pub port: u16,
+}
+
+pub const DEFAULT_WEBHOOK_LISTENER_HOST: &str = "127.0.0.1";
+pub const DEFAULT_WEBHOOK_LISTENER_PORT: u16 = 8080;
+
+fn required_legacy_http_bind<'a>(
+    legacy_http_bind: Option<&'a WebhookListenerConfig>,
+    context: &str,
+) -> Result<&'a WebhookListenerConfig, ConfigError> {
+    legacy_http_bind.ok_or_else(|| {
+        ConfigError::ParseError(format!(
+            "internal config invariant violated: missing legacy HTTP bind for {context}"
+        ))
+    })
 }
 
 /// Maximum allowed broadcast buffer size to prevent OOM from misconfiguration.
@@ -150,27 +171,104 @@ impl ChannelsConfig {
         let cs = &settings.channels;
         let defaults = ChannelSettings::default();
 
-        let http_enabled_by_env =
-            optional_env("HTTP_PORT")?.is_some() || optional_env("HTTP_HOST")?.is_some();
-        let http_enabled_by_db =
-            db_first_bool(cs.http_enabled, defaults.http_enabled, "HTTP_ENABLED")?;
-        let http = if http_enabled_by_env || http_enabled_by_db {
+        let legacy_http_host_from_env = optional_env("HTTP_HOST")?;
+        let legacy_http_port_from_env = optional_env("HTTP_PORT")?;
+        let legacy_http_enable_by_env =
+            legacy_http_host_from_env.is_some() || legacy_http_port_from_env.is_some();
+        let legacy_http_bind_configured =
+            legacy_http_enable_by_env || cs.http_host.is_some() || cs.http_port.is_some();
+        let explicit_http_enabled = if cs.http_enabled != defaults.http_enabled {
+            Some(db_first_bool(
+                cs.http_enabled,
+                defaults.http_enabled,
+                "HTTP_ENABLED",
+            )?)
+        } else if optional_env("HTTP_ENABLED")?.is_some() {
+            Some(parse_bool_env("HTTP_ENABLED", defaults.http_enabled)?)
+        } else {
+            None
+        };
+        let webhook_host = optional_env("WEBHOOK_HOST")?;
+        let webhook_port = parse_option_env("WEBHOOK_PORT")?;
+        let http_enabled = explicit_http_enabled == Some(true)
+            || (explicit_http_enabled.is_none() && legacy_http_enable_by_env);
+        let webhook_host_uses_legacy_env_fallback =
+            webhook_host.is_none() && legacy_http_bind_configured;
+        let webhook_port_uses_legacy_env_fallback =
+            webhook_port.is_none() && legacy_http_bind_configured;
+        let legacy_http_bind = (http_enabled
+            || webhook_host_uses_legacy_env_fallback
+            || webhook_port_uses_legacy_env_fallback)
+            .then(|| resolve_legacy_http_bind(cs))
+            .transpose()?;
+        let http = if explicit_http_enabled == Some(true)
+            || (explicit_http_enabled.is_none() && legacy_http_enable_by_env)
+        {
+            let legacy_http_bind = required_legacy_http_bind(
+                legacy_http_bind.as_ref(),
+                "named HTTP channel enablement",
+            )?;
+            if explicit_http_enabled.is_none() && legacy_http_enable_by_env {
+                tracing::warn!(
+                    "HTTP_HOST/HTTP_PORT enabled the named HTTP webhook channel without \
+                     HTTP_ENABLED=true. This compatibility path is deprecated; set \
+                     HTTP_ENABLED=true explicitly."
+                );
+            }
             Some(HttpConfig {
-                host: db_first_optional_string(&cs.http_host, "HTTP_HOST")?
-                    .unwrap_or_else(|| "127.0.0.1".to_string()),
-                port: {
-                    // defaults.http_port is None, so any Some(..) is an explicit DB override.
-                    if let Some(ref db_port) = cs.http_port {
-                        db_first_or_default(db_port, &8080, "HTTP_PORT")?
-                    } else {
-                        parse_optional_env("HTTP_PORT", 8080)?
-                    }
-                },
+                host: legacy_http_bind.host.clone(),
+                port: legacy_http_bind.port,
                 webhook_secret: optional_env("HTTP_WEBHOOK_SECRET")?.map(SecretString::from),
                 user_id: owner_id.to_string(),
             })
         } else {
             None
+        };
+        if explicit_http_enabled == Some(false)
+            && legacy_http_bind_configured
+            && (webhook_host.is_none() || webhook_port.is_none())
+        {
+            tracing::warn!(
+                "WEBHOOK_HOST and/or WEBHOOK_PORT are unset; using legacy HTTP bind settings as a \
+                 compatibility fallback for the unified webhook listener. Migrate to \
+                 WEBHOOK_HOST/WEBHOOK_PORT because HTTP_* now configures the named HTTP \
+                 webhook channel."
+            );
+        }
+        let webhook_listener_host = match (
+            webhook_host,
+            http.as_ref(),
+            webhook_host_uses_legacy_env_fallback,
+        ) {
+            (Some(host), _, _) => host,
+            (None, Some(http), _) => http.host.clone(),
+            (None, None, true) => required_legacy_http_bind(
+                legacy_http_bind.as_ref(),
+                "webhook listener host fallback",
+            )?
+            .host
+            .clone(),
+            (None, None, false) => DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+        };
+        let webhook_listener_port = match (
+            webhook_port,
+            http.as_ref(),
+            webhook_port_uses_legacy_env_fallback,
+        ) {
+            (Some(port), _, _) => port,
+            (None, Some(http), _) => http.port,
+            (None, None, true) => {
+                required_legacy_http_bind(
+                    legacy_http_bind.as_ref(),
+                    "webhook listener port fallback",
+                )?
+                .port
+            }
+            (None, None, false) => DEFAULT_WEBHOOK_LISTENER_PORT,
+        };
+        let webhook_listener = WebhookListenerConfig {
+            host: webhook_listener_host,
+            port: webhook_listener_port,
         };
 
         let gateway_enabled = db_first_bool(
@@ -414,6 +512,7 @@ impl ChannelsConfig {
                 enabled: cli_enabled,
             },
             http,
+            webhook_listener,
             gateway,
             signal,
             tui,
@@ -456,6 +555,20 @@ impl ChannelsConfig {
 /// other modules that need to construct a gateway URL.
 pub const DEFAULT_GATEWAY_PORT: u16 = 3000;
 
+fn resolve_legacy_http_bind(cs: &ChannelSettings) -> Result<WebhookListenerConfig, ConfigError> {
+    Ok(WebhookListenerConfig {
+        host: db_first_optional_string(&cs.http_host, "HTTP_HOST")?
+            .unwrap_or_else(|| DEFAULT_WEBHOOK_LISTENER_HOST.to_string()),
+        port: {
+            if let Some(ref db_port) = cs.http_port {
+                db_first_or_default(db_port, &DEFAULT_WEBHOOK_LISTENER_PORT, "HTTP_PORT")?
+            } else {
+                parse_optional_env("HTTP_PORT", DEFAULT_WEBHOOK_LISTENER_PORT)?
+            }
+        },
+    })
+}
+
 /// Get the default channels directory (~/.ironclaw/channels/).
 fn default_channels_dir() -> PathBuf {
     ironclaw_base_dir().join("channels")
@@ -465,6 +578,7 @@ fn default_channels_dir() -> PathBuf {
 mod tests {
     use crate::config::channels::*;
     use crate::config::helpers::lock_env;
+    use crate::error::ConfigError;
     use crate::settings::Settings;
 
     #[test]
@@ -500,6 +614,16 @@ mod tests {
         };
         assert!(cfg.webhook_secret.is_some());
         assert_eq!(cfg.port, 9090);
+    }
+
+    #[test]
+    fn webhook_listener_config_fields() {
+        let cfg = WebhookListenerConfig {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+        };
+        assert_eq!(cfg.host, "127.0.0.1");
+        assert_eq!(cfg.port, 8080);
     }
 
     #[test]
@@ -622,6 +746,10 @@ mod tests {
         let cfg = ChannelsConfig {
             cli: CliConfig { enabled: true },
             http: None,
+            webhook_listener: WebhookListenerConfig {
+                host: DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+                port: DEFAULT_WEBHOOK_LISTENER_PORT,
+            },
             gateway: None,
             signal: None,
             tui: None,
@@ -632,6 +760,8 @@ mod tests {
         };
         assert!(cfg.cli.enabled);
         assert!(cfg.http.is_none());
+        assert_eq!(cfg.webhook_listener.host, DEFAULT_WEBHOOK_LISTENER_HOST);
+        assert_eq!(cfg.webhook_listener.port, DEFAULT_WEBHOOK_LISTENER_PORT);
         assert!(cfg.gateway.is_none());
         assert!(cfg.signal.is_none());
         assert_eq!(cfg.wasm_channels_dir, PathBuf::from("/tmp/channels"));
@@ -648,6 +778,10 @@ mod tests {
         let cfg = ChannelsConfig {
             cli: CliConfig { enabled: false },
             http: None,
+            webhook_listener: WebhookListenerConfig {
+                host: DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+                port: DEFAULT_WEBHOOK_LISTENER_PORT,
+            },
             gateway: None,
             signal: None,
             tui: None,
@@ -669,6 +803,295 @@ mod tests {
             dir.ends_with("channels"),
             "expected path ending in 'channels', got: {dir:?}"
         );
+    }
+
+    #[test]
+    fn resolve_populates_dedicated_webhook_listener_from_webhook_env_vars() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+            std::env::set_var("WEBHOOK_HOST", "127.0.0.1");
+            std::env::set_var("WEBHOOK_PORT", "9091");
+        }
+
+        let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
+
+        assert_eq!(cfg.webhook_listener.host, "127.0.0.1");
+        assert_eq!(cfg.webhook_listener.port, 9091);
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+            std::env::remove_var("WEBHOOK_HOST");
+            std::env::remove_var("WEBHOOK_PORT");
+        }
+    }
+
+    #[test]
+    fn resolve_defaults_dedicated_webhook_listener_to_localhost_8080() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+            std::env::remove_var("WEBHOOK_HOST");
+            std::env::remove_var("WEBHOOK_PORT");
+        }
+
+        let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
+
+        assert_eq!(cfg.webhook_listener.host, "127.0.0.1");
+        assert_eq!(cfg.webhook_listener.port, 8080);
+    }
+
+    #[test]
+    fn resolve_does_not_enable_named_http_channel_from_legacy_host_port_when_http_enabled_is_false()
+    {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::set_var("HTTP_ENABLED", "false");
+            std::env::set_var("HTTP_HOST", "0.0.0.0");
+            std::env::set_var("HTTP_PORT", "8089");
+            std::env::set_var("WEBHOOK_HOST", "127.0.0.1");
+            std::env::set_var("WEBHOOK_PORT", "9091");
+        }
+
+        let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
+
+        assert!(
+            cfg.http.is_none(),
+            "legacy HTTP_HOST/HTTP_PORT must not re-enable the named HTTP channel when HTTP_ENABLED=false"
+        );
+        assert_eq!(cfg.webhook_listener.host, "127.0.0.1");
+        assert_eq!(cfg.webhook_listener.port, 9091);
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+            std::env::remove_var("WEBHOOK_HOST");
+            std::env::remove_var("WEBHOOK_PORT");
+        }
+    }
+
+    #[test]
+    fn resolve_preserves_named_http_channel_when_http_enabled_is_true() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::set_var("HTTP_ENABLED", "true");
+            std::env::set_var("HTTP_HOST", "0.0.0.0");
+            std::env::set_var("HTTP_PORT", "8089");
+            std::env::remove_var("WEBHOOK_HOST");
+            std::env::remove_var("WEBHOOK_PORT");
+        }
+
+        let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
+        let http = cfg.http.expect("http config");
+
+        assert_eq!(http.host, "0.0.0.0");
+        assert_eq!(http.port, 8089);
+        assert_eq!(http.user_id, "owner-scope");
+        assert_eq!(cfg.webhook_listener.host, "0.0.0.0");
+        assert_eq!(cfg.webhook_listener.port, 8089);
+
+        // SAFETY: under ENV_MUTEX
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+        }
+    }
+
+    fn clear_webhook_channel_env() {
+        // SAFETY: callers hold ENV_MUTEX via lock_env()
+        unsafe {
+            std::env::remove_var("HTTP_ENABLED");
+            std::env::remove_var("HTTP_HOST");
+            std::env::remove_var("HTTP_PORT");
+            std::env::remove_var("WEBHOOK_HOST");
+            std::env::remove_var("WEBHOOK_PORT");
+        }
+    }
+
+    fn set_webhook_channel_env(entries: &[(&str, &str)]) {
+        clear_webhook_channel_env();
+        for (key, value) in entries {
+            // SAFETY: callers hold ENV_MUTEX via lock_env()
+            unsafe { std::env::set_var(key, value) };
+        }
+    }
+
+    #[test]
+    fn resolve_webhook_listener_compatibility_matrix() {
+        struct Case<'a> {
+            name: &'a str,
+            env: &'a [(&'a str, &'a str)],
+            expected_http: Option<(&'a str, u16)>,
+            expected_webhook: (&'a str, u16),
+        }
+
+        let _guard = lock_env();
+        let settings = Settings::default();
+        let cases = [
+            Case {
+                name: "no_config_defaults_to_local_listener",
+                env: &[],
+                expected_http: None,
+                expected_webhook: (DEFAULT_WEBHOOK_LISTENER_HOST, DEFAULT_WEBHOOK_LISTENER_PORT),
+            },
+            Case {
+                name: "legacy_http_env_unset_http_enabled_keeps_compatibility_path",
+                env: &[("HTTP_HOST", "0.0.0.0"), ("HTTP_PORT", "8089")],
+                expected_http: Some(("0.0.0.0", 8089)),
+                expected_webhook: ("0.0.0.0", 8089),
+            },
+            Case {
+                name: "explicit_http_enabled_true_preserves_compatibility_path",
+                env: &[
+                    ("HTTP_ENABLED", "true"),
+                    ("HTTP_HOST", "0.0.0.0"),
+                    ("HTTP_PORT", "8089"),
+                ],
+                expected_http: Some(("0.0.0.0", 8089)),
+                expected_webhook: ("0.0.0.0", 8089),
+            },
+            Case {
+                name: "explicit_http_enabled_false_without_webhook_or_legacy_bind_uses_default_listener",
+                env: &[("HTTP_ENABLED", "false")],
+                expected_http: None,
+                expected_webhook: (DEFAULT_WEBHOOK_LISTENER_HOST, DEFAULT_WEBHOOK_LISTENER_PORT),
+            },
+            Case {
+                name: "explicit_webhook_env_overrides_http_compatibility_bind",
+                env: &[
+                    ("HTTP_ENABLED", "true"),
+                    ("HTTP_HOST", "0.0.0.0"),
+                    ("HTTP_PORT", "8089"),
+                    ("WEBHOOK_HOST", "127.0.0.9"),
+                    ("WEBHOOK_PORT", "9091"),
+                ],
+                expected_http: Some(("0.0.0.0", 8089)),
+                expected_webhook: ("127.0.0.9", 9091),
+            },
+            Case {
+                name: "partial_migration_webhook_host_overrides_legacy_host_only",
+                env: &[
+                    ("HTTP_ENABLED", "false"),
+                    ("HTTP_HOST", "0.0.0.0"),
+                    ("HTTP_PORT", "8089"),
+                    ("WEBHOOK_HOST", "127.0.0.9"),
+                ],
+                expected_http: None,
+                expected_webhook: ("127.0.0.9", 8089),
+            },
+            Case {
+                name: "partial_migration_webhook_port_overrides_legacy_port_only",
+                env: &[
+                    ("HTTP_ENABLED", "false"),
+                    ("HTTP_HOST", "0.0.0.0"),
+                    ("HTTP_PORT", "8089"),
+                    ("WEBHOOK_PORT", "9091"),
+                ],
+                expected_http: None,
+                expected_webhook: ("0.0.0.0", 9091),
+            },
+        ];
+
+        for case in cases {
+            set_webhook_channel_env(case.env);
+            let cfg = ChannelsConfig::resolve(&settings, "owner-scope")
+                .unwrap_or_else(|err| panic!("case {} should resolve: {err}", case.name));
+
+            match (cfg.http.as_ref(), case.expected_http) {
+                (Some(http), Some((expected_host, expected_port))) => {
+                    assert_eq!(http.host, expected_host, "case {}", case.name);
+                    assert_eq!(http.port, expected_port, "case {}", case.name);
+                }
+                (None, None) => {}
+                (Some(http), None) => panic!(
+                    "case {} expected no HTTP config, got {}:{}",
+                    case.name, http.host, http.port
+                ),
+                (None, Some((expected_host, expected_port))) => panic!(
+                    "case {} expected HTTP config {}:{}, got none",
+                    case.name, expected_host, expected_port
+                ),
+            }
+
+            assert_eq!(
+                cfg.webhook_listener.host, case.expected_webhook.0,
+                "case {}",
+                case.name
+            );
+            assert_eq!(
+                cfg.webhook_listener.port, case.expected_webhook.1,
+                "case {}",
+                case.name
+            );
+        }
+
+        clear_webhook_channel_env();
+    }
+
+    #[test]
+    fn resolve_invalid_legacy_http_port_for_webhook_listener_returns_config_error() {
+        let _guard = lock_env();
+        let settings = Settings::default();
+
+        set_webhook_channel_env(&[
+            ("HTTP_ENABLED", "false"),
+            ("HTTP_HOST", "0.0.0.0"),
+            ("HTTP_PORT", "not-a-port"),
+        ]);
+
+        let err = ChannelsConfig::resolve(&settings, "owner-scope")
+            .expect_err("invalid legacy HTTP_PORT should surface as a config error");
+
+        match err {
+            ConfigError::InvalidValue { key, .. } => {
+                assert_eq!(key, "HTTP_PORT");
+            }
+            other => panic!("expected ConfigError::InvalidValue for HTTP_PORT, got {other}"),
+        }
+
+        clear_webhook_channel_env();
+    }
+
+    #[test]
+    fn resolve_persisted_legacy_http_bind_keeps_http_disabled_but_sets_webhook_listener() {
+        let _guard = lock_env();
+        clear_webhook_channel_env();
+
+        let mut settings = Settings::default();
+        settings.channels.http_enabled = false;
+        settings.channels.http_host = Some("127.0.0.9".to_string());
+        settings.channels.http_port = Some(9091);
+
+        let cfg = ChannelsConfig::resolve(&settings, "owner-scope").expect("resolve");
+
+        assert!(
+            cfg.http.is_none(),
+            "persisted legacy HTTP settings must not re-enable the named HTTP channel when http_enabled=false"
+        );
+        assert_eq!(cfg.webhook_listener.host, "127.0.0.9");
+        assert_eq!(cfg.webhook_listener.port, 9091);
     }
 
     #[test]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -53,8 +53,9 @@ use crate::settings::Settings;
 pub use self::agent::AgentConfig;
 pub use self::builder::BuilderModeConfig;
 pub use self::channels::{
-    ChannelsConfig, CliConfig, DEFAULT_GATEWAY_PORT, GatewayConfig, GatewayOidcConfig, HttpConfig,
-    SignalConfig, TuiChannelConfig,
+    ChannelsConfig, CliConfig, DEFAULT_GATEWAY_PORT, DEFAULT_WEBHOOK_LISTENER_HOST,
+    DEFAULT_WEBHOOK_LISTENER_PORT, GatewayConfig, GatewayOidcConfig, HttpConfig, SignalConfig,
+    TuiChannelConfig, WebhookListenerConfig,
 };
 pub use self::database::{DatabaseBackend, DatabaseConfig, SslMode, default_libsql_path};
 pub use self::embeddings::{DEFAULT_EMBEDDING_CACHE_SIZE, EmbeddingsConfig};
@@ -193,6 +194,10 @@ impl Config {
             channels: ChannelsConfig {
                 cli: CliConfig { enabled: false },
                 http: None,
+                webhook_listener: WebhookListenerConfig {
+                    host: DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+                    port: DEFAULT_WEBHOOK_LISTENER_PORT,
+                },
                 gateway: None,
                 signal: None,
                 tui: None,

--- a/src/config/tunnel.rs
+++ b/src/config/tunnel.rs
@@ -5,7 +5,9 @@ use crate::settings::{Settings, TunnelSettings};
 /// Tunnel configuration for exposing the agent to the internet.
 ///
 /// Used by channels and tools that need public webhook endpoints.
-/// The tunnel URL is shared across all channels (Telegram, Slack, etc.).
+/// The tunnel URL is shared across webhook consumers (Telegram, Slack, etc.),
+/// but managed webhook tunnel URLs are not implicitly reused as the web
+/// gateway's OAuth/public base.
 ///
 /// Resolution priority: DB/settings > env var > default.
 ///

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -396,7 +396,8 @@ pub struct ExtensionManager {
     tool_registry: Arc<ToolRegistry>,
     hooks: Option<Arc<HookRegistry>>,
     pending_auth: RwLock<HashMap<PendingAuthKey, PendingAuth>>,
-    /// Tunnel URL for webhook configuration and remote OAuth callbacks.
+    /// Explicit public URL for webhook configuration and, when intentionally
+    /// configured that way, remote OAuth callbacks.
     tunnel_url: Option<String>,
     user_id: String,
     /// Optional database store for DB-backed MCP config.

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,37 @@ fn non_cli_channels_enabled(cli_only: bool) -> bool {
     !cli_only
 }
 
+fn webhook_listener_addr(
+    channels: &ironclaw::config::ChannelsConfig,
+) -> anyhow::Result<std::net::SocketAddr> {
+    format!(
+        "{}:{}",
+        channels.webhook_listener.host, channels.webhook_listener.port
+    )
+    .parse()
+    .map_err(|error| {
+        anyhow::anyhow!(
+            "Webhook listener host:port must be a valid SocketAddr: {}:{} ({error})",
+            channels.webhook_listener.host,
+            channels.webhook_listener.port
+        )
+    })
+}
+
+fn prepare_sighup_reload(
+    channels: &ironclaw::config::ChannelsConfig,
+) -> anyhow::Result<(std::net::SocketAddr, Option<secrecy::SecretString>)> {
+    use secrecy::ExposeSecret;
+
+    let rotated_secret = channels
+        .http
+        .as_ref()
+        .and_then(|http| http.webhook_secret.as_ref())
+        .map(|secret| secrecy::SecretString::from(secret.expose_secret().to_string()));
+
+    webhook_listener_addr(channels).map(|addr| (addr, rotated_secret))
+}
+
 fn normalize_persisted_wasm_channel_names<I, S>(names: I) -> std::collections::HashSet<String>
 where
     I: IntoIterator<Item = S>,
@@ -731,41 +762,30 @@ async fn async_main() -> anyhow::Result<()> {
     }
 
     // Add HTTP channel if configured and not CLI-only mode.
-    let mut webhook_server_addr: Option<std::net::SocketAddr> = None;
+    let mut http_channel_enabled = false;
     #[cfg(unix)]
     let mut http_channel_state: Option<Arc<ironclaw::channels::HttpChannelState>> = None;
     if enable_non_cli && let Some(ref http_config) = config.channels.http {
         let http_channel = HttpChannel::new(http_config.clone());
+        http_channel_enabled = true;
         #[cfg(unix)]
         {
             http_channel_state = Some(http_channel.shared_state());
         }
         webhook_routes.push(http_channel.routes());
-        let (host, port) = http_channel.addr();
-        webhook_server_addr = Some(
-            format!("{}:{}", host, port)
-                .parse()
-                .expect("HttpConfig host:port must be a valid SocketAddr"),
-        );
         channel_names.push("http".to_string());
         channels.add(Box::new(http_channel)).await;
-        tracing::debug!(
-            "HTTP channel enabled on {}:{}",
-            http_config.host,
-            http_config.port
-        );
     }
 
     // Start the unified webhook server if any routes were registered.
     let webhook_server: Option<Arc<tokio::sync::Mutex<WebhookServer>>> = if !webhook_routes
         .is_empty()
     {
-        let addr = webhook_server_addr
-            .unwrap_or_else(|| std::net::SocketAddr::from(([127, 0, 0, 1], 8080)));
+        let addr = webhook_listener_addr(&config.channels)?;
         if addr.ip().is_unspecified() {
             tracing::warn!(
                 "Webhook server is binding to {} — it will be reachable from all network interfaces. \
-                 Set HTTP_HOST=127.0.0.1 to restrict to localhost.",
+                 Set WEBHOOK_HOST=127.0.0.1 to restrict to localhost.",
                 addr.ip()
             );
         }
@@ -774,6 +794,12 @@ async fn async_main() -> anyhow::Result<()> {
             server.add_routes(routes);
         }
         server.start().await?;
+        if http_channel_enabled {
+            tracing::info!(
+                "HTTP channel enabled; /webhook is served by the unified webhook listener on {}",
+                addr
+            );
+        }
         Some(Arc::new(tokio::sync::Mutex::new(server)))
     } else {
         None
@@ -1356,7 +1382,9 @@ async fn async_main() -> anyhow::Result<()> {
                         // Handle SIGHUP signal
                     }
                 }
-                tracing::info!("SIGHUP received — reloading HTTP webhook config");
+                tracing::info!(
+                    "SIGHUP received — reloading webhook listener and HTTP webhook config"
+                );
 
                 // Flush settings cache so direct DB edits are picked up.
                 if let Some(ref cache) = sighup_settings_cache {
@@ -1398,94 +1426,90 @@ async fn async_main() -> anyhow::Result<()> {
                     }
                 };
 
-                let new_http = match new_config.channels.http {
-                    Some(c) => c,
-                    None => {
-                        tracing::warn!("SIGHUP: HTTP channel no longer configured, skipping");
-                        continue;
+                // Atomic reload contract for the webhook surface:
+                // validate the replacement listener first, then only apply secret
+                // updates if listener validation and any required rebind succeed.
+                // Restart listener if addr changed. Two-phase approach: bind
+                // outside the lock, then swap under lock.
+                let mut restart_failed = false;
+                let (replacement_listener_addr, new_secret) = match prepare_sighup_reload(
+                    &new_config.channels,
+                ) {
+                    Ok((addr, secret)) => (Some(addr), secret),
+                    Err(error) => {
+                        tracing::error!(
+                            "SIGHUP: invalid webhook listener config; keeping existing listener and skipping secret rotation: {}",
+                            error
+                        );
+                        restart_failed = true;
+                        (None, None)
                     }
                 };
-
-                // Compute new socket addr
-                let new_addr: std::net::SocketAddr =
-                    match format!("{}:{}", new_http.host, new_http.port).parse() {
-                        Ok(a) => a,
-                        Err(e) => {
-                            tracing::error!("SIGHUP: invalid addr in config: {}", e);
-                            continue;
-                        }
-                    };
-
-                // Restart listener if addr changed.
-                // Two-phase approach: bind outside the lock, then swap under lock.
-                let mut restart_failed = false;
                 if let Some(ref ws_arc) = sighup_webhook_server {
                     let (old_addr, router) = {
                         let ws = ws_arc.lock().await;
                         (ws.current_addr(), ws.merged_router_clone())
                     }; // Lock released here
 
-                    if old_addr != new_addr {
-                        tracing::info!(
-                            "SIGHUP: HTTP addr {} -> {}, restarting listener",
-                            old_addr,
-                            new_addr
-                        );
+                    match replacement_listener_addr {
+                        Some(new_addr) if old_addr != new_addr => {
+                            tracing::info!(
+                                "SIGHUP: webhook listener addr {} -> {}, restarting listener",
+                                old_addr,
+                                new_addr
+                            );
 
-                        match router {
-                            Some(app) => {
-                                // Phase 1: Bind new listener WITHOUT holding the lock.
-                                match tokio::net::TcpListener::bind(new_addr).await {
-                                    Ok(listener) => {
-                                        // Phase 2: Swap state under lock (no await inside).
-                                        let (old_tx, old_handle) = {
-                                            let mut ws = ws_arc.lock().await;
-                                            ws.install_listener(new_addr, listener, app)
-                                        }; // Lock released here
+                            match router {
+                                Some(app) => {
+                                    // Phase 1: Bind new listener WITHOUT holding the lock.
+                                    match tokio::net::TcpListener::bind(new_addr).await {
+                                        Ok(listener) => {
+                                            // Phase 2: Swap state under lock (no await inside).
+                                            let (old_tx, old_handle) = {
+                                                let mut ws = ws_arc.lock().await;
+                                                ws.install_listener(new_addr, listener, app)
+                                            }; // Lock released here
 
-                                        // Phase 3: Shut down old listener outside the lock.
-                                        if let Some(tx) = old_tx {
-                                            let _ = tx.send(());
+                                            // Phase 3: Shut down old listener outside the lock.
+                                            if let Some(tx) = old_tx {
+                                                let _ = tx.send(());
+                                            }
+                                            if let Some(handle) = old_handle {
+                                                let _ = handle.await;
+                                            }
+
+                                            tracing::info!(
+                                                "SIGHUP: webhook server restarted on {}",
+                                                new_addr
+                                            );
                                         }
-                                        if let Some(handle) = old_handle {
-                                            let _ = handle.await;
+                                        Err(e) => {
+                                            tracing::error!(
+                                                "SIGHUP: failed to bind to {}: {}",
+                                                new_addr,
+                                                e
+                                            );
+                                            restart_failed = true;
                                         }
-
-                                        tracing::info!(
-                                            "SIGHUP: webhook server restarted on {}",
-                                            new_addr
-                                        );
-                                    }
-                                    Err(e) => {
-                                        tracing::error!(
-                                            "SIGHUP: failed to bind to {}: {}",
-                                            new_addr,
-                                            e
-                                        );
-                                        restart_failed = true;
                                     }
                                 }
-                            }
-                            None => {
-                                tracing::error!(
-                                    "SIGHUP: cannot restart — server was never started"
-                                );
-                                restart_failed = true;
+                                None => {
+                                    tracing::error!(
+                                        "SIGHUP: cannot restart — server was never started"
+                                    );
+                                    restart_failed = true;
+                                }
                             }
                         }
-                    } else {
-                        tracing::debug!("SIGHUP: addr unchanged ({})", old_addr);
+                        Some(_) => {
+                            tracing::debug!("SIGHUP: addr unchanged ({})", old_addr);
+                        }
+                        None => {}
                     }
                 }
 
                 // Update secrets in all configured channels (if restart succeeded or wasn't needed)
                 if !restart_failed {
-                    use secrecy::{ExposeSecret, SecretString};
-                    let new_secret = new_http
-                        .webhook_secret
-                        .as_ref()
-                        .map(|s| SecretString::from(s.expose_secret().to_string()));
-
                     // Update all channels that support secret swapping
                     for updater in &secret_updaters {
                         updater.update_secret(new_secret.clone()).await;
@@ -1574,6 +1598,46 @@ fn oauth_base_url(host: &str, port: u16) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use secrecy::SecretString;
+
+    fn test_channels_config(
+        webhook_host: &str,
+        webhook_port: u16,
+    ) -> ironclaw::config::ChannelsConfig {
+        ironclaw::config::ChannelsConfig {
+            cli: ironclaw::config::CliConfig { enabled: false },
+            http: None,
+            webhook_listener: ironclaw::config::WebhookListenerConfig {
+                host: webhook_host.to_string(),
+                port: webhook_port,
+            },
+            gateway: Some(ironclaw::config::GatewayConfig {
+                host: "10.0.0.1".to_string(),
+                port: 3000,
+                auth_token: None,
+                max_connections: 100,
+                broadcast_buffer: ironclaw::channels::web::sse::DEFAULT_BROADCAST_BUFFER,
+                workspace_read_scopes: Vec::new(),
+                memory_layers: Vec::new(),
+                oidc: None,
+            }),
+            signal: None,
+            tui: None,
+            wasm_channels_dir: std::env::temp_dir().join("ironclaw-test-channels"),
+            wasm_channels_enabled: false,
+            configured_wasm_channels: Vec::new(),
+            wasm_channel_owner_ids: std::collections::HashMap::new(),
+        }
+    }
+
+    fn test_http_config(webhook_secret: &str) -> ironclaw::config::HttpConfig {
+        ironclaw::config::HttpConfig {
+            host: "127.0.0.1".to_string(),
+            port: 8080,
+            webhook_secret: Some(SecretString::from(webhook_secret.to_string())),
+            user_id: "test-user".to_string(),
+        }
+    }
 
     /// Regression test for <https://github.com/nearai/ironclaw/issues/1840>:
     /// `--cli-only` must suppress webhook server and all non-CLI channels.
@@ -1586,6 +1650,39 @@ mod tests {
         assert!(
             non_cli_channels_enabled(false),
             "default mode should enable non-CLI channels"
+        );
+    }
+
+    #[test]
+    fn webhook_listener_addr_uses_dedicated_listener_config() {
+        let channels = test_channels_config("127.0.0.1", 9091);
+        let addr =
+            webhook_listener_addr(&channels).expect("valid webhook listener config should resolve");
+
+        assert_eq!(addr, "127.0.0.1:9091".parse().expect("socket addr"));
+    }
+
+    // Use a double-port host string so the failure is unambiguously malformed
+    // socket syntax, not a hostname-validity question.
+    #[test]
+    fn webhook_listener_addr_returns_error_for_malformed_listener_config() {
+        let channels = test_channels_config("127.0.0.1:9091", 9092);
+        let result = webhook_listener_addr(&channels);
+
+        assert!(
+            result.is_err(),
+            "malformed webhook listener config should return an error"
+        );
+    }
+
+    #[test]
+    fn webhook_listener_sighup_reload_blocks_secret_rotation_when_listener_config_is_malformed() {
+        let mut channels = test_channels_config("127.0.0.1:9091", 9092);
+        channels.http = Some(test_http_config("rotated-secret"));
+
+        assert!(
+            prepare_sighup_reload(&channels).is_err(),
+            "malformed listener config must block secret rotation by failing reload preparation"
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,15 @@ fn prepare_sighup_reload(
     webhook_listener_addr(channels).map(|addr| (addr, rotated_secret))
 }
 
+fn gateway_public_base_url(
+    gateway: &ironclaw::config::GatewayConfig,
+    explicit_tunnel_public_url: Option<&str>,
+) -> String {
+    explicit_tunnel_public_url
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| oauth_base_url(&gateway.host, gateway.port))
+}
+
 fn normalize_persisted_wasm_channel_names<I, S>(names: I) -> std::collections::HashSet<String>
 where
     I: IntoIterator<Item = S>,
@@ -459,6 +468,7 @@ async fn async_main() -> anyhow::Result<()> {
     .await?;
 
     let config = components.config;
+    let explicit_tunnel_public_url = config.tunnel.public_url.clone();
 
     // ── Tunnel setup ───────────────────────────────────────────────────
 
@@ -892,12 +902,11 @@ async fn async_main() -> anyhow::Result<()> {
         }
         if let Some(ref ext_mgr) = components.extension_manager {
             // Enable gateway mode so MCP OAuth returns auth URLs to the frontend
-            // instead of calling open::that() on the server.
-            let gw_base = config
-                .tunnel
-                .public_url
-                .clone()
-                .unwrap_or_else(|| oauth_base_url(&gw_config.host, gw_config.port));
+            // instead of calling open::that() on the server. Use only an
+            // operator-configured static tunnel URL here: managed tunnels in
+            // this process target the unified webhook listener, not the gateway.
+            let gw_base =
+                gateway_public_base_url(&gw_config, explicit_tunnel_public_url.as_deref());
             ext_mgr.enable_gateway_mode(gw_base).await;
             gw = gw.with_extension_manager(Arc::clone(ext_mgr));
         }
@@ -1683,6 +1692,23 @@ mod tests {
         assert!(
             prepare_sighup_reload(&channels).is_err(),
             "malformed listener config must block secret rotation by failing reload preparation"
+        );
+    }
+
+    #[test]
+    fn gateway_oauth_base_defaults_to_gateway_bind_when_tunnel_public_url_came_from_managed_webhook_tunnel()
+     {
+        let gateway = test_channels_config("127.0.0.1", 9091)
+            .gateway
+            .expect("gateway config");
+
+        assert_eq!(
+            gateway_public_base_url(&gateway, None),
+            "http://10.0.0.1:3000"
+        );
+        assert_eq!(
+            gateway_public_base_url(&gateway, Some("https://gateway.example.com")),
+            "https://gateway.example.com"
         );
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -314,7 +314,7 @@ impl Default for EmbeddingsSettings {
 
 /// Tunnel settings for public webhook endpoints.
 ///
-/// The tunnel URL is shared across all channels that need webhooks.
+/// The tunnel URL is shared across channels that need webhooks.
 /// Two modes:
 /// - **Static URL**: `public_url` set directly (manual tunnel management).
 /// - **Managed provider**: `provider` is set and the agent starts/stops the
@@ -368,7 +368,7 @@ pub struct TunnelSettings {
 pub struct ChannelSettings {
     /// Whether HTTP webhook channel is enabled.
     #[serde(default)]
-    pub http_enabled: bool,
+    pub http_enabled: Option<bool>,
 
     /// HTTP webhook port (if enabled).
     #[serde(default)]
@@ -462,7 +462,7 @@ pub struct ChannelSettings {
 impl Default for ChannelSettings {
     fn default() -> Self {
         Self {
-            http_enabled: false,
+            http_enabled: None,
             http_port: None,
             http_host: None,
             gateway_enabled: true,
@@ -2046,7 +2046,7 @@ mod tests {
                 ..Default::default()
             },
             channels: ChannelSettings {
-                http_enabled: true,
+                http_enabled: Some(true),
                 http_port: Some(9090),
                 wasm_channel_owner_ids: {
                     let mut m = std::collections::HashMap::new();
@@ -2125,7 +2125,11 @@ mod tests {
             Some("ngrok".to_string()),
             "tunnel.provider lost"
         );
-        assert!(restored.channels.http_enabled, "http_enabled lost");
+        assert_eq!(
+            restored.channels.http_enabled,
+            Some(true),
+            "http_enabled lost"
+        );
         assert_eq!(restored.channels.http_port, Some(9090), "http_port lost");
         assert_eq!(
             restored.channels.wasm_channel_owner_ids.get("telegram"),
@@ -2298,7 +2302,7 @@ mod tests {
                 model: "text-embedding-3-small".to_string(),
             },
             channels: ChannelSettings {
-                http_enabled: true,
+                http_enabled: Some(true),
                 http_port: Some(8080),
                 signal_enabled: true,
                 signal_account: Some("+1234567890".to_string()),
@@ -2330,7 +2334,11 @@ mod tests {
         assert_eq!(current.selected_model.as_deref(), Some("claude-sonnet-4-5"));
 
         // Verify: everything else preserved
-        assert!(current.channels.http_enabled, "HTTP channel must survive");
+        assert_eq!(
+            current.channels.http_enabled,
+            Some(true),
+            "HTTP channel must survive"
+        );
         assert_eq!(current.channels.http_port, Some(8080));
         assert!(current.channels.signal_enabled, "Signal must survive");
         assert_eq!(
@@ -2371,7 +2379,7 @@ mod tests {
                 ..Default::default()
             },
             channels: ChannelSettings {
-                http_enabled: false,
+                http_enabled: Some(false),
                 wasm_channels: vec!["telegram".to_string()],
                 ..Default::default()
             },
@@ -2383,12 +2391,12 @@ mod tests {
         let mut current = Settings::from_db_map(&db_map);
 
         // Simulate step_channels: user enables HTTP and adds discord
-        current.channels.http_enabled = true;
+        current.channels.http_enabled = Some(true);
         current.channels.http_port = Some(9090);
         current.channels.wasm_channels = vec!["telegram".to_string(), "discord".to_string()];
 
         // Verify: channels changed
-        assert!(current.channels.http_enabled);
+        assert_eq!(current.channels.http_enabled, Some(true));
         assert_eq!(current.channels.http_port, Some(9090));
         assert_eq!(current.channels.wasm_channels.len(), 2);
 
@@ -2414,7 +2422,7 @@ mod tests {
             llm_backend: Some("openai".to_string()),
             selected_model: Some("gpt-4o".to_string()),
             channels: ChannelSettings {
-                http_enabled: true,
+                http_enabled: Some(true),
                 http_port: Some(8080),
                 signal_enabled: true,
                 wasm_channels: vec!["telegram".to_string()],
@@ -2460,8 +2468,9 @@ mod tests {
         assert_eq!(current.selected_model.as_deref(), Some("claude-opus-4-6"));
 
         // Verify: channels, embeddings, heartbeat survived quick mode
-        assert!(
+        assert_eq!(
             current.channels.http_enabled,
+            Some(true),
             "HTTP channel must survive quick mode re-run"
         );
         assert_eq!(current.channels.http_port, Some(8080));
@@ -2705,7 +2714,7 @@ mod tests {
                 ..Default::default()
             },
             channels: ChannelSettings {
-                http_enabled: true,
+                http_enabled: Some(true),
                 signal_enabled: true,
                 ..Default::default()
             },
@@ -2729,9 +2738,10 @@ mod tests {
             current.heartbeat.enabled,
             "heartbeat.enabled=true must not be reset to false by default overlay"
         );
-        assert!(
+        assert_eq!(
             current.channels.http_enabled,
-            "http_enabled=true must not be reset to false by default overlay"
+            Some(true),
+            "http_enabled=true must not be reset to default by overlay"
         );
         assert!(
             current.channels.signal_enabled,

--- a/src/setup/wizard.rs
+++ b/src/setup/wizard.rs
@@ -2628,7 +2628,7 @@ impl SetupWizard {
             ("CLI/TUI (always enabled)".to_string(), true),
             (
                 "HTTP webhook".to_string(),
-                self.settings.channels.http_enabled,
+                self.settings.channels.http_enabled.unwrap_or(false),
             ),
             ("Signal".to_string(), self.settings.channels.signal_enabled),
         ];
@@ -2724,15 +2724,15 @@ impl SetupWizard {
             println!();
             if let Some(ref ctx) = secrets {
                 let result = setup_http(ctx).await?;
-                self.settings.channels.http_enabled = result.enabled;
+                self.settings.channels.http_enabled = Some(result.enabled);
                 self.settings.channels.http_port = Some(result.port);
             } else {
-                self.settings.channels.http_enabled = true;
+                self.settings.channels.http_enabled = Some(true);
                 self.settings.channels.http_port = Some(8080);
                 print_info("HTTP webhook enabled on port 8080 (set HTTP_WEBHOOK_SECRET in env)");
             }
         } else {
-            self.settings.channels.http_enabled = false;
+            self.settings.channels.http_enabled = Some(false);
         }
 
         // Signal channel

--- a/src/tunnel/cloudflare.rs
+++ b/src/tunnel/cloudflare.rs
@@ -33,7 +33,7 @@ impl Tunnel for CloudflareTunnel {
     }
 
     async fn start(&self, local_host: &str, local_port: u16) -> Result<String> {
-        let origin = format!("http://{local_host}:{local_port}");
+        let origin = super::format_tunnel_origin(local_host, local_port);
         let mut child = Command::new("cloudflared")
             .args([
                 "tunnel",

--- a/src/tunnel/custom.rs
+++ b/src/tunnel/custom.rs
@@ -78,7 +78,7 @@ impl Tunnel for CustomTunnel {
         let stdout = child.stdout.take();
         let stderr = child.stderr.take();
 
-        let mut public_url = format!("http://{local_host}:{local_port}");
+        let mut public_url = super::format_tunnel_origin(local_host, local_port);
         let mut drain_handle: Option<tokio::task::JoinHandle<()>> = None;
 
         if self.url_pattern.is_some()

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -204,7 +204,12 @@ fn resolve_tunnel_target(channels: &crate::config::ChannelsConfig) -> (&str, u16
 pub(crate) fn format_tunnel_origin(local_host: &str, local_port: u16) -> String {
     let normalized_host = local_host.trim_matches(|c| c == '[' || c == ']');
     if normalized_host.contains(':') {
-        format!("http://[{normalized_host}]:{local_port}")
+        let encoded_host = if normalized_host.contains('%') && !normalized_host.contains("%25") {
+            normalized_host.replacen('%', "%25", 1)
+        } else {
+            normalized_host.to_string()
+        };
+        format!("http://[{encoded_host}]:{local_port}")
     } else {
         format!("http://{normalized_host}:{local_port}")
     }
@@ -517,6 +522,18 @@ mod tests {
         assert_eq!(
             format_tunnel_origin("localhost", 8083),
             "http://localhost:8083"
+        );
+    }
+
+    #[test]
+    fn format_tunnel_origin_encodes_ipv6_zone_ids() {
+        assert_eq!(
+            format_tunnel_origin("fe80::1%en0", 8084),
+            "http://[fe80::1%25en0]:8084"
+        );
+        assert_eq!(
+            format_tunnel_origin("[fe80::1%eth0]", 8085),
+            "http://[fe80::1%25eth0]:8085"
         );
     }
 }

--- a/src/tunnel/mod.rs
+++ b/src/tunnel/mod.rs
@@ -188,18 +188,26 @@ pub fn create_tunnel(config: &TunnelProviderConfig) -> Result<Option<Box<dyn Tun
 
 /// Determine which local address the tunnel should forward traffic to.
 ///
-/// Prefers the webhook server (`HTTP_PORT`) since that's where webhook routes
-/// (Telegram, etc.) are served. Falls back to the gateway port if configured,
-/// otherwise defaults to 127.0.0.1:8080 (the same fallback the webhook server
-/// uses in main.rs when no HTTP config is present).
+/// Managed tunnels must forward to the unified webhook listener because that
+/// is where generic tool webhooks, channel webhooks, and WASM webhook routes
+/// are actually served.
 fn resolve_tunnel_target(channels: &crate::config::ChannelsConfig) -> (&str, u16) {
-    if let Some(ref http) = channels.http {
-        return (http.host.as_str(), http.port);
+    let host = match channels.webhook_listener.host.as_str() {
+        "0.0.0.0" => "127.0.0.1",
+        "::" | "[::]" => "::1",
+        host => host,
+    };
+
+    (host, channels.webhook_listener.port)
+}
+
+pub(crate) fn format_tunnel_origin(local_host: &str, local_port: u16) -> String {
+    let normalized_host = local_host.trim_matches(|c| c == '[' || c == ']');
+    if normalized_host.contains(':') {
+        format!("http://[{normalized_host}]:{local_port}")
+    } else {
+        format!("http://{normalized_host}:{local_port}")
     }
-    if let Some(ref gw) = channels.gateway {
-        return (gw.host.as_str(), gw.port);
-    }
-    ("127.0.0.1", 8080)
 }
 
 /// Start a managed tunnel if configured and no static URL is already set.
@@ -403,12 +411,16 @@ mod tests {
         assert!(proc.lock().await.is_none());
     }
 
-    // ── Port selection regression tests ──────────────────────────────
+    // ── Tunnel target resolution regression tests ────────────────────
 
     fn base_channels() -> crate::config::ChannelsConfig {
         crate::config::ChannelsConfig {
             cli: crate::config::CliConfig { enabled: false },
             http: None,
+            webhook_listener: crate::config::WebhookListenerConfig {
+                host: crate::config::DEFAULT_WEBHOOK_LISTENER_HOST.to_string(),
+                port: crate::config::DEFAULT_WEBHOOK_LISTENER_PORT,
+            },
             gateway: None,
             signal: None,
             tui: None,
@@ -419,11 +431,15 @@ mod tests {
         }
     }
 
-    fn channels_with_http(host: &str, port: u16) -> crate::config::ChannelsConfig {
+    fn channels_with_webhook_listener(host: &str, port: u16) -> crate::config::ChannelsConfig {
         let mut c = base_channels();
-        c.http = Some(crate::config::HttpConfig {
+        c.webhook_listener = crate::config::WebhookListenerConfig {
             host: host.to_string(),
             port,
+        };
+        c.http = Some(crate::config::HttpConfig {
+            host: "198.51.100.12".to_string(),
+            port: 9443,
             webhook_secret: None,
             user_id: "test".to_string(),
         });
@@ -440,68 +456,67 @@ mod tests {
         c
     }
 
-    fn channels_gateway_only(host: &str, port: u16) -> crate::config::ChannelsConfig {
-        let mut c = base_channels();
-        c.gateway = Some(crate::config::GatewayConfig {
-            host: host.to_string(),
-            port,
-            auth_token: None,
-            max_connections: 100,
-            broadcast_buffer: DEFAULT_BROADCAST_BUFFER,
-            workspace_read_scopes: Vec::new(),
-            memory_layers: Vec::new(),
-            oidc: None,
-        });
-        c
-    }
-
-    fn channels_neither() -> crate::config::ChannelsConfig {
-        base_channels()
+    #[test]
+    fn tunnel_target_webhook_listener_wildcard_ipv4_normalizes_to_loopback() {
+        let channels = channels_with_webhook_listener("0.0.0.0", 8080);
+        let (host, port) = resolve_tunnel_target(&channels);
+        assert_eq!(host, "127.0.0.1");
+        assert_eq!(port, 8080);
     }
 
     #[test]
-    fn tunnel_target_prefers_http_port() {
-        let channels = channels_with_http("127.0.0.1", 8080);
+    fn tunnel_target_webhook_listener_wildcard_ipv6_normalizes_to_loopback() {
+        let channels = channels_with_webhook_listener("[::]", 8081);
         let (host, port) = resolve_tunnel_target(&channels);
-        assert_eq!(host, "127.0.0.1"); // safety: test-only
-        assert_eq!(port, 8080); // safety: test-only
+        assert_eq!(host, "::1");
+        assert_eq!(port, 8081);
     }
 
     #[test]
-    fn tunnel_target_falls_back_to_gateway() {
-        let channels = channels_gateway_only("10.0.0.1", 4000);
+    fn tunnel_target_webhook_listener_connectable_host_is_unchanged() {
+        let channels = channels_with_webhook_listener("localhost", 8082);
         let (host, port) = resolve_tunnel_target(&channels);
-        assert_eq!(host, "10.0.0.1"); // safety: test-only
-        assert_eq!(port, 4000); // safety: test-only
+        assert_eq!(host, "localhost");
+        assert_eq!(port, 8082);
     }
 
     #[test]
-    fn tunnel_target_defaults_to_webhook_fallback() {
-        let channels = channels_neither();
+    fn tunnel_target_custom_webhook_listener_is_used_when_http_channel_is_disabled() {
+        let mut channels = base_channels();
+        channels.webhook_listener = crate::config::WebhookListenerConfig {
+            host: "127.0.0.9".to_string(),
+            port: 9091,
+        };
+
         let (host, port) = resolve_tunnel_target(&channels);
-        // Matches the webhook server's hardcoded fallback in main.rs
-        assert_eq!(host, "127.0.0.1"); // safety: test-only
-        assert_eq!(port, 8080); // safety: test-only
+
+        assert_eq!(host, "127.0.0.9");
+        assert_eq!(port, 9091);
+        assert!(
+            channels.http.is_none(),
+            "test precondition: HTTP channel disabled"
+        );
     }
 
     #[test]
-    fn tunnel_target_http_takes_priority_over_gateway() {
-        let channels = channels_with_http("192.168.1.1", 9090);
-        let (host, port) = resolve_tunnel_target(&channels);
-        // Should use HTTP config, not gateway's 127.0.0.1:3000
-        assert_eq!(host, "192.168.1.1"); // safety: test-only
-        assert_eq!(port, 9090); // safety: test-only
+    fn format_tunnel_origin_brackets_ipv6_loopback() {
+        assert_eq!(format_tunnel_origin("::1", 8080), "http://[::1]:8080");
     }
 
     #[test]
-    fn tunnel_target_no_http_no_gateway_matches_webhook_fallback() {
-        // When HTTP_PORT is not set and gateway is not configured (e.g. WASM
-        // channels exist but no explicit HTTP config), the webhook server in
-        // main.rs binds to 127.0.0.1:8080 as a hardcoded fallback. The tunnel
-        // must target the same address so webhook traffic reaches the right
-        // server.
-        let channels = channels_neither();
-        let (host, port) = resolve_tunnel_target(&channels);
-        assert_eq!((host, port), ("127.0.0.1", 8080)); // safety: test-only
+    fn format_tunnel_origin_preserves_bracketed_ipv6_loopback() {
+        assert_eq!(format_tunnel_origin("[::1]", 8081), "http://[::1]:8081");
+    }
+
+    #[test]
+    fn format_tunnel_origin_leaves_ipv4_and_hostnames_unbracketed() {
+        assert_eq!(
+            format_tunnel_origin("127.0.0.1", 8082),
+            "http://127.0.0.1:8082"
+        );
+        assert_eq!(
+            format_tunnel_origin("localhost", 8083),
+            "http://localhost:8083"
+        );
     }
 }

--- a/src/tunnel/ngrok.rs
+++ b/src/tunnel/ngrok.rs
@@ -28,6 +28,10 @@ impl NgrokTunnel {
     }
 }
 
+fn build_local_target(local_host: &str, local_port: u16) -> String {
+    super::format_tunnel_origin(local_host, local_port)
+}
+
 #[async_trait::async_trait]
 impl Tunnel for NgrokTunnel {
     fn name(&self) -> &str {
@@ -35,7 +39,10 @@ impl Tunnel for NgrokTunnel {
     }
 
     async fn start(&self, local_host: &str, local_port: u16) -> Result<String> {
-        let mut args = vec!["http".to_string(), format!("{local_host}:{local_port}")];
+        let mut args = vec![
+            "http".to_string(),
+            build_local_target(local_host, local_port),
+        ];
         if let Some(ref domain) = self.domain {
             args.push("--domain".into());
             args.push(domain.clone());
@@ -164,6 +171,15 @@ impl Tunnel for NgrokTunnel {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ngrok_start_uses_ipv6_safe_origin_formatting() {
+        assert_eq!(build_local_target("::1", 8080), "http://[::1]:8080",);
+        assert_eq!(
+            build_local_target("[fe80::1%eth0]", 8081),
+            "http://[fe80::1%25eth0]:8081",
+        );
+    }
 
     #[test]
     fn constructor_stores_domain() {

--- a/src/tunnel/tailscale.rs
+++ b/src/tunnel/tailscale.rs
@@ -65,7 +65,7 @@ impl Tunnel for TailscaleTunnel {
                 .to_string()
         };
 
-        let target = format!("http://{}:{}", local_host, local_port);
+        let target = super::format_tunnel_origin(local_host, local_port);
 
         // `tailscale funnel --bg <target>` configures the tunnel and exits.
         // Without `--bg`, the command may hang without establishing the tunnel.

--- a/tests/channels_cli.rs
+++ b/tests/channels_cli.rs
@@ -1,0 +1,41 @@
+use std::process::Command;
+
+#[test]
+fn channels_list_http_entry_reports_unified_webhook_listener_address() {
+    let home = tempfile::tempdir().expect("temp home");
+    let libsql_path = home.path().join("ironclaw.db");
+    let output = Command::new(env!("CARGO_BIN_EXE_ironclaw"))
+        .args(["channels", "list", "--verbose"])
+        .env_clear()
+        .env("HOME", home.path())
+        .env("DATABASE_BACKEND", "libsql")
+        .env("LIBSQL_PATH", &libsql_path)
+        .env("HTTP_ENABLED", "true")
+        .env("HTTP_HOST", "0.0.0.0")
+        .env("HTTP_PORT", "8089")
+        .env("WEBHOOK_HOST", "127.0.0.1")
+        .env("WEBHOOK_PORT", "9091")
+        .output()
+        .expect("run ironclaw channels list");
+
+    assert!(
+        output.status.success(),
+        "channels list should succeed: status={:?}, stderr={}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("  http [enabled] (built-in)"),
+        "expected enabled HTTP channel entry in stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("host: 127.0.0.1"),
+        "HTTP channel entry must report the unified listener host:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("port: 9091"),
+        "HTTP channel entry must report the unified listener port:\n{stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- add dedicated `WEBHOOK_HOST` / `WEBHOOK_PORT` config for the unified webhook listener, defaulting to `127.0.0.1:8080`
- make `HTTP_ENABLED` the authoritative switch for the named HTTP webhook channel while preserving legacy HTTP listener settings as a compatibility fallback when `WEBHOOK_*` is unset
- keep managed tunnels targeting the actual unified webhook listener and format IPv6 tunnel origins correctly for provider URLs
- harden webhook listener reload so malformed replacement config does not panic the process or partially rotate the HTTP webhook secret
- update docs and examples to distinguish the web gateway, unified webhook listener, and named HTTP webhook channel, including the correct `X-Hub-Signature-256` auth flow

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation
- [ ] CI/Infrastructure
- [x] Security
- [ ] Dependencies

## Linked Issue

Fixes #2900

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo test --locked --bin ironclaw tests::webhook_listener_addr_uses_dedicated_listener_config -- --exact`
- [x] `cargo test --locked --bin ironclaw tests::webhook_listener_sighup_reload_blocks_secret_rotation_when_listener_config_is_malformed -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::tunnel_target_webhook_listener_wildcard_ipv4_normalizes_to_loopback -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::tunnel_target_webhook_listener_wildcard_ipv6_normalizes_to_loopback -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::tunnel_target_custom_webhook_listener_is_used_when_http_channel_is_disabled -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::format_tunnel_origin_brackets_ipv6_loopback -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::format_tunnel_origin_preserves_bracketed_ipv6_loopback -- --exact`
- [x] `cargo test --locked --lib tunnel::tests::format_tunnel_origin_leaves_ipv4_and_hostnames_unbracketed -- --exact`
- [x] `cargo test --locked --lib config::channels::tests::resolve_webhook_listener_compatibility_matrix -- --exact`
- [x] `cargo test --locked --lib config::channels::tests::resolve_invalid_legacy_http_port_for_webhook_listener_returns_config_error -- --exact`
- [x] `cargo test --locked --lib config::channels::tests::resolve_persisted_legacy_http_bind_keeps_http_disabled_but_sets_webhook_listener -- --exact`
- [ ] `cargo check --locked --bin ironclaw --target x86_64-pc-windows-msvc` (target not installed locally: `rustup target add x86_64-pc-windows-msvc` required before a Windows compile check can run)

## Security Impact

This is config hardening for a network-facing surface. It does not change webhook auth, gateway auth, CORS/origin handling, body limits, rate limits, allowlists, or secret storage. It does make `HTTP_ENABLED=false` reliably disable the named HTTP webhook channel even when operators still set legacy HTTP listener settings, and it aligns webhook docs with the actual HMAC header and request schema.

## Database Impact

None.

## Blast Radius

Touches channel config resolution, unified webhook listener startup/reload, managed tunnel target resolution, and operator-facing docs/examples, including `docs/channels/webhook.mdx`.

## Rollback Plan

Revert this PR to restore the previous coupling between `HTTP_HOST` / `HTTP_PORT` and the named HTTP channel enablement. That also restores the prior tunnel-target resolution behavior and pre-decoupling docs.

## Compatibility Notes

- Legacy `HTTP_HOST` / `HTTP_PORT` settings still provide the unified listener bind when `WEBHOOK_HOST` / `WEBHOOK_PORT` are unset, including persisted settings.
- Implicit named HTTP channel enablement from `HTTP_HOST` / `HTTP_PORT` is retained only when `HTTP_ENABLED` is unset, and now emits a deprecation warning.
- SIGHUP reload of the webhook surface is documented as atomic for listener validation plus HTTP secret rotation: if listener validation or rebind fails, IronClaw keeps the existing listener and skips secret rotation.
