### PR TITLE
feat(reborn): add host foundation crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,6 +3976,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_architecture"
+version = "0.1.0"
+dependencies = [
+ "serde_json",
+]
+
+[[package]]
 name = "ironclaw_common"
 version = "0.2.0"
 dependencies = [
@@ -4016,6 +4023,31 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "tracing",
+]
+
+[[package]]
+name = "ironclaw_host_api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
+name = "ironclaw_resources"
+version = "0.1.0"
+dependencies = [
+ "ironclaw_host_api",
+ "rust_decimal",
+ "rust_decimal_macros",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4036,6 +4036,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "static_assertions",
  "thiserror 2.0.18",
  "uuid",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_resources", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_architecture/CLAUDE.md
+++ b/crates/ironclaw_architecture/CLAUDE.md
@@ -1,0 +1,6 @@
+# ironclaw_architecture guardrails
+
+- This crate is test-only architecture enforcement; do not add production dependencies or runtime behavior.
+- Use `cargo metadata` or equivalent workspace graph checks to enforce Reborn dependency direction.
+- Boundary tests should fail loudly with the exact forbidden edge and crate name.
+- Keep rules conservative and explicit; update docs when intentional architecture edges change.

--- a/crates/ironclaw_architecture/Cargo.toml
+++ b/crates/ironclaw_architecture/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "ironclaw_architecture"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/ironclaw_architecture/src/lib.rs
+++ b/crates/ironclaw_architecture/src/lib.rs
@@ -1,0 +1,4 @@
+//! Workspace architecture contract tests for IronClaw Reborn.
+//!
+//! This crate intentionally has no production dependencies. Its tests inspect
+//! workspace metadata and fail when Reborn crate dependency boundaries drift.

--- a/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
+++ b/crates/ironclaw_architecture/tests/reborn_dependency_boundaries.rs
@@ -1,0 +1,349 @@
+use std::{collections::HashMap, path::PathBuf, process::Command};
+
+use serde_json::Value;
+
+#[test]
+fn reborn_crate_dependency_boundaries_hold() {
+    let metadata = cargo_metadata();
+    let packages = metadata["packages"]
+        .as_array()
+        .expect("cargo metadata must include packages");
+    let dependencies = packages
+        .iter()
+        .filter_map(package_dependencies)
+        .collect::<HashMap<_, _>>();
+
+    assert_no_normal_workspace_deps(
+        &dependencies,
+        "ironclaw_host_api",
+        workspace_ironclaw_crates(&dependencies)
+            .into_iter()
+            .filter(|name| *name != "ironclaw_host_api")
+            .collect::<Vec<_>>(),
+    );
+
+    for rule in boundary_rules() {
+        assert_no_normal_workspace_deps(&dependencies, rule.crate_name, rule.forbidden);
+    }
+}
+
+struct BoundaryRule {
+    crate_name: &'static str,
+    forbidden: Vec<&'static str>,
+}
+
+fn boundary_rules() -> Vec<BoundaryRule> {
+    vec![
+        BoundaryRule {
+            crate_name: "ironclaw_filesystem",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_memory",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_resources",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_filesystem",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_extensions",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_events",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_secrets",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_network",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_filesystem",
+                "ironclaw_host_runtime",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_secrets",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_authorization",
+            forbidden: vec![
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_run_state",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_events",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_approvals",
+            forbidden: vec![
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_resources",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_processes",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_dispatcher",
+                "ironclaw_extensions",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_capabilities",
+            forbidden: vec![
+                "ironclaw_dispatcher",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+        BoundaryRule {
+            crate_name: "ironclaw_dispatcher",
+            forbidden: vec![
+                "ironclaw_authorization",
+                "ironclaw_approvals",
+                "ironclaw_capabilities",
+                "ironclaw_host_runtime",
+                "ironclaw_secrets",
+                "ironclaw_network",
+                "ironclaw_mcp",
+                "ironclaw_processes",
+                "ironclaw_run_state",
+                "ironclaw_scripts",
+                "ironclaw_wasm",
+            ],
+        },
+    ]
+}
+
+fn cargo_metadata() -> Value {
+    let manifest_path = workspace_root().join("Cargo.toml");
+    let output = Command::new("cargo")
+        .args([
+            "metadata",
+            "--format-version",
+            "1",
+            "--no-deps",
+            "--manifest-path",
+        ])
+        .arg(&manifest_path)
+        .output()
+        .unwrap_or_else(|error| panic!("failed to run cargo metadata: {error}"));
+
+    assert!(
+        output.status.success(),
+        "cargo metadata failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).expect("cargo metadata output must be JSON")
+}
+
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(|path| path.parent())
+        .expect("architecture crate must live under crates/ironclaw_architecture")
+        .to_path_buf()
+}
+
+fn package_dependencies(package: &Value) -> Option<(String, Vec<String>)> {
+    let name = package["name"].as_str()?.to_string();
+    let dependencies = package["dependencies"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .filter(|dependency| is_normal_dependency(dependency))
+        .filter_map(|dependency| dependency["name"].as_str())
+        .filter(|name| name.starts_with("ironclaw_"))
+        .map(ToString::to_string)
+        .collect::<Vec<_>>();
+    Some((name, dependencies))
+}
+
+fn is_normal_dependency(dependency: &Value) -> bool {
+    dependency
+        .get("kind")
+        .and_then(Value::as_str)
+        .is_none_or(|kind| kind == "normal")
+}
+
+fn workspace_ironclaw_crates(dependencies: &HashMap<String, Vec<String>>) -> Vec<&str> {
+    dependencies
+        .keys()
+        .filter_map(|name| name.starts_with("ironclaw_").then_some(name.as_str()))
+        .collect()
+}
+
+fn assert_no_normal_workspace_deps<'a>(
+    dependencies: &HashMap<String, Vec<String>>,
+    crate_name: &str,
+    forbidden: impl IntoIterator<Item = &'a str>,
+) {
+    let Some(actual) = dependencies.get(crate_name) else {
+        // The landing plan introduces Reborn crates in grouped PRs. Boundary
+        // rules become active as soon as their crate is present in the
+        // workspace, while absent future crates are ignored in earlier slices.
+        return;
+    };
+    for forbidden in forbidden {
+        assert!(
+            !actual.iter().any(|dependency| dependency == forbidden),
+            "{crate_name} must not have a normal dependency on {forbidden}; actual normal ironclaw deps: {actual:?}"
+        );
+    }
+}

--- a/crates/ironclaw_host_api/CLAUDE.md
+++ b/crates/ironclaw_host_api/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_host_api guardrails
+
+- Own shared authority vocabulary only: IDs, scopes, paths, actions, decisions, resources, approvals, audits, and dispatch port contracts.
+- Do not depend on any other `ironclaw_*` system-service or runtime crate.
+- Keep behavior to validation/serialization helpers; do not add runtime execution, persistence, policy engines, or product workflow.
+- Serializable API types must not contain raw `HostPath`, secrets, or backend-specific error details.
+- Prefer strong enums/types over strings when the shape is known.

--- a/crates/ironclaw_host_api/Cargo.toml
+++ b/crates/ironclaw_host_api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "ironclaw_host_api"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+description = "Shared host API contracts for IronClaw Reborn"
+authors = ["NEAR AI <support@near.ai>"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/nearai/ironclaw"
+repository = "https://github.com/nearai/ironclaw"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "2"
+uuid = { version = "1", features = ["v4", "serde"] }
+
+[dev-dependencies]
+rust_decimal_macros = "1"

--- a/crates/ironclaw_host_api/Cargo.toml
+++ b/crates/ironclaw_host_api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ironclaw_host_api"
 version = "0.1.0"
 edition = "2024"
+# Keep in sync with the workspace-level package.rust-version.
 rust-version = "1.92"
 description = "Shared host API contracts for IronClaw Reborn"
 authors = ["NEAR AI <support@near.ai>"]
@@ -22,3 +23,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 rust_decimal_macros = "1"
+static_assertions = "1"

--- a/crates/ironclaw_host_api/src/action.rs
+++ b/crates/ironclaw_host_api/src/action.rs
@@ -1,0 +1,121 @@
+//! Action contracts for host authorization.
+//!
+//! An [`Action`] is the normalized description of something an execution wants
+//! to do before any service performs it: read/write a scoped path, dispatch a
+//! capability, spawn a capability-backed process, use a secret, contact the network, or
+//! reserve resources. Runtime crates should convert their concrete operations
+//! into these variants so policy, approvals, resources, and audit all reason
+//! about the same shape. Actions intentionally contain scoped/virtual contract
+//! types, never raw host paths or secret values.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ApprovalRequest, CapabilityId, EffectKind, ExtensionId, ResourceEstimate, ScopedPath,
+    SecretHandle,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretUseMode {
+    InjectIntoRequest,
+    InjectIntoEnvironment,
+    ReadRaw,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkScheme {
+    Http,
+    Https,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NetworkMethod {
+    Get,
+    Post,
+    Put,
+    Patch,
+    Delete,
+    Head,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NetworkTarget {
+    pub scheme: NetworkScheme,
+    pub host: String,
+    pub port: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct NetworkTargetPattern {
+    pub scheme: Option<NetworkScheme>,
+    pub host_pattern: String,
+    pub port: Option<u16>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NetworkPolicy {
+    pub allowed_targets: Vec<NetworkTargetPattern>,
+    pub deny_private_ip_ranges: bool,
+    pub max_egress_bytes: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtensionLifecycleOperation {
+    Install,
+    Update,
+    Remove,
+    Enable,
+    Disable,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Action {
+    ReadFile {
+        path: ScopedPath,
+    },
+    ListDir {
+        path: ScopedPath,
+    },
+    WriteFile {
+        path: ScopedPath,
+        bytes: Option<u64>,
+    },
+    DeleteFile {
+        path: ScopedPath,
+    },
+    Dispatch {
+        capability: CapabilityId,
+        estimated_resources: ResourceEstimate,
+    },
+    SpawnCapability {
+        capability: CapabilityId,
+        estimated_resources: ResourceEstimate,
+    },
+    UseSecret {
+        handle: SecretHandle,
+        mode: SecretUseMode,
+    },
+    Network {
+        target: NetworkTarget,
+        method: NetworkMethod,
+        estimated_bytes: Option<u64>,
+    },
+    ReserveResources {
+        estimate: ResourceEstimate,
+    },
+    Approve {
+        request: Box<ApprovalRequest>,
+    },
+    ExtensionLifecycle {
+        extension_id: ExtensionId,
+        operation: ExtensionLifecycleOperation,
+    },
+    EmitExternalEffect {
+        effect: EffectKind,
+    },
+}

--- a/crates/ironclaw_host_api/src/action.rs
+++ b/crates/ironclaw_host_api/src/action.rs
@@ -23,6 +23,16 @@ pub enum SecretUseMode {
     ReadRaw,
 }
 
+impl std::fmt::Display for SecretUseMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::InjectIntoRequest => "inject_into_request",
+            Self::InjectIntoEnvironment => "inject_into_environment",
+            Self::ReadRaw => "read_raw",
+        })
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum NetworkScheme {
@@ -39,6 +49,19 @@ pub enum NetworkMethod {
     Patch,
     Delete,
     Head,
+}
+
+impl std::fmt::Display for NetworkMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Get => "get",
+            Self::Post => "post",
+            Self::Put => "put",
+            Self::Patch => "patch",
+            Self::Delete => "delete",
+            Self::Head => "head",
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -70,6 +93,18 @@ pub enum ExtensionLifecycleOperation {
     Remove,
     Enable,
     Disable,
+}
+
+impl std::fmt::Display for ExtensionLifecycleOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Install => "install",
+            Self::Update => "update",
+            Self::Remove => "remove",
+            Self::Enable => "enable",
+            Self::Disable => "disable",
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/ironclaw_host_api/src/approval.rs
+++ b/crates/ironclaw_host_api/src/approval.rs
@@ -74,7 +74,7 @@ fn canonical_json(value: &serde_json::Value) -> serde_json::Value {
         }
         serde_json::Value::Object(map) => {
             let mut entries = map.iter().collect::<Vec<_>>();
-            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            entries.sort_by_key(|(key, _)| *key);
             let mut canonical = serde_json::Map::new();
             for (key, value) in entries {
                 canonical.insert(key.clone(), canonical_json(value));

--- a/crates/ironclaw_host_api/src/approval.rs
+++ b/crates/ironclaw_host_api/src/approval.rs
@@ -1,0 +1,130 @@
+//! Approval contracts for user-mediated authority.
+//!
+//! Approval is a scoped grant to continue a specific action, not a vague
+//! confirmation. [`ApprovalRequest`] carries the exact action that needs a
+//! decision and may optionally describe a reusable [`ApprovalScope`] such as a
+//! capability, path prefix, or network target. Matching must be exact or
+//! policy-defined by the host; callers must not infer broader authority from a
+//! one-off approval.
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::{
+    Action, ApprovalRequestId, CapabilityId, CorrelationId, HostApiError, NetworkTargetPattern,
+    Principal, ResourceEstimate, ResourceScope, ScopedPath, Timestamp,
+};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalRequest {
+    pub id: ApprovalRequestId,
+    pub correlation_id: CorrelationId,
+    pub requested_by: Principal,
+    pub action: Box<Action>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub invocation_fingerprint: Option<InvocationFingerprint>,
+    pub reason: String,
+    pub reusable_scope: Option<ApprovalScope>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct InvocationFingerprint(String);
+
+impl InvocationFingerprint {
+    pub fn for_dispatch(
+        scope: &ResourceScope,
+        capability: &CapabilityId,
+        estimate: &ResourceEstimate,
+        input: &serde_json::Value,
+    ) -> Result<Self, HostApiError> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            version: u8,
+            kind: &'static str,
+            scope: &'a ResourceScope,
+            capability: &'a CapabilityId,
+            estimate: &'a ResourceEstimate,
+            input: &'a serde_json::Value,
+        }
+
+        let canonical_input = canonical_json(input);
+        let payload = Payload {
+            version: 1,
+            kind: "dispatch",
+            scope,
+            capability,
+            estimate,
+            input: &canonical_input,
+        };
+        let bytes = serde_json::to_vec(&payload)
+            .map_err(|error| HostApiError::invariant(error.to_string()))?;
+        let digest = Sha256::digest(bytes);
+        Ok(Self(format!("sha256:{}", to_lower_hex(&digest))))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+fn canonical_json(value: &serde_json::Value) -> serde_json::Value {
+    match value {
+        serde_json::Value::Array(items) => {
+            serde_json::Value::Array(items.iter().map(canonical_json).collect())
+        }
+        serde_json::Value::Object(map) => {
+            let mut entries = map.iter().collect::<Vec<_>>();
+            entries.sort_by(|(left, _), (right, _)| left.cmp(right));
+            let mut canonical = serde_json::Map::new();
+            for (key, value) in entries {
+                canonical.insert(key.clone(), canonical_json(value));
+            }
+            serde_json::Value::Object(canonical)
+        }
+        _ => value.clone(),
+    }
+}
+
+fn to_lower_hex(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(HEX[(byte >> 4) as usize] as char);
+        output.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    output
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalScope {
+    pub principal: Principal,
+    pub action_pattern: ActionPattern,
+    pub expires_at: Option<Timestamp>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ActionPattern {
+    ExactAction {
+        action: Box<Action>,
+    },
+    Capability {
+        capability: CapabilityId,
+    },
+    PathPrefix {
+        action_kind: FileActionKind,
+        prefix: ScopedPath,
+    },
+    NetworkTarget {
+        target: NetworkTargetPattern,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FileActionKind {
+    Read,
+    List,
+    Write,
+    Delete,
+}

--- a/crates/ironclaw_host_api/src/audit.rs
+++ b/crates/ironclaw_host_api/src/audit.rs
@@ -180,7 +180,7 @@ impl ActionSummary {
                 operation,
             } => Self::new(
                 "extension_lifecycle",
-                Some(format!("{}:{operation:?}", extension_id.as_str())),
+                Some(format!("{}:{operation}", extension_id.as_str())),
                 vec![EffectKind::ModifyExtension],
             ),
             Action::EmitExternalEffect { effect } => {
@@ -215,13 +215,13 @@ fn extension_from_principal(principal: &Principal) -> Option<ExtensionId> {
 
 fn network_target(method: &NetworkMethod, host: &str, port: Option<u16>) -> String {
     match port {
-        Some(port) => format!("{method:?}:{host}:{port}"),
-        None => format!("{method:?}:{host}"),
+        Some(port) => format!("{method}:{host}:{port}"),
+        None => format!("{method}:{host}"),
     }
 }
 
 fn secret_target(handle: &str, mode: &SecretUseMode) -> String {
-    format!("{handle}:{mode:?}")
+    format!("{handle}:{mode}")
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_host_api/src/audit.rs
+++ b/crates/ironclaw_host_api/src/audit.rs
@@ -1,0 +1,240 @@
+//! Audit envelope contracts for durable provenance.
+//!
+//! [`AuditEnvelope`] is the redacted, durable record shape for authorization
+//! decisions and externally visible side effects. It carries scope, correlation,
+//! action summary, decision summary, and optional result metadata without raw
+//! secrets or raw host paths. Service crates are responsible for persisting and
+//! emitting these envelopes at the required before/after/denied stages.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    Action, AgentId, ApprovalRequest, AuditEventId, CapabilityId, CorrelationId, DenyReason,
+    EffectKind, ExecutionContext, ExtensionId, InvocationId, MissionId, NetworkMethod, Principal,
+    ProcessId, ProjectId, SecretUseMode, TenantId, ThreadId, Timestamp, UserId,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuditEnvelope {
+    pub event_id: AuditEventId,
+    pub correlation_id: CorrelationId,
+    pub stage: AuditStage,
+    pub timestamp: Timestamp,
+
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
+    pub project_id: Option<ProjectId>,
+    pub mission_id: Option<MissionId>,
+    pub thread_id: Option<ThreadId>,
+    pub invocation_id: InvocationId,
+    pub process_id: Option<ProcessId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approval_request_id: Option<crate::ApprovalRequestId>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extension_id: Option<ExtensionId>,
+
+    pub action: ActionSummary,
+    pub decision: DecisionSummary,
+    pub result: Option<ActionResultSummary>,
+}
+
+impl AuditEnvelope {
+    pub fn denied(
+        ctx: &ExecutionContext,
+        stage: AuditStage,
+        action: ActionSummary,
+        reason: DenyReason,
+    ) -> Self {
+        Self {
+            event_id: AuditEventId::new(),
+            correlation_id: ctx.correlation_id,
+            stage,
+            timestamp: Utc::now(),
+            tenant_id: ctx.tenant_id.clone(),
+            user_id: ctx.user_id.clone(),
+            agent_id: ctx.agent_id.clone(),
+            project_id: ctx.project_id.clone(),
+            mission_id: ctx.mission_id.clone(),
+            thread_id: ctx.thread_id.clone(),
+            invocation_id: ctx.invocation_id,
+            process_id: ctx.process_id,
+            approval_request_id: None,
+            extension_id: Some(ctx.extension_id.clone()),
+            action,
+            decision: DecisionSummary {
+                kind: "deny".to_string(),
+                reason: Some(reason),
+                actor: None,
+            },
+            result: None,
+        }
+    }
+
+    pub fn approval_resolved(
+        scope: &crate::ResourceScope,
+        request: &ApprovalRequest,
+        resolved_by: Principal,
+        decision: impl Into<String>,
+    ) -> Self {
+        let decision = decision.into();
+        Self {
+            event_id: AuditEventId::new(),
+            correlation_id: request.correlation_id,
+            stage: AuditStage::ApprovalResolved,
+            timestamp: Utc::now(),
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
+            invocation_id: scope.invocation_id,
+            process_id: None,
+            approval_request_id: Some(request.id),
+            extension_id: extension_from_principal(&request.requested_by),
+            action: ActionSummary::from_action(request.action.as_ref()),
+            decision: DecisionSummary {
+                kind: decision,
+                reason: None,
+                actor: Some(resolved_by),
+            },
+            result: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditStage {
+    Before,
+    After,
+    Denied,
+    ApprovalRequested,
+    ApprovalResolved,
+    ResourceReserved,
+    ResourceReconciled,
+    ResourceReleased,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionSummary {
+    pub kind: String,
+    pub target: Option<String>,
+    pub effects: Vec<EffectKind>,
+}
+
+impl ActionSummary {
+    pub fn from_action(action: &Action) -> Self {
+        match action {
+            Action::ReadFile { path } => Self::new(
+                "read_file",
+                Some(path.as_str().to_string()),
+                vec![EffectKind::ReadFilesystem],
+            ),
+            Action::ListDir { path } => Self::new(
+                "list_dir",
+                Some(path.as_str().to_string()),
+                vec![EffectKind::ReadFilesystem],
+            ),
+            Action::WriteFile { path, .. } => Self::new(
+                "write_file",
+                Some(path.as_str().to_string()),
+                vec![EffectKind::WriteFilesystem],
+            ),
+            Action::DeleteFile { path } => Self::new(
+                "delete_file",
+                Some(path.as_str().to_string()),
+                vec![EffectKind::DeleteFilesystem],
+            ),
+            Action::Dispatch { capability, .. } => {
+                Self::capability("dispatch", capability, vec![EffectKind::DispatchCapability])
+            }
+            Action::SpawnCapability { capability, .. } => Self::capability(
+                "spawn_capability",
+                capability,
+                vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+            ),
+            Action::UseSecret { handle, mode } => Self::new(
+                "use_secret",
+                Some(secret_target(handle.as_str(), mode)),
+                vec![EffectKind::UseSecret],
+            ),
+            Action::Network { target, method, .. } => Self::new(
+                "network",
+                Some(network_target(method, target.host.as_str(), target.port)),
+                vec![EffectKind::Network],
+            ),
+            Action::ReserveResources { .. } => {
+                Self::new("reserve_resources", None, vec![EffectKind::ModifyBudget])
+            }
+            Action::Approve { request } => Self::new(
+                "approve",
+                Some(request.id.to_string()),
+                vec![EffectKind::ModifyApproval],
+            ),
+            Action::ExtensionLifecycle {
+                extension_id,
+                operation,
+            } => Self::new(
+                "extension_lifecycle",
+                Some(format!("{}:{operation:?}", extension_id.as_str())),
+                vec![EffectKind::ModifyExtension],
+            ),
+            Action::EmitExternalEffect { effect } => {
+                Self::new("emit_external_effect", None, vec![*effect])
+            }
+        }
+    }
+
+    fn capability(
+        kind: impl Into<String>,
+        capability: &CapabilityId,
+        effects: Vec<EffectKind>,
+    ) -> Self {
+        Self::new(kind, Some(capability.as_str().to_string()), effects)
+    }
+
+    fn new(kind: impl Into<String>, target: Option<String>, effects: Vec<EffectKind>) -> Self {
+        Self {
+            kind: kind.into(),
+            target,
+            effects,
+        }
+    }
+}
+
+fn extension_from_principal(principal: &Principal) -> Option<ExtensionId> {
+    match principal {
+        Principal::Extension(extension_id) => Some(extension_id.clone()),
+        _ => None,
+    }
+}
+
+fn network_target(method: &NetworkMethod, host: &str, port: Option<u16>) -> String {
+    match port {
+        Some(port) => format!("{method:?}:{host}:{port}"),
+        None => format!("{method:?}:{host}"),
+    }
+}
+
+fn secret_target(handle: &str, mode: &SecretUseMode) -> String {
+    format!("{handle}:{mode:?}")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DecisionSummary {
+    pub kind: String,
+    pub reason: Option<DenyReason>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub actor: Option<Principal>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionResultSummary {
+    pub success: bool,
+    pub status: Option<String>,
+    pub output_bytes: Option<u64>,
+}

--- a/crates/ironclaw_host_api/src/capability.rs
+++ b/crates/ironclaw_host_api/src/capability.rs
@@ -1,0 +1,79 @@
+//! Capability declaration and grant contracts.
+//!
+//! A [`CapabilityDescriptor`] says what an extension can provide; it does not
+//! grant anyone authority to use it. Authority comes from active
+//! [`CapabilityGrant`] values collected in a [`CapabilitySet`]. Grants carry
+//! constraints for effects, mounts, network access, secrets, resources, expiry,
+//! and invocation count so delegated authority can be attenuated across spawned
+//! work.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    CapabilityGrantId, CapabilityId, ExtensionId, MountView, NetworkPolicy, Principal,
+    ResourceCeiling, ResourceProfile, RuntimeKind, SecretHandle, Timestamp, TrustClass,
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EffectKind {
+    ReadFilesystem,
+    WriteFilesystem,
+    DeleteFilesystem,
+    Network,
+    UseSecret,
+    ExecuteCode,
+    SpawnProcess,
+    DispatchCapability,
+    ModifyExtension,
+    ModifyApproval,
+    ModifyBudget,
+    ExternalWrite,
+    Financial,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PermissionMode {
+    Allow,
+    Ask,
+    Deny,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CapabilityDescriptor {
+    pub id: CapabilityId,
+    pub provider: ExtensionId,
+    pub runtime: RuntimeKind,
+    pub trust_ceiling: TrustClass,
+    pub description: String,
+    pub parameters_schema: serde_json::Value,
+    pub effects: Vec<EffectKind>,
+    pub default_permission: PermissionMode,
+    pub resource_profile: Option<ResourceProfile>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityGrant {
+    pub id: CapabilityGrantId,
+    pub capability: CapabilityId,
+    pub grantee: Principal,
+    pub issued_by: Principal,
+    pub constraints: GrantConstraints,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilitySet {
+    pub grants: Vec<CapabilityGrant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GrantConstraints {
+    pub allowed_effects: Vec<EffectKind>,
+    pub mounts: MountView,
+    pub network: NetworkPolicy,
+    pub secrets: Vec<SecretHandle>,
+    pub resource_ceiling: Option<ResourceCeiling>,
+    pub expires_at: Option<Timestamp>,
+    pub max_invocations: Option<u64>,
+}

--- a/crates/ironclaw_host_api/src/decision.rs
+++ b/crates/ironclaw_host_api/src/decision.rs
@@ -10,12 +10,12 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ApprovalRequest;
-use crate::{MountView, NetworkPolicy, ResourceReservationId, SecretHandle};
+use crate::{HostApiError, MountView, NetworkPolicy, ResourceReservationId, SecretHandle};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
 pub enum Decision {
-    Allow { obligations: Vec<Obligation> },
+    Allow { obligations: Obligations },
     Deny { reason: DenyReason },
     RequireApproval { request: ApprovalRequest },
 }
@@ -57,4 +57,113 @@ pub enum Obligation {
     EnforceOutputLimit {
         bytes: u64,
     },
+}
+
+/// Canonical obligation evaluation classes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ObligationKind {
+    ReserveResources,
+    UseScopedMounts,
+    ApplyNetworkPolicy,
+    InjectSecretOnce,
+    AuditBefore,
+    RedactOutput,
+    EnforceOutputLimit,
+    AuditAfter,
+}
+
+/// Canonical order runtime handlers must follow when satisfying allow obligations.
+pub const OBLIGATION_EVALUATION_ORDER: &[ObligationKind] = &[
+    ObligationKind::ReserveResources,
+    ObligationKind::UseScopedMounts,
+    ObligationKind::ApplyNetworkPolicy,
+    ObligationKind::InjectSecretOnce,
+    ObligationKind::AuditBefore,
+    ObligationKind::RedactOutput,
+    ObligationKind::EnforceOutputLimit,
+    ObligationKind::AuditAfter,
+];
+
+/// Validated, canonicalized obligation list for an allowed decision.
+///
+/// `Decision::Allow` uses this wrapper instead of a raw `Vec<Obligation>` so
+/// callers cannot accidentally encode duplicate or conflicting obligations, and
+/// runtime handlers observe one stable evaluation order. Exact duplicates and
+/// same-kind conflicting obligations are rejected at construction/deserialization
+/// time; policy code must collapse conflicts before producing an allow decision.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(transparent)]
+pub struct Obligations(Vec<Obligation>);
+
+impl Obligations {
+    pub fn new(obligations: Vec<Obligation>) -> Result<Self, HostApiError> {
+        for obligation in &obligations {
+            if !OBLIGATION_EVALUATION_ORDER.contains(&obligation.kind()) {
+                return Err(HostApiError::invariant(format!(
+                    "{kind:?} is missing from OBLIGATION_EVALUATION_ORDER",
+                    kind = obligation.kind()
+                )));
+            }
+        }
+
+        let mut normalized = Vec::with_capacity(obligations.len());
+        for kind in OBLIGATION_EVALUATION_ORDER {
+            let mut matching = obligations
+                .iter()
+                .filter(|obligation| obligation.kind() == *kind);
+            if let Some(first) = matching.next() {
+                if matching.next().is_some() {
+                    return Err(HostApiError::invariant(format!(
+                        "duplicate or conflicting {kind:?} obligations are not allowed"
+                    )));
+                }
+                normalized.push(first.clone());
+            }
+        }
+        Ok(Self(normalized))
+    }
+
+    pub fn empty() -> Self {
+        Self(Vec::new())
+    }
+
+    pub fn as_slice(&self) -> &[Obligation] {
+        &self.0
+    }
+
+    pub fn into_vec(self) -> Vec<Obligation> {
+        self.0
+    }
+}
+
+impl Default for Obligations {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
+impl<'de> Deserialize<'de> for Obligations {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let obligations = Vec::<Obligation>::deserialize(deserializer)?;
+        Self::new(obligations).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Obligation {
+    pub fn kind(&self) -> ObligationKind {
+        match self {
+            Self::AuditBefore => ObligationKind::AuditBefore,
+            Self::AuditAfter => ObligationKind::AuditAfter,
+            Self::RedactOutput => ObligationKind::RedactOutput,
+            Self::ReserveResources { .. } => ObligationKind::ReserveResources,
+            Self::UseScopedMounts { .. } => ObligationKind::UseScopedMounts,
+            Self::InjectSecretOnce { .. } => ObligationKind::InjectSecretOnce,
+            Self::ApplyNetworkPolicy { .. } => ObligationKind::ApplyNetworkPolicy,
+            Self::EnforceOutputLimit { .. } => ObligationKind::EnforceOutputLimit,
+        }
+    }
 }

--- a/crates/ironclaw_host_api/src/decision.rs
+++ b/crates/ironclaw_host_api/src/decision.rs
@@ -1,0 +1,60 @@
+//! Authorization decision contracts.
+//!
+//! [`Decision`] is the host-facing result of evaluating an action in context:
+//! allow with required [`Obligation`]s, deny with a structured [`DenyReason`],
+//! or require a user approval request. Allowing an action is not enough by
+//! itself; runtime services must also satisfy attached obligations such as
+//! resource reservation, audit events, output limits, secret injection, and
+//! scoped mounts.
+
+use serde::{Deserialize, Serialize};
+
+use crate::ApprovalRequest;
+use crate::{MountView, NetworkPolicy, ResourceReservationId, SecretHandle};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Decision {
+    Allow { obligations: Vec<Obligation> },
+    Deny { reason: DenyReason },
+    RequireApproval { request: ApprovalRequest },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DenyReason {
+    MissingGrant,
+    InvalidPath,
+    PathOutsideMount,
+    UnknownCapability,
+    UnknownSecret,
+    NetworkDenied,
+    BudgetDenied,
+    ApprovalDenied,
+    PolicyDenied,
+    ResourceLimitExceeded,
+    InternalInvariantViolation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum Obligation {
+    AuditBefore,
+    AuditAfter,
+    RedactOutput,
+    ReserveResources {
+        reservation_id: ResourceReservationId,
+    },
+    UseScopedMounts {
+        mounts: MountView,
+    },
+    InjectSecretOnce {
+        handle: SecretHandle,
+    },
+    ApplyNetworkPolicy {
+        policy: NetworkPolicy,
+    },
+    EnforceOutputLimit {
+        bytes: u64,
+    },
+}

--- a/crates/ironclaw_host_api/src/dispatch.rs
+++ b/crates/ironclaw_host_api/src/dispatch.rs
@@ -1,0 +1,137 @@
+//! Neutral capability dispatch port contracts.
+//!
+//! These types describe an already-authorized capability dispatch request and
+//! normalized runtime result. Concrete dispatcher/runtime crates implement the
+//! behavior; caller-facing workflow crates depend only on this neutral port.
+
+use async_trait::async_trait;
+use serde_json::Value;
+use thiserror::Error;
+
+use crate::{
+    CapabilityId, ExtensionId, MountView, ResourceEstimate, ResourceReceipt, ResourceReservation,
+    ResourceScope, ResourceUsage, RuntimeKind,
+};
+
+/// Request for one already-authorized declared capability dispatch.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CapabilityDispatchRequest {
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+    pub mounts: Option<MountView>,
+    pub resource_reservation: Option<ResourceReservation>,
+    pub input: Value,
+}
+
+/// Normalized dispatch result returned by a runtime dispatcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapabilityDispatchResult {
+    pub capability_id: CapabilityId,
+    pub provider: ExtensionId,
+    pub runtime: RuntimeKind,
+    pub output: Value,
+    pub usage: ResourceUsage,
+    pub receipt: ResourceReceipt,
+}
+
+/// Stable, redacted runtime failure categories surfaced through the dispatch port.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RuntimeDispatchErrorKind {
+    Backend,
+    Client,
+    Executor,
+    ExitFailure,
+    ExtensionRuntimeMismatch,
+    FilesystemDenied,
+    Guest,
+    InputEncode,
+    InvalidResult,
+    Manifest,
+    Memory,
+    MethodMissing,
+    NetworkDenied,
+    OutputDecode,
+    OutputTooLarge,
+    Resource,
+    UndeclaredCapability,
+    UnsupportedRunner,
+    Unknown,
+}
+
+impl RuntimeDispatchErrorKind {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Backend => "Backend",
+            Self::Client => "Client",
+            Self::Executor => "Executor",
+            Self::ExitFailure => "ExitFailure",
+            Self::ExtensionRuntimeMismatch => "ExtensionRuntimeMismatch",
+            Self::FilesystemDenied => "FilesystemDenied",
+            Self::Guest => "Guest",
+            Self::InputEncode => "InputEncode",
+            Self::InvalidResult => "InvalidResult",
+            Self::Manifest => "Manifest",
+            Self::Memory => "Memory",
+            Self::MethodMissing => "MethodMissing",
+            Self::NetworkDenied => "NetworkDenied",
+            Self::OutputDecode => "OutputDecode",
+            Self::OutputTooLarge => "OutputTooLarge",
+            Self::Resource => "Resource",
+            Self::UndeclaredCapability => "UndeclaredCapability",
+            Self::UnsupportedRunner => "UnsupportedRunner",
+            Self::Unknown => "Unknown",
+        }
+    }
+}
+
+impl std::fmt::Display for RuntimeDispatchErrorKind {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Runtime dispatch failures surfaced through the neutral host API port.
+#[derive(Debug, Error)]
+pub enum DispatchError {
+    #[error("unknown capability {capability}")]
+    UnknownCapability { capability: CapabilityId },
+    #[error("capability {capability} provider {provider} is not registered")]
+    UnknownProvider {
+        capability: CapabilityId,
+        provider: ExtensionId,
+    },
+    #[error(
+        "capability {capability} descriptor runtime {descriptor_runtime:?} does not match package runtime {package_runtime:?}"
+    )]
+    RuntimeMismatch {
+        capability: CapabilityId,
+        descriptor_runtime: RuntimeKind,
+        package_runtime: RuntimeKind,
+    },
+    #[error("runtime backend {runtime:?} is not configured")]
+    MissingRuntimeBackend { runtime: RuntimeKind },
+    #[error(
+        "runtime {runtime:?} is recognized but not supported by this dispatcher yet for capability {capability}"
+    )]
+    UnsupportedRuntime {
+        capability: CapabilityId,
+        runtime: RuntimeKind,
+    },
+    #[error("MCP dispatch failed: {kind}")]
+    Mcp { kind: RuntimeDispatchErrorKind },
+    #[error("script dispatch failed: {kind}")]
+    Script { kind: RuntimeDispatchErrorKind },
+    #[error("WASM dispatch failed: {kind}")]
+    Wasm { kind: RuntimeDispatchErrorKind },
+}
+
+/// Interface for already-authorized runtime dispatch.
+#[async_trait]
+pub trait CapabilityDispatcher: Send + Sync {
+    /// Dispatches one already-authorized JSON capability request and must not perform caller-facing authorization or approval resolution.
+    async fn dispatch_json(
+        &self,
+        request: CapabilityDispatchRequest,
+    ) -> Result<CapabilityDispatchResult, DispatchError>;
+}

--- a/crates/ironclaw_host_api/src/error.rs
+++ b/crates/ironclaw_host_api/src/error.rs
@@ -1,0 +1,67 @@
+//! Host API validation errors.
+//!
+//! [`HostApiError`] reports invalid contract values: malformed identifiers,
+//! paths, mounts, network targets, and invariant violations. It is deliberately
+//! not a service/runtime error type. Filesystem, resources, auth, network, and
+//! runtime crates should wrap these errors when validation failures surface
+//! through their APIs.
+
+use thiserror::Error;
+
+/// Contract validation failures for host API value types.
+///
+/// Service crates should wrap this in their own error types for runtime
+/// failures. This error is only about invalid contract values.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum HostApiError {
+    #[error("invalid {kind} id '{value}': {reason}")]
+    InvalidId {
+        kind: &'static str,
+        value: String,
+        reason: String,
+    },
+    #[error("invalid path '{value}': {reason}")]
+    InvalidPath { value: String, reason: String },
+    #[error("invalid capability '{value}': {reason}")]
+    InvalidCapability { value: String, reason: String },
+    #[error("invalid mount '{value}': {reason}")]
+    InvalidMount { value: String, reason: String },
+    #[error("invalid network target '{value}': {reason}")]
+    InvalidNetworkTarget { value: String, reason: String },
+    #[error("host API invariant violation: {reason}")]
+    InvariantViolation { reason: String },
+}
+
+impl HostApiError {
+    pub(crate) fn invalid_id(
+        kind: &'static str,
+        value: impl Into<String>,
+        reason: impl Into<String>,
+    ) -> Self {
+        Self::InvalidId {
+            kind,
+            value: value.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub(crate) fn invalid_path(value: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidPath {
+            value: value.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub(crate) fn invalid_mount(value: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::InvalidMount {
+            value: value.into(),
+            reason: reason.into(),
+        }
+    }
+
+    pub(crate) fn invariant(reason: impl Into<String>) -> Self {
+        Self::InvariantViolation {
+            reason: reason.into(),
+        }
+    }
+}

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -99,8 +99,7 @@ fn validate_name_segment(kind: &'static str, value: &str) -> Result<(), HostApiE
 
 macro_rules! string_id {
     ($name:ident, $kind:literal, $validator:ident) => {
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-        #[serde(transparent)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash)]
         pub struct $name(String);
 
         impl $name {
@@ -122,6 +121,25 @@ macro_rules! string_id {
         impl std::fmt::Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
                 f.write_str(&self.0)
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: serde::Serializer,
+            {
+                serializer.serialize_str(&self.0)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde::Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
             }
         }
     };
@@ -173,9 +191,13 @@ string_id!(MissionId, "mission", validate_scope_id);
 string_id!(ThreadId, "thread", validate_scope_id);
 string_id!(ExtensionId, "extension", validate_name_segment);
 string_id!(SecretHandle, "secret", validate_name_segment);
+string_id!(SystemServiceId, "system_service", validate_name_segment);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
+/// Extension-prefixed capability identifier.
+///
+/// Capability IDs require at least two dot-separated segments and may use
+/// additional segments for namespacing, e.g. `github.issues.search`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CapabilityId(String);
 
 impl CapabilityId {
@@ -185,7 +207,7 @@ impl CapabilityId {
             return Err(HostApiError::invalid_id(
                 "capability",
                 value,
-                "must be '<extension>.<capability>'",
+                "must be '<extension>.<capability>[.<sub>...]'",
             ));
         }
         if value.split('.').count() < 2 || value.split('.').any(str::is_empty) {
@@ -213,6 +235,25 @@ impl CapabilityId {
 impl std::fmt::Display for CapabilityId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.0)
+    }
+}
+
+impl Serialize for CapabilityId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for CapabilityId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
     }
 }
 

--- a/crates/ironclaw_host_api/src/ids.rs
+++ b/crates/ironclaw_host_api/src/ids.rs
@@ -1,0 +1,225 @@
+//! Authority-bearing identifier contracts.
+//!
+//! This module defines the newtypes used to prevent stringly-typed authority
+//! flow: tenant/user/agent/project/thread scope IDs, extension and capability IDs,
+//! secret handles, and UUID-backed invocation/process/grant/reservation/audit
+//! IDs. Constructors validate path-adjacent strings so invalid names cannot be
+//! smuggled into manifests, mount paths, approvals, or audit records.
+
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::HostApiError;
+
+fn has_forbidden_control(value: &str) -> bool {
+    value.chars().any(|c| c == '\0' || c.is_control())
+}
+
+fn validate_scope_id(kind: &'static str, value: &str) -> Result<(), HostApiError> {
+    if value.is_empty() {
+        return Err(HostApiError::invalid_id(kind, value, "must not be empty"));
+    }
+    if value.len() > 256 {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "must be at most 256 bytes",
+        ));
+    }
+    if value == "." || value == ".." {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "dot segments are not allowed",
+        ));
+    }
+    if value.contains('/') || value.contains('\\') {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "path separators are not allowed",
+        ));
+    }
+    if has_forbidden_control(value) {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "NUL/control characters are not allowed",
+        ));
+    }
+    Ok(())
+}
+
+fn is_name_char(byte: u8) -> bool {
+    byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'_' || byte == b'-'
+}
+
+fn validate_name_segment(kind: &'static str, value: &str) -> Result<(), HostApiError> {
+    if value.is_empty() {
+        return Err(HostApiError::invalid_id(kind, value, "must not be empty"));
+    }
+    if value.len() > 128 {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "must be at most 128 bytes",
+        ));
+    }
+    let first = value.as_bytes()[0];
+    if !(first.is_ascii_lowercase() || first.is_ascii_digit()) {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "must start with lowercase ASCII letter or digit",
+        ));
+    }
+    if value == "." || value == ".." || value.contains("..") {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "dot-dot segments are not allowed",
+        ));
+    }
+    if value.bytes().any(|b| !(is_name_char(b) || b == b'.')) {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "only lowercase ASCII letters, digits, '_', '-', and '.' are allowed",
+        ));
+    }
+    if value.split('.').any(str::is_empty) {
+        return Err(HostApiError::invalid_id(
+            kind,
+            value,
+            "empty dot segments are not allowed",
+        ));
+    }
+    Ok(())
+}
+
+macro_rules! string_id {
+    ($name:ident, $kind:literal, $validator:ident) => {
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+                let value = value.into();
+                $validator($kind, &value)?;
+                Ok(Self(value))
+            }
+
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+    };
+}
+
+macro_rules! uuid_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(Uuid);
+
+        impl $name {
+            pub fn new() -> Self {
+                Self(Uuid::new_v4())
+            }
+
+            pub fn from_uuid(value: Uuid) -> Self {
+                Self(value)
+            }
+
+            pub fn parse(value: &str) -> Result<Self, uuid::Error> {
+                Uuid::parse_str(value).map(Self)
+            }
+
+            pub fn as_uuid(&self) -> Uuid {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
+}
+
+string_id!(TenantId, "tenant", validate_scope_id);
+string_id!(UserId, "user", validate_scope_id);
+string_id!(AgentId, "agent", validate_scope_id);
+string_id!(ProjectId, "project", validate_scope_id);
+string_id!(MissionId, "mission", validate_scope_id);
+string_id!(ThreadId, "thread", validate_scope_id);
+string_id!(ExtensionId, "extension", validate_name_segment);
+string_id!(SecretHandle, "secret", validate_name_segment);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CapabilityId(String);
+
+impl CapabilityId {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let value = value.into();
+        if value.is_empty() || !value.contains('.') {
+            return Err(HostApiError::invalid_id(
+                "capability",
+                value,
+                "must be '<extension>.<capability>'",
+            ));
+        }
+        if value.split('.').count() < 2 || value.split('.').any(str::is_empty) {
+            return Err(HostApiError::invalid_id(
+                "capability",
+                value,
+                "empty dot segments are not allowed",
+            ));
+        }
+        for segment in value.split('.') {
+            validate_name_segment("capability", segment)?;
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub fn into_string(self) -> String {
+        self.0
+    }
+}
+
+impl std::fmt::Display for CapabilityId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+uuid_id!(InvocationId);
+uuid_id!(ProcessId);
+uuid_id!(CapabilityGrantId);
+uuid_id!(ResourceReservationId);
+uuid_id!(ApprovalRequestId);
+uuid_id!(AuditEventId);
+uuid_id!(CorrelationId);

--- a/crates/ironclaw_host_api/src/lib.rs
+++ b/crates/ironclaw_host_api/src/lib.rs
@@ -1,0 +1,56 @@
+//! Shared host API contracts for IronClaw Reborn.
+//!
+//! `ironclaw_host_api` is the vocabulary every Reborn system-service crate uses
+//! to describe authority: who is acting, which extension/runtime is acting, what
+//! filesystem mounts are visible, which capabilities were granted, what resources
+//! may be spent, what action is requested, and what decision/obligations the host
+//! produced.
+//!
+//! This crate intentionally contains authority-bearing types, validation, and
+//! serialization contracts only. Runtime behavior belongs in system-service
+//! crates such as filesystem, resources, extensions, WASM, MCP, auth, network,
+//! and kernel.
+//!
+//! The main contract groups are:
+//!
+//! - [`ids`]: validated identity, scope, extension, capability, and audit IDs.
+//! - [`path`] and [`mount`]: host-internal paths, virtual durable paths, scoped
+//!   runtime paths, and mount permissions.
+//! - [`scope`]: [`ExecutionContext`], the authority envelope for one invocation.
+//! - [`capability`]: capability descriptors and grants; declarations do not grant
+//!   authority by themselves.
+//! - [`action`], [`decision`], and [`approval`]: normalized requested effects,
+//!   host decisions, obligations, and approval scopes.
+//! - [`resource`]: budget/resource scopes, estimates, usage, and quota contracts.
+//! - [`audit`]: redacted durable audit envelope shapes.
+
+pub mod action;
+pub mod approval;
+pub mod audit;
+pub mod capability;
+pub mod decision;
+pub mod dispatch;
+pub mod error;
+pub mod ids;
+pub mod mount;
+pub mod path;
+pub mod resource;
+pub mod runtime;
+pub mod scope;
+
+pub use action::*;
+pub use approval::*;
+pub use audit::*;
+pub use capability::*;
+pub use decision::*;
+pub use dispatch::*;
+pub use error::*;
+pub use ids::*;
+pub use mount::*;
+pub use path::*;
+pub use resource::*;
+pub use runtime::*;
+pub use scope::*;
+
+/// Canonical timestamp type for host API wire contracts.
+pub type Timestamp = chrono::DateTime<chrono::Utc>;

--- a/crates/ironclaw_host_api/src/lib.rs
+++ b/crates/ironclaw_host_api/src/lib.rs
@@ -38,6 +38,9 @@ pub mod resource;
 pub mod runtime;
 pub mod scope;
 
+// Flat re-exports are intentional: downstream Reborn service crates consume
+// `ironclaw_host_api` as a contract prelude, while module docs remain the
+// authoritative grouping for each vocabulary family.
 pub use action::*;
 pub use approval::*;
 pub use audit::*;

--- a/crates/ironclaw_host_api/src/mount.rs
+++ b/crates/ironclaw_host_api/src/mount.rs
@@ -1,0 +1,135 @@
+//! Mount view contracts for scoped filesystem authority.
+//!
+//! A [`MountView`] is the filesystem authority visible to one execution
+//! context. It maps extension-facing aliases such as `/workspace` or
+//! `/extension/state` to canonical [`VirtualPath`] roots with explicit
+//! [`MountPermissions`]. Resolution is lexical and fail-closed; backend-specific
+//! symlink and storage containment checks belong in `ironclaw_filesystem`.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{HostApiError, MountAlias, ScopedPath, VirtualPath};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MountPermissions {
+    pub read: bool,
+    pub write: bool,
+    pub delete: bool,
+    pub list: bool,
+    pub execute: bool,
+}
+
+impl MountPermissions {
+    pub fn none() -> Self {
+        Self {
+            read: false,
+            write: false,
+            delete: false,
+            list: false,
+            execute: false,
+        }
+    }
+
+    pub fn read_only() -> Self {
+        Self {
+            read: true,
+            write: false,
+            delete: false,
+            list: true,
+            execute: false,
+        }
+    }
+
+    pub fn read_write() -> Self {
+        Self {
+            read: true,
+            write: true,
+            delete: false,
+            list: true,
+            execute: false,
+        }
+    }
+
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        (!self.read || parent.read)
+            && (!self.write || parent.write)
+            && (!self.delete || parent.delete)
+            && (!self.list || parent.list)
+            && (!self.execute || parent.execute)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MountGrant {
+    pub alias: MountAlias,
+    pub target: VirtualPath,
+    pub permissions: MountPermissions,
+}
+
+impl MountGrant {
+    pub fn new(alias: MountAlias, target: VirtualPath, permissions: MountPermissions) -> Self {
+        Self {
+            alias,
+            target,
+            permissions,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MountView {
+    pub mounts: Vec<MountGrant>,
+}
+
+impl MountView {
+    pub fn new(mounts: Vec<MountGrant>) -> Result<Self, HostApiError> {
+        let view = Self { mounts };
+        view.validate()?;
+        Ok(view)
+    }
+
+    pub fn validate(&self) -> Result<(), HostApiError> {
+        let mut seen = std::collections::HashSet::new();
+        for mount in &self.mounts {
+            if !seen.insert(mount.alias.as_str()) {
+                return Err(HostApiError::invalid_mount(
+                    mount.alias.as_str(),
+                    "duplicate mount alias",
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    pub fn resolve(&self, path: &ScopedPath) -> Result<VirtualPath, HostApiError> {
+        let raw = path.as_str();
+        let mount = self
+            .mounts
+            .iter()
+            .filter(|mount| alias_matches(mount.alias.as_str(), raw))
+            .max_by_key(|mount| mount.alias.as_str().len())
+            .ok_or_else(|| {
+                HostApiError::invalid_mount(raw, "no mount alias matches scoped path")
+            })?;
+
+        let tail = raw
+            .strip_prefix(mount.alias.as_str())
+            .unwrap_or_default()
+            .trim_start_matches('/');
+        mount.target.join_tail(tail)
+    }
+
+    pub fn is_subset_of(&self, parent: &Self) -> bool {
+        self.mounts.iter().all(|child| {
+            parent.mounts.iter().any(|parent_mount| {
+                child.alias == parent_mount.alias
+                    && child.target.as_str() == parent_mount.target.as_str()
+                    && child.permissions.is_subset_of(&parent_mount.permissions)
+            })
+        })
+    }
+}
+
+fn alias_matches(alias: &str, path: &str) -> bool {
+    path == alias || path.starts_with(&format!("{alias}/"))
+}

--- a/crates/ironclaw_host_api/src/mount.rs
+++ b/crates/ironclaw_host_api/src/mount.rs
@@ -119,6 +119,13 @@ impl MountView {
         mount.target.join_tail(tail)
     }
 
+    /// Returns true when every child mount is present in the parent with the
+    /// same alias and exact same target plus no broader permissions.
+    ///
+    /// V1 intentionally does not treat a narrower child target (for example, a
+    /// child `/workspace -> /projects/p1/subdir`) as a subset of a parent
+    /// `/workspace -> /projects/p1`; callers must issue an explicit mount for
+    /// each delegated target.
     pub fn is_subset_of(&self, parent: &Self) -> bool {
         self.mounts.iter().all(|child| {
             parent.mounts.iter().any(|parent_mount| {

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -1,0 +1,192 @@
+//! Path contracts for host, virtual, and scoped namespaces.
+//!
+//! Reborn separates physical host paths from the paths exposed to extensions.
+//! [`HostPath`] is backend-internal and intentionally not serializable.
+//! [`VirtualPath`] names canonical durable roots such as `/projects` or
+//! `/system/extensions`. [`ScopedPath`] is what runtimes receive through a
+//! [`MountView`](crate::MountView), such as `/workspace/README.md`. This split is
+//! a core containment invariant.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::HostApiError;
+
+/// Physical host/backend path. This type is intentionally not serializable.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HostPath(PathBuf);
+
+impl HostPath {
+    pub fn from_path_buf(path: PathBuf) -> Self {
+        Self(path)
+    }
+
+    pub fn as_path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct VirtualPath(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ScopedPath(String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct MountAlias(String);
+
+const VIRTUAL_ROOTS: &[&str] = &[
+    "/engine",
+    "/system/extensions",
+    "/users",
+    "/projects",
+    "/memory",
+];
+
+const RAW_HOST_PREFIXES: &[&str] = &[
+    "/Users/",
+    "/home/",
+    "/etc/",
+    "/var/",
+    "/private/",
+    "/Volumes/",
+];
+
+impl VirtualPath {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let normalized = normalize_absolute_path(value.into(), PathKind::Virtual)?;
+        if !VIRTUAL_ROOTS
+            .iter()
+            .any(|root| normalized == *root || normalized.starts_with(&format!("{root}/")))
+        {
+            return Err(HostApiError::invalid_path(
+                normalized,
+                "virtual path must begin with a known root",
+            ));
+        }
+        Ok(Self(normalized))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    pub(crate) fn join_tail(&self, tail: &str) -> Result<Self, HostApiError> {
+        if tail.is_empty() {
+            return Ok(self.clone());
+        }
+        Self::new(format!("{}/{}", self.0.trim_end_matches('/'), tail))
+    }
+}
+
+impl ScopedPath {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let raw = value.into();
+        if looks_like_url(&raw) {
+            return Err(HostApiError::invalid_path(raw, "URLs are not scoped paths"));
+        }
+        if looks_like_windows_path(&raw) {
+            return Err(HostApiError::invalid_path(
+                raw,
+                "Windows host paths are not scoped paths",
+            ));
+        }
+        if RAW_HOST_PREFIXES
+            .iter()
+            .any(|prefix| raw.starts_with(prefix))
+        {
+            return Err(HostApiError::invalid_path(
+                raw,
+                "raw host paths are not scoped paths",
+            ));
+        }
+        let normalized = normalize_absolute_path(raw, PathKind::Scoped)?;
+        Ok(Self(normalized))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl MountAlias {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let normalized = normalize_absolute_path(value.into(), PathKind::MountAlias)?;
+        Ok(Self(normalized))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum PathKind {
+    Virtual,
+    Scoped,
+    MountAlias,
+}
+
+fn normalize_absolute_path(raw: String, kind: PathKind) -> Result<String, HostApiError> {
+    if raw.is_empty() {
+        return Err(HostApiError::invalid_path(raw, "path must not be empty"));
+    }
+    if raw.contains('\0') || raw.chars().any(char::is_control) {
+        return Err(HostApiError::invalid_path(
+            raw,
+            "NUL/control characters are not allowed",
+        ));
+    }
+    if raw.contains('\\') {
+        return Err(HostApiError::invalid_path(
+            raw,
+            "backslashes are not allowed",
+        ));
+    }
+    if !raw.starts_with('/') {
+        return Err(HostApiError::invalid_path(raw, "path must be absolute"));
+    }
+
+    let mut parts = Vec::new();
+    for part in raw.split('/') {
+        match part {
+            "" | "." => {}
+            ".." => {
+                return Err(HostApiError::invalid_path(
+                    raw,
+                    "`..` segments are not allowed",
+                ));
+            }
+            part => parts.push(part),
+        }
+    }
+
+    if parts.is_empty() {
+        return Err(HostApiError::invalid_path(
+            raw,
+            "root path is not valid here",
+        ));
+    }
+
+    let normalized = format!("/{}", parts.join("/"));
+    if matches!(kind, PathKind::MountAlias) && normalized.ends_with('/') {
+        return Err(HostApiError::invalid_path(
+            normalized,
+            "mount alias must not end with slash",
+        ));
+    }
+    Ok(normalized)
+}
+
+fn looks_like_url(value: &str) -> bool {
+    value.contains("://")
+}
+
+fn looks_like_windows_path(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 3 && bytes[1] == b':' && (bytes[2] == b'\\' || bytes[2] == b'/')
+}

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -7,6 +7,7 @@
 //! [`MountView`](crate::MountView), such as `/workspace/README.md`. This split is
 //! a core containment invariant.
 
+use std::fmt;
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -14,8 +15,14 @@ use serde::{Deserialize, Serialize};
 use crate::HostApiError;
 
 /// Physical host/backend path. This type is intentionally not serializable.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct HostPath(PathBuf);
+
+impl fmt::Debug for HostPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("HostPath(<redacted>)")
+    }
+}
 
 impl HostPath {
     pub fn from_path_buf(path: PathBuf) -> Self {
@@ -27,16 +34,13 @@ impl HostPath {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VirtualPath(String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ScopedPath(String);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MountAlias(String);
 
 const VIRTUAL_ROOTS: &[&str] = &[
@@ -47,14 +51,84 @@ const VIRTUAL_ROOTS: &[&str] = &[
     "/memory",
 ];
 
+/// Common raw host-path prefixes rejected before scoped-path normalization.
+///
+/// This is a defense-in-depth heuristic for obvious host paths at the host API
+/// boundary. Authoritative containment still belongs to `ironclaw_filesystem`
+/// and backend-specific mount resolution; do not treat this list as the complete
+/// sandbox boundary.
 const RAW_HOST_PREFIXES: &[&str] = &[
     "/Users/",
     "/home/",
+    "/root/",
     "/etc/",
     "/var/",
     "/private/",
     "/Volumes/",
+    "/Library/",
+    "/usr/",
+    "/opt/",
+    "/tmp/", // safety: host-path prefix literal, not temp file creation
+    "/proc/",
+    "/sys/",
 ];
+
+impl Serialize for VirtualPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for VirtualPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for ScopedPath {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for ScopedPath {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for MountAlias {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for MountAlias {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
+    }
+}
 
 impl VirtualPath {
     pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {

--- a/crates/ironclaw_host_api/src/resource.rs
+++ b/crates/ironclaw_host_api/src/resource.rs
@@ -1,0 +1,129 @@
+//! Resource scope, estimate, usage, and quota contracts.
+//!
+//! `ironclaw_resources` owns enforcement, but this module defines the shared
+//! shapes used by callers and audit records. [`ResourceScope`] captures the
+//! tenant/user/agent/project/mission/thread/invocation cascade. [`ResourceEstimate`]
+//! and [`ResourceUsage`] describe budgeted work, while [`SandboxQuota`] and
+//! [`ResourceCeiling`] describe runtime limits that sandbox providers enforce.
+
+use rust_decimal::Decimal;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AgentId, HostApiError, InvocationId, MissionId, ProjectId, TenantId, ThreadId, UserId,
+};
+
+/// Canonical local/single-user tenant id.
+pub const LOCAL_DEFAULT_TENANT_ID: &str = "default";
+/// Canonical local/single-user default agent id.
+pub const LOCAL_DEFAULT_AGENT_ID: &str = "default";
+/// Canonical local/single-user default bootstrap project id.
+pub const LOCAL_DEFAULT_PROJECT_ID: &str = "bootstrap";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceScope {
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
+    pub project_id: Option<ProjectId>,
+    pub mission_id: Option<MissionId>,
+    pub thread_id: Option<ThreadId>,
+    pub invocation_id: InvocationId,
+}
+
+impl ResourceScope {
+    /// Build the canonical local/single-user scope.
+    ///
+    /// This intentionally uses concrete `default` tenant/agent ids and the
+    /// `bootstrap` project. Optional `None` scopes remain reserved for
+    /// deliberately unscoped/shared records, not for the normal local default.
+    pub fn local_default(
+        user_id: UserId,
+        invocation_id: InvocationId,
+    ) -> Result<Self, HostApiError> {
+        Ok(Self {
+            tenant_id: TenantId::new(LOCAL_DEFAULT_TENANT_ID)?,
+            user_id,
+            agent_id: Some(AgentId::new(LOCAL_DEFAULT_AGENT_ID)?),
+            project_id: Some(ProjectId::new(LOCAL_DEFAULT_PROJECT_ID)?),
+            mission_id: None,
+            thread_id: None,
+            invocation_id,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceEstimate {
+    pub usd: Option<Decimal>,
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub wall_clock_ms: Option<u64>,
+    pub output_bytes: Option<u64>,
+    pub network_egress_bytes: Option<u64>,
+    pub process_count: Option<u32>,
+    pub concurrency_slots: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceUsage {
+    pub usd: Decimal,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub wall_clock_ms: u64,
+    pub output_bytes: u64,
+    pub network_egress_bytes: u64,
+    pub process_count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceProfile {
+    pub default_estimate: ResourceEstimate,
+    pub hard_ceiling: Option<ResourceCeiling>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceCeiling {
+    pub max_usd: Option<Decimal>,
+    pub max_input_tokens: Option<u64>,
+    pub max_output_tokens: Option<u64>,
+    pub max_wall_clock_ms: Option<u64>,
+    pub max_output_bytes: Option<u64>,
+    pub sandbox: Option<SandboxQuota>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SandboxQuota {
+    pub cpu_time_ms: Option<u64>,
+    pub memory_bytes: Option<u64>,
+    pub disk_bytes: Option<u64>,
+    pub network_egress_bytes: Option<u64>,
+    pub process_count: Option<u32>,
+}
+
+/// Active reservation returned by a resource governor.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceReservation {
+    pub id: crate::ResourceReservationId,
+    pub scope: ResourceScope,
+    pub estimate: ResourceEstimate,
+}
+
+/// Reservation lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReservationStatus {
+    Active,
+    Reconciled,
+    Released,
+}
+
+/// Receipt returned when a reservation is reconciled or released.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ResourceReceipt {
+    pub id: crate::ResourceReservationId,
+    pub scope: ResourceScope,
+    pub status: ReservationStatus,
+    pub estimate: ResourceEstimate,
+    pub actual: Option<ResourceUsage>,
+}

--- a/crates/ironclaw_host_api/src/runtime.rs
+++ b/crates/ironclaw_host_api/src/runtime.rs
@@ -1,0 +1,28 @@
+//! Runtime and trust classification contracts.
+//!
+//! [`RuntimeKind`] identifies the execution lane required for a capability or
+//! invocation: WASM, MCP, script, first-party extension, or system service.
+//! [`TrustClass`] is an authority ceiling, not a grant. Even first-party and
+//! system contexts still need explicit mounts, capability grants, resource
+//! scopes, and audit obligations.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeKind {
+    Wasm,
+    Mcp,
+    Script,
+    FirstParty,
+    System,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TrustClass {
+    Sandbox,
+    UserTrusted,
+    FirstParty,
+    System,
+}

--- a/crates/ironclaw_host_api/src/runtime.rs
+++ b/crates/ironclaw_host_api/src/runtime.rs
@@ -5,6 +5,10 @@
 //! [`TrustClass`] is an authority ceiling, not a grant. Even first-party and
 //! system contexts still need explicit mounts, capability grants, resource
 //! scopes, and audit obligations.
+//!
+//! Privileged runtime/trust variants are host-assigned only. They serialize for
+//! audit and durable trusted records, but plain serde deserialization rejects
+//! them so untrusted manifests cannot self-assert first-party or system status.
 
 use serde::{Deserialize, Serialize};
 
@@ -14,7 +18,9 @@ pub enum RuntimeKind {
     Wasm,
     Mcp,
     Script,
+    #[serde(skip_deserializing)]
     FirstParty,
+    #[serde(skip_deserializing)]
     System,
 }
 
@@ -23,6 +29,8 @@ pub enum RuntimeKind {
 pub enum TrustClass {
     Sandbox,
     UserTrusted,
+    #[serde(skip_deserializing)]
     FirstParty,
+    #[serde(skip_deserializing)]
     System,
 }

--- a/crates/ironclaw_host_api/src/scope.rs
+++ b/crates/ironclaw_host_api/src/scope.rs
@@ -10,8 +10,8 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     AgentId, CapabilitySet, CorrelationId, ExtensionId, HostApiError, InvocationId, MissionId,
-    MountView, ProcessId, ProjectId, ResourceScope, RuntimeKind, TenantId, ThreadId, TrustClass,
-    UserId,
+    MountView, ProcessId, ProjectId, ResourceScope, RuntimeKind, SystemServiceId, TenantId,
+    ThreadId, TrustClass, UserId,
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -24,7 +24,10 @@ pub enum Principal {
     Mission(MissionId),
     Thread(ThreadId),
     Extension(ExtensionId),
-    System,
+    /// Host runtime internals acting on their own behalf. Never match this as a grantable userland principal.
+    HostRuntime,
+    /// Named trusted system service, such as heartbeat, routine engine, or migration runner.
+    System(SystemServiceId),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ironclaw_host_api/src/scope.rs
+++ b/crates/ironclaw_host_api/src/scope.rs
@@ -1,0 +1,130 @@
+//! Execution scope contracts.
+//!
+//! [`ExecutionContext`] is the authority envelope for one invocation. It ties
+//! together identity, tenancy, optional process/thread/mission/project context,
+//! runtime/trust class, capability grants, mount view, resource scope, and
+//! correlation ID. Every filesystem, resource, secret, network, dispatch, spawn,
+//! and audit decision should be traceable back to this context.
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    AgentId, CapabilitySet, CorrelationId, ExtensionId, HostApiError, InvocationId, MissionId,
+    MountView, ProcessId, ProjectId, ResourceScope, RuntimeKind, TenantId, ThreadId, TrustClass,
+    UserId,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type", content = "id")]
+pub enum Principal {
+    Tenant(TenantId),
+    User(UserId),
+    Agent(AgentId),
+    Project(ProjectId),
+    Mission(MissionId),
+    Thread(ThreadId),
+    Extension(ExtensionId),
+    System,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExecutionContext {
+    pub invocation_id: InvocationId,
+    pub correlation_id: CorrelationId,
+    pub process_id: Option<ProcessId>,
+    pub parent_process_id: Option<ProcessId>,
+
+    pub tenant_id: TenantId,
+    pub user_id: UserId,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_id: Option<AgentId>,
+    pub project_id: Option<ProjectId>,
+    pub mission_id: Option<MissionId>,
+    pub thread_id: Option<ThreadId>,
+
+    pub extension_id: ExtensionId,
+    pub runtime: RuntimeKind,
+    pub trust: TrustClass,
+
+    pub grants: CapabilitySet,
+    pub mounts: MountView,
+    pub resource_scope: ResourceScope,
+}
+
+impl ExecutionContext {
+    /// Build a local/single-user execution context using the canonical default
+    /// tenant, agent, and bootstrap project.
+    ///
+    /// Callers still supply extension/runtime/trust/grants/mounts because those
+    /// are product-workflow decisions; this helper only normalizes local scope.
+    pub fn local_default(
+        user_id: UserId,
+        extension_id: ExtensionId,
+        runtime: RuntimeKind,
+        trust: TrustClass,
+        grants: CapabilitySet,
+        mounts: MountView,
+    ) -> Result<Self, HostApiError> {
+        let invocation_id = InvocationId::new();
+        let resource_scope = ResourceScope::local_default(user_id.clone(), invocation_id)?;
+        let context = Self {
+            invocation_id,
+            correlation_id: CorrelationId::new(),
+            process_id: None,
+            parent_process_id: None,
+            tenant_id: resource_scope.tenant_id.clone(),
+            user_id,
+            agent_id: resource_scope.agent_id.clone(),
+            project_id: resource_scope.project_id.clone(),
+            mission_id: None,
+            thread_id: None,
+            extension_id,
+            runtime,
+            trust,
+            grants,
+            mounts,
+            resource_scope,
+        };
+        context.validate()?;
+        Ok(context)
+    }
+
+    pub fn validate(&self) -> Result<(), HostApiError> {
+        if self.resource_scope.invocation_id != self.invocation_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.invocation_id must match execution context invocation_id",
+            ));
+        }
+        if self.resource_scope.tenant_id != self.tenant_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.tenant_id must match execution context tenant_id",
+            ));
+        }
+        if self.resource_scope.user_id != self.user_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.user_id must match execution context user_id",
+            ));
+        }
+        if self.resource_scope.agent_id != self.agent_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.agent_id must match execution context agent_id",
+            ));
+        }
+        if self.resource_scope.project_id != self.project_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.project_id must match execution context project_id",
+            ));
+        }
+        if self.resource_scope.mission_id != self.mission_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.mission_id must match execution context mission_id",
+            ));
+        }
+        if self.resource_scope.thread_id != self.thread_id {
+            return Err(HostApiError::invariant(
+                "resource_scope.thread_id must match execution context thread_id",
+            ));
+        }
+        self.mounts.validate()
+    }
+}

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use ironclaw_host_api::*;
 use rust_decimal_macros::dec;
 use serde_json::json;
@@ -29,6 +31,9 @@ fn capability_id_requires_extension_prefixed_name() {
     let id = CapabilityId::new("github.search_issues").unwrap();
     assert_eq!(id.as_str(), "github.search_issues");
 
+    let nested = CapabilityId::new("github.issues.search").unwrap();
+    assert_eq!(nested.as_str(), "github.issues.search");
+
     for invalid in [
         "github",
         "github.",
@@ -40,6 +45,10 @@ fn capability_id_requires_extension_prefixed_name() {
         assert!(
             CapabilityId::new(invalid).is_err(),
             "{invalid:?} should be rejected"
+        );
+        assert!(
+            serde_json::from_value::<CapabilityId>(json!(invalid)).is_err(),
+            "{invalid:?} should also be rejected when deserialized"
         );
     }
 }
@@ -61,6 +70,10 @@ fn scope_ids_reject_path_segments_and_controls() {
         assert!(
             UserId::new(invalid).is_err(),
             "{invalid:?} should be rejected"
+        );
+        assert!(
+            serde_json::from_value::<UserId>(json!(invalid)).is_err(),
+            "{invalid:?} should also be rejected when deserialized"
         );
     }
 }
@@ -134,6 +147,8 @@ fn scoped_path_rejects_raw_host_paths_urls_and_traversal() {
         "file:///etc/passwd",
         "https://example.com/file",
         "/Users/alice/project",
+        "/opt/ironclaw/project",
+        "/tmp/ironclaw/project",
         "C:\\Users\\alice\\project",
         "/workspace/has\0nul",
     ] {
@@ -160,6 +175,19 @@ fn virtual_path_requires_known_root_and_rejects_traversal() {
             "{invalid:?} should be rejected"
         );
     }
+}
+
+#[test]
+fn host_path_debug_redacts_and_host_path_is_not_serializable() {
+    static_assertions::assert_not_impl_any!(HostPath: serde::Serialize);
+
+    let debug = format!(
+        "{:?}",
+        HostPath::from_path_buf(PathBuf::from("/Users/alice/private-secret"))
+    );
+    assert_eq!(debug, "HostPath(<redacted>)");
+    assert!(!debug.contains("alice"));
+    assert!(!debug.contains("private-secret"));
 }
 
 #[test]
@@ -190,7 +218,7 @@ fn mount_view_resolves_longest_alias_match() {
 }
 
 #[test]
-fn mount_view_denies_unknown_alias_and_broader_child_permissions() {
+fn mount_view_denies_unknown_alias_broader_permissions_and_narrower_targets() {
     let parent = MountView::new(vec![MountGrant::new(
         MountAlias::new("/workspace").unwrap(),
         VirtualPath::new("/projects/p1").unwrap(),
@@ -212,6 +240,32 @@ fn mount_view_denies_unknown_alias_and_broader_child_permissions() {
     .unwrap();
 
     assert!(!child.is_subset_of(&parent));
+
+    let narrower_child = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/p1/subdir").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+    assert!(!narrower_child.is_subset_of(&parent));
+}
+
+#[test]
+fn mount_view_traversal_is_rejected_before_or_during_resolution() {
+    let view = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/p1").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+
+    assert!(ScopedPath::new("/workspace/../secret").is_err());
+
+    assert!(serde_json::from_value::<ScopedPath>(json!("/workspace/../secret")).is_err());
+    assert!(
+        view.resolve(&ScopedPath::new("/workspace/file.txt").unwrap())
+            .is_ok()
+    );
 }
 
 #[test]
@@ -238,20 +292,27 @@ fn agent_id_is_first_class_optional_execution_scope() {
 #[test]
 fn audit_envelope_carries_agent_scope_without_leaking_payloads() {
     let ctx = sample_context_with_agent(Some("agent1"));
+    let action = Action::WriteFile {
+        path: ScopedPath::new("/workspace/secret.txt").unwrap(),
+        bytes: Some(12),
+    };
     let envelope = AuditEnvelope::denied(
         &ctx,
         AuditStage::Denied,
-        ActionSummary {
-            kind: "dispatch".to_string(),
-            target: Some("echo.say".to_string()),
-            effects: vec![EffectKind::DispatchCapability],
-        },
+        ActionSummary::from_action(&action),
         DenyReason::MissingGrant,
     );
 
     assert_eq!(envelope.agent_id, Some(AgentId::new("agent1").unwrap()));
+    assert_eq!(
+        envelope.action.target.as_deref(),
+        Some("/workspace/secret.txt")
+    );
     let json = serde_json::to_value(&envelope).unwrap();
     assert_eq!(json["agent_id"], "agent1");
+    let serialized = serde_json::to_string(&json).unwrap();
+    assert!(serialized.contains("/workspace/secret.txt"));
+    assert!(!serialized.contains("/Users/alice"));
     assert!(json.get("host_path").is_none());
 }
 
@@ -290,7 +351,7 @@ fn principal_agent_serializes_as_first_class_principal() {
 }
 
 #[test]
-fn invocation_fingerprint_is_stable_and_input_redacted() {
+fn invocation_fingerprint_is_stable_and_input_hashed() {
     let ctx = sample_context();
     let capability = CapabilityId::new("echo.say").unwrap();
     let estimate = ResourceEstimate {
@@ -406,6 +467,99 @@ fn actions_and_decisions_serialize_with_stable_snake_case_tags() {
     };
     let json = serde_json::to_value(&decision).unwrap();
     assert_eq!(json, json!({"type":"deny","reason":"missing_grant"}));
+}
+
+#[test]
+fn action_summaries_use_stable_snake_case_targets() {
+    let network = ActionSummary::from_action(&Action::Network {
+        target: NetworkTarget {
+            scheme: NetworkScheme::Https,
+            host: "api.example.com".to_string(),
+            port: Some(443),
+        },
+        method: NetworkMethod::Post,
+        estimated_bytes: None,
+    });
+    assert_eq!(network.target.as_deref(), Some("post:api.example.com:443"));
+
+    let secret = ActionSummary::from_action(&Action::UseSecret {
+        handle: SecretHandle::new("google_oauth").unwrap(),
+        mode: SecretUseMode::InjectIntoRequest,
+    });
+    assert_eq!(
+        secret.target.as_deref(),
+        Some("google_oauth:inject_into_request")
+    );
+
+    let extension = ActionSummary::from_action(&Action::ExtensionLifecycle {
+        extension_id: ExtensionId::new("github").unwrap(),
+        operation: ExtensionLifecycleOperation::Install,
+    });
+    assert_eq!(extension.target.as_deref(), Some("github:install"));
+}
+
+#[test]
+fn obligations_are_unique_and_canonicalized() {
+    let reservation_id = ResourceReservationId::new();
+    let obligations = Obligations::new(vec![
+        Obligation::AuditAfter,
+        Obligation::ReserveResources { reservation_id },
+        Obligation::AuditBefore,
+    ])
+    .unwrap();
+
+    assert_eq!(
+        obligations
+            .as_slice()
+            .iter()
+            .map(Obligation::kind)
+            .collect::<Vec<_>>(),
+        vec![
+            ObligationKind::ReserveResources,
+            ObligationKind::AuditBefore,
+            ObligationKind::AuditAfter,
+        ]
+    );
+
+    assert!(Obligations::new(vec![Obligation::AuditBefore, Obligation::AuditBefore]).is_err());
+
+    let duplicate_json = json!([
+        {"type":"audit_before"},
+        {"type":"audit_before"}
+    ]);
+    assert!(serde_json::from_value::<Obligations>(duplicate_json).is_err());
+}
+
+#[test]
+fn privileged_runtime_and_trust_classes_cannot_be_self_asserted_from_json() {
+    assert_eq!(
+        serde_json::from_value::<RuntimeKind>(json!("wasm")).unwrap(),
+        RuntimeKind::Wasm
+    );
+    assert_eq!(
+        serde_json::from_value::<TrustClass>(json!("sandbox")).unwrap(),
+        TrustClass::Sandbox
+    );
+
+    assert!(serde_json::from_value::<RuntimeKind>(json!("first_party")).is_err());
+    assert!(serde_json::from_value::<RuntimeKind>(json!("system")).is_err());
+    assert!(serde_json::from_value::<TrustClass>(json!("first_party")).is_err());
+    assert!(serde_json::from_value::<TrustClass>(json!("system")).is_err());
+}
+
+#[test]
+fn system_principals_distinguish_host_runtime_from_named_services() {
+    assert_eq!(
+        serde_json::to_value(Principal::HostRuntime).unwrap(),
+        json!({"type":"host_runtime"})
+    );
+    assert_eq!(
+        serde_json::to_value(Principal::System(
+            SystemServiceId::new("heartbeat").unwrap()
+        ))
+        .unwrap(),
+        json!({"type":"system","id":"heartbeat"})
+    );
 }
 
 #[test]

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -1,0 +1,477 @@
+use ironclaw_host_api::*;
+use rust_decimal_macros::dec;
+use serde_json::json;
+
+#[test]
+fn extension_id_rejects_path_like_or_uppercase_values() {
+    assert!(ExtensionId::new("github").is_ok());
+    assert!(ExtensionId::new("github-mcp.v1").is_ok());
+
+    for invalid in [
+        "",
+        "GitHub",
+        "../github",
+        "github/search",
+        "github\\search",
+        "github search",
+        "github\0search",
+        "github..search",
+    ] {
+        assert!(
+            ExtensionId::new(invalid).is_err(),
+            "{invalid:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn capability_id_requires_extension_prefixed_name() {
+    let id = CapabilityId::new("github.search_issues").unwrap();
+    assert_eq!(id.as_str(), "github.search_issues");
+
+    for invalid in [
+        "github",
+        "github.",
+        ".search",
+        "GitHub.search",
+        "github/search",
+        "github..search",
+    ] {
+        assert!(
+            CapabilityId::new(invalid).is_err(),
+            "{invalid:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn scope_ids_reject_path_segments_and_controls() {
+    assert!(TenantId::new("tenant_123").is_ok());
+    assert!(UserId::new("user-123").is_ok());
+
+    for invalid in [
+        "",
+        ".",
+        "..",
+        "user/name",
+        "user\\name",
+        "user\nname",
+        "user\0name",
+    ] {
+        assert!(
+            UserId::new(invalid).is_err(),
+            "{invalid:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn local_default_resource_scope_uses_default_agent_and_bootstrap_project() {
+    let invocation_id = InvocationId::new();
+    let scope = ResourceScope::local_default(UserId::new("alice").unwrap(), invocation_id).unwrap();
+
+    assert_eq!(LOCAL_DEFAULT_TENANT_ID, "default");
+    assert_eq!(LOCAL_DEFAULT_AGENT_ID, "default");
+    assert_eq!(LOCAL_DEFAULT_PROJECT_ID, "bootstrap");
+    assert_eq!(scope.tenant_id.as_str(), LOCAL_DEFAULT_TENANT_ID);
+    assert_eq!(scope.user_id.as_str(), "alice");
+    assert_eq!(
+        scope.agent_id.as_ref().map(AgentId::as_str),
+        Some(LOCAL_DEFAULT_AGENT_ID)
+    );
+    assert_eq!(
+        scope.project_id.as_ref().map(ProjectId::as_str),
+        Some(LOCAL_DEFAULT_PROJECT_ID)
+    );
+    assert_eq!(scope.invocation_id, invocation_id);
+    assert!(scope.mission_id.is_none());
+    assert!(scope.thread_id.is_none());
+}
+
+#[test]
+fn local_default_execution_context_keeps_scope_fields_aligned() {
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/bootstrap").unwrap(),
+        MountPermissions::read_write(),
+    )])
+    .unwrap();
+
+    let ctx = ExecutionContext::local_default(
+        UserId::new("alice").unwrap(),
+        ExtensionId::new("echo").unwrap(),
+        RuntimeKind::Wasm,
+        TrustClass::Sandbox,
+        CapabilitySet::default(),
+        mounts,
+    )
+    .unwrap();
+
+    ctx.validate().unwrap();
+    assert_eq!(ctx.tenant_id.as_str(), LOCAL_DEFAULT_TENANT_ID);
+    assert_eq!(
+        ctx.agent_id.as_ref().map(AgentId::as_str),
+        Some(LOCAL_DEFAULT_AGENT_ID)
+    );
+    assert_eq!(
+        ctx.project_id.as_ref().map(ProjectId::as_str),
+        Some(LOCAL_DEFAULT_PROJECT_ID)
+    );
+    assert_eq!(ctx.resource_scope.tenant_id, ctx.tenant_id);
+    assert_eq!(ctx.resource_scope.user_id, ctx.user_id);
+    assert_eq!(ctx.resource_scope.agent_id, ctx.agent_id);
+    assert_eq!(ctx.resource_scope.project_id, ctx.project_id);
+}
+
+#[test]
+fn scoped_path_rejects_raw_host_paths_urls_and_traversal() {
+    assert!(ScopedPath::new("/workspace/README.md").is_ok());
+    assert!(ScopedPath::new("/extension/state/db.json").is_ok());
+
+    for invalid in [
+        "relative/path",
+        "/workspace/../../secret",
+        "file:///etc/passwd",
+        "https://example.com/file",
+        "/Users/alice/project",
+        "C:\\Users\\alice\\project",
+        "/workspace/has\0nul",
+    ] {
+        assert!(
+            ScopedPath::new(invalid).is_err(),
+            "{invalid:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn virtual_path_requires_known_root_and_rejects_traversal() {
+    assert!(VirtualPath::new("/projects/p1/threads/t1").is_ok());
+    assert!(VirtualPath::new("/system/extensions/echo/state").is_ok());
+
+    for invalid in [
+        "/unknown/root",
+        "relative",
+        "/projects/../users/u1",
+        "file:///projects/p1",
+    ] {
+        assert!(
+            VirtualPath::new(invalid).is_err(),
+            "{invalid:?} should be rejected"
+        );
+    }
+}
+
+#[test]
+fn mount_view_resolves_longest_alias_match() {
+    let view = MountView::new(vec![
+        MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/p1").unwrap(),
+            MountPermissions::read_only(),
+        ),
+        MountGrant::new(
+            MountAlias::new("/workspace/docs").unwrap(),
+            VirtualPath::new("/projects/p1/documentation").unwrap(),
+            MountPermissions::read_write(),
+        ),
+    ])
+    .unwrap();
+
+    let resolved = view
+        .resolve(&ScopedPath::new("/workspace/docs/intro.md").unwrap())
+        .unwrap();
+    assert_eq!(resolved.as_str(), "/projects/p1/documentation/intro.md");
+
+    let resolved = view
+        .resolve(&ScopedPath::new("/workspace/src/lib.rs").unwrap())
+        .unwrap();
+    assert_eq!(resolved.as_str(), "/projects/p1/src/lib.rs");
+}
+
+#[test]
+fn mount_view_denies_unknown_alias_and_broader_child_permissions() {
+    let parent = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/p1").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+
+    assert!(
+        parent
+            .resolve(&ScopedPath::new("/memory/note.md").unwrap())
+            .is_err()
+    );
+
+    let child = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/p1").unwrap(),
+        MountPermissions::read_write(),
+    )])
+    .unwrap();
+
+    assert!(!child.is_subset_of(&parent));
+}
+
+#[test]
+fn execution_context_validation_rejects_mismatched_resource_scope() {
+    let ctx = sample_context();
+    assert!(ctx.validate().is_ok());
+
+    let mut mismatched = ctx.clone();
+    mismatched.resource_scope.user_id = UserId::new("other_user").unwrap();
+    assert!(mismatched.validate().is_err());
+}
+
+#[test]
+fn agent_id_is_first_class_optional_execution_scope() {
+    let mut ctx = sample_context_with_agent(Some("agent1"));
+    assert!(ctx.validate().is_ok());
+    assert_eq!(ctx.agent_id.as_ref().unwrap().as_str(), "agent1");
+    assert_eq!(ctx.resource_scope.agent_id, ctx.agent_id);
+
+    ctx.resource_scope.agent_id = Some(AgentId::new("other-agent").unwrap());
+    assert!(ctx.validate().is_err());
+}
+
+#[test]
+fn audit_envelope_carries_agent_scope_without_leaking_payloads() {
+    let ctx = sample_context_with_agent(Some("agent1"));
+    let envelope = AuditEnvelope::denied(
+        &ctx,
+        AuditStage::Denied,
+        ActionSummary {
+            kind: "dispatch".to_string(),
+            target: Some("echo.say".to_string()),
+            effects: vec![EffectKind::DispatchCapability],
+        },
+        DenyReason::MissingGrant,
+    );
+
+    assert_eq!(envelope.agent_id, Some(AgentId::new("agent1").unwrap()));
+    let json = serde_json::to_value(&envelope).unwrap();
+    assert_eq!(json["agent_id"], "agent1");
+    assert!(json.get("host_path").is_none());
+}
+
+#[test]
+fn invocation_fingerprint_changes_when_agent_scope_changes() {
+    let capability = CapabilityId::new("echo.say").unwrap();
+    let estimate = ResourceEstimate::default();
+    let input = json!({"message":"same"});
+    let agent_a = sample_context_with_agent(Some("agent-a"));
+    let agent_b = sample_context_with_agent(Some("agent-b"));
+
+    let first = InvocationFingerprint::for_dispatch(
+        &agent_a.resource_scope,
+        &capability,
+        &estimate,
+        &input,
+    )
+    .unwrap();
+    let second = InvocationFingerprint::for_dispatch(
+        &agent_b.resource_scope,
+        &capability,
+        &estimate,
+        &input,
+    )
+    .unwrap();
+
+    assert_ne!(first, second);
+}
+
+#[test]
+fn principal_agent_serializes_as_first_class_principal() {
+    let principal = Principal::Agent(AgentId::new("agent-a").unwrap());
+    let json = serde_json::to_value(&principal).unwrap();
+
+    assert_eq!(json, json!({"type":"agent","id":"agent-a"}));
+}
+
+#[test]
+fn invocation_fingerprint_is_stable_and_input_redacted() {
+    let ctx = sample_context();
+    let capability = CapabilityId::new("echo.say").unwrap();
+    let estimate = ResourceEstimate {
+        concurrency_slots: Some(1),
+        output_bytes: Some(10_000),
+        ..ResourceEstimate::default()
+    };
+    let input = json!({"message": "secret payload"});
+    let mut reordered = serde_json::Map::new();
+    reordered.insert("z".to_string(), json!(1));
+    reordered.insert("a".to_string(), json!({"b": 2, "a": 1}));
+
+    let first =
+        InvocationFingerprint::for_dispatch(&ctx.resource_scope, &capability, &estimate, &input)
+            .unwrap();
+    let second = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &capability,
+        &estimate,
+        &json!({"message": "secret payload"}),
+    )
+    .unwrap();
+    let canonical_first = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &capability,
+        &estimate,
+        &serde_json::Value::Object(reordered),
+    )
+    .unwrap();
+    let canonical_second = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &capability,
+        &estimate,
+        &json!({"a": {"a": 1, "b": 2}, "z": 1}),
+    )
+    .unwrap();
+
+    assert_eq!(first, second);
+    assert_eq!(canonical_first, canonical_second);
+    assert!(first.as_str().starts_with("sha256:"));
+    assert!(!first.as_str().contains("secret payload"));
+}
+
+#[test]
+fn invocation_fingerprint_changes_when_authorized_invocation_changes() {
+    let ctx = sample_context();
+    let capability = CapabilityId::new("echo.say").unwrap();
+    let estimate = ResourceEstimate::default();
+    let baseline = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &capability,
+        &estimate,
+        &json!({"message": "one"}),
+    )
+    .unwrap();
+
+    let changed_input = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &capability,
+        &estimate,
+        &json!({"message": "two"}),
+    )
+    .unwrap();
+    let changed_capability = InvocationFingerprint::for_dispatch(
+        &ctx.resource_scope,
+        &CapabilityId::new("echo.other").unwrap(),
+        &estimate,
+        &json!({"message": "one"}),
+    )
+    .unwrap();
+    let mut other_scope = ctx.resource_scope.clone();
+    other_scope.invocation_id = InvocationId::new();
+    let changed_scope = InvocationFingerprint::for_dispatch(
+        &other_scope,
+        &capability,
+        &estimate,
+        &json!({"message": "one"}),
+    )
+    .unwrap();
+
+    assert_ne!(baseline, changed_input);
+    assert_ne!(baseline, changed_capability);
+    assert_ne!(baseline, changed_scope);
+}
+
+#[test]
+fn actions_and_decisions_serialize_with_stable_snake_case_tags() {
+    let action = Action::Dispatch {
+        capability: CapabilityId::new("github.search_issues").unwrap(),
+        estimated_resources: ResourceEstimate {
+            usd: Some(dec!(0.01)),
+            ..ResourceEstimate::default()
+        },
+    };
+    let json = serde_json::to_value(&action).unwrap();
+    assert_eq!(json["type"], "dispatch");
+
+    let spawn = Action::SpawnCapability {
+        capability: CapabilityId::new("github.watch_issues").unwrap(),
+        estimated_resources: ResourceEstimate {
+            concurrency_slots: Some(1),
+            ..ResourceEstimate::default()
+        },
+    };
+    let json = serde_json::to_value(&spawn).unwrap();
+    assert_eq!(json["type"], "spawn_capability");
+    assert_eq!(json["capability"], "github.watch_issues");
+    assert!(json.get("extension_id").is_none());
+    assert!(json.get("requested_capabilities").is_none());
+
+    let decision = Decision::Deny {
+        reason: DenyReason::MissingGrant,
+    };
+    let json = serde_json::to_value(&decision).unwrap();
+    assert_eq!(json, json!({"type":"deny","reason":"missing_grant"}));
+}
+
+#[test]
+fn audit_envelope_serializes_redacted_summary_shape() {
+    let ctx = sample_context();
+    let envelope = AuditEnvelope::denied(
+        &ctx,
+        AuditStage::Denied,
+        ActionSummary {
+            kind: "dispatch".to_string(),
+            target: Some("github.search_issues".to_string()),
+            effects: vec![EffectKind::DispatchCapability],
+        },
+        DenyReason::MissingGrant,
+    );
+
+    let json = serde_json::to_value(&envelope).unwrap();
+    assert_eq!(json["stage"], "denied");
+    assert_eq!(json["decision"]["reason"], "missing_grant");
+    assert!(json.get("host_path").is_none());
+}
+
+fn sample_context_with_agent(agent: Option<&str>) -> ExecutionContext {
+    let mut ctx = sample_context();
+    let agent_id = agent.map(|id| AgentId::new(id).unwrap());
+    ctx.agent_id = agent_id.clone();
+    ctx.resource_scope.agent_id = agent_id;
+    ctx
+}
+
+fn sample_context() -> ExecutionContext {
+    let invocation_id = InvocationId::new();
+    let tenant_id = TenantId::new("tenant1").unwrap();
+    let user_id = UserId::new("user1").unwrap();
+    let extension_id = ExtensionId::new("echo").unwrap();
+    let project_id = ProjectId::new("project1").unwrap();
+
+    ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: tenant_id.clone(),
+        user_id: user_id.clone(),
+        agent_id: None,
+        project_id: Some(project_id.clone()),
+        mission_id: None,
+        thread_id: None,
+        extension_id,
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::Sandbox,
+        grants: CapabilitySet::default(),
+        mounts: MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+        resource_scope: ResourceScope {
+            tenant_id,
+            user_id,
+            agent_id: None,
+            project_id: Some(project_id),
+            mission_id: None,
+            thread_id: None,
+            invocation_id,
+        },
+    }
+}

--- a/crates/ironclaw_resources/CLAUDE.md
+++ b/crates/ironclaw_resources/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_resources guardrails
+
+- Own resource reservation, reconciliation, release, and quota accounting.
+- No costed or quota-limited work should execute without an active reservation or explicit documented exception.
+- Do not import runtimes, dispatcher, capabilities, approvals, processes, events, or product workflow crates.
+- Preserve tenant/user/project scope in every reservation and receipt.
+- Keep accounting deterministic and safe under concurrent reservations.

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ironclaw_resources"
 version = "0.1.0"
 edition = "2024"
+# Keep in sync with the workspace-level package.rust-version.
 rust-version = "1.92"
 description = "Resource reservation governor for IronClaw Reborn"
 authors = ["NEAR AI <support@near.ai>"]

--- a/crates/ironclaw_resources/Cargo.toml
+++ b/crates/ironclaw_resources/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ironclaw_resources"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+description = "Resource reservation governor for IronClaw Reborn"
+authors = ["NEAR AI <support@near.ai>"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/nearai/ironclaw"
+repository = "https://github.com/nearai/ironclaw"
+publish = false
+
+[dependencies]
+ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+rust_decimal = { version = "1", features = ["serde", "serde-with-str"] }
+thiserror = "2"
+
+[dev-dependencies]
+rust_decimal_macros = "1"

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -1,0 +1,684 @@
+//! Resource reservation governor for IronClaw Reborn.
+//!
+//! `ironclaw_resources` enforces the host-level reservation protocol used by
+//! runtime lanes before they spend money or consume scarce sandbox capacity:
+//! reserve estimated resources, execute work, then reconcile actual usage or
+//! release the unused hold.
+
+use std::collections::HashMap;
+use std::sync::{Mutex, MutexGuard};
+
+use ironclaw_host_api::{
+    AgentId, MissionId, ProjectId, ResourceEstimate, ResourceReservationId, ResourceScope,
+    ResourceUsage, TenantId, ThreadId, UserId,
+};
+pub use ironclaw_host_api::{ReservationStatus, ResourceReceipt, ResourceReservation};
+use rust_decimal::Decimal;
+use thiserror::Error;
+
+/// Durable account level that can carry resource limits and ledgers.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ResourceAccount {
+    Tenant {
+        tenant_id: TenantId,
+    },
+    User {
+        tenant_id: TenantId,
+        user_id: UserId,
+    },
+    Project {
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: ProjectId,
+    },
+    Agent {
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        agent_id: AgentId,
+    },
+    Mission {
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        mission_id: MissionId,
+    },
+    Thread {
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        mission_id: Option<MissionId>,
+        thread_id: ThreadId,
+    },
+}
+
+impl ResourceAccount {
+    pub fn tenant(tenant_id: TenantId) -> Self {
+        Self::Tenant { tenant_id }
+    }
+
+    pub fn user(tenant_id: TenantId, user_id: UserId) -> Self {
+        Self::User { tenant_id, user_id }
+    }
+
+    pub fn project(tenant_id: TenantId, user_id: UserId, project_id: ProjectId) -> Self {
+        Self::Project {
+            tenant_id,
+            user_id,
+            project_id,
+        }
+    }
+
+    pub fn agent(
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        agent_id: AgentId,
+    ) -> Self {
+        Self::Agent {
+            tenant_id,
+            user_id,
+            project_id,
+            agent_id,
+        }
+    }
+
+    pub fn mission(
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        mission_id: MissionId,
+    ) -> Self {
+        Self::Mission {
+            tenant_id,
+            user_id,
+            project_id,
+            mission_id,
+        }
+    }
+
+    pub fn thread(
+        tenant_id: TenantId,
+        user_id: UserId,
+        project_id: Option<ProjectId>,
+        mission_id: Option<MissionId>,
+        thread_id: ThreadId,
+    ) -> Self {
+        Self::Thread {
+            tenant_id,
+            user_id,
+            project_id,
+            mission_id,
+            thread_id,
+        }
+    }
+
+    pub fn cascade(scope: &ResourceScope) -> Vec<Self> {
+        let mut accounts = vec![
+            Self::tenant(scope.tenant_id.clone()),
+            Self::user(scope.tenant_id.clone(), scope.user_id.clone()),
+        ];
+
+        if let Some(project_id) = &scope.project_id {
+            accounts.push(Self::project(
+                scope.tenant_id.clone(),
+                scope.user_id.clone(),
+                project_id.clone(),
+            ));
+        }
+
+        if let Some(agent_id) = &scope.agent_id {
+            accounts.push(Self::agent(
+                scope.tenant_id.clone(),
+                scope.user_id.clone(),
+                scope.project_id.clone(),
+                agent_id.clone(),
+            ));
+        }
+
+        if let Some(mission_id) = &scope.mission_id {
+            accounts.push(Self::mission(
+                scope.tenant_id.clone(),
+                scope.user_id.clone(),
+                scope.project_id.clone(),
+                mission_id.clone(),
+            ));
+        }
+
+        if let Some(thread_id) = &scope.thread_id {
+            accounts.push(Self::thread(
+                scope.tenant_id.clone(),
+                scope.user_id.clone(),
+                scope.project_id.clone(),
+                scope.mission_id.clone(),
+                thread_id.clone(),
+            ));
+        }
+
+        accounts
+    }
+}
+
+/// Optional maximums for each resource dimension.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResourceLimits {
+    pub max_usd: Option<Decimal>,
+    pub max_input_tokens: Option<u64>,
+    pub max_output_tokens: Option<u64>,
+    pub max_wall_clock_ms: Option<u64>,
+    pub max_output_bytes: Option<u64>,
+    pub max_network_egress_bytes: Option<u64>,
+    pub max_process_count: Option<u32>,
+    pub max_concurrency_slots: Option<u32>,
+}
+
+/// Resource dimension that may deny a reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ResourceDimension {
+    Usd,
+    InputTokens,
+    OutputTokens,
+    WallClockMs,
+    OutputBytes,
+    NetworkEgressBytes,
+    ProcessCount,
+    ConcurrencySlots,
+}
+
+impl std::fmt::Display for ResourceDimension {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Usd => "usd",
+            Self::InputTokens => "input_tokens",
+            Self::OutputTokens => "output_tokens",
+            Self::WallClockMs => "wall_clock_ms",
+            Self::OutputBytes => "output_bytes",
+            Self::NetworkEgressBytes => "network_egress_bytes",
+            Self::ProcessCount => "process_count",
+            Self::ConcurrencySlots => "concurrency_slots",
+        })
+    }
+}
+
+/// Comparable amount for denial details.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ResourceValue {
+    Decimal(Decimal),
+    Integer(u64),
+}
+
+/// Structured reservation denial.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResourceDenial {
+    pub account: ResourceAccount,
+    pub dimension: ResourceDimension,
+    pub limit: ResourceValue,
+    pub current_usage: ResourceValue,
+    pub active_reserved: ResourceValue,
+    pub requested: ResourceValue,
+}
+
+/// Resource governor errors.
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum ResourceError {
+    #[error("resource limit exceeded for {dimension} at {account:?}", account = .0.account, dimension = .0.dimension)]
+    LimitExceeded(Box<ResourceDenial>),
+    #[error("resource reservation {id} already exists")]
+    ReservationAlreadyExists { id: ResourceReservationId },
+    #[error("resource reservation {id} does not match requested scope or estimate")]
+    ReservationMismatch { id: ResourceReservationId },
+    #[error("unknown resource reservation {id}")]
+    UnknownReservation { id: ResourceReservationId },
+    #[error("resource reservation {id} is already {status:?}")]
+    ReservationClosed {
+        id: ResourceReservationId,
+        status: ReservationStatus,
+    },
+}
+
+/// Aggregated resource usage/reservation tally.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ResourceTally {
+    pub usd: Decimal,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub wall_clock_ms: u64,
+    pub output_bytes: u64,
+    pub network_egress_bytes: u64,
+    pub process_count: u32,
+    pub concurrency_slots: u32,
+}
+
+impl ResourceTally {
+    fn from_estimate(estimate: &ResourceEstimate) -> Self {
+        Self {
+            usd: estimate.usd.unwrap_or_default(),
+            input_tokens: estimate.input_tokens.unwrap_or_default(),
+            output_tokens: estimate.output_tokens.unwrap_or_default(),
+            wall_clock_ms: estimate.wall_clock_ms.unwrap_or_default(),
+            output_bytes: estimate.output_bytes.unwrap_or_default(),
+            network_egress_bytes: estimate.network_egress_bytes.unwrap_or_default(),
+            process_count: estimate.process_count.unwrap_or_default(),
+            concurrency_slots: estimate.concurrency_slots.unwrap_or_default(),
+        }
+    }
+
+    fn from_usage(usage: &ResourceUsage) -> Self {
+        Self {
+            usd: usage.usd,
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            wall_clock_ms: usage.wall_clock_ms,
+            output_bytes: usage.output_bytes,
+            network_egress_bytes: usage.network_egress_bytes,
+            process_count: usage.process_count,
+            concurrency_slots: 0,
+        }
+    }
+
+    fn add_assign(&mut self, other: &Self) {
+        self.usd += other.usd;
+        self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
+        self.wall_clock_ms = self.wall_clock_ms.saturating_add(other.wall_clock_ms);
+        self.output_bytes = self.output_bytes.saturating_add(other.output_bytes);
+        self.network_egress_bytes = self
+            .network_egress_bytes
+            .saturating_add(other.network_egress_bytes);
+        self.process_count = self.process_count.saturating_add(other.process_count);
+        self.concurrency_slots = self
+            .concurrency_slots
+            .saturating_add(other.concurrency_slots);
+    }
+
+    fn sub_assign(&mut self, other: &Self) {
+        self.usd -= other.usd;
+        self.input_tokens = self.input_tokens.saturating_sub(other.input_tokens);
+        self.output_tokens = self.output_tokens.saturating_sub(other.output_tokens);
+        self.wall_clock_ms = self.wall_clock_ms.saturating_sub(other.wall_clock_ms);
+        self.output_bytes = self.output_bytes.saturating_sub(other.output_bytes);
+        self.network_egress_bytes = self
+            .network_egress_bytes
+            .saturating_sub(other.network_egress_bytes);
+        self.process_count = self.process_count.saturating_sub(other.process_count);
+        self.concurrency_slots = self
+            .concurrency_slots
+            .saturating_sub(other.concurrency_slots);
+    }
+}
+
+/// Synchronous resource governor contract.
+pub trait ResourceGovernor: Send + Sync {
+    /// Sets or replaces limits for a scoped resource account without mutating existing reservations.
+    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits);
+
+    /// Reserves estimated resources before costed/quota-limited work starts, failing closed if any scoped account would exceed limits.
+    fn reserve(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+    ) -> Result<ResourceReservation, ResourceError>;
+
+    /// Reserves estimated resources with a caller-supplied reservation id for obligation handoff.
+    fn reserve_with_id(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReservation, ResourceError>;
+
+    /// Reconciles an active reservation with actual usage and releases reserved capacity exactly once.
+    fn reconcile(
+        &self,
+        reservation_id: ResourceReservationId,
+        actual: ResourceUsage,
+    ) -> Result<ResourceReceipt, ResourceError>;
+
+    /// Releases an active reservation without usage when work is cancelled or fails before reconciliation.
+    fn release(
+        &self,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReceipt, ResourceError>;
+}
+
+/// In-memory governor used by early Reborn contract tests.
+#[derive(Debug, Default)]
+pub struct InMemoryResourceGovernor {
+    state: Mutex<ResourceState>,
+}
+
+#[derive(Debug, Default)]
+struct ResourceState {
+    limits: HashMap<ResourceAccount, ResourceLimits>,
+    reserved_by_account: HashMap<ResourceAccount, ResourceTally>,
+    usage_by_account: HashMap<ResourceAccount, ResourceTally>,
+    reservations: HashMap<ResourceReservationId, ReservationRecord>,
+}
+
+#[derive(Debug, Clone)]
+struct ReservationRecord {
+    reservation: ResourceReservation,
+    accounts: Vec<ResourceAccount>,
+    tally: ResourceTally,
+    status: ReservationStatus,
+    actual: Option<ResourceUsage>,
+}
+
+impl InMemoryResourceGovernor {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn reserved_for(&self, account: &ResourceAccount) -> ResourceTally {
+        self.lock_state()
+            .reserved_by_account
+            .get(account)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn usage_for(&self, account: &ResourceAccount) -> ResourceTally {
+        self.lock_state()
+            .usage_by_account
+            .get(account)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn lock_state(&self) -> MutexGuard<'_, ResourceState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+impl ResourceGovernor for InMemoryResourceGovernor {
+    fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits) {
+        self.lock_state().limits.insert(account, limits);
+    }
+
+    fn reserve(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+    ) -> Result<ResourceReservation, ResourceError> {
+        self.reserve_with_id(scope, estimate, ResourceReservationId::new())
+    }
+
+    fn reserve_with_id(
+        &self,
+        scope: ResourceScope,
+        estimate: ResourceEstimate,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReservation, ResourceError> {
+        let mut state = self.lock_state();
+        if state.reservations.contains_key(&reservation_id) {
+            return Err(ResourceError::ReservationAlreadyExists { id: reservation_id });
+        }
+        let accounts = ResourceAccount::cascade(&scope);
+        let requested = ResourceTally::from_estimate(&estimate);
+
+        for account in &accounts {
+            if let Some(limits) = state.limits.get(account) {
+                let usage = state
+                    .usage_by_account
+                    .get(account)
+                    .cloned()
+                    .unwrap_or_default();
+                let reserved = state
+                    .reserved_by_account
+                    .get(account)
+                    .cloned()
+                    .unwrap_or_default();
+                if let Some(denial) = check_limits(account, limits, &usage, &reserved, &requested) {
+                    return Err(ResourceError::LimitExceeded(Box::new(denial)));
+                }
+            }
+        }
+
+        let reservation = ResourceReservation {
+            id: reservation_id,
+            scope,
+            estimate,
+        };
+
+        for account in &accounts {
+            state
+                .reserved_by_account
+                .entry(account.clone())
+                .or_default()
+                .add_assign(&requested);
+        }
+
+        state.reservations.insert(
+            reservation.id,
+            ReservationRecord {
+                reservation: reservation.clone(),
+                accounts,
+                tally: requested,
+                status: ReservationStatus::Active,
+                actual: None,
+            },
+        );
+
+        Ok(reservation)
+    }
+
+    fn reconcile(
+        &self,
+        reservation_id: ResourceReservationId,
+        actual: ResourceUsage,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        let mut state = self.lock_state();
+        let mut record = state
+            .reservations
+            .remove(&reservation_id)
+            .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
+
+        if record.status != ReservationStatus::Active {
+            let status = record.status;
+            state.reservations.insert(reservation_id, record);
+            return Err(ResourceError::ReservationClosed {
+                id: reservation_id,
+                status,
+            });
+        }
+
+        for account in &record.accounts {
+            state
+                .reserved_by_account
+                .entry(account.clone())
+                .or_default()
+                .sub_assign(&record.tally);
+            state
+                .usage_by_account
+                .entry(account.clone())
+                .or_default()
+                .add_assign(&ResourceTally::from_usage(&actual));
+        }
+
+        record.status = ReservationStatus::Reconciled;
+        record.actual = Some(actual.clone());
+        let receipt = ResourceReceipt {
+            id: reservation_id,
+            scope: record.reservation.scope.clone(),
+            status: ReservationStatus::Reconciled,
+            estimate: record.reservation.estimate.clone(),
+            actual: Some(actual),
+        };
+        state.reservations.insert(reservation_id, record);
+        Ok(receipt)
+    }
+
+    fn release(
+        &self,
+        reservation_id: ResourceReservationId,
+    ) -> Result<ResourceReceipt, ResourceError> {
+        let mut state = self.lock_state();
+        let mut record = state
+            .reservations
+            .remove(&reservation_id)
+            .ok_or(ResourceError::UnknownReservation { id: reservation_id })?;
+
+        if record.status != ReservationStatus::Active {
+            let status = record.status;
+            state.reservations.insert(reservation_id, record);
+            return Err(ResourceError::ReservationClosed {
+                id: reservation_id,
+                status,
+            });
+        }
+
+        for account in &record.accounts {
+            state
+                .reserved_by_account
+                .entry(account.clone())
+                .or_default()
+                .sub_assign(&record.tally);
+        }
+
+        record.status = ReservationStatus::Released;
+        let receipt = ResourceReceipt {
+            id: reservation_id,
+            scope: record.reservation.scope.clone(),
+            status: ReservationStatus::Released,
+            estimate: record.reservation.estimate.clone(),
+            actual: None,
+        };
+        state.reservations.insert(reservation_id, record);
+        Ok(receipt)
+    }
+}
+
+fn check_limits(
+    account: &ResourceAccount,
+    limits: &ResourceLimits,
+    usage: &ResourceTally,
+    reserved: &ResourceTally,
+    requested: &ResourceTally,
+) -> Option<ResourceDenial> {
+    check_decimal(
+        account,
+        ResourceDimension::Usd,
+        limits.max_usd,
+        usage.usd,
+        reserved.usd,
+        requested.usd,
+    )
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::InputTokens,
+            limits.max_input_tokens,
+            usage.input_tokens,
+            reserved.input_tokens,
+            requested.input_tokens,
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::OutputTokens,
+            limits.max_output_tokens,
+            usage.output_tokens,
+            reserved.output_tokens,
+            requested.output_tokens,
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::WallClockMs,
+            limits.max_wall_clock_ms,
+            usage.wall_clock_ms,
+            reserved.wall_clock_ms,
+            requested.wall_clock_ms,
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::OutputBytes,
+            limits.max_output_bytes,
+            usage.output_bytes,
+            reserved.output_bytes,
+            requested.output_bytes,
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::NetworkEgressBytes,
+            limits.max_network_egress_bytes,
+            usage.network_egress_bytes,
+            reserved.network_egress_bytes,
+            requested.network_egress_bytes,
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::ProcessCount,
+            limits.max_process_count.map(u64::from),
+            u64::from(usage.process_count),
+            u64::from(reserved.process_count),
+            u64::from(requested.process_count),
+        )
+    })
+    .or_else(|| {
+        check_integer(
+            account,
+            ResourceDimension::ConcurrencySlots,
+            limits.max_concurrency_slots.map(u64::from),
+            u64::from(usage.concurrency_slots),
+            u64::from(reserved.concurrency_slots),
+            u64::from(requested.concurrency_slots),
+        )
+    })
+}
+
+fn check_decimal(
+    account: &ResourceAccount,
+    dimension: ResourceDimension,
+    limit: Option<Decimal>,
+    usage: Decimal,
+    reserved: Decimal,
+    requested: Decimal,
+) -> Option<ResourceDenial> {
+    let limit = limit?;
+    if usage + reserved + requested > limit {
+        Some(ResourceDenial {
+            account: account.clone(),
+            dimension,
+            limit: ResourceValue::Decimal(limit),
+            current_usage: ResourceValue::Decimal(usage),
+            active_reserved: ResourceValue::Decimal(reserved),
+            requested: ResourceValue::Decimal(requested),
+        })
+    } else {
+        None
+    }
+}
+
+fn check_integer(
+    account: &ResourceAccount,
+    dimension: ResourceDimension,
+    limit: Option<u64>,
+    usage: u64,
+    reserved: u64,
+    requested: u64,
+) -> Option<ResourceDenial> {
+    let limit = limit?;
+    if usage.saturating_add(reserved).saturating_add(requested) > limit {
+        Some(ResourceDenial {
+            account: account.clone(),
+            dimension,
+            limit: ResourceValue::Integer(limit),
+            current_usage: ResourceValue::Integer(usage),
+            active_reserved: ResourceValue::Integer(reserved),
+            requested: ResourceValue::Integer(requested),
+        })
+    } else {
+        None
+    }
+}

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -113,6 +113,13 @@ impl ResourceAccount {
         }
     }
 
+    /// Returns every account whose limit applies to this scope, from broadest to
+    /// narrowest.
+    ///
+    /// A reservation succeeds only if every account returned by this cascade
+    /// remains within its limit. Deeper accounts do not override shallower
+    /// accounts; tenant, user, project, agent, mission, and thread limits all
+    /// apply when present.
     pub fn cascade(scope: &ResourceScope) -> Vec<Self> {
         let mut accounts = vec![
             Self::tenant(scope.tenant_id.clone()),
@@ -277,7 +284,7 @@ impl ResourceTally {
     }
 
     fn add_assign(&mut self, other: &Self) {
-        self.usd += other.usd;
+        self.usd = self.usd.checked_add(other.usd).unwrap_or(Decimal::MAX);
         self.input_tokens = self.input_tokens.saturating_add(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_add(other.output_tokens);
         self.wall_clock_ms = self.wall_clock_ms.saturating_add(other.wall_clock_ms);
@@ -292,7 +299,11 @@ impl ResourceTally {
     }
 
     fn sub_assign(&mut self, other: &Self) {
-        self.usd -= other.usd;
+        self.usd = self
+            .usd
+            .checked_sub(other.usd)
+            .map(|value| value.max(Decimal::ZERO))
+            .unwrap_or(Decimal::ZERO);
         self.input_tokens = self.input_tokens.saturating_sub(other.input_tokens);
         self.output_tokens = self.output_tokens.saturating_sub(other.output_tokens);
         self.wall_clock_ms = self.wall_clock_ms.saturating_sub(other.wall_clock_ms);
@@ -550,6 +561,10 @@ impl ResourceGovernor for InMemoryResourceGovernor {
     }
 }
 
+/// Returns the first denied dimension in canonical resource order.
+///
+/// This intentionally reports one denial rather than aggregating all failed
+/// dimensions so callers have a deterministic, compact failure reason.
 fn check_limits(
     account: &ResourceAccount,
     limits: &ResourceLimits,
@@ -646,7 +661,14 @@ fn check_decimal(
     requested: Decimal,
 ) -> Option<ResourceDenial> {
     let limit = limit?;
-    if usage + reserved + requested > limit {
+    let exceeds = match usage
+        .checked_add(reserved)
+        .and_then(|subtotal| subtotal.checked_add(requested))
+    {
+        Some(total) => total > limit,
+        None => true,
+    };
+    if exceeds {
         Some(ResourceDenial {
             account: account.clone(),
             dimension,

--- a/crates/ironclaw_resources/src/lib.rs
+++ b/crates/ironclaw_resources/src/lib.rs
@@ -323,7 +323,12 @@ pub trait ResourceGovernor: Send + Sync {
     /// Sets or replaces limits for a scoped resource account without mutating existing reservations.
     fn set_limit(&self, account: ResourceAccount, limits: ResourceLimits);
 
-    /// Reserves estimated resources before costed/quota-limited work starts, failing closed if any scoped account would exceed limits.
+    /// Reserves estimated resources before costed/quota-limited work starts.
+    ///
+    /// A reservation succeeds only if every account in [`ResourceAccount::cascade`]
+    /// would remain within its limits. Limits at deeper accounts do not override
+    /// shallower limits; tenant, user, project, agent, mission, and thread limits
+    /// all apply when present.
     fn reserve(
         &self,
         scope: ResourceScope,

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -533,6 +533,85 @@ fn sample_scope_with_agent(
 }
 
 #[test]
+fn project_and_agent_limits_both_apply_without_override() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope_with_agent("tenant1", "user1", Some("project1"), Some("agent1"));
+    let project_account = ResourceAccount::project(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone().unwrap(),
+    );
+    let agent_account = ResourceAccount::agent(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone(),
+        scope.agent_id.clone().unwrap(),
+    );
+
+    governor.set_limit(
+        project_account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(0.50)),
+            ..ResourceLimits::default()
+        },
+    );
+    governor.set_limit(
+        agent_account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == project_account && denial.dimension == ResourceDimension::Usd
+    ));
+
+    governor.set_limit(
+        project_account,
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+    governor.set_limit(
+        agent_account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(0.50)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == agent_account && denial.dimension == ResourceDimension::Usd
+    ));
+}
+
+#[test]
 fn reservation_and_usage_are_charged_to_full_scope_cascade() {
     let governor = InMemoryResourceGovernor::new();
     let mut scope = sample_scope("tenant1", "user1", Some("project1"));

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -1,0 +1,825 @@
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use ironclaw_host_api::*;
+use ironclaw_resources::*;
+use rust_decimal_macros::dec;
+
+#[test]
+fn reserve_succeeds_when_budget_is_available() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            max_concurrency_slots: Some(2),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let reservation = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.25)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(reservation.scope, scope);
+    assert_eq!(reservation.estimate.usd, Some(dec!(0.25)));
+    assert_eq!(governor.reserved_for(&account).usd, dec!(0.25));
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
+}
+
+#[test]
+fn reserve_with_id_uses_requested_identifier_and_rejects_duplicates() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    let reservation_id = ResourceReservationId::new();
+    let estimate = ResourceEstimate {
+        concurrency_slots: Some(1),
+        ..ResourceEstimate::default()
+    };
+
+    let reservation = governor
+        .reserve_with_id(scope.clone(), estimate.clone(), reservation_id)
+        .unwrap();
+
+    assert_eq!(reservation.id, reservation_id);
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
+    assert!(matches!(
+        governor.reserve_with_id(scope, estimate, reservation_id),
+        Err(ResourceError::ReservationAlreadyExists { id }) if id == reservation_id
+    ));
+}
+
+#[test]
+fn reserve_denies_when_usd_limit_would_be_exceeded() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(0.50)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == ResourceDimension::Usd
+    ));
+}
+
+#[test]
+fn reserve_denies_runtime_quota_even_without_usd() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::project(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone().unwrap(),
+    );
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_wall_clock_ms: Some(1_000),
+            max_process_count: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                wall_clock_ms: Some(2_000),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == ResourceDimension::WallClockMs
+    ));
+}
+
+#[test]
+fn active_reservations_consume_concurrency_until_released() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::project(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone().unwrap(),
+    );
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let first = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 1);
+
+    let second = governor.reserve(
+        scope.clone(),
+        ResourceEstimate {
+            concurrency_slots: Some(1),
+            ..ResourceEstimate::default()
+        },
+    );
+    assert!(matches!(
+        second,
+        Err(ResourceError::LimitExceeded(denial))
+            if denial.dimension == ResourceDimension::ConcurrencySlots
+    ));
+
+    governor.release(first.id).unwrap();
+    assert_eq!(governor.reserved_for(&account).concurrency_slots, 0);
+
+    governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+}
+
+#[test]
+fn concurrent_reservations_cannot_oversubscribe_scope() {
+    let governor = Arc::new(InMemoryResourceGovernor::new());
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::project(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone().unwrap(),
+    );
+    governor.set_limit(
+        account,
+        ResourceLimits {
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let barrier = Arc::new(Barrier::new(8));
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let governor = Arc::clone(&governor);
+        let barrier = Arc::clone(&barrier);
+        let mut scope = scope.clone();
+        scope.invocation_id = InvocationId::new();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            governor
+                .reserve(
+                    scope,
+                    ResourceEstimate {
+                        concurrency_slots: Some(1),
+                        ..ResourceEstimate::default()
+                    },
+                )
+                .is_ok()
+        }));
+    }
+
+    let successes = handles
+        .into_iter()
+        .map(|handle| handle.join().unwrap())
+        .filter(|success| *success)
+        .count();
+    assert_eq!(successes, 1);
+}
+
+#[test]
+fn reconcile_records_actual_usage_and_closes_reservation() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let receipt = governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.20),
+                input_tokens: 10,
+                output_tokens: 20,
+                wall_clock_ms: 100,
+                output_bytes: 50,
+                network_egress_bytes: 0,
+                process_count: 1,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(receipt.status, ReservationStatus::Reconciled);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account).usd, dec!(0.20));
+    assert_eq!(governor.usage_for(&account).input_tokens, 10);
+    assert!(matches!(
+        governor.reconcile(reservation.id, ResourceUsage::default()),
+        Err(ResourceError::ReservationClosed { .. })
+    ));
+}
+
+#[test]
+fn release_frees_reserved_capacity_without_recording_spend() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            max_concurrency_slots: Some(1),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let receipt = governor.release(reservation.id).unwrap();
+    assert_eq!(receipt.status, ReservationStatus::Released);
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account), ResourceTally::default());
+    assert!(matches!(
+        governor.release(reservation.id),
+        Err(ResourceError::ReservationClosed { .. })
+    ));
+}
+
+#[test]
+fn unknown_reservation_cannot_be_reconciled_or_released() {
+    let governor = InMemoryResourceGovernor::new();
+    let unknown = ResourceReservationId::new();
+
+    assert!(matches!(
+        governor.reconcile(unknown, ResourceUsage::default()),
+        Err(ResourceError::UnknownReservation { id }) if id == unknown
+    ));
+    assert!(matches!(
+        governor.release(unknown),
+        Err(ResourceError::UnknownReservation { id }) if id == unknown
+    ));
+}
+
+#[test]
+fn tenant_limit_applies_across_projects() {
+    let governor = InMemoryResourceGovernor::new();
+    let project_a = sample_scope("tenant1", "user1", Some("project_a"));
+    let project_b = sample_scope("tenant1", "user1", Some("project_b"));
+    let tenant_account = ResourceAccount::tenant(project_a.tenant_id.clone());
+    governor.set_limit(
+        tenant_account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    governor
+        .reserve(
+            project_a,
+            ResourceEstimate {
+                usd: Some(dec!(0.75)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let err = governor
+        .reserve(
+            project_b,
+            ResourceEstimate {
+                usd: Some(dec!(0.50)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == tenant_account && denial.dimension == ResourceDimension::Usd
+    ));
+}
+
+#[test]
+fn resource_governor_enforces_agent_scoped_limits_independently() {
+    let governor = InMemoryResourceGovernor::new();
+    let tenant = TenantId::new("tenant1").unwrap();
+    let user = UserId::new("user1").unwrap();
+    let agent_a = AgentId::new("agent-a").unwrap();
+    let agent_b = AgentId::new("agent-b").unwrap();
+    governor.set_limit(
+        ResourceAccount::agent(tenant.clone(), user.clone(), None, agent_a.clone()),
+        ResourceLimits {
+            max_output_bytes: Some(10),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let estimate = ResourceEstimate {
+        output_bytes: Some(8),
+        ..ResourceEstimate::default()
+    };
+    governor
+        .reserve(
+            sample_scope_with_agent("tenant1", "user1", None, Some("agent-a")),
+            estimate.clone(),
+        )
+        .unwrap();
+    governor
+        .reserve(
+            sample_scope_with_agent("tenant1", "user1", None, Some("agent-b")),
+            estimate.clone(),
+        )
+        .unwrap();
+
+    let denial = governor
+        .reserve(
+            sample_scope_with_agent("tenant1", "user1", None, Some("agent-a")),
+            estimate,
+        )
+        .unwrap_err();
+
+    assert!(matches!(denial, ResourceError::LimitExceeded(_)));
+    assert_eq!(
+        governor.reserved_for(&ResourceAccount::agent(tenant, user, None, agent_a)),
+        ResourceTally {
+            output_bytes: 8,
+            ..ResourceTally::default()
+        }
+    );
+    assert_eq!(
+        governor.reserved_for(&ResourceAccount::agent(
+            TenantId::new("tenant1").unwrap(),
+            UserId::new("user1").unwrap(),
+            None,
+            agent_b,
+        )),
+        ResourceTally {
+            output_bytes: 8,
+            ..ResourceTally::default()
+        }
+    );
+}
+
+fn sample_scope(tenant: &str, user: &str, project: Option<&str>) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: project.map(|value| ProjectId::new(value).unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: InvocationId::new(),
+    }
+}
+
+fn sample_scope_with_agent(
+    tenant: &str,
+    user: &str,
+    project: Option<&str>,
+    agent: Option<&str>,
+) -> ResourceScope {
+    let mut scope = sample_scope(tenant, user, project);
+    scope.agent_id = agent.map(|id| AgentId::new(id).unwrap());
+    scope
+}
+
+#[test]
+fn reservation_and_usage_are_charged_to_full_scope_cascade() {
+    let governor = InMemoryResourceGovernor::new();
+    let mut scope = sample_scope("tenant1", "user1", Some("project1"));
+    scope.mission_id = Some(MissionId::new("mission1").unwrap());
+    scope.thread_id = Some(ThreadId::new("thread1").unwrap());
+
+    let accounts = ResourceAccount::cascade(&scope);
+    assert_eq!(accounts.len(), 5);
+
+    let reservation = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                output_bytes: Some(100),
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    for account in &accounts {
+        let reserved = governor.reserved_for(account);
+        assert_eq!(reserved.usd, dec!(0.10));
+        assert_eq!(reserved.output_bytes, 100);
+        assert_eq!(reserved.concurrency_slots, 1);
+    }
+
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.06),
+                input_tokens: 11,
+                output_tokens: 7,
+                wall_clock_ms: 55,
+                output_bytes: 80,
+                network_egress_bytes: 9,
+                process_count: 1,
+            },
+        )
+        .unwrap();
+
+    for account in &accounts {
+        assert_eq!(governor.reserved_for(account), ResourceTally::default());
+        let usage = governor.usage_for(account);
+        assert_eq!(usage.usd, dec!(0.06));
+        assert_eq!(usage.input_tokens, 11);
+        assert_eq!(usage.output_tokens, 7);
+        assert_eq!(usage.wall_clock_ms, 55);
+        assert_eq!(usage.output_bytes, 80);
+        assert_eq!(usage.network_egress_bytes, 9);
+        assert_eq!(usage.process_count, 1);
+        assert_eq!(usage.concurrency_slots, 0);
+    }
+}
+
+#[test]
+fn project_limit_denies_leaf_even_when_tenant_allows() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let tenant = ResourceAccount::tenant(scope.tenant_id.clone());
+    let project = ResourceAccount::project(
+        scope.tenant_id.clone(),
+        scope.user_id.clone(),
+        scope.project_id.clone().unwrap(),
+    );
+    governor.set_limit(
+        tenant,
+        ResourceLimits {
+            max_usd: Some(dec!(10.00)),
+            ..ResourceLimits::default()
+        },
+    );
+    governor.set_limit(
+        project.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(1.50)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == project && denial.dimension == ResourceDimension::Usd
+    ));
+}
+
+#[test]
+fn reconciled_usage_counts_against_future_reservations() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let reservation = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.80),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.30)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::Usd
+                && denial.current_usage == ResourceValue::Decimal(dec!(0.80))
+                && denial.active_reserved == ResourceValue::Decimal(dec!(0))
+                && denial.requested == ResourceValue::Decimal(dec!(0.30))
+    ));
+}
+
+#[test]
+fn active_reserved_and_usage_appear_in_denial_details() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let completed = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.40)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reconcile(
+            completed.id,
+            ResourceUsage {
+                usd: dec!(0.40),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.30)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.40)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account
+                && denial.dimension == ResourceDimension::Usd
+                && denial.limit == ResourceValue::Decimal(dec!(1.00))
+                && denial.current_usage == ResourceValue::Decimal(dec!(0.40))
+                && denial.active_reserved == ResourceValue::Decimal(dec!(0.30))
+                && denial.requested == ResourceValue::Decimal(dec!(0.40))
+    ));
+}
+
+#[test]
+fn actual_usage_above_estimate_is_recorded_and_blocks_future_work() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(dec!(1.00)),
+            ..ResourceLimits::default()
+        },
+    );
+
+    let reservation = governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(dec!(0.20)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reconcile(
+            reservation.id,
+            ResourceUsage {
+                usd: dec!(0.95),
+                ..ResourceUsage::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(governor.usage_for(&account).usd, dec!(0.95));
+    assert!(matches!(
+        governor.reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(0.10)),
+                ..ResourceEstimate::default()
+            },
+        ),
+        Err(ResourceError::LimitExceeded(denial))
+            if denial.current_usage == ResourceValue::Decimal(dec!(0.95))
+    ));
+}
+
+#[test]
+fn closed_reservations_reject_cross_lifecycle_operations_with_status() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+
+    let reconciled = governor
+        .reserve(scope.clone(), ResourceEstimate::default())
+        .unwrap();
+    governor
+        .reconcile(reconciled.id, ResourceUsage::default())
+        .unwrap();
+    assert!(matches!(
+        governor.release(reconciled.id),
+        Err(ResourceError::ReservationClosed {
+            status: ReservationStatus::Reconciled,
+            ..
+        })
+    ));
+
+    let released = governor
+        .reserve(scope, ResourceEstimate::default())
+        .unwrap();
+    governor.release(released.id).unwrap();
+    assert!(matches!(
+        governor.reconcile(released.id, ResourceUsage::default()),
+        Err(ResourceError::ReservationClosed {
+            status: ReservationStatus::Released,
+            ..
+        })
+    ));
+}
+
+#[test]
+fn non_usd_dimensions_can_deny_reservations() {
+    assert_denied_dimension(
+        ResourceLimits {
+            max_input_tokens: Some(10),
+            ..ResourceLimits::default()
+        },
+        ResourceEstimate {
+            input_tokens: Some(11),
+            ..ResourceEstimate::default()
+        },
+        ResourceDimension::InputTokens,
+    );
+    assert_denied_dimension(
+        ResourceLimits {
+            max_output_tokens: Some(10),
+            ..ResourceLimits::default()
+        },
+        ResourceEstimate {
+            output_tokens: Some(11),
+            ..ResourceEstimate::default()
+        },
+        ResourceDimension::OutputTokens,
+    );
+    assert_denied_dimension(
+        ResourceLimits {
+            max_output_bytes: Some(10),
+            ..ResourceLimits::default()
+        },
+        ResourceEstimate {
+            output_bytes: Some(11),
+            ..ResourceEstimate::default()
+        },
+        ResourceDimension::OutputBytes,
+    );
+    assert_denied_dimension(
+        ResourceLimits {
+            max_network_egress_bytes: Some(10),
+            ..ResourceLimits::default()
+        },
+        ResourceEstimate {
+            network_egress_bytes: Some(11),
+            ..ResourceEstimate::default()
+        },
+        ResourceDimension::NetworkEgressBytes,
+    );
+    assert_denied_dimension(
+        ResourceLimits {
+            max_process_count: Some(1),
+            ..ResourceLimits::default()
+        },
+        ResourceEstimate {
+            process_count: Some(2),
+            ..ResourceEstimate::default()
+        },
+        ResourceDimension::ProcessCount,
+    );
+}
+
+fn assert_denied_dimension(
+    limits: ResourceLimits,
+    estimate: ResourceEstimate,
+    expected: ResourceDimension,
+) {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(account.clone(), limits);
+
+    let err = governor.reserve(scope, estimate).unwrap_err();
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == expected
+    ));
+}

