### PR TITLE
fix(llm): honor api_key_required in unusable_reason (fixes #2946)

### DIFF
--- a/src/cli/models.rs
+++ b/src/cli/models.rs
@@ -188,6 +188,7 @@ async fn try_fetch_models(provider_id: &str, config_path: Option<&Path>) -> Opti
                 provider_id: def.id.clone(),
                 model: def.default_model.clone(),
                 api_key: api_key.map(secrecy::SecretString::from),
+                api_key_required: def.api_key_required,
                 base_url,
                 extra_headers: Vec::new(),
                 oauth_token: None,

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -142,18 +142,6 @@ impl LlmConfig {
             .any(|c| c.id == provider.provider_id);
         let is_ollama = matches!(provider.protocol, ProviderProtocol::Ollama);
 
-        // Honor the registry's `api_key_required` flag: providers that
-        // explicitly mark a key as optional (e.g. `openai_compatible` for
-        // self-hosted vLLM/LiteLLM, `ollama`) must not be flagged unusable
-        // when no key is present. Without this, every restart with a
-        // keyless self-hosted provider would silently demote `llm_backend`
-        // to `nearai` via the post-fallback DB sync — fixes
-        // nearai/ironclaw#2946.
-        let api_key_required = ProviderRegistry::load()
-            .find(&provider.provider_id)
-            .map(|def| def.api_key_required)
-            .unwrap_or(true);
-
         // Custom providers have no hardcoded base URL in the client layer —
         // an empty `base_url` here means requests will be sent to a bare
         // path with no host, which always fails.
@@ -161,11 +149,15 @@ impl LlmConfig {
             return Some("missing base URL");
         }
 
-        // Ollama runs locally and has no API key concept. Every other
-        // provider needs at least one form of authentication, unless the
-        // registry marks the key as optional.
+        // Honor the resolved `api_key_required` flag (mirrors the registry's
+        // value for built-in providers; `!is_ollama` for custom providers).
+        // Providers that mark the key as optional (e.g. `openai_compatible`
+        // for self-hosted vLLM/LiteLLM, Ollama) must not be flagged unusable
+        // when no key is present. Without this, every restart with a keyless
+        // self-hosted provider would silently demote `llm_backend` to
+        // `nearai` via the post-fallback DB sync — fixes nearai/ironclaw#2946.
         if !is_ollama
-            && api_key_required
+            && provider.api_key_required
             && provider.api_key.is_none()
             && provider.oauth_token.is_none()
             && provider.refresh_token.is_none()
@@ -650,6 +642,11 @@ impl LlmConfig {
             protocol,
             provider_id: custom.id.clone(),
             api_key,
+            // Custom providers don't carry a registry `api_key_required`
+            // flag. Treat anything non-Ollama as requiring auth — matches
+            // the historical `unusable_reason` behavior. Custom Ollama
+            // providers are still keyless via the `is_ollama` short-circuit.
+            api_key_required: !matches!(protocol, ProviderProtocol::Ollama),
             base_url,
             model,
             extra_headers: Vec::new(),
@@ -877,6 +874,7 @@ impl LlmConfig {
             protocol,
             provider_id: canonical_id.to_string(),
             api_key,
+            api_key_required,
             base_url,
             model,
             extra_headers,
@@ -2846,6 +2844,51 @@ mod tests {
             cfg.backend, "my-ollama",
             "custom ollama provider without api_key must NOT fall back"
         );
+    }
+
+    /// Regression for codex review on PR #2961: a custom provider whose
+    /// `id` collides with a built-in (e.g. `openai_compatible`) but uses
+    /// a non-Ollama adapter that genuinely needs auth must still trigger
+    /// fallback when no key is present. The fix derives
+    /// `api_key_required` from the resolved provider config (which sets
+    /// `!is_ollama` for custom providers) rather than re-loading the
+    /// registry — which would have pulled `false` from the built-in
+    /// `openai_compatible` entry and skipped the fallback.
+    #[test]
+    fn custom_provider_with_builtin_id_collision_still_requires_key() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_API_KEY");
+            std::env::remove_var("LLM_BASE_URL");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            llm_custom_providers: vec![crate::settings::CustomLlmProviderSettings {
+                // Same id as the built-in registry entry — collisions
+                // are only format-validated in `validate_custom_providers`.
+                id: "openai_compatible".to_string(),
+                name: "Custom OpenAI-Compatible".to_string(),
+                adapter: "open_ai_completions".to_string(),
+                base_url: Some("http://localhost:18888/v1".to_string()),
+                default_model: Some("model-x".to_string()),
+                api_key: None,
+                builtin: false,
+            }],
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve_with_fallback(&settings)
+            .expect("resolve should succeed via fallback");
+        assert_eq!(
+            cfg.backend, "nearai",
+            "custom provider with no api_key (non-Ollama adapter) must fall back \
+             even when its id collides with a keyless built-in"
+        );
+
+        clear_openai_compatible_env();
     }
 
     /// Regression for nearai/ironclaw#2946.

--- a/src/config/llm.rs
+++ b/src/config/llm.rs
@@ -142,6 +142,18 @@ impl LlmConfig {
             .any(|c| c.id == provider.provider_id);
         let is_ollama = matches!(provider.protocol, ProviderProtocol::Ollama);
 
+        // Honor the registry's `api_key_required` flag: providers that
+        // explicitly mark a key as optional (e.g. `openai_compatible` for
+        // self-hosted vLLM/LiteLLM, `ollama`) must not be flagged unusable
+        // when no key is present. Without this, every restart with a
+        // keyless self-hosted provider would silently demote `llm_backend`
+        // to `nearai` via the post-fallback DB sync — fixes
+        // nearai/ironclaw#2946.
+        let api_key_required = ProviderRegistry::load()
+            .find(&provider.provider_id)
+            .map(|def| def.api_key_required)
+            .unwrap_or(true);
+
         // Custom providers have no hardcoded base URL in the client layer —
         // an empty `base_url` here means requests will be sent to a bare
         // path with no host, which always fails.
@@ -150,8 +162,10 @@ impl LlmConfig {
         }
 
         // Ollama runs locally and has no API key concept. Every other
-        // provider needs at least one form of authentication.
+        // provider needs at least one form of authentication, unless the
+        // registry marks the key as optional.
         if !is_ollama
+            && api_key_required
             && provider.api_key.is_none()
             && provider.oauth_token.is_none()
             && provider.refresh_token.is_none()
@@ -2832,6 +2846,40 @@ mod tests {
             cfg.backend, "my-ollama",
             "custom ollama provider without api_key must NOT fall back"
         );
+    }
+
+    /// Regression for nearai/ironclaw#2946.
+    ///
+    /// The `openai_compatible` registry entry has `api_key_required: false`
+    /// (self-hosted vLLM/LiteLLM/etc. don't always need a key). Before the
+    /// fix, `unusable_reason` ignored this flag and flagged any keyless
+    /// resolve as `"missing API key"` — which triggered `fallback_fired` in
+    /// `resolve_llm_with_secrets_inner` and silently rewrote `llm_backend`
+    /// to `nearai` in the DB on every restart, overriding the user's
+    /// explicit `ironclaw models set-provider openai_compatible`.
+    #[test]
+    fn resolve_does_not_fall_back_for_openai_compatible_without_api_key() {
+        let _guard = lock_env();
+        clear_openai_compatible_env();
+        // SAFETY: Under ENV_MUTEX.
+        unsafe {
+            std::env::remove_var("LLM_API_KEY");
+            std::env::set_var("LLM_BASE_URL", "http://localhost:8000/v1");
+        }
+
+        let settings = Settings {
+            llm_backend: Some("openai_compatible".to_string()),
+            openai_compatible_base_url: Some("http://localhost:8000/v1".to_string()),
+            ..Default::default()
+        };
+
+        let cfg = LlmConfig::resolve_with_fallback(&settings).expect("resolve should succeed");
+        assert_eq!(
+            cfg.backend, "openai_compatible",
+            "openai_compatible (api_key_required=false) without LLM_API_KEY must NOT fall back to nearai"
+        );
+
+        clear_openai_compatible_env();
     }
 
     #[test]

--- a/src/llm/config.rs
+++ b/src/llm/config.rs
@@ -79,6 +79,11 @@ pub struct RegistryProviderConfig {
     /// API key (optional for some providers like Ollama).
     /// For Anthropic OAuth, this is set to `OAUTH_PLACEHOLDER`.
     pub api_key: Option<SecretString>,
+    /// Whether this provider requires an API key. Mirrors the registry's
+    /// `api_key_required` flag so `LlmConfig::unusable_reason` can decide
+    /// whether a missing `api_key` is fatal without re-loading the registry
+    /// (which would also miss the custom-vs-builtin id collision case).
+    pub api_key_required: bool,
     /// Base URL for the API endpoint.
     pub base_url: String,
     /// Model identifier.

--- a/tests/support/gateway_workflow_harness.rs
+++ b/tests/support/gateway_workflow_harness.rs
@@ -141,6 +141,7 @@ impl GatewayWorkflowHarness {
             protocol: ProviderProtocol::OpenAiCompletions,
             provider_id: "openai_compatible".to_string(),
             api_key: Some(SecretString::from("dummy".to_string())),
+            api_key_required: false,
             base_url: base_url.to_string(),
             model: model.to_string(),
             extra_headers: Vec::new(),


### PR DESCRIPTION
## Summary

Fixes #2946. Self-hosted `openai_compatible` setups (vLLM, LiteLLM, etc.) without an API key were silently demoted to NearAI on every restart, overwriting the user's explicit \`ironclaw models set-provider openai_compatible\` and \`config.toml\`.

## Root cause

The `openai_compatible` registry entry declares \`api_key_required: false\`, but `LlmConfig::unusable_reason` ignored that flag and required a non-`None` `api_key` (or oauth/refresh token) for every non-Ollama provider:

\`\`\`rust
// src/config/llm.rs (before the fix)
if !is_ollama
    && provider.api_key.is_none()
    && provider.oauth_token.is_none()
    && provider.refresh_token.is_none()
{
    return Some(\"missing API key\");
}
\`\`\`

The cycle on every restart:

1. \`init_secrets\` → \`re_resolve_llm_with_secrets\` → \`resolve_llm_with_secrets_inner\`.
2. \`hydrate_llm_keys_from_secrets\` only seeds \`llm_builtin_overrides\` / \`llm_custom_providers\` — keyless self-hosted setups have neither.
3. \`LlmConfig::resolve_with_fallback\` resolves \`openai_compatible\`, then \`unusable_reason\` returns \`\"missing API key\"\`, and \`resolve_nearai_fallback\` runs.
4. Back in \`resolve_llm_with_secrets_inner\`, \`fallback_fired(Some(\"openai_compatible\"), \"nearai\")\` is true, so the function calls \`store.set_setting(user_id, \"llm_backend\", \"nearai\")\`.
5. Next startup: DB has \`nearai\`, which beats both \`config.toml\` and \`LLM_BACKEND\` env in the merge order.

## Fix

Look up the registry definition by \`provider.provider_id\` inside \`unusable_reason\` and skip the missing-key check when \`api_key_required = false\`. The Ollama short-circuit at the same site is preserved for both built-in and custom Ollama-protocol providers.

The post-fallback DB sync block in \`resolve_llm_with_secrets_inner\` is left intact — when a fallback genuinely fires (e.g. an Anthropic backend with no key), persisting the runtime backend so the UI doesn't lie is still correct. We just don't fire it for legitimate keyless configurations any more.

## Test plan

- [x] \`cargo fmt --check\` — clean
- [x] \`cargo clippy --all --benches --tests --examples --all-features\` — zero warnings
- [x] \`cargo test --lib config::llm\` — all 74 tests pass (including new regression \`resolve_does_not_fall_back_for_openai_compatible_without_api_key\`)
- [x] New regression test reproduces the original cycle: \`openai_compatible\` + \`LLM_BASE_URL\` + no \`LLM_API_KEY\` → \`cfg.backend == \"openai_compatible\"\`, not \`\"nearai\"\`. Without the fix it asserts-failed; with it, it passes and no fallback fires.