### PR TITLE
fix(mcp): skip OAuth discovery for stdio/unix transports (fixes #2923)

### DIFF
--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -3772,6 +3772,21 @@ impl ExtensionManager {
             return Ok(AuthResult::authenticated(name, ExtensionKind::McpServer));
         }
 
+        // Non-HTTP transports (stdio, unix) never use HTTP-based OAuth.
+        // `requires_auth()` already returns `false` for these — `factory.rs`
+        // gates client construction on the same predicate. Without this
+        // short-circuit, `auth_mcp_build_url` below feeds a non-HTTP URL
+        // placeholder to `discover_full_oauth_metadata` and the `url` crate
+        // surfaces "Invalid URL: relative URL without a base". Fixes
+        // nearai/ironclaw#2923.
+        if !server.requires_auth() {
+            return Ok(AuthResult {
+                name: name.to_string(),
+                kind: ExtensionKind::McpServer,
+                status: crate::extensions::AuthStatus::NoAuthRequired,
+            });
+        }
+
         // In gateway mode, build an auth URL and return it for the frontend to
         // open in the same browser. The gateway's /oauth/callback handler will
         // complete the token exchange.
@@ -11264,6 +11279,56 @@ mod tests {
         );
         assert_eq!(oauth.token_url, "https://example.com/oauth/token");
         assert_eq!(oauth.scopes, vec!["search:read".to_string()]);
+    }
+
+    /// Regression for nearai/ironclaw#2923.
+    ///
+    /// Activating a stdio-transport MCP server used to fail with
+    /// `Failed to discover authorization endpoints: Invalid URL: relative URL
+    /// without a base` because `auth_mcp` ran the OAuth pre-flight
+    /// unconditionally. `requires_auth()` returns `false` for stdio/unix, so
+    /// `auth_mcp` now short-circuits with `NoAuthRequired` for those
+    /// transports and never feeds a non-HTTP URL to the OAuth discovery.
+    ///
+    /// Per `.claude/rules/testing.md` "Test Through the Caller, Not Just
+    /// the Helper": the bug was the wrapper ignoring `requires_auth()`,
+    /// so the test must drive `auth()` end-to-end (which dispatches to
+    /// `auth_mcp` via `determine_installed_kind`), not the predicate alone.
+    #[tokio::test]
+    async fn auth_mcp_skips_oauth_discovery_for_stdio_transport() {
+        use std::collections::HashMap;
+
+        let dir = tempfile::tempdir().expect("temp dir");
+        let (store, _db_dir) = make_test_store().await;
+        let mgr = make_test_manager_with_dirs(
+            None,
+            dir.path().join("tools"),
+            dir.path().join("channels"),
+            Some(Arc::clone(&store)),
+        );
+
+        let stdio_server = McpServerConfig::new_stdio(
+            "demo-stdio",
+            "/bin/echo",
+            Vec::<String>::new(),
+            HashMap::new(),
+        );
+        mgr.add_mcp_server(stdio_server, "test")
+            .await
+            .expect("add stdio mcp server");
+
+        let result = mgr
+            .auth("demo-stdio", "test")
+            .await
+            .expect("stdio auth must short-circuit instead of attempting OAuth endpoint discovery");
+
+        assert_eq!(
+            result.status,
+            crate::extensions::AuthStatus::NoAuthRequired,
+            "stdio MCP servers should report NoAuthRequired, got {:?}",
+            result.status
+        );
+        assert_eq!(result.kind, ExtensionKind::McpServer);
     }
 
     #[test]

--- a/src/extensions/manager.rs
+++ b/src/extensions/manager.rs
@@ -3780,11 +3780,7 @@ impl ExtensionManager {
         // surfaces "Invalid URL: relative URL without a base". Fixes
         // nearai/ironclaw#2923.
         if !server.requires_auth() {
-            return Ok(AuthResult {
-                name: name.to_string(),
-                kind: ExtensionKind::McpServer,
-                status: crate::extensions::AuthStatus::NoAuthRequired,
-            });
+            return Ok(AuthResult::no_auth_required(name, ExtensionKind::McpServer));
         }
 
         // In gateway mode, build an auth URL and return it for the frontend to


### PR DESCRIPTION
## Summary

Fixes #2923. Activating a stdio-transport MCP server failed with:

\`\`\`
Authentication failed: Failed to discover authorization endpoints:
Invalid URL: relative URL without a base
\`\`\`

`ExtensionManager::auth_mcp` ran the OAuth pre-flight unconditionally for every `McpServer` kind. In gateway mode it called `auth_mcp_build_url` → `discover_full_oauth_metadata(&server.url)`. Stdio servers have no HTTP `url`, so the `url` crate returned `Invalid URL: relative URL without a base`, which bubbled up as the auth error.

The predicate that should gate this already exists — `McpServerConfig::requires_auth()` returns `false` for non-HTTP transports, and `src/tools/mcp/factory.rs:114` already uses it. `auth_mcp` just didn't. Same shape as #1948.

## Fix

Short-circuit `auth_mcp` immediately after the existing `mcp_has_configured_auth` check: if `requires_auth()` is false, return `AuthResult { status: AuthStatus::NoAuthRequired, ... }`. This matches the `ExtensionKind::AcpAgent` arm at `manager.rs:1681-1686`. `ensure_extension_ready` treats `NoAuthRequired` identically to `Authenticated` and proceeds to activation.

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all --benches --tests --examples --all-features` — zero warnings
- [x] New regression test `auth_mcp_skips_oauth_discovery_for_stdio_transport` — drives `auth()` end-to-end (per `.claude/rules/testing.md` "Test Through the Caller, Not Just the Helper" — the bug was the wrapper ignoring the predicate, so a unit test on `requires_auth()` alone wouldn't have caught it). Constructs a manager + DB, persists a stdio server via `add_mcp_server`, calls `mgr.auth("demo-stdio", "test")`, asserts `AuthStatus::NoAuthRequired`. Without the fix this reproduces the original error. With the fix it passes and makes zero network calls.

## Notes

- Replaces #2474 (closed in error per #2923 history).
- Issue body had the exact root-cause analysis and proposed fix; this PR is a faithful implementation of it.