### PR TITLE
feat(reborn): add auth control substrate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3976,10 +3976,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "ironclaw_approvals"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_authorization",
+ "ironclaw_events",
+ "ironclaw_filesystem",
+ "ironclaw_host_api",
+ "ironclaw_run_state",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
+]
+
+[[package]]
 name = "ironclaw_architecture"
 version = "0.1.0"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "ironclaw_authorization"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "ironclaw_filesystem",
+ "ironclaw_host_api",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4078,6 +4109,20 @@ dependencies = [
  "rust_decimal",
  "rust_decimal_macros",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "ironclaw_run_state"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "ironclaw_filesystem",
+ "ironclaw_host_api",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_resources", "crates/ironclaw_events", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
+members = [".", "crates/ironclaw_common", "crates/ironclaw_host_api", "crates/ironclaw_filesystem", "crates/ironclaw_events", "crates/ironclaw_authorization", "crates/ironclaw_run_state", "crates/ironclaw_approvals", "crates/ironclaw_resources", "crates/ironclaw_architecture", "crates/ironclaw_safety", "crates/ironclaw_skills", "crates/ironclaw_engine", "crates/ironclaw_gateway", "crates/ironclaw_tui"]
 exclude = [
     "channels-src/discord",
     "channels-src/telegram",

--- a/crates/ironclaw_approvals/CLAUDE.md
+++ b/crates/ironclaw_approvals/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_approvals guardrails
+
+- Own approval resolution workflow: pending approval record to scoped lease or denial.
+- Do not prompt users, dispatch capabilities, manage processes, reserve resources, or import runtime/dispatcher/capability workflow crates.
+- Approve fail-closed: issue durable lease first, then mark approved; revoke issued lease best-effort if status write fails.
+- Denials issue no lease.
+- Audit emission is metadata-only and best-effort.

--- a/crates/ironclaw_approvals/Cargo.toml
+++ b/crates/ironclaw_approvals/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ironclaw_approvals"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+ironclaw_authorization = { path = "../ironclaw_authorization" }
+ironclaw_events = { path = "../ironclaw_events" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+ironclaw_run_state = { path = "../ironclaw_run_state" }
+thiserror = "2"
+
+[dev-dependencies]
+async-trait = "0.1"
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+serde_json = "1"
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -88,7 +88,12 @@ where
         let lease = self.leases.issue(lease).await?;
         if let Err(error) = self.approvals.approve(scope, request_id).await {
             let _ = self.leases.revoke(&lease.scope, lease.grant.id).await;
-            return Err(error.into());
+            return match error {
+                RunStateError::ApprovalNotPending { status, .. } => {
+                    Err(ApprovalResolutionError::NotPending { status })
+                }
+                error => Err(error.into()),
+            };
         }
         self.emit_audit_best_effort(ironclaw_host_api::AuditEnvelope::approval_resolved(
             &record.scope,
@@ -117,7 +122,13 @@ where
             });
         }
 
-        let denied = self.approvals.deny(scope, request_id).await?;
+        let denied = match self.approvals.deny(scope, request_id).await {
+            Ok(denied) => denied,
+            Err(RunStateError::ApprovalNotPending { status, .. }) => {
+                return Err(ApprovalResolutionError::NotPending { status });
+            }
+            Err(error) => return Err(error.into()),
+        };
         self.emit_audit_best_effort(ironclaw_host_api::AuditEnvelope::approval_resolved(
             &denied.scope,
             &denied.request,

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -7,8 +7,8 @@
 use ironclaw_authorization::{CapabilityLease, CapabilityLeaseError, CapabilityLeaseStore};
 use ironclaw_events::AuditSink;
 use ironclaw_host_api::{
-    Action, CapabilityGrant, CapabilityGrantId, EffectKind, GrantConstraints, Principal,
-    ResourceScope, Timestamp,
+    Action, CapabilityGrant, CapabilityGrantId, EffectKind, GrantConstraints, MountView,
+    NetworkPolicy, Principal, ResourceCeiling, ResourceScope, SecretHandle, Timestamp,
 };
 use ironclaw_run_state::{ApprovalRecord, ApprovalRequestStore, ApprovalStatus, RunStateError};
 use thiserror::Error;
@@ -75,10 +75,10 @@ where
             issued_by: approval.issued_by,
             constraints: GrantConstraints {
                 allowed_effects: approval.allowed_effects,
-                mounts: Default::default(),
-                network: Default::default(),
-                secrets: Vec::new(),
-                resource_ceiling: None,
+                mounts: approval.mounts,
+                network: approval.network,
+                secrets: approval.secrets,
+                resource_ceiling: approval.resource_ceiling,
                 expires_at: approval.expires_at,
                 max_invocations: approval.max_invocations,
             },
@@ -148,15 +148,20 @@ where
 
 /// Approval resolution input supplied by a trusted human/admin policy surface.
 ///
-/// `allowed_effects` is the final attenuated effect set that the resolver stamps
-/// onto the resume-only lease. The current [`ApprovalRequest`] shape does not
-/// carry the originating capability descriptor's effect list, so callers must
-/// derive this set from the same reviewed descriptor/request they presented to
-/// the approver rather than widening it in the UI layer.
+/// `allowed_effects` and the constraint fields are the final attenuated grant
+/// shape that the resolver stamps onto the resume-only lease. The current
+/// [`ApprovalRequest`] shape does not carry the originating capability
+/// descriptor's full grant constraints, so callers must derive these values from
+/// the same reviewed descriptor/request they presented to the approver rather
+/// than widening them in the UI layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaseApproval {
     pub issued_by: Principal,
     pub allowed_effects: Vec<EffectKind>,
+    pub mounts: MountView,
+    pub network: NetworkPolicy,
+    pub secrets: Vec<SecretHandle>,
+    pub resource_ceiling: Option<ResourceCeiling>,
     pub expires_at: Option<Timestamp>,
     pub max_invocations: Option<u64>,
 }

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -62,6 +62,11 @@ where
             return Err(ApprovalResolutionError::UnsupportedAction);
         };
 
+        let invocation_fingerprint = record
+            .request
+            .invocation_fingerprint
+            .clone()
+            .ok_or(ApprovalResolutionError::MissingInvocationFingerprint)?;
         let resolved_by = approval.issued_by.clone();
         let grant = CapabilityGrant {
             id: CapabilityGrantId::new(),
@@ -79,7 +84,7 @@ where
             },
         };
         let mut lease = CapabilityLease::new(record.scope.clone(), grant);
-        lease.invocation_fingerprint = record.request.invocation_fingerprint.clone();
+        lease.invocation_fingerprint = Some(invocation_fingerprint);
         let lease = self.leases.issue(lease).await?;
         if let Err(error) = self.approvals.approve(scope, request_id).await {
             let _ = self.leases.revoke(&lease.scope, lease.grant.id).await;
@@ -130,6 +135,13 @@ where
     }
 }
 
+/// Approval resolution input supplied by a trusted human/admin policy surface.
+///
+/// `allowed_effects` is the final attenuated effect set that the resolver stamps
+/// onto the resume-only lease. The current [`ApprovalRequest`] shape does not
+/// carry the originating capability descriptor's effect list, so callers must
+/// derive this set from the same reviewed descriptor/request they presented to
+/// the approver rather than widening it in the UI layer.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeaseApproval {
     pub issued_by: Principal,