--- a/crates/ironclaw_resources/tests/resource_governor_contract.rs
+++ b/crates/ironclaw_resources/tests/resource_governor_contract.rs
@@ -61,6 +61,77 @@ fn reserve_with_id_uses_requested_identifier_and_rejects_duplicates() {
 }
 
 #[test]
+fn usd_tally_saturates_instead_of_panicking_on_decimal_overflow() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+
+    governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(rust_decimal::Decimal::MAX),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+    governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(1)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        governor.reserved_for(&account).usd,
+        rust_decimal::Decimal::MAX
+    );
+}
+
+#[test]
+fn usd_limit_check_denies_instead_of_panicking_on_decimal_overflow() {
+    let governor = InMemoryResourceGovernor::new();
+    let scope = sample_scope("tenant1", "user1", Some("project1"));
+    let account = ResourceAccount::tenant(scope.tenant_id.clone());
+    governor.set_limit(
+        account.clone(),
+        ResourceLimits {
+            max_usd: Some(rust_decimal::Decimal::MAX),
+            ..ResourceLimits::default()
+        },
+    );
+
+    governor
+        .reserve(
+            scope.clone(),
+            ResourceEstimate {
+                usd: Some(rust_decimal::Decimal::MAX),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap();
+
+    let err = governor
+        .reserve(
+            scope,
+            ResourceEstimate {
+                usd: Some(dec!(1)),
+                ..ResourceEstimate::default()
+            },
+        )
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ResourceError::LimitExceeded(denial)
+            if denial.account == account && denial.dimension == ResourceDimension::Usd
+    ));
+}
+
+#[test]
 fn reserve_denies_when_usd_limit_would_be_exceeded() {
     let governor = InMemoryResourceGovernor::new();
     let scope = sample_scope("tenant1", "user1", Some("project1"));
@@ -275,6 +346,15 @@ fn reconcile_records_actual_usage_and_closes_reservation() {
         governor.reconcile(reservation.id, ResourceUsage::default()),
         Err(ResourceError::ReservationClosed { .. })
     ));
