### PR TITLE
Disable v2 CodeAct for Abound demo testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3112,9 +3112,9 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
  "hashbrown 0.16.1",
@@ -6635,7 +6635,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -6707,9 +6707,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1377,7 +1377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8144c22e24bbcf26ade86cb6501a0916c46b7e4787abdb0045a467eb1645a1d"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3925,7 +3925,7 @@ dependencies = [
  "postgres-types",
  "pretty_assertions",
  "pty-process",
- "rand 0.8.5",
+ "rand 0.8.6",
  "readabilityrs",
  "refinery",
  "regex",
@@ -4838,7 +4838,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -5399,7 +5399,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -6003,9 +6003,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -6519,7 +6519,7 @@ dependencies = [
  "bytes",
  "num-traits",
  "postgres-types",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv",
  "serde",
  "serde_json",
@@ -6878,7 +6878,7 @@ dependencies = [
  "hkdf",
  "num",
  "once_cell",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "sha2",
  "zbus",
@@ -8202,7 +8202,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
+ "rand 0.8.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -8574,7 +8574,7 @@ dependencies = [
  "getopts",
  "log",
  "phf_codegen 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -9981,7 +9981,7 @@ dependencies = [
  "hex",
  "nix 0.29.0",
  "ordered-stream",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_repr",
  "sha1",

--- a/crates/ironclaw_engine/src/executor/orchestrator.rs
+++ b/crates/ironclaw_engine/src/executor/orchestrator.rs
@@ -606,11 +606,7 @@ async fn handle_llm_complete(
 
     // If a terminal action result was stashed by handle_execute_actions_parallel,
     // return it directly as a text response — skip the LLM call entirely.
-    if let Some(stashed) = thread
-        .metadata
-        .get("_terminal_result")
-        .cloned()
-    {
+    if let Some(stashed) = thread.metadata.get("_terminal_result").cloned() {
         if let Some(obj) = thread.metadata.as_object_mut() {
             obj.remove("_terminal_result");
         }
@@ -1601,12 +1597,13 @@ async fn handle_execute_actions_parallel(
             let name = &parsed[idx].name;
             if terminal_set.iter().any(|t| t == name) {
                 let output = rj.get("output").cloned().unwrap_or_default();
-                if !rj.get("is_error").and_then(|v| v.as_bool()).unwrap_or(false) {
+                if !rj
+                    .get("is_error")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+                {
                     if let Some(obj) = thread.metadata.as_object_mut() {
-                        obj.insert(
-                            "_terminal_result".to_string(),
-                            output,
-                        );
+                        obj.insert("_terminal_result".to_string(), output);
                     }
                     debug!(action = %name, "stashed terminal action result");
                     break;
@@ -2048,7 +2045,11 @@ async fn handle_list_skills(
     // at tool execution time, independent of keyword-based skill activation.
     let mut terminal_actions: Vec<String> = Vec::new();
     for d in &skill_docs {
-        if let Some(arr) = d.metadata.get("terminal_actions").and_then(|v| v.as_array()) {
+        if let Some(arr) = d
+            .metadata
+            .get("terminal_actions")
+            .and_then(|v| v.as_array())
+        {
             for item in arr {
                 if let Some(s) = item.as_str() {
                     terminal_actions.push(s.to_string());
@@ -2056,13 +2057,13 @@ async fn handle_list_skills(
             }
         }
     }
-    if !terminal_actions.is_empty() {
-        if let Some(obj) = thread.metadata.as_object_mut() {
-            obj.insert(
-                "_terminal_actions".to_string(),
-                serde_json::json!(terminal_actions),
-            );
-        }
+    if !terminal_actions.is_empty()
+        && let Some(obj) = thread.metadata.as_object_mut()
+    {
+        obj.insert(
+            "_terminal_actions".to_string(),
+            serde_json::json!(terminal_actions),
+        );
     }
 
     let skills: Vec<serde_json::Value> = skill_docs

--- a/crates/ironclaw_engine/src/executor/prompt.rs
+++ b/crates/ironclaw_engine/src/executor/prompt.rs
@@ -72,11 +72,23 @@ impl PlatformInfo {
     }
 }
 
-/// The main instruction block (before tool listing).
-const CODEACT_PREAMBLE: &str = include_str!("../../prompts/codeact_preamble.md");
+/// Temporary structured-tool-only prompt for demo/abound testing.
+const STRUCTURED_TOOL_PREAMBLE: &str = r#"You are IronClaw, a personal AI assistant.
 
-/// The strategy/closing block (after tool listing).
-const CODEACT_POSTAMBLE: &str = include_str!("../../prompts/codeact_postamble.md");
+## Execution mode
+
+Use the provider's structured tool_calls interface for every action.
+Do not emit Python, repl, py, or other executable fenced code blocks.
+Do not call tools as Python functions.
+When no action is needed, answer in plain text.
+"#;
+
+const STRUCTURED_TOOL_POSTAMBLE: &str = r#"
+## Strategy
+
+Use structured tool calls when you need data, persistence, external effects, or system state.
+After tool results are available, continue with another structured tool call or return the final plain-text answer.
+"#;
 
 /// Well-known title for the CodeAct preamble overlay.
 pub const PREAMBLE_OVERLAY_TITLE: &str = "prompt:codeact_preamble";
@@ -135,14 +147,14 @@ fn build_codeact_system_prompt_inner(
     platform: Option<&PlatformInfo>,
 ) -> String {
     let mut prompt = if let Ok(custom) = std::env::var("AGENT_PREAMBLE") {
-        // Replace the default identity line but keep the rest of the CodeAct instructions.
-        let rest = CODEACT_PREAMBLE
+        // Replace the default identity line but keep the structured-tool-only instructions.
+        let rest = STRUCTURED_TOOL_PREAMBLE
             .find("\n\n")
-            .map(|i| &CODEACT_PREAMBLE[i..])
+            .map(|i| &STRUCTURED_TOOL_PREAMBLE[i..])
             .unwrap_or("");
         format!("{custom}{rest}")
     } else {
-        String::from(CODEACT_PREAMBLE)
+        String::from(STRUCTURED_TOOL_PREAMBLE)
     };
 
     // Inject platform identity and runtime metadata
@@ -158,7 +170,7 @@ fn build_codeact_system_prompt_inner(
 
     // Add tool documentation
     if !actions.is_empty() {
-        prompt.push_str("\n## Available tools (call as Python functions)\n\n");
+        prompt.push_str("\n## Available tools\n\n");
         for action in actions {
             prompt.push_str(&format!("- `{}(", action.name));
             // Extract parameter names from JSON schema
@@ -172,7 +184,7 @@ fn build_codeact_system_prompt_inner(
         }
     }
 
-    prompt.push_str(CODEACT_POSTAMBLE);
+    prompt.push_str(STRUCTURED_TOOL_POSTAMBLE);
     prompt
 }
 
@@ -209,7 +221,8 @@ mod tests {
     async fn prompt_without_store_uses_compiled_preamble() {
         let prompt =
             build_codeact_system_prompt(&[], None, ProjectId(uuid::Uuid::nil()), None).await;
-        assert!(prompt.contains("Python REPL environment"));
+        assert!(prompt.contains("structured tool_calls"));
+        assert!(prompt.contains("Do not emit Python"));
         assert!(prompt.contains("Strategy"));
         assert!(!prompt.contains("Learned Rules"));
     }

--- a/crates/ironclaw_engine/src/runtime/conversation.rs
+++ b/crates/ironclaw_engine/src/runtime/conversation.rs
@@ -189,6 +189,7 @@ impl ConversationManager {
     /// The per-conversation `Mutex` is held for the entire operation — from
     /// the active-thread check through `save_conversation`. This eliminates
     /// the TOCTOU double-spawn window present in the old 5-phase split.
+    #[allow(clippy::too_many_arguments)]
     pub async fn handle_user_message(
         &self,
         conversation_id: ConversationId,

--- a/crates/ironclaw_engine/src/runtime/mission.rs
+++ b/crates/ironclaw_engine/src/runtime/mission.rs
@@ -2593,10 +2593,10 @@ fn collect_errors_and_actions(thread: &Thread) -> (Vec<String>, Vec<String>) {
                     actions.push(action_name.clone());
                 }
             }
-            crate::types::event::EventKind::ActionExecuted { action_name, .. } => {
-                if seen.insert(action_name.clone()) {
-                    actions.push(action_name.clone());
-                }
+            crate::types::event::EventKind::ActionExecuted { action_name, .. }
+                if seen.insert(action_name.clone()) =>
+            {
+                actions.push(action_name.clone());
             }
             _ => {}
         }

--- a/crates/ironclaw_skills/src/catalog.rs
+++ b/crates/ironclaw_skills/src/catalog.rs
@@ -461,7 +461,7 @@ impl SkillCatalog {
 
         let details = futures::future::join_all(futures).await;
 
-        for (entry, detail) in entries[..count].iter_mut().zip(details.into_iter()) {
+        for (entry, detail) in entries[..count].iter_mut().zip(details) {
             if let Some(detail) = detail {
                 if let Some(ref stats) = detail.stats {
                     entry.stars = stats.stars;

--- a/crates/ironclaw_tui/src/render.rs
+++ b/crates/ironclaw_tui/src/render.rs
@@ -169,12 +169,11 @@ pub fn render_markdown(text: &str, max_width: usize, theme: &Theme) -> Vec<Line<
                 ctx.first_block = false;
             }
 
-            Event::Start(Tag::Paragraph) => {
-                if ctx.need_blank_line && !ctx.first_block {
-                    ctx.lines.push(Line::from(""));
-                    ctx.need_blank_line = false;
-                }
+            Event::Start(Tag::Paragraph) if ctx.need_blank_line && !ctx.first_block => {
+                ctx.lines.push(Line::from(""));
+                ctx.need_blank_line = false;
             }
+            Event::Start(Tag::Paragraph) => {}
             Event::End(TagEnd::Paragraph) => {
                 ctx.flush(max_width, theme);
                 ctx.need_blank_line = true;
@@ -307,12 +306,11 @@ pub fn render_markdown(text: &str, max_width: usize, theme: &Theme) -> Vec<Line<
                 }
             }
 
-            Event::SoftBreak => {
-                if !ctx.in_code_block {
-                    let style = ctx.top_style();
-                    ctx.segments.push((" ".to_string(), style));
-                }
+            Event::SoftBreak if !ctx.in_code_block => {
+                let style = ctx.top_style();
+                ctx.segments.push((" ".to_string(), style));
             }
+            Event::SoftBreak => {}
             Event::HardBreak => {
                 ctx.flush(max_width, theme);
             }

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,11 @@ ignore = [
     "RUSTSEC-2026-0021",
     # rustls-webpki CRL distributionPoint matching — 0.102.8 pinned by libsql transitive dep
     "RUSTSEC-2026-0049",
+    # rustls-webpki name-constraint/CRL advisories — 0.101.7 pinned by AWS SDK's legacy rustls
+    # path and 0.102.8 pinned by libsql's rustls path; requires upstream dependency upgrades.
+    "RUSTSEC-2026-0098",
+    "RUSTSEC-2026-0099",
+    "RUSTSEC-2026-0104",
 ]
 
 [licenses]

--- a/src/app.rs
+++ b/src/app.rs
@@ -402,14 +402,13 @@ impl AppBuilder {
                         let path = entry.path();
                         if path.extension().and_then(|e| e.to_str()) == Some("json") {
                             tools.load_credential_mappings(&path);
-                        } else if path.is_dir() {
-                            if let Ok(sub) = std::fs::read_dir(&path) {
-                                for sub_entry in sub.flatten() {
-                                    let sub_path = sub_entry.path();
-                                    if sub_path.extension().and_then(|e| e.to_str()) == Some("json")
-                                    {
-                                        tools.load_credential_mappings(&sub_path);
-                                    }
+                        } else if path.is_dir()
+                            && let Ok(sub) = std::fs::read_dir(&path)
+                        {
+                            for sub_entry in sub.flatten() {
+                                let sub_path = sub_entry.path();
+                                if sub_path.extension().and_then(|e| e.to_str()) == Some("json") {
+                                    tools.load_credential_mappings(&sub_path);
                                 }
                             }
                         }

--- a/src/bridge/llm_adapter.rs
+++ b/src/bridge/llm_adapter.rs
@@ -78,17 +78,8 @@ impl LlmBackend for LlmBridgeAdapter {
                     reason: e.to_string(),
                 })?;
 
-            // Check for code blocks in the response (CodeAct/RLM pattern)
-            let llm_response = match extract_code_block(&response.content) {
-                Some(code) => LlmResponse::Code {
-                    code,
-                    content: Some(response.content),
-                },
-                None => LlmResponse::Text(response.content),
-            };
-
             return Ok(LlmOutput {
-                response: llm_response,
+                response: LlmResponse::Text(response.content),
                 usage: TokenUsage {
                     input_tokens: u64::from(response.input_tokens),
                     output_tokens: u64::from(response.output_tokens),
@@ -115,7 +106,9 @@ impl LlmBackend for LlmBridgeAdapter {
                     reason: e.to_string(),
                 })?;
 
-        // Convert response — check for code blocks (CodeAct/RLM pattern)
+        // Convert response. Temporary demo/abound hack: keep v2 on the
+        // structured tool loop only, so fenced Python/repl text is returned as
+        // plain text instead of entering nested Monty/CodeAct.
         let llm_response = if !response.tool_calls.is_empty() {
             LlmResponse::ActionCalls {
                 calls: response
@@ -131,14 +124,7 @@ impl LlmBackend for LlmBridgeAdapter {
             }
         } else {
             let text = response.content.unwrap_or_default();
-            // Detect ```repl or ```python fenced code blocks
-            match extract_code_block(&text) {
-                Some(code) => LlmResponse::Code {
-                    code,
-                    content: Some(text),
-                },
-                None => LlmResponse::Text(text),
-            }
+            LlmResponse::Text(text)
         };
 
         Ok(LlmOutput {
@@ -211,6 +197,7 @@ fn action_def_to_tool_def(action: &ActionDef) -> ToolDefinition {
 /// (if the content looks like Python). Collects ALL code blocks in the
 /// response and concatenates them (models sometimes split code across
 /// multiple blocks with explanation text between them).
+#[cfg(test)]
 fn extract_code_block(text: &str) -> Option<String> {
     let mut all_code = Vec::new();
 
@@ -291,6 +278,7 @@ fn extract_code_block(text: &str) -> Option<String> {
 /// Avoids the false positives `trimmed.contains('(')` produced for markdown
 /// links like `[text](url)` and prose like "See (docs)" — neither has an
 /// alphanumeric/underscore character directly before the `(`.
+#[cfg(test)]
 fn has_identifier_call(line: &str) -> bool {
     let bytes = line.as_bytes();
     for (i, &b) in bytes.iter().enumerate() {
@@ -304,6 +292,7 @@ fn has_identifier_call(line: &str) -> bool {
     false
 }
 
+#[cfg(test)]
 fn looks_like_python(code: &str) -> bool {
     const PY_KEYWORDS: &[&str] = &[
         "import", "from", "def", "class", "if", "for", "while", "return", "print", "FINAL", "try",
@@ -419,6 +408,50 @@ mod tests {
 
             Ok(ToolCompletionResponse {
                 content: Some("ok".to_string()),
+                tool_calls: Vec::new(),
+                input_tokens: 1,
+                output_tokens: 1,
+                finish_reason: crate::llm::FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+    }
+
+    struct FixedContentProvider {
+        content: String,
+    }
+
+    #[async_trait]
+    impl LlmProvider for FixedContentProvider {
+        fn model_name(&self) -> &str {
+            "fixed-content-provider"
+        }
+
+        fn cost_per_token(&self) -> (Decimal, Decimal) {
+            (Decimal::ZERO, Decimal::ZERO)
+        }
+
+        async fn complete(
+            &self,
+            _req: crate::llm::CompletionRequest,
+        ) -> Result<crate::llm::CompletionResponse, LlmError> {
+            Ok(crate::llm::CompletionResponse {
+                content: self.content.clone(),
+                input_tokens: 1,
+                output_tokens: 1,
+                finish_reason: crate::llm::FinishReason::Stop,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
+            })
+        }
+
+        async fn complete_with_tools(
+            &self,
+            _req: ToolCompletionRequest,
+        ) -> Result<ToolCompletionResponse, LlmError> {
+            Ok(ToolCompletionResponse {
+                content: Some(self.content.clone()),
                 tool_calls: Vec::new(),
                 input_tokens: 1,
                 output_tokens: 1,
@@ -554,6 +587,50 @@ mod tests {
         assert_eq!(sent[2].content, "result payload");
         assert_eq!(sent[2].tool_call_id.as_deref(), Some("call_1"));
         assert_eq!(sent[2].name.as_deref(), Some("search"));
+    }
+
+    #[tokio::test]
+    async fn complete_without_tools_keeps_python_blocks_as_text() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FixedContentProvider {
+            content: "```python\nFINAL('done')\n```".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("compute this")],
+                &[],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => assert!(text.contains("FINAL('done')")),
+            other => panic!("expected code block to stay text, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn complete_with_tools_keeps_python_blocks_as_text_when_no_tool_calls() {
+        let provider: Arc<dyn LlmProvider> = Arc::new(FixedContentProvider {
+            content: "```repl\nmemory_read(path='x')\n```".to_string(),
+        });
+        let adapter = LlmBridgeAdapter::new(provider, None);
+
+        let output = adapter
+            .complete(
+                &[ThreadMessage::user("read x")],
+                &[test_action("memory_read")],
+                &LlmCallConfig::default(),
+            )
+            .await
+            .unwrap();
+
+        match output.response {
+            LlmResponse::Text(text) => assert!(text.contains("memory_read")),
+            other => panic!("expected code block to stay text, got {other:?}"),
+        }
     }
 
     // ── extract_code_block tests ────────────────────────────

--- a/src/channels/web/responses_api.rs
+++ b/src/channels/web/responses_api.rs
@@ -1169,17 +1169,16 @@ pub async fn get_response_handler(
     let mut output = Vec::new();
     for msg in &messages {
         match msg.role.as_str() {
-            "assistant" => {
-                if !msg.content.is_empty() {
-                    output.push(ResponseOutputItem::Message {
-                        id: format!("msg_{}", msg.id.simple()),
-                        role: "assistant".to_string(),
-                        content: vec![MessageContent::OutputText {
-                            text: msg.content.clone(),
-                        }],
-                    });
-                }
+            "assistant" if !msg.content.is_empty() => {
+                output.push(ResponseOutputItem::Message {
+                    id: format!("msg_{}", msg.id.simple()),
+                    role: "assistant".to_string(),
+                    content: vec![MessageContent::OutputText {
+                        text: msg.content.clone(),
+                    }],
+                });
             }
+            "assistant" => {}
             "tool_calls" => {
                 // Tool calls may be stored as a plain JSON array (legacy) or
                 // as an object wrapper: `{ "calls": [...], "narrative": "..." }`.

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -1099,13 +1099,12 @@ fn read_hidden_input() -> anyhow::Result<String> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        print!("\x08 \x08");
-                        std::io::stdout().flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    print!("\x08 \x08");
+                    std::io::stdout().flush()?;
                 }
+                KeyCode::Backspace => {}
                 KeyCode::Char('c') if key_event.modifiers.contains(KeyModifiers::CONTROL) => {
                     terminal::disable_raw_mode()?;
                     return Err(anyhow::anyhow!("Interrupted"));

--- a/src/llm/rig_adapter.rs
+++ b/src/llm/rig_adapter.rs
@@ -841,11 +841,10 @@ fn extract_response(
 
     for content in choice.iter() {
         match content {
-            AssistantContent::Text(t) => {
-                if !t.text.is_empty() {
-                    text_parts.push(t.text.clone());
-                }
+            AssistantContent::Text(t) if !t.text.is_empty() => {
+                text_parts.push(t.text.clone());
             }
+            AssistantContent::Text(_) => {}
             AssistantContent::ToolCall(tc) => {
                 tool_calls.push(IronToolCall {
                     id: tc.id.clone(),

--- a/src/setup/prompts.rs
+++ b/src/setup/prompts.rs
@@ -167,11 +167,10 @@ pub fn select_many(prompt: &str, options: &[(&str, bool)]) -> io::Result<Vec<usi
                     KeyCode::Up => {
                         cursor_pos = cursor_pos.saturating_sub(1);
                     }
-                    KeyCode::Down => {
-                        if cursor_pos < options.len() - 1 {
-                            cursor_pos += 1;
-                        }
+                    KeyCode::Down if cursor_pos < options.len() - 1 => {
+                        cursor_pos += 1;
                     }
+                    KeyCode::Down => {}
                     KeyCode::Char(' ') => {
                         selected[cursor_pos] = !selected[cursor_pos];
                     }
@@ -250,13 +249,12 @@ fn read_secret_line() -> io::Result<SecretString> {
                 KeyCode::Enter => {
                     break;
                 }
-                KeyCode::Backspace => {
-                    if !input.is_empty() {
-                        input.pop();
-                        execute!(stdout, Print("\x08 \x08"))?;
-                        stdout.flush()?;
-                    }
+                KeyCode::Backspace if !input.is_empty() => {
+                    input.pop();
+                    execute!(stdout, Print("\x08 \x08"))?;
+                    stdout.flush()?;
                 }
+                KeyCode::Backspace => {}
                 KeyCode::Char('c') if modifiers.contains(KeyModifiers::CONTROL) => {
                     return Err(io::Error::new(io::ErrorKind::Interrupted, "Ctrl-C"));
                 }

--- a/src/tools/builtin/abound.rs
+++ b/src/tools/builtin/abound.rs
@@ -13,9 +13,7 @@ use serde_json::json;
 use crate::context::JobContext;
 use crate::secrets::SecretsStore;
 use crate::tools::registry::MissionSlot;
-use crate::tools::tool::{
-    RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str,
-};
+use crate::tools::tool::{RiskLevel, Tool, ToolDomain, ToolError, ToolOutput, require_str};
 
 use super::forex::{format_rate, run_transfer_analysis};
 
@@ -31,18 +29,18 @@ fn normalize_exchange_rate_response(mut result: serde_json::Value) -> serde_json
         return result;
     };
     for key in ["current_exchange_rate", "effective_exchange_rate"] {
-        if let Some(entry) = data.get_mut(key).and_then(|e| e.as_object_mut()) {
-            if let Some(value) = entry.get("value").and_then(|v| v.as_f64()) {
-                entry.insert("formatted_value".into(), json!(format_rate(value)));
-            }
+        if let Some(entry) = data.get_mut(key).and_then(|e| e.as_object_mut())
+            && let Some(value) = entry.get("value").and_then(|v| v.as_f64())
+        {
+            entry.insert("formatted_value".into(), json!(format_rate(value)));
         }
     }
     result
 }
 use super::validate_currency_code;
 
-
-pub(crate) const REMITTANCE_BASE: &str = "https://devneobank.timesclub.co/times/bank/remittance/agent";
+pub(crate) const REMITTANCE_BASE: &str =
+    "https://devneobank.timesclub.co/times/bank/remittance/agent";
 const NOTIFICATION_BASE: &str = "https://dev.timesclub.co/times/users/agent";
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -55,17 +53,29 @@ fn extract_abound_error(status: u64, body: Option<&serde_json::Value>) -> String
         .and_then(|b| b.get("error"))
         .and_then(|e| e.as_object())
         .map(|e| {
-            let msg = e.get("message").and_then(|m| m.as_str()).unwrap_or("Unknown error");
+            let msg = e
+                .get("message")
+                .and_then(|m| m.as_str())
+                .unwrap_or("Unknown error");
             let code = e.get("code").and_then(|c| c.as_str()).unwrap_or("");
-            if code.is_empty() { msg.to_string() } else { format!("{msg} (code: {code})") }
+            if code.is_empty() {
+                msg.to_string()
+            } else {
+                format!("{msg} (code: {code})")
+            }
         })
-        .or_else(|| body.and_then(|b| b.get("message")).and_then(|m| m.as_str()).map(String::from))
+        .or_else(|| {
+            body.and_then(|b| b.get("message"))
+                .and_then(|m| m.as_str())
+                .map(String::from)
+        })
         .or_else(|| body.and_then(|b| b.as_str()).map(String::from));
     match msg {
         Some(m) => format!("(HTTP {status}): {m}"),
         None => format!(
             "(HTTP {status}). Response: {}",
-            body.map(|b| b.to_string()).unwrap_or_else(|| "empty".into())
+            body.map(|b| b.to_string())
+                .unwrap_or_else(|| "empty".into())
         ),
     }
 }
@@ -147,11 +157,10 @@ pub(crate) async fn abound_get(
         .text()
         .await
         .map_err(|e| ToolError::ExternalService(e.to_string()))?;
-    let body: serde_json::Value =
-        serde_json::from_str(&text).unwrap_or_else(|e| {
-            tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
-            serde_json::Value::String(text)
-        });
+    let body: serde_json::Value = serde_json::from_str(&text).unwrap_or_else(|e| {
+        tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
+        serde_json::Value::String(text)
+    });
 
     Ok(json!({ "status": status, "body": body }))
 }
@@ -181,11 +190,10 @@ async fn abound_post(
         .text()
         .await
         .map_err(|e| ToolError::ExternalService(e.to_string()))?;
-    let body: serde_json::Value =
-        serde_json::from_str(&text).unwrap_or_else(|e| {
-            tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
-            serde_json::Value::String(text)
-        });
+    let body: serde_json::Value = serde_json::from_str(&text).unwrap_or_else(|e| {
+        tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
+        serde_json::Value::String(text)
+    });
 
     Ok(json!({ "status": status, "body": body }))
 }
@@ -215,11 +223,10 @@ async fn abound_post_write(
         .text()
         .await
         .map_err(|e| ToolError::ExternalService(e.to_string()))?;
-    let body: serde_json::Value =
-        serde_json::from_str(&text).unwrap_or_else(|e| {
-            tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
-            serde_json::Value::String(text)
-        });
+    let body: serde_json::Value = serde_json::from_str(&text).unwrap_or_else(|e| {
+        tracing::debug!(body = %text, "Failed to parse Abound response as JSON: {e}");
+        serde_json::Value::String(text)
+    });
 
     Ok(json!({ "status": status, "body": body }))
 }
@@ -444,7 +451,9 @@ impl Tool for AboundSendWireTool {
             let amount = params
                 .get("amount")
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| ToolError::InvalidParameters("amount is required for send action".into()))?;
+                .ok_or_else(|| {
+                    ToolError::InvalidParameters("amount is required for send action".into())
+                })?;
             let beneficiary = require_str(&params, "beneficiary_ref_id")?;
             let payment_reason = require_str(&params, "payment_reason_key")?;
 
@@ -505,15 +514,23 @@ impl Tool for AboundSendWireTool {
             );
 
             let notif_result = abound_post(
-                &self.client, &*self.secrets, &ctx.user_id, &notif_url, &notif_body,
-            ).await?;
+                &self.client,
+                &*self.secrets,
+                &ctx.user_id,
+                &notif_url,
+                &notif_body,
+            )
+            .await?;
 
             tracing::debug!(
                 response = %notif_result,
                 "abound_send_wire: notification response"
             );
 
-            let status = notif_result.get("status").and_then(|v| v.as_u64()).unwrap_or(0);
+            let status = notif_result
+                .get("status")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
             if (200..300).contains(&status) {
                 return Ok(ToolOutput::text(
                     format!(
@@ -543,11 +560,15 @@ impl Tool for AboundSendWireTool {
             let target_rate = params
                 .get("target_rate")
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| ToolError::InvalidParameters("target_rate is required for wait action".into()))?;
+                .ok_or_else(|| {
+                    ToolError::InvalidParameters("target_rate is required for wait action".into())
+                })?;
             let current_rate = params
                 .get("current_rate")
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| ToolError::InvalidParameters("current_rate is required for wait action".into()))?;
+                .ok_or_else(|| {
+                    ToolError::InvalidParameters("current_rate is required for wait action".into())
+                })?;
 
             if target_rate <= 0.0 {
                 return Err(ToolError::InvalidParameters(
@@ -615,7 +636,9 @@ impl Tool for AboundSendWireTool {
                     max_concurrent: None,
                     dedup_window_secs: None,
                 };
-                let guardrail_note = if let Err(e) = mgr.update_mission(mission_id, &ctx.user_id, updates).await {
+                let guardrail_note = if let Err(e) =
+                    mgr.update_mission(mission_id, &ctx.user_id, updates).await
+                {
                     tracing::debug!("failed to update mission guardrails: {e}");
                     " (warning: 24-run guardrail could not be applied — mission may run longer than expected)"
                 } else {
@@ -646,7 +669,9 @@ impl Tool for AboundSendWireTool {
             let amount = params
                 .get("amount")
                 .and_then(|v| v.as_f64())
-                .ok_or_else(|| ToolError::InvalidParameters("amount is required for execute".into()))?;
+                .ok_or_else(|| {
+                    ToolError::InvalidParameters("amount is required for execute".into())
+                })?;
             let payment_reason_key = require_str(&params, "payment_reason_key")?;
 
             let mut missing = Vec::new();
@@ -708,14 +733,21 @@ impl Tool for AboundSendWireTool {
             });
             let url = format!("{REMITTANCE_BASE}/send-wire");
             let wire_result =
-                abound_post_write(&self.client, &*self.secrets, &ctx.user_id, &url, &wire_body).await?;
+                abound_post_write(&self.client, &*self.secrets, &ctx.user_id, &url, &wire_body)
+                    .await?;
 
-            let status = wire_result.get("status").and_then(|v| v.as_u64()).unwrap_or(0);
+            let status = wire_result
+                .get("status")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
 
             let message = if (200..300).contains(&status) {
                 format!("Wire transfer of ${amount} executed successfully.")
             } else {
-                format!("Wire transfer failed {}", extract_abound_error(status, wire_result.get("body")))
+                format!(
+                    "Wire transfer failed {}",
+                    extract_abound_error(status, wire_result.get("body"))
+                )
             };
 
             return Ok(ToolOutput::text(message, start.elapsed()));
@@ -1005,8 +1037,7 @@ impl Tool for AboundRateAlertTool {
 
         // Step 1: Fetch exchange rate
         let url = format!("{REMITTANCE_BASE}/exchange-rate?from_currency={from}&to_currency={to}");
-        let rate_response =
-            abound_get(&self.client, &*self.secrets, &ctx.user_id, &url).await?;
+        let rate_response = abound_get(&self.client, &*self.secrets, &ctx.user_id, &url).await?;
 
         // Parse rate from response: body.data.current_exchange_rate.formatted_value
         let current_rate = rate_response
@@ -1014,16 +1045,16 @@ impl Tool for AboundRateAlertTool {
             .and_then(|b| b.get("data"))
             .and_then(|d| d.get("current_exchange_rate"))
             .and_then(|r| {
-                r.get("value")
-                    .and_then(|v| v.as_f64())
-                    .or_else(|| {
-                        r.get("formatted_value")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse::<f64>().ok())
-                    })
+                r.get("value").and_then(|v| v.as_f64()).or_else(|| {
+                    r.get("formatted_value")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| s.parse::<f64>().ok())
+                })
             })
             .unwrap_or_else(|| {
-                tracing::debug!("abound_rate_alert: could not parse current_rate — unexpected response shape");
+                tracing::debug!(
+                    "abound_rate_alert: could not parse current_rate — unexpected response shape"
+                );
                 0.0
             });
 
@@ -1032,13 +1063,11 @@ impl Tool for AboundRateAlertTool {
             .and_then(|b| b.get("data"))
             .and_then(|d| d.get("effective_exchange_rate"))
             .and_then(|r| {
-                r.get("value")
-                    .and_then(|v| v.as_f64())
-                    .or_else(|| {
-                        r.get("formatted_value")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse::<f64>().ok())
-                    })
+                r.get("value").and_then(|v| v.as_f64()).or_else(|| {
+                    r.get("formatted_value")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| s.parse::<f64>().ok())
+                })
             })
             .unwrap_or(0.0);
 

--- a/src/tools/builtin/forex.rs
+++ b/src/tools/builtin/forex.rs
@@ -261,7 +261,9 @@ fn compute_cone(
 
     let mut projection = Vec::new();
     for t in 0..=HORIZON_DAYS {
-        let date_str = (today + chrono::Duration::days(t)).format("%Y-%m-%d").to_string();
+        let date_str = (today + chrono::Duration::days(t))
+            .format("%Y-%m-%d")
+            .to_string();
         let center = current_rate + (target_rate - current_rate) * t as f64 / HORIZON_DAYS as f64;
         let (upper, lower) = if t == 0 {
             (current_rate, current_rate)
@@ -555,12 +557,13 @@ pub async fn run_transfer_analysis(
 ) -> Result<serde_json::Value, ToolError> {
     let now = chrono::Utc::now();
     let today = now.date_naive();
-    let start_str = (today - chrono::Duration::days(220)).format("%Y-%m-%d").to_string();
+    let start_str = (today - chrono::Duration::days(220))
+        .format("%Y-%m-%d")
+        .to_string();
     let end_str = today.format("%Y-%m-%d").to_string();
 
-    let massive_url = format!(
-        "{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{end_str}?sort=asc&limit=5000"
-    );
+    let massive_url =
+        format!("{MASSIVE_BASE}/C:USDINR/range/1/day/{start_str}/{end_str}?sort=asc&limit=5000");
     let now_unix = now.timestamp();
     let dxy_url = format!(
         "https://query1.finance.yahoo.com/v8/finance/chart/DX-Y.NYB?interval=1d&period1={}&period2={now_unix}",
@@ -569,23 +572,22 @@ pub async fn run_transfer_analysis(
 
     let bearer = massive_bearer(secrets, user_id).await?;
 
-    let abound_rate_url = format!(
-        "{REMITTANCE_BASE}/exchange-rate?from_currency=USD&to_currency=INR"
-    );
+    let abound_rate_url =
+        format!("{REMITTANCE_BASE}/exchange-rate?from_currency=USD&to_currency=INR");
     let abound_rate_fut = async {
-        let result = abound_get(client, secrets, user_id, &abound_rate_url).await.ok()?;
+        let result = abound_get(client, secrets, user_id, &abound_rate_url)
+            .await
+            .ok()?;
         result
             .get("body")
             .and_then(|b| b.get("data"))
             .and_then(|d| d.get("effective_exchange_rate"))
             .and_then(|r| {
-                r.get("value")
-                    .and_then(|v| v.as_f64())
-                    .or_else(|| {
-                        r.get("formatted_value")
-                            .and_then(|v| v.as_str())
-                            .and_then(|s| s.parse::<f64>().ok())
-                    })
+                r.get("value").and_then(|v| v.as_f64()).or_else(|| {
+                    r.get("formatted_value")
+                        .and_then(|v| v.as_str())
+                        .and_then(|s| s.parse::<f64>().ok())
+                })
             })
             .filter(|&r| r > 0.0)
     };
@@ -673,15 +675,14 @@ pub async fn run_transfer_analysis(
             .unwrap_or_else(|| "N/A".into()),
         (hr * 10.0).round() / 10.0,
     );
-    if recommend == "wait" {
-        if let Some(save) = could_save
-            && save > 0.0
-        {
-            message.push_str(&format!(
-                " If you wait, you could get ₹{} more on your transfer.",
-                format_rate(save)
-            ));
-        }
+    if recommend == "wait"
+        && let Some(save) = could_save
+        && save > 0.0
+    {
+        message.push_str(&format!(
+            " If you wait, you could get ₹{} more on your transfer.",
+            format_rate(save)
+        ));
     }
     if for_wire {
         message.push_str(
@@ -822,7 +823,9 @@ impl Tool for ValidateTransferTargetTool {
 
         let now = chrono::Utc::now();
         let today = now.date_naive();
-        let start_str = (today - chrono::Duration::days(5)).format("%Y-%m-%d").to_string();
+        let start_str = (today - chrono::Duration::days(5))
+            .format("%Y-%m-%d")
+            .to_string();
         let today_str = today.format("%Y-%m-%d").to_string();
 
         let url = format!(

--- a/src/tools/builtin/glob_tool.rs
+++ b/src/tools/builtin/glob_tool.rs
@@ -173,7 +173,7 @@ impl Tool for GlobTool {
 
         // Sort by mtime descending (newest first)
         let mut files = files;
-        files.sort_by(|a, b| b.1.cmp(&a.1));
+        files.sort_by_key(|item| std::cmp::Reverse(item.1));
 
         // Truncate
         let truncated = files.len() > max_results;

--- a/src/tools/builtin/grep_tool.rs
+++ b/src/tools/builtin/grep_tool.rs
@@ -352,7 +352,7 @@ impl Tool for GrepTool {
                     }
                 }
 
-                file_entries.sort_by(|a, b| b.1.cmp(&a.1));
+                file_entries.sort_by_key(|item| std::cmp::Reverse(item.1));
 
                 // Apply pagination after sorting
                 let total_count = file_entries.len();

--- a/src/tools/builtin/mission.rs
+++ b/src/tools/builtin/mission.rs
@@ -64,11 +64,7 @@ fn extract_notify_channels(params: &serde_json::Value, ctx: &JobContext) -> Vec<
         arr.iter()
             .filter_map(|v| v.as_str().map(String::from))
             .collect()
-    } else if let Some(ch) = ctx
-        .metadata
-        .get("notify_channel")
-        .and_then(|v| v.as_str())
-    {
+    } else if let Some(ch) = ctx.metadata.get("notify_channel").and_then(|v| v.as_str()) {
         vec![ch.to_string()]
     } else {
         vec![]
@@ -168,10 +164,7 @@ impl Tool for MissionCreateTool {
                 success_criteria: Some(criteria.to_string()),
                 ..Default::default()
             };
-            let _ = self
-                .manager
-                .update_mission(id, &ctx.user_id, updates)
-                .await;
+            let _ = self.manager.update_mission(id, &ctx.user_id, updates).await;
         }
 
         let result = json!({"mission_id": id.to_string(), "status": "created"});
@@ -395,7 +388,10 @@ impl Tool for MissionPauseTool {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("failed to pause mission: {e}")))?;
 
-        Ok(ToolOutput::success(json!({"status": "paused"}), start.elapsed()))
+        Ok(ToolOutput::success(
+            json!({"status": "paused"}),
+            start.elapsed(),
+        ))
     }
 
     fn engine_compatibility(&self) -> EngineCompatibility {
@@ -457,7 +453,10 @@ impl Tool for MissionResumeTool {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("failed to resume mission: {e}")))?;
 
-        Ok(ToolOutput::success(json!({"status": "resumed"}), start.elapsed()))
+        Ok(ToolOutput::success(
+            json!({"status": "resumed"}),
+            start.elapsed(),
+        ))
     }
 
     fn engine_compatibility(&self) -> EngineCompatibility {
@@ -523,7 +522,10 @@ impl Tool for MissionDeleteTool {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("failed to delete mission: {e}")))?;
 
-        Ok(ToolOutput::success(json!({"status": "deleted"}), start.elapsed()))
+        Ok(ToolOutput::success(
+            json!({"status": "deleted"}),
+            start.elapsed(),
+        ))
     }
 
     fn engine_compatibility(&self) -> EngineCompatibility {
@@ -638,7 +640,10 @@ impl Tool for MissionUpdateTool {
             .await
             .map_err(|e| ToolError::ExecutionFailed(format!("failed to update mission: {e}")))?;
 
-        Ok(ToolOutput::success(json!({"status": "updated"}), start.elapsed()))
+        Ok(ToolOutput::success(
+            json!({"status": "updated"}),
+            start.elapsed(),
+        ))
     }
 
     fn engine_compatibility(&self) -> EngineCompatibility {

--- a/src/tools/registry.rs
+++ b/src/tools/registry.rs
@@ -20,10 +20,10 @@ use crate::tools::builtin::{
     AboundRateAlertTool, AboundSendWireTool, AnalyzeTransferTool, ApplyPatchTool, CancelJobTool,
     CreateJobTool, EchoTool, ExtensionInfoTool, FileUndoTool, ForexHistoricalDataTool, GlobTool,
     GrepTool, HttpTool, JobEventsTool, JobPromptTool, JobStatusTool, JsonTool, ListDirTool,
-    ListJobsTool, MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool, PlanUpdateTool,
-    PromptQueue, ReadFileTool, ShellTool, SkillInstallTool, SkillListTool, SkillRemoveTool,
-    SkillSearchTool, TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool, ToolListTool,
-    ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
+    ListJobsTool, MemoryReadTool, MemorySearchTool, MemoryTreeTool, MemoryWriteTool,
+    PlanUpdateTool, PromptQueue, ReadFileTool, ShellTool, SkillInstallTool, SkillListTool,
+    SkillRemoveTool, SkillSearchTool, TimeTool, ToolActivateTool, ToolAuthTool, ToolInstallTool,
+    ToolListTool, ToolPermissionSetTool, ToolRemoveTool, ToolSearchTool, ToolUpgradeTool,
     ValidateTransferTargetTool, WriteFileTool, shared_file_history, shared_read_file_state,
 };
 use crate::tools::rate_limiter::RateLimiter;
@@ -169,8 +169,14 @@ pub struct ToolRegistry {
 }
 
 /// Shared slot for deferred mission manager injection into tools.
-pub type MissionSlot =
-    Arc<tokio::sync::RwLock<Option<(Arc<ironclaw_engine::MissionManager>, ironclaw_engine::ProjectId)>>>;
+pub type MissionSlot = Arc<
+    tokio::sync::RwLock<
+        Option<(
+            Arc<ironclaw_engine::MissionManager>,
+            ironclaw_engine::ProjectId,
+        )>,
+    >,
+>;
 
 impl ToolRegistry {
     fn tool_definition(tool: &Arc<dyn Tool>) -> ToolDefinition {

--- a/src/tools/wasm/wrapper.rs
+++ b/src/tools/wasm/wrapper.rs
@@ -2618,8 +2618,7 @@ mod tests {
         };
 
         // Expired credential — should report missing required
-        let result =
-            resolve_host_credentials(&caps, Some(&store), "user1", None, None).await;
+        let result = resolve_host_credentials(&caps, Some(&store), "user1", None, None).await;
         assert!(
             !result.missing_required.is_empty(),
             "expired credential should be reported as missing"


### PR DESCRIPTION
## Summary

Temporarily forces the engine v2 path onto structured tool calls for the Abound demo branch.

- stop converting fenced `python` / `repl` model output into `LlmResponse::Code`
- keep provider `tool_calls` as the only executable v2 action path
- replace the v2 system prompt text with structured-tool-only instructions for this demo test

## How this prevents CodeAct from running

The normal foreground v2 path reaches the model through `LlmBridgeAdapter`.

Before this PR, if the provider returned text containing a fenced `python`, `py`, `repl`, or Python-looking bare code block, the adapter converted that text into `LlmResponse::Code`. The Rust host then serialized that as `{ "type": "code" }` for the Python orchestrator, and the orchestrator's `resp_type == "code"` branch called `__execute_code_step__`, which enters nested Monty/CodeAct execution.

After this PR:

- provider `tool_calls` still become `LlmResponse::ActionCalls` and run through the structured tool loop
- provider text responses always stay `LlmResponse::Text`, even when they contain fenced Python/repl blocks
- because the normal bridge no longer creates `LlmResponse::Code`, it no longer serializes `{ "type": "code" }` for the orchestrator
- without `{ "type": "code" }`, the orchestrator's `__execute_code_step__` / nested Monty CodeAct branch is not reached on the normal app/provider path

In short: this does not delete the CodeAct executor; it cuts off the foreground v2 bridge path that used to route model text into that executor.

## Prompt leak audit

The foreground v2 system prompt built by `build_codeact_system_prompt_inner` no longer includes `codeact_preamble.md` or `codeact_postamble.md`. For this demo branch it uses a structured-tool-only prompt that explicitly says to use provider `tool_calls`, not Python/repl code or Python function-style tool calls.

Remaining CodeAct references are still present in the repo, but they are not all model-visible in the Abound foreground path:

- Rust doc comments, function names, test names, and orchestrator comments still mention CodeAct; these are not prompt text sent to the foreground model.
- The compiled `crates/ironclaw_engine/prompts/codeact_*.md` files still exist, but this PR stops the foreground prompt builder from including them.
- Learning/mission prompt files can still mention `CodeAct`, `FINAL`, or related concepts. Those are separate mission prompt surfaces, not the normal foreground Abound demo prompt.

Known caveat: runtime shared-memory prompt overlays titled `prompt:codeact_preamble` can still be appended under `## Learned Rules (from self-improvement)` if such a shared memory doc exists. A stored overlay could therefore still mention CodeAct in prompt text, even though the bridge-level conversion still prevents that text from entering nested Monty execution through the normal provider path.

## Residual risk

This is intentionally a branch-local demo/testing hack, not a polished long-term feature flag or hard engine-wide CodeAct removal.

- Tests or custom `LlmBackend` implementations can still directly return `LlmResponse::Code`.
- The Python orchestrator still contains its `resp_type == "code"` branch.
- A hard kill switch would also reject or downgrade `LlmResponse::Code` at the orchestrator boundary, but this PR intentionally avoids that broader change.

## Validation

- `cargo test -p ironclaw_engine executor::prompt::tests`
- `cargo test -p ironclaw --lib bridge::llm_adapter::tests`

The adapter tests specifically assert that fenced Python/repl responses remain text in both the no-tools path and the with-tools/no-tool-call path.