@@ -149,6 +161,8 @@ pub enum ApprovalResolutionError {
     RunState(#[from] RunStateError),
     #[error("approval request is not pending: {status:?}")]
     NotPending { status: ApprovalStatus },
+    #[error("approval request is missing an invocation fingerprint")]
+    MissingInvocationFingerprint,
     #[error("approval action cannot issue a dispatch lease")]
     UnsupportedAction,
     #[error("capability lease failed: {0}")]

--- a/crates/ironclaw_approvals/src/lib.rs
+++ b/crates/ironclaw_approvals/src/lib.rs
@@ -1,0 +1,156 @@
+//! Approval resolution service for IronClaw Reborn.
+//!
+//! `ironclaw_approvals` resolves durable approval requests and issues scoped
+//! authorization leases. It does not prompt users, execute capabilities, or
+//! dispatch runtime work.
+
+use ironclaw_authorization::{CapabilityLease, CapabilityLeaseError, CapabilityLeaseStore};
+use ironclaw_events::AuditSink;
+use ironclaw_host_api::{
+    Action, CapabilityGrant, CapabilityGrantId, EffectKind, GrantConstraints, Principal,
+    ResourceScope, Timestamp,
+};
+use ironclaw_run_state::{ApprovalRecord, ApprovalRequestStore, ApprovalStatus, RunStateError};
+use thiserror::Error;
+
+pub struct ApprovalResolver<'a, A, L>
+where
+    A: ApprovalRequestStore + ?Sized,
+    L: CapabilityLeaseStore + ?Sized,
+{
+    approvals: &'a A,
+    leases: &'a L,
+    audit_sink: Option<&'a dyn AuditSink>,
+}
+
+impl<'a, A, L> ApprovalResolver<'a, A, L>
+where
+    A: ApprovalRequestStore + ?Sized,
+    L: CapabilityLeaseStore + ?Sized,
+{
+    pub fn new(approvals: &'a A, leases: &'a L) -> Self {
+        Self {
+            approvals,
+            leases,
+            audit_sink: None,
+        }
+    }
+
+    pub fn with_audit_sink(mut self, audit_sink: &'a dyn AuditSink) -> Self {
+        self.audit_sink = Some(audit_sink);
+        self
+    }
+
+    pub async fn approve_dispatch(
+        &self,
+        scope: &ResourceScope,
+        request_id: ironclaw_host_api::ApprovalRequestId,
+        approval: LeaseApproval,
+    ) -> Result<CapabilityLease, ApprovalResolutionError> {
+        let record = self
+            .approvals
+            .get(scope, request_id)
+            .await?
+            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        if record.status != ApprovalStatus::Pending {
+            return Err(ApprovalResolutionError::NotPending {
+                status: record.status,
+            });
+        }
+
+        let Action::Dispatch { capability, .. } = record.request.action.as_ref() else {
+            return Err(ApprovalResolutionError::UnsupportedAction);
+        };
+
+        let resolved_by = approval.issued_by.clone();
+        let grant = CapabilityGrant {
+            id: CapabilityGrantId::new(),
+            capability: capability.clone(),
+            grantee: record.request.requested_by.clone(),
+            issued_by: approval.issued_by,
+            constraints: GrantConstraints {
+                allowed_effects: approval.allowed_effects,
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
+                expires_at: approval.expires_at,
+                max_invocations: approval.max_invocations,
+            },
+        };
+        let mut lease = CapabilityLease::new(record.scope.clone(), grant);
+        lease.invocation_fingerprint = record.request.invocation_fingerprint.clone();
+        let lease = self.leases.issue(lease).await?;
+        if let Err(error) = self.approvals.approve(scope, request_id).await {
+            let _ = self.leases.revoke(&lease.scope, lease.grant.id).await;
+            return Err(error.into());
+        }
+        self.emit_audit_best_effort(ironclaw_host_api::AuditEnvelope::approval_resolved(
+            &record.scope,
+            &record.request,
+            resolved_by,
+            "approved",
+        ))
+        .await;
+        Ok(lease)
+    }
+
+    pub async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ironclaw_host_api::ApprovalRequestId,
+        denial: DenyApproval,
+    ) -> Result<ApprovalRecord, ApprovalResolutionError> {
+        let record = self
+            .approvals
+            .get(scope, request_id)
+            .await?
+            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        if record.status != ApprovalStatus::Pending {
+            return Err(ApprovalResolutionError::NotPending {
+                status: record.status,
+            });
+        }
+
+        let denied = self.approvals.deny(scope, request_id).await?;
+        self.emit_audit_best_effort(ironclaw_host_api::AuditEnvelope::approval_resolved(
+            &denied.scope,
+            &denied.request,
+            denial.denied_by,
+            "denied",
+        ))
+        .await;
+        Ok(denied)
+    }
+
+    async fn emit_audit_best_effort(&self, record: ironclaw_host_api::AuditEnvelope) {
+        if let Some(sink) = self.audit_sink {
+            let _ = sink.emit_audit(record).await;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeaseApproval {
+    pub issued_by: Principal,
+    pub allowed_effects: Vec<EffectKind>,
+    pub expires_at: Option<Timestamp>,
+    pub max_invocations: Option<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DenyApproval {
+    pub denied_by: Principal,
+}
+
+#[derive(Debug, Error)]
+pub enum ApprovalResolutionError {
+    #[error("approval store failed: {0}")]
+    RunState(#[from] RunStateError),
+    #[error("approval request is not pending: {status:?}")]
+    NotPending { status: ApprovalStatus },
+    #[error("approval action cannot issue a dispatch lease")]
+    UnsupportedAction,
+    #[error("capability lease failed: {0}")]
+    Lease(#[from] CapabilityLeaseError),
+}

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -26,6 +26,10 @@ async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -60,6 +64,76 @@ async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
 }
 
 #[tokio::test]
+async fn approving_pending_dispatch_request_preserves_reviewed_grant_constraints() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/project1").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+    let network = NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.com".to_string(),
+            port: Some(443),
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(1024),
+    };
+    let secret = SecretHandle::new("api-key").unwrap();
+    let resource_ceiling = ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: Some(10),
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    };
+
+    let lease = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![
+                    EffectKind::DispatchCapability,
+                    EffectKind::ReadFilesystem,
+                    EffectKind::Network,
+                    EffectKind::UseSecret,
+                ],
+                mounts: mounts.clone(),
+                network: network.clone(),
+                secrets: vec![secret.clone()],
+                resource_ceiling: Some(resource_ceiling.clone()),
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(lease.grant.constraints.mounts, mounts);
+    assert_eq!(lease.grant.constraints.network, network);
+    assert_eq!(lease.grant.constraints.secrets, vec![secret]);
+    assert_eq!(
+        lease.grant.constraints.resource_ceiling,
+        Some(resource_ceiling)
+    );
+}
+
+#[tokio::test]
 async fn approving_pending_request_keeps_pending_when_lease_issue_fails() {
     let approvals = InMemoryApprovalRequestStore::new();
     let leases = FailingIssueLeaseStore;
@@ -80,6 +154,10 @@ async fn approving_pending_request_keeps_pending_when_lease_issue_fails() {
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -125,6 +203,10 @@ async fn approving_pending_request_revokes_issued_lease_when_approval_update_fai
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -162,6 +244,10 @@ async fn approving_pending_request_revokes_issued_lease_when_status_was_resolved
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -200,6 +286,10 @@ async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
             LeaseApproval {
                 issued_by: Principal::User(context.user_id.clone()),
                 allowed_effects: descriptor.effects.clone(),
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: None,
             },
@@ -242,6 +332,10 @@ async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_ch
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -287,6 +381,10 @@ async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event(
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -385,6 +483,10 @@ async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() 
             LeaseApproval {
                 issued_by: Principal::User(scope.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: Some(1),
             },
@@ -498,6 +600,10 @@ async fn approving_request_from_other_tenant_fails_closed() {
             LeaseApproval {
                 issued_by: Principal::User(tenant_b.user_id.clone()),
                 allowed_effects: vec![EffectKind::DispatchCapability],
+                mounts: Default::default(),
+                network: Default::default(),
+                secrets: Vec::new(),
+                resource_ceiling: None,
                 expires_at: None,
                 max_invocations: None,
             },

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -179,6 +179,51 @@ async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
 }
 
 #[tokio::test]
+async fn approving_dispatch_without_fingerprint_fails_without_lease_or_status_change() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let mut approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    approval.invocation_fingerprint = None;
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+
+    let err = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ApprovalResolutionError::MissingInvocationFingerprint
+    ));
+    assert_eq!(leases.leases_for_scope(&scope).await, Vec::new());
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Pending
+    );
+}
+
+#[tokio::test]
 async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event() {
     let approvals = InMemoryApprovalRequestStore::new();
     let leases = InMemoryCapabilityLeaseStore::new();

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -139,6 +139,48 @@ async fn approving_pending_request_revokes_issued_lease_when_approval_update_fai
 }
 
 #[tokio::test]
+async fn approving_pending_request_revokes_issued_lease_when_status_was_resolved_concurrently() {
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    let approvals = AlreadyResolvedOnApproveStore {
+        record: ApprovalRecord {
+            scope: scope.clone(),
+            request: approval,
+            status: ApprovalStatus::Pending,
+        },
+        resolved_status: ApprovalStatus::Denied,
+    };
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+
+    let err = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ApprovalResolutionError::NotPending {
+            status: ApprovalStatus::Denied
+        }
+    ));
+    let issued = leases.leases_for_scope(&scope).await;
+    assert_eq!(issued.len(), 1);
+    assert_eq!(issued[0].status, CapabilityLeaseStatus::Revoked);
+}
+
+#[tokio::test]
 async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
     let approvals = InMemoryApprovalRequestStore::new();
     let leases = InMemoryCapabilityLeaseStore::new();
@@ -521,6 +563,67 @@ impl ApprovalRequestStore for FailingApproveApprovalStore {
         _request_id: ApprovalRequestId,
     ) -> Result<ApprovalRecord, RunStateError> {
         Ok(self.record.clone())
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        if same_tenant_user_for_test(&self.record.scope, scope) {
+            Ok(vec![self.record.clone()])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+}
+
+struct AlreadyResolvedOnApproveStore {
+    record: ApprovalRecord,
+    resolved_status: ApprovalStatus,
+}
+
+#[async_trait]
+impl ApprovalRequestStore for AlreadyResolvedOnApproveStore {
+    async fn save_pending(
+        &self,
+        _scope: ResourceScope,
+        _request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Ok(self.record.clone())
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        if self.record.scope == *scope && self.record.request.id == request_id {
+            Ok(Some(self.record.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn approve(
+        &self,
+        _scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::ApprovalNotPending {
+            request_id,
+            status: self.resolved_status,
+        })
+    }
+
+    async fn deny(
+        &self,
+        _scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::ApprovalNotPending {
+            request_id,
+            status: self.resolved_status,
+        })
     }
 
     async fn records_for_scope(

--- a/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_approvals/tests/approval_resolution_contract.rs
@@ -1,0 +1,622 @@
+use async_trait::async_trait;
+use ironclaw_approvals::*;
+use ironclaw_authorization::*;
+use ironclaw_events::{AuditSink, EventError, InMemoryAuditSink};
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+
+#[tokio::test]
+async fn approving_pending_dispatch_request_issues_scoped_capability_lease() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    let lease = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(lease.scope, scope);
+    assert_eq!(
+        lease.grant.capability,
+        CapabilityId::new("echo.say").unwrap()
+    );
+    assert_eq!(lease.grant.grantee, approval.requested_by);
+    assert_eq!(
+        lease.invocation_fingerprint,
+        approval.invocation_fingerprint
+    );
+    assert_eq!(lease.grant.constraints.max_invocations, Some(1));
+    assert_eq!(
+        approvals
+            .get(&lease.scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Approved
+    );
+    assert_eq!(
+        leases.get(&lease.scope, lease.grant.id).await.unwrap(),
+        lease
+    );
+}
+
+#[tokio::test]
+async fn approving_pending_request_keeps_pending_when_lease_issue_fails() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = FailingIssueLeaseStore;
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+
+    let err = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ApprovalResolutionError::Lease(CapabilityLeaseError::Persistence { .. })
+    ));
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Pending
+    );
+}
+
+#[tokio::test]
+async fn approving_pending_request_revokes_issued_lease_when_approval_update_fails() {
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    let approvals = FailingApproveApprovalStore {
+        record: ApprovalRecord {
+            scope: scope.clone(),
+            request: approval,
+            status: ApprovalStatus::Pending,
+        },
+    };
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+
+    let err = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, ApprovalResolutionError::RunState(_)));
+    let issued = leases.leases_for_scope(&scope).await;
+    assert_eq!(issued.len(), 1);
+    assert_eq!(issued[0].status, CapabilityLeaseStatus::Revoked);
+}
+
+#[tokio::test]
+async fn lease_from_approved_request_is_resume_only_and_not_plain_authority() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let approval = approval_request(context.invocation_id, descriptor.id.clone());
+    approvals
+        .save_pending(context.resource_scope.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    resolver
+        .approve_dispatch(
+            &context.resource_scope,
+            approval.id,
+            LeaseApproval {
+                issued_by: Principal::User(context.user_id.clone()),
+                allowed_effects: descriptor.effects.clone(),
+                expires_at: None,
+                max_invocations: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn approving_pending_dispatch_request_emits_redacted_approval_audit_event() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let audit = InMemoryAuditSink::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    let emitted = audit.records();
+    assert_eq!(emitted.len(), 1);
+    assert_eq!(emitted[0].stage, AuditStage::ApprovalResolved);
+    assert_eq!(emitted[0].correlation_id, approval.correlation_id);
+    assert_eq!(emitted[0].tenant_id, scope.tenant_id);
+    assert_eq!(emitted[0].user_id, scope.user_id);
+    assert_eq!(emitted[0].invocation_id, scope.invocation_id);
+    assert_eq!(emitted[0].process_id, None);
+    assert_eq!(
+        emitted[0].extension_id,
+        Some(ExtensionId::new("caller").unwrap())
+    );
+    assert_eq!(emitted[0].action.kind, "dispatch");
+    assert_eq!(emitted[0].action.target.as_deref(), Some("echo.say"));
+    assert_eq!(emitted[0].decision.kind, "approved");
+    assert_eq!(
+        emitted[0].decision.actor,
+        Some(Principal::User(scope.user_id.clone()))
+    );
+    assert_eq!(emitted[0].result, None);
+}
+
+#[tokio::test]
+async fn denying_pending_dispatch_request_emits_redacted_approval_audit_event() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let audit = InMemoryAuditSink::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    resolver
+        .deny(
+            &scope,
+            request_id,
+            DenyApproval {
+                denied_by: Principal::User(scope.user_id.clone()),
+            },
+        )
+        .await
+        .unwrap();
+
+    let emitted = audit.records();
+    assert_eq!(emitted.len(), 1);
+    assert_eq!(emitted[0].stage, AuditStage::ApprovalResolved);
+    assert_eq!(emitted[0].correlation_id, approval.correlation_id);
+    assert_eq!(emitted[0].tenant_id, scope.tenant_id);
+    assert_eq!(emitted[0].user_id, scope.user_id);
+    assert_eq!(emitted[0].invocation_id, scope.invocation_id);
+    assert_eq!(
+        emitted[0].extension_id,
+        Some(ExtensionId::new("caller").unwrap())
+    );
+    assert_eq!(emitted[0].action.kind, "dispatch");
+    assert_eq!(emitted[0].action.target.as_deref(), Some("echo.say"));
+    assert_eq!(emitted[0].decision.kind, "denied");
+    assert_eq!(
+        emitted[0].decision.actor,
+        Some(Principal::User(scope.user_id.clone()))
+    );
+    assert_eq!(emitted[0].result, None);
+}
+
+#[tokio::test]
+async fn approval_audit_event_sink_failure_does_not_change_resolution_outcome() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let audit = FailingAuditSink;
+    let resolver = ApprovalResolver::new(&approvals, &leases).with_audit_sink(&audit);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+
+    let lease = resolver
+        .approve_dispatch(
+            &scope,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(scope.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: Some(1),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Approved
+    );
+    assert_eq!(leases.get(&scope, lease.grant.id).await, Some(lease));
+}
+
+#[tokio::test]
+async fn denying_pending_request_does_not_issue_lease() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+
+    let denied = resolver
+        .deny(
+            &scope,
+            request_id,
+            DenyApproval {
+                denied_by: Principal::User(scope.user_id.clone()),
+            },
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(denied.status, ApprovalStatus::Denied);
+    assert_eq!(leases.leases_for_scope(&scope).await, Vec::new());
+}
+
+#[tokio::test]
+async fn denying_non_pending_request_fails_without_changing_status() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap();
+    approvals.approve(&scope, request_id).await.unwrap();
+
+    let err = resolver
+        .deny(
+            &scope,
+            request_id,
+            DenyApproval {
+                denied_by: Principal::User(scope.user_id.clone()),
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        ApprovalResolutionError::NotPending {
+            status: ApprovalStatus::Approved
+        }
+    ));
+    assert_eq!(
+        approvals
+            .get(&scope, request_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        ApprovalStatus::Approved
+    );
+}
+
+#[tokio::test]
+async fn approving_request_from_other_tenant_fails_closed() {
+    let approvals = InMemoryApprovalRequestStore::new();
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let resolver = ApprovalResolver::new(&approvals, &leases);
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let approval = approval_request(invocation_id, CapabilityId::new("echo.say").unwrap());
+    let request_id = approval.id;
+    approvals
+        .save_pending(tenant_a.clone(), approval)
+        .await
+        .unwrap();
+
+    let err = resolver
+        .approve_dispatch(
+            &tenant_b,
+            request_id,
+            LeaseApproval {
+                issued_by: Principal::User(tenant_b.user_id.clone()),
+                allowed_effects: vec![EffectKind::DispatchCapability],
+                expires_at: None,
+                max_invocations: None,
+            },
+        )
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, ApprovalResolutionError::RunState(_)));
+    assert_eq!(leases.leases_for_scope(&tenant_a).await, Vec::new());
+    assert_eq!(leases.leases_for_scope(&tenant_b).await, Vec::new());
+}
+
+struct FailingAuditSink;
+
+#[async_trait]
+impl AuditSink for FailingAuditSink {
+    async fn emit_audit(&self, _record: AuditEnvelope) -> Result<(), EventError> {
+        Err(EventError::Sink {
+            reason: "audit sink unavailable".to_string(),
+        })
+    }
+}
+
+struct FailingApproveApprovalStore {
+    record: ApprovalRecord,
+}
+
+#[async_trait]
+impl ApprovalRequestStore for FailingApproveApprovalStore {
+    async fn save_pending(
+        &self,
+        _scope: ResourceScope,
+        _request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Ok(self.record.clone())
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        if self.record.scope == *scope && self.record.request.id == request_id {
+            Ok(Some(self.record.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn approve(
+        &self,
+        _scope: &ResourceScope,
+        _request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Err(RunStateError::Filesystem(
+            "injected approval write failure".to_string(),
+        ))
+    }
+
+    async fn deny(
+        &self,
+        _scope: &ResourceScope,
+        _request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        Ok(self.record.clone())
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        if same_tenant_user_for_test(&self.record.scope, scope) {
+            Ok(vec![self.record.clone()])
+        } else {
+            Ok(Vec::new())
+        }
+    }
+}
+
+struct FailingIssueLeaseStore;
+
+#[async_trait]
+impl CapabilityLeaseStore for FailingIssueLeaseStore {
+    async fn issue(
+        &self,
+        _lease: CapabilityLease,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        Err(CapabilityLeaseError::Persistence {
+            reason: "injected lease write failure".to_string(),
+        })
+    }
+
+    async fn revoke(
+        &self,
+        _scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        Err(CapabilityLeaseError::UnknownLease { lease_id })
+    }
+
+    async fn get(
+        &self,
+        _scope: &ResourceScope,
+        _lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        None
+    }
+
+    async fn claim(
+        &self,
+        _scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        _invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        Err(CapabilityLeaseError::UnknownLease { lease_id })
+    }
+
+    async fn consume(
+        &self,
+        _scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        Err(CapabilityLeaseError::UnknownLease { lease_id })
+    }
+
+    async fn leases_for_scope(&self, _scope: &ResourceScope) -> Vec<CapabilityLease> {
+        Vec::new()
+    }
+
+    async fn active_leases_for_context(&self, _context: &ExecutionContext) -> Vec<CapabilityLease> {
+        Vec::new()
+    }
+}
+
+fn approval_request(invocation_id: InvocationId, capability: CapabilityId) -> ApprovalRequest {
+    ApprovalRequest {
+        id: ApprovalRequestId::new(),
+        correlation_id: CorrelationId::new(),
+        requested_by: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        action: Box::new(Action::Dispatch {
+            capability: capability.clone(),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        reason: format!("approval for {invocation_id}"),
+        reusable_scope: None,
+        invocation_fingerprint: Some(
+            InvocationFingerprint::for_dispatch(
+                &sample_scope(invocation_id, "tenant1", "user1"),
+                &capability,
+                &ResourceEstimate::default(),
+                &serde_json::json!({"message": "approved"}),
+            )
+            .unwrap(),
+        ),
+    }
+}
+
+fn descriptor(id: CapabilityId) -> CapabilityDescriptor {
+    CapabilityDescriptor {
+        provider: ExtensionId::new(id.as_str().split('.').next().unwrap()).unwrap(),
+        id,
+        runtime: RuntimeKind::Wasm,
+        trust_ceiling: TrustClass::Sandbox,
+        description: "test".to_string(),
+        parameters_schema: serde_json::json!({"type": "object"}),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Deny,
+        resource_profile: None,
+    }
+}
+
+fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    }
+}
+
+fn same_tenant_user_for_test(left: &ResourceScope, right: &ResourceScope) -> bool {
+    left.tenant_id == right.tenant_id && left.user_id == right.user_id
+}
+
+fn execution_context(grants: CapabilitySet) -> ExecutionContext {
+    let invocation_id = InvocationId::new();
+    let resource_scope = sample_scope(invocation_id, "tenant1", "user1");
+    ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: resource_scope.tenant_id.clone(),
+        user_id: resource_scope.user_id.clone(),
+        agent_id: None,
+        project_id: resource_scope.project_id.clone(),
+        mission_id: resource_scope.mission_id.clone(),
+        thread_id: resource_scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::Sandbox,
+        grants,
+        mounts: MountView::default(),
+        resource_scope,
+    }
+}

--- a/crates/ironclaw_approvals/tests/boundary_contract.rs
+++ b/crates/ironclaw_approvals/tests/boundary_contract.rs
@@ -1,0 +1,31 @@
+#[test]
+fn approvals_crate_stays_out_of_runtime_and_host_workflow_crates() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {manifest_path:?}: {error}"));
+    let dependencies = dependencies_section(&manifest);
+
+    for forbidden in [
+        "ironclaw_capabilities",
+        "ironclaw_dispatcher",
+        "ironclaw_processes",
+        "ironclaw_host_runtime",
+        "ironclaw_resources",
+        "ironclaw_extensions",
+        "ironclaw_wasm",
+        "ironclaw_scripts",
+        "ironclaw_mcp",
+    ] {
+        assert!(
+            !dependencies.contains(forbidden),
+            "ironclaw_approvals should resolve approval records into leases/audit without depending on {forbidden}"
+        );
+    }
+}
+
+fn dependencies_section(manifest: &str) -> &str {
+    manifest
+        .split_once("[dependencies]")
+        .and_then(|(_, rest)| rest.split_once("[dev-dependencies]").map(|(deps, _)| deps))
+        .expect("Cargo.toml must contain [dependencies] before [dev-dependencies]")
+}

--- a/crates/ironclaw_authorization/CLAUDE.md
+++ b/crates/ironclaw_authorization/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_authorization guardrails
+
+- Own grant matching, lease state, and dispatch/spawn authorization decisions.
+- Do not execute capabilities, persist run-state, resolve approvals, reserve resources, prompt users, or import runtime/process/dispatcher/capability workflow crates.
+- Authorization is default-deny and tenant/user/invocation scoped.
+- Filesystem-backed leases must use async filesystem calls, not nested `block_on`.
+- Fingerprinted approval leases are resume-only authority and must not become ambient grants.

--- a/crates/ironclaw_authorization/CLAUDE.md
+++ b/crates/ironclaw_authorization/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - Own grant matching, lease state, and dispatch/spawn authorization decisions.
 - Do not execute capabilities, persist run-state, resolve approvals, reserve resources, prompt users, or import runtime/process/dispatcher/capability workflow crates.
-- Authorization is default-deny and tenant/user/invocation scoped.
+- Authorization is default-deny and resource-owner/invocation scoped (tenant/user/agent/project/mission/thread plus invocation where applicable).
 - Filesystem-backed leases must use async filesystem calls, not nested `block_on`.
 - The filesystem lease store is an early/local backend: its per-owner keyed mutation locks are process-local and not a cross-process transaction/CAS mechanism. Production shared roots must use a transactional backend or explicit compare-and-swap before real concurrent callers.
 - Fingerprinted approval leases are resume-only authority and must not become ambient grants.

--- a/crates/ironclaw_authorization/CLAUDE.md
+++ b/crates/ironclaw_authorization/CLAUDE.md
@@ -4,5 +4,5 @@
 - Do not execute capabilities, persist run-state, resolve approvals, reserve resources, prompt users, or import runtime/process/dispatcher/capability workflow crates.
 - Authorization is default-deny and tenant/user/invocation scoped.
 - Filesystem-backed leases must use async filesystem calls, not nested `block_on`.
-- The filesystem lease store is an early/local backend: its mutex is process-local and not a cross-process transaction/CAS mechanism. Production shared roots must use a transactional backend or explicit compare-and-swap before real concurrent callers.
+- The filesystem lease store is an early/local backend: its per-owner keyed mutation locks are process-local and not a cross-process transaction/CAS mechanism. Production shared roots must use a transactional backend or explicit compare-and-swap before real concurrent callers.
 - Fingerprinted approval leases are resume-only authority and must not become ambient grants.

--- a/crates/ironclaw_authorization/CLAUDE.md
+++ b/crates/ironclaw_authorization/CLAUDE.md
@@ -4,4 +4,5 @@
 - Do not execute capabilities, persist run-state, resolve approvals, reserve resources, prompt users, or import runtime/process/dispatcher/capability workflow crates.
 - Authorization is default-deny and tenant/user/invocation scoped.
 - Filesystem-backed leases must use async filesystem calls, not nested `block_on`.
+- The filesystem lease store is an early/local backend: its mutex is process-local and not a cross-process transaction/CAS mechanism. Production shared roots must use a transactional backend or explicit compare-and-swap before real concurrent callers.
 - Fingerprinted approval leases are resume-only authority and must not become ambient grants.

--- a/crates/ironclaw_authorization/Cargo.toml
+++ b/crates/ironclaw_authorization/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ironclaw_authorization"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+chrono = { version = "0.4", features = ["serde"] }
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -7,7 +7,7 @@
 
 use std::{
     collections::HashMap,
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
 };
 
 use async_trait::async_trait;
@@ -297,7 +297,7 @@ where
     F: RootFilesystem,
 {
     filesystem: &'a F,
-    lock: tokio::sync::Mutex<()>,
+    mutation_locks: Mutex<HashMap<CapabilityLeaseOwnerKey, Arc<tokio::sync::Mutex<()>>>>,
 }
 
 impl<'a, F> FilesystemCapabilityLeaseStore<'a, F>
@@ -307,8 +307,18 @@ where
     pub fn new(filesystem: &'a F) -> Self {
         Self {
             filesystem,
-            lock: tokio::sync::Mutex::new(()),
+            mutation_locks: Mutex::new(HashMap::new()),
         }
+    }
+
+    fn mutation_lock(&self, scope: &ResourceScope) -> Arc<tokio::sync::Mutex<()>> {
+        let key = CapabilityLeaseOwnerKey::new(scope);
+        self.mutation_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .entry(key)
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
     }
 
     async fn read_lease(
@@ -332,6 +342,69 @@ where
             .write_file(&path, &bytes)
             .await
             .map_err(lease_persistence_error)
+    }
+
+    async fn read_lease_index(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Option<Vec<VirtualPath>>, CapabilityLeaseError> {
+        let path = lease_index_path(scope)?;
+        let bytes = match self.filesystem.read_file(&path).await {
+            Ok(bytes) => bytes,
+            Err(error) if is_not_found(&error) => return Ok(None),
+            Err(error) => return Err(lease_persistence_error(error)),
+        };
+        let index: CapabilityLeaseIndex = deserialize(&bytes)?;
+        Ok(Some(index.paths))
+    }
+
+    async fn write_lease_index(
+        &self,
+        scope: &ResourceScope,
+        mut paths: Vec<VirtualPath>,
+    ) -> Result<(), CapabilityLeaseError> {
+        paths.sort_by(|left, right| left.as_str().cmp(right.as_str()));
+        paths.dedup_by(|left, right| left.as_str() == right.as_str());
+        let path = lease_index_path(scope)?;
+        let bytes = serialize_pretty(&CapabilityLeaseIndex { paths })?;
+        self.filesystem
+            .write_file(&path, &bytes)
+            .await
+            .map_err(lease_persistence_error)
+    }
+
+    async fn index_lease_path(
+        &self,
+        scope: &ResourceScope,
+        path: VirtualPath,
+    ) -> Result<(), CapabilityLeaseError> {
+        let mut paths = self.read_lease_index(scope).await?.unwrap_or_default();
+        if !paths.iter().any(|existing| existing == &path) {
+            paths.push(path);
+        }
+        self.write_lease_index(scope, paths).await
+    }
+
+    async fn list_lease_paths_from_index_or_scan(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
+        if let Some(paths) = self.read_lease_index(scope).await? {
+            return Ok(paths);
+        }
+        self.scan_lease_paths(scope).await
+    }
+
+    async fn scan_lease_paths(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
+        let roots = self.list_invocation_roots(scope).await?;
+        let mut paths = Vec::new();
+        for root in roots {
+            paths.extend(self.list_lease_files(&root).await?);
+        }
+        Ok(paths)
     }
 
     async fn list_invocation_roots(
@@ -386,7 +459,10 @@ where
     F: RootFilesystem,
 {
     async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let _guard = self.lock.lock().await;
+        let lock = self.mutation_lock(&lease.scope);
+        let _guard = lock.lock().await;
+        self.index_lease_path(&lease.scope, lease_path(&lease.scope, lease.grant.id)?)
+            .await?;
         self.write_lease(&lease).await?;
         Ok(lease)
     }
@@ -396,7 +472,8 @@ where
         scope: &ResourceScope,
         lease_id: CapabilityGrantId,
     ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let _guard = self.lock.lock().await;
+        let lock = self.mutation_lock(scope);
+        let _guard = lock.lock().await;
         let mut lease = self
             .read_lease(scope, lease_id)
             .await?
@@ -420,7 +497,8 @@ where
         lease_id: CapabilityGrantId,
         invocation_fingerprint: &InvocationFingerprint,
     ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let _guard = self.lock.lock().await;
+        let lock = self.mutation_lock(scope);
+        let _guard = lock.lock().await;
         let mut lease = self
             .read_lease(scope, lease_id)
             .await?
@@ -436,7 +514,8 @@ where
         scope: &ResourceScope,
         lease_id: CapabilityGrantId,
     ) -> Result<CapabilityLease, CapabilityLeaseError> {
-        let _guard = self.lock.lock().await;
+        let lock = self.mutation_lock(scope);
+        let _guard = lock.lock().await;
         let mut lease = self
             .read_lease(scope, lease_id)
             .await?
@@ -458,18 +537,13 @@ where
     }
 
     async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
-        let Ok(roots) = self.list_invocation_roots(scope).await else {
+        let Ok(paths) = self.list_lease_paths_from_index_or_scan(scope).await else {
             return Vec::new();
         };
         let mut leases = Vec::new();
-        for root in roots {
-            let Ok(files) = self.list_lease_files(&root).await else {
-                continue;
-            };
-            for path in files {
-                if let Ok(lease) = self.read_lease_file(&path).await {
-                    leases.push(lease);
-                }
+        for path in paths {
+            if let Ok(lease) = self.read_lease_file(&path).await {
+                leases.push(lease);
             }
         }
         let mut leases = leases
@@ -508,6 +582,28 @@ impl CapabilityLeaseKey {
             lease_id,
         }
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CapabilityLeaseOwnerKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    agent_id: Option<AgentId>,
+}
+
+impl CapabilityLeaseOwnerKey {
+    fn new(scope: &ResourceScope) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+struct CapabilityLeaseIndex {
+    paths: Vec<VirtualPath>,
 }
 
 /// Authorizer that combines request-scoped grants with active capability leases.
@@ -705,6 +801,14 @@ fn lease_path(
     VirtualPath::new(format!(
         "{}/{lease_id}.json",
         lease_invocation_root(scope)?.as_str()
+    ))
+    .map_err(lease_host_api_error)
+}
+
+fn lease_index_path(scope: &ResourceScope) -> Result<VirtualPath, CapabilityLeaseError> {
+    VirtualPath::new(format!(
+        "{}/_lease_index.json",
+        lease_tenant_user_root(scope)?.as_str()
     ))
     .map_err(lease_host_api_error)
 }

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -1,0 +1,776 @@
+//! Capability authorization contracts for IronClaw Reborn.
+//!
+//! `ironclaw_authorization` evaluates authority-bearing host API contracts. It
+//! does not execute capabilities, reserve resources, prompt users, or reach into
+//! runtime internals. The first slices implement grant- and lease-backed gates
+//! for capability dispatch.
+
+use std::{
+    collections::HashMap,
+    sync::{Mutex, MutexGuard},
+};
+
+use async_trait::async_trait;
+use chrono::Utc;
+use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
+use ironclaw_host_api::{
+    AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
+    EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, Principal,
+    ResourceEstimate, ResourceScope, TenantId, UserId, VirtualPath,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Authorizes a capability dispatch request against an execution context.
+#[async_trait]
+pub trait CapabilityDispatchAuthorizer: Send + Sync {
+    /// Returns `Allow` only when the context has matching authority for the capability and declared effects; otherwise fails closed.
+    async fn authorize_dispatch(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        estimate: &ResourceEstimate,
+    ) -> Decision;
+
+    /// Returns `Allow` only when dispatch authority and `SpawnProcess` authority are both present for the target capability.
+    async fn authorize_spawn(
+        &self,
+        _context: &ExecutionContext,
+        _descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+    ) -> Decision {
+        Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        }
+    }
+}
+
+/// Grant-backed capability dispatch authorizer.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GrantAuthorizer;
+
+impl GrantAuthorizer {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl CapabilityDispatchAuthorizer for GrantAuthorizer {
+    async fn authorize_dispatch(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+    ) -> Decision {
+        authorize_from_grants(context, descriptor, context.grants.grants.iter())
+    }
+
+    async fn authorize_spawn(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+    ) -> Decision {
+        authorize_from_grants(
+            context,
+            &spawn_descriptor(descriptor),
+            context.grants.grants.iter(),
+        )
+    }
+}
+
+/// Capability lease issued from an approved request or policy workflow.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilityLease {
+    pub scope: ResourceScope,
+    pub grant: CapabilityGrant,
+    pub invocation_fingerprint: Option<InvocationFingerprint>,
+    pub status: CapabilityLeaseStatus,
+}
+
+impl CapabilityLease {
+    pub fn new(scope: ResourceScope, grant: CapabilityGrant) -> Self {
+        Self {
+            scope,
+            grant,
+            invocation_fingerprint: None,
+            status: CapabilityLeaseStatus::Active,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CapabilityLeaseStatus {
+    Active,
+    Claimed,
+    Consumed,
+    Revoked,
+}
+
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum CapabilityLeaseError {
+    #[error("unknown capability lease {lease_id}")]
+    UnknownLease { lease_id: CapabilityGrantId },
+    #[error("capability lease {lease_id} is expired")]
+    ExpiredLease { lease_id: CapabilityGrantId },
+    #[error("capability lease {lease_id} has no remaining invocations")]
+    ExhaustedLease { lease_id: CapabilityGrantId },
+    #[error("capability lease {lease_id} fingerprint does not match")]
+    FingerprintMismatch { lease_id: CapabilityGrantId },
+    #[error("capability lease {lease_id} is not active: {status:?}")]
+    InactiveLease {
+        lease_id: CapabilityGrantId,
+        status: CapabilityLeaseStatus,
+    },
+    #[error("capability lease persistence error: {reason}")]
+    Persistence { reason: String },
+}
+
+/// Store of active/revoked capability leases.
+#[async_trait]
+pub trait CapabilityLeaseStore: Send + Sync {
+    /// Persists a scoped lease before any approval record is marked approved.
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError>;
+
+    /// Revokes a lease only within the exact tenant/user/agent/invocation scope that owns it.
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError>;
+
+    /// Loads a lease by exact scope and ID; wrong-scope lookups must behave as unknown.
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease>;
+
+    /// Atomically marks an active fingerprinted lease as claimed after matching the replay fingerprint.
+    async fn claim(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError>;
+
+    /// Consumes or decrements an active/claimed lease after successful dispatch.
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError>;
+
+    /// Lists leases visible to the tenant/user/agent scope without exposing cross-scope records.
+    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease>;
+
+    /// Returns active, unexpired, unexhausted leases for the exact invocation context.
+    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease>;
+
+    /// Converts only non-fingerprinted active leases into ambient grants for authorization.
+    async fn active_grants_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityGrant> {
+        self.active_leases_for_context(context)
+            .await
+            .into_iter()
+            .filter(|lease| lease.invocation_fingerprint.is_none())
+            .map(|lease| lease.grant)
+            .collect()
+    }
+}
+
+/// In-memory lease store for early Reborn flows and tests.
+#[derive(Debug, Default)]
+pub struct InMemoryCapabilityLeaseStore {
+    leases: Mutex<HashMap<CapabilityLeaseKey, CapabilityLease>>,
+}
+
+impl InMemoryCapabilityLeaseStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn leases_guard(&self) -> MutexGuard<'_, HashMap<CapabilityLeaseKey, CapabilityLease>> {
+        self.leases
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[async_trait]
+impl CapabilityLeaseStore for InMemoryCapabilityLeaseStore {
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
+        self.leases_guard().insert(
+            CapabilityLeaseKey::new(&lease.scope, lease.grant.id),
+            lease.clone(),
+        );
+        Ok(lease)
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let mut leases = self.leases_guard();
+        let lease = leases
+            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+        lease.status = CapabilityLeaseStatus::Revoked;
+        Ok(lease.clone())
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        self.leases_guard()
+            .get(&CapabilityLeaseKey::new(scope, lease_id))
+            .cloned()
+    }
+
+    async fn claim(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let mut leases = self.leases_guard();
+        let lease = leases
+            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+
+        ensure_claimable(lease, invocation_fingerprint)?;
+        lease.status = CapabilityLeaseStatus::Claimed;
+        Ok(lease.clone())
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let mut leases = self.leases_guard();
+        let lease = leases
+            .get_mut(&CapabilityLeaseKey::new(scope, lease_id))
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+
+        let was_claimed = lease.status == CapabilityLeaseStatus::Claimed;
+        ensure_consumable(lease)?;
+        if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+            *remaining -= 1;
+            if *remaining == 0 {
+                lease.status = CapabilityLeaseStatus::Consumed;
+            } else if was_claimed {
+                lease.status = CapabilityLeaseStatus::Active;
+            }
+        } else if was_claimed {
+            lease.status = CapabilityLeaseStatus::Active;
+        }
+        Ok(lease.clone())
+    }
+
+    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
+        let mut leases = self
+            .leases_guard()
+            .values()
+            .filter(|lease| same_scope_owner(&lease.scope, scope))
+            .cloned()
+            .collect::<Vec<_>>();
+        leases.sort_by_key(|lease| lease.grant.id.as_uuid());
+        leases
+    }
+
+    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
+        self.leases_for_scope(&context.resource_scope)
+            .await
+            .into_iter()
+            .filter(|lease| lease_is_authorizing(lease, context))
+            .collect()
+    }
+}
+
+/// Filesystem-backed capability lease store under tenant/user/agent/invocation-scoped `/engine` paths.
+pub struct FilesystemCapabilityLeaseStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    filesystem: &'a F,
+    lock: tokio::sync::Mutex<()>,
+}
+
+impl<'a, F> FilesystemCapabilityLeaseStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(filesystem: &'a F) -> Self {
+        Self {
+            filesystem,
+            lock: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    async fn read_lease(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<Option<CapabilityLease>, CapabilityLeaseError> {
+        let path = lease_path(scope, lease_id)?;
+        let bytes = match self.filesystem.read_file(&path).await {
+            Ok(bytes) => bytes,
+            Err(error) if is_not_found(&error) => return Ok(None),
+            Err(error) => return Err(lease_persistence_error(error)),
+        };
+        deserialize(&bytes).map(Some)
+    }
+
+    async fn write_lease(&self, lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
+        let path = lease_path(&lease.scope, lease.grant.id)?;
+        let bytes = serialize_pretty(lease)?;
+        self.filesystem
+            .write_file(&path, &bytes)
+            .await
+            .map_err(lease_persistence_error)
+    }
+
+    async fn list_invocation_roots(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
+        let root = lease_tenant_user_root(scope)?;
+        let entries = match self.filesystem.list_dir(&root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(lease_persistence_error(error)),
+        };
+        Ok(entries
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::Directory)
+            .map(|entry| entry.path)
+            .collect())
+    }
+
+    async fn list_lease_files(
+        &self,
+        root: &VirtualPath,
+    ) -> Result<Vec<VirtualPath>, CapabilityLeaseError> {
+        let entries = match self.filesystem.list_dir(root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(lease_persistence_error(error)),
+        };
+        Ok(entries
+            .into_iter()
+            .filter(|entry| entry.file_type == FileType::File)
+            .map(|entry| entry.path)
+            .collect())
+    }
+
+    async fn read_lease_file(
+        &self,
+        path: &VirtualPath,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let bytes = self
+            .filesystem
+            .read_file(path)
+            .await
+            .map_err(lease_persistence_error)?;
+        deserialize(&bytes)
+    }
+}
+
+#[async_trait]
+impl<F> CapabilityLeaseStore for FilesystemCapabilityLeaseStore<'_, F>
+where
+    F: RootFilesystem,
+{
+    async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let _guard = self.lock.lock().await;
+        self.write_lease(&lease).await?;
+        Ok(lease)
+    }
+
+    async fn revoke(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let _guard = self.lock.lock().await;
+        let mut lease = self
+            .read_lease(scope, lease_id)
+            .await?
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+        lease.status = CapabilityLeaseStatus::Revoked;
+        self.write_lease(&lease).await?;
+        Ok(lease)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Option<CapabilityLease> {
+        self.read_lease(scope, lease_id).await.ok().flatten()
+    }
+
+    async fn claim(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+        invocation_fingerprint: &InvocationFingerprint,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let _guard = self.lock.lock().await;
+        let mut lease = self
+            .read_lease(scope, lease_id)
+            .await?
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+        ensure_claimable(&lease, invocation_fingerprint)?;
+        lease.status = CapabilityLeaseStatus::Claimed;
+        self.write_lease(&lease).await?;
+        Ok(lease)
+    }
+
+    async fn consume(
+        &self,
+        scope: &ResourceScope,
+        lease_id: CapabilityGrantId,
+    ) -> Result<CapabilityLease, CapabilityLeaseError> {
+        let _guard = self.lock.lock().await;
+        let mut lease = self
+            .read_lease(scope, lease_id)
+            .await?
+            .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
+        let was_claimed = lease.status == CapabilityLeaseStatus::Claimed;
+        ensure_consumable(&lease)?;
+        if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+            *remaining -= 1;
+            if *remaining == 0 {
+                lease.status = CapabilityLeaseStatus::Consumed;
+            } else if was_claimed {
+                lease.status = CapabilityLeaseStatus::Active;
+            }
+        } else if was_claimed {
+            lease.status = CapabilityLeaseStatus::Active;
+        }
+        self.write_lease(&lease).await?;
+        Ok(lease)
+    }
+
+    async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease> {
+        let Ok(roots) = self.list_invocation_roots(scope).await else {
+            return Vec::new();
+        };
+        let mut leases = Vec::new();
+        for root in roots {
+            let Ok(files) = self.list_lease_files(&root).await else {
+                continue;
+            };
+            for path in files {
+                if let Ok(lease) = self.read_lease_file(&path).await {
+                    leases.push(lease);
+                }
+            }
+        }
+        let mut leases = leases
+            .into_iter()
+            .filter(|lease| same_scope_owner(&lease.scope, scope))
+            .collect::<Vec<_>>();
+        leases.sort_by_key(|lease| lease.grant.id.as_uuid());
+        leases
+    }
+
+    async fn active_leases_for_context(&self, context: &ExecutionContext) -> Vec<CapabilityLease> {
+        self.leases_for_scope(&context.resource_scope)
+            .await
+            .into_iter()
+            .filter(|lease| lease_is_authorizing(lease, context))
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct CapabilityLeaseKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    agent_id: Option<AgentId>,
+    invocation_id: InvocationId,
+    lease_id: CapabilityGrantId,
+}
+
+impl CapabilityLeaseKey {
+    fn new(scope: &ResourceScope, lease_id: CapabilityGrantId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            invocation_id: scope.invocation_id,
+            lease_id,
+        }
+    }
+}
+
+/// Authorizer that combines request-scoped grants with active capability leases.
+pub struct LeaseBackedAuthorizer<'a, S>
+where
+    S: CapabilityLeaseStore + ?Sized,
+{
+    leases: &'a S,
+}
+
+impl<'a, S> LeaseBackedAuthorizer<'a, S>
+where
+    S: CapabilityLeaseStore + ?Sized,
+{
+    pub fn new(leases: &'a S) -> Self {
+        Self { leases }
+    }
+}
+
+#[async_trait]
+impl<S> CapabilityDispatchAuthorizer for LeaseBackedAuthorizer<'_, S>
+where
+    S: CapabilityLeaseStore + ?Sized,
+{
+    async fn authorize_dispatch(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+    ) -> Decision {
+        if context.validate().is_err() {
+            return Decision::Deny {
+                reason: DenyReason::InternalInvariantViolation,
+            };
+        }
+
+        let lease_grants = self.leases.active_grants_for_context(context).await;
+        authorize_from_grants(
+            context,
+            descriptor,
+            context.grants.grants.iter().chain(lease_grants.iter()),
+        )
+    }
+
+    async fn authorize_spawn(
+        &self,
+        context: &ExecutionContext,
+        descriptor: &CapabilityDescriptor,
+        _estimate: &ResourceEstimate,
+    ) -> Decision {
+        if context.validate().is_err() {
+            return Decision::Deny {
+                reason: DenyReason::InternalInvariantViolation,
+            };
+        }
+
+        let lease_grants = self.leases.active_grants_for_context(context).await;
+        authorize_from_grants(
+            context,
+            &spawn_descriptor(descriptor),
+            context.grants.grants.iter().chain(lease_grants.iter()),
+        )
+    }
+}
+
+fn spawn_descriptor(descriptor: &CapabilityDescriptor) -> CapabilityDescriptor {
+    let mut descriptor = descriptor.clone();
+    if !descriptor.effects.contains(&EffectKind::SpawnProcess) {
+        descriptor.effects.push(EffectKind::SpawnProcess);
+    }
+    descriptor
+}
+
+fn authorize_from_grants<'a>(
+    context: &ExecutionContext,
+    descriptor: &CapabilityDescriptor,
+    grants: impl Iterator<Item = &'a CapabilityGrant>,
+) -> Decision {
+    if context.validate().is_err() {
+        return Decision::Deny {
+            reason: DenyReason::InternalInvariantViolation,
+        };
+    }
+
+    let Some(grant) = grants
+        .filter(|grant| grant.capability == descriptor.id)
+        .find(|grant| principal_matches_context(&grant.grantee, context))
+    else {
+        return Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        };
+    };
+
+    if !effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects) {
+        return Decision::Deny {
+            reason: DenyReason::PolicyDenied,
+        };
+    }
+
+    Decision::Allow {
+        obligations: Default::default(),
+    }
+}
+
+fn principal_matches_context(principal: &Principal, context: &ExecutionContext) -> bool {
+    match principal {
+        Principal::Tenant(id) => id == &context.tenant_id,
+        Principal::User(id) => id == &context.user_id,
+        Principal::Agent(id) => context.agent_id.as_ref() == Some(id),
+        Principal::Project(id) => context.project_id.as_ref() == Some(id),
+        Principal::Mission(id) => context.mission_id.as_ref() == Some(id),
+        Principal::Thread(id) => context.thread_id.as_ref() == Some(id),
+        Principal::Extension(id) => id == &context.extension_id,
+        Principal::HostRuntime | Principal::System(_) => false,
+    }
+}
+
+fn effects_are_covered(required: &[EffectKind], allowed: &[EffectKind]) -> bool {
+    required.iter().all(|effect| allowed.contains(effect))
+}
+
+fn lease_is_authorizing(lease: &CapabilityLease, context: &ExecutionContext) -> bool {
+    lease.status == CapabilityLeaseStatus::Active
+        && lease.scope.invocation_id == context.invocation_id
+        && !lease_is_expired(lease)
+        && lease.grant.constraints.max_invocations != Some(0)
+}
+
+fn ensure_claimable(
+    lease: &CapabilityLease,
+    invocation_fingerprint: &InvocationFingerprint,
+) -> Result<(), CapabilityLeaseError> {
+    let lease_id = lease.grant.id;
+    if lease.status != CapabilityLeaseStatus::Active {
+        return Err(CapabilityLeaseError::InactiveLease {
+            lease_id,
+            status: lease.status,
+        });
+    }
+    if lease.invocation_fingerprint.as_ref() != Some(invocation_fingerprint) {
+        return Err(CapabilityLeaseError::FingerprintMismatch { lease_id });
+    }
+    ensure_not_expired_or_exhausted(lease)
+}
+
+fn ensure_consumable(lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
+    let lease_id = lease.grant.id;
+    match lease.status {
+        CapabilityLeaseStatus::Active | CapabilityLeaseStatus::Claimed => {}
+        CapabilityLeaseStatus::Consumed => {
+            return Err(CapabilityLeaseError::ExhaustedLease { lease_id });
+        }
+        CapabilityLeaseStatus::Revoked => {
+            return Err(CapabilityLeaseError::InactiveLease {
+                lease_id,
+                status: lease.status,
+            });
+        }
+    }
+
+    ensure_not_expired_or_exhausted(lease)
+}
+
+fn ensure_not_expired_or_exhausted(lease: &CapabilityLease) -> Result<(), CapabilityLeaseError> {
+    let lease_id = lease.grant.id;
+    if lease_is_expired(lease) {
+        return Err(CapabilityLeaseError::ExpiredLease { lease_id });
+    }
+
+    if lease.grant.constraints.max_invocations == Some(0) {
+        return Err(CapabilityLeaseError::ExhaustedLease { lease_id });
+    }
+
+    Ok(())
+}
+
+fn lease_is_expired(lease: &CapabilityLease) -> bool {
+    lease
+        .grant
+        .constraints
+        .expires_at
+        .is_some_and(|expires_at| expires_at <= Utc::now())
+}
+
+fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
+    left.tenant_id == right.tenant_id
+        && left.user_id == right.user_id
+        && left.agent_id == right.agent_id
+}
+
+fn lease_path(
+    scope: &ResourceScope,
+    lease_id: CapabilityGrantId,
+) -> Result<VirtualPath, CapabilityLeaseError> {
+    VirtualPath::new(format!(
+        "{}/{lease_id}.json",
+        lease_invocation_root(scope)?.as_str()
+    ))
+    .map_err(lease_host_api_error)
+}
+
+fn lease_invocation_root(scope: &ResourceScope) -> Result<VirtualPath, CapabilityLeaseError> {
+    VirtualPath::new(format!(
+        "{}/{}",
+        lease_tenant_user_root(scope)?.as_str(),
+        scope.invocation_id
+    ))
+    .map_err(lease_host_api_error)
+}
+
+fn lease_tenant_user_root(scope: &ResourceScope) -> Result<VirtualPath, CapabilityLeaseError> {
+    VirtualPath::new(format!("{}/capability-leases", scoped_owner_root(scope)))
+        .map_err(lease_host_api_error)
+}
+
+fn scoped_owner_root(scope: &ResourceScope) -> String {
+    let base = format!(
+        "/engine/tenants/{}/users/{}",
+        scope.tenant_id, scope.user_id
+    );
+    match &scope.agent_id {
+        Some(agent_id) => format!("{base}/agents/{agent_id}"),
+        None => base,
+    }
+}
+
+fn serialize_pretty<T>(value: &T) -> Result<Vec<u8>, CapabilityLeaseError>
+where
+    T: Serialize,
+{
+    serde_json::to_vec_pretty(value).map_err(|error| CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    })
+}
+
+fn deserialize<T>(bytes: &[u8]) -> Result<T, CapabilityLeaseError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    serde_json::from_slice(bytes).map_err(|error| CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    })
+}
+
+fn lease_host_api_error(error: HostApiError) -> CapabilityLeaseError {
+    CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    }
+}
+
+fn lease_persistence_error(error: FilesystemError) -> CapabilityLeaseError {
+    CapabilityLeaseError::Persistence {
+        reason: error.to_string(),
+    }
+}
+
+fn is_not_found(error: &FilesystemError) -> bool {
+    match error {
+        FilesystemError::Backend { reason, .. } => {
+            reason.contains("No such file")
+                || reason.contains("not found")
+                || reason.contains("entity not found")
+        }
+        _ => false,
+    }
+}

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -118,6 +118,8 @@ pub enum CapabilityLeaseError {
     ExpiredLease { lease_id: CapabilityGrantId },
     #[error("capability lease {lease_id} has no remaining invocations")]
     ExhaustedLease { lease_id: CapabilityGrantId },
+    #[error("capability lease {lease_id} has not been claimed with its fingerprint")]
+    UnclaimedFingerprintLease { lease_id: CapabilityGrantId },
     #[error("capability lease {lease_id} fingerprint does not match")]
     FingerprintMismatch { lease_id: CapabilityGrantId },
     #[error("capability lease {lease_id} is not active: {status:?}")]
@@ -770,13 +772,13 @@ fn obligations_for_grant(
         }
     }
 
