### PR TITLE
[codex] Fix v2 tool_info action inventory lookup

### DIFF
--- a/crates/ironclaw_engine/prompts/codeact_preamble.md
+++ b/crates/ironclaw_engine/prompts/codeact_preamble.md
@@ -33,16 +33,8 @@ This is much faster than calling tools sequentially. Use `asyncio.gather()` when
 - `llm_query_batched(prompts, context=None, model=None, models=None)` — Same but for multiple prompts in parallel. Returns a list of strings. Pass `model="gpt-4o"` to apply one model to every prompt, or `models=["gpt-4o", "claude-sonnet-4-20250514", ...]` (parallel array, must match `prompts` length) to send each prompt to a different model. The "LLM council" pattern is `prompts=[same_question]*N, models=[m1, m2, ...]`.
 - `rlm_query(prompt)` — Spawn a full sub-agent with its own tools and iteration budget. Use for complex sub-tasks that need tool access. Returns the sub-agent's final answer as a string. More powerful but more expensive than llm_query.
 - `FINAL(answer)` — Call this when you have the final answer. The argument is returned to the user.
-- `mission_create(name, goal, cadence, notify_channels=None, success_criteria=None, timezone=None, cooldown_secs=None, max_concurrent=None, dedup_window_secs=None, max_threads_per_day=None)` — Create a long-running mission that spawns threads over time. Use this only when the user explicitly asks to schedule, automate, monitor, or create a recurring/manual mission.
 
-    Do not use it for immediate one-shot requests such as "do it now", "right now", or "immediately" — perform those in the current thread and call `FINAL`.
-
-    **`cadence` is required** — use "manual", a cron expression (e.g. "0 9 * * *"), "event:<channel>:<regex_pattern>" (e.g. "event:telegram:.*" to match all messages on the telegram channel, or "event:*:.*" to match any channel), or "webhook:path". Cron expressions accept 5-field (`min hr dom mon dow`), 6-field (`sec min hr dom mon dow` — NOT Quartz-style with year), or 7-field (`sec min hr dom mon dow year`). Cron missions default to the user's timezone from `user_timezone`; pass an explicit `timezone` param to override. Guardrail params: `cooldown_secs` (minimum seconds between triggers, default 300 for event/webhook, 0 for cron/manual), `max_concurrent` (max simultaneous threads), `dedup_window_secs` (suppress duplicate events within window), `max_threads_per_day` (daily budget). Returns {"mission_id": "...", "name": "...", "status": "created"}. When telling the user about a created mission, refer to it by `name`, not by `mission_id` (the UUID is internal).
-- `mission_list()` — List all missions with their status, goal, cadence, guardrails, and current focus.
-- `mission_update(id, name=None, goal=None, cadence=None, notify_channels=None, timezone=None, cooldown_secs=None, max_concurrent=None, dedup_window_secs=None, max_threads_per_day=None, success_criteria=None)` — Update a mission's configuration. Only provided fields are changed.
-- `mission_complete(id)` — Mark a mission as completed (sets status to completed).
-- `mission_fire(id)` — Manually trigger a mission to spawn a thread now.
-- `mission_pause(id)` / `mission_resume(id)` — Pause or resume a mission.
+Other callable tools are exposed dynamically in the enabled-tools/action sections below. For compact enabled tools, call `tool_info(name="<tool>", detail="schema")` before using the tool; do not invent parameter signatures from memory.
 
 ## Context variables
 

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -640,6 +640,7 @@ mod tests {
             "Before calling one, always check its schema with `tool_info(name=\"<tool>\", detail=\"schema\")`."
         ));
         assert!(prompt.contains("- `mission_create`"));
+        assert!(!prompt.contains("mission_create(name, goal, cadence"));
         assert!(!prompt.contains("- `http`"));
         assert!(prompt.contains("## Activatable Integrations"));
         assert_eq!(prompt.matches("`gmail` [provider]").count(), 1);