+    assert!(matches!(
+        governor.release(reservation.id),
+        Err(ResourceError::ReservationClosed {
+            status: ReservationStatus::Reconciled,
+            ..
+        })
+    ));
+    assert_eq!(governor.reserved_for(&account), ResourceTally::default());
+    assert_eq!(governor.usage_for(&account).usd, dec!(0.20));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Carves the first Reborn landing slice onto the new integration branch.

This PR adds the foundation crates needed by later Reborn slices:

```text
crates/ironclaw_host_api
crates/ironclaw_resources
crates/ironclaw_architecture
```

Target branch:

```text
reborn-integration
```

Tracking issue:

```text
#2987
```

## Included

### `ironclaw_host_api`

Neutral host API vocabulary and contracts:

- scope/ID types, including first-class optional `AgentId`
- `ExecutionContext` / `ResourceScope`
- runtime and trust vocabulary
- capability descriptors and decisions
- mount/path/resource/action/approval/audit/dispatch contracts
- local default scope helpers:
  - `tenant_id = "default"`
  - stable local `user_id`
  - `agent_id = Some("default")`
  - `project_id = Some("bootstrap")`

### `ironclaw_resources`

Resource-governor foundation:

- `ResourceEstimate`
- `ResourceReservation`
- `ResourceGovernor`
- scoped in-memory governor
- `reserve_with_id(...)` support for later obligation handoff
- duplicate/mismatch reservation errors
- tenant/user/project/agent scope cascade tests