-    if let Some(bytes) = grant
-        .constraints
-        .resource_ceiling
-        .as_ref()
-        .and_then(|ceiling| ceiling.max_output_bytes)
-    {
-        obligations.push(Obligation::EnforceOutputLimit { bytes });
+    if let Some(ceiling) = grant.constraints.resource_ceiling.as_ref() {
+        obligations.push(Obligation::EnforceResourceCeiling {
+            ceiling: ceiling.clone(),
+        });
+        if let Some(bytes) = ceiling.max_output_bytes {
+            obligations.push(Obligation::EnforceOutputLimit { bytes });
+        }
     }
 
     Obligations::new(obligations).ok()
@@ -850,17 +852,13 @@ fn resource_estimate_is_covered(
             ceiling.max_output_bytes.as_ref(),
         )
         && ceiling.sandbox.as_ref().is_none_or(|sandbox| {
-            sandbox.cpu_time_ms.is_none()
-                && sandbox.memory_bytes.is_none()
-                && sandbox.disk_bytes.is_none()
-                && options_within_ceiling(
-                    estimate.network_egress_bytes.as_ref(),
-                    sandbox.network_egress_bytes.as_ref(),
-                )
-                && options_within_ceiling(
-                    estimate.process_count.as_ref(),
-                    sandbox.process_count.as_ref(),
-                )
+            options_within_ceiling(
+                estimate.network_egress_bytes.as_ref(),
+                sandbox.network_egress_bytes.as_ref(),
+            ) && options_within_ceiling(
+                estimate.process_count.as_ref(),
+                sandbox.process_count.as_ref(),
+            )
         })
 }
 
@@ -912,6 +910,10 @@ fn ensure_consumable(lease: &CapabilityLease) -> Result<(), CapabilityLeaseError
                 status: lease.status,
             });
         }
+    }
+
+    if lease.invocation_fingerprint.is_some() && lease.status != CapabilityLeaseStatus::Claimed {
+        return Err(CapabilityLeaseError::UnclaimedFingerprintLease { lease_id });
     }
 
     ensure_not_expired_or_exhausted(lease)

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -16,8 +16,8 @@ use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
     EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, MissionId,
-    Principal, ProjectId, ResourceCeiling, ResourceEstimate, ResourceScope, TenantId, ThreadId,
-    UserId, VirtualPath,
+    NetworkPolicy, Obligation, Obligations, Principal, ProjectId, ResourceCeiling,
+    ResourceEstimate, ResourceScope, TenantId, ThreadId, UserId, VirtualPath,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -260,7 +260,12 @@ impl CapabilityLeaseStore for InMemoryCapabilityLeaseStore {
 
         let was_claimed = lease.status == CapabilityLeaseStatus::Claimed;
         ensure_consumable(lease)?;
-        if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+        if lease.invocation_fingerprint.is_some() {
+            if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+                *remaining = 0;
+            }
+            lease.status = CapabilityLeaseStatus::Consumed;
+        } else if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
             *remaining -= 1;
             if *remaining == 0 {
                 lease.status = CapabilityLeaseStatus::Consumed;
@@ -524,7 +529,12 @@ where
             .ok_or(CapabilityLeaseError::UnknownLease { lease_id })?;
         let was_claimed = lease.status == CapabilityLeaseStatus::Claimed;
         ensure_consumable(&lease)?;
-        if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+        if lease.invocation_fingerprint.is_some() {
+            if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
+                *remaining = 0;
+            }
+            lease.status = CapabilityLeaseStatus::Consumed;
+        } else if let Some(remaining) = lease.grant.constraints.max_invocations.as_mut() {
             *remaining -= 1;
             if *remaining == 0 {
                 lease.status = CapabilityLeaseStatus::Consumed;
@@ -714,10 +724,9 @@ fn authorize_from_grants<'a>(
         saw_active_matching_grant = true;
         if effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects)
             && resource_estimate_is_covered(estimate, grant.constraints.resource_ceiling.as_ref())
+            && let Some(obligations) = obligations_for_grant(descriptor, grant)
         {
-            return Decision::Allow {
-                obligations: Default::default(),
-            };
+            return Decision::Allow { obligations };
         }
     }
 
@@ -730,6 +739,65 @@ fn authorize_from_grants<'a>(
             reason: DenyReason::MissingGrant,
         }
     }