--- a/crates/ironclaw_engine/src/executor/scripting.rs
+++ b/crates/ironclaw_engine/src/executor/scripting.rs
@@ -2198,12 +2198,23 @@ mod tests {
                             .iter()
                             .find(|action| action.matches_name(requested))
                     }) {
-                    Some(action) => serde_json::json!({
-                        "name": action.name,
-                        "summary": {
-                            "always_required": ["name", "goal", "cadence"]
+                    Some(action) => {
+                        if parameters.get("detail").and_then(|value| value.as_str())
+                            == Some("schema")
+                        {
+                            serde_json::json!({
+                                "name": action.name.clone(),
+                                "schema": action.parameters_schema.clone()
+                            })
+                        } else {
+                            serde_json::json!({
+                                "name": action.name.clone(),
+                                "summary": {
+                                    "always_required": ["name", "goal", "cadence"]
+                                }
+                            })
                         }
-                    }),
+                    }
                     None => serde_json::json!({"error": "missing inventory snapshot"}),
                 }
             } else {
@@ -3511,7 +3522,7 @@ except Exception as e:
     }
 
     #[tokio::test]
-    async fn execute_code_propagates_snapshot_to_tool_execution_context() {
+    async fn execute_code_resolves_tool_info_schema_from_action_inventory_snapshot() {
         let thread = make_test_thread();
         let effects: Arc<dyn EffectExecutor> = Arc::new(SnapshotAwareToolInfoEffects);
         let leases = LeaseManager::new();
@@ -3525,7 +3536,7 @@ except Exception as e:
 
         let result = execute_code(
             r#"
-result = await tool_info(name="mission-create", detail="summary")
+result = await tool_info(name="mission-create", detail="schema")
 "#,
             &thread,
             &(Arc::new(StubLlm) as Arc<dyn crate::traits::llm::LlmBackend>),
@@ -3549,6 +3560,10 @@ result = await tool_info(name="mission-create", detail="summary")
         assert_eq!(
             result.action_results[0].output["name"],
             serde_json::json!("mission_create")
+        );
+        assert_eq!(
+            result.action_results[0].output["schema"]["required"],
+            serde_json::json!(["name", "goal", "cadence"])
         );
     }
 

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -1415,18 +1415,32 @@ mod tests {
                     .get("name")
                     .and_then(|value| value.as_str())
                     .unwrap_or_default();
-                let discovered = ctx
-                    .available_action_inventory_snapshot
-                    .as_ref()
-                    .and_then(|inventory| {
-                        inventory
-                            .discoverable
-                            .iter()
-                            .find(|action| action.matches_name(requested))
-                    })
-                    .map(|action| action.name.clone())
-                    .unwrap_or_else(|| format!("missing_discoverable:{requested}"));
-                serde_json::json!({ "resolved": discovered })
+                let action =
+                    ctx.available_action_inventory_snapshot
+                        .as_ref()
+                        .and_then(|inventory| {
+                            inventory
+                                .inline
+                                .iter()
+                                .chain(inventory.discoverable.iter())
+                                .find(|action| action.matches_name(requested))
+                        });
+                if params.get("detail").and_then(|value| value.as_str()) == Some("schema") {
+                    match action {
+                        Some(action) => serde_json::json!({
+                            "name": action.name.clone(),
+                            "schema": action.parameters_schema.clone()
+                        }),
+                        None => serde_json::json!({
+                            "error": format!("missing_action:{requested}")
+                        }),
+                    }
+                } else {
+                    let discovered = action
+                        .map(|action| action.name.clone())
+                        .unwrap_or_else(|| format!("missing_action:{requested}"));
+                    serde_json::json!({ "resolved": discovered })
+                }
             } else {
                 serde_json::json!({ "ok": true })
             };
@@ -1454,7 +1468,26 @@ mod tests {
             _context: &ThreadExecutionContext,
         ) -> Result<crate::types::capability::ActionInventory, EngineError> {
             Ok(crate::types::capability::ActionInventory {
-                inline: vec![test_action("tool_info")],
+                inline: vec![
+                    test_action("tool_info"),
+                    ActionDef {
+                        name: "mission_create".to_string(),
+                        description: "Create a mission".to_string(),
+                        parameters_schema: serde_json::json!({
+                            "type": "object",
+                            "properties": {
+                                "name": {"type": "string"},
+                                "goal": {"type": "string"},
+                                "cadence": {"type": "string"}
+                            },
+                            "required": ["name", "goal", "cadence"]
+                        }),
+                        effects: vec![],
+                        requires_approval: false,
+                        model_tool_surface: ModelToolSurface::CompactToolInfo,
+                        discovery: None,
+                    },
+                ],
                 discoverable: vec![ActionDef {
                     name: "gmail_send".to_string(),
                     description: "Send an email".to_string(),
@@ -1517,6 +1550,53 @@ mod tests {
             serde_json::json!("gmail_send")
         );
         assert!(!result.results[0].is_error);
+    }
+
+    #[tokio::test]
+    async fn structured_execution_resolves_tool_info_schema_from_action_inventory() {
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+        let effects: Arc<dyn EffectExecutor> = Arc::new(StructuredToolInfoEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(
+                thread.id,
+                "tools",
+                GrantedActions::Specific(vec!["tool_info".into()]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let calls = vec![ActionCall {
+            id: "call_tool_info_schema".into(),
+            action_name: "tool_info".into(),
+            parameters: serde_json::json!({"name": "mission-create", "detail": "schema"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(result.results.len(), 1);
+        assert!(!result.results[0].is_error);
+        assert_eq!(
+            result.results[0].output["name"],
+            serde_json::json!("mission_create")
+        );
+        assert_eq!(
+            result.results[0].output["schema"]["required"],
+            serde_json::json!(["name", "goal", "cadence"])
+        );
     }
 
     struct DiscoverableOnlyEffects {

--- a/crates/ironclaw_engine/src/executor/structured.rs
+++ b/crates/ironclaw_engine/src/executor/structured.rs
@@ -1448,8 +1448,8 @@ mod tests {
             Ok(ActionResult {
                 call_id: String::new(),
                 action_name: name.replace('-', "_"),
+                is_error: output.get("error").is_some(),
                 output,
-                is_error: false,
                 duration: Duration::from_millis(1),
             })
         }
@@ -1596,6 +1596,53 @@ mod tests {
         assert_eq!(
             result.results[0].output["schema"]["required"],
             serde_json::json!(["name", "goal", "cadence"])
+        );
+    }
+
+    #[tokio::test]
+    async fn structured_execution_marks_missing_tool_info_action_as_error() {
+        let thread = Thread::new(
+            "test",
+            ThreadType::Foreground,
+            ProjectId::new(),
+            "test-user",
+            ThreadConfig::default(),
+        );
+        let effects: Arc<dyn EffectExecutor> = Arc::new(StructuredToolInfoEffects);
+        let leases = Arc::new(LeaseManager::new());
+        let policy = Arc::new(PolicyEngine::new());
+        let ctx = make_exec_context(&thread);
+
+        leases
+            .grant(
+                thread.id,
+                "tools",
+                GrantedActions::Specific(vec!["tool_info".into()]),
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+
+        let calls = vec![ActionCall {
+            id: "call_tool_info_missing_action".into(),
+            action_name: "tool_info".into(),
+            parameters: serde_json::json!({"name": "missing-action", "detail": "schema"}),
+        }];
+
+        let result = execute_action_calls(&calls, &thread, &effects, &leases, &policy, &ctx, &[])
+            .await
+            .unwrap();
+
+        assert_eq!(result.results.len(), 1);
+        assert!(
+            result.results[0].is_error,
+            "tool_info missing-action output must be marked as an error: {:?}",
+            result.results[0].output
+        );
+        assert_eq!(
+            result.results[0].output["error"],
+            serde_json::json!("missing_action:missing-action")
         );
     }
 

--- a/src/bridge/action_discovery.rs
+++ b/src/bridge/action_discovery.rs
@@ -164,6 +164,13 @@ mod tests {
         }
     }
 
+    fn action_with_schema(name: &str, schema: serde_json::Value) -> ActionDef {
+        ActionDef {
+            parameters_schema: schema,
+            ..action(name)
+        }
+    }
+
     #[test]
     fn resolves_underscored_and_hyphenated_names() {
         let actions = vec![action("mission_create")];
@@ -237,6 +244,117 @@ mod tests {
         .expect("action should resolve");
 
         assert_eq!(output.result["name"], serde_json::json!("mission_create"));
+    }
+
+    #[test]
+    fn tool_info_schema_detail_returns_full_schema() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "name": {"type": "string"},
+                "goal": {"type": "string"},
+                "cadence": {"type": "string"}
+            },
+            "required": ["name", "goal", "cadence"]
+        });
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "mission_create", "detail": "schema"}),
+            &ActionInventory {
+                inline: vec![action_with_schema("mission_create", schema.clone())],
+                discoverable: Vec::new(),
+            },
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(output.result["name"], serde_json::json!("mission_create"));
+        assert_eq!(output.result["schema"], schema);
+        assert_eq!(
+            output.result["schema"]["required"],
+            serde_json::json!(["name", "goal", "cadence"])
+        );
+    }
+
+    #[test]
+    fn tool_info_include_schema_alias_returns_schema_detail() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"}
+            },
+            "required": ["query"]
+        });
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "custom_provider_send", "include_schema": true}),
+            &ActionInventory {
+                inline: vec![action_with_schema("custom_provider_send", schema.clone())],
+                discoverable: Vec::new(),
+            },
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(output.result["schema"], schema);
+    }
+
+    #[test]
+    fn tool_info_schema_uses_discovery_schema_override() {
+        let mut action = action_with_schema(
+            "custom_provider_send",
+            serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "raw": {"type": "string"}
+                },
+                "required": ["raw"]
+            }),
+        );
+        let discovery_schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "message": {"type": "string"},
+                "recipient": {"type": "string"}
+            },
+            "required": ["message", "recipient"]
+        });
+        action.discovery = Some(ActionDiscoveryMetadata {
+            name: "custom_provider_send".to_string(),
+            summary: None,
+            schema_override: Some(discovery_schema.clone()),
+        });
+
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "custom-provider-send", "detail": "schema"}),
+            &ActionInventory {
+                inline: vec![action],
+                discoverable: Vec::new(),
+            },
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(output.result["schema"], discovery_schema);
+        assert_eq!(
+            output.result["parameters"],
+            serde_json::json!(["message", "recipient"])
+        );
+    }
+
+    #[test]
+    fn tool_info_names_detail_omits_summary_and_schema() {
+        let output = ActionDiscovery::tool_info(
+            &serde_json::json!({"name": "mission-create", "detail": "names"}),
+            &ActionInventory {
+                inline: vec![action("mission_create")],
+                discoverable: Vec::new(),
+            },
+        )
+        .expect("tool_info should succeed")
+        .expect("action should resolve");
+
+        assert_eq!(output.result["name"], serde_json::json!("mission_create"));
+        assert!(output.result.get("summary").is_none());
+        assert!(output.result.get("schema").is_none());
     }
 
     #[test]

