### PR TITLE
fix: incorrect ironclaw version in staging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "ironclaw"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "aes-gcm",
  "agent-client-protocol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [
 
 [package]
 name = "ironclaw"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2024"
 rust-version = "1.92"
 description = "Secure personal AI assistant that protects your data and expands its capabilities on the fly"


### PR DESCRIPTION
## Summary

- Aligns the package version metadata with the latest release by updating `ironclaw` from `0.25.0` to `0.26.0` in both `Cargo.toml` and `Cargo.lock`.
- Fixes version mismatch that caused downstream consumers (for example `ironclaw-dind` CI summary/version detection) to report stale `0.25.0`.
- Keeps release metadata consistent across manifests so builds and `--version` reporting match the intended release line. 
- Fixes the ironclaw version in ironclaw-dind build, e.g. https://github.com/nearai/ironclaw-dind/actions/runs/24979607787

## Change Type

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

Related: version mismatch between released IronClaw line and workspace manifest version (no formal issue linked).

## Validation

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: N/A (metadata/version-only change)
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: verified diff updates `version = "0.26.0"` in both `Cargo.toml` and `Cargo.lock`
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

None.

## Database Impact

None.

## Blast Radius

Low. Touches only release/version metadata for the root `ironclaw` package. Main risk is release automation or version-gating logic that depends on this value (intended behavior).

## Rollback Plan

Revert this commit to restore `0.25.0` in `Cargo.toml` and `Cargo.lock` if any downstream release process unexpectedly depends on the previous value.

## Review Follow-Through

Please confirm this aligns with the expected release source of truth (`v0.26.0`) and that downstream image/version pipelines should consume this updated manifest version.

---

**Review track**: A