### PR TITLE
fix(web): drop SSE plan_update/approval_needed events without thread_id

### DIFF
--- a/crates/ironclaw_gateway/static/js/core/sse.js
+++ b/crates/ironclaw_gateway/static/js/core/sse.js
@@ -390,8 +390,6 @@ function connectSSE(lastEventIdOverride) {
 
   addTrackedEventListener('approval_needed', (e) => {
     const data = JSON.parse(e.data);
-    const hasThread = !!data.thread_id;
-    const forCurrentThread = !hasThread || isCurrentThread(data.thread_id);
     if (data.thread_id) {
       activeWorkStore.updateThread(data.thread_id, {
         statusText: ActivityEntry.t('activity.waitingApproval', 'Waiting for approval'),
@@ -399,9 +397,9 @@ function connectSSE(lastEventIdOverride) {
       });
     }
 
-    if (forCurrentThread) {
+    if (isCurrentThread(data.thread_id)) {
       showApproval(data);
-    } else {
+    } else if (data.thread_id) {
       // Keep thread list fresh when approval is requested in a background thread.
       unreadThreads.set(data.thread_id, (unreadThreads.get(data.thread_id) || 0) + 1);
       debouncedLoadThreads();
@@ -545,7 +543,7 @@ function connectSSE(lastEventIdOverride) {
   // Plan progress checklist
   addTrackedEventListener('plan_update', (e) => {
     const data = JSON.parse(e.data);
-    if (data.thread_id && !isCurrentThread(data.thread_id)) return;
+    if (!isCurrentThread(data.thread_id)) return;
     renderPlanChecklist(data);
   });
 }


### PR DESCRIPTION
## Summary


- Plan checklists and approval cards from one conversation could leak into another conversation's chat view when the user switched threads, because two SSE handlers (`plan_update`, `approval_needed`) used short-circuit guards that treated missing `thread_id` as "applies to current view".
- Replaced both with strict `isCurrentThread(data.thread_id)` filtering — matching the convention every other thread-scoped handler in `sse.js` (`response`, `stream_chunk`, `tool_started`, …) already uses.
- Also guarded `approval_needed`'s else branch on `data.thread_id` so a null value no longer pollutes the `unreadThreads` Map.

### Root cause

`PlanUpdateTool::execute` at [`src/tools/builtin/plan.rs:143`](src/tools/builtin/plan.rs#L143) emits:

```rust
thread_id: ctx.conversation_id.map(|id| id.to_string()),
When the tool runs in a context without a chat conversation (mission runner, routine engine, heartbeat-driven flows), ctx.conversation_id is None, so the SSE event arrives with thread_id: null.
```
The old frontend guard:


if (data.thread_id && !isCurrentThread(data.thread_id)) return;
short-circuits on the falsy thread_id and falls through to renderPlanChecklist(data), which renders into the currently-displayed conversation. Same shape on approval_needed via forCurrentThread = !hasThread || isCurrentThread(...).

The fix is at the correct boundary: isCurrentThread(null) === false per chat.js:1-5, so !isCurrentThread(data.thread_id) filters thread_id-less events out instead of routing them to the active view.

<!-- 2-5 bullet points: what changed and why -->


## Change Type

<!-- Check all that apply. Refactor-only PRs are for core team or maintainer-requested work. -->

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] CI/Infrastructure
- [ ] Security
- [ ] Dependencies

## Linked Issue

fixes #2833 

<!-- Closes #N, Fixes #N, Related #N, or "None". New feature PRs must link an approved issue. -->

## Validation

<!-- How did you verify this works? -->

- [ ] `cargo fmt --all -- --check`
- [ ] `cargo clippy --all --benches --tests --examples --all-features -- -D warnings`
- [ ] `cargo build`
- [ ] Relevant tests pass: <!-- list specific tests -->
- [ ] `cargo test --features integration` if database-backed or integration behavior changed
- [ ] Manual testing: <!-- describe what you tested -->
- [ ] If a coding agent was used and supports it, `review-pr` or `pr-shepherd --fix` was run before requesting review

## Security Impact

<!-- Does this change affect: permissions, network calls, secrets, file access, tool execution, sandbox policy? If yes, describe. If no, write "None". -->

## Database Impact

<!-- Does this add/modify migrations, change schema, or affect both PostgreSQL and libSQL? If yes, describe. If no, write "None". -->

## Blast Radius

<!-- What subsystems does this touch? What could break? -->

## Rollback Plan

<!-- How to revert if this causes problems? For Track C changes, this is mandatory. -->

## Review Follow-Through

<!-- Review conversations are author-owned. Summarize any known follow-up or areas where reviewer judgment is still needed. -->

---

**Review track**: <!-- A (docs/tests/chore) | B (feature/maintainer-requested refactor) | C (security/runtime/DB/CI) -->