--- a/src/bridge/effect_adapter.rs
+++ b/src/bridge/effect_adapter.rs
@@ -463,21 +463,25 @@ impl EffectBridgeAdapter {
             .await?;
         }
 
-        let snapshot_result = tool_info
+        let snapshot_result = if let Some(inventory) = tool_info
             .context
             .available_action_inventory_snapshot
             .as_deref()
-            .map(|inventory| ActionDiscovery::tool_info(tool_info.parameters, inventory))
-            .or_else(|| {
-                tool_info
-                    .context
-                    .available_actions_snapshot
-                    .as_deref()
-                    .map(|actions| {
-                        ActionDiscovery::tool_info_from_actions(tool_info.parameters, actions)
-                    })
-            })
-            .unwrap_or(Ok(None));
+        {
+            ActionDiscovery::tool_info(tool_info.parameters, inventory)
+        } else if let Some(actions) = tool_info.context.available_actions_snapshot.as_deref() {
+            ActionDiscovery::tool_info_from_actions(tool_info.parameters, actions)
+        } else {
+            let error_msg = "tool_info: action inventory unavailable in this execution context";
+            let sanitized = self.safety.sanitize_tool_output("tool_info", error_msg);
+            return Ok(Self::snapshot_action_result(
+                tool_info.context,
+                tool_info.canonical_action_name,
+                serde_json::json!({"error": sanitized.content}),
+                true,
+                tool_info.started_at,
+            ));
+        };
 
         match snapshot_result {
             Ok(Some(output)) => Ok(Self::snapshot_action_result(
@@ -3083,6 +3087,122 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_info_schema_reads_action_inventory_for_engine_native_actions() {
+        let adapter = make_adapter();
+        let mut ctx = exec_ctx(
+            ironclaw_engine::ThreadId::new(),
+            Some("call_tool_info_schema"),
+        );
+        ctx.available_action_inventory_snapshot = Some(Arc::new(ActionInventory {
+            inline: vec![
+                ActionDef {
+                    name: "tool_info".to_string(),
+                    description: "Inspect actions".to_string(),
+                    parameters_schema: serde_json::json!({"type": "object"}),
+                    effects: vec![],
+                    requires_approval: false,
+                    model_tool_surface: ModelToolSurface::FullSchema,
+                    discovery: None,
+                },
+                ActionDef {
+                    name: "mission_create".to_string(),
+                    description: "Create a mission".to_string(),
+                    parameters_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "name": {"type": "string"},
+                            "goal": {"type": "string"},
+                            "cadence": {"type": "string"}
+                        },
+                        "required": ["name", "goal", "cadence"]
+                    }),
+                    effects: vec![],
+                    requires_approval: false,
+                    model_tool_surface: ModelToolSurface::CompactToolInfo,
+                    discovery: None,
+                },
+            ],
+            discoverable: Vec::new(),
+        }));
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "mission-create", "detail": "schema"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should succeed through action inventory discovery");
+
+        assert!(!result.is_error);
+        assert_eq!(result.output["name"], serde_json::json!("mission_create"));
+        assert_eq!(
+            result.output["schema"]["required"],
+            serde_json::json!(["name", "goal", "cadence"])
+        );
+    }
+
+    #[tokio::test]
+    async fn tool_info_reads_non_registry_action_from_current_inventory() {
+        let adapter = make_adapter();
+        let mut ctx = exec_ctx(
+            ironclaw_engine::ThreadId::new(),
+            Some("call_tool_info_custom_action"),
+        );
+        ctx.available_action_inventory_snapshot = Some(Arc::new(ActionInventory {
+            inline: vec![
+                ActionDef {
+                    name: "tool_info".to_string(),
+                    description: "Inspect actions".to_string(),
+                    parameters_schema: serde_json::json!({"type": "object"}),
+                    effects: vec![],
+                    requires_approval: false,
+                    model_tool_surface: ModelToolSurface::FullSchema,
+                    discovery: None,
+                },
+                ActionDef {
+                    name: "custom_provider_send".to_string(),
+                    description: "Send through a provider action".to_string(),
+                    parameters_schema: serde_json::json!({
+                        "type": "object",
+                        "properties": {
+                            "recipient": {"type": "string"},
+                            "message": {"type": "string"}
+                        },
+                        "required": ["recipient", "message"]
+                    }),
+                    effects: vec![],
+                    requires_approval: false,
+                    model_tool_surface: ModelToolSurface::CompactToolInfo,
+                    discovery: None,
+                },
+            ],
+            discoverable: Vec::new(),
+        }));
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "custom-provider-send", "detail": "schema"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should resolve non-registry action from inventory");
+
+        assert!(!result.is_error);
+        assert_eq!(
+            result.output["name"],
+            serde_json::json!("custom_provider_send")
+        );
+        assert_eq!(
+            result.output["schema"]["required"],
+            serde_json::json!(["recipient", "message"])
+        );
+    }
+
+    #[tokio::test]
     async fn tool_info_rejects_actions_outside_callable_snapshot() {
         let adapter = make_adapter();
         let mut ctx = exec_ctx(
@@ -3125,6 +3245,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn tool_info_does_not_fall_back_to_registry_when_snapshot_omits_tool() {
+        let adapter = make_tool_info_registry_adapter().await;
+        let mut ctx = exec_ctx(
+            ironclaw_engine::ThreadId::new(),
+            Some("call_tool_info_registry_fallback_guard"),
+        );
+        ctx.available_action_inventory_snapshot = Some(Arc::new(ActionInventory {
+            inline: vec![ActionDef {
+                name: "tool_info".to_string(),
+                description: "Inspect actions".to_string(),
+                parameters_schema: serde_json::json!({"type": "object"}),
+                effects: vec![],
+                requires_approval: false,
+                model_tool_surface: ModelToolSurface::FullSchema,
+                discovery: None,
+            }],
+            discoverable: Vec::new(),
+        }));
+
+        let result = adapter
+            .execute_action(
+                "tool_info",
+                serde_json::json!({"name": "approval_test", "detail": "schema"}),
+                &lease(),
+                &ctx,
+            )
+            .await
+            .expect("tool_info should return an error result for out-of-snapshot action");
+
+        assert!(result.is_error);
+        let error = result.output["error"].as_str().unwrap_or_default();
+        assert!(
+            error.contains("no callable or discoverable action named 'approval_test'"),
+            "unexpected error output: {:?}",
+            result.output
+        );
+        assert!(
+            !error.contains("No tool named 'approval_test' is registered"),
+            "registry-backed tool_info leaked through: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn tool_info_rejects_registered_tools_when_snapshots_are_missing() {
         let adapter = make_tool_info_registry_adapter().await;
         let ctx = exec_ctx(
@@ -3148,7 +3311,7 @@ mod tests {
             result.output["error"]
                 .as_str()
                 .unwrap_or_default()
-                .contains("no callable or discoverable action named 'approval_test'"),
+                .contains("action inventory unavailable in this execution context"),
             "unexpected error output: {:?}",
             result.output
         );


### PR DESCRIPTION
## Summary

Fixes v2 `tool_info` discovery so it resolves against the current `ActionInventory` surface instead of falling back to the global `ToolRegistry`. This lets engine-native actions like `mission_create` return schema details even though they are not registered builtin tools, and prevents `tool_info` from explaining globally registered tools that are not callable/discoverable in the current v2 context.

Also removes the hardcoded `mission_*` Python signatures from the CodeAct preamble so compact tools are discovered through the runtime action surface and `tool_info(..., detail="schema")`.

## Root cause

The model could follow the prompt and call `tool_info(name="mission_create", detail="schema")`, but the executed path could still hit registry-backed lookup. Since `mission_create` is engine-native and lives in `ActionInventory`, not `ToolRegistry`, that produced `No tool named 'mission_create' is registered`.

## Validation

- `cargo fmt`
- `cargo test tool_info --lib`
- `cargo test -p ironclaw_engine tool_info --lib`
- `cargo test -p ironclaw_engine prompt_renders_compact_enabled_tools_once_with_schema_instruction --lib`
- `git diff --check`

## Notes

This PR intentionally keeps `mission_create` outside `ToolRegistry`; the v2 source of truth is the current action inventory.