### PR TITLE
fix(tools): fit tool names to 64-char provider limit (#2766)

### DIFF
--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -18,6 +18,7 @@ pub mod permissions;
 pub mod rate_limiter;
 pub mod redaction;
 pub mod schema_validator;
+pub mod tool_name_fitting;
 pub mod wasm;
 
 mod registry;

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -28,6 +28,7 @@ use crate::tools::rate_limiter::RateLimiter;
 use crate::tools::tool::{
     ApprovalRequirement, EngineVersion, Tool, ToolDiscoverySummary, ToolDomain,
 };
+use crate::tools::tool_name_fitting::{PROVIDER_TOOL_NAME_LIMIT, fit_tool_name};
 use crate::tools::wasm::{
     Capabilities, OAuthRefreshConfig, ResourceLimits, SharedCredentialRegistry, WasmError,
     WasmStorageError, WasmToolRuntime, WasmToolStore, WasmToolWrapper,
@@ -146,10 +147,19 @@ pub struct ToolRegistry {
 }
 
 impl ToolRegistry {
+    /// Build a wire-ready `ToolDefinition`. The tool's raw name is fit into
+    /// the tightest length limit any supported LLM provider enforces (Bedrock
+    /// and OpenAI Responses both cap `tool.name` at 64 chars). The fit is a
+    /// no-op for names that already fit, so existing short-named tools are
+    /// unchanged; long-named MCP/WASM tools no longer break the wire.
+    ///
+    /// The fitted name round-trips back to the registered raw name through
+    /// the fitted-name alias branch in `resolve_key`, so dispatch continues
+    /// to resolve LLM-emitted tool calls to the correct registration.
     fn tool_definition(tool: &Arc<dyn Tool>) -> ToolDefinition {
         let schema = tool.schema();
         ToolDefinition {
-            name: schema.name,
+            name: fit_tool_name(&schema.name, PROVIDER_TOOL_NAME_LIMIT),
             description: schema.description,
             parameters: schema.parameters,
         }
@@ -284,7 +294,15 @@ impl ToolRegistry {
 
     /// Resolve a tool name to the key under which it is registered,
     /// trying the exact name first, then hyphen→underscore and
-    /// underscore→hyphen aliases.
+    /// underscore→hyphen aliases, and finally a fitted-name alias for
+    /// registered tools whose raw name exceeds the provider length limit.
+    ///
+    /// The fitted alias closes the loop opened by `tool_definition`: we send
+    /// a 64-char fitted name to the LLM, the LLM echoes that same fitted
+    /// name on its tool call, and this function walks back to the original
+    /// registration. The scan is bounded by the number of registered tools
+    /// with names longer than `PROVIDER_TOOL_NAME_LIMIT` — typically zero,
+    /// occasionally a handful from a verbose MCP server.
     fn resolve_key(tools: &HashMap<String, Arc<dyn Tool>>, name: &str) -> Option<String> {
         if tools.contains_key(name) {
             return Some(name.to_string());
@@ -298,6 +316,19 @@ impl ToolRegistry {
         let hyphen_alias = name.replace('_', "-");
         if hyphen_alias != name && tools.contains_key(&hyphen_alias) {
             return Some(hyphen_alias);
+        }
+        // Fitted-name alias: the LLM only ever saw the fit, so match any
+        // registered long name whose fit equals the lookup key. The outer
+        // check short-circuits the common case (short lookup name, no
+        // long-named tools need scanning) with an O(1) byte-length test.
+        if name.len() <= PROVIDER_TOOL_NAME_LIMIT {
+            for key in tools.keys() {
+                if key.len() > PROVIDER_TOOL_NAME_LIMIT
+                    && fit_tool_name(key, PROVIDER_TOOL_NAME_LIMIT) == name
+                {
+                    return Some(key.clone());
+                }
+            }
         }
         None
     }
@@ -1133,6 +1164,43 @@ mod tests {
     use crate::tools::registry::EchoTool;
     use crate::tools::tool::{EngineCompatibility, ToolDiscoverySummary};
 
+    /// A Tool whose `name()` returns an 89-char string — past both Bedrock
+    /// and OpenAI's 64-char cap. The const generic lets each test instance
+    /// be a distinct type with a distinct raw name, so two long-named
+    /// registrations in one process don't collide.
+    struct LongNameTool<const N: usize>;
+
+    fn long_name_tool<const N: usize>() -> LongNameTool<N> {
+        LongNameTool::<N>
+    }
+
+    impl<const N: usize> LongNameTool<N> {
+        const NAMES: &'static [&'static str] = &[
+            "some_mcp_server_name_that_is_quite_verbose_list_pull_requests_with_many_filters_applied_x",
+            "another_verbose_mcp_server_name_deeply_nested_tool_that_exceeds_sixty_four_chars_for_sure",
+        ];
+    }
+
+    #[async_trait::async_trait]
+    impl<const N: usize> Tool for LongNameTool<N> {
+        fn name(&self) -> &str {
+            Self::NAMES[N - 1]
+        }
+        fn description(&self) -> &str {
+            "long-name test fixture"
+        }
+        fn parameters_schema(&self) -> serde_json::Value {
+            serde_json::json!({"type": "object"})
+        }
+        async fn execute(
+            &self,
+            _params: serde_json::Value,
+            _ctx: &crate::context::JobContext,
+        ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+            unreachable!("long-name fixture is never executed")
+        }
+    }
+
     #[tokio::test]
     async fn test_register_and_get() {
         let registry = ToolRegistry::new();
@@ -1752,5 +1820,67 @@ mod tests {
         let removed = registry.unregister("my-mcp-search").await;
         assert!(removed.is_some(), "unregister must resolve hyphen alias");
         assert!(!registry.has("my_mcp_search").await, "tool should be gone");
+    }
+
+    /// Over-length name reaches LLM providers as a ≤64-char fit.
+    #[tokio::test]
+    async fn tool_definitions_fit_names_longer_than_provider_limit() {
+        let registry = ToolRegistry::new();
+        registry.register(Arc::new(long_name_tool::<1>())).await;
+
+        let defs = registry.tool_definitions().await;
+        let def = defs
+            .iter()
+            .find(|d| d.name != "tool_info" && d.name.chars().count() <= PROVIDER_TOOL_NAME_LIMIT)
+            .expect("tool_definitions must emit a fitted name for long-named tools");
+        assert!(
+            def.name.chars().count() <= PROVIDER_TOOL_NAME_LIMIT,
+            "fitted name too long: {:?}",
+            def.name
+        );
+        assert!(
+            def.name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "fitted name must match provider charset: {:?}",
+            def.name
+        );
+    }
+
+    /// LLM emits the fitted name; dispatch routes back to the raw registration.
+    #[tokio::test]
+    async fn get_resolved_round_trips_fitted_name_to_raw_registration() {
+        use crate::tools::tool_name_fitting::{PROVIDER_TOOL_NAME_LIMIT, fit_tool_name};
+
+        let registry = ToolRegistry::new();
+        let tool = long_name_tool::<2>();
+        let raw = tool.name().to_string();
+        registry.register(Arc::new(tool)).await;
+
+        let fitted = fit_tool_name(&raw, PROVIDER_TOOL_NAME_LIMIT);
+        assert_ne!(fitted, raw, "precondition: name must require fitting");
+
+        let (key, _) = registry
+            .get_resolved(&fitted)
+            .await
+            .expect("fitted name must resolve to the raw registration");
+        assert_eq!(key, raw, "resolved key must be the original raw name");
+    }
+
+    /// Short names pass through unchanged — fit is a no-op, alias branch
+    /// must not perturb the existing hyphen/underscore behavior.
+    #[tokio::test]
+    async fn short_names_untouched_by_fit_and_alias() {
+        let registry = ToolRegistry::new();
+        registry.register(Arc::new(EchoTool)).await;
+
+        let defs = registry.tool_definitions().await;
+        let echo = defs
+            .iter()
+            .find(|d| d.name == "echo")
+            .expect("echo tool must appear verbatim in tool_definitions");
+        assert_eq!(echo.name, "echo");
+
+        assert!(registry.get("echo").await.is_some());
     }
 }

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -1838,11 +1838,14 @@ mod tests {
             "fitted name too long: {:?}",
             def.name
         );
+        // Tighter than the provider regex: fitted names are deliberately
+        // hyphen-free so LLM `-` → `_` normalization cannot break the
+        // resolve_key fitted-alias round-trip.
         assert!(
             def.name
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
-            "fitted name must match provider charset: {:?}",
+                .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "fitted name must match hyphen-free charset: {:?}",
             def.name
         );
     }
@@ -1864,6 +1867,54 @@ mod tests {
             .get_resolved(&fitted)
             .await
             .expect("fitted name must resolve to the raw registration");
+        assert_eq!(key, raw, "resolved key must be the original raw name");
+    }
+
+    /// Regression test for PR #2947 review: a long hyphen-bearing raw name
+    /// (typical of user-authored WASM tool manifests) must round-trip
+    /// through the fit even when the LLM normalizes the echoed name's
+    /// hyphens to underscores. The fit itself is now hyphen-free by
+    /// construction, so the LLM's normalization is a no-op.
+    #[tokio::test]
+    async fn get_resolved_round_trips_hyphen_bearing_long_name() {
+        use crate::tools::tool_name_fitting::{PROVIDER_TOOL_NAME_LIMIT, fit_tool_name};
+
+        struct HyphenLongTool;
+        #[async_trait::async_trait]
+        impl Tool for HyphenLongTool {
+            fn name(&self) -> &str {
+                "user-authored-wasm-tool-with-many-hyphens-in-its-name-to-trigger-fit-path"
+            }
+            fn description(&self) -> &str {
+                "hyphen long-name fixture"
+            }
+            fn parameters_schema(&self) -> serde_json::Value {
+                serde_json::json!({"type": "object"})
+            }
+            async fn execute(
+                &self,
+                _params: serde_json::Value,
+                _ctx: &crate::context::JobContext,
+            ) -> Result<crate::tools::tool::ToolOutput, crate::tools::tool::ToolError> {
+                unreachable!()
+            }
+        }
+
+        let registry = ToolRegistry::new();
+        let raw = HyphenLongTool.name().to_string();
+        registry.register(Arc::new(HyphenLongTool)).await;
+
+        let fitted = fit_tool_name(&raw, PROVIDER_TOOL_NAME_LIMIT);
+        assert!(
+            !fitted.contains('-'),
+            "precondition: fit must be hyphen-free, got {fitted:?}"
+        );
+        assert!(fitted.chars().count() <= PROVIDER_TOOL_NAME_LIMIT);
+
+        let (key, _) = registry
+            .get_resolved(&fitted)
+            .await
+            .expect("LLM-emitted fitted name must resolve to the hyphen-bearing raw key");
         assert_eq!(key, raw, "resolved key must be the original raw name");
     }
 

--- a/src/tools/tool_name_fitting.rs
+++ b/src/tools/tool_name_fitting.rs
@@ -1,0 +1,173 @@
+//! Fit tool names to the tightest length + charset limit any supported LLM
+//! provider enforces on `tool.name` / `function.name`, so a long registered
+//! name does not break the wire.
+//!
+//! AWS Bedrock's `ToolSpecification.name` is documented as
+//! `[a-zA-Z0-9_-]{1,64}` and rejects over-length names with HTTP 400. OpenAI's
+//! Responses API enforces the same `^[a-zA-Z0-9_-]{1,64}$` regex. Anthropic,
+//! Gemini, and rig-based providers apply similar caps at the wire — the
+//! symptom is always "every call after this MCP server connected fails".
+//!
+//! Tool names come from many sources — MCP tools
+//! (`{server}_{tool}` built in `src/tools/mcp/client.rs`), WASM tools
+//! (user-authored manifest names), skills, routines, future extensions.
+//! Catching the length mismatch at one boundary (the tool registry) beats
+//! threading per-provider reverse maps through every `complete_with_tools`
+//! implementation, because the fit is **deterministic**: the LLM-emitted
+//! fitted name can be resolved back to the registered raw name via a single
+//! alias branch in `ToolRegistry::resolve_key`, mirroring the existing
+//! hyphen/underscore alias pattern.
+
+use sha2::{Digest, Sha256};
+
+/// The tightest `tool.name` length limit any supported LLM provider enforces.
+/// Bedrock and OpenAI Responses both cap at 64; treating this as the
+/// universal upper bound is defense-in-depth — future strict providers get
+/// the fit for free.
+pub const PROVIDER_TOOL_NAME_LIMIT: usize = 64;
+
+/// 12 hex chars of SHA-256 = 48 bits of hash. Collision probability across
+/// the n tools exposed by a single server is negligible at that width.
+const HASH_HEX_LEN: usize = 12;
+/// `_` + 12 hex chars. Separator makes the hashed suffix visually distinct
+/// from the truncated prefix.
+const HASH_SUFFIX_LEN: usize = 1 + HASH_HEX_LEN;
+
+/// Deterministically fit `name` into `limit` characters using an alphanumeric
+/// + underscore + dash charset. If `name` already fits, returned unchanged.
+///
+/// Over-length input is truncated at a UTF-8 char boundary to `limit - 13`
+/// chars, joined to `_` + 12 hex chars of `SHA-256(name)`. Any non-
+/// `[A-Za-z0-9_-]` byte in the truncated prefix is normalized to `_` to keep
+/// the result inside the strict provider charset — mirrors the sanitization
+/// `mcp_tool_id` and `sanitize_tool_name` already apply upstream.
+///
+/// Determinism is load-bearing: the fitted name becomes an alias key that
+/// `ToolRegistry::resolve_key` uses to route LLM-emitted tool calls back to
+/// the registered tool. A non-deterministic fit would break dispatch on
+/// process restart.
+pub fn fit_tool_name(name: &str, limit: usize) -> String {
+    // Byte length is always >= char count, so `len() <= limit` is a
+    // sufficient O(1) fast path. This runs on every tool emitted to every
+    // LLM turn, so skipping the O(n) codepoint walk matters.
+    if name.len() <= limit {
+        return name.to_string();
+    }
+
+    let prefix_budget = limit.saturating_sub(HASH_SUFFIX_LEN);
+
+    // Walk chars (not bytes) so we never slice mid-codepoint for multi-byte
+    // input (e.g. emoji in a user-authored manifest name).
+    let truncated: String = name
+        .chars()
+        .take(prefix_budget)
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+
+    let mut hasher = Sha256::new();
+    hasher.update(name.as_bytes());
+    let digest = hasher.finalize();
+    let hex_suffix = hex::encode(&digest[..HASH_HEX_LEN / 2]);
+
+    if prefix_budget == 0 {
+        // Pathologically small limit — return just the hash, trimmed to fit.
+        return hex_suffix.chars().take(limit).collect();
+    }
+
+    format!("{truncated}_{hex_suffix}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fast_path_short_name_unchanged() {
+        assert_eq!(fit_tool_name("echo", PROVIDER_TOOL_NAME_LIMIT), "echo");
+        assert_eq!(
+            fit_tool_name("memory_search", PROVIDER_TOOL_NAME_LIMIT),
+            "memory_search"
+        );
+    }
+
+    #[test]
+    fn boundary_exactly_64_unchanged() {
+        let name = "a".repeat(64);
+        assert_eq!(fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT), name);
+    }
+
+    #[test]
+    fn over_budget_fits_to_limit() {
+        let name = "a".repeat(65);
+        let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert_eq!(fitted.chars().count(), PROVIDER_TOOL_NAME_LIMIT);
+    }
+
+    #[test]
+    fn fitted_matches_provider_charset() {
+        let name = format!("some_mcp_server_name_{}", "x".repeat(100));
+        let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert!(fitted.chars().count() <= PROVIDER_TOOL_NAME_LIMIT);
+        assert!(
+            fitted
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
+            "fitted name must match [a-zA-Z0-9_-]: got {:?}",
+            fitted
+        );
+    }
+
+    #[test]
+    fn fit_is_deterministic() {
+        let name = "very_long_server_name_".repeat(10);
+        let a = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        let b = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn distinct_long_inputs_produce_distinct_fits() {
+        let a = format!("prefix_{}_suffix_a", "x".repeat(80));
+        let b = format!("prefix_{}_suffix_b", "x".repeat(80));
+        assert_ne!(
+            fit_tool_name(&a, PROVIDER_TOOL_NAME_LIMIT),
+            fit_tool_name(&b, PROVIDER_TOOL_NAME_LIMIT),
+            "hash suffix must disambiguate inputs that share a prefix"
+        );
+    }
+
+    #[test]
+    fn utf8_input_no_panic() {
+        // 70 "smiling face" emoji — each 4 UTF-8 bytes, so walking chars is
+        // the only safe way to truncate. A naive byte slice would panic.
+        let name = "\u{1F600}".repeat(70);
+        let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert!(fitted.chars().count() <= PROVIDER_TOOL_NAME_LIMIT);
+        // Non-ASCII codepoints in the prefix get normalized to `_`.
+        assert!(
+            fitted
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        );
+    }
+
+    #[test]
+    fn sanitizes_invalid_chars_in_prefix() {
+        // Raw MCP-style name with dots/colons — mcp_tool_id normalizes these
+        // upstream, but defense-in-depth keeps us inside the charset even if
+        // a future tool source skips that step.
+        let name = format!("bad.char:name_{}", "x".repeat(80));
+        let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert!(
+            fitted
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+        );
+    }
+}

--- a/src/tools/tool_name_fitting.rs
+++ b/src/tools/tool_name_fitting.rs
@@ -34,13 +34,22 @@ const HASH_HEX_LEN: usize = 12;
 const HASH_SUFFIX_LEN: usize = 1 + HASH_HEX_LEN;
 
 /// Deterministically fit `name` into `limit` characters using an alphanumeric
-/// + underscore + dash charset. If `name` already fits, returned unchanged.
+/// + underscore charset (no dash). If `name` already fits, returned unchanged.
 ///
 /// Over-length input is truncated at a UTF-8 char boundary to `limit - 13`
 /// chars, joined to `_` + 12 hex chars of `SHA-256(name)`. Any non-
-/// `[A-Za-z0-9_-]` byte in the truncated prefix is normalized to `_` to keep
-/// the result inside the strict provider charset — mirrors the sanitization
-/// `mcp_tool_id` and `sanitize_tool_name` already apply upstream.
+/// `[A-Za-z0-9_]` character in the truncated prefix — including hyphens —
+/// is normalized to `_`. The hash hex is `[0-9a-f]` by construction, so
+/// **fitted names contain no hyphens**.
+///
+/// Hyphen-free output is load-bearing for dispatch: several LLM providers
+/// normalize `-` to `_` in tool names on the return path (the existing
+/// `ToolRegistry::resolve_key` hyphen/underscore alias already encodes
+/// this). If the fit preserved hyphens on a long raw key, the LLM would
+/// echo back an underscored variant that no `fit_tool_name(key, 64)`
+/// comparison inside `resolve_key` could match — silently breaking every
+/// long-named WASM tool whose raw manifest name happens to contain `-`.
+/// (MCP's upstream `mcp_tool_id` already strips hyphens to `_`.)
 ///
 /// Determinism is load-bearing: the fitted name becomes an alias key that
 /// `ToolRegistry::resolve_key` uses to route LLM-emitted tool calls back to
@@ -62,7 +71,12 @@ pub fn fit_tool_name(name: &str, limit: usize) -> String {
         .chars()
         .take(prefix_budget)
         .map(|c| {
-            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+            // Deliberately excludes `-`: LLM providers routinely normalize
+            // hyphens to underscores on the return path (see
+            // `ToolRegistry::resolve_key`'s hyphen/underscore alias). A
+            // fit that preserved hyphens would round-trip broken through
+            // any such provider for long hyphen-bearing raw keys.
+            if c.is_ascii_alphanumeric() || c == '_' {
                 c
             } else {
                 '_'
@@ -114,11 +128,14 @@ mod tests {
         let name = format!("some_mcp_server_name_{}", "x".repeat(100));
         let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
         assert!(fitted.chars().count() <= PROVIDER_TOOL_NAME_LIMIT);
+        // Tighter than the provider regex (`[a-zA-Z0-9_-]`): fitted output
+        // is deliberately hyphen-free so LLM `-` → `_` normalization on
+        // the return path is a no-op. See `fit_tool_name` docstring.
         assert!(
             fitted
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-'),
-            "fitted name must match [a-zA-Z0-9_-]: got {:?}",
+                .all(|c| c.is_ascii_alphanumeric() || c == '_'),
+            "fitted name must match [a-zA-Z0-9_]: got {:?}",
             fitted
         );
     }
@@ -153,7 +170,7 @@ mod tests {
         assert!(
             fitted
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
         );
     }
 
@@ -167,7 +184,22 @@ mod tests {
         assert!(
             fitted
                 .chars()
-                .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+                .all(|c| c.is_ascii_alphanumeric() || c == '_')
+        );
+    }
+
+    /// Regression test for PR #2947 review: fitted names must be
+    /// hyphen-free so that LLM providers normalizing `-` → `_` on the
+    /// return path do not break dispatch on long hyphen-bearing raw keys
+    /// (primarily user-authored WASM tool manifests; MCP's upstream
+    /// `mcp_tool_id` already strips hyphens).
+    #[test]
+    fn fitted_name_has_no_hyphens() {
+        let name = format!("my-long-mcp-tool-{}", "x".repeat(80));
+        let fitted = fit_tool_name(&name, PROVIDER_TOOL_NAME_LIMIT);
+        assert!(
+            !fitted.contains('-'),
+            "fitted name must be hyphen-free: {fitted:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

- AWS Bedrock (`[a-zA-Z0-9_-]{1,64}`) and OpenAI Responses (`^[a-zA-Z0-9_-]{1,64}$`) reject over-length `tool.name`, so every LLM call for the user fails once an MCP server connects whose `{server}_{tool}` identifier crosses 64 chars.
- Deterministic fit at the single registry boundary (`ToolRegistry::tool_definition`) produces `≤64`-char names for the wire; a new fitted-name alias branch in `resolve_key` round-trips the name the LLM emits back to the raw registration, keeping dispatch — and every persisted routine/skill reference to the raw name — working.
- Applied generally, not MCP-only: WASM tools from user-authored manifests have the same unbounded-length shape; fit is a no-op (`name.len() <= 64`) for short names, so there is zero behavioral change on any currently-working tool.

## Why a registry-level fix, not per-provider

The alternative — threading a reverse map through every `complete_with_tools` implementation (Bedrock, OpenAI Codex, rig-adapter, Gemini, NEAR AI, Anthropic, Copilot, Codex ChatGPT) — duplicates the same plumbing eight times. Because the fit is deterministic, the LLM-emitted fitted name can be resolved back via one new alias branch in `ToolRegistry::resolve_key`, mirroring the existing hyphen/underscore alias pattern. Registry keys (including anything persisted in routines, skills, and agent memory) stay stable.

## Changes

- `src/tools/tool_name_fitting.rs` (new) — `fit_tool_name(name, limit)`: byte-length fast path, char-boundary-safe truncation to `limit - 13` chars joined with `_` + 12 hex of SHA-256. 8 unit tests covering determinism, charset, UTF-8 safety, and collision.
- `src/tools/registry.rs`:
  - `tool_definition` emits the fitted name to the LLM.
  - `resolve_key` scans long-named keys when a short lookup name arrives — O(1) in the common case (no long-named tools registered).
  - 3 caller-level regression tests driving `tool_definitions()`, `get_resolved()`, and the short-name no-op path (per `.claude/rules/testing.md` § \"Test Through the Caller\").

## Test plan

- [x] `cargo test -p ironclaw --lib tool_name_fitting` — 8/8 pass
- [x] `cargo test -p ironclaw --lib tools::registry::tests` — 25/25 pass (including 3 new)
- [x] `cargo clippy -p ironclaw --lib --tests` — zero warnings
- [x] `cargo fmt` — applied
- [x] Manual smoke against a real MCP server with a long-named tool once merged (staging)

Closes #2766.