### PR TITLE
feat(reborn): add filesystem substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4030,6 +4030,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_filesystem"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "deadpool-postgres",
+ "ironclaw_host_api",
+ "libsql",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "ironclaw_gateway"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4041,6 +4041,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-postgres",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_resources", "crates/ironclaw_events", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_resources", "crates/ironclaw_events", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_filesystem/CLAUDE.md
+++ b/crates/ironclaw_filesystem/CLAUDE.md
@@ -1,0 +1,11 @@
+# ironclaw_filesystem guardrails
+
+- Own `RootFilesystem`, `ScopedFilesystem`, `CompositeRootFilesystem`, `FilesystemCatalog`, virtual-path persistence, backend placement metadata, and backend containment checks.
+- Depend on `ironclaw_host_api`; do not depend on product, authorization, dispatcher, runtime, process, event, secrets, memory/search, or extension workflow crates.
+- Keep `HostPath` backend-internal and non-serializable.
+- Reject traversal, mount escapes, unknown mounts, duplicate exact backend roots, and permission mismatches fail-closed.
+- Use longest virtual-prefix routing for composite backend selection and catalog placement.
+- Catalog metadata describes placement and content/index policy; it does not grant runtime authority.
+- Keep memory-specific path grammar and memory document repository adapters in `ironclaw_memory`, not this crate.
+- Do not force structured/control-plane records through file byte APIs. Secrets, approvals, leases, process records, events, and search indexes should stay in typed service repositories unless exposed as deliberate file-shaped projections.
+- New persistence behavior must preserve tenant/user virtual-path scoping.

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -23,6 +23,7 @@ libsql = { version = "0.6", optional = true, default-features = false, features 
 thiserror = "2"
 tokio = { version = "1", features = ["fs", "io-util"] }
 tokio-postgres = { version = "0.7", optional = true }
+tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "ironclaw_filesystem"
+version = "0.1.0"
+edition = "2024"
+rust-version = "1.92"
+description = "Scoped filesystem service for IronClaw Reborn"
+authors = ["NEAR AI <support@near.ai>"]
+license = "MIT OR Apache-2.0"
+homepage = "https://github.com/nearai/ironclaw"
+repository = "https://github.com/nearai/ironclaw"
+publish = false
+
+[features]
+default = []
+postgres = ["dep:deadpool-postgres", "dep:tokio-postgres"]
+libsql = ["dep:libsql"]
+
+[dependencies]
+async-trait = "0.1"
+deadpool-postgres = { version = "0.14", optional = true }
+ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
+libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
+thiserror = "2"
+tokio-postgres = { version = "0.7", optional = true }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_filesystem/Cargo.toml
+++ b/crates/ironclaw_filesystem/Cargo.toml
@@ -21,6 +21,7 @@ deadpool-postgres = { version = "0.14", optional = true }
 ironclaw_host_api = { path = "../ironclaw_host_api", version = "0.1.0" }
 libsql = { version = "0.6", optional = true, default-features = false, features = ["core", "replication", "remote", "tls"] }
 thiserror = "2"
+tokio = { version = "1", features = ["fs", "io-util"] }
 tokio-postgres = { version = "0.7", optional = true }
 
 [dev-dependencies]

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -6,7 +6,6 @@
 //! operation against a trusted root filesystem namespace addressed by
 //! [`VirtualPath`]. Backend implementations alone touch raw host paths.
 
-use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -15,6 +14,7 @@ use ironclaw_host_api::{
     HostApiError, HostPath, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
 };
 use thiserror::Error;
+use tokio::io::AsyncWriteExt;
 
 /// Filesystem operation used for permission checks and audit/error reporting.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,6 +60,11 @@ pub enum FilesystemError {
     },
     #[error("no backend mount found for virtual path {path:?}")]
     MountNotFound { path: VirtualPath },
+    #[error("virtual path not found for {operation} at {path:?}")]
+    NotFound {
+        path: VirtualPath,
+        operation: FilesystemOperation,
+    },
     #[error("virtual path escaped backend mount {path:?}")]
     PathOutsideMount { path: VirtualPath },
     #[error("symlink escapes backend mount at virtual path {path:?}")]
@@ -570,36 +575,33 @@ impl LocalFilesystem {
         Ok(())
     }
 
-    fn resolve_existing(
+    async fn resolve_existing(
         &self,
         path: &VirtualPath,
         operation: FilesystemOperation,
     ) -> Result<PathBuf, FilesystemError> {
         let (mount, joined) = self.resolve_joined(path)?;
-        let canonical =
-            std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation,
-                reason: io_reason(error),
-            })?;
+        let canonical = tokio::fs::canonicalize(&joined)
+            .await
+            .map_err(|error| io_error(path.clone(), operation, error))?;
         ensure_contained(path, mount, &canonical, true)?;
         Ok(canonical)
     }
 
-    fn resolve_for_write(
+    async fn resolve_for_write(
         &self,
         path: &VirtualPath,
         operation: FilesystemOperation,
     ) -> Result<PathBuf, FilesystemError> {
         let (mount, joined) = self.resolve_joined(path)?;
 
-        if joined.exists() {
-            let canonical =
-                std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
-                    path: path.clone(),
-                    operation,
-                    reason: io_reason(error),
-                })?;
+        if tokio::fs::try_exists(&joined)
+            .await
+            .map_err(|error| io_error(path.clone(), operation, error))?
+        {
+            let canonical = tokio::fs::canonicalize(&joined)
+                .await
+                .map_err(|error| io_error(path.clone(), operation, error))?;
             ensure_contained(path, mount, &canonical, true)?;
             return Ok(canonical);
         }
@@ -607,18 +609,13 @@ impl LocalFilesystem {
         let parent = joined
             .parent()
             .ok_or_else(|| FilesystemError::PathOutsideMount { path: path.clone() })?;
-        ensure_existing_ancestor_contained(path, mount, parent, operation)?;
-        std::fs::create_dir_all(parent).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::CreateDirAll,
-            reason: io_reason(error),
-        })?;
-        let canonical_parent =
-            std::fs::canonicalize(parent).map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::CreateDirAll,
-                reason: io_reason(error),
-            })?;
+        ensure_existing_ancestor_contained(path, mount, parent, operation).await?;
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
+        let canonical_parent = tokio::fs::canonicalize(parent)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
         // `joined` is constructed from validated virtual path segments under the
         // backend root. If its canonical parent leaves the backend root, an
         // existing symlink in the parent chain caused the escape.
@@ -626,25 +623,19 @@ impl LocalFilesystem {
         Ok(joined)
     }
 
-    fn resolve_for_create_dir_all(&self, path: &VirtualPath) -> Result<PathBuf, FilesystemError> {
+    async fn resolve_for_create_dir_all(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<PathBuf, FilesystemError> {
         let (mount, joined) = self.resolve_joined(path)?;
-        ensure_existing_ancestor_contained(
-            path,
-            mount,
-            &joined,
-            FilesystemOperation::CreateDirAll,
-        )?;
-        std::fs::create_dir_all(&joined).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::CreateDirAll,
-            reason: io_reason(error),
-        })?;
-        let canonical =
-            std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::CreateDirAll,
-                reason: io_reason(error),
-            })?;
+        ensure_existing_ancestor_contained(path, mount, &joined, FilesystemOperation::CreateDirAll)
+            .await?;
+        tokio::fs::create_dir_all(&joined)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
+        let canonical = tokio::fs::canonicalize(&joined)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
         ensure_contained(path, mount, &canonical, true)?;
         Ok(canonical)
     }
@@ -679,63 +670,62 @@ impl LocalFilesystem {
 #[async_trait]
 impl RootFilesystem for LocalFilesystem {
     async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
-        let resolved = self.resolve_existing(path, FilesystemOperation::ReadFile)?;
-        std::fs::read(resolved).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ReadFile,
-            reason: io_reason(error),
-        })
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::ReadFile)
+            .await?;
+        tokio::fs::read(resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ReadFile, error))
     }
 
     async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        let resolved = self.resolve_for_write(path, FilesystemOperation::WriteFile)?;
-        std::fs::write(resolved, bytes).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::WriteFile,
-            reason: io_reason(error),
-        })
+        let resolved = self
+            .resolve_for_write(path, FilesystemOperation::WriteFile)
+            .await?;
+        tokio::fs::write(resolved, bytes)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::WriteFile, error))
     }
 
     async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
-        let resolved = self.resolve_for_write(path, FilesystemOperation::AppendFile)?;
-        let mut file = std::fs::OpenOptions::new()
+        let resolved = self
+            .resolve_for_write(path, FilesystemOperation::AppendFile)
+            .await?;
+        let mut file = tokio::fs::OpenOptions::new()
             .create(true)
             .append(true)
+            .write(true)
             .open(resolved)
-            .map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::AppendFile,
-                reason: io_reason(error),
-            })?;
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))?;
         file.write_all(bytes)
-            .map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::AppendFile,
-                reason: io_reason(error),
-            })
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))?;
+        file.flush()
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::AppendFile, error))
     }
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        let resolved = self.resolve_existing(path, FilesystemOperation::ListDir)?;
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::ListDir)
+            .await?;
+        let mut read_dir = tokio::fs::read_dir(resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?;
         let mut entries = Vec::new();
-        for entry in std::fs::read_dir(resolved).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::ListDir,
-            reason: io_reason(error),
-        })? {
-            let entry = entry.map_err(|error| FilesystemError::Backend {
-                path: path.clone(),
-                operation: FilesystemOperation::ListDir,
-                reason: io_reason(error),
-            })?;
+        while let Some(entry) = read_dir
+            .next_entry()
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::ListDir, error))?
+        {
             let name = entry.file_name().to_string_lossy().to_string();
             let entry_path =
                 VirtualPath::new(format!("{}/{}", path.as_str().trim_end_matches('/'), name))?;
-            let metadata = entry.metadata().map_err(|error| FilesystemError::Backend {
-                path: entry_path.clone(),
-                operation: FilesystemOperation::Stat,
-                reason: io_reason(error),
-            })?;
+            let metadata = entry
+                .metadata()
+                .await
+                .map_err(|error| io_error(entry_path.clone(), FilesystemOperation::Stat, error))?;
             entries.push(DirEntry {
                 name,
                 path: entry_path,
@@ -747,12 +737,12 @@ impl RootFilesystem for LocalFilesystem {
     }
 
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        let resolved = self.resolve_existing(path, FilesystemOperation::Stat)?;
-        let metadata = std::fs::metadata(resolved).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::Stat,
-            reason: io_reason(error),
-        })?;
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::Stat)
+            .await?;
+        let metadata = tokio::fs::metadata(resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::Stat, error))?;
         Ok(FileStat {
             path: path.clone(),
             file_type: file_type_from_metadata(&metadata),
@@ -761,26 +751,22 @@ impl RootFilesystem for LocalFilesystem {
     }
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        let resolved = self.resolve_existing(path, FilesystemOperation::Delete)?;
-        let metadata = std::fs::metadata(&resolved).map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::Delete,
-            reason: io_reason(error),
-        })?;
-        if metadata.is_dir() {
-            std::fs::remove_dir_all(resolved)
+        let resolved = self
+            .resolve_existing(path, FilesystemOperation::Delete)
+            .await?;
+        let metadata = tokio::fs::metadata(&resolved)
+            .await
+            .map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))?;
+        let result = if metadata.is_dir() {
+            tokio::fs::remove_dir_all(resolved).await
         } else {
-            std::fs::remove_file(resolved)
-        }
-        .map_err(|error| FilesystemError::Backend {
-            path: path.clone(),
-            operation: FilesystemOperation::Delete,
-            reason: io_reason(error),
-        })
+            tokio::fs::remove_file(resolved).await
+        };
+        result.map_err(|error| io_error(path.clone(), FilesystemOperation::Delete, error))
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        self.resolve_for_create_dir_all(path).map(|_| ())
+        self.resolve_for_create_dir_all(path).await.map(|_| ())
     }
 }
 
@@ -788,25 +774,27 @@ fn virtual_prefix_matches(prefix: &str, path: &str) -> bool {
     path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
-fn ensure_existing_ancestor_contained(
+async fn ensure_existing_ancestor_contained(
     virtual_path: &VirtualPath,
     mount: &LocalMount,
     candidate: &Path,
     operation: FilesystemOperation,
 ) -> Result<(), FilesystemError> {
-    let mut ancestor = candidate;
-    while !ancestor.exists() {
+    let mut ancestor = candidate.to_path_buf();
+    while !tokio::fs::try_exists(&ancestor)
+        .await
+        .map_err(|error| io_error(virtual_path.clone(), operation, error))?
+    {
         ancestor = ancestor
             .parent()
             .ok_or_else(|| FilesystemError::PathOutsideMount {
                 path: virtual_path.clone(),
-            })?;
+            })?
+            .to_path_buf();
     }
-    let canonical = std::fs::canonicalize(ancestor).map_err(|error| FilesystemError::Backend {
-        path: virtual_path.clone(),
-        operation,
-        reason: io_reason(error),
-    })?;
+    let canonical = tokio::fs::canonicalize(&ancestor)
+        .await
+        .map_err(|error| io_error(virtual_path.clone(), operation, error))?;
     ensure_contained(virtual_path, mount, &canonical, true)
 }
 
@@ -839,6 +827,22 @@ fn file_type_from_metadata(metadata: &std::fs::Metadata) -> FileType {
         FileType::Symlink
     } else {
         FileType::Other
+    }
+}
+
+fn io_error(
+    path: VirtualPath,
+    operation: FilesystemOperation,
+    error: std::io::Error,
+) -> FilesystemError {
+    if error.kind() == std::io::ErrorKind::NotFound {
+        FilesystemError::NotFound { path, operation }
+    } else {
+        FilesystemError::Backend {
+            path,
+            operation,
+            reason: error.kind().to_string(),
+        }
     }
 }
 
@@ -967,7 +971,9 @@ impl RootFilesystem for PostgresRootFilesystem {
                 reason: "not a directory".to_string(),
             });
         }
-        let rows = self.all_paths().await?;
+        let rows = self
+            .child_entries(path, FilesystemOperation::ListDir)
+            .await?;
         let children = direct_children(path, rows);
         if matches!(exact_entry, Some((_, FileType::Directory))) && is_not_found(&children) {
             return Ok(Vec::new());
@@ -983,11 +989,7 @@ impl RootFilesystem for PostgresRootFilesystem {
                 len,
             });
         }
-        let rows = self.all_paths().await?;
-        if rows
-            .iter()
-            .any(|(child_path, _, _)| virtual_prefix_matches(path.as_str(), child_path.as_str()))
-        {
+        if self.has_child_entry(path).await? {
             return Ok(FileStat {
                 path: path.clone(),
                 file_type: FileType::Directory,
@@ -999,13 +1001,11 @@ impl RootFilesystem for PostgresRootFilesystem {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let client = self.client().await?;
+        let child_pattern = child_path_like_pattern(path);
         client
             .execute(
-                "DELETE FROM root_filesystem_entries WHERE path = $1 OR path LIKE $2",
-                &[
-                    &path.as_str(),
-                    &format!("{}/%", path.as_str().trim_end_matches('/')),
-                ],
+                "DELETE FROM root_filesystem_entries WHERE path = $1 OR path LIKE $2 ESCAPE '!'",
+                &[&path.as_str(), &child_pattern],
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::Delete, error))?;
@@ -1068,21 +1068,20 @@ impl PostgresRootFilesystem {
         }))
     }
 
-    async fn all_paths(&self) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
+    async fn child_entries(
+        &self,
+        parent: &VirtualPath,
+        operation: FilesystemOperation,
+    ) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
         let client = self.client().await?;
+        let pattern = child_path_like_pattern(parent);
         let rows = client
             .query(
-                "SELECT path, OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries ORDER BY path",
-                &[],
+                "SELECT path, OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries WHERE path LIKE $1 ESCAPE '!' ORDER BY path",
+                &[&pattern],
             )
             .await
-            .map_err(|error| {
-                db_error(
-                    VirtualPath::new("/engine").unwrap_or_else(|_| unreachable!("literal virtual path is valid")),
-                    FilesystemOperation::ListDir,
-                    error,
-                )
-            })?;
+            .map_err(|error| db_error(parent.clone(), operation, error))?;
         rows.into_iter()
             .map(|row| {
                 let path: String = row.get("path");
@@ -1099,6 +1098,19 @@ impl PostgresRootFilesystem {
                 ))
             })
             .collect()