+}
+
+fn obligations_for_grant(
+    descriptor: &CapabilityDescriptor,
+    grant: &CapabilityGrant,
+) -> Option<Obligations> {
+    let mut obligations = Vec::new();
+
+    if descriptor_requires_mount_policy(descriptor) {
+        obligations.push(Obligation::UseScopedMounts {
+            mounts: grant.constraints.mounts.clone(),
+        });
+    }
+
+    if descriptor.effects.contains(&EffectKind::Network)
+        || network_policy_is_constrained(&grant.constraints.network)
+    {
+        obligations.push(Obligation::ApplyNetworkPolicy {
+            policy: grant.constraints.network.clone(),
+        });
+    }
+
+    if descriptor.effects.contains(&EffectKind::UseSecret) {
+        match grant.constraints.secrets.as_slice() {
+            [handle] => obligations.push(Obligation::InjectSecretOnce {
+                handle: handle.clone(),
+            }),
+            _ => return None,
+        }
+    }
+
+    if let Some(bytes) = grant
+        .constraints
+        .resource_ceiling
+        .as_ref()
+        .and_then(|ceiling| ceiling.max_output_bytes)
+    {
+        obligations.push(Obligation::EnforceOutputLimit { bytes });
+    }
+
+    Obligations::new(obligations).ok()
+}
+
+fn descriptor_requires_mount_policy(descriptor: &CapabilityDescriptor) -> bool {
+    descriptor.effects.iter().any(|effect| {
+        matches!(
+            effect,
+            EffectKind::ReadFilesystem
+                | EffectKind::WriteFilesystem
+                | EffectKind::DeleteFilesystem
+                | EffectKind::ExecuteCode
+        )
+    })
+}
+
+fn network_policy_is_constrained(policy: &NetworkPolicy) -> bool {
+    !policy.allowed_targets.is_empty()
+        || policy.deny_private_ip_ranges
+        || policy.max_egress_bytes.is_some()
 }
 
 fn principal_matches_context(principal: &Principal, context: &ExecutionContext) -> bool {
@@ -782,13 +850,17 @@ fn resource_estimate_is_covered(
             ceiling.max_output_bytes.as_ref(),
         )
         && ceiling.sandbox.as_ref().is_none_or(|sandbox| {
-            options_within_ceiling(
-                estimate.network_egress_bytes.as_ref(),
-                sandbox.network_egress_bytes.as_ref(),
-            ) && options_within_ceiling(
-                estimate.process_count.as_ref(),
-                sandbox.process_count.as_ref(),
-            )
+            sandbox.cpu_time_ms.is_none()
+                && sandbox.memory_bytes.is_none()
+                && sandbox.disk_bytes.is_none()
+                && options_within_ceiling(
+                    estimate.network_egress_bytes.as_ref(),
+                    sandbox.network_egress_bytes.as_ref(),
+                )
+                && options_within_ceiling(
+                    estimate.process_count.as_ref(),
+                    sandbox.process_count.as_ref(),
+                )
         })
 }
 
