### PR TITLE
fix(mcp): skip OAuth discovery for stdio/unix transports (#2923)

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -3772,6 +3772,15 @@ impl ExtensionManager {
             return Ok(AuthResult::authenticated(name, ExtensionKind::McpServer));
         }
 
+        // Don't run OAuth endpoint discovery when the server doesn't need HTTP
+        // auth. For stdio/unix transports `server.url` is an empty placeholder
+        // and the `url` crate fails with "Invalid URL: relative URL without a
+        // base"; for non-OAuth HTTP (e.g. localhost dev servers) there's
+        // nothing to discover. Issue #2923.
+        if !server.requires_auth() {
+            return Ok(AuthResult::no_auth_required(name, ExtensionKind::McpServer));
+        }
+
         // In gateway mode, build an auth URL and return it for the frontend to
         // open in the same browser. The gateway's /oauth/callback handler will
         // complete the token exchange.
@@ -4305,6 +4314,16 @@ impl ExtensionManager {
     async fn mcp_supports_auth(&self, server: &McpServerConfig) -> bool {
         if server.oauth.is_some() || server.requires_auth() {
             return true;
+        }
+
+        // Non-HTTP transports have no URL to probe for OAuth metadata.
+        // Short-circuit before the cache lookup so list() doesn't emit a
+        // "Failed to determine MCP auth support" debug log per stdio server.
+        if !matches!(
+            server.effective_transport(),
+            crate::tools::mcp::config::EffectiveTransport::Http
+        ) {
+            return false;
         }
 
         // Cache hit: avoid the network probe on every list() call. Cache is
@@ -11264,6 +11283,46 @@ mod tests {
         );
         assert_eq!(oauth.token_url, "https://example.com/oauth/token");
         assert_eq!(oauth.scopes, vec!["search:read".to_string()]);
+    }
+
+    /// Regression test for #2923. Drives `auth()` (the public caller) per
+    /// `.claude/rules/testing.md` → "Test Through the Caller": `requires_auth()`
+    /// was always correct; the bug was `auth_mcp` ignoring it.
+    #[tokio::test]
+    async fn auth_mcp_skips_oauth_discovery_for_stdio_transport() {
+        use crate::extensions::AuthStatus;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        // Real store — `add_mcp_server` with `None` falls back to
+        // `default_config_path()` (~/.ironclaw/mcp_servers.json), which
+        // isn't writable in sandboxed test runs.
+        let (store, _db_dir) = make_test_store().await;
+        let mgr = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+
+        let stdio_server = McpServerConfig::new_stdio(
+            "local-stdio",
+            "/bin/echo",
+            vec![],
+            std::collections::HashMap::new(),
+        );
+        mgr.add_mcp_server(stdio_server, "test")
+            .await
+            .expect("add stdio server");
+
+        let result = mgr
+            .auth("local-stdio", "test")
+            .await
+            .expect("auth must not attempt OAuth discovery for stdio transport");
+        assert!(
+            matches!(result.status, AuthStatus::NoAuthRequired),
+            "expected NoAuthRequired for stdio transport, got {:?}",
+            result.status
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #2923. Re-files #2474 (closed in error with an incorrect "stdio transport is not yet supported" comment — stdio is fully wired up via `McpTransportConfig::Stdio` + `create_client_from_config`; only the activation pre-flight was buggy).

## Summary

- `ExtensionManager::auth_mcp` now short-circuits to `NoAuthRequired` when `server.requires_auth()` is false, so stdio/unix activation never reaches OAuth endpoint discovery (which was failing with `Invalid URL: relative URL without a base` on the empty-string `url` placeholder).
- `ExtensionManager::mcp_supports_auth` bails on non-HTTP transports before the metadata probe, so `extensions_list` stops emitting a spurious `Failed to determine MCP auth support` debug log per stdio server per call.
- Regression test drives `mgr.auth("local-stdio", ...)` end-to-end per `.claude/rules/testing.md` → "Test Through the Caller". Without the fix it reproduces the original activation failure; with it the call returns `AuthStatus::NoAuthRequired` with no network I/O.

## Why it works

The existing `McpServerConfig::requires_auth()` predicate already encodes the full rule: `false` for non-HTTP transports, for HTTPS servers with a user-configured `Authorization` header, and for localhost HTTP. Same predicate is already used by `src/tools/mcp/factory.rs:120` to gate authenticated-transport selection. The fix consults it one layer earlier, in the wrapper that was ignoring it. Same shape as the fix for #1948 (`has_custom_auth_header` existed but `requires_auth()` didn't consult it).

Both activation entry points converge on the patched path:
- Settings UI: `POST /api/extensions/{name}/activate` → `extensions_activate_handler` → `ensure_extension_ready(ExplicitActivate)` → `auth()` → `auth_mcp()`
- Agent tool: `tool_activate` → `ensure_extension_ready(ExplicitActivate)` → `auth()` → `auth_mcp()`

After the guard returns `NoAuthRequired`, `ensure_extension_ready` falls through to `activate_mcp`, which discovers tools via `client.list_tools()` and registers them in the global `ToolRegistry`. Discovered tool names are returned in `ActivateResult.tools_loaded`.

## Scope kept

Deliberately did **not** touch `authorize_mcp_server` in `src/cli/mcp.rs:463` (CLI `ironclaw mcp auth`). Separate surface, separate issue; the CLI already prints a meaningful error on failure.

## Test plan

- [x] `cargo test --lib auth_mcp` — both `test_auth_mcp_build_url_uses_explicit_oauth_endpoints` and the new `auth_mcp_skips_oauth_discovery_for_stdio_transport` pass
- [x] `cargo check --lib` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: `ironclaw mcp add demo-stdio --transport stdio --command npx --arg=-y --arg=@google-cloud/gcloud-mcp` → activate from Settings UI and via agent `tool_activate{name: "demo-stdio"}`; confirm tools are discovered and registered