+    }
+
+    async fn has_child_entry(&self, parent: &VirtualPath) -> Result<bool, FilesystemError> {
+        let client = self.client().await?;
+        let pattern = child_path_like_pattern(parent);
+        let row = client
+            .query_opt(
+                "SELECT 1 FROM root_filesystem_entries WHERE path LIKE $1 ESCAPE '!' LIMIT 1",
+                &[&pattern],
+            )
+            .await
+            .map_err(|error| db_error(parent.clone(), FilesystemOperation::Stat, error))?;
+        Ok(row.is_some())
     }
 }
 
@@ -1226,13 +1238,21 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 reason: "cannot append to a directory".to_string(),
             });
         }
-        let mut contents = match self.read_file(path).await {
-            Ok(contents) => contents,
-            Err(FilesystemError::Backend { reason, .. }) if reason == "not found" => Vec::new(),
-            Err(error) => return Err(error),
-        };
-        contents.extend_from_slice(bytes);
-        self.write_file(path, &contents).await
+        let conn = self.connect().await?;
+        conn.execute(
+            r#"
+            INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
+            VALUES (?1, ?2, 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            ON CONFLICT (path) DO UPDATE SET
+                contents = CAST(root_filesystem_entries.contents || excluded.contents AS BLOB),
+                is_dir = 0,
+                updated_at = excluded.updated_at
+            "#,
+            libsql::params![path.as_str(), libsql::Value::Blob(bytes.to_vec())],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::AppendFile, error))?;
+        Ok(())
     }
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
@@ -1244,7 +1264,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 reason: "not a directory".to_string(),
             });
         }
-        let rows = self.all_paths().await?;
+        let rows = self
+            .child_entries(path, FilesystemOperation::ListDir)
+            .await?;
         let children = direct_children(path, rows);
         if matches!(exact_entry, Some((_, FileType::Directory))) && is_not_found(&children) {
             return Ok(Vec::new());
@@ -1260,11 +1282,7 @@ impl RootFilesystem for LibSqlRootFilesystem {
                 len,
             });
         }
-        let rows = self.all_paths().await?;
-        if rows
-            .iter()
-            .any(|(child_path, _, _)| virtual_prefix_matches(path.as_str(), child_path.as_str()))
-        {
+        if self.has_child_entry(path).await? {
             return Ok(FileStat {
                 path: path.clone(),
                 file_type: FileType::Directory,
@@ -1277,11 +1295,8 @@ impl RootFilesystem for LibSqlRootFilesystem {
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
         conn.execute(
-            "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2",
-            libsql::params![
-                path.as_str(),
-                format!("{}/%", path.as_str().trim_end_matches('/'))
-            ],
+            "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
+            libsql::params![path.as_str(), child_path_like_pattern(path)],
         )
         .await
         .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
@@ -1393,24 +1408,29 @@ impl LibSqlRootFilesystem {
         }))
     }
 
-    async fn all_paths(&self) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
+    async fn child_entries(
+        &self,
+        parent: &VirtualPath,
+        operation: FilesystemOperation,
+    ) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
         let conn = self.connect().await?;
+        let pattern = child_path_like_pattern(parent);
         let mut rows = conn
             .query(
-                "SELECT path, length(contents), is_dir FROM root_filesystem_entries ORDER BY path",
-                (),
+                "SELECT path, length(contents), is_dir FROM root_filesystem_entries WHERE path LIKE ?1 ESCAPE '!' ORDER BY path",
+                libsql::params![pattern],
             )
             .await
-            .map_err(|error| {
-                libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
-            })?;
+            .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
         let mut paths = Vec::new();
-        while let Some(row) = rows.next().await.map_err(|error| {
-            libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
-        })? {
-            let path: String = row.get(0).map_err(|error| {
-                libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
-            })?;
+        while let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(parent.clone(), operation, error))?
+        {
+            let path: String = row
+                .get(0)
+                .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
             let len = row.get::<i64>(1).unwrap_or(0).max(0) as u64;
             let is_dir = row.get::<i64>(2).unwrap_or(0) != 0;
             paths.push((
@@ -1424,6 +1444,23 @@ impl LibSqlRootFilesystem {
             ));
         }
         Ok(paths)
+    }
+
+    async fn has_child_entry(&self, parent: &VirtualPath) -> Result<bool, FilesystemError> {
+        let conn = self.connect().await?;
+        let pattern = child_path_like_pattern(parent);
+        let mut rows = conn
+            .query(
+                "SELECT 1 FROM root_filesystem_entries WHERE path LIKE ?1 ESCAPE '!' LIMIT 1",
+                libsql::params![pattern],
+            )
+            .await
+            .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?;
+        Ok(rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(parent.clone(), FilesystemOperation::Stat, error))?
+            .is_some())
     }
 }
 
@@ -1492,20 +1529,29 @@ fn direct_children(
 }
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
-fn not_found(path: VirtualPath, operation: FilesystemOperation) -> FilesystemError {
-    FilesystemError::Backend {
-        path,
-        operation,
-        reason: "not found".to_string(),
+fn child_path_like_pattern(path: &VirtualPath) -> String {
+    let mut pattern = String::new();
+    for character in path.as_str().trim_end_matches('/').chars() {
+        match character {
+            '!' | '%' | '_' => {
+                pattern.push('!');
+                pattern.push(character);
+            }
+            _ => pattern.push(character),
+        }
     }
+    pattern.push_str("/%");
+    pattern
+}
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn not_found(path: VirtualPath, operation: FilesystemOperation) -> FilesystemError {
+    FilesystemError::NotFound { path, operation }
 }
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]
 fn is_not_found<T>(result: &Result<T, FilesystemError>) -> bool {
-    matches!(
-        result,
-        Err(FilesystemError::Backend { reason, .. }) if reason == "not found"
-    )
+    matches!(result, Err(FilesystemError::NotFound { .. }))
 }
 
 #[cfg(feature = "postgres")]

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -1,0 +1,1540 @@
+//! Scoped filesystem service for IronClaw Reborn.
+//!
+//! `ironclaw_filesystem` is the first service crate above
+//! `ironclaw_host_api`. It resolves runtime-visible [`ScopedPath`] values
+//! through a caller's [`MountView`], checks mount permissions, then performs the
+//! operation against a trusted root filesystem namespace addressed by
+//! [`VirtualPath`]. Backend implementations alone touch raw host paths.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use ironclaw_host_api::{
+    HostApiError, HostPath, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
+};
+use thiserror::Error;
+
+/// Filesystem operation used for permission checks and audit/error reporting.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FilesystemOperation {
+    MountLocal,
+    ReadFile,
+    WriteFile,
+    AppendFile,
+    ListDir,
+    Stat,
+    Delete,
+    CreateDirAll,
+}
+
+impl std::fmt::Display for FilesystemOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::MountLocal => "mount_local",
+            Self::ReadFile => "read_file",
+            Self::WriteFile => "write_file",
+            Self::AppendFile => "append_file",
+            Self::ListDir => "list_dir",
+            Self::Stat => "stat",
+            Self::Delete => "delete",
+            Self::CreateDirAll => "create_dir_all",
+        })
+    }
+}
+
+/// Filesystem service failures.
+///
+/// Display output intentionally uses scoped/virtual paths rather than raw host
+/// paths. Backend implementations may log lower-level errors separately, but
+/// user-facing errors should preserve host path confidentiality.
+#[derive(Debug, Error)]
+pub enum FilesystemError {
+    #[error(transparent)]
+    Contract(#[from] HostApiError),
+    #[error("permission denied for {operation} on scoped path {path:?}")]
+    PermissionDenied {
+        path: ScopedPath,
+        operation: FilesystemOperation,
+    },
+    #[error("no backend mount found for virtual path {path:?}")]
+    MountNotFound { path: VirtualPath },
+    #[error("virtual path escaped backend mount {path:?}")]
+    PathOutsideMount { path: VirtualPath },
+    #[error("symlink escapes backend mount at virtual path {path:?}")]
+    SymlinkEscape { path: VirtualPath },
+    #[error("backend mount conflict at virtual path {path:?}")]
+    MountConflict { path: VirtualPath },
+    #[error("filesystem backend error during {operation} at {path:?}: {reason}")]
+    Backend {
+        path: VirtualPath,
+        operation: FilesystemOperation,
+        reason: String,
+    },
+}
+
+/// Coarse file type returned by [`FileStat`] and [`DirEntry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FileType {
+    File,
+    Directory,
+    Symlink,
+    Other,
+}
+
+/// Directory entry returned by [`RootFilesystem::list_dir`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DirEntry {
+    pub name: String,
+    pub path: VirtualPath,
+    pub file_type: FileType,
+}
+
+/// File metadata returned by [`RootFilesystem::stat`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileStat {
+    pub path: VirtualPath,
+    pub file_type: FileType,
+    pub len: u64,
+}
+
+/// Stable identifier for a mounted filesystem backend.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BackendId(String);
+
+impl BackendId {
+    pub fn new(value: impl Into<String>) -> Result<Self, HostApiError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(HostApiError::InvalidId {
+                kind: "filesystem backend",
+                value,
+                reason: "backend id must not be empty".to_string(),
+            });
+        }
+        if value.contains('/')
+            || value.contains('\\')
+            || value.contains('\0')
+            || value.chars().any(char::is_control)
+        {
+            return Err(HostApiError::InvalidId {
+                kind: "filesystem backend",
+                value,
+                reason: "backend id must be a simple non-path identifier".to_string(),
+            });
+        }
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Coarse class of backend implementation behind a virtual mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackendKind {
+    LocalFilesystem,
+    DatabaseFilesystem,
+    MemoryDocuments,
+    ObjectStore,
+    Custom(String),
+}
+
+/// Storage shape represented by a mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StorageClass {
+    /// File-like contents addressed by virtual paths.
+    FileContent,
+    /// Structured records that may expose file-shaped projections.
+    StructuredRecords,
+    /// Derived data such as chunks, indexes, or embeddings.
+    DerivedProjection,
+}
+
+/// Semantic kind of content exposed at a mount.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentKind {
+    GenericFile,
+    ProjectFile,
+    Artifact,
+    MemoryDocument,
+    SystemState,
+    ExtensionPackage,
+    StructuredRecord,
+}
+
+/// Indexing/embedding policy associated with file-shaped content.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum IndexPolicy {
+    NotIndexed,
+    FullText,
+    Vector,
+    FullTextAndVector,
+    BackendDefined,
+}
+
+/// Capabilities advertised by a mounted backend for diagnostics and routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct BackendCapabilities {
+    pub read: bool,
+    pub write: bool,
+    pub append: bool,
+    pub list: bool,
+    pub stat: bool,
+    pub delete: bool,
+    pub indexed: bool,
+    pub embedded: bool,
+}
+
+/// Trusted catalog record for one virtual filesystem mount.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MountDescriptor {
+    pub virtual_root: VirtualPath,
+    pub backend_id: BackendId,
+    pub backend_kind: BackendKind,
+    pub storage_class: StorageClass,
+    pub content_kind: ContentKind,
+    pub index_policy: IndexPolicy,
+    pub capabilities: BackendCapabilities,
+}
+
+/// Catalog answer for the backend that owns a virtual path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PathPlacement {
+    pub path: VirtualPath,
+    pub matched_root: VirtualPath,
+    pub backend_id: BackendId,
+    pub backend_kind: BackendKind,
+    pub storage_class: StorageClass,
+    pub content_kind: ContentKind,
+    pub index_policy: IndexPolicy,
+    pub capabilities: BackendCapabilities,
+}
+
+impl PathPlacement {
+    fn from_descriptor(path: VirtualPath, descriptor: &MountDescriptor) -> Self {
+        Self {
+            path,
+            matched_root: descriptor.virtual_root.clone(),
+            backend_id: descriptor.backend_id.clone(),
+            backend_kind: descriptor.backend_kind.clone(),
+            storage_class: descriptor.storage_class,
+            content_kind: descriptor.content_kind,
+            index_policy: descriptor.index_policy,
+            capabilities: descriptor.capabilities,
+        }
+    }
+}
+
+/// Trusted catalog over virtual filesystem mount placement.
+///
+/// The catalog explains where a [`VirtualPath`] is placed; it does not grant
+/// runtime access. Untrusted callers must still go through [`ScopedFilesystem`]
+/// and a scoped [`MountView`].
+#[async_trait]
+pub trait FilesystemCatalog: Send + Sync {
+    async fn describe_path(&self, path: &VirtualPath) -> Result<PathPlacement, FilesystemError>;
+
+    async fn mounts(&self) -> Result<Vec<MountDescriptor>, FilesystemError>;
+}
+
+/// Root filesystem that composes multiple backend roots behind one virtual namespace.
+pub struct CompositeRootFilesystem {
+    mounts: Vec<CompositeMount>,
+}
+
+struct CompositeMount {
+    descriptor: MountDescriptor,
+    backend: Arc<dyn RootFilesystem>,
+}
+
+impl CompositeRootFilesystem {
+    pub fn new() -> Self {
+        Self { mounts: Vec::new() }
+    }
+
+    pub fn mount<F>(
+        &mut self,
+        descriptor: MountDescriptor,
+        backend: Arc<F>,
+    ) -> Result<(), FilesystemError>
+    where
+        F: RootFilesystem + 'static,
+    {
+        let backend: Arc<dyn RootFilesystem> = backend;
+        self.mount_dyn(descriptor, backend)
+    }
+
+    pub fn mount_dyn(
+        &mut self,
+        descriptor: MountDescriptor,
+        backend: Arc<dyn RootFilesystem>,
+    ) -> Result<(), FilesystemError> {
+        if self
+            .mounts
+            .iter()
+            .any(|mount| mount.descriptor.virtual_root.as_str() == descriptor.virtual_root.as_str())
+        {
+            return Err(FilesystemError::MountConflict {
+                path: descriptor.virtual_root,
+            });
+        }
+        self.mounts.push(CompositeMount {
+            descriptor,
+            backend,
+        });
+        Ok(())
+    }
+
+    fn matching_mount(&self, path: &VirtualPath) -> Result<&CompositeMount, FilesystemError> {
+        self.mounts
+            .iter()
+            .filter(|mount| {
+                virtual_prefix_matches(mount.descriptor.virtual_root.as_str(), path.as_str())
+            })
+            .max_by_key(|mount| mount.descriptor.virtual_root.as_str().len())
+            .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })
+    }
+}
+
+impl Default for CompositeRootFilesystem {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl FilesystemCatalog for CompositeRootFilesystem {
+    async fn describe_path(&self, path: &VirtualPath) -> Result<PathPlacement, FilesystemError> {
+        let mount = self.matching_mount(path)?;
+        Ok(PathPlacement::from_descriptor(
+            path.clone(),
+            &mount.descriptor,
+        ))
+    }
+
+    async fn mounts(&self) -> Result<Vec<MountDescriptor>, FilesystemError> {
+        let mut mounts: Vec<_> = self
+            .mounts
+            .iter()
+            .map(|mount| mount.descriptor.clone())
+            .collect();
+        mounts.sort_by(|left, right| left.virtual_root.as_str().cmp(right.virtual_root.as_str()));
+        Ok(mounts)
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for CompositeRootFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        self.matching_mount(path)?.backend.read_file(path).await
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .write_file(path, bytes)
+            .await
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .append_file(path, bytes)
+            .await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.matching_mount(path)?.backend.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.matching_mount(path)?.backend.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?.backend.delete(path).await
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.matching_mount(path)?
+            .backend
+            .create_dir_all(path)
+            .await
+    }
+}
+
+/// Trusted root filesystem interface over canonical virtual paths.
+#[async_trait]
+pub trait RootFilesystem: Send + Sync {
+    /// Reads a file by canonical virtual path without exposing backend host paths in errors.
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError>;
+
+    /// Writes bytes to a canonical virtual path while preserving backend containment.
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError>;
+
+    /// Appends bytes to a canonical virtual path. Backends that do not support append must fail closed before side effects.
+    async fn append_file(&self, path: &VirtualPath, _bytes: &[u8]) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::AppendFile,
+            reason: "append_file is not supported by this backend".to_string(),
+        })
+    }
+
+    /// Lists direct children of a canonical virtual directory; callers must handle pagination/backends in future implementations without bypassing scope.
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError>;
+
+    /// Returns metadata for a canonical virtual path without revealing raw host paths.
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
+
+    /// Deletes a canonical virtual file or directory. Backends that do not support delete must fail closed before side effects.
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::Delete,
+            reason: "delete is not supported by this backend".to_string(),
+        })
+    }
+
+    /// Creates a canonical virtual directory and any missing parents. Backends that do not support directories must fail closed before side effects.
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        Err(FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::CreateDirAll,
+            reason: "create_dir_all is not supported by this backend".to_string(),
+        })
+    }
+}
+
+/// Invocation-scoped filesystem view over [`ScopedPath`] values.
+#[derive(Debug, Clone)]
+pub struct ScopedFilesystem<F> {
+    root: Arc<F>,
+    mounts: MountView,
+}
+
+impl<F> ScopedFilesystem<F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(root: Arc<F>, mounts: MountView) -> Self {
+        Self { root, mounts }
+    }
+
+    pub fn mounts(&self) -> &MountView {
+        &self.mounts
+    }
+
+    pub async fn read_file(&self, path: &ScopedPath) -> Result<Vec<u8>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::ReadFile)?;
+        self.root.read_file(&virtual_path).await
+    }
+
+    pub async fn write_file(&self, path: &ScopedPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::WriteFile)?;
+        self.root.write_file(&virtual_path, bytes).await
+    }
+
+    pub async fn append_file(
+        &self,
+        path: &ScopedPath,
+        bytes: &[u8],
+    ) -> Result<(), FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::AppendFile)?;
+        self.root.append_file(&virtual_path, bytes).await
+    }
+
+    pub async fn list_dir(&self, path: &ScopedPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::ListDir)?;
+        self.root.list_dir(&virtual_path).await
+    }
+
+    pub async fn stat(&self, path: &ScopedPath) -> Result<FileStat, FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::Stat)?;
+        self.root.stat(&virtual_path).await
+    }
+
+    pub async fn delete(&self, path: &ScopedPath) -> Result<(), FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::Delete)?;
+        self.root.delete(&virtual_path).await
+    }
+
+    pub async fn create_dir_all(&self, path: &ScopedPath) -> Result<(), FilesystemError> {
+        let virtual_path = self.resolve_with_permission(path, FilesystemOperation::CreateDirAll)?;
+        self.root.create_dir_all(&virtual_path).await
+    }
+
+    fn resolve_with_permission(
+        &self,
+        path: &ScopedPath,
+        operation: FilesystemOperation,
+    ) -> Result<VirtualPath, FilesystemError> {
+        let grant =
+            matching_mount(&self.mounts, path).ok_or_else(|| match self.mounts.resolve(path) {
+                Ok(_) => FilesystemError::from(HostApiError::InvalidMount {
+                    value: path.as_str().to_string(),
+                    reason: "scoped path matched no mount grant".to_string(),
+                }),
+                Err(error) => FilesystemError::from(error),
+            })?;
+
+        if !operation_allowed(&grant.permissions, operation) {
+            return Err(FilesystemError::PermissionDenied {
+                path: path.clone(),
+                operation,
+            });
+        }
+
+        self.mounts.resolve(path).map_err(FilesystemError::from)
+    }
+}
+
+fn matching_mount<'a>(view: &'a MountView, path: &ScopedPath) -> Option<&'a MountGrant> {
+    let raw = path.as_str();
+    view.mounts
+        .iter()
+        .filter(|mount| alias_matches(mount.alias.as_str(), raw))
+        .max_by_key(|mount| mount.alias.as_str().len())
+}
+
+fn alias_matches(alias: &str, path: &str) -> bool {
+    path == alias || path.starts_with(&format!("{alias}/"))
+}
+
+fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperation) -> bool {
+    match operation {
+        FilesystemOperation::ReadFile => permissions.read,
+        FilesystemOperation::WriteFile => permissions.write,
+        FilesystemOperation::AppendFile => permissions.write,
+        FilesystemOperation::ListDir => permissions.list,
+        FilesystemOperation::Stat => permissions.read || permissions.list,
+        FilesystemOperation::Delete => permissions.delete,
+        FilesystemOperation::CreateDirAll => permissions.write,
+        FilesystemOperation::MountLocal => false,
+    }
+}
+
+/// Local filesystem backend mounted into the virtual namespace.
+#[derive(Debug, Default)]
+pub struct LocalFilesystem {
+    mounts: Vec<LocalMount>,
+}
+
+#[derive(Debug, Clone)]
+struct LocalMount {
+    virtual_root: VirtualPath,
+    host_root: PathBuf,
+}
+
+impl LocalFilesystem {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn mount_local(
+        &mut self,
+        virtual_root: VirtualPath,
+        host_root: HostPath,
+    ) -> Result<(), FilesystemError> {
+        if self
+            .mounts
+            .iter()
+            .any(|mount| mount.virtual_root.as_str() == virtual_root.as_str())
+        {
+            return Err(FilesystemError::MountConflict { path: virtual_root });
+        }
+
+        let canonical_root = std::fs::canonicalize(host_root.as_path()).map_err(|error| {
+            FilesystemError::Backend {
+                path: virtual_root.clone(),
+                operation: FilesystemOperation::MountLocal,
+                reason: io_reason(error),
+            }
+        })?;
+
+        if !canonical_root.is_dir() {
+            return Err(FilesystemError::Backend {
+                path: virtual_root,
+                operation: FilesystemOperation::MountLocal,
+                reason: "host root is not a directory".to_string(),
+            });
+        }
+
+        self.mounts.push(LocalMount {
+            virtual_root,
+            host_root: canonical_root,
+        });
+        Ok(())
+    }
+
+    fn resolve_existing(
+        &self,
+        path: &VirtualPath,
+        operation: FilesystemOperation,
+    ) -> Result<PathBuf, FilesystemError> {
+        let (mount, joined) = self.resolve_joined(path)?;
+        let canonical =
+            std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation,
+                reason: io_reason(error),
+            })?;
+        ensure_contained(path, mount, &canonical, true)?;
+        Ok(canonical)
+    }
+
+    fn resolve_for_write(
+        &self,
+        path: &VirtualPath,
+        operation: FilesystemOperation,
+    ) -> Result<PathBuf, FilesystemError> {
+        let (mount, joined) = self.resolve_joined(path)?;
+
+        if joined.exists() {
+            let canonical =
+                std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
+                    path: path.clone(),
+                    operation,
+                    reason: io_reason(error),
+                })?;
+            ensure_contained(path, mount, &canonical, true)?;
+            return Ok(canonical);
+        }
+
+        let parent = joined
+            .parent()
+            .ok_or_else(|| FilesystemError::PathOutsideMount { path: path.clone() })?;
+        ensure_existing_ancestor_contained(path, mount, parent, operation)?;
+        std::fs::create_dir_all(parent).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::CreateDirAll,
+            reason: io_reason(error),
+        })?;
+        let canonical_parent =
+            std::fs::canonicalize(parent).map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::CreateDirAll,
+                reason: io_reason(error),
+            })?;
+        // `joined` is constructed from validated virtual path segments under the
+        // backend root. If its canonical parent leaves the backend root, an
+        // existing symlink in the parent chain caused the escape.
+        ensure_contained(path, mount, &canonical_parent, true)?;
+        Ok(joined)
+    }
+
+    fn resolve_for_create_dir_all(&self, path: &VirtualPath) -> Result<PathBuf, FilesystemError> {
+        let (mount, joined) = self.resolve_joined(path)?;
+        ensure_existing_ancestor_contained(
+            path,
+            mount,
+            &joined,
+            FilesystemOperation::CreateDirAll,
+        )?;
+        std::fs::create_dir_all(&joined).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::CreateDirAll,
+            reason: io_reason(error),
+        })?;
+        let canonical =
+            std::fs::canonicalize(&joined).map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::CreateDirAll,
+                reason: io_reason(error),
+            })?;
+        ensure_contained(path, mount, &canonical, true)?;
+        Ok(canonical)
+    }
+
+    fn resolve_joined(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<(&LocalMount, PathBuf), FilesystemError> {
+        let mount = self
+            .mounts
+            .iter()
+            .filter(|mount| virtual_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
+            .max_by_key(|mount| mount.virtual_root.as_str().len())
+            .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })?;
+
+        let tail = path
+            .as_str()
+            .strip_prefix(mount.virtual_root.as_str())
+            .unwrap_or_default()
+            .trim_start_matches('/');
+
+        let mut joined = mount.host_root.clone();
+        if !tail.is_empty() {
+            for segment in tail.split('/') {
+                joined.push(segment);
+            }
+        }
+        Ok((mount, joined))
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for LocalFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        let resolved = self.resolve_existing(path, FilesystemOperation::ReadFile)?;
+        std::fs::read(resolved).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::ReadFile,
+            reason: io_reason(error),
+        })
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let resolved = self.resolve_for_write(path, FilesystemOperation::WriteFile)?;
+        std::fs::write(resolved, bytes).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::WriteFile,
+            reason: io_reason(error),
+        })
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let resolved = self.resolve_for_write(path, FilesystemOperation::AppendFile)?;
+        let mut file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(resolved)
+            .map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::AppendFile,
+                reason: io_reason(error),
+            })?;
+        file.write_all(bytes)
+            .map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::AppendFile,
+                reason: io_reason(error),
+            })
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let resolved = self.resolve_existing(path, FilesystemOperation::ListDir)?;
+        let mut entries = Vec::new();
+        for entry in std::fs::read_dir(resolved).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::ListDir,
+            reason: io_reason(error),
+        })? {
+            let entry = entry.map_err(|error| FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ListDir,
+                reason: io_reason(error),
+            })?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            let entry_path =
+                VirtualPath::new(format!("{}/{}", path.as_str().trim_end_matches('/'), name))?;
+            let metadata = entry.metadata().map_err(|error| FilesystemError::Backend {
+                path: entry_path.clone(),
+                operation: FilesystemOperation::Stat,
+                reason: io_reason(error),
+            })?;
+            entries.push(DirEntry {
+                name,
+                path: entry_path,
+                file_type: file_type_from_metadata(&metadata),
+            });
+        }
+        entries.sort_by(|left, right| left.name.cmp(&right.name));
+        Ok(entries)
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        let resolved = self.resolve_existing(path, FilesystemOperation::Stat)?;
+        let metadata = std::fs::metadata(resolved).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::Stat,
+            reason: io_reason(error),
+        })?;
+        Ok(FileStat {
+            path: path.clone(),
+            file_type: file_type_from_metadata(&metadata),
+            len: metadata.len(),
+        })
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let resolved = self.resolve_existing(path, FilesystemOperation::Delete)?;
+        let metadata = std::fs::metadata(&resolved).map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::Delete,
+            reason: io_reason(error),
+        })?;
+        if metadata.is_dir() {
+            std::fs::remove_dir_all(resolved)
+        } else {
+            std::fs::remove_file(resolved)
+        }
+        .map_err(|error| FilesystemError::Backend {
+            path: path.clone(),
+            operation: FilesystemOperation::Delete,
+            reason: io_reason(error),
+        })
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.resolve_for_create_dir_all(path).map(|_| ())
+    }
+}
+
+fn virtual_prefix_matches(prefix: &str, path: &str) -> bool {
+    path == prefix || path.starts_with(&format!("{prefix}/"))
+}
+
+fn ensure_existing_ancestor_contained(
+    virtual_path: &VirtualPath,
+    mount: &LocalMount,
+    candidate: &Path,
+    operation: FilesystemOperation,
+) -> Result<(), FilesystemError> {
+    let mut ancestor = candidate;
+    while !ancestor.exists() {
+        ancestor = ancestor
+            .parent()
+            .ok_or_else(|| FilesystemError::PathOutsideMount {
+                path: virtual_path.clone(),
+            })?;
+    }
+    let canonical = std::fs::canonicalize(ancestor).map_err(|error| FilesystemError::Backend {
+        path: virtual_path.clone(),
+        operation,
+        reason: io_reason(error),
+    })?;
+    ensure_contained(virtual_path, mount, &canonical, true)
+}
+
+fn ensure_contained(
+    virtual_path: &VirtualPath,
+    mount: &LocalMount,
+    candidate: &Path,
+    existing_target: bool,
+) -> Result<(), FilesystemError> {
+    if candidate.starts_with(&mount.host_root) {
+        Ok(())
+    } else if existing_target {
+        Err(FilesystemError::SymlinkEscape {
+            path: virtual_path.clone(),
+        })
+    } else {
+        Err(FilesystemError::PathOutsideMount {
+            path: virtual_path.clone(),
+        })
+    }
+}
+
+fn file_type_from_metadata(metadata: &std::fs::Metadata) -> FileType {
+    let file_type = metadata.file_type();
+    if file_type.is_file() {
+        FileType::File
+    } else if file_type.is_dir() {
+        FileType::Directory
+    } else if file_type.is_symlink() {
+        FileType::Symlink
+    } else {
+        FileType::Other
+    }
+}
+
+fn io_reason(error: std::io::Error) -> String {
+    error.kind().to_string()
+}
+
+#[cfg(feature = "postgres")]
+/// PostgreSQL-backed [`RootFilesystem`] storing file contents by virtual path.
+pub struct PostgresRootFilesystem {
+    pool: deadpool_postgres::Pool,
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresRootFilesystem {
+    pub fn new(pool: deadpool_postgres::Pool) -> Self {
+        Self { pool }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        client
+            .batch_execute(POSTGRES_ROOT_FILESYSTEM_SCHEMA)
+            .await
+            .map_err(|error| {
+                db_error(
+                    valid_engine_path(),
+                    FilesystemOperation::CreateDirAll,
+                    error,
+                )
+            })
+    }
+
+    async fn client(&self) -> Result<deadpool_postgres::Object, FilesystemError> {
+        self.pool
+            .get()
+            .await
+            .map_err(|error| FilesystemError::Backend {
+                path: valid_engine_path(),
+                operation: FilesystemOperation::Stat,
+                reason: error.to_string(),
+            })
+    }
+}
+
+#[cfg(feature = "postgres")]
+#[async_trait]
+impl RootFilesystem for PostgresRootFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        let client = self.client().await?;
+        let row = client
+            .query_opt(
+                "SELECT contents, is_dir FROM root_filesystem_entries WHERE path = $1",
+                &[&path.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = row else {
+            return Err(not_found(path.clone(), FilesystemOperation::ReadFile));
+        };
+        let is_dir: bool = row.get("is_dir");
+        if is_dir {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "is a directory".to_string(),
+            });
+        }
+        Ok(row.get("contents"))
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        client
+            .execute(
+                r#"
+                INSERT INTO root_filesystem_entries (path, contents, is_dir)
+                VALUES ($1, $2, FALSE)
+                ON CONFLICT (path) DO UPDATE SET
+                    contents = EXCLUDED.contents,
+                    is_dir = FALSE,
+                    updated_at = NOW()
+                "#,
+                &[&path.as_str(), &bytes],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::WriteFile, error))?;
+        Ok(())
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        if matches!(
+            self.exact_entry(path).await?,
+            Some((_, FileType::Directory))
+        ) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::AppendFile,
+                reason: "cannot append to a directory".to_string(),
+            });
+        }
+        client
+            .execute(
+                r#"
+                INSERT INTO root_filesystem_entries (path, contents, is_dir)
+                VALUES ($1, $2, FALSE)
+                ON CONFLICT (path) DO UPDATE SET
+                    contents = root_filesystem_entries.contents || EXCLUDED.contents,
+                    is_dir = FALSE,
+                    updated_at = NOW()
+                "#,
+                &[&path.as_str(), &bytes],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::AppendFile, error))?;
+        Ok(())
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let exact_entry = self.exact_entry(path).await?;
+        if matches!(exact_entry, Some((_, FileType::File))) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ListDir,
+                reason: "not a directory".to_string(),
+            });
+        }
+        let rows = self.all_paths().await?;
+        let children = direct_children(path, rows);
+        if matches!(exact_entry, Some((_, FileType::Directory))) && is_not_found(&children) {
+            return Ok(Vec::new());
+        }
+        children
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        if let Some((len, file_type)) = self.exact_entry(path).await? {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type,
+                len,
+            });
+        }
+        let rows = self.all_paths().await?;
+        if rows
+            .iter()
+            .any(|(child_path, _, _)| virtual_prefix_matches(path.as_str(), child_path.as_str()))
+        {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type: FileType::Directory,
+                len: 0,
+            });
+        }
+        Err(not_found(path.clone(), FilesystemOperation::Stat))
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        client
+            .execute(
+                "DELETE FROM root_filesystem_entries WHERE path = $1 OR path LIKE $2",
+                &[
+                    &path.as_str(),
+                    &format!("{}/%", path.as_str().trim_end_matches('/')),
+                ],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        Ok(())
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let client = self.client().await?;
+        for prefix in virtual_path_prefixes(path)? {
+            if matches!(self.exact_entry(&prefix).await?, Some((_, FileType::File))) {
+                return Err(FilesystemError::Backend {
+                    path: prefix,
+                    operation: FilesystemOperation::CreateDirAll,
+                    reason: "file exists where directory is required".to_string(),
+                });
+            }
+            client
+                .execute(
+                    r#"
+                    INSERT INTO root_filesystem_entries (path, contents, is_dir)
+                    VALUES ($1, '\\x'::bytea, TRUE)
+                    ON CONFLICT (path) DO NOTHING
+                    "#,
+                    &[&prefix.as_str()],
+                )
+                .await
+                .map_err(|error| {
+                    db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
+                })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "postgres")]
+impl PostgresRootFilesystem {
+    async fn exact_entry(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<(u64, FileType)>, FilesystemError> {
+        let client = self.client().await?;
+        let row = client
+            .query_opt(
+                "SELECT OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries WHERE path = $1",
+                &[&path.as_str()],
+            )
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::Stat, error))?;
+        Ok(row.map(|row| {
+            let len: i32 = row.get("len");
+            let is_dir: bool = row.get("is_dir");
+            (
+                if is_dir { 0 } else { len.max(0) as u64 },
+                if is_dir {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            )
+        }))
+    }
+
+    async fn all_paths(&self) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
+        let client = self.client().await?;
+        let rows = client
+            .query(
+                "SELECT path, OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries ORDER BY path",
+                &[],
+            )
+            .await
+            .map_err(|error| {
+                db_error(
+                    VirtualPath::new("/engine").unwrap_or_else(|_| unreachable!("literal virtual path is valid")),
+                    FilesystemOperation::ListDir,
+                    error,
+                )
+            })?;
+        rows.into_iter()
+            .map(|row| {
+                let path: String = row.get("path");
+                let len: i32 = row.get("len");
+                let is_dir: bool = row.get("is_dir");
+                Ok((
+                    VirtualPath::new(path)?,
+                    if is_dir { 0 } else { len.max(0) as u64 },
+                    if is_dir {
+                        FileType::Directory
+                    } else {
+                        FileType::File
+                    },
+                ))
+            })
+            .collect()
+    }
+}
+
+#[cfg(feature = "postgres")]
+const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS root_filesystem_entries (
+    path TEXT PRIMARY KEY CHECK (path LIKE '/%'),
+    contents BYTEA NOT NULL DEFAULT '\\x',
+    is_dir BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS is_dir BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE root_filesystem_entries
+    ALTER COLUMN contents SET DEFAULT '\\x';
+CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
+    ON root_filesystem_entries(path);
+"#;
+
+#[cfg(feature = "libsql")]
+/// libSQL-backed [`RootFilesystem`] storing file contents by virtual path.
+pub struct LibSqlRootFilesystem {
+    db: Arc<libsql::Database>,
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlRootFilesystem {
+    pub fn new(db: Arc<libsql::Database>) -> Self {
+        Self { db }
+    }
+
+    pub async fn run_migrations(&self) -> Result<(), FilesystemError> {
+        let conn = self.connect().await?;
+        conn.execute_batch(LIBSQL_ROOT_FILESYSTEM_SCHEMA)
+            .await
+            .map_err(|error| {
+                libsql_db_error(
+                    valid_engine_path(),
+                    FilesystemOperation::CreateDirAll,
+                    error,
+                )
+            })?;
+        ensure_libsql_root_is_dir_column(&conn).await?;
+        Ok(())
+    }
+
+    async fn connect(&self) -> Result<libsql::Connection, FilesystemError> {
+        let conn = self
+            .db
+            .connect()
+            .map_err(|error| FilesystemError::Backend {
+                path: valid_engine_path(),
+                operation: FilesystemOperation::Stat,
+                reason: error.to_string(),
+            })?;
+        conn.query("PRAGMA busy_timeout = 5000", ())
+            .await
+            .map_err(|error| {
+                libsql_db_error(valid_engine_path(), FilesystemOperation::Stat, error)
+            })?;
+        Ok(conn)
+    }
+}
+
+#[cfg(feature = "libsql")]
+#[async_trait]
+impl RootFilesystem for LibSqlRootFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT contents, is_dir FROM root_filesystem_entries WHERE path = ?1",
+                libsql::params![path.as_str()],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        let Some(row) = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?
+        else {
+            return Err(not_found(path.clone(), FilesystemOperation::ReadFile));
+        };
+        let is_dir: i64 = row
+            .get(1)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))?;
+        if is_dir != 0 {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ReadFile,
+                reason: "is a directory".to_string(),
+            });
+        }
+        row.get(0)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::ReadFile, error))
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        let conn = self.connect().await?;
+        conn.execute(
+            r#"
+            INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
+            VALUES (?1, ?2, 0, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+            ON CONFLICT (path) DO UPDATE SET
+                contents = excluded.contents,
+                is_dir = 0,
+                updated_at = excluded.updated_at
+            "#,
+            libsql::params![path.as_str(), libsql::Value::Blob(bytes.to_vec())],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::WriteFile, error))?;
+        Ok(())
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        if matches!(
+            self.exact_entry(path).await?,
+            Some((_, FileType::Directory))
+        ) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::AppendFile,
+                reason: "cannot append to a directory".to_string(),
+            });
+        }
+        let mut contents = match self.read_file(path).await {
+            Ok(contents) => contents,
+            Err(FilesystemError::Backend { reason, .. }) if reason == "not found" => Vec::new(),
+            Err(error) => return Err(error),
+        };
+        contents.extend_from_slice(bytes);
+        self.write_file(path, &contents).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        let exact_entry = self.exact_entry(path).await?;
+        if matches!(exact_entry, Some((_, FileType::File))) {
+            return Err(FilesystemError::Backend {
+                path: path.clone(),
+                operation: FilesystemOperation::ListDir,
+                reason: "not a directory".to_string(),
+            });
+        }
+        let rows = self.all_paths().await?;
+        let children = direct_children(path, rows);
+        if matches!(exact_entry, Some((_, FileType::Directory))) && is_not_found(&children) {
+            return Ok(Vec::new());
+        }
+        children
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        if let Some((len, file_type)) = self.exact_entry(path).await? {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type,
+                len,
+            });
+        }
+        let rows = self.all_paths().await?;
+        if rows
+            .iter()
+            .any(|(child_path, _, _)| virtual_prefix_matches(path.as_str(), child_path.as_str()))
+        {
+            return Ok(FileStat {
+                path: path.clone(),
+                file_type: FileType::Directory,
+                len: 0,
+            });
+        }
+        Err(not_found(path.clone(), FilesystemOperation::Stat))
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let conn = self.connect().await?;
+        conn.execute(
+            "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2",
+            libsql::params![
+                path.as_str(),
+                format!("{}/%", path.as_str().trim_end_matches('/'))
+            ],
+        )
+        .await
+        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        Ok(())
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        let conn = self.connect().await?;
+        for prefix in virtual_path_prefixes(path)? {
+            if matches!(self.exact_entry(&prefix).await?, Some((_, FileType::File))) {
+                return Err(FilesystemError::Backend {
+                    path: prefix,
+                    operation: FilesystemOperation::CreateDirAll,
+                    reason: "file exists where directory is required".to_string(),
+                });
+            }
+            conn.execute(
+                r#"
+                INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
+                VALUES (?1, X'', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                ON CONFLICT (path) DO NOTHING
+                "#,
+                libsql::params![prefix.as_str()],
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
+            })?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn ensure_libsql_root_is_dir_column(
+    conn: &libsql::Connection,
+) -> Result<(), FilesystemError> {
+    let mut rows = conn
+        .query(
+            "SELECT 1 FROM pragma_table_info('root_filesystem_entries') WHERE name = 'is_dir'",
+            (),
+        )
+        .await
+        .map_err(|error| {
+            libsql_db_error(
+                valid_engine_path(),
+                FilesystemOperation::CreateDirAll,
+                error,
+            )
+        })?;
+    if rows
+        .next()
+        .await
+        .map_err(|error| {
+            libsql_db_error(
+                valid_engine_path(),
+                FilesystemOperation::CreateDirAll,
+                error,
+            )
+        })?
+        .is_some()
+    {
+        return Ok(());
+    }
+    conn.execute(
+        "ALTER TABLE root_filesystem_entries ADD COLUMN is_dir INTEGER NOT NULL DEFAULT 0 CHECK (is_dir IN (0, 1))",
+        (),
+    )
+    .await
+    .map_err(|error| {
+        libsql_db_error(
+            valid_engine_path(),
+            FilesystemOperation::CreateDirAll,
+            error,
+        )
+    })?;
+    Ok(())
+}
+
+#[cfg(feature = "libsql")]
+impl LibSqlRootFilesystem {
+    async fn exact_entry(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<Option<(u64, FileType)>, FilesystemError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT length(contents), is_dir FROM root_filesystem_entries WHERE path = ?1",
+                libsql::params![path.as_str()],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Stat, error))?;
+        let row = rows
+            .next()
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Stat, error))?;
+        Ok(row.map(|row| {
+            let len = row.get::<i64>(0).unwrap_or(0).max(0) as u64;
+            let is_dir = row.get::<i64>(1).unwrap_or(0) != 0;
+            (
+                if is_dir { 0 } else { len },
+                if is_dir {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            )
+        }))
+    }
+
+    async fn all_paths(&self) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
+        let conn = self.connect().await?;
+        let mut rows = conn
+            .query(
+                "SELECT path, length(contents), is_dir FROM root_filesystem_entries ORDER BY path",
+                (),
+            )
+            .await
+            .map_err(|error| {
+                libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
+            })?;
+        let mut paths = Vec::new();
+        while let Some(row) = rows.next().await.map_err(|error| {
+            libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
+        })? {
+            let path: String = row.get(0).map_err(|error| {
+                libsql_db_error(valid_engine_path(), FilesystemOperation::ListDir, error)
+            })?;
+            let len = row.get::<i64>(1).unwrap_or(0).max(0) as u64;
+            let is_dir = row.get::<i64>(2).unwrap_or(0) != 0;
+            paths.push((
+                VirtualPath::new(path)?,
+                if is_dir { 0 } else { len },
+                if is_dir {
+                    FileType::Directory
+                } else {
+                    FileType::File
+                },
+            ));
+        }
+        Ok(paths)
+    }
+}
+
+#[cfg(feature = "libsql")]
+const LIBSQL_ROOT_FILESYSTEM_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS root_filesystem_entries (
+    path TEXT PRIMARY KEY,
+    contents BLOB NOT NULL DEFAULT X'',
+    is_dir INTEGER NOT NULL DEFAULT 0 CHECK (is_dir IN (0, 1)),
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
+    ON root_filesystem_entries(path);
+"#;
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn virtual_path_prefixes(path: &VirtualPath) -> Result<Vec<VirtualPath>, HostApiError> {
+    let mut prefixes = Vec::new();
+    let mut current = String::new();
+    for segment in path.as_str().trim_matches('/').split('/') {
+        if segment.is_empty() {
+            continue;
+        }
+        current.push('/');
+        current.push_str(segment);
+        prefixes.push(VirtualPath::new(current.clone())?);
+    }
+    Ok(prefixes)
+}
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn direct_children(
+    parent: &VirtualPath,
+    rows: Vec<(VirtualPath, u64, FileType)>,
+) -> Result<Vec<DirEntry>, FilesystemError> {
+    let mut entries = std::collections::BTreeMap::<String, DirEntry>::new();
+    let prefix = format!("{}/", parent.as_str().trim_end_matches('/'));
+    for (path, _len, row_file_type) in rows {
+        let Some(tail) = path.as_str().strip_prefix(&prefix) else {
+            continue;
+        };
+        if tail.is_empty() {
+            continue;
+        }
+        let (name, file_type) = if let Some((directory, _rest)) = tail.split_once('/') {
+            (directory.to_string(), FileType::Directory)
+        } else {
+            (tail.to_string(), row_file_type)
+        };
+        let entry_path = VirtualPath::new(format!(
+            "{}/{}",
+            parent.as_str().trim_end_matches('/'),
+            name
+        ))?;
+        entries.entry(name.clone()).or_insert(DirEntry {
+            name,
+            path: entry_path,
+            file_type,
+        });
+    }
+    if entries.is_empty() {
+        return Err(not_found(parent.clone(), FilesystemOperation::ListDir));
+    }
+    Ok(entries.into_values().collect())
+}
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn not_found(path: VirtualPath, operation: FilesystemOperation) -> FilesystemError {
+    FilesystemError::Backend {
+        path,
+        operation,
+        reason: "not found".to_string(),
+    }
+}
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn is_not_found<T>(result: &Result<T, FilesystemError>) -> bool {
+    matches!(
+        result,
+        Err(FilesystemError::Backend { reason, .. }) if reason == "not found"
+    )
+}
+
+#[cfg(feature = "postgres")]
+fn db_error(
+    path: VirtualPath,
+    operation: FilesystemOperation,
+    error: tokio_postgres::Error,
+) -> FilesystemError {
+    FilesystemError::Backend {
+        path,
+        operation,
+        reason: error.to_string(),
+    }
+}
+
+#[cfg(feature = "libsql")]
+fn libsql_db_error(
+    path: VirtualPath,
+    operation: FilesystemOperation,
+    error: libsql::Error,
+) -> FilesystemError {
+    FilesystemError::Backend {
+        path,
+        operation,
+        reason: error.to_string(),
+    }
+}
+
+#[cfg(any(feature = "postgres", feature = "libsql"))]
+fn valid_engine_path() -> VirtualPath {
+    VirtualPath::new("/engine").unwrap_or_else(|_| unreachable!("literal virtual path is valid"))
+}

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use ironclaw_host_api::{
-    HostApiError, HostPath, MountGrant, MountPermissions, MountView, ScopedPath, VirtualPath,
+    HostApiError, HostPath, MountPermissions, MountView, ScopedPath, VirtualPath,
 };
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
@@ -61,25 +61,25 @@ impl std::fmt::Display for FilesystemOperation {
 pub enum FilesystemError {
     #[error(transparent)]
     Contract(#[from] HostApiError),
-    #[error("permission denied for {operation} on scoped path {path:?}")]
+    #[error("permission denied for {operation} on scoped path {path}")]
     PermissionDenied {
         path: ScopedPath,
         operation: FilesystemOperation,
     },
-    #[error("no backend mount found for virtual path {path:?}")]
+    #[error("no backend mount found for virtual path {path}")]
     MountNotFound { path: VirtualPath },
-    #[error("virtual path not found for {operation} at {path:?}")]
+    #[error("virtual path not found for {operation} at {path}")]
     NotFound {
         path: VirtualPath,
         operation: FilesystemOperation,
     },
-    #[error("virtual path escaped backend mount {path:?}")]
+    #[error("virtual path escaped backend mount {path}")]
     PathOutsideMount { path: VirtualPath },
-    #[error("symlink escapes backend mount at virtual path {path:?}")]
+    #[error("symlink escapes backend mount at virtual path {path}")]
     SymlinkEscape { path: VirtualPath },
-    #[error("backend mount conflict at virtual path {path:?}")]
+    #[error("backend mount conflict at virtual path {path}")]
     MountConflict { path: VirtualPath },
-    #[error("filesystem backend error during {operation} at {path:?}: {reason}")]
+    #[error("filesystem backend error during {operation} at {path}: {reason}")]
     Backend {
         path: VirtualPath,
         operation: FilesystemOperation,
@@ -305,7 +305,7 @@ impl CompositeRootFilesystem {
         self.mounts
             .iter()
             .filter(|mount| {
-                virtual_prefix_matches(mount.descriptor.virtual_root.as_str(), path.as_str())
+                path_prefix_matches(mount.descriptor.virtual_root.as_str(), path.as_str())
             })
             .max_by_key(|mount| mount.descriptor.virtual_root.as_str().len())
             .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })
@@ -403,7 +403,7 @@ pub trait RootFilesystem: Send + Sync {
     /// Returns metadata for a canonical virtual path without revealing raw host paths.
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError>;
 
-    /// Deletes a canonical virtual file or directory. Backends that do not support delete must fail closed before side effects.
+    /// Deletes an existing canonical virtual file or directory. Missing paths return [`FilesystemError::NotFound`]; backends that do not support delete must fail closed before side effects.
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         Err(FilesystemError::Backend {
             path: path.clone(),
@@ -485,14 +485,7 @@ where
         path: &ScopedPath,
         operation: FilesystemOperation,
     ) -> Result<VirtualPath, FilesystemError> {
-        let grant =
-            matching_mount(&self.mounts, path).ok_or_else(|| match self.mounts.resolve(path) {
-                Ok(_) => FilesystemError::from(HostApiError::InvalidMount {
-                    value: path.as_str().to_string(),
-                    reason: "scoped path matched no mount grant".to_string(),
-                }),
-                Err(error) => FilesystemError::from(error),
-            })?;
+        let (virtual_path, grant) = self.mounts.resolve_with_grant(path)?;
 
         if !operation_allowed(&grant.permissions, operation) {
             return Err(FilesystemError::PermissionDenied {
@@ -501,20 +494,8 @@ where
             });
         }
 
-        self.mounts.resolve(path).map_err(FilesystemError::from)
+        Ok(virtual_path)
     }
-}
-
-fn matching_mount<'a>(view: &'a MountView, path: &ScopedPath) -> Option<&'a MountGrant> {
-    let raw = path.as_str();
-    view.mounts
-        .iter()
-        .filter(|mount| alias_matches(mount.alias.as_str(), raw))
-        .max_by_key(|mount| mount.alias.as_str().len())
-}
-
-fn alias_matches(alias: &str, path: &str) -> bool {
-    path == alias || path.starts_with(&format!("{alias}/"))
 }
 
 fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperation) -> bool {
@@ -523,6 +504,8 @@ fn operation_allowed(permissions: &MountPermissions, operation: FilesystemOperat
         FilesystemOperation::WriteFile => permissions.write,
         FilesystemOperation::AppendFile => permissions.write,
         FilesystemOperation::ListDir => permissions.list,
+        // Stat is metadata-only: either read authority or list authority reveals
+        // equivalent existence/type information without file contents.
         FilesystemOperation::Stat => permissions.read || permissions.list,
         FilesystemOperation::Delete => permissions.delete,
         FilesystemOperation::CreateDirAll => permissions.write,
@@ -547,6 +530,11 @@ impl LocalFilesystem {
         Self::default()
     }
 
+    /// Mounts a host directory during trusted setup.
+    ///
+    /// This API is intentionally synchronous because it mutates in-memory mount
+    /// configuration and is not part of the async runtime operation path. Async
+    /// file operations after mount setup use `tokio::fs`.
     pub fn mount_local(
         &mut self,
         virtual_root: VirtualPath,
@@ -665,7 +653,7 @@ impl LocalFilesystem {
         let mount = self
             .mounts
             .iter()
-            .filter(|mount| virtual_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
+            .filter(|mount| path_prefix_matches(mount.virtual_root.as_str(), path.as_str()))
             .max_by_key(|mount| mount.virtual_root.as_str().len())
             .ok_or_else(|| FilesystemError::MountNotFound { path: path.clone() })?;
 
@@ -788,7 +776,7 @@ impl RootFilesystem for LocalFilesystem {
     }
 }
 
-fn virtual_prefix_matches(prefix: &str, path: &str) -> bool {
+fn path_prefix_matches(prefix: &str, path: &str) -> bool {
     path == prefix || path.starts_with(&format!("{prefix}/"))
 }
 
@@ -853,6 +841,12 @@ fn io_error(
     operation: FilesystemOperation,
     error: std::io::Error,
 ) -> FilesystemError {
+    tracing::debug!(
+        virtual_path = path.as_str(),
+        %operation,
+        error = %error,
+        "local filesystem backend error"
+    );
     if error.kind() == std::io::ErrorKind::NotFound {
         FilesystemError::NotFound { path, operation }
     } else {
@@ -954,7 +948,7 @@ impl RootFilesystem for PostgresRootFilesystem {
     async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
         let client = self.client().await?;
         if matches!(
-            self.exact_entry(path).await?,
+            self.exact_entry_with_client(&client, path).await?,
             Some((_, FileType::Directory))
         ) {
             return Err(FilesystemError::Backend {
@@ -963,6 +957,9 @@ impl RootFilesystem for PostgresRootFilesystem {
                 reason: "cannot append to a directory".to_string(),
             });
         }
+        // TODO(reborn): append rewrites the whole DB row. Do not use this path
+        // for high-volume JSONL/event streams; route those through typed event
+        // stores or append-capable artifact backends instead.
         client
             .execute(
                 r#"
@@ -981,7 +978,8 @@ impl RootFilesystem for PostgresRootFilesystem {
     }
 
     async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
-        let exact_entry = self.exact_entry(path).await?;
+        let client = self.client().await?;
+        let exact_entry = self.exact_entry_with_client(&client, path).await?;
         if matches!(exact_entry, Some((_, FileType::File))) {
             return Err(FilesystemError::Backend {
                 path: path.clone(),
@@ -990,7 +988,7 @@ impl RootFilesystem for PostgresRootFilesystem {
             });
         }
         let rows = self
-            .child_entries(path, FilesystemOperation::ListDir)
+            .child_entries_with_client(&client, path, FilesystemOperation::ListDir)
             .await?;
         let children = direct_children(path, rows);
         if matches!(exact_entry, Some((_, FileType::Directory))) && is_not_found(&children) {
@@ -1000,14 +998,15 @@ impl RootFilesystem for PostgresRootFilesystem {
     }
 
     async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
-        if let Some((len, file_type)) = self.exact_entry(path).await? {
+        let client = self.client().await?;
+        if let Some((len, file_type)) = self.exact_entry_with_client(&client, path).await? {
             return Ok(FileStat {
                 path: path.clone(),
                 file_type,
                 len,
             });
         }
-        if self.has_child_entry(path).await? {
+        if self.has_child_entry_with_client(&client, path).await? {
             return Ok(FileStat {
                 path: path.clone(),
                 file_type: FileType::Directory,
@@ -1020,13 +1019,16 @@ impl RootFilesystem for PostgresRootFilesystem {
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let client = self.client().await?;
         let child_pattern = child_path_like_pattern(path);
-        client
+        let deleted = client
             .execute(
                 "DELETE FROM root_filesystem_entries WHERE path = $1 OR path LIKE $2 ESCAPE '!'",
                 &[&path.as_str(), &child_pattern],
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        if deleted == 0 {
+            return Err(not_found(path.clone(), FilesystemOperation::Delete));
+        }
         Ok(())
     }
 
@@ -1077,11 +1079,11 @@ impl RootFilesystem for PostgresRootFilesystem {
 
 #[cfg(feature = "postgres")]
 impl PostgresRootFilesystem {
-    async fn exact_entry(
+    async fn exact_entry_with_client(
         &self,
+        client: &tokio_postgres::Client,
         path: &VirtualPath,
     ) -> Result<Option<(u64, FileType)>, FilesystemError> {
-        let client = self.client().await?;
         let row = client
             .query_opt(
                 "SELECT OCTET_LENGTH(contents)::bigint AS len, is_dir FROM root_filesystem_entries WHERE path = $1",
@@ -1103,12 +1105,12 @@ impl PostgresRootFilesystem {
         }))
     }
 
-    async fn child_entries(
+    async fn child_entries_with_client(
         &self,
+        client: &tokio_postgres::Client,
         parent: &VirtualPath,
         operation: FilesystemOperation,
     ) -> Result<Vec<(VirtualPath, u64, FileType)>, FilesystemError> {
-        let client = self.client().await?;
         let pattern = child_path_like_pattern(parent);
         let rows = client
             .query(
@@ -1135,8 +1137,11 @@ impl PostgresRootFilesystem {
             .collect()
     }
 
-    async fn has_child_entry(&self, parent: &VirtualPath) -> Result<bool, FilesystemError> {
-        let client = self.client().await?;
+    async fn has_child_entry_with_client(
+        &self,
+        client: &tokio_postgres::Client,
+        parent: &VirtualPath,
+    ) -> Result<bool, FilesystemError> {
         let pattern = child_path_like_pattern(parent);
         let row = client
             .query_opt(
@@ -1264,6 +1269,9 @@ impl RootFilesystem for LibSqlRootFilesystem {
             });
         }
         let conn = self.connect().await?;
+        // TODO(reborn): append rewrites the whole DB row. Do not use this path
+        // for high-volume JSONL/event streams; route those through typed event
+        // stores or append-capable artifact backends instead.
         conn.execute(
             r#"
             INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
@@ -1319,12 +1327,16 @@ impl RootFilesystem for LibSqlRootFilesystem {
 
     async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
-        conn.execute(
-            "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
-            libsql::params![path.as_str(), child_path_like_pattern(path)],
-        )
-        .await
-        .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        let deleted = conn
+            .execute(
+                "DELETE FROM root_filesystem_entries WHERE path = ?1 OR path LIKE ?2 ESCAPE '!'",
+                libsql::params![path.as_str(), child_path_like_pattern(path)],
+            )
+            .await
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Delete, error))?;
+        if deleted == 0 {
+            return Err(not_found(path.clone(), FilesystemOperation::Delete));
+        }
         Ok(())
     }
 

--- a/crates/ironclaw_filesystem/src/lib.rs
+++ b/crates/ironclaw_filesystem/src/lib.rs
@@ -5,6 +5,14 @@
 //! through a caller's [`MountView`], checks mount permissions, then performs the
 //! operation against a trusted root filesystem namespace addressed by
 //! [`VirtualPath`]. Backend implementations alone touch raw host paths.
+//!
+//! The local backend canonicalizes existing paths and their nearest existing
+//! ancestors before opening files, and it re-roots new leaf paths on the checked
+//! canonical parent. That narrows symlink escape opportunities but does not
+//! provide a kernel-enforced race-free guarantee against a writable mount root
+//! being modified between containment checks and opens. Production hardening for
+//! hostile local directories should use fd-relative traversal such as `openat2`
+//! with `RESOLVE_BENEATH`, `O_NOFOLLOW`, or a capability filesystem crate.
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -620,7 +628,17 @@ impl LocalFilesystem {
         // backend root. If its canonical parent leaves the backend root, an
         // existing symlink in the parent chain caused the escape.
         ensure_contained(path, mount, &canonical_parent, true)?;
-        Ok(joined)
+        // Re-root the final path on the canonicalized, containment-checked
+        // parent rather than returning `joined` (which still contains the
+        // un-canonicalized ancestor components). This narrows the TOCTOU
+        // window between the containment check and the eventual write — a
+        // later swap of an ancestor symlink does not change the path we hand
+        // back. Robust defense (openat / O_NOFOLLOW / cap-std) is tracked as a
+        // follow-up; see PR #2996 review.
+        let file_name = joined
+            .file_name()
+            .ok_or_else(|| FilesystemError::PathOutsideMount { path: path.clone() })?;
+        Ok(canonical_parent.join(file_name))
     }
 
     async fn resolve_for_create_dir_all(
@@ -1013,20 +1031,33 @@ impl RootFilesystem for PostgresRootFilesystem {
     }
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
-        let client = self.client().await?;
+        let mut client = self.client().await?;
+        let transaction = client
+            .transaction()
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
         for prefix in virtual_path_prefixes(path)? {
-            if matches!(self.exact_entry(&prefix).await?, Some((_, FileType::File))) {
+            let row = transaction
+                .query_opt(
+                    "SELECT is_dir FROM root_filesystem_entries WHERE path = $1",
+                    &[&prefix.as_str()],
+                )
+                .await
+                .map_err(|error| {
+                    db_error(prefix.clone(), FilesystemOperation::CreateDirAll, error)
+                })?;
+            if row.is_some_and(|row| !row.get::<_, bool>("is_dir")) {
                 return Err(FilesystemError::Backend {
                     path: prefix,
                     operation: FilesystemOperation::CreateDirAll,
                     reason: "file exists where directory is required".to_string(),
                 });
             }
-            client
+            transaction
                 .execute(
                     r#"
                     INSERT INTO root_filesystem_entries (path, contents, is_dir)
-                    VALUES ($1, '\\x'::bytea, TRUE)
+                    VALUES ($1, ''::bytea, TRUE)
                     ON CONFLICT (path) DO NOTHING
                     "#,
                     &[&prefix.as_str()],
@@ -1036,6 +1067,10 @@ impl RootFilesystem for PostgresRootFilesystem {
                     db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
                 })?;
         }
+        transaction
+            .commit()
+            .await
+            .map_err(|error| db_error(path.clone(), FilesystemOperation::CreateDirAll, error))?;
         Ok(())
     }
 }
@@ -1049,13 +1084,13 @@ impl PostgresRootFilesystem {
         let client = self.client().await?;
         let row = client
             .query_opt(
-                "SELECT OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries WHERE path = $1",
+                "SELECT OCTET_LENGTH(contents)::bigint AS len, is_dir FROM root_filesystem_entries WHERE path = $1",
                 &[&path.as_str()],
             )
             .await
             .map_err(|error| db_error(path.clone(), FilesystemOperation::Stat, error))?;
         Ok(row.map(|row| {
-            let len: i32 = row.get("len");
+            let len: i64 = row.get("len");
             let is_dir: bool = row.get("is_dir");
             (
                 if is_dir { 0 } else { len.max(0) as u64 },
@@ -1077,7 +1112,7 @@ impl PostgresRootFilesystem {
         let pattern = child_path_like_pattern(parent);
         let rows = client
             .query(
-                "SELECT path, OCTET_LENGTH(contents) AS len, is_dir FROM root_filesystem_entries WHERE path LIKE $1 ESCAPE '!' ORDER BY path",
+                "SELECT path, OCTET_LENGTH(contents)::bigint AS len, is_dir FROM root_filesystem_entries WHERE path LIKE $1 ESCAPE '!' ORDER BY path",
                 &[&pattern],
             )
             .await
@@ -1085,7 +1120,7 @@ impl PostgresRootFilesystem {
         rows.into_iter()
             .map(|row| {
                 let path: String = row.get("path");
-                let len: i32 = row.get("len");
+                let len: i64 = row.get("len");
                 let is_dir: bool = row.get("is_dir");
                 Ok((
                     VirtualPath::new(path)?,
@@ -1115,21 +1150,11 @@ impl PostgresRootFilesystem {
 }
 
 #[cfg(feature = "postgres")]
-const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = r#"
-CREATE TABLE IF NOT EXISTS root_filesystem_entries (
-    path TEXT PRIMARY KEY CHECK (path LIKE '/%'),
-    contents BYTEA NOT NULL DEFAULT '\\x',
-    is_dir BOOLEAN NOT NULL DEFAULT FALSE,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+const POSTGRES_ROOT_FILESYSTEM_SCHEMA: &str = concat!(
+    include_str!("../../../migrations/V26__root_filesystem_entries.sql"),
+    "\n",
+    include_str!("../../../migrations/V27__root_filesystem_entries_directories.sql"),
 );
-ALTER TABLE root_filesystem_entries
-    ADD COLUMN IF NOT EXISTS is_dir BOOLEAN NOT NULL DEFAULT FALSE;
-ALTER TABLE root_filesystem_entries
-    ALTER COLUMN contents SET DEFAULT '\\x';
-CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
-    ON root_filesystem_entries(path);
-"#;
 
 #[cfg(feature = "libsql")]
 /// libSQL-backed [`RootFilesystem`] storing file contents by virtual path.
@@ -1305,27 +1330,50 @@ impl RootFilesystem for LibSqlRootFilesystem {
 
     async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
         let conn = self.connect().await?;
+        let transaction = conn.transaction().await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
+        })?;
         for prefix in virtual_path_prefixes(path)? {
-            if matches!(self.exact_entry(&prefix).await?, Some((_, FileType::File))) {
-                return Err(FilesystemError::Backend {
-                    path: prefix,
-                    operation: FilesystemOperation::CreateDirAll,
-                    reason: "file exists where directory is required".to_string(),
-                });
+            let mut rows = transaction
+                .query(
+                    "SELECT is_dir FROM root_filesystem_entries WHERE path = ?1",
+                    libsql::params![prefix.as_str()],
+                )
+                .await
+                .map_err(|error| {
+                    libsql_db_error(prefix.clone(), FilesystemOperation::CreateDirAll, error)
+                })?;
+            if let Some(row) = rows.next().await.map_err(|error| {
+                libsql_db_error(prefix.clone(), FilesystemOperation::CreateDirAll, error)
+            })? {
+                let is_dir: i64 = row.get(0).map_err(|error| {
+                    libsql_db_error(prefix.clone(), FilesystemOperation::CreateDirAll, error)
+                })?;
+                if is_dir == 0 {
+                    return Err(FilesystemError::Backend {
+                        path: prefix,
+                        operation: FilesystemOperation::CreateDirAll,
+                        reason: "file exists where directory is required".to_string(),
+                    });
+                }
             }
-            conn.execute(
-                r#"
-                INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
-                VALUES (?1, X'', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-                ON CONFLICT (path) DO NOTHING
-                "#,
-                libsql::params![prefix.as_str()],
-            )
-            .await
-            .map_err(|error| {
-                libsql_db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
-            })?;
+            transaction
+                .execute(
+                    r#"
+                    INSERT INTO root_filesystem_entries (path, contents, is_dir, updated_at)
+                    VALUES (?1, X'', 1, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+                    ON CONFLICT (path) DO NOTHING
+                    "#,
+                    libsql::params![prefix.as_str()],
+                )
+                .await
+                .map_err(|error| {
+                    libsql_db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
+                })?;
         }
+        transaction.commit().await.map_err(|error| {
+            libsql_db_error(path.clone(), FilesystemOperation::CreateDirAll, error)
+        })?;
         Ok(())
     }
 }
@@ -1394,18 +1442,23 @@ impl LibSqlRootFilesystem {
             .next()
             .await
             .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Stat, error))?;
-        Ok(row.map(|row| {
-            let len = row.get::<i64>(0).unwrap_or(0).max(0) as u64;
-            let is_dir = row.get::<i64>(1).unwrap_or(0) != 0;
-            (
-                if is_dir { 0 } else { len },
-                if is_dir {
-                    FileType::Directory
-                } else {
-                    FileType::File
-                },
-            )
-        }))
+        let Some(row) = row else { return Ok(None) };
+        let len_raw: i64 = row
+            .get(0)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Stat, error))?;
+        let is_dir_raw: i64 = row
+            .get(1)
+            .map_err(|error| libsql_db_error(path.clone(), FilesystemOperation::Stat, error))?;
+        let len = len_raw.max(0) as u64;
+        let is_dir = is_dir_raw != 0;
+        Ok(Some((
+            if is_dir { 0 } else { len },
+            if is_dir {
+                FileType::Directory
+            } else {
+                FileType::File
+            },
+        )))
     }
 
     async fn child_entries(
@@ -1431,8 +1484,14 @@ impl LibSqlRootFilesystem {
             let path: String = row
                 .get(0)
                 .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
-            let len = row.get::<i64>(1).unwrap_or(0).max(0) as u64;
-            let is_dir = row.get::<i64>(2).unwrap_or(0) != 0;
+            let len_raw: i64 = row
+                .get(1)
+                .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
+            let is_dir_raw: i64 = row
+                .get(2)
+                .map_err(|error| libsql_db_error(parent.clone(), operation, error))?;
+            let len = len_raw.max(0) as u64;
+            let is_dir = is_dir_raw != 0;
             paths.push((
                 VirtualPath::new(path)?,
                 if is_dir { 0 } else { len },
@@ -1473,8 +1532,8 @@ CREATE TABLE IF NOT EXISTS root_filesystem_entries (
     created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
     updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
 );
-CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
-    ON root_filesystem_entries(path);
+-- The PRIMARY KEY on `path` already provides a unique index for equality
+-- lookups, so no separate index is created.
 "#;
 
 #[cfg(any(feature = "postgres", feature = "libsql"))]

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -1,0 +1,272 @@
+use std::sync::Arc;
+
+use ironclaw_filesystem::*;
+use ironclaw_host_api::{HostPath, VirtualPath};
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn catalog_describes_paths_by_longest_matching_mount() {
+    let mut root = CompositeRootFilesystem::new();
+    let broad_backend = empty_local_backend("/memory");
+    let private_backend = empty_local_backend("/memory/private");
+
+    root.mount(
+        descriptor(
+            "/memory",
+            "memory-documents",
+            BackendKind::MemoryDocuments,
+            StorageClass::FileContent,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+        ),
+        Arc::new(broad_backend),
+    )
+    .unwrap();
+    root.mount(
+        descriptor(
+            "/memory/private",
+            "private-memory-documents",
+            BackendKind::MemoryDocuments,
+            StorageClass::FileContent,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+        ),
+        Arc::new(private_backend),
+    )
+    .unwrap();
+
+    let placement = root
+        .describe_path(&VirtualPath::new("/memory/private/SOUL.md").unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(placement.path.as_str(), "/memory/private/SOUL.md");
+    assert_eq!(placement.matched_root.as_str(), "/memory/private");
+    assert_eq!(placement.backend_id.as_str(), "private-memory-documents");
+    assert_eq!(placement.backend_kind, BackendKind::MemoryDocuments);
+    assert_eq!(placement.content_kind, ContentKind::MemoryDocument);
+    assert_eq!(placement.index_policy, IndexPolicy::FullTextAndVector);
+    assert!(placement.capabilities.indexed);
+    assert!(placement.capabilities.embedded);
+}
+
+#[tokio::test]
+async fn composite_routes_filesystem_operations_to_matching_backend() {
+    let memory_dir = tempdir().unwrap();
+    let project_dir = tempdir().unwrap();
+    std::fs::write(memory_dir.path().join("MEMORY.md"), b"remember this").unwrap();
+    std::fs::write(project_dir.path().join("README.md"), b"project readme").unwrap();
+
+    let mut memory_backend = LocalFilesystem::new();
+    memory_backend
+        .mount_local(
+            VirtualPath::new("/memory").unwrap(),
+            HostPath::from_path_buf(memory_dir.path().to_path_buf()),
+        )
+        .unwrap();
+    let mut project_backend = LocalFilesystem::new();
+    project_backend
+        .mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(project_dir.path().to_path_buf()),
+        )
+        .unwrap();
+
+    let mut root = CompositeRootFilesystem::new();
+    root.mount(
+        descriptor(
+            "/memory",
+            "memory-documents",
+            BackendKind::MemoryDocuments,
+            StorageClass::FileContent,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+        ),
+        Arc::new(memory_backend),
+    )
+    .unwrap();
+    root.mount(
+        descriptor(
+            "/projects",
+            "project-files",
+            BackendKind::LocalFilesystem,
+            StorageClass::FileContent,
+            ContentKind::ProjectFile,
+            IndexPolicy::NotIndexed,
+        ),
+        Arc::new(project_backend),
+    )
+    .unwrap();
+
+    assert_eq!(
+        root.read_file(&VirtualPath::new("/memory/MEMORY.md").unwrap())
+            .await
+            .unwrap(),
+        b"remember this"
+    );
+    assert_eq!(
+        root.read_file(&VirtualPath::new("/projects/README.md").unwrap())
+            .await
+            .unwrap(),
+        b"project readme"
+    );
+
+    root.write_file(
+        &VirtualPath::new("/memory/notes/new.md").unwrap(),
+        b"new memory",
+    )
+    .await
+    .unwrap();
+    root.append_file(
+        &VirtualPath::new("/memory/notes/new.md").unwrap(),
+        b" appended",
+    )
+    .await
+    .unwrap();
+    assert_eq!(
+        std::fs::read(memory_dir.path().join("notes/new.md")).unwrap(),
+        b"new memory appended"
+    );
+
+    root.create_dir_all(&VirtualPath::new("/projects/generated/deep").unwrap())
+        .await
+        .unwrap();
+    assert!(project_dir.path().join("generated/deep").is_dir());
+
+    root.delete(&VirtualPath::new("/memory/notes/new.md").unwrap())
+        .await
+        .unwrap();
+    assert!(!memory_dir.path().join("notes/new.md").exists());
+}
+
+#[tokio::test]
+async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
+    let mut root = CompositeRootFilesystem::new();
+    root.mount(
+        descriptor(
+            "/projects",
+            "project-files",
+            BackendKind::LocalFilesystem,
+            StorageClass::FileContent,
+            ContentKind::ProjectFile,
+            IndexPolicy::NotIndexed,
+        ),
+        Arc::new(empty_local_backend("/projects")),
+    )
+    .unwrap();
+    root.mount(
+        descriptor(
+            "/memory",
+            "memory-documents",
+            BackendKind::MemoryDocuments,
+            StorageClass::FileContent,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+        ),
+        Arc::new(empty_local_backend("/memory")),
+    )
+    .unwrap();
+
+    let roots: Vec<String> = root
+        .mounts()
+        .await
+        .unwrap()
+        .into_iter()
+        .map(|mount| mount.virtual_root.as_str().to_string())
+        .collect();
+
+    assert_eq!(roots, vec!["/memory", "/projects"]);
+}
+
+#[tokio::test]
+async fn duplicate_composite_mount_roots_fail_closed() {
+    let mut root = CompositeRootFilesystem::new();
+    root.mount(
+        descriptor(
+            "/memory",
+            "memory-documents",
+            BackendKind::MemoryDocuments,
+            StorageClass::FileContent,
+            ContentKind::MemoryDocument,
+            IndexPolicy::FullTextAndVector,
+        ),
+        Arc::new(empty_local_backend("/memory")),
+    )
+    .unwrap();
+
+    let err = root
+        .mount(
+            descriptor(
+                "/memory",
+                "other-memory-documents",
+                BackendKind::MemoryDocuments,
+                StorageClass::FileContent,
+                ContentKind::MemoryDocument,
+                IndexPolicy::FullTextAndVector,
+            ),
+            Arc::new(empty_local_backend("/memory")),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::MountConflict { .. }));
+}
+
+#[tokio::test]
+async fn missing_composite_mount_fails_without_backend_side_effects() {
+    let root = CompositeRootFilesystem::new();
+    let err = root
+        .read_file(&VirtualPath::new("/memory/MEMORY.md").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::MountNotFound { .. }));
+}
+
+fn empty_local_backend(virtual_root: &str) -> LocalFilesystem {
+    let dir = tempdir().unwrap();
+    let path = dir.path().to_path_buf();
+    std::mem::forget(dir);
+
+    let mut backend = LocalFilesystem::new();
+    backend
+        .mount_local(
+            VirtualPath::new(virtual_root).unwrap(),
+            HostPath::from_path_buf(path),
+        )
+        .unwrap();
+    backend
+}
+
+fn descriptor(
+    virtual_root: &str,
+    backend_id: &str,
+    backend_kind: BackendKind,
+    storage_class: StorageClass,
+    content_kind: ContentKind,
+    index_policy: IndexPolicy,
+) -> MountDescriptor {
+    MountDescriptor {
+        virtual_root: VirtualPath::new(virtual_root).unwrap(),
+        backend_id: BackendId::new(backend_id).unwrap(),
+        backend_kind,
+        storage_class,
+        content_kind,
+        index_policy,
+        capabilities: BackendCapabilities {
+            read: true,
+            write: true,
+            append: true,
+            list: true,
+            stat: true,
+            delete: false,
+            indexed: matches!(
+                index_policy,
+                IndexPolicy::FullText | IndexPolicy::FullTextAndVector
+            ),
+            embedded: matches!(
+                index_policy,
+                IndexPolicy::Vector | IndexPolicy::FullTextAndVector
+            ),
+        },
+    }
+}

--- a/crates/ironclaw_filesystem/tests/catalog_contract.rs
+++ b/crates/ironclaw_filesystem/tests/catalog_contract.rs
@@ -7,8 +7,8 @@ use tempfile::tempdir;
 #[tokio::test]
 async fn catalog_describes_paths_by_longest_matching_mount() {
     let mut root = CompositeRootFilesystem::new();
-    let broad_backend = empty_local_backend("/memory");
-    let private_backend = empty_local_backend("/memory/private");
+    let (broad_backend, _broad_dir) = empty_local_backend("/memory");
+    let (private_backend, _private_dir) = empty_local_backend("/memory/private");
 
     root.mount(
         descriptor(
@@ -142,6 +142,8 @@ async fn composite_routes_filesystem_operations_to_matching_backend() {
 #[tokio::test]
 async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
     let mut root = CompositeRootFilesystem::new();
+    let (project_backend, _project_dir) = empty_local_backend("/projects");
+    let (memory_backend, _memory_dir) = empty_local_backend("/memory");
     root.mount(
         descriptor(
             "/projects",
@@ -151,7 +153,7 @@ async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
             ContentKind::ProjectFile,
             IndexPolicy::NotIndexed,
         ),
-        Arc::new(empty_local_backend("/projects")),
+        Arc::new(project_backend),
     )
     .unwrap();
     root.mount(
@@ -163,7 +165,7 @@ async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
             ContentKind::MemoryDocument,
             IndexPolicy::FullTextAndVector,
         ),
-        Arc::new(empty_local_backend("/memory")),
+        Arc::new(memory_backend),
     )
     .unwrap();
 
@@ -181,6 +183,8 @@ async fn catalog_mounts_are_sorted_for_stable_diagnostics() {
 #[tokio::test]
 async fn duplicate_composite_mount_roots_fail_closed() {
     let mut root = CompositeRootFilesystem::new();
+    let (memory_backend, _memory_dir) = empty_local_backend("/memory");
+    let (other_backend, _other_dir) = empty_local_backend("/memory");
     root.mount(
         descriptor(
             "/memory",
@@ -190,7 +194,7 @@ async fn duplicate_composite_mount_roots_fail_closed() {
             ContentKind::MemoryDocument,
             IndexPolicy::FullTextAndVector,
         ),
-        Arc::new(empty_local_backend("/memory")),
+        Arc::new(memory_backend),
     )
     .unwrap();
 
@@ -204,7 +208,7 @@ async fn duplicate_composite_mount_roots_fail_closed() {
                 ContentKind::MemoryDocument,
                 IndexPolicy::FullTextAndVector,
             ),
-            Arc::new(empty_local_backend("/memory")),
+            Arc::new(other_backend),
         )
         .unwrap_err();
 
@@ -222,19 +226,16 @@ async fn missing_composite_mount_fails_without_backend_side_effects() {
     assert!(matches!(err, FilesystemError::MountNotFound { .. }));
 }
 
-fn empty_local_backend(virtual_root: &str) -> LocalFilesystem {
+fn empty_local_backend(virtual_root: &str) -> (LocalFilesystem, tempfile::TempDir) {
     let dir = tempdir().unwrap();
-    let path = dir.path().to_path_buf();
-    std::mem::forget(dir);
-
     let mut backend = LocalFilesystem::new();
     backend
         .mount_local(
             VirtualPath::new(virtual_root).unwrap(),
-            HostPath::from_path_buf(path),
+            HostPath::from_path_buf(dir.path().to_path_buf()),
         )
         .unwrap();
-    backend
+    (backend, dir)
 }
 
 fn descriptor(

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -1,0 +1,157 @@
+#![cfg(any(feature = "libsql", feature = "postgres"))]
+
+use ironclaw_filesystem::RootFilesystem;
+
+#[cfg(feature = "postgres")]
+use ironclaw_filesystem::PostgresRootFilesystem;
+#[cfg(feature = "libsql")]
+use ironclaw_filesystem::{FileType, FilesystemError, FilesystemOperation, LibSqlRootFilesystem};
+#[cfg(feature = "libsql")]
+use ironclaw_host_api::VirtualPath;
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_root_filesystem_reads_writes_and_stats_files() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/engine/tenants/t1/users/u1/file.txt").unwrap();
+
+    filesystem.write_file(&path, b"hello db fs").await.unwrap();
+
+    assert_eq!(filesystem.read_file(&path).await.unwrap(), b"hello db fs");
+    let stat = filesystem.stat(&path).await.unwrap();
+    assert_eq!(stat.path, path);
+    assert_eq!(stat.file_type, FileType::File);
+    assert_eq!(stat.len, 11);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_root_filesystem_lists_direct_children_sorted_with_virtual_paths() {
+    let filesystem = libsql_root().await;
+    filesystem
+        .write_file(
+            &VirtualPath::new("/engine/tenants/t1/users/u1/zeta.txt").unwrap(),
+            b"z",
+        )
+        .await
+        .unwrap();
+    filesystem
+        .write_file(
+            &VirtualPath::new("/engine/tenants/t1/users/u1/alpha.txt").unwrap(),
+            b"a",
+        )
+        .await
+        .unwrap();
+    filesystem
+        .write_file(
+            &VirtualPath::new("/engine/tenants/t1/users/u1/nested/file.txt").unwrap(),
+            b"nested",
+        )
+        .await
+        .unwrap();
+
+    let entries = filesystem
+        .list_dir(&VirtualPath::new("/engine/tenants/t1/users/u1").unwrap())
+        .await
+        .unwrap();
+
+    let names: Vec<_> = entries.iter().map(|entry| entry.name.as_str()).collect();
+    assert_eq!(names, vec!["alpha.txt", "nested", "zeta.txt"]);
+
+    let paths: Vec<_> = entries.iter().map(|entry| entry.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec![
+            "/engine/tenants/t1/users/u1/alpha.txt",
+            "/engine/tenants/t1/users/u1/nested",
+            "/engine/tenants/t1/users/u1/zeta.txt",
+        ]
+    );
+    assert_eq!(entries[1].file_type, FileType::Directory);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
+    let filesystem = libsql_root().await;
+    let dir = VirtualPath::new("/engine/tenants/t1/users/u1/logs").unwrap();
+    let path = VirtualPath::new("/engine/tenants/t1/users/u1/logs/events.jsonl").unwrap();
+
+    filesystem.create_dir_all(&dir).await.unwrap();
+    assert_eq!(
+        filesystem.stat(&dir).await.unwrap().file_type,
+        FileType::Directory
+    );
+    assert!(filesystem.list_dir(&dir).await.unwrap().is_empty());
+
+    filesystem.append_file(&path, b"one\n").await.unwrap();
+    filesystem.append_file(&path, b"two\n").await.unwrap();
+    assert_eq!(filesystem.read_file(&path).await.unwrap(), b"one\ntwo\n");
+
+    filesystem.delete(&path).await.unwrap();
+    let err = filesystem.read_file(&path).await.unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::Backend {
+            operation: FilesystemOperation::ReadFile,
+            ..
+        }
+    ));
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_root_filesystem_overwrites_existing_file() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/memory/tenants/t1/users/u1/facts.md").unwrap();
+
+    filesystem.write_file(&path, b"first").await.unwrap();
+    filesystem.write_file(&path, b"second").await.unwrap();
+
+    assert_eq!(filesystem.read_file(&path).await.unwrap(), b"second");
+    assert_eq!(filesystem.stat(&path).await.unwrap().len, 6);
+}
+
+#[cfg(feature = "libsql")]
+#[tokio::test]
+async fn libsql_root_filesystem_fails_closed_for_missing_paths_without_host_paths() {
+    let filesystem = libsql_root().await;
+    let path = VirtualPath::new("/projects/missing.txt").unwrap();
+
+    let err = filesystem.read_file(&path).await.unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::Backend {
+            operation: FilesystemOperation::ReadFile,
+            ..
+        }
+    ));
+    let display = err.to_string();
+    assert!(display.contains("/projects/missing.txt"));
+    assert!(!display.contains("/tmp"));
+    assert!(!display.contains(".db"));
+}
+
+#[cfg(feature = "postgres")]
+#[test]
+fn postgres_root_filesystem_implements_root_filesystem_contract() {
+    fn assert_root<T: RootFilesystem>() {}
+    assert_root::<PostgresRootFilesystem>();
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_root() -> LibSqlRootFilesystem {
+    static NEXT_DB_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+    let db_id = NEXT_DB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let db_dir = std::env::temp_dir().join(format!(
+        "ironclaw-root-fs-test-{}-{db_id}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&db_dir);
+    std::fs::create_dir_all(&db_dir).unwrap();
+    let db_path = db_dir.join("root-filesystem.db");
+    let db = std::sync::Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
+    let filesystem = LibSqlRootFilesystem::new(db);
+    filesystem.run_migrations().await.unwrap();
+    filesystem
+}

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -140,18 +140,29 @@ fn postgres_root_filesystem_implements_root_filesystem_contract() {
 }
 
 #[cfg(feature = "libsql")]
-async fn libsql_root() -> LibSqlRootFilesystem {
-    static NEXT_DB_ID: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
-    let db_id = NEXT_DB_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-    let db_dir = std::env::temp_dir().join(format!(
-        "ironclaw-root-fs-test-{}-{db_id}",
-        std::process::id()
-    ));
-    let _ = std::fs::remove_dir_all(&db_dir);
-    std::fs::create_dir_all(&db_dir).unwrap();
-    let db_path = db_dir.join("root-filesystem.db");
+struct TestLibSqlRootFilesystem {
+    filesystem: LibSqlRootFilesystem,
+    _dir: tempfile::TempDir,
+}
+
+#[cfg(feature = "libsql")]
+impl std::ops::Deref for TestLibSqlRootFilesystem {
+    type Target = LibSqlRootFilesystem;
+
+    fn deref(&self) -> &Self::Target {
+        &self.filesystem
+    }
+}
+
+#[cfg(feature = "libsql")]
+async fn libsql_root() -> TestLibSqlRootFilesystem {
+    let db_dir = tempfile::tempdir().unwrap();
+    let db_path = db_dir.path().join("root-filesystem.db");
     let db = std::sync::Arc::new(libsql::Builder::new_local(db_path).build().await.unwrap());
     let filesystem = LibSqlRootFilesystem::new(db);
     filesystem.run_migrations().await.unwrap();
-    filesystem
+    TestLibSqlRootFilesystem {
+        filesystem,
+        _dir: db_dir,
+    }
 }

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -97,6 +97,15 @@ async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
             ..
         }
     ));
+
+    let err = filesystem.delete(&path).await.unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::NotFound {
+            operation: FilesystemOperation::Delete,
+            ..
+        }
+    ));
 }
 
 #[cfg(feature = "libsql")]

--- a/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/db_root_filesystem_contract.rs
@@ -92,7 +92,7 @@ async fn libsql_root_filesystem_appends_deletes_and_creates_directories() {
     let err = filesystem.read_file(&path).await.unwrap_err();
     assert!(matches!(
         err,
-        FilesystemError::Backend {
+        FilesystemError::NotFound {
             operation: FilesystemOperation::ReadFile,
             ..
         }
@@ -121,7 +121,7 @@ async fn libsql_root_filesystem_fails_closed_for_missing_paths_without_host_path
     let err = filesystem.read_file(&path).await.unwrap_err();
     assert!(matches!(
         err,
-        FilesystemError::Backend {
+        FilesystemError::NotFound {
             operation: FilesystemOperation::ReadFile,
             ..
         }

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -1,0 +1,622 @@
+use std::sync::Arc;
+
+use ironclaw_filesystem::*;
+use ironclaw_host_api::*;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn scoped_read_resolves_mount_view_and_reads_bytes() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(
+        storage.path().join("project1/README.md"),
+        b"hello filesystem",
+    )
+    .unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(
+        Arc::new(root),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+    );
+
+    let bytes = scoped
+        .read_file(&ScopedPath::new("/workspace/README.md").unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(bytes, b"hello filesystem");
+}
+
+#[tokio::test]
+async fn scoped_write_is_denied_on_read_only_mount() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(
+        Arc::new(root),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+    );
+
+    let err = scoped
+        .write_file(
+            &ScopedPath::new("/workspace/generated.txt").unwrap(),
+            b"nope",
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::WriteFile,
+            ..
+        }
+    ));
+    assert!(!storage.path().join("project1/generated.txt").exists());
+}
+
+#[tokio::test]
+async fn scoped_append_requires_write_permission_and_appends_bytes() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/log.jsonl"), b"one\n").unwrap();
+
+    let read_only = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let err = read_only
+        .append_file(
+            &ScopedPath::new("/workspace/log.jsonl").unwrap(),
+            b"denied\n",
+        )
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::AppendFile,
+            ..
+        }
+    ));
+
+    let writable = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    writable
+        .append_file(&ScopedPath::new("/workspace/log.jsonl").unwrap(), b"two\n")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        std::fs::read(storage.path().join("project1/log.jsonl")).unwrap(),
+        b"one\ntwo\n"
+    );
+}
+
+#[tokio::test]
+async fn scoped_delete_requires_delete_permission_and_removes_file() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/generated.txt"), b"delete me").unwrap();
+
+    let no_delete = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    let err = no_delete
+        .delete(&ScopedPath::new("/workspace/generated.txt").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::Delete,
+            ..
+        }
+    ));
+    assert!(storage.path().join("project1/generated.txt").exists());
+
+    let can_delete = scoped_project_fs(
+        storage.path(),
+        MountPermissions {
+            read: true,
+            write: true,
+            delete: true,
+            list: true,
+            execute: false,
+        },
+    );
+    can_delete
+        .delete(&ScopedPath::new("/workspace/generated.txt").unwrap())
+        .await
+        .unwrap();
+
+    assert!(!storage.path().join("project1/generated.txt").exists());
+}
+
+#[tokio::test]
+async fn scoped_create_dir_all_requires_write_permission() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+
+    let read_only = scoped_project_fs(storage.path(), MountPermissions::read_only());
+    let err = read_only
+        .create_dir_all(&ScopedPath::new("/workspace/generated/deep").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::CreateDirAll,
+            ..
+        }
+    ));
+
+    let writable = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    writable
+        .create_dir_all(&ScopedPath::new("/workspace/generated/deep").unwrap())
+        .await
+        .unwrap();
+
+    assert!(storage.path().join("project1/generated/deep").is_dir());
+}
+
+#[tokio::test]
+async fn list_requires_list_permission_through_scoped_api() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1/src")).unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(
+        Arc::new(root),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            MountPermissions {
+                read: true,
+                write: false,
+                delete: false,
+                list: false,
+                execute: false,
+            },
+        )])
+        .unwrap(),
+    );
+
+    let err = scoped
+        .list_dir(&ScopedPath::new("/workspace").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::ListDir,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn longest_backend_virtual_mount_wins() {
+    let broad = tempdir().unwrap();
+    let narrow = tempdir().unwrap();
+    std::fs::create_dir_all(broad.path().join("project1")).unwrap();
+    std::fs::write(broad.path().join("project1/value.txt"), b"broad").unwrap();
+    std::fs::write(narrow.path().join("value.txt"), b"narrow").unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(broad.path().to_path_buf()),
+    )
+    .unwrap();
+    root.mount_local(
+        VirtualPath::new("/projects/project1").unwrap(),
+        HostPath::from_path_buf(narrow.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let bytes = root
+        .read_file(&VirtualPath::new("/projects/project1/value.txt").unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(bytes, b"narrow");
+}
+
+#[tokio::test]
+async fn unknown_scoped_alias_fails_closed_through_filesystem_api() {
+    let storage = tempdir().unwrap();
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(Arc::new(root), MountView::new(Vec::new()).unwrap());
+    let err = scoped
+        .read_file(&ScopedPath::new("/memory/facts.md").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::Contract(_)));
+}
+
+#[tokio::test]
+async fn artifact_write_is_confined_to_approved_virtual_mount() {
+    let artifacts = tempdir().unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/engine/tmp/invocations/inv1/artifacts").unwrap(),
+        HostPath::from_path_buf(artifacts.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(
+        Arc::new(root),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/artifacts").unwrap(),
+            VirtualPath::new("/engine/tmp/invocations/inv1/artifacts").unwrap(),
+            MountPermissions::read_write(),
+        )])
+        .unwrap(),
+    );
+
+    scoped
+        .write_file(&ScopedPath::new("/artifacts/result.json").unwrap(), b"{}")
+        .await
+        .unwrap();
+
+    assert_eq!(
+        std::fs::read(artifacts.path().join("result.json")).unwrap(),
+        b"{}"
+    );
+}
+
+#[tokio::test]
+async fn display_errors_do_not_leak_raw_host_paths() {
+    let storage = tempdir().unwrap();
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let err = root
+        .read_file(&VirtualPath::new("/projects/missing.txt").unwrap())
+        .await
+        .unwrap_err();
+
+    let display = err.to_string();
+    assert!(display.contains("/projects/missing.txt"));
+    assert!(!display.contains(&storage.path().display().to_string()));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_denies_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(outside.path().join("secret.txt"), b"secret").unwrap();
+    symlink(
+        outside.path().join("secret.txt"),
+        storage.path().join("project1/escape.txt"),
+    )
+    .unwrap();
+
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let scoped = ScopedFilesystem::new(
+        Arc::new(root),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            MountPermissions::read_only(),
+        )])
+        .unwrap(),
+    );
+
+    let err = scoped
+        .read_file(&ScopedPath::new("/workspace/escape.txt").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::SymlinkEscape { .. }));
+}
+
+#[tokio::test]
+async fn read_requires_read_permission_through_scoped_api() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/secret.txt"), b"secret").unwrap();
+
+    let scoped = scoped_project_fs(
+        storage.path(),
+        MountPermissions {
+            read: false,
+            write: true,
+            delete: false,
+            list: true,
+            execute: false,
+        },
+    );
+
+    let err = scoped
+        .read_file(&ScopedPath::new("/workspace/secret.txt").unwrap())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::ReadFile,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn stat_is_allowed_by_read_or_list_and_denied_without_both() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/file.txt"), b"abc").unwrap();
+
+    let read_only = scoped_project_fs(
+        storage.path(),
+        MountPermissions {
+            read: true,
+            write: false,
+            delete: false,
+            list: false,
+            execute: false,
+        },
+    );
+    let stat = read_only
+        .stat(&ScopedPath::new("/workspace/file.txt").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(stat.len, 3);
+
+    let list_only = scoped_project_fs(
+        storage.path(),
+        MountPermissions {
+            read: false,
+            write: false,
+            delete: false,
+            list: true,
+            execute: false,
+        },
+    );
+    let stat = list_only
+        .stat(&ScopedPath::new("/workspace/file.txt").unwrap())
+        .await
+        .unwrap();
+    assert_eq!(stat.file_type, FileType::File);
+
+    let no_stat = scoped_project_fs(storage.path(), MountPermissions::none());
+    let err = no_stat
+        .stat(&ScopedPath::new("/workspace/file.txt").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::PermissionDenied {
+            operation: FilesystemOperation::Stat,
+            ..
+        }
+    ));
+}
+
+#[tokio::test]
+async fn list_success_returns_sorted_entries_with_virtual_paths() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(storage.path().join("project1/zeta.txt"), b"z").unwrap();
+    std::fs::write(storage.path().join("project1/alpha.txt"), b"a").unwrap();
+
+    let root = local_root_with_projects_mount(storage.path());
+    let entries = root
+        .list_dir(&VirtualPath::new("/projects/project1").unwrap())
+        .await
+        .unwrap();
+
+    let names: Vec<_> = entries.iter().map(|entry| entry.name.as_str()).collect();
+    assert_eq!(names, vec!["alpha.txt", "zeta.txt"]);
+    let paths: Vec<_> = entries.iter().map(|entry| entry.path.as_str()).collect();
+    assert_eq!(
+        paths,
+        vec![
+            "/projects/project1/alpha.txt",
+            "/projects/project1/zeta.txt"
+        ]
+    );
+}
+
+#[tokio::test]
+async fn workspace_write_creates_parent_directories() {
+    let storage = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    scoped
+        .write_file(
+            &ScopedPath::new("/workspace/generated/deep/file.txt").unwrap(),
+            b"created",
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        std::fs::read(storage.path().join("project1/generated/deep/file.txt")).unwrap(),
+        b"created"
+    );
+}
+
+#[tokio::test]
+async fn duplicate_backend_mount_is_rejected() {
+    let storage = tempdir().unwrap();
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(storage.path().to_path_buf()),
+    )
+    .unwrap();
+
+    let err = root
+        .mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(storage.path().to_path_buf()),
+        )
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::MountConflict { .. }));
+}
+
+#[tokio::test]
+async fn nonexistent_backend_mount_root_fails_without_leaking_host_path() {
+    let storage = tempdir().unwrap();
+    let missing = storage.path().join("missing-root");
+    let mut root = LocalFilesystem::new();
+
+    let err = root
+        .mount_local(
+            VirtualPath::new("/projects").unwrap(),
+            HostPath::from_path_buf(missing.clone()),
+        )
+        .unwrap_err();
+
+    let display = err.to_string();
+    assert!(display.contains("/projects"));
+    assert!(!display.contains(&missing.display().to_string()));
+}
+
+#[test]
+fn invalid_scoped_paths_are_rejected_before_filesystem_access() {
+    for invalid in [
+        "/workspace/../secret.txt",
+        "file:///etc/passwd",
+        "https://example.com/file",
+        "/Users/alice/project/secret.txt",
+        "C:\\Users\\alice\\project\\secret.txt",
+        "/workspace/has\0nul",
+    ] {
+        assert!(
+            ScopedPath::new(invalid).is_err(),
+            "{invalid:?} should be rejected before filesystem access"
+        );
+    }
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_denies_write_through_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    std::fs::write(outside.path().join("secret.txt"), b"original").unwrap();
+    symlink(
+        outside.path().join("secret.txt"),
+        storage.path().join("project1/escape.txt"),
+    )
+    .unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    let err = scoped
+        .write_file(
+            &ScopedPath::new("/workspace/escape.txt").unwrap(),
+            b"changed",
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::SymlinkEscape { .. }));
+    assert_eq!(
+        std::fs::read(outside.path().join("secret.txt")).unwrap(),
+        b"original"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn local_backend_denies_write_through_symlinked_parent_escape() {
+    use std::os::unix::fs::symlink;
+
+    let storage = tempdir().unwrap();
+    let outside = tempdir().unwrap();
+    std::fs::create_dir_all(storage.path().join("project1")).unwrap();
+    symlink(outside.path(), storage.path().join("project1/outside-dir")).unwrap();
+
+    let scoped = scoped_project_fs(storage.path(), MountPermissions::read_write());
+    let err = scoped
+        .write_file(
+            &ScopedPath::new("/workspace/outside-dir/new.txt").unwrap(),
+            b"escaped",
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, FilesystemError::SymlinkEscape { .. }));
+    assert!(!outside.path().join("new.txt").exists());
+}
+
+fn local_root_with_projects_mount(path: &std::path::Path) -> LocalFilesystem {
+    let mut root = LocalFilesystem::new();
+    root.mount_local(
+        VirtualPath::new("/projects").unwrap(),
+        HostPath::from_path_buf(path.to_path_buf()),
+    )
+    .unwrap();
+    root
+}
+
+fn scoped_project_fs(
+    path: &std::path::Path,
+    permissions: MountPermissions,
+) -> ScopedFilesystem<LocalFilesystem> {
+    ScopedFilesystem::new(
+        Arc::new(local_root_with_projects_mount(path)),
+        MountView::new(vec![MountGrant::new(
+            MountAlias::new("/workspace").unwrap(),
+            VirtualPath::new("/projects/project1").unwrap(),
+            permissions,
+        )])
+        .unwrap(),
+    )
+}

--- a/crates/ironclaw_filesystem/tests/filesystem_contract.rs
+++ b/crates/ironclaw_filesystem/tests/filesystem_contract.rs
@@ -149,6 +149,18 @@ async fn scoped_delete_requires_delete_permission_and_removes_file() {
         .unwrap();
 
     assert!(!storage.path().join("project1/generated.txt").exists());
+
+    let err = can_delete
+        .delete(&ScopedPath::new("/workspace/generated.txt").unwrap())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        FilesystemError::NotFound {
+            operation: FilesystemOperation::Delete,
+            ..
+        }
+    ));
 }
 
 #[tokio::test]
@@ -316,6 +328,7 @@ async fn display_errors_do_not_leak_raw_host_paths() {
 
     let display = err.to_string();
     assert!(display.contains("/projects/missing.txt"));
+    assert!(!display.contains("VirtualPath("));
     assert!(!display.contains(&storage.path().display().to_string()));
 }
 

--- a/crates/ironclaw_host_api/src/mount.rs
+++ b/crates/ironclaw_host_api/src/mount.rs
@@ -102,6 +102,14 @@ impl MountView {
     }
 
     pub fn resolve(&self, path: &ScopedPath) -> Result<VirtualPath, HostApiError> {
+        self.resolve_with_grant(path)
+            .map(|(virtual_path, _grant)| virtual_path)
+    }
+
+    pub fn resolve_with_grant(
+        &self,
+        path: &ScopedPath,
+    ) -> Result<(VirtualPath, &MountGrant), HostApiError> {
         let raw = path.as_str();
         let mount = self
             .mounts
@@ -116,7 +124,7 @@ impl MountView {
             .strip_prefix(mount.alias.as_str())
             .unwrap_or_default()
             .trim_start_matches('/');
-        mount.target.join_tail(tail)
+        Ok((mount.target.join_tail(tail)?, mount))
     }
 
     /// Returns true when every child mount is present in the parent with the

--- a/crates/ironclaw_host_api/src/path.rs
+++ b/crates/ironclaw_host_api/src/path.rs
@@ -43,6 +43,24 @@ pub struct ScopedPath(String);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MountAlias(String);
 
+impl fmt::Display for VirtualPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for ScopedPath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl fmt::Display for MountAlias {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
 const VIRTUAL_ROOTS: &[&str] = &[
     "/engine",
     "/system/extensions",

--- a/migrations/V26__root_filesystem_entries.sql
+++ b/migrations/V26__root_filesystem_entries.sql
@@ -1,0 +1,12 @@
+-- Reborn RootFilesystem database backend storage.
+-- Stores canonical virtual-path file contents; directories are inferred from path prefixes.
+
+CREATE TABLE IF NOT EXISTS root_filesystem_entries (
+    path TEXT PRIMARY KEY CHECK (path LIKE '/%'),
+    contents BYTEA NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
+    ON root_filesystem_entries(path);

--- a/migrations/V26__root_filesystem_entries.sql
+++ b/migrations/V26__root_filesystem_entries.sql
@@ -8,5 +8,8 @@ CREATE TABLE IF NOT EXISTS root_filesystem_entries (
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
+-- Index uses text_pattern_ops so prefix `LIKE '/path/%'` queries used by the
+-- DB backend's child-entry scans can be served from the index. Equality
+-- lookups already use the PRIMARY KEY's btree.
 CREATE INDEX IF NOT EXISTS idx_root_filesystem_entries_path
-    ON root_filesystem_entries(path);
+    ON root_filesystem_entries(path text_pattern_ops);

--- a/migrations/V27__root_filesystem_entries_directories.sql
+++ b/migrations/V27__root_filesystem_entries_directories.sql
@@ -4,4 +4,4 @@ ALTER TABLE root_filesystem_entries
     ADD COLUMN IF NOT EXISTS is_dir BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE root_filesystem_entries
-    ALTER COLUMN contents SET DEFAULT '\\x';
+    ALTER COLUMN contents SET DEFAULT ''::bytea;

--- a/migrations/V27__root_filesystem_entries_directories.sql
+++ b/migrations/V27__root_filesystem_entries_directories.sql
@@ -1,0 +1,7 @@
+-- Add explicit directory entries for the Reborn RootFilesystem DB backend.
+
+ALTER TABLE root_filesystem_entries
+    ADD COLUMN IF NOT EXISTS is_dir BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE root_filesystem_entries
+    ALTER COLUMN contents SET DEFAULT '\\x';

--- a/migrations/checksums.lock
+++ b/migrations/checksums.lock
@@ -38,3 +38,5 @@ V22__sandbox_restart_params = 12611649486554869350
 V23__list_workspace_files_escape_like = 12519024535161914473
 V24__llm_calls_created_at_index = 2650126284755685421
 V25__wasm_fuel_limit_bump = 8924323300096627270
+V26__root_filesystem_entries = 11094038407147728260
+V27__root_filesystem_entries_directories = 4126641792698406758


### PR DESCRIPTION
## Summary

Closes the filesystem half of PR2 from #2987. The event substrate half is already in review as #2993; this PR keeps the filesystem substrate separate so reviewers can evaluate it independently.

Adds `crates/ironclaw_filesystem` with:

- `RootFilesystem`, `ScopedFilesystem`, and `CompositeRootFilesystem`
- `FilesystemCatalog`, `MountDescriptor`, `PathPlacement`, and backend placement metadata
- V1 filesystem operations: `read_file`, `write_file`, `append_file`, `list_dir`, `stat`, `delete`, `create_dir_all`
- local filesystem backend with containment/symlink escape checks
- PostgreSQL and libSQL DB-backed root filesystem backends behind feature flags
- explicit directory representation for DB-backed filesystem entries
- crate-local guardrails in `crates/ironclaw_filesystem/CLAUDE.md`

Migrations are included as `V26`/`V27` because `reborn-integration` already has `V25__wasm_fuel_limit_bump.sql`:

- `migrations/V26__root_filesystem_entries.sql`
- `migrations/V27__root_filesystem_entries_directories.sql`

## Scope boundaries

This PR intentionally does **not** include:

- `ironclaw_events` changes — covered by #2993
- event JSONL filesystem backends — can be layered after #2993 + this PR
- `ironclaw_extensions` — deferred from PR1 and should land as a separate follow-up after filesystem substrate review
- memory `/memory` grammar or memory repository adapters — those remain owned by `ironclaw_memory`
- production wiring or user-visible behavior changes

## Exposure checklist

```text
Does this affect existing src/ runtime behavior? no
Does this alter app startup/config defaults? no
Does this expose new routes/CLI/user-visible APIs? no
Does this create a second writer for existing production state? no
Are all Reborn paths feature-gated or unused by default? yes, unused internal crate substrate
Are docs/status labels accurate: implemented slice vs product complete? yes, filesystem substrate only
```

## Verification

TDD note: copied the filesystem contract tests first against a RED stub and confirmed `cargo test -p ironclaw_filesystem` failed due to missing contract types before porting the implementation.

Passed:

```bash
CARGO_TARGET_DIR=/tmp/ironclaw-fs-target cargo test -p ironclaw_host_api -p ironclaw_filesystem
CARGO_TARGET_DIR=/tmp/ironclaw-fs-target cargo test -p ironclaw_filesystem --features libsql
CARGO_TARGET_DIR=/tmp/ironclaw-fs-target cargo test -p ironclaw_filesystem --features postgres
CARGO_TARGET_DIR=/tmp/ironclaw-fs-target cargo clippy -p ironclaw_host_api -p ironclaw_filesystem --all-targets --features libsql,postgres -- -D warnings
cargo fmt --check
git diff --check
```

Earlier boundary grep returned no forbidden normal Reborn dependencies:

```bash
cargo tree -p ironclaw_filesystem -e normal --features libsql,postgres | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|events|extensions|host_runtime|mcp|network|processes|resources|run_state|scripts|secrets|wasm)' || true
```

Refs #2987.