@@ -798,6 +870,7 @@ where
 {
     match (estimate, maximum) {
         (Some(estimate), Some(maximum)) => estimate <= maximum,
+        (None, Some(_)) => false,
         _ => true,
     }
 }

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -15,8 +15,9 @@ use chrono::Utc;
 use ironclaw_filesystem::{FileType, FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
     AgentId, CapabilityDescriptor, CapabilityGrant, CapabilityGrantId, Decision, DenyReason,
-    EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, Principal,
-    ResourceEstimate, ResourceScope, TenantId, UserId, VirtualPath,
+    EffectKind, ExecutionContext, HostApiError, InvocationFingerprint, InvocationId, MissionId,
+    Principal, ProjectId, ResourceCeiling, ResourceEstimate, ResourceScope, TenantId, ThreadId,
+    UserId, VirtualPath,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -61,20 +62,21 @@ impl CapabilityDispatchAuthorizer for GrantAuthorizer {
         &self,
         context: &ExecutionContext,
         descriptor: &CapabilityDescriptor,
-        _estimate: &ResourceEstimate,
+        estimate: &ResourceEstimate,
     ) -> Decision {
-        authorize_from_grants(context, descriptor, context.grants.grants.iter())
+        authorize_from_grants(context, descriptor, estimate, context.grants.grants.iter())
     }
 
     async fn authorize_spawn(
         &self,
         context: &ExecutionContext,
         descriptor: &CapabilityDescriptor,
-        _estimate: &ResourceEstimate,
+        estimate: &ResourceEstimate,
     ) -> Decision {
         authorize_from_grants(
             context,
             &spawn_descriptor(descriptor),
+            estimate,
             context.grants.grants.iter(),
         )
     }
@@ -133,7 +135,7 @@ pub trait CapabilityLeaseStore: Send + Sync {
     /// Persists a scoped lease before any approval record is marked approved.
     async fn issue(&self, lease: CapabilityLease) -> Result<CapabilityLease, CapabilityLeaseError>;
 
-    /// Revokes a lease only within the exact tenant/user/agent/invocation scope that owns it.
+    /// Revokes a lease only within the exact resource-owner/invocation scope that owns it.
     async fn revoke(
         &self,
         scope: &ResourceScope,
@@ -162,7 +164,7 @@ pub trait CapabilityLeaseStore: Send + Sync {
         lease_id: CapabilityGrantId,
     ) -> Result<CapabilityLease, CapabilityLeaseError>;
 
-    /// Lists leases visible to the tenant/user/agent scope without exposing cross-scope records.
+    /// Lists leases visible to the exact resource-owner scope without exposing cross-scope records.
     async fn leases_for_scope(&self, scope: &ResourceScope) -> Vec<CapabilityLease>;
 
     /// Returns active, unexpired, unexhausted leases for the exact invocation context.
@@ -291,7 +293,7 @@ impl CapabilityLeaseStore for InMemoryCapabilityLeaseStore {
     }
 }
 
-/// Filesystem-backed capability lease store under tenant/user/agent/invocation-scoped `/engine` paths.
+/// Filesystem-backed capability lease store under resource-owner/invocation-scoped `/engine` paths.
 pub struct FilesystemCapabilityLeaseStore<'a, F>
 where
     F: RootFilesystem,
@@ -568,6 +570,9 @@ struct CapabilityLeaseKey {
     tenant_id: TenantId,
     user_id: UserId,
     agent_id: Option<AgentId>,
+    project_id: Option<ProjectId>,
+    mission_id: Option<MissionId>,
+    thread_id: Option<ThreadId>,
     invocation_id: InvocationId,
     lease_id: CapabilityGrantId,
 }
@@ -578,6 +583,9 @@ impl CapabilityLeaseKey {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
             agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
             invocation_id: scope.invocation_id,
             lease_id,
         }
@@ -589,6 +597,9 @@ struct CapabilityLeaseOwnerKey {
     tenant_id: TenantId,
     user_id: UserId,
     agent_id: Option<AgentId>,
+    project_id: Option<ProjectId>,
+    mission_id: Option<MissionId>,
+    thread_id: Option<ThreadId>,
 }
 
 impl CapabilityLeaseOwnerKey {
@@ -597,6 +608,9 @@ impl CapabilityLeaseOwnerKey {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
             agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
         }
     }
 }
@@ -632,7 +646,7 @@ where
         &self,
         context: &ExecutionContext,
         descriptor: &CapabilityDescriptor,
-        _estimate: &ResourceEstimate,
+        estimate: &ResourceEstimate,
     ) -> Decision {
         if context.validate().is_err() {
             return Decision::Deny {
@@ -644,6 +658,7 @@ where
         authorize_from_grants(
             context,
             descriptor,
+            estimate,
             context.grants.grants.iter().chain(lease_grants.iter()),
         )
     }
@@ -652,7 +667,7 @@ where
         &self,
         context: &ExecutionContext,
         descriptor: &CapabilityDescriptor,
-        _estimate: &ResourceEstimate,
+        estimate: &ResourceEstimate,
     ) -> Decision {
         if context.validate().is_err() {
             return Decision::Deny {
@@ -664,6 +679,7 @@ where
         authorize_from_grants(
             context,
             &spawn_descriptor(descriptor),
+            estimate,
             context.grants.grants.iter().chain(lease_grants.iter()),
         )
     }
@@ -680,6 +696,7 @@ fn spawn_descriptor(descriptor: &CapabilityDescriptor) -> CapabilityDescriptor {
 fn authorize_from_grants<'a>(
     context: &ExecutionContext,
     descriptor: &CapabilityDescriptor,
+    estimate: &ResourceEstimate,
     grants: impl Iterator<Item = &'a CapabilityGrant>,
 ) -> Decision {
     if context.validate().is_err() {
@@ -688,23 +705,30 @@ fn authorize_from_grants<'a>(
         };
     }
 
-    let Some(grant) = grants
+    let mut saw_active_matching_grant = false;
+    for grant in grants
         .filter(|grant| grant.capability == descriptor.id)
-        .find(|grant| principal_matches_context(&grant.grantee, context))
-    else {
-        return Decision::Deny {
-            reason: DenyReason::MissingGrant,
-        };
-    };
-
-    if !effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects) {
-        return Decision::Deny {
-            reason: DenyReason::PolicyDenied,
-        };
+        .filter(|grant| principal_matches_context(&grant.grantee, context))
+        .filter(|grant| grant_is_active(grant))
+    {
+        saw_active_matching_grant = true;
+        if effects_are_covered(&descriptor.effects, &grant.constraints.allowed_effects)
+            && resource_estimate_is_covered(estimate, grant.constraints.resource_ceiling.as_ref())
+        {
+            return Decision::Allow {
+                obligations: Default::default(),
+            };
+        }
     }
 
-    Decision::Allow {
-        obligations: Default::default(),
+    if saw_active_matching_grant {
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied,
+        }
+    } else {
+        Decision::Deny {
+            reason: DenyReason::MissingGrant,
+        }
     }
 }
 
@@ -723,6 +747,59 @@ fn principal_matches_context(principal: &Principal, context: &ExecutionContext) 
 
 fn effects_are_covered(required: &[EffectKind], allowed: &[EffectKind]) -> bool {
     required.iter().all(|effect| allowed.contains(effect))
+}
+
+fn grant_is_active(grant: &CapabilityGrant) -> bool {
+    grant
+        .constraints
+        .expires_at
+        .is_none_or(|expires_at| expires_at > Utc::now())
+        && grant.constraints.max_invocations != Some(0)
+}
+
+fn resource_estimate_is_covered(
+    estimate: &ResourceEstimate,
+    ceiling: Option<&ResourceCeiling>,
+) -> bool {
+    let Some(ceiling) = ceiling else {
+        return true;
+    };
+    options_within_ceiling(estimate.usd.as_ref(), ceiling.max_usd.as_ref())
+        && options_within_ceiling(
+            estimate.input_tokens.as_ref(),
+            ceiling.max_input_tokens.as_ref(),
+        )
+        && options_within_ceiling(
+            estimate.output_tokens.as_ref(),
+            ceiling.max_output_tokens.as_ref(),
+        )
+        && options_within_ceiling(
+            estimate.wall_clock_ms.as_ref(),
+            ceiling.max_wall_clock_ms.as_ref(),
+        )
+        && options_within_ceiling(
+            estimate.output_bytes.as_ref(),
+            ceiling.max_output_bytes.as_ref(),
+        )
+        && ceiling.sandbox.as_ref().is_none_or(|sandbox| {
+            options_within_ceiling(
+                estimate.network_egress_bytes.as_ref(),
+                sandbox.network_egress_bytes.as_ref(),
+            ) && options_within_ceiling(
+                estimate.process_count.as_ref(),
+                sandbox.process_count.as_ref(),
+            )
+        })
+}
+
+fn options_within_ceiling<T>(estimate: Option<&T>, maximum: Option<&T>) -> bool
+where
+    T: PartialOrd,
+{
+    match (estimate, maximum) {
+        (Some(estimate), Some(maximum)) => estimate <= maximum,
+        _ => true,
+    }
 }
 
 fn lease_is_authorizing(lease: &CapabilityLease, context: &ExecutionContext) -> bool {
@@ -792,6 +869,9 @@ fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
     left.tenant_id == right.tenant_id
         && left.user_id == right.user_id
         && left.agent_id == right.agent_id
+        && left.project_id == right.project_id
+        && left.mission_id == right.mission_id
+        && left.thread_id == right.thread_id
 }
 
 fn lease_path(
@@ -828,14 +908,23 @@ fn lease_tenant_user_root(scope: &ResourceScope) -> Result<VirtualPath, Capabili
 }
 
 fn scoped_owner_root(scope: &ResourceScope) -> String {
-    let base = format!(
+    let mut base = format!(
         "/engine/tenants/{}/users/{}",
         scope.tenant_id, scope.user_id
     );
-    match &scope.agent_id {
-        Some(agent_id) => format!("{base}/agents/{agent_id}"),
-        None => base,
+    if let Some(agent_id) = &scope.agent_id {
+        base = format!("{base}/agents/{agent_id}");
     }
+    if let Some(project_id) = &scope.project_id {
+        base = format!("{base}/projects/{project_id}");
+    }
+    if let Some(mission_id) = &scope.mission_id {
+        base = format!("{base}/missions/{mission_id}");
+    }
+    if let Some(thread_id) = &scope.thread_id {
+        base = format!("{base}/threads/{thread_id}");
+    }
+    base
 }
 
 fn serialize_pretty<T>(value: &T) -> Result<Vec<u8>, CapabilityLeaseError>

--- a/crates/ironclaw_authorization/src/lib.rs
+++ b/crates/ironclaw_authorization/src/lib.rs
@@ -765,12 +765,5 @@ fn lease_persistence_error(error: FilesystemError) -> CapabilityLeaseError {
 }
 
 fn is_not_found(error: &FilesystemError) -> bool {
-    match error {
-        FilesystemError::Backend { reason, .. } => {
-            reason.contains("No such file")
-                || reason.contains("not found")
-                || reason.contains("entity not found")
-        }
-        _ => false,
-    }
+    matches!(error, FilesystemError::NotFound { .. })
 }

--- a/crates/ironclaw_authorization/tests/boundary_contract.rs
+++ b/crates/ironclaw_authorization/tests/boundary_contract.rs
@@ -1,0 +1,44 @@
+#[test]
+fn authorization_crate_stays_below_workflow_and_runtime_crates() {
+    let manifest_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let manifest = std::fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|error| panic!("failed to read {manifest_path:?}: {error}"));
+    let dependencies = dependencies_section(&manifest);
+
+    for forbidden in [
+        "ironclaw_approvals",
+        "ironclaw_capabilities",
+        "ironclaw_dispatcher",
+        "ironclaw_processes",
+        "ironclaw_host_runtime",
+        "ironclaw_resources",
+        "ironclaw_extensions",
+        "ironclaw_wasm",
+        "ironclaw_scripts",
+        "ironclaw_mcp",
+    ] {
+        assert!(
+            !dependencies.contains(forbidden),
+            "ironclaw_authorization should evaluate grants/leases without depending on {forbidden}"
+        );
+    }
+}
+
+#[test]
+fn filesystem_lease_store_does_not_block_on_async_filesystem_calls() {
+    let lib_path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/lib.rs");
+    let lib = std::fs::read_to_string(&lib_path)
+        .unwrap_or_else(|error| panic!("failed to read {lib_path:?}: {error}"));
+
+    assert!(
+        !lib.contains("block_on"),
+        "filesystem-backed lease persistence should be async instead of blocking on RootFilesystem futures"
+    );
+}
+
+fn dependencies_section(manifest: &str) -> &str {
+    manifest
+        .split_once("[dependencies]")
+        .and_then(|(_, rest)| rest.split_once("[dev-dependencies]").map(|(deps, _)| deps))
+        .expect("Cargo.toml must contain [dependencies] before [dev-dependencies]")
+}

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -1,0 +1,250 @@
+use ironclaw_authorization::*;
+use ironclaw_host_api::*;
+use serde_json::json;
+
+#[tokio::test]
+async fn capability_access_denies_without_matching_grant() {
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = wasm_descriptor();
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_allows_matching_extension_grant() {
+    let descriptor = wasm_descriptor();
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &context,
+            &descriptor,
+            &ResourceEstimate {
+                concurrency_slots: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Allow {
+            obligations: Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_denies_when_grant_is_for_different_principal_or_capability() {
+    let descriptor = wasm_descriptor();
+    let wrong_principal = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("other-extension").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let wrong_capability = grant_for(
+        CapabilityId::new("echo.other").unwrap(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let authorizer = GrantAuthorizer::new();
+
+    assert_eq!(
+        authorizer
+            .authorize_dispatch(
+                &execution_context(CapabilitySet {
+                    grants: vec![wrong_principal]
+                }),
+                &descriptor,
+                &ResourceEstimate::default(),
+            )
+            .await,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    );
+    assert_eq!(
+        authorizer
+            .authorize_dispatch(
+                &execution_context(CapabilitySet {
+                    grants: vec![wrong_capability]
+                }),
+                &descriptor,
+                &ResourceEstimate::default(),
+            )
+            .await,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_denies_when_grant_does_not_cover_declared_effects() {
+    let descriptor = CapabilityDescriptor {
+        effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+        ..wasm_descriptor()
+    };
+    let grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn spawn_access_requires_spawn_process_effect_in_addition_to_capability_effects() {
+    let descriptor = wasm_descriptor();
+    let dispatch_only = execution_context(CapabilitySet {
+        grants: vec![grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(ExtensionId::new("caller").unwrap()),
+            vec![EffectKind::DispatchCapability],
+        )],
+    });
+    let spawn_grant = execution_context(CapabilitySet {
+        grants: vec![grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(ExtensionId::new("caller").unwrap()),
+            vec![EffectKind::DispatchCapability, EffectKind::SpawnProcess],
+        )],
+    });
+    let authorizer = GrantAuthorizer::new();
+
+    assert_eq!(
+        authorizer
+            .authorize_spawn(&dispatch_only, &descriptor, &ResourceEstimate::default())
+            .await,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+    assert_eq!(
+        authorizer
+            .authorize_spawn(&spawn_grant, &descriptor, &ResourceEstimate::default())
+            .await,
+        Decision::Allow {
+            obligations: Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_denies_invalid_execution_context() {
+    let grant = grant_for(
+        CapabilityId::new("echo.say").unwrap(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let mut context = execution_context(CapabilitySet {
+        grants: vec![grant],
+    });
+    context.resource_scope.tenant_id = TenantId::new("wrong-tenant").unwrap();
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(&context, &wasm_descriptor(), &ResourceEstimate::default())
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::InternalInvariantViolation
+        }
+    );
+}
+
+fn wasm_descriptor() -> CapabilityDescriptor {
+    CapabilityDescriptor {
+        id: CapabilityId::new("echo.say").unwrap(),
+        provider: ExtensionId::new("echo").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        trust_ceiling: TrustClass::Sandbox,
+        description: "Echo text".to_string(),
+        parameters_schema: json!({"type": "object"}),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Allow,
+        resource_profile: None,
+    }
+}
+
+fn grant_for(
+    capability: CapabilityId,
+    grantee: Principal,
+    allowed_effects: Vec<EffectKind>,
+) -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability,
+        grantee,
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects,
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
+}
+
+fn execution_context(grants: CapabilitySet) -> ExecutionContext {
+    let invocation_id = InvocationId::new();
+    let resource_scope = ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    };
+    ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: resource_scope.tenant_id.clone(),
+        user_id: resource_scope.user_id.clone(),
+        agent_id: resource_scope.agent_id.clone(),
+        project_id: resource_scope.project_id.clone(),
+        mission_id: resource_scope.mission_id.clone(),
+        thread_id: resource_scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::Sandbox,
+        grants,
+        mounts: MountView::default(),
+        resource_scope,
+    }
+}

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -1,3 +1,4 @@
+use chrono::{Duration, Utc};
 use ironclaw_authorization::*;
 use ironclaw_host_api::*;
 use serde_json::json;
@@ -111,6 +112,113 @@ async fn capability_access_denies_when_grant_does_not_cover_declared_effects() {
 
     let decision = GrantAuthorizer::new()
         .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_skips_expired_and_exhausted_grants() {
+    let descriptor = wasm_descriptor();
+    let mut expired = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    expired.constraints.expires_at = Some(Utc::now() - Duration::minutes(1));
+    let mut exhausted = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    exhausted.constraints.max_invocations = Some(0);
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![expired, exhausted],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_allows_later_grant_that_covers_effects() {
+    let descriptor = CapabilityDescriptor {
+        effects: vec![EffectKind::DispatchCapability, EffectKind::Network],
+        ..wasm_descriptor()
+    };
+    let weak = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    let strong = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability, EffectKind::Network],
+    );
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![weak, strong],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Allow {
+            obligations: Default::default()
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_denies_when_resource_estimate_exceeds_grant_ceiling() {
+    let descriptor = wasm_descriptor();
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: Some(10),
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: None,
+        sandbox: None,
+    });
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate {
+                input_tokens: Some(11),
+                ..ResourceEstimate::default()
+            },
+        )
         .await;
 
     assert_eq!(

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -51,6 +51,88 @@ async fn capability_access_allows_matching_extension_grant() {
 }
 
 #[tokio::test]
+async fn capability_access_returns_grant_constraints_as_runtime_obligations() {
+    let descriptor = CapabilityDescriptor {
+        effects: vec![
+            EffectKind::DispatchCapability,
+            EffectKind::Network,
+            EffectKind::UseSecret,
+            EffectKind::ReadFilesystem,
+        ],
+        ..wasm_descriptor()
+    };
+    let secret = SecretHandle::new("api-key").unwrap();
+    let mounts = MountView::new(vec![MountGrant::new(
+        MountAlias::new("/workspace").unwrap(),
+        VirtualPath::new("/projects/project1").unwrap(),
+        MountPermissions::read_only(),
+    )])
+    .unwrap();
+    let network = NetworkPolicy {
+        allowed_targets: vec![NetworkTargetPattern {
+            scheme: Some(NetworkScheme::Https),
+            host_pattern: "api.example.com".to_string(),
+            port: Some(443),
+        }],
+        deny_private_ip_ranges: true,
+        max_egress_bytes: Some(1024),
+    };
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![
+            EffectKind::DispatchCapability,
+            EffectKind::Network,
+            EffectKind::UseSecret,
+            EffectKind::ReadFilesystem,
+        ],
+    );
+    grant.constraints.mounts = mounts.clone();
+    grant.constraints.network = network.clone();
+    grant.constraints.secrets = vec![secret.clone()];
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: None,
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    });
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate {
+                output_bytes: Some(512),
+                ..ResourceEstimate::default()
+            },
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision with obligations, got {decision:?}");
+    };
+    assert!(obligations.as_slice().iter().any(
+        |obligation| matches!(obligation, Obligation::UseScopedMounts { mounts: value } if value == &mounts)
+    ));
+    assert!(obligations.as_slice().iter().any(
+        |obligation| matches!(obligation, Obligation::ApplyNetworkPolicy { policy } if policy == &network)
+    ));
+    assert!(obligations.as_slice().iter().any(
+        |obligation| matches!(obligation, Obligation::InjectSecretOnce { handle } if handle == &secret)
+    ));
+    assert!(
+        obligations
+            .as_slice()
+            .iter()
+            .any(|obligation| matches!(obligation, Obligation::EnforceOutputLimit { bytes: 2048 }))
+    );
+}
+
+#[tokio::test]
 async fn capability_access_denies_when_grant_is_for_different_principal_or_capability() {
     let descriptor = wasm_descriptor();
     let wrong_principal = grant_for(
@@ -183,12 +265,7 @@ async fn capability_access_allows_later_grant_that_covers_effects() {
         )
         .await;
 
-    assert_eq!(
-        decision,
-        Decision::Allow {
-            obligations: Default::default()
-        }
-    );
+    assert!(matches!(decision, Decision::Allow { .. }));
 }
 
 #[tokio::test]
@@ -218,6 +295,41 @@ async fn capability_access_denies_when_resource_estimate_exceeds_grant_ceiling()
                 input_tokens: Some(11),
                 ..ResourceEstimate::default()
             },
+        )
+        .await;
+
+    assert_eq!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::PolicyDenied
+        }
+    );
+}
+
+#[tokio::test]
+async fn capability_access_denies_when_grant_ceiling_dimension_has_no_estimate() {
+    let descriptor = wasm_descriptor();
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: Some(10),
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: None,
+        sandbox: None,
+    });
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate::default(),
         )
         .await;
 

--- a/crates/ironclaw_authorization/tests/capability_access_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_access_contract.rs
@@ -342,6 +342,56 @@ async fn capability_access_denies_when_grant_ceiling_dimension_has_no_estimate()
 }
 
 #[tokio::test]
+async fn capability_access_returns_full_resource_ceiling_as_runtime_obligation() {
+    let descriptor = wasm_descriptor();
+    let ceiling = ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: Some(10),
+        max_output_tokens: Some(20),
+        max_wall_clock_ms: Some(1_000),
+        max_output_bytes: Some(2_048),
+        sandbox: Some(SandboxQuota {
+            cpu_time_ms: None,
+            memory_bytes: None,
+            disk_bytes: None,
+            network_egress_bytes: Some(4_096),
+            process_count: Some(1),
+        }),
+    };
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(ExtensionId::new("caller").unwrap()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.resource_ceiling = Some(ceiling.clone());
+
+    let decision = GrantAuthorizer::new()
+        .authorize_dispatch(
+            &execution_context(CapabilitySet {
+                grants: vec![grant],
+            }),
+            &descriptor,
+            &ResourceEstimate {
+                input_tokens: Some(5),
+                output_tokens: Some(10),
+                wall_clock_ms: Some(500),
+                output_bytes: Some(1_024),
+                network_egress_bytes: Some(2_048),
+                process_count: Some(1),
+                ..ResourceEstimate::default()
+            },
+        )
+        .await;
+
+    let Decision::Allow { obligations } = decision else {
+        panic!("expected allow decision with resource ceiling obligation, got {decision:?}");
+    };
+    assert!(obligations.as_slice().iter().any(
+        |obligation| matches!(obligation, Obligation::EnforceResourceCeiling { ceiling: value } if value == &ceiling)
+    ));
+}
+
+#[tokio::test]
 async fn spawn_access_requires_spawn_process_effect_in_addition_to_capability_effects() {
     let descriptor = wasm_descriptor();
     let dispatch_only = execution_context(CapabilitySet {

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -477,6 +477,50 @@ async fn consumed_lease_no_longer_authorizes_dispatch() {
 }
 
 #[tokio::test]
+async fn fingerprinted_lease_without_invocation_limit_is_consumed_after_one_use() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint.clone());
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    leases
+        .claim(&context.resource_scope, lease_id, &fingerprint)
+        .await
+        .unwrap();
+    let consumed = leases
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+    assert!(matches!(
+        leases
+            .claim(&context.resource_scope, lease_id, &fingerprint)
+            .await
+            .unwrap_err(),
+        CapabilityLeaseError::InactiveLease { lease_id: id, status: CapabilityLeaseStatus::Consumed }
+            if id == lease_id
+    ));
+}
+
+#[tokio::test]
 async fn expired_lease_no_longer_authorizes_or_consumes() {
     let leases = InMemoryCapabilityLeaseStore::new();
     let context = execution_context(CapabilitySet::default());
@@ -678,6 +722,51 @@ async fn filesystem_lease_store_persists_revoke_claim_and_consume() {
             .status,
         CapabilityLeaseStatus::Revoked
     );
+}
+
+#[tokio::test]
+async fn filesystem_fingerprinted_lease_without_invocation_limit_is_consumed_after_one_use() {
+    let fs = engine_filesystem();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint.clone());
+    let lease_id = lease.grant.id;
+    let store = FilesystemCapabilityLeaseStore::new(&fs);
+    store.issue(lease).await.unwrap();
+
+    store
+        .claim(&context.resource_scope, lease_id, &fingerprint)
+        .await
+        .unwrap();
+    let consumed = FilesystemCapabilityLeaseStore::new(&fs)
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+    assert!(matches!(
+        FilesystemCapabilityLeaseStore::new(&fs)
+            .claim(&context.resource_scope, lease_id, &fingerprint)
+            .await
+            .unwrap_err(),
+        CapabilityLeaseError::InactiveLease { lease_id: id, status: CapabilityLeaseStatus::Consumed }
+            if id == lease_id
+    ));
 }
 
 #[tokio::test]

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -236,6 +236,32 @@ async fn lease_store_hides_leases_across_agent_scope() {
 }
 
 #[tokio::test]
+async fn lease_store_hides_leases_across_project_scope() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let mut other_scope = context.resource_scope.clone();
+    other_scope.project_id = Some(ProjectId::new("project2").unwrap());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    assert!(leases.get(&other_scope, lease_id).await.is_none());
+    assert_eq!(leases.leases_for_scope(&other_scope).await, Vec::new());
+    assert!(matches!(
+        leases.revoke(&other_scope, lease_id).await.unwrap_err(),
+        CapabilityLeaseError::UnknownLease { .. }
+    ));
+}
+
+#[tokio::test]
 async fn lease_authorizer_denies_other_agent_context() {
     let leases = InMemoryCapabilityLeaseStore::new();
     let mut context = execution_context(CapabilitySet::default());

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -1,0 +1,759 @@
+use ironclaw_authorization::*;
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+
+#[tokio::test]
+async fn lease_authorizer_allows_matching_active_lease_without_context_grant() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    leases.issue(lease.clone()).await.unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(decision, Decision::Allow { .. }));
+    assert_eq!(
+        leases
+            .get(&context.resource_scope, lease.grant.id)
+            .await
+            .unwrap(),
+        lease
+    );
+}
+
+#[tokio::test]
+async fn fingerprinted_approval_lease_does_not_authorize_plain_dispatch() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint);
+    leases.issue(lease).await.unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn claim_marks_fingerprinted_lease_claimed_and_hides_it_from_authorizer() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint.clone());
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    let claimed = leases
+        .claim(&context.resource_scope, lease_id, &fingerprint)
+        .await
+        .unwrap();
+
+    assert_eq!(claimed.status, CapabilityLeaseStatus::Claimed);
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn claim_rejects_fingerprint_mismatch_without_mutating_lease() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let other_fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "tampered"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint);
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    let err = leases
+        .claim(&context.resource_scope, lease_id, &other_fingerprint)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::FingerprintMismatch { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        leases
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
+async fn lease_authorizer_hides_leases_across_tenant_scope() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let other_scope = ResourceScope {
+        tenant_id: TenantId::new("tenant2").unwrap(),
+        user_id: context.resource_scope.user_id.clone(),
+        agent_id: None,
+        project_id: context.resource_scope.project_id.clone(),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: context.invocation_id,
+    };
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+
+    leases
+        .issue(CapabilityLease::new(
+            other_scope,
+            grant_for(
+                descriptor.id.clone(),
+                Principal::Extension(context.extension_id.clone()),
+                vec![EffectKind::DispatchCapability],
+            ),
+        ))
+        .await
+        .unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn lease_store_hides_leases_across_agent_scope() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let mut context = execution_context(CapabilitySet::default());
+    context.agent_id = Some(AgentId::new("agent-a").unwrap());
+    context.resource_scope.agent_id = context.agent_id.clone();
+    let mut other_scope = context.resource_scope.clone();
+    other_scope.agent_id = Some(AgentId::new("agent-b").unwrap());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    assert!(leases.get(&other_scope, lease_id).await.is_none());
+    assert_eq!(leases.leases_for_scope(&other_scope).await, Vec::new());
+    assert!(matches!(
+        leases.revoke(&other_scope, lease_id).await.unwrap_err(),
+        CapabilityLeaseError::UnknownLease { .. }
+    ));
+}
+
+#[tokio::test]
+async fn lease_authorizer_denies_other_agent_context() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let mut context = execution_context(CapabilitySet::default());
+    context.agent_id = Some(AgentId::new("agent-a").unwrap());
+    context.resource_scope.agent_id = context.agent_id.clone();
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    leases
+        .issue(CapabilityLease::new(
+            context.resource_scope.clone(),
+            grant_for(
+                descriptor.id.clone(),
+                Principal::Extension(context.extension_id.clone()),
+                vec![EffectKind::DispatchCapability],
+            ),
+        ))
+        .await
+        .unwrap();
+
+    let mut other_context = context.clone();
+    other_context.agent_id = Some(AgentId::new("agent-b").unwrap());
+    other_context.resource_scope.agent_id = other_context.agent_id.clone();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&other_context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn revocation_is_scoped_to_tenant_and_user() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let other_scope = ResourceScope {
+        tenant_id: TenantId::new("tenant2").unwrap(),
+        user_id: context.resource_scope.user_id.clone(),
+        agent_id: None,
+        project_id: context.resource_scope.project_id.clone(),
+        mission_id: None,
+        thread_id: None,
+        invocation_id: context.invocation_id,
+    };
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    let lease_id = lease.grant.id;
+    leases.issue(lease.clone()).await.unwrap();
+
+    let err = leases.revoke(&other_scope, lease_id).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::UnknownLease { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        leases
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
+async fn lease_authorizer_denies_invalid_context_before_grant_match() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let mut context = execution_context(CapabilitySet::default());
+    context.tenant_id = TenantId::new("tenant2").unwrap();
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    leases
+        .issue(CapabilityLease::new(
+            context.resource_scope.clone(),
+            grant_for(
+                descriptor.id.clone(),
+                Principal::Extension(context.extension_id.clone()),
+                vec![EffectKind::DispatchCapability],
+            ),
+        ))
+        .await
+        .unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::InternalInvariantViolation
+        }
+    ));
+}
+
+#[tokio::test]
+async fn one_off_lease_does_not_authorize_different_invocation_in_same_tenant() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let mut next_invocation_context = execution_context(CapabilitySet::default());
+    next_invocation_context.tenant_id = context.tenant_id.clone();
+    next_invocation_context.user_id = context.user_id.clone();
+    next_invocation_context.project_id = context.project_id.clone();
+    next_invocation_context.resource_scope.tenant_id = context.tenant_id.clone();
+    next_invocation_context.resource_scope.user_id = context.user_id.clone();
+    next_invocation_context.resource_scope.project_id = context.project_id.clone();
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    leases.issue(lease).await.unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(
+            &next_invocation_context,
+            &descriptor,
+            &ResourceEstimate::default(),
+        )
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn consume_decrements_remaining_invocations_and_consumes_one_shot_lease() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.max_invocations = Some(2);
+    let lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    let after_first = leases
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    assert_eq!(after_first.status, CapabilityLeaseStatus::Active);
+    assert_eq!(after_first.grant.constraints.max_invocations, Some(1));
+
+    let after_second = leases
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    assert_eq!(after_second.status, CapabilityLeaseStatus::Consumed);
+    assert_eq!(after_second.grant.constraints.max_invocations, Some(0));
+    assert!(matches!(
+        leases.consume(&context.resource_scope, lease_id).await.unwrap_err(),
+        CapabilityLeaseError::ExhaustedLease { lease_id: id } if id == lease_id
+    ));
+}
+
+#[tokio::test]
+async fn consumed_lease_no_longer_authorizes_dispatch() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.max_invocations = Some(1);
+    let lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+    leases
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+#[tokio::test]
+async fn expired_lease_no_longer_authorizes_or_consumes() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.expires_at = Some(timestamp("2000-01-01T00:00:00Z"));
+    let lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+    assert!(matches!(
+        leases.consume(&context.resource_scope, lease_id).await.unwrap_err(),
+        CapabilityLeaseError::ExpiredLease { lease_id: id } if id == lease_id
+    ));
+}
+
+#[tokio::test]
+async fn consume_is_scoped_to_exact_invocation() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let mut next_invocation_scope = execution_context(CapabilitySet::default()).resource_scope;
+    next_invocation_scope.tenant_id = context.resource_scope.tenant_id.clone();
+    next_invocation_scope.user_id = context.resource_scope.user_id.clone();
+    next_invocation_scope.project_id = context.resource_scope.project_id.clone();
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.max_invocations = Some(1);
+    let lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    let lease_id = lease.grant.id;
+    leases.issue(lease.clone()).await.unwrap();
+
+    let err = leases
+        .consume(&next_invocation_scope, lease_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::UnknownLease { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        leases
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
+async fn filesystem_lease_store_persists_and_reloads_issued_leases() {
+    let fs = engine_filesystem();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.max_invocations = Some(3);
+    let lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    let lease_id = lease.grant.id;
+
+    FilesystemCapabilityLeaseStore::new(&fs)
+        .issue(lease.clone())
+        .await
+        .unwrap();
+    let reloaded = FilesystemCapabilityLeaseStore::new(&fs);
+
+    assert_eq!(
+        reloaded.get(&context.resource_scope, lease_id).await,
+        Some(lease)
+    );
+    assert_eq!(
+        reloaded.leases_for_scope(&context.resource_scope).await,
+        vec![
+            reloaded
+                .get(&context.resource_scope, lease_id)
+                .await
+                .unwrap()
+        ]
+    );
+}
+
+#[tokio::test]
+async fn filesystem_lease_store_persists_revoke_claim_and_consume() {
+    let fs = engine_filesystem();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut grant = grant_for(
+        descriptor.id.clone(),
+        Principal::Extension(context.extension_id.clone()),
+        vec![EffectKind::DispatchCapability],
+    );
+    grant.constraints.max_invocations = Some(1);
+    let mut lease = CapabilityLease::new(context.resource_scope.clone(), grant);
+    lease.invocation_fingerprint = Some(fingerprint.clone());
+    let lease_id = lease.grant.id;
+    let store = FilesystemCapabilityLeaseStore::new(&fs);
+    store.issue(lease).await.unwrap();
+
+    let claimed = store
+        .claim(&context.resource_scope, lease_id, &fingerprint)
+        .await
+        .unwrap();
+    assert_eq!(claimed.status, CapabilityLeaseStatus::Claimed);
+    assert_eq!(
+        FilesystemCapabilityLeaseStore::new(&fs)
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Claimed
+    );
+
+    let consumed = FilesystemCapabilityLeaseStore::new(&fs)
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+    assert_eq!(consumed.status, CapabilityLeaseStatus::Consumed);
+    assert_eq!(consumed.grant.constraints.max_invocations, Some(0));
+
+    let revoked = FilesystemCapabilityLeaseStore::new(&fs)
+        .revoke(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+    assert_eq!(revoked.status, CapabilityLeaseStatus::Revoked);
+    assert_eq!(
+        FilesystemCapabilityLeaseStore::new(&fs)
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Revoked
+    );
+}
+
+#[tokio::test]
+async fn filesystem_lease_store_is_tenant_user_invocation_scoped() {
+    let fs = engine_filesystem();
+    let context = execution_context(CapabilitySet::default());
+    let mut other_invocation_scope = execution_context(CapabilitySet::default()).resource_scope;
+    other_invocation_scope.tenant_id = context.resource_scope.tenant_id.clone();
+    other_invocation_scope.user_id = context.resource_scope.user_id.clone();
+    other_invocation_scope.project_id = context.resource_scope.project_id.clone();
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    let lease_id = lease.grant.id;
+    let store = FilesystemCapabilityLeaseStore::new(&fs);
+    store.issue(lease.clone()).await.unwrap();
+
+    assert_eq!(store.get(&other_invocation_scope, lease_id).await, None);
+    assert!(matches!(
+        store.revoke(&other_invocation_scope, lease_id).await.unwrap_err(),
+        CapabilityLeaseError::UnknownLease { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        store.get(&context.resource_scope, lease_id).await,
+        Some(lease)
+    );
+}
+
+#[tokio::test]
+async fn revoked_lease_no_longer_authorizes_dispatch() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+    leases
+        .revoke(&context.resource_scope, lease_id)
+        .await
+        .unwrap();
+
+    let authorizer = LeaseBackedAuthorizer::new(&leases);
+    let decision = authorizer
+        .authorize_dispatch(&context, &descriptor, &ResourceEstimate::default())
+        .await;
+
+    assert!(matches!(
+        decision,
+        Decision::Deny {
+            reason: DenyReason::MissingGrant
+        }
+    ));
+}
+
+fn descriptor(id: CapabilityId) -> CapabilityDescriptor {
+    CapabilityDescriptor {
+        provider: ExtensionId::new(id.as_str().split('.').next().unwrap()).unwrap(),
+        id,
+        runtime: RuntimeKind::Wasm,
+        trust_ceiling: TrustClass::Sandbox,
+        description: "test".to_string(),
+        parameters_schema: serde_json::json!({"type": "object"}),
+        effects: vec![EffectKind::DispatchCapability],
+        default_permission: PermissionMode::Deny,
+        resource_profile: None,
+    }
+}
+
+fn grant_for(
+    capability: CapabilityId,
+    grantee: Principal,
+    allowed_effects: Vec<EffectKind>,
+) -> CapabilityGrant {
+    CapabilityGrant {
+        id: CapabilityGrantId::new(),
+        capability,
+        grantee,
+        issued_by: Principal::HostRuntime,
+        constraints: GrantConstraints {
+            allowed_effects,
+            mounts: MountView::default(),
+            network: NetworkPolicy::default(),
+            secrets: Vec::new(),
+            resource_ceiling: None,
+            expires_at: None,
+            max_invocations: None,
+        },
+    }
+}
+
+fn timestamp(value: &str) -> Timestamp {
+    serde_json::from_value(serde_json::Value::String(value.to_string())).unwrap()
+}
+
+fn engine_filesystem() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let engine_root = storage.join("engine");
+    std::fs::create_dir_all(&engine_root).unwrap();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/engine").unwrap(),
+        HostPath::from_path_buf(engine_root),
+    )
+    .unwrap();
+    fs
+}
+
+fn execution_context(grants: CapabilitySet) -> ExecutionContext {
+    let invocation_id = InvocationId::new();
+    let resource_scope = ResourceScope {
+        tenant_id: TenantId::new("tenant1").unwrap(),
+        user_id: UserId::new("user1").unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    };
+    ExecutionContext {
+        invocation_id,
+        correlation_id: CorrelationId::new(),
+        process_id: None,
+        parent_process_id: None,
+        tenant_id: resource_scope.tenant_id.clone(),
+        user_id: resource_scope.user_id.clone(),
+        agent_id: resource_scope.agent_id.clone(),
+        project_id: resource_scope.project_id.clone(),
+        mission_id: resource_scope.mission_id.clone(),
+        thread_id: resource_scope.thread_id.clone(),
+        extension_id: ExtensionId::new("caller").unwrap(),
+        runtime: RuntimeKind::Wasm,
+        trust: TrustClass::Sandbox,
+        grants,
+        mounts: MountView::default(),
+        resource_scope,
+    }
+}

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -1,5 +1,11 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use async_trait::async_trait;
 use ironclaw_authorization::*;
-use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_filesystem::{DirEntry, FileStat, FilesystemError, LocalFilesystem, RootFilesystem};
 use ironclaw_host_api::*;
 
 #[tokio::test]
@@ -550,6 +556,45 @@ async fn filesystem_lease_store_persists_and_reloads_issued_leases() {
 }
 
 #[tokio::test]
+async fn filesystem_lease_store_lists_from_owner_index_without_scanning_invocation_roots() {
+    let fs = CountingFilesystem::new(engine_filesystem());
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let store = FilesystemCapabilityLeaseStore::new(&fs);
+    let mut expected = Vec::new();
+
+    for _ in 0..3 {
+        let scope = execution_context(CapabilitySet::default()).resource_scope;
+        let lease = CapabilityLease::new(
+            scope,
+            grant_for(
+                descriptor.id.clone(),
+                Principal::Extension(context.extension_id.clone()),
+                vec![EffectKind::DispatchCapability],
+            ),
+        );
+        expected.push(lease.grant.id);
+        store.issue(lease).await.unwrap();
+    }
+
+    fs.reset_list_dir_calls();
+    let leases = store.leases_for_scope(&context.resource_scope).await;
+
+    let mut actual = leases
+        .into_iter()
+        .map(|lease| lease.grant.id)
+        .collect::<Vec<_>>();
+    actual.sort_by_key(|lease_id| lease_id.as_uuid());
+    expected.sort_by_key(|lease_id| lease_id.as_uuid());
+    assert_eq!(actual, expected);
+    assert_eq!(
+        fs.list_dir_calls(),
+        0,
+        "indexed lease listing should not scan every invocation directory"
+    );
+}
+
+#[tokio::test]
 async fn filesystem_lease_store_persists_revoke_claim_and_consume() {
     let fs = engine_filesystem();
     let context = execution_context(CapabilitySet::default());
@@ -672,6 +717,60 @@ async fn revoked_lease_no_longer_authorizes_dispatch() {
             reason: DenyReason::MissingGrant
         }
     ));
+}
+
+struct CountingFilesystem {
+    inner: LocalFilesystem,
+    list_dir_calls: Arc<AtomicUsize>,
+}
+
+impl CountingFilesystem {
+    fn new(inner: LocalFilesystem) -> Self {
+        Self {
+            inner,
+            list_dir_calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    fn reset_list_dir_calls(&self) {
+        self.list_dir_calls.store(0, Ordering::SeqCst);
+    }
+
+    fn list_dir_calls(&self) -> usize {
+        self.list_dir_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl RootFilesystem for CountingFilesystem {
+    async fn read_file(&self, path: &VirtualPath) -> Result<Vec<u8>, FilesystemError> {
+        self.inner.read_file(path).await
+    }
+
+    async fn write_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.inner.write_file(path, bytes).await
+    }
+
+    async fn append_file(&self, path: &VirtualPath, bytes: &[u8]) -> Result<(), FilesystemError> {
+        self.inner.append_file(path, bytes).await
+    }
+
+    async fn list_dir(&self, path: &VirtualPath) -> Result<Vec<DirEntry>, FilesystemError> {
+        self.list_dir_calls.fetch_add(1, Ordering::SeqCst);
+        self.inner.list_dir(path).await
+    }
+
+    async fn stat(&self, path: &VirtualPath) -> Result<FileStat, FilesystemError> {
+        self.inner.stat(path).await
+    }
+
+    async fn delete(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.delete(path).await
+    }
+
+    async fn create_dir_all(&self, path: &VirtualPath) -> Result<(), FilesystemError> {
+        self.inner.create_dir_all(path).await
+    }
 }
 
 fn descriptor(id: CapabilityId) -> CapabilityDescriptor {

--- a/crates/ironclaw_authorization/tests/capability_lease_contract.rs
+++ b/crates/ironclaw_authorization/tests/capability_lease_contract.rs
@@ -477,6 +477,49 @@ async fn consumed_lease_no_longer_authorizes_dispatch() {
 }
 
 #[tokio::test]
+async fn fingerprinted_lease_cannot_be_consumed_before_claim() {
+    let leases = InMemoryCapabilityLeaseStore::new();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint);
+    let lease_id = lease.grant.id;
+    leases.issue(lease).await.unwrap();
+
+    let err = leases
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::UnclaimedFingerprintLease { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        leases
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
+    );
+}
+
+#[tokio::test]
 async fn fingerprinted_lease_without_invocation_limit_is_consumed_after_one_use() {
     let leases = InMemoryCapabilityLeaseStore::new();
     let context = execution_context(CapabilitySet::default());
@@ -721,6 +764,50 @@ async fn filesystem_lease_store_persists_revoke_claim_and_consume() {
             .unwrap()
             .status,
         CapabilityLeaseStatus::Revoked
+    );
+}
+
+#[tokio::test]
+async fn filesystem_fingerprinted_lease_cannot_be_consumed_before_claim() {
+    let fs = engine_filesystem();
+    let context = execution_context(CapabilitySet::default());
+    let descriptor = descriptor(CapabilityId::new("echo.say").unwrap());
+    let fingerprint = InvocationFingerprint::for_dispatch(
+        &context.resource_scope,
+        &descriptor.id,
+        &ResourceEstimate::default(),
+        &serde_json::json!({"message": "approved"}),
+    )
+    .unwrap();
+    let mut lease = CapabilityLease::new(
+        context.resource_scope.clone(),
+        grant_for(
+            descriptor.id.clone(),
+            Principal::Extension(context.extension_id.clone()),
+            vec![EffectKind::DispatchCapability],
+        ),
+    );
+    lease.invocation_fingerprint = Some(fingerprint);
+    let lease_id = lease.grant.id;
+    let store = FilesystemCapabilityLeaseStore::new(&fs);
+    store.issue(lease).await.unwrap();
+
+    let err = store
+        .consume(&context.resource_scope, lease_id)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        CapabilityLeaseError::UnclaimedFingerprintLease { lease_id: id } if id == lease_id
+    ));
+    assert_eq!(
+        FilesystemCapabilityLeaseStore::new(&fs)
+            .get(&context.resource_scope, lease_id)
+            .await
+            .unwrap()
+            .status,
+        CapabilityLeaseStatus::Active
     );
 }
 

--- a/crates/ironclaw_host_api/src/decision.rs
+++ b/crates/ironclaw_host_api/src/decision.rs
@@ -10,7 +10,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ApprovalRequest;
-use crate::{HostApiError, MountView, NetworkPolicy, ResourceReservationId, SecretHandle};
+use crate::{
+    HostApiError, MountView, NetworkPolicy, ResourceCeiling, ResourceReservationId, SecretHandle,
+};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case", tag = "type")]
@@ -54,6 +56,9 @@ pub enum Obligation {
     ApplyNetworkPolicy {
         policy: NetworkPolicy,
     },
+    EnforceResourceCeiling {
+        ceiling: ResourceCeiling,
+    },
     EnforceOutputLimit {
         bytes: u64,
     },
@@ -69,6 +74,7 @@ pub enum ObligationKind {
     InjectSecretOnce,
     AuditBefore,
     RedactOutput,
+    EnforceResourceCeiling,
     EnforceOutputLimit,
     AuditAfter,
 }
@@ -81,6 +87,7 @@ pub const OBLIGATION_EVALUATION_ORDER: &[ObligationKind] = &[
     ObligationKind::InjectSecretOnce,
     ObligationKind::AuditBefore,
     ObligationKind::RedactOutput,
+    ObligationKind::EnforceResourceCeiling,
     ObligationKind::EnforceOutputLimit,
     ObligationKind::AuditAfter,
 ];
@@ -163,6 +170,7 @@ impl Obligation {
             Self::UseScopedMounts { .. } => ObligationKind::UseScopedMounts,
             Self::InjectSecretOnce { .. } => ObligationKind::InjectSecretOnce,
             Self::ApplyNetworkPolicy { .. } => ObligationKind::ApplyNetworkPolicy,
+            Self::EnforceResourceCeiling { .. } => ObligationKind::EnforceResourceCeiling,
             Self::EnforceOutputLimit { .. } => ObligationKind::EnforceOutputLimit,
         }
     }

--- a/crates/ironclaw_host_api/tests/host_api_contract.rs
+++ b/crates/ironclaw_host_api/tests/host_api_contract.rs
@@ -529,8 +529,17 @@ fn action_summaries_use_stable_snake_case_targets() {
 #[test]
 fn obligations_are_unique_and_canonicalized() {
     let reservation_id = ResourceReservationId::new();
+    let ceiling = ResourceCeiling {
+        max_usd: None,
+        max_input_tokens: Some(10),
+        max_output_tokens: None,
+        max_wall_clock_ms: None,
+        max_output_bytes: Some(2048),
+        sandbox: None,
+    };
     let obligations = Obligations::new(vec![
         Obligation::AuditAfter,
+        Obligation::EnforceResourceCeiling { ceiling },
         Obligation::ReserveResources { reservation_id },
         Obligation::AuditBefore,
     ])
@@ -545,6 +554,7 @@ fn obligations_are_unique_and_canonicalized() {
         vec![
             ObligationKind::ReserveResources,
             ObligationKind::AuditBefore,
+            ObligationKind::EnforceResourceCeiling,
             ObligationKind::AuditAfter,
         ]
     );

--- a/crates/ironclaw_run_state/CLAUDE.md
+++ b/crates/ironclaw_run_state/CLAUDE.md
@@ -3,5 +3,6 @@
 - Own durable invocation state and approval request records.
 - Do not own authorization policy, approval resolution, dispatch, runtime execution, process lifecycle, or product workflow.
 - All lookups and transitions are tenant/user scoped; wrong-scope access must look unknown.
+- Filesystem-backed run/approval stores use process-local serialization only; production shared roots need transactional/CAS backends before real multi-process callers.
 - Do not persist raw replay input or runtime output in run-state records.
 - Keep approval records as control-plane state, not authority by themselves.

--- a/crates/ironclaw_run_state/CLAUDE.md
+++ b/crates/ironclaw_run_state/CLAUDE.md
@@ -1,0 +1,7 @@
+# ironclaw_run_state guardrails
+
+- Own durable invocation state and approval request records.
+- Do not own authorization policy, approval resolution, dispatch, runtime execution, process lifecycle, or product workflow.
+- All lookups and transitions are tenant/user scoped; wrong-scope access must look unknown.
+- Do not persist raw replay input or runtime output in run-state records.
+- Keep approval records as control-plane state, not authority by themselves.

--- a/crates/ironclaw_run_state/CLAUDE.md
+++ b/crates/ironclaw_run_state/CLAUDE.md
@@ -2,7 +2,7 @@
 
 - Own durable invocation state and approval request records.
 - Do not own authorization policy, approval resolution, dispatch, runtime execution, process lifecycle, or product workflow.
-- All lookups and transitions are tenant/user scoped; wrong-scope access must look unknown.
+- All lookups and transitions are resource-owner scoped (tenant/user/agent/project/mission/thread); wrong-scope access must look unknown.
 - Filesystem-backed run/approval stores use process-local serialization only; production shared roots need transactional/CAS backends before real multi-process callers.
 - Do not persist raw replay input or runtime output in run-state records.
 - Keep approval records as control-plane state, not authority by themselves.

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ironclaw_run_state"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+async-trait = "0.1"
+ironclaw_filesystem = { path = "../ironclaw_filesystem" }
+ironclaw_host_api = { path = "../ironclaw_host_api" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+
+[dev-dependencies]
+tempfile = "3"
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/ironclaw_run_state/Cargo.toml
+++ b/crates/ironclaw_run_state/Cargo.toml
@@ -11,6 +11,7 @@ ironclaw_host_api = { path = "../ironclaw_host_api" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
+tokio = { version = "1", features = ["sync"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -123,12 +123,6 @@ pub enum RunStateError {
     Deserialization(String),
 }
 
-impl From<HostApiError> for RunStateError {
-    fn from(error: HostApiError) -> Self {
-        Self::InvalidPath(error.to_string())
-    }
-}
-
 impl From<FilesystemError> for RunStateError {
     fn from(error: FilesystemError) -> Self {
         Self::Filesystem(error.to_string())
@@ -452,6 +446,7 @@ where
     F: RootFilesystem,
 {
     filesystem: &'a F,
+    lock: tokio::sync::Mutex<()>,
 }
 
 impl<'a, F> FilesystemRunStateStore<'a, F>
@@ -459,7 +454,10 @@ where
     F: RootFilesystem,
 {
     pub fn new(filesystem: &'a F) -> Self {
-        Self { filesystem }
+        Self {
+            filesystem,
+            lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     async fn write_record(&self, record: &RunRecord) -> Result<(), RunStateError> {
@@ -476,6 +474,7 @@ where
     F: RootFilesystem,
 {
     async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         if self.get(&start.scope, start.invocation_id).await?.is_some() {
             return Err(RunStateError::InvocationAlreadyExists {
                 invocation_id: start.invocation_id,
@@ -499,6 +498,7 @@ where
         invocation_id: InvocationId,
         approval: ApprovalRequest,
     ) -> Result<RunRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let mut record = self
             .get(scope, invocation_id)
             .await?
@@ -516,6 +516,7 @@ where
         invocation_id: InvocationId,
         error_kind: String,
     ) -> Result<RunRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let mut record = self
             .get(scope, invocation_id)
             .await?
@@ -531,6 +532,7 @@ where
         scope: &ResourceScope,
         invocation_id: InvocationId,
     ) -> Result<RunRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let mut record = self
             .get(scope, invocation_id)
             .await?
@@ -547,6 +549,7 @@ where
         invocation_id: InvocationId,
         error_kind: String,
     ) -> Result<RunRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let mut record = self
             .get(scope, invocation_id)
             .await?
@@ -607,6 +610,7 @@ where
     F: RootFilesystem,
 {
     filesystem: &'a F,
+    lock: tokio::sync::Mutex<()>,
 }
 
 impl<'a, F> FilesystemApprovalRequestStore<'a, F>
@@ -614,7 +618,10 @@ where
     F: RootFilesystem,
 {
     pub fn new(filesystem: &'a F) -> Self {
-        Self { filesystem }
+        Self {
+            filesystem,
+            lock: tokio::sync::Mutex::new(()),
+        }
     }
 
     async fn update_status(
@@ -623,6 +630,7 @@ where
         request_id: ApprovalRequestId,
         status: ApprovalStatus,
     ) -> Result<ApprovalRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let mut record = self
             .get(scope, request_id)
             .await?
@@ -650,6 +658,7 @@ where
         scope: ResourceScope,
         request: ApprovalRequest,
     ) -> Result<ApprovalRecord, RunStateError> {
+        let _guard = self.lock.lock().await;
         let record = ApprovalRecord {
             scope,
             request,
@@ -729,11 +738,11 @@ fn run_record_path(
         "{}/{invocation_id}.json",
         run_records_root(scope)?.as_str()
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn run_records_root(scope: &ResourceScope) -> Result<VirtualPath, RunStateError> {
-    VirtualPath::new(format!("{}/runs", tenant_user_root(scope))).map_err(Into::into)
+    VirtualPath::new(format!("{}/runs", tenant_user_root(scope))).map_err(invalid_path)
 }
 
 fn approval_record_path(
@@ -744,11 +753,11 @@ fn approval_record_path(
         "{}/{request_id}.json",
         approval_records_root(scope)?.as_str()
     ))
-    .map_err(Into::into)
+    .map_err(invalid_path)
 }
 
 fn approval_records_root(scope: &ResourceScope) -> Result<VirtualPath, RunStateError> {
-    VirtualPath::new(format!("{}/approvals", tenant_user_root(scope))).map_err(Into::into)
+    VirtualPath::new(format!("{}/approvals", tenant_user_root(scope))).map_err(invalid_path)
 }
 
 fn tenant_user_root(scope: &ResourceScope) -> String {
@@ -761,6 +770,10 @@ fn tenant_user_root(scope: &ResourceScope) -> String {
         Some(agent_id) => format!("{base}/agents/{}", agent_id.as_str()),
         None => base,
     }
+}
+
+fn invalid_path(error: HostApiError) -> RunStateError {
+    RunStateError::InvalidPath(error.to_string())
 }
 
 fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
@@ -785,12 +798,5 @@ where
 }
 
 fn is_not_found(error: &FilesystemError) -> bool {
-    match error {
-        FilesystemError::Backend { reason, .. } => {
-            reason.contains("No such file")
-                || reason.contains("not found")
-                || reason.contains("os error 2")
-        }
-        _ => false,
-    }
+    matches!(error, FilesystemError::NotFound { .. })
 }

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -125,6 +125,8 @@ pub enum RunStateError {
     InvocationAlreadyExists { invocation_id: InvocationId },
     #[error("unknown approval request {request_id}")]
     UnknownApprovalRequest { request_id: ApprovalRequestId },
+    #[error("approval request {request_id} already exists")]
+    ApprovalRequestAlreadyExists { request_id: ApprovalRequestId },
     #[error("approval request {request_id} is not pending (status: {status:?})")]
     ApprovalNotPending {
         request_id: ApprovalRequestId,
@@ -417,10 +419,14 @@ impl ApprovalRequestStore for InMemoryApprovalRequestStore {
             request,
             status: ApprovalStatus::Pending,
         };
-        self.records_guard().insert(
-            ApprovalKey::new(&record.scope, record.request.id),
-            record.clone(),
-        );
+        let key = ApprovalKey::new(&record.scope, record.request.id);
+        let mut records = self.records_guard();
+        if records.contains_key(&key) {
+            return Err(RunStateError::ApprovalRequestAlreadyExists {
+                request_id: record.request.id,
+            });
+        }
+        records.insert(key, record.clone());
         Ok(record)
     }
 
@@ -694,6 +700,11 @@ where
         request: ApprovalRequest,
     ) -> Result<ApprovalRecord, RunStateError> {
         let _guard = self.lock.lock().await;
+        if self.get(&scope, request.id).await?.is_some() {
+            return Err(RunStateError::ApprovalRequestAlreadyExists {
+                request_id: request.id,
+            });
+        }
         let record = ApprovalRecord {
             scope,
             request,

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -1,0 +1,796 @@
+//! Run-state contracts for IronClaw Reborn.
+//!
+//! `ironclaw_run_state` stores the current lifecycle state for host-managed
+//! invocations. It is separate from runtime events: events are append-only
+//! history, while run state answers "what is this invocation waiting on now?".
+
+use std::{
+    collections::HashMap,
+    sync::{Mutex, MutexGuard},
+};
+
+use async_trait::async_trait;
+use ironclaw_filesystem::{FilesystemError, RootFilesystem};
+use ironclaw_host_api::{
+    AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId,
+    ResourceScope, TenantId, UserId, VirtualPath,
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Current lifecycle state for one invocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunStatus {
+    Running,
+    BlockedApproval,
+    BlockedAuth,
+    Completed,
+    Failed,
+}
+
+/// State record keyed by invocation ID.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RunRecord {
+    pub invocation_id: InvocationId,
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+    pub status: RunStatus,
+    pub approval_request_id: Option<ApprovalRequestId>,
+    pub error_kind: Option<String>,
+}
+
+/// Start metadata for a capability invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunStart {
+    pub invocation_id: InvocationId,
+    pub capability_id: CapabilityId,
+    pub scope: ResourceScope,
+}
+
+/// Approval request lifecycle state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalStatus {
+    Pending,
+    Approved,
+    Denied,
+    Expired,
+}
+
+/// Durable approval request record.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ApprovalRecord {
+    pub scope: ResourceScope,
+    pub request: ApprovalRequest,
+    pub status: ApprovalStatus,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RunStateKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    agent_id: Option<AgentId>,
+    invocation_id: InvocationId,
+}
+
+impl RunStateKey {
+    fn new(scope: &ResourceScope, invocation_id: InvocationId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            invocation_id,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct ApprovalKey {
+    tenant_id: TenantId,
+    user_id: UserId,
+    agent_id: Option<AgentId>,
+    request_id: ApprovalRequestId,
+}
+
+impl ApprovalKey {
+    fn new(scope: &ResourceScope, request_id: ApprovalRequestId) -> Self {
+        Self {
+            tenant_id: scope.tenant_id.clone(),
+            user_id: scope.user_id.clone(),
+            agent_id: scope.agent_id.clone(),
+            request_id,
+        }
+    }
+}
+
+/// Run-state and approval persistence errors.
+#[derive(Debug, Error)]
+pub enum RunStateError {
+    #[error("unknown invocation {invocation_id}")]
+    UnknownInvocation { invocation_id: InvocationId },
+    #[error("invocation {invocation_id} already exists")]
+    InvocationAlreadyExists { invocation_id: InvocationId },
+    #[error("unknown approval request {request_id}")]
+    UnknownApprovalRequest { request_id: ApprovalRequestId },
+    #[error("invalid storage path: {0}")]
+    InvalidPath(String),
+    #[error("filesystem error: {0}")]
+    Filesystem(String),
+    #[error("serialization error: {0}")]
+    Serialization(String),
+    #[error("deserialization error: {0}")]
+    Deserialization(String),
+}
+
+impl From<HostApiError> for RunStateError {
+    fn from(error: HostApiError) -> Self {
+        Self::InvalidPath(error.to_string())
+    }
+}
+
+impl From<FilesystemError> for RunStateError {
+    fn from(error: FilesystemError) -> Self {
+        Self::Filesystem(error.to_string())
+    }
+}
+
+/// Current-state store for invocation lifecycle.
+#[async_trait]
+pub trait RunStateStore: Send + Sync {
+    /// Creates a running invocation record in the exact tenant/user/agent scope.
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError>;
+
+    /// Marks an invocation blocked on an approval request without granting authority by itself.
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError>;
+
+    /// Marks an invocation blocked on external auth/secret resolution without exposing secret material.
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError>;
+
+    /// Marks an invocation completed only within the matching scope.
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError>;
+
+    /// Marks an invocation failed with a classified error kind, not raw runtime details.
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError>;
+
+    /// Loads one scoped invocation record; wrong-scope lookups must look unknown.
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError>;
+
+    /// Lists invocation records visible to the tenant/user/agent scope only.
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError>;
+}
+
+/// Store for approval requests emitted by authorization decisions.
+#[async_trait]
+pub trait ApprovalRequestStore: Send + Sync {
+    /// Persists a pending approval request in the tenant/user/agent scope without resolving it.
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError>;
+
+    /// Loads one scoped approval record; wrong-scope lookups must look unknown.
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError>;
+
+    /// Marks a pending approval request approved only within the matching scope.
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError>;
+
+    /// Marks a pending approval request denied only within the matching scope.
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError>;
+
+    /// Lists approval records visible to the tenant/user/agent scope only.
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError>;
+}
+
+/// In-memory run-state store for tests and early host wiring.
+#[derive(Debug, Default)]
+pub struct InMemoryRunStateStore {
+    records: Mutex<HashMap<RunStateKey, RunRecord>>,
+}
+
+impl InMemoryRunStateStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn update(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        update: impl FnOnce(&mut RunRecord),
+    ) -> Result<RunRecord, RunStateError> {
+        let key = RunStateKey::new(scope, invocation_id);
+        let mut records = self.records_guard();
+        let record = records
+            .get_mut(&key)
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        update(record);
+        Ok(record.clone())
+    }
+
+    fn records_guard(&self) -> MutexGuard<'_, HashMap<RunStateKey, RunRecord>> {
+        self.records
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[async_trait]
+impl RunStateStore for InMemoryRunStateStore {
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        let record = RunRecord {
+            invocation_id: start.invocation_id,
+            capability_id: start.capability_id,
+            scope: start.scope,
+            status: RunStatus::Running,
+            approval_request_id: None,
+            error_kind: None,
+        };
+        let key = RunStateKey::new(&record.scope, record.invocation_id);
+        let mut records = self.records_guard();
+        if records.contains_key(&key) {
+            return Err(RunStateError::InvocationAlreadyExists {
+                invocation_id: record.invocation_id,
+            });
+        }
+        records.insert(key, record.clone());
+        Ok(record)
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedApproval;
+            record.approval_request_id = Some(approval.id);
+            record.error_kind = None;
+        })
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update(scope, invocation_id, |record| {
+            record.status = RunStatus::BlockedAuth;
+            record.error_kind = Some(error_kind);
+        })
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update(scope, invocation_id, |record| {
+            record.status = RunStatus::Completed;
+            record.error_kind = None;
+        })
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        self.update(scope, invocation_id, |record| {
+            record.status = RunStatus::Failed;
+            record.error_kind = Some(error_kind);
+        })
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        Ok(self
+            .records_guard()
+            .get(&RunStateKey::new(scope, invocation_id))
+            .cloned())
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        let mut records = self
+            .records_guard()
+            .values()
+            .filter(|record| same_scope_owner(&record.scope, scope))
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.invocation_id.as_uuid());
+        Ok(records)
+    }
+}
+
+/// In-memory approval request store for tests and early host wiring.
+#[derive(Debug, Default)]
+pub struct InMemoryApprovalRequestStore {
+    records: Mutex<HashMap<ApprovalKey, ApprovalRecord>>,
+}
+
+impl InMemoryApprovalRequestStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn update_status(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        status: ApprovalStatus,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let mut records = self.records_guard();
+        let record = records
+            .get_mut(&ApprovalKey::new(scope, request_id))
+            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        record.status = status;
+        Ok(record.clone())
+    }
+
+    fn records_guard(&self) -> MutexGuard<'_, HashMap<ApprovalKey, ApprovalRecord>> {
+        self.records
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+}
+
+#[async_trait]
+impl ApprovalRequestStore for InMemoryApprovalRequestStore {
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let record = ApprovalRecord {
+            scope,
+            request,
+            status: ApprovalStatus::Pending,
+        };
+        self.records_guard().insert(
+            ApprovalKey::new(&record.scope, record.request.id),
+            record.clone(),
+        );
+        Ok(record)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        Ok(self
+            .records_guard()
+            .get(&ApprovalKey::new(scope, request_id))
+            .cloned())
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Approved)
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Denied)
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        let mut records = self
+            .records_guard()
+            .values()
+            .filter(|record| same_scope_owner(&record.scope, scope))
+            .cloned()
+            .collect::<Vec<_>>();
+        records.sort_by_key(|record| record.request.id.as_uuid());
+        Ok(records)
+    }
+}
+
+/// Filesystem-backed run-state store under tenant/user/agent-scoped `/engine` paths.
+pub struct FilesystemRunStateStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    filesystem: &'a F,
+}
+
+impl<'a, F> FilesystemRunStateStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(filesystem: &'a F) -> Self {
+        Self { filesystem }
+    }
+
+    async fn write_record(&self, record: &RunRecord) -> Result<(), RunStateError> {
+        let path = run_record_path(&record.scope, record.invocation_id)?;
+        let bytes = serialize_pretty(record)?;
+        self.filesystem.write_file(&path, &bytes).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<F> RunStateStore for FilesystemRunStateStore<'_, F>
+where
+    F: RootFilesystem,
+{
+    async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError> {
+        if self.get(&start.scope, start.invocation_id).await?.is_some() {
+            return Err(RunStateError::InvocationAlreadyExists {
+                invocation_id: start.invocation_id,
+            });
+        }
+        let record = RunRecord {
+            invocation_id: start.invocation_id,
+            capability_id: start.capability_id,
+            scope: start.scope,
+            status: RunStatus::Running,
+            approval_request_id: None,
+            error_kind: None,
+        };
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn block_approval(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        approval: ApprovalRequest,
+    ) -> Result<RunRecord, RunStateError> {
+        let mut record = self
+            .get(scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        record.status = RunStatus::BlockedApproval;
+        record.approval_request_id = Some(approval.id);
+        record.error_kind = None;
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn block_auth(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        let mut record = self
+            .get(scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        record.status = RunStatus::BlockedAuth;
+        record.error_kind = Some(error_kind);
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn complete(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<RunRecord, RunStateError> {
+        let mut record = self
+            .get(scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        record.status = RunStatus::Completed;
+        record.error_kind = None;
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn fail(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+        error_kind: String,
+    ) -> Result<RunRecord, RunStateError> {
+        let mut record = self
+            .get(scope, invocation_id)
+            .await?
+            .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
+        record.status = RunStatus::Failed;
+        record.error_kind = Some(error_kind);
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        invocation_id: InvocationId,
+    ) -> Result<Option<RunRecord>, RunStateError> {
+        let path = run_record_path(scope, invocation_id)?;
+        let bytes = match self.filesystem.read_file(&path).await {
+            Ok(bytes) => bytes,
+            Err(error) if is_not_found(&error) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let record = deserialize::<RunRecord>(&bytes)?;
+        if same_scope_owner(&record.scope, scope) {
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<RunRecord>, RunStateError> {
+        let root = run_records_root(scope)?;
+        let entries = match self.filesystem.list_dir(&root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        let mut records = Vec::new();
+        for entry in entries {
+            if entry.name.ends_with(".json") {
+                let bytes = self.filesystem.read_file(&entry.path).await?;
+                let record = deserialize::<RunRecord>(&bytes)?;
+                if same_scope_owner(&record.scope, scope) {
+                    records.push(record);
+                }
+            }
+        }
+        records.sort_by_key(|record| record.invocation_id.as_uuid());
+        Ok(records)
+    }
+}
+
+/// Filesystem-backed approval request store under tenant/user/agent-scoped `/engine` paths.
+pub struct FilesystemApprovalRequestStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    filesystem: &'a F,
+}
+
+impl<'a, F> FilesystemApprovalRequestStore<'a, F>
+where
+    F: RootFilesystem,
+{
+    pub fn new(filesystem: &'a F) -> Self {
+        Self { filesystem }
+    }
+
+    async fn update_status(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+        status: ApprovalStatus,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let mut record = self
+            .get(scope, request_id)
+            .await?
+            .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        record.status = status;
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn write_record(&self, record: &ApprovalRecord) -> Result<(), RunStateError> {
+        let path = approval_record_path(&record.scope, record.request.id)?;
+        let bytes = serialize_pretty(record)?;
+        self.filesystem.write_file(&path, &bytes).await?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl<F> ApprovalRequestStore for FilesystemApprovalRequestStore<'_, F>
+where
+    F: RootFilesystem,
+{
+    async fn save_pending(
+        &self,
+        scope: ResourceScope,
+        request: ApprovalRequest,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        let record = ApprovalRecord {
+            scope,
+            request,
+            status: ApprovalStatus::Pending,
+        };
+        self.write_record(&record).await?;
+        Ok(record)
+    }
+
+    async fn get(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<Option<ApprovalRecord>, RunStateError> {
+        let path = approval_record_path(scope, request_id)?;
+        let bytes = match self.filesystem.read_file(&path).await {
+            Ok(bytes) => bytes,
+            Err(error) if is_not_found(&error) => return Ok(None),
+            Err(error) => return Err(error.into()),
+        };
+        let record = deserialize::<ApprovalRecord>(&bytes)?;
+        if same_scope_owner(&record.scope, scope) {
+            Ok(Some(record))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn approve(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Approved)
+            .await
+    }
+
+    async fn deny(
+        &self,
+        scope: &ResourceScope,
+        request_id: ApprovalRequestId,
+    ) -> Result<ApprovalRecord, RunStateError> {
+        self.update_status(scope, request_id, ApprovalStatus::Denied)
+            .await
+    }
+
+    async fn records_for_scope(
+        &self,
+        scope: &ResourceScope,
+    ) -> Result<Vec<ApprovalRecord>, RunStateError> {
+        let root = approval_records_root(scope)?;
+        let entries = match self.filesystem.list_dir(&root).await {
+            Ok(entries) => entries,
+            Err(error) if is_not_found(&error) => return Ok(Vec::new()),
+            Err(error) => return Err(error.into()),
+        };
+        let mut records = Vec::new();
+        for entry in entries {
+            if entry.name.ends_with(".json") {
+                let bytes = self.filesystem.read_file(&entry.path).await?;
+                let record = deserialize::<ApprovalRecord>(&bytes)?;
+                if same_scope_owner(&record.scope, scope) {
+                    records.push(record);
+                }
+            }
+        }
+        records.sort_by_key(|record| record.request.id.as_uuid());
+        Ok(records)
+    }
+}
+
+fn run_record_path(
+    scope: &ResourceScope,
+    invocation_id: InvocationId,
+) -> Result<VirtualPath, RunStateError> {
+    VirtualPath::new(format!(
+        "{}/{invocation_id}.json",
+        run_records_root(scope)?.as_str()
+    ))
+    .map_err(Into::into)
+}
+
+fn run_records_root(scope: &ResourceScope) -> Result<VirtualPath, RunStateError> {
+    VirtualPath::new(format!("{}/runs", tenant_user_root(scope))).map_err(Into::into)
+}
+
+fn approval_record_path(
+    scope: &ResourceScope,
+    request_id: ApprovalRequestId,
+) -> Result<VirtualPath, RunStateError> {
+    VirtualPath::new(format!(
+        "{}/{request_id}.json",
+        approval_records_root(scope)?.as_str()
+    ))
+    .map_err(Into::into)
+}
+
+fn approval_records_root(scope: &ResourceScope) -> Result<VirtualPath, RunStateError> {
+    VirtualPath::new(format!("{}/approvals", tenant_user_root(scope))).map_err(Into::into)
+}
+
+fn tenant_user_root(scope: &ResourceScope) -> String {
+    let base = format!(
+        "/engine/tenants/{}/users/{}",
+        scope.tenant_id.as_str(),
+        scope.user_id.as_str()
+    );
+    match &scope.agent_id {
+        Some(agent_id) => format!("{base}/agents/{}", agent_id.as_str()),
+        None => base,
+    }
+}
+
+fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
+    left.tenant_id == right.tenant_id
+        && left.user_id == right.user_id
+        && left.agent_id == right.agent_id
+}
+
+fn serialize_pretty<T>(value: &T) -> Result<Vec<u8>, RunStateError>
+where
+    T: Serialize,
+{
+    serde_json::to_vec_pretty(value)
+        .map_err(|error| RunStateError::Serialization(error.to_string()))
+}
+
+fn deserialize<T>(bytes: &[u8]) -> Result<T, RunStateError>
+where
+    T: for<'de> Deserialize<'de>,
+{
+    serde_json::from_slice(bytes).map_err(|error| RunStateError::Deserialization(error.to_string()))
+}
+
+fn is_not_found(error: &FilesystemError) -> bool {
+    match error {
+        FilesystemError::Backend { reason, .. } => {
+            reason.contains("No such file")
+                || reason.contains("not found")
+                || reason.contains("os error 2")
+        }
+        _ => false,
+    }
+}

--- a/crates/ironclaw_run_state/src/lib.rs
+++ b/crates/ironclaw_run_state/src/lib.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use ironclaw_filesystem::{FilesystemError, RootFilesystem};
 use ironclaw_host_api::{
     AgentId, ApprovalRequest, ApprovalRequestId, CapabilityId, HostApiError, InvocationId,
-    ResourceScope, TenantId, UserId, VirtualPath,
+    MissionId, ProjectId, ResourceScope, TenantId, ThreadId, UserId, VirtualPath,
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -71,6 +71,9 @@ struct RunStateKey {
     tenant_id: TenantId,
     user_id: UserId,
     agent_id: Option<AgentId>,
+    project_id: Option<ProjectId>,
+    mission_id: Option<MissionId>,
+    thread_id: Option<ThreadId>,
     invocation_id: InvocationId,
 }
 
@@ -80,6 +83,9 @@ impl RunStateKey {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
             agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
             invocation_id,
         }
     }
@@ -90,6 +96,9 @@ struct ApprovalKey {
     tenant_id: TenantId,
     user_id: UserId,
     agent_id: Option<AgentId>,
+    project_id: Option<ProjectId>,
+    mission_id: Option<MissionId>,
+    thread_id: Option<ThreadId>,
     request_id: ApprovalRequestId,
 }
 
@@ -99,6 +108,9 @@ impl ApprovalKey {
             tenant_id: scope.tenant_id.clone(),
             user_id: scope.user_id.clone(),
             agent_id: scope.agent_id.clone(),
+            project_id: scope.project_id.clone(),
+            mission_id: scope.mission_id.clone(),
+            thread_id: scope.thread_id.clone(),
             request_id,
         }
     }
@@ -113,6 +125,11 @@ pub enum RunStateError {
     InvocationAlreadyExists { invocation_id: InvocationId },
     #[error("unknown approval request {request_id}")]
     UnknownApprovalRequest { request_id: ApprovalRequestId },
+    #[error("approval request {request_id} is not pending (status: {status:?})")]
+    ApprovalNotPending {
+        request_id: ApprovalRequestId,
+        status: ApprovalStatus,
+    },
     #[error("invalid storage path: {0}")]
     InvalidPath(String),
     #[error("filesystem error: {0}")]
@@ -132,7 +149,7 @@ impl From<FilesystemError> for RunStateError {
 /// Current-state store for invocation lifecycle.
 #[async_trait]
 pub trait RunStateStore: Send + Sync {
-    /// Creates a running invocation record in the exact tenant/user/agent scope.
+    /// Creates a running invocation record in the exact resource-owner scope.
     async fn start(&self, start: RunStart) -> Result<RunRecord, RunStateError>;
 
     /// Marks an invocation blocked on an approval request without granting authority by itself.
@@ -173,7 +190,7 @@ pub trait RunStateStore: Send + Sync {
         invocation_id: InvocationId,
     ) -> Result<Option<RunRecord>, RunStateError>;
 
-    /// Lists invocation records visible to the tenant/user/agent scope only.
+    /// Lists invocation records visible to the exact resource-owner scope only.
     async fn records_for_scope(
         &self,
         scope: &ResourceScope,
@@ -183,7 +200,7 @@ pub trait RunStateStore: Send + Sync {
 /// Store for approval requests emitted by authorization decisions.
 #[async_trait]
 pub trait ApprovalRequestStore: Send + Sync {
-    /// Persists a pending approval request in the tenant/user/agent scope without resolving it.
+    /// Persists a pending approval request in the exact resource-owner scope without resolving it.
     async fn save_pending(
         &self,
         scope: ResourceScope,
@@ -211,7 +228,7 @@ pub trait ApprovalRequestStore: Send + Sync {
         request_id: ApprovalRequestId,
     ) -> Result<ApprovalRecord, RunStateError>;
 
-    /// Lists approval records visible to the tenant/user/agent scope only.
+    /// Lists approval records visible to the exact resource-owner scope only.
     async fn records_for_scope(
         &self,
         scope: &ResourceScope,
@@ -294,6 +311,7 @@ impl RunStateStore for InMemoryRunStateStore {
     ) -> Result<RunRecord, RunStateError> {
         self.update(scope, invocation_id, |record| {
             record.status = RunStatus::BlockedAuth;
+            record.approval_request_id = None;
             record.error_kind = Some(error_kind);
         })
     }
@@ -305,6 +323,7 @@ impl RunStateStore for InMemoryRunStateStore {
     ) -> Result<RunRecord, RunStateError> {
         self.update(scope, invocation_id, |record| {
             record.status = RunStatus::Completed;
+            record.approval_request_id = None;
             record.error_kind = None;
         })
     }
@@ -317,6 +336,7 @@ impl RunStateStore for InMemoryRunStateStore {
     ) -> Result<RunRecord, RunStateError> {
         self.update(scope, invocation_id, |record| {
             record.status = RunStatus::Failed;
+            record.approval_request_id = None;
             record.error_kind = Some(error_kind);
         })
     }
@@ -368,6 +388,12 @@ impl InMemoryApprovalRequestStore {
         let record = records
             .get_mut(&ApprovalKey::new(scope, request_id))
             .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        if record.status != ApprovalStatus::Pending {
+            return Err(RunStateError::ApprovalNotPending {
+                request_id,
+                status: record.status,
+            });
+        }
         record.status = status;
         Ok(record.clone())
     }
@@ -440,7 +466,7 @@ impl ApprovalRequestStore for InMemoryApprovalRequestStore {
     }
 }
 
-/// Filesystem-backed run-state store under tenant/user/agent-scoped `/engine` paths.
+/// Filesystem-backed run-state store under resource-owner-scoped `/engine` paths.
 pub struct FilesystemRunStateStore<'a, F>
 where
     F: RootFilesystem,
@@ -522,6 +548,7 @@ where
             .await?
             .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
         record.status = RunStatus::BlockedAuth;
+        record.approval_request_id = None;
         record.error_kind = Some(error_kind);
         self.write_record(&record).await?;
         Ok(record)
@@ -538,6 +565,7 @@ where
             .await?
             .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
         record.status = RunStatus::Completed;
+        record.approval_request_id = None;
         record.error_kind = None;
         self.write_record(&record).await?;
         Ok(record)
@@ -555,6 +583,7 @@ where
             .await?
             .ok_or(RunStateError::UnknownInvocation { invocation_id })?;
         record.status = RunStatus::Failed;
+        record.approval_request_id = None;
         record.error_kind = Some(error_kind);
         self.write_record(&record).await?;
         Ok(record)
@@ -604,7 +633,7 @@ where
     }
 }
 
-/// Filesystem-backed approval request store under tenant/user/agent-scoped `/engine` paths.
+/// Filesystem-backed approval request store under resource-owner-scoped `/engine` paths.
 pub struct FilesystemApprovalRequestStore<'a, F>
 where
     F: RootFilesystem,
@@ -635,6 +664,12 @@ where
             .get(scope, request_id)
             .await?
             .ok_or(RunStateError::UnknownApprovalRequest { request_id })?;
+        if record.status != ApprovalStatus::Pending {
+            return Err(RunStateError::ApprovalNotPending {
+                request_id,
+                status: record.status,
+            });
+        }
         record.status = status;
         self.write_record(&record).await?;
         Ok(record)
@@ -761,15 +796,24 @@ fn approval_records_root(scope: &ResourceScope) -> Result<VirtualPath, RunStateE
 }
 
 fn tenant_user_root(scope: &ResourceScope) -> String {
-    let base = format!(
+    let mut base = format!(
         "/engine/tenants/{}/users/{}",
         scope.tenant_id.as_str(),
         scope.user_id.as_str()
     );
-    match &scope.agent_id {
-        Some(agent_id) => format!("{base}/agents/{}", agent_id.as_str()),
-        None => base,
+    if let Some(agent_id) = &scope.agent_id {
+        base = format!("{base}/agents/{}", agent_id.as_str());
     }
+    if let Some(project_id) = &scope.project_id {
+        base = format!("{base}/projects/{}", project_id.as_str());
+    }
+    if let Some(mission_id) = &scope.mission_id {
+        base = format!("{base}/missions/{}", mission_id.as_str());
+    }
+    if let Some(thread_id) = &scope.thread_id {
+        base = format!("{base}/threads/{}", thread_id.as_str());
+    }
+    base
 }
 
 fn invalid_path(error: HostApiError) -> RunStateError {
@@ -780,6 +824,9 @@ fn same_scope_owner(left: &ResourceScope, right: &ResourceScope) -> bool {
     left.tenant_id == right.tenant_id
         && left.user_id == right.user_id
         && left.agent_id == right.agent_id
+        && left.project_id == right.project_id
+        && left.mission_id == right.mission_id
+        && left.thread_id == right.thread_id
 }
 
 fn serialize_pretty<T>(value: &T) -> Result<Vec<u8>, RunStateError>

--- a/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
@@ -48,6 +48,60 @@ async fn approval_resolution_is_scoped_to_tenant_and_user() {
     ));
 }
 
+#[tokio::test]
+async fn approval_store_rejects_second_resolution_attempt() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store.save_pending(scope.clone(), approval).await.unwrap();
+    store.approve(&scope, request_id).await.unwrap();
+
+    let err = store.deny(&scope, request_id).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::ApprovalNotPending {
+            request_id: id,
+            status: ApprovalStatus::Approved,
+        } if id == request_id
+    ));
+}
+
+#[tokio::test]
+async fn filesystem_approval_store_rejects_second_resolution_attempt() {
+    let fs = {
+        let storage = tempfile::tempdir().unwrap().keep();
+        let mut fs = ironclaw_filesystem::LocalFilesystem::new();
+        fs.mount_local(
+            VirtualPath::new("/engine").unwrap(),
+            HostPath::from_path_buf(storage),
+        )
+        .unwrap();
+        fs
+    };
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store.save_pending(scope.clone(), approval).await.unwrap();
+    store.approve(&scope, request_id).await.unwrap();
+
+    let err = store.deny(&scope, request_id).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::ApprovalNotPending {
+            request_id: id,
+            status: ApprovalStatus::Approved,
+        } if id == request_id
+    ));
+}
+
 fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
     ResourceScope {
         tenant_id: TenantId::new(tenant).unwrap(),

--- a/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
@@ -71,17 +71,37 @@ async fn approval_store_rejects_second_resolution_attempt() {
 }
 
 #[tokio::test]
-async fn filesystem_approval_store_rejects_second_resolution_attempt() {
-    let fs = {
-        let storage = tempfile::tempdir().unwrap().keep();
-        let mut fs = ironclaw_filesystem::LocalFilesystem::new();
-        fs.mount_local(
-            VirtualPath::new("/engine").unwrap(),
-            HostPath::from_path_buf(storage),
-        )
+async fn approval_store_rejects_duplicate_pending_save() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store
+        .save_pending(scope.clone(), approval.clone())
+        .await
         .unwrap();
-        fs
-    };
+    store.approve(&scope, request_id).await.unwrap();
+
+    let err = store
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::ApprovalRequestAlreadyExists { request_id: id } if id == request_id
+    ));
+    assert_eq!(
+        store.get(&scope, request_id).await.unwrap().unwrap().status,
+        ApprovalStatus::Approved
+    );
+}
+
+#[tokio::test]
+async fn filesystem_approval_store_rejects_second_resolution_attempt() {
+    let fs = engine_filesystem();
     let store = FilesystemApprovalRequestStore::new(&fs);
     let invocation_id = InvocationId::new();
     let scope = sample_scope(invocation_id, "tenant1", "user1");
@@ -100,6 +120,47 @@ async fn filesystem_approval_store_rejects_second_resolution_attempt() {
             status: ApprovalStatus::Approved,
         } if id == request_id
     ));
+}
+
+#[tokio::test]
+async fn filesystem_approval_store_rejects_duplicate_pending_save() {
+    let fs = engine_filesystem();
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+    store.approve(&scope, request_id).await.unwrap();
+
+    let err = store
+        .save_pending(scope.clone(), approval)
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::ApprovalRequestAlreadyExists { request_id: id } if id == request_id
+    ));
+    assert_eq!(
+        store.get(&scope, request_id).await.unwrap().unwrap().status,
+        ApprovalStatus::Approved
+    );
+}
+
+fn engine_filesystem() -> ironclaw_filesystem::LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = ironclaw_filesystem::LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/engine").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
 }
 
 fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {

--- a/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
+++ b/crates/ironclaw_run_state/tests/approval_resolution_contract.rs
@@ -1,0 +1,76 @@
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+
+#[tokio::test]
+async fn approval_store_marks_pending_request_approved_or_denied_with_scope() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store.save_pending(scope.clone(), approval).await.unwrap();
+    let approved = store.approve(&scope, request_id).await.unwrap();
+
+    assert_eq!(approved.status, ApprovalStatus::Approved);
+    assert_eq!(
+        store.get(&scope, request_id).await.unwrap().unwrap().status,
+        ApprovalStatus::Approved
+    );
+
+    let denied_request = approval_request(invocation_id);
+    let denied_id = denied_request.id;
+    store
+        .save_pending(scope.clone(), denied_request)
+        .await
+        .unwrap();
+    let denied = store.deny(&scope, denied_id).await.unwrap();
+
+    assert_eq!(denied.status, ApprovalStatus::Denied);
+}
+
+#[tokio::test]
+async fn approval_resolution_is_scoped_to_tenant_and_user() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let approval = approval_request(invocation_id);
+    let request_id = approval.id;
+
+    store.save_pending(tenant_a, approval).await.unwrap();
+
+    let err = store.approve(&tenant_b, request_id).await.unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::UnknownApprovalRequest { request_id: id } if id == request_id
+    ));
+}
+
+fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    }
+}
+
+fn approval_request(invocation_id: InvocationId) -> ApprovalRequest {
+    ApprovalRequest {
+        id: ApprovalRequestId::new(),
+        correlation_id: CorrelationId::new(),
+        requested_by: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        action: Box::new(Action::Dispatch {
+            capability: CapabilityId::new("echo.say").unwrap(),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        invocation_fingerprint: None,
+        reason: format!("approval for {invocation_id}"),
+        reusable_scope: None,
+    }
+}

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -1,0 +1,528 @@
+use ironclaw_filesystem::LocalFilesystem;
+use ironclaw_host_api::*;
+use ironclaw_run_state::*;
+
+#[tokio::test]
+async fn in_memory_run_state_tracks_running_to_completed() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let capability_id = CapabilityId::new("echo.say").unwrap();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+
+    let running = store
+        .start(RunStart {
+            invocation_id,
+            capability_id: capability_id.clone(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(running.status, RunStatus::Running);
+    assert_eq!(running.capability_id, capability_id);
+    assert_eq!(running.scope, scope);
+
+    let completed = store.complete(&scope, invocation_id).await.unwrap();
+    assert_eq!(completed.status, RunStatus::Completed);
+    assert_eq!(
+        store
+            .get(&scope, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .status,
+        RunStatus::Completed
+    );
+}
+
+#[tokio::test]
+async fn in_memory_run_state_tracks_blocked_approval_with_request_id() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    let approval = approval_request(invocation_id);
+
+    let blocked = store
+        .block_approval(&scope, invocation_id, approval.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(blocked.status, RunStatus::BlockedApproval);
+    assert_eq!(blocked.approval_request_id, Some(approval.id));
+    assert_eq!(blocked.error_kind, None);
+}
+
+#[tokio::test]
+async fn in_memory_run_state_tracks_failed_with_error_kind() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+
+    let failed = store
+        .fail(&scope, invocation_id, "AuthorizationDenied".to_string())
+        .await
+        .unwrap();
+
+    assert_eq!(failed.status, RunStatus::Failed);
+    assert_eq!(failed.error_kind.as_deref(), Some("AuthorizationDenied"));
+}
+
+#[tokio::test]
+async fn run_state_transitions_fail_for_unknown_invocation() {
+    let store = InMemoryRunStateStore::new();
+    let missing = InvocationId::new();
+    let scope = sample_scope(missing, "tenant1", "user1");
+
+    let err = store.complete(&scope, missing).await.unwrap_err();
+
+    assert!(
+        matches!(err, RunStateError::UnknownInvocation { invocation_id } if invocation_id == missing)
+    );
+}
+
+#[tokio::test]
+async fn in_memory_run_state_rejects_duplicate_invocation_in_same_tenant_user() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.one").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    let err = store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.two").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::InvocationAlreadyExists { invocation_id: id } if id == invocation_id
+    ));
+    assert_eq!(
+        store
+            .get(&scope, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .capability_id,
+        CapabilityId::new("echo.one").unwrap()
+    );
+}
+
+#[tokio::test]
+async fn filesystem_run_state_rejects_duplicate_invocation_in_same_tenant_user() {
+    let fs = engine_filesystem();
+    let store = FilesystemRunStateStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.one").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    let err = store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.two").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        err,
+        RunStateError::InvocationAlreadyExists { invocation_id: id } if id == invocation_id
+    ));
+    assert_eq!(
+        store
+            .get(&scope, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .capability_id,
+        CapabilityId::new("echo.one").unwrap()
+    );
+}
+
+#[tokio::test]
+async fn in_memory_run_state_allows_same_invocation_id_in_different_tenants() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.one").unwrap(),
+            scope: tenant_a.clone(),
+        })
+        .await
+        .unwrap();
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.two").unwrap(),
+            scope: tenant_b.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store
+            .get(&tenant_a, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .capability_id,
+        CapabilityId::new("echo.one").unwrap()
+    );
+    assert_eq!(
+        store
+            .get(&tenant_b, invocation_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .capability_id,
+        CapabilityId::new("echo.two").unwrap()
+    );
+}
+
+#[tokio::test]
+async fn in_memory_run_state_hides_records_from_other_tenants_and_users() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let user_b = sample_scope(invocation_id, "tenant1", "user2");
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: tenant_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(store.get(&tenant_b, invocation_id).await.unwrap().is_none());
+    assert!(store.get(&user_b, invocation_id).await.unwrap().is_none());
+    assert_eq!(
+        store.records_for_scope(&tenant_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&user_b).await.unwrap(), Vec::new());
+    assert!(matches!(
+        store.complete(&tenant_b, invocation_id).await.unwrap_err(),
+        RunStateError::UnknownInvocation { .. }
+    ));
+}
+
+#[tokio::test]
+async fn filesystem_run_state_store_persists_records_under_tenant_user_engine_runs() {
+    let fs = engine_filesystem();
+    let store = FilesystemRunStateStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    store
+        .block_approval(&scope, invocation_id, approval.clone())
+        .await
+        .unwrap();
+
+    let reloaded = FilesystemRunStateStore::new(&fs)
+        .get(&scope, invocation_id)
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(reloaded.status, RunStatus::BlockedApproval);
+    assert_eq!(reloaded.approval_request_id, Some(approval.id));
+    assert_eq!(
+        FilesystemRunStateStore::new(&fs)
+            .records_for_scope(&scope)
+            .await
+            .unwrap()
+            .len(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn filesystem_run_state_store_hides_records_from_other_tenants_and_users() {
+    let fs = engine_filesystem();
+    let store = FilesystemRunStateStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let user_b = sample_scope(invocation_id, "tenant1", "user2");
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: tenant_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(store.get(&tenant_b, invocation_id).await.unwrap().is_none());
+    assert!(store.get(&user_b, invocation_id).await.unwrap().is_none());
+    assert_eq!(
+        store.records_for_scope(&tenant_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&user_b).await.unwrap(), Vec::new());
+    assert!(matches!(
+        store.complete(&tenant_b, invocation_id).await.unwrap_err(),
+        RunStateError::UnknownInvocation { .. }
+    ));
+}
+
+#[tokio::test]
+async fn filesystem_approval_request_store_persists_pending_requests_under_tenant_user_engine_approvals()
+ {
+    let fs = engine_filesystem();
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    let approval = approval_request(invocation_id);
+
+    let record = store
+        .save_pending(scope.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(record.scope, scope);
+    assert_eq!(record.status, ApprovalStatus::Pending);
+    assert_eq!(record.request, approval);
+    let reloaded = FilesystemApprovalRequestStore::new(&fs)
+        .get(&record.scope, record.request.id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(reloaded, record);
+}
+
+#[tokio::test]
+async fn in_memory_approval_store_allows_same_request_id_in_different_tenants() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let approval = approval_request(invocation_id);
+
+    store
+        .save_pending(tenant_a.clone(), approval.clone())
+        .await
+        .unwrap();
+    store
+        .save_pending(tenant_b.clone(), approval.clone())
+        .await
+        .unwrap();
+
+    assert_eq!(
+        store
+            .get(&tenant_a, approval.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .scope,
+        tenant_a
+    );
+    assert_eq!(
+        store
+            .get(&tenant_b, approval.id)
+            .await
+            .unwrap()
+            .unwrap()
+            .scope,
+        tenant_b
+    );
+}
+
+#[tokio::test]
+async fn approval_request_store_hides_records_from_other_tenants_and_users() {
+    let fs = engine_filesystem();
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let tenant_a = sample_scope(invocation_id, "tenant1", "user1");
+    let tenant_b = sample_scope(invocation_id, "tenant2", "user1");
+    let user_b = sample_scope(invocation_id, "tenant1", "user2");
+    let approval = approval_request(invocation_id);
+
+    let record = store.save_pending(tenant_a, approval).await.unwrap();
+
+    assert!(
+        store
+            .get(&tenant_b, record.request.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert!(
+        store
+            .get(&user_b, record.request.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        store.records_for_scope(&tenant_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&user_b).await.unwrap(), Vec::new());
+}
+
+#[tokio::test]
+async fn run_state_isolates_records_by_agent_scope() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let agent_a = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-a"));
+    let agent_b = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-b"));
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: agent_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(store.get(&agent_b, invocation_id).await.unwrap().is_none());
+    assert_eq!(store.records_for_scope(&agent_b).await.unwrap(), Vec::new());
+    assert!(matches!(
+        store.complete(&agent_b, invocation_id).await.unwrap_err(),
+        RunStateError::UnknownInvocation { .. }
+    ));
+}
+
+#[tokio::test]
+async fn filesystem_run_state_uses_agent_scoped_paths() {
+    let fs = engine_filesystem();
+    let store = FilesystemRunStateStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let agent_a = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-a"));
+    let agent_b = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-b"));
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: agent_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(store.get(&agent_b, invocation_id).await.unwrap().is_none());
+    assert_eq!(store.records_for_scope(&agent_b).await.unwrap(), Vec::new());
+    assert_eq!(store.records_for_scope(&agent_a).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn approval_request_store_isolates_records_by_agent_scope() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let agent_a = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-a"));
+    let agent_b = sample_scope_with_agent(invocation_id, "tenant1", "user1", Some("agent-b"));
+    let approval = approval_request(invocation_id);
+
+    let record = store.save_pending(agent_a.clone(), approval).await.unwrap();
+
+    assert!(
+        store
+            .get(&agent_b, record.request.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(store.records_for_scope(&agent_b).await.unwrap(), Vec::new());
+    assert_eq!(store.records_for_scope(&agent_a).await.unwrap().len(), 1);
+}
+
+fn engine_filesystem() -> LocalFilesystem {
+    let storage = tempfile::tempdir().unwrap().keep();
+    let mut fs = LocalFilesystem::new();
+    fs.mount_local(
+        VirtualPath::new("/engine").unwrap(),
+        HostPath::from_path_buf(storage),
+    )
+    .unwrap();
+    fs
+}
+
+fn sample_scope(invocation_id: InvocationId, tenant: &str, user: &str) -> ResourceScope {
+    ResourceScope {
+        tenant_id: TenantId::new(tenant).unwrap(),
+        user_id: UserId::new(user).unwrap(),
+        agent_id: None,
+        project_id: Some(ProjectId::new("project1").unwrap()),
+        mission_id: None,
+        thread_id: None,
+        invocation_id,
+    }
+}
+
+fn sample_scope_with_agent(
+    invocation_id: InvocationId,
+    tenant: &str,
+    user: &str,
+    agent: Option<&str>,
+) -> ResourceScope {
+    let mut scope = sample_scope(invocation_id, tenant, user);
+    scope.agent_id = agent.map(|id| AgentId::new(id).unwrap());
+    scope
+}
+
+fn approval_request(invocation_id: InvocationId) -> ApprovalRequest {
+    ApprovalRequest {
+        id: ApprovalRequestId::new(),
+        correlation_id: CorrelationId::new(),
+        requested_by: Principal::Extension(ExtensionId::new("caller").unwrap()),
+        action: Box::new(Action::Dispatch {
+            capability: CapabilityId::new("echo.say").unwrap(),
+            estimated_resources: ResourceEstimate::default(),
+        }),
+        invocation_fingerprint: None,
+        reason: format!("approval for {invocation_id}"),
+        reusable_scope: None,
+    }
+}

--- a/crates/ironclaw_run_state/tests/run_state_contract.rs
+++ b/crates/ironclaw_run_state/tests/run_state_contract.rs
@@ -478,6 +478,171 @@ async fn approval_request_store_isolates_records_by_agent_scope() {
     assert_eq!(store.records_for_scope(&agent_a).await.unwrap().len(), 1);
 }
 
+#[tokio::test]
+async fn run_state_isolates_records_by_project_scope() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let project_a = sample_scope(invocation_id, "tenant1", "user1");
+    let mut project_b = project_a.clone();
+    project_b.project_id = Some(ProjectId::new("project2").unwrap());
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: project_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .get(&project_b, invocation_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        store.records_for_scope(&project_b).await.unwrap(),
+        Vec::new()
+    );
+    assert!(matches!(
+        store.complete(&project_b, invocation_id).await.unwrap_err(),
+        RunStateError::UnknownInvocation { .. }
+    ));
+}
+
+#[tokio::test]
+async fn filesystem_run_state_isolates_records_by_project_scope() {
+    let fs = engine_filesystem();
+    let store = FilesystemRunStateStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let project_a = sample_scope(invocation_id, "tenant1", "user1");
+    let mut project_b = project_a.clone();
+    project_b.project_id = Some(ProjectId::new("project2").unwrap());
+
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: project_a.clone(),
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .get(&project_b, invocation_id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        store.records_for_scope(&project_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&project_a).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn run_state_clears_stale_approval_request_on_non_approval_transitions() {
+    let store = InMemoryRunStateStore::new();
+    let invocation_id = InvocationId::new();
+    let scope = sample_scope(invocation_id, "tenant1", "user1");
+    store
+        .start(RunStart {
+            invocation_id,
+            capability_id: CapabilityId::new("echo.say").unwrap(),
+            scope: scope.clone(),
+        })
+        .await
+        .unwrap();
+    store
+        .block_approval(&scope, invocation_id, approval_request(invocation_id))
+        .await
+        .unwrap();
+
+    let auth_blocked = store
+        .block_auth(&scope, invocation_id, "ExternalAuth".to_string())
+        .await
+        .unwrap();
+    assert_eq!(auth_blocked.approval_request_id, None);
+
+    store
+        .block_approval(&scope, invocation_id, approval_request(invocation_id))
+        .await
+        .unwrap();
+    let failed = store
+        .fail(&scope, invocation_id, "AuthorizationDenied".to_string())
+        .await
+        .unwrap();
+    assert_eq!(failed.approval_request_id, None);
+
+    store
+        .block_approval(&scope, invocation_id, approval_request(invocation_id))
+        .await
+        .unwrap();
+    let completed = store.complete(&scope, invocation_id).await.unwrap();
+    assert_eq!(completed.approval_request_id, None);
+}
+
+#[tokio::test]
+async fn approval_request_store_isolates_records_by_project_scope() {
+    let store = InMemoryApprovalRequestStore::new();
+    let invocation_id = InvocationId::new();
+    let project_a = sample_scope(invocation_id, "tenant1", "user1");
+    let mut project_b = project_a.clone();
+    project_b.project_id = Some(ProjectId::new("project2").unwrap());
+    let approval = approval_request(invocation_id);
+
+    let record = store
+        .save_pending(project_a.clone(), approval)
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .get(&project_b, record.request.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        store.records_for_scope(&project_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&project_a).await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn filesystem_approval_request_store_isolates_records_by_project_scope() {
+    let fs = engine_filesystem();
+    let store = FilesystemApprovalRequestStore::new(&fs);
+    let invocation_id = InvocationId::new();
+    let project_a = sample_scope(invocation_id, "tenant1", "user1");
+    let mut project_b = project_a.clone();
+    project_b.project_id = Some(ProjectId::new("project2").unwrap());
+    let approval = approval_request(invocation_id);
+
+    let record = store
+        .save_pending(project_a.clone(), approval)
+        .await
+        .unwrap();
+
+    assert!(
+        store
+            .get(&project_b, record.request.id)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        store.records_for_scope(&project_b).await.unwrap(),
+        Vec::new()
+    );
+    assert_eq!(store.records_for_scope(&project_a).await.unwrap().len(), 1);
+}
+
 fn engine_filesystem() -> LocalFilesystem {
     let storage = tempfile::tempdir().unwrap().keep();
     let mut fs = LocalFilesystem::new();


### PR DESCRIPTION
## Summary

Carves the PR3 auth/control substrate from the Reborn stack.

Adds:

- `crates/ironclaw_authorization`
  - capability grant matching
  - capability lease model/store
  - in-memory and filesystem-backed lease store
  - lease-backed authorizer
- `crates/ironclaw_run_state`
  - invocation lifecycle records
  - pending approval records
  - in-memory and filesystem-backed stores
  - tenant/user/agent/project scoped persistence paths
- `crates/ironclaw_approvals`
  - approval resolver
  - approve/deny flows
  - exact-invocation lease issuance
  - redacted approval audit event emission

## Rebase status

Rebased onto current `reborn-integration` after #2993 and #2996 landed. The PR diff is now narrowed to:

```text
crates/ironclaw_authorization
crates/ironclaw_run_state
crates/ironclaw_approvals
Cargo.toml / Cargo.lock membership for those crates
```

## Scope boundary

This deliberately does **not** include `ironclaw_capabilities` / `CapabilityHost` yet. The current stacked `ironclaw_capabilities` slice depends on future `ironclaw_extensions` and `ironclaw_processes`, so landing it cleanly belongs with/after the process/runtime slice instead of forcing PR3 to pull PR4 dependencies forward.

## Exposure checklist

```text
Does this affect existing src/ runtime behavior? no
Does this alter app startup/config defaults? no
Does this expose new routes/CLI/user-visible APIs? no
Does this create a second writer for existing production state? no
Are all Reborn paths feature-gated or unused by default? yes, unused internal crate substrate
Are docs/status labels accurate: implemented slice vs product complete? yes, auth/control substrate only
```

## TDD note

Copied the PR3 contract tests first against RED stubs for `ironclaw_authorization`, `ironclaw_run_state`, and `ironclaw_approvals`, and confirmed they failed before porting the implementation.

## CI note

The latest review-fix commit includes `[skip-regression-check]` because the regression-test enforcement job false-negatives this large Rust diff: its `git diff | grep -q` fast path runs with `pipefail`, so grep's early exit after seeing the added `#[test]` / `#[tokio::test]` lines is treated as a failed pipeline. Regression coverage is included in the added crate contract tests listed above.

## Verification

Passed after rebase:

```bash
CARGO_TARGET_DIR=/tmp/ironclaw-auth-target cargo test -p ironclaw_authorization -p ironclaw_run_state -p ironclaw_approvals
CARGO_TARGET_DIR=/tmp/ironclaw-auth-target cargo clippy -p ironclaw_authorization -p ironclaw_run_state -p ironclaw_approvals --all-targets -- -D warnings
cargo fmt --check
git diff --check
cargo tree -p ironclaw_authorization -e normal | grep -E 'ironclaw_(approvals|capabilities|dispatcher|events|extensions|host_runtime|mcp|network|processes|resources|run_state|scripts|secrets|wasm)' || true
cargo tree -p ironclaw_approvals -e normal | grep -E 'ironclaw_(capabilities|dispatcher|extensions|host_runtime|mcp|network|processes|resources|scripts|secrets|wasm)' || true
cargo tree -p ironclaw_run_state -e normal | grep -E 'ironclaw_(authorization|approvals|capabilities|dispatcher|events|extensions|host_runtime|mcp|network|processes|resources|scripts|secrets|wasm)' || true
```

Boundary greps returned no forbidden normal Reborn dependencies.

Refs #2987.
