### PR TITLE
[codex] Fix bridge restart approval floor

### DIFF
--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -30,7 +30,9 @@ use crate::bridge::action_projector::ActionProjector;
 use crate::bridge::capability_projector::CapabilityProjector;
 use crate::bridge::router::synthetic_action_call_id;
 use crate::bridge::sandbox::{InterceptOutcome, maybe_intercept};
-use crate::bridge::tool_permissions::{ToolPermissionResolution, ToolPermissionSnapshot};
+use crate::bridge::tool_permissions::{
+    ToolPermissionResolution, ToolPermissionSnapshot, canonical_tool_name,
+};
 use crate::context::JobContext;
 use crate::extensions::InstalledExtension;
 use crate::extensions::naming::extension_name_candidates;
@@ -317,13 +319,27 @@ impl EffectBridgeAdapter {
     }
 
     fn apply_user_permission_override(
+        lookup_name: &str,
         base_requirement: ApprovalRequirement,
-        explicit_user_permission: Option<PermissionState>,
+        user_permission: ToolPermissionResolution,
     ) -> ApprovalRequirement {
-        match explicit_user_permission {
-            Some(PermissionState::AskEachTime) => ApprovalRequirement::Always,
+        if matches!(user_permission.explicit, Some(PermissionState::AskEachTime)) {
+            return ApprovalRequirement::Always;
+        }
+        match (base_requirement, user_permission.configured) {
+            (ApprovalRequirement::Never, Some(PermissionState::AskEachTime))
+                if Self::enforce_static_ask_floor_for_base_never_tool(lookup_name) =>
+            {
+                ApprovalRequirement::Always
+            }
             _ => base_requirement,
         }
+    }
+
+    fn enforce_static_ask_floor_for_base_never_tool(lookup_name: &str) -> bool {
+        // Other base-Never bridge tools manage auth/install gates internally.
+        // Restart's command-level confirmation does not cover direct v2 calls.
+        canonical_tool_name(lookup_name) == "restart"
     }
 
     fn ensure_tool_not_disabled(
@@ -356,7 +372,7 @@ impl EffectBridgeAdapter {
         } else {
             tool.requires_approval(parameters)
         };
-        Self::apply_user_permission_override(base_requirement, user_permission.explicit)
+        Self::apply_user_permission_override(lookup_name, base_requirement, user_permission)
     }
 
     async fn enforce_tool_approval(

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -2,12 +2,13 @@ use std::collections::HashMap;
 
 use crate::settings::Settings;
 use crate::tools::ToolRegistry;
-use crate::tools::permissions::{PermissionState, effective_permission};
+use crate::tools::permissions::{PermissionState, TOOL_RISK_DEFAULTS};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ToolPermissionResolution {
     pub(crate) effective: PermissionState,
     pub(crate) explicit: Option<PermissionState>,
+    pub(crate) configured: Option<PermissionState>,
 }
 
 #[derive(Clone, Default)]
@@ -37,13 +38,14 @@ impl ToolPermissionSnapshot {
     }
 
     pub(crate) fn resolve_permission(&self, tool_name: &str) -> ToolPermissionResolution {
+        let canonical = canonical_tool_name(tool_name);
         let explicit = self.explicit_permission(tool_name);
-        let effective = explicit.unwrap_or_else(|| {
-            effective_permission(&canonical_tool_name(tool_name), &self.overrides)
-        });
+        let configured = explicit.or_else(|| TOOL_RISK_DEFAULTS.get(canonical.as_str()).copied());
+        let effective = configured.unwrap_or(PermissionState::AskEachTime);
         ToolPermissionResolution {
             effective,
             explicit,
+            configured,
         }
     }
 

--- a/src/bridge/tool_permissions.rs
+++ b/src/bridge/tool_permissions.rs
@@ -39,7 +39,8 @@ impl ToolPermissionSnapshot {
 
     pub(crate) fn resolve_permission(&self, tool_name: &str) -> ToolPermissionResolution {
         let canonical = canonical_tool_name(tool_name);
-        let explicit = self.explicit_permission(tool_name);
+        let hyphenated = canonical.replace('_', "-");
+        let explicit = self.explicit_permission_with_names(tool_name, &canonical, &hyphenated);
         let configured = explicit.or_else(|| TOOL_RISK_DEFAULTS.get(canonical.as_str()).copied());
         let effective = configured.unwrap_or(PermissionState::AskEachTime);
         ToolPermissionResolution {
@@ -49,15 +50,17 @@ impl ToolPermissionSnapshot {
         }
     }
 
-    pub(crate) fn explicit_permission(&self, tool_name: &str) -> Option<PermissionState> {
-        let canonical = canonical_tool_name(tool_name);
-        let hyphenated = canonical.replace('_', "-");
-
+    fn explicit_permission_with_names(
+        &self,
+        tool_name: &str,
+        canonical: &str,
+        hyphenated: &str,
+    ) -> Option<PermissionState> {
         self.overrides
             .get(tool_name)
             .copied()
-            .or_else(|| self.overrides.get(&canonical).copied())
-            .or_else(|| self.overrides.get(&hyphenated).copied())
+            .or_else(|| self.overrides.get(canonical).copied())
+            .or_else(|| self.overrides.get(hyphenated).copied())
     }
 }
 


### PR DESCRIPTION
## Summary

- distinguish explicit/static tool permission policy from the unknown-tool fallback in the engine-v2 bridge permission snapshot
- require approval for direct v2 `restart` calls when the static default is `AskEachTime`
- preserve existing bridge-managed auth/install gate ordering for `tool_activate`, `tool_install`, and `skill_install`

## Root Cause

`restart` is configured as `AskEachTime` in `TOOL_RISK_DEFAULTS`, but the bridge approval path only treated explicit DB `AskEachTime` overrides as approval-forcing. Because `RestartTool::requires_approval()` intentionally returns `Never` for the legacy slash-command confirmation flow, direct v2 calls could bypass the default permission floor.

## Validation

- `cargo fmt`
- `git diff --check`
- `cargo test bridge::effect_adapter::tests:: --features libsql -- --nocapture`
- `cargo test bridge::effect_adapter::tests::restart_uses_default_permission_floor_without_explicit_override --features libsql -- --nocapture`