### PR TITLE
fix: perserve executable permission for skill bundled executable

### DIFF
--- a/crates/ironclaw_skills/src/registry.rs
+++ b/crates/ironclaw_skills/src/registry.rs
@@ -14,6 +14,8 @@
 //! Uses async I/O throughout to avoid blocking the tokio runtime.
 
 use std::collections::HashSet;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::{Component, Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
@@ -208,6 +210,7 @@ pub struct SkillRegistry {
 pub struct InstallFile {
     pub relative_path: PathBuf,
     pub contents: Vec<u8>,
+    pub executable: bool,
 }
 
 /// Persisted metadata about how a skill bundle was installed.
@@ -673,6 +676,23 @@ impl SkillRegistry {
                     path: absolute_path.display().to_string(),
                     reason: e.to_string(),
                 })?;
+            #[cfg(unix)]
+            if file.executable {
+                let metadata = tokio::fs::metadata(&absolute_path).await.map_err(|e| {
+                    SkillRegistryError::WriteError {
+                        path: absolute_path.display().to_string(),
+                        reason: e.to_string(),
+                    }
+                })?;
+                let mode = metadata.permissions().mode();
+                let perms = std::fs::Permissions::from_mode(mode | 0o111);
+                tokio::fs::set_permissions(&absolute_path, perms)
+                    .await
+                    .map_err(|e| SkillRegistryError::WriteError {
+                        path: absolute_path.display().to_string(),
+                        reason: e.to_string(),
+                    })?;
+            }
         }
 
         if let Some(metadata) = install_metadata {
@@ -1221,10 +1241,12 @@ mod tests {
             InstallFile {
                 relative_path: PathBuf::from("requirements.txt"),
                 contents: b"requests>=2.32.5\n".to_vec(),
+                executable: false,
             },
             InstallFile {
                 relative_path: PathBuf::from("scripts/run.py"),
                 contents: b"print('ok')\n".to_vec(),
+                executable: false,
             },
         ];
         let metadata = InstalledSkillMetadata {
@@ -1261,6 +1283,7 @@ mod tests {
         let extra_files = vec![InstallFile {
             relative_path: PathBuf::from("../escape.sh"),
             contents: b"echo no\n".to_vec(),
+            executable: false,
         }];
 
         let err = SkillRegistry::prepare_install_bundle_to_disk(

--- a/src/channels/web/handlers/skills.rs
+++ b/src/channels/web/handlers/skills.rs
@@ -467,10 +467,12 @@ mod tests {
             ironclaw_skills::registry::InstallFile {
                 relative_path: Path::new("requirements.txt").to_path_buf(),
                 contents: b"httpx==0.27.0\n".to_vec(),
+                executable: false,
             },
             ironclaw_skills::registry::InstallFile {
                 relative_path: Path::new("scripts/run.py").to_path_buf(),
                 contents: b"print('ok')\n".to_vec(),
+                executable: false,
             },
         ];
 

--- a/src/tools/builtin/skill_tools.rs
+++ b/src/tools/builtin/skill_tools.rs
@@ -1591,7 +1591,7 @@ fn extract_skill_bundle_from_zip(
     }
 
     let strip_root = strip_common_archive_root(&raw_paths);
-    let mut files = Vec::<(PathBuf, Vec<u8>)>::new();
+    let mut files = Vec::<(PathBuf, Vec<u8>, bool)>::new();
     let mut skill_dirs = HashSet::<PathBuf>::new();
     let mut total_unzipped_bytes = 0u64;
 
@@ -1663,7 +1663,8 @@ fn extract_skill_bundle_from_zip(
         if path.file_name().is_some_and(|name| name == "SKILL.md") {
             skill_dirs.insert(path.parent().unwrap_or(Path::new("")).to_path_buf());
         }
-        files.push((path, contents));
+        let executable = file.unix_mode().is_some_and(|m| m & 0o111 != 0);
+        files.push((path, contents, executable));
     }
 
     let requested_dir = if let Some(subdir) = requested_subdir {
@@ -1699,7 +1700,7 @@ fn extract_skill_bundle_from_zip(
 
     let mut skill_md = None;
     let mut extra_files = Vec::new();
-    for (path, contents) in files {
+    for (path, contents, executable) in files {
         let Ok(relative) = path.strip_prefix(&requested_dir) else {
             continue;
         };
@@ -1722,6 +1723,7 @@ fn extract_skill_bundle_from_zip(
         extra_files.push(ironclaw_skills::registry::InstallFile {
             relative_path: relative.to_path_buf(),
             contents,
+            executable,
         });
     }
 


### PR DESCRIPTION
  - detect executable from zip and add 0o111 permission on linux

## Summary

<!-- 2-5 bullet points: what changed and why -->

  - Preserve Unix executable permissions from ZIP archives when installing skill bundles                                                                       
  - New `executable: bool` field on `InstallFile` detects any execute bit (`0o111`) in the ZIP entry's Unix mode
  - On Linux/macOS, after writing the file, reads existing permissions and ORs in `0o111` rather than hardcoding a mode                                        
  - Non-Unix platforms silently skip (gated by `#[cfg(unix)]`)   

## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [x] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [x] Manual testing: installed a skill ZIP containing a `scripts/run.sh` with execute bit set, verified the installed file has `0o755` on disk
- [x] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

  - `crates/ironclaw_skills/src/registry.rs` — `InstallFile` struct, `prepare_install_bundle_to_disk`
  - `src/tools/builtin/skill_tools.rs` — `extract_skill_bundle_from_zip`
  - Test files updated for new required field

  Existing skill installs are unaffected (files without execute bits in the ZIP stay unchanged).

## Rollback Plan

revert this commit

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