### `ironclaw_architecture`

Boundary guardrails:

- `cargo metadata` based dependency-boundary test crate
- incremental grouped-landing behavior: rules activate for Reborn crates once the crate is present in the workspace, so earlier grouped PRs do not fail because later crates are not landed yet

## Out of scope

- `ironclaw_extensions` is intentionally deferred from PR1 because the current implementation depends on `ironclaw_filesystem`; it should move with/after the filesystem substrate slice.
- filesystem, events, authorization, approvals, dispatcher, process, secrets, network, memory, runtime lanes, and obligation handling are later grouped PRs.
- no production/user-visible Reborn wiring is enabled by this PR.

## Exposure checklist

- [x] Does not alter app startup/config defaults.
- [x] Does not expose new routes/CLI/user-visible APIs.
- [x] Does not create a second writer for production state.
- [x] Adds internal Reborn crates only.
- [x] Status remains “implemented slice,” not product-complete Reborn.

## Verification

Run from `.worktrees/reborn-land-01-foundation`:

```bash
cargo test -p ironclaw_host_api -p ironclaw_resources -p ironclaw_architecture
cargo clippy -p ironclaw_host_api -p ironclaw_resources -p ironclaw_architecture --all-targets -- -D warnings
cargo fmt --check
git diff --check
```

All passed